### PR TITLE
gh-482: fixed filter options / design mismatch

### DIFF
--- a/graphqlapi/filters.go
+++ b/graphqlapi/filters.go
@@ -46,25 +46,21 @@ func genStaticWhereFilterElements() graphql.InputObjectConfigFieldMap {
 			Type:        graphql.NewList(graphql.String),
 			Description: "Path of from 'Things' or 'Actions' to the property name through the classes",
 		},
-		"int": &graphql.InputObjectFieldConfig{
+		"valueInt": &graphql.InputObjectFieldConfig{
 			Type:        graphql.Int,
 			Description: "Integer value that the property at the provided path will be compared to by an operator",
 		},
-		"number": &graphql.InputObjectFieldConfig{
+		"valueNumber": &graphql.InputObjectFieldConfig{
 			Type:        graphql.Float,
-			Description: "Float value that the property at the provided path will be compared to by an operator",
+			Description: "Number value that the property at the provided path will be compared to by an operator",
 		},
-		"boolean": &graphql.InputObjectFieldConfig{
+		"valueBoolean": &graphql.InputObjectFieldConfig{
 			Type:        graphql.Boolean,
 			Description: "Boolean value that the property at the provided path will be compared to by an operator",
 		},
-		"string": &graphql.InputObjectFieldConfig{
+		"valueString": &graphql.InputObjectFieldConfig{
 			Type:        graphql.String,
 			Description: "String value that the property at the provided path will be compared to by an operator",
-		},
-		"date": &graphql.InputObjectFieldConfig{
-			Type:        graphql.String,
-			Description: "Date value that the property at the provided path will be compared to by an operator",
 		},
 	}
 

--- a/test/graphql_schema/schema_design.json
+++ b/test/graphql_schema/schema_design.json
@@ -155,7 +155,7 @@
               "defaultValue": null
             },
             {
-              "name": "int",
+              "name": "valueInt",
               "description": "Integer value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
@@ -165,8 +165,8 @@
               "defaultValue": null
             },
             {
-              "name": "number",
-              "description": "Float value that the property at the provided path will be compared to by an operator",
+              "name": "valueNumber",
+              "description": "Number value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -175,7 +175,7 @@
               "defaultValue": null
             },
             {
-              "name": "boolean",
+              "name": "valueBoolean",
               "description": "Boolean value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
@@ -185,18 +185,8 @@
               "defaultValue": null
             },
             {
-              "name": "string",
+              "name": "valueString",
               "description": "String value that the property at the provided path will be compared to by an operator",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "date",
-              "description": "Date value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -319,7 +309,7 @@
               "defaultValue": null
             },
             {
-              "name": "int",
+              "name": "valueInt",
               "description": "Integer value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
@@ -329,8 +319,8 @@
               "defaultValue": null
             },
             {
-              "name": "number",
-              "description": "Float value that the property at the provided path will be compared to by an operator",
+              "name": "valueNumber",
+              "description": "Number value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -339,7 +329,7 @@
               "defaultValue": null
             },
             {
-              "name": "boolean",
+              "name": "valueBoolean",
               "description": "Boolean value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
@@ -349,18 +339,8 @@
               "defaultValue": null
             },
                         {
-              "name": "string",
+              "name": "valueString",
               "description": "String value that the property at the provided path will be compared to by an operator",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "date",
-              "description": "Date value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1131,7 +1111,7 @@
               "defaultValue": null
             },
             {
-              "name": "int",
+              "name": "valueInt",
               "description": "Integer value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
@@ -1141,8 +1121,8 @@
               "defaultValue": null
             },
             {
-              "name": "number",
-              "description": "Float value that the property at the provided path will be compared to by an operator",
+              "name": "valueNumber",
+              "description": "Number value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
@@ -1151,7 +1131,7 @@
               "defaultValue": null
             },
             {
-              "name": "boolean",
+              "name": "valueBoolean",
               "description": "Boolean value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
@@ -1161,18 +1141,8 @@
               "defaultValue": null
             },
                         {
-              "name": "string",
+              "name": "valueString",
               "description": "String value that the property at the provided path will be compared to by an operator",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "date",
-              "description": "Date value that the property at the provided path will be compared to by an operator",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",


### PR DESCRIPTION
corrected filter option names, removed date field, updated schema_design.json.

This PR contains minor changes. It updates the `filters.go` file to be compliant with the design / prototype, and replaces `schema_design.json` to match the reworked filters.