### PR TITLE
Add vector to additional fields of reference

### DIFF
--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -233,6 +233,54 @@ func TestNestedReferences(t *testing.T) {
 													search.LocalRef{
 														Class: "Planet",
 														Fields: map[string]interface{}{
+															"name": "Earth",
+															"id":   strfmt.UUID("32c69af9-cbbe-4ec9-bf6c-365cd6c22fdf"),
+														},
+													},
+												},
+												"name": "North America",
+												"id":   strfmt.UUID("4aad8154-e7f3-45b8-81a6-725171419e55"),
+											},
+										},
+									},
+									"name": "USA",
+									"id":   strfmt.UUID("18c80a16-346a-477d-849d-9d92e5040ac9"),
+								},
+							},
+						},
+						"name": "San Francisco",
+						"id":   strfmt.UUID("2297e094-6218-43d4-85b1-3d20af752f23"),
+					},
+				},
+			},
+			"name": "Tim Apple's Fruit Bar",
+			"id":   strfmt.UUID("4ef47fb0-3cf5-44fc-b378-9e217dff13ac"),
+		}
+
+		res, err := repo.ObjectByID(context.Background(), "4ef47fb0-3cf5-44fc-b378-9e217dff13ac",
+			fullyNestedSelectProperties(), additional.Properties{})
+		require.Nil(t, err)
+		assert.Equal(t, expectedSchema, res.Schema)
+	})
+
+	t.Run("fully resolving the place with vectors", func(t *testing.T) {
+		expectedSchema := map[string]interface{}{
+			"inCity": []interface{}{
+				search.LocalRef{
+					Class: "City",
+					Fields: map[string]interface{}{
+						"inCountry": []interface{}{
+							search.LocalRef{
+								Class: "Country",
+								Fields: map[string]interface{}{
+									"onContinent": []interface{}{
+										search.LocalRef{
+											Class: "Continent",
+											Fields: map[string]interface{}{
+												"onPlanet": []interface{}{
+													search.LocalRef{
+														Class: "Planet",
+														Fields: map[string]interface{}{
 															"name":   "Earth",
 															"id":     strfmt.UUID("32c69af9-cbbe-4ec9-bf6c-365cd6c22fdf"),
 															"vector": []float32{1, 2, 3, 4, 5, 6, 7},
@@ -262,7 +310,7 @@ func TestNestedReferences(t *testing.T) {
 		}
 
 		res, err := repo.ObjectByID(context.Background(), "4ef47fb0-3cf5-44fc-b378-9e217dff13ac",
-			fullyNestedSelectProperties(), additional.Properties{})
+			fullyNestedSelectPropertiesWithVector(), additional.Properties{})
 		require.Nil(t, err)
 		assert.Equal(t, expectedSchema, res.Schema)
 	})
@@ -288,7 +336,6 @@ func TestNestedReferences(t *testing.T) {
 								Beacon: "weaviate://localhost/18c80a16-346a-477d-849d-9d92e5040ac9",
 							},
 						},
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
 					},
 				},
 			},
@@ -382,6 +429,66 @@ func fullyNestedSelectProperties() search.SelectProperties {
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fullyNestedSelectPropertiesWithVector() search.SelectProperties {
+	return search.SelectProperties{
+		search.SelectProperty{
+			Name:        "inCity",
+			IsPrimitive: false,
+			Refs: []search.SelectClass{
+				{
+					ClassName: "City",
+					RefProperties: search.SelectProperties{
+						search.SelectProperty{
+							Name:        "inCountry",
+							IsPrimitive: false,
+							Refs: []search.SelectClass{
+								{
+									ClassName: "Country",
+									RefProperties: search.SelectProperties{
+										search.SelectProperty{
+											Name:        "onContinent",
+											IsPrimitive: false,
+											Refs: []search.SelectClass{
+												{
+													ClassName: "Continent",
+													RefProperties: search.SelectProperties{
+														search.SelectProperty{
+															Name:        "onPlanet",
+															IsPrimitive: false,
+															Refs: []search.SelectClass{
+																{
+																	ClassName:     "Planet",
+																	RefProperties: nil,
+																	AdditionalProperties: additional.Properties{
+																		Vector: true,
+																	},
+																},
+															},
+														},
+													},
+													AdditionalProperties: additional.Properties{
+														Vector: true,
+													},
+												},
+											},
+										},
+									},
+									AdditionalProperties: additional.Properties{
+										Vector: true,
+									},
+								},
+							},
+						},
+					},
+					AdditionalProperties: additional.Properties{
+						Vector: true,
 					},
 				},
 			},

--- a/adapters/repos/db/crud_references_multiple_types_integration_test.go
+++ b/adapters/repos/db/crud_references_multiple_types_integration_test.go
@@ -252,24 +252,32 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 			},
 		}
 
-		expectedSchemaWithRefs := map[string]interface{}{
-			"name": "Car which is parked in a garage",
-			"id":   id,
-			"parkedAt": []interface{}{
-				search.LocalRef{
-					Class: "MultiRefParkingGarage",
-					Fields: map[string]interface{}{
-						"name": "Luxury Parking Garage",
-						"location": &models.GeoCoordinates{
-							Latitude:  ptFloat32(48.864716),
-							Longitude: ptFloat32(2.349014),
-						},
-						"id":     strfmt.UUID("a7e10b55-1ac4-464f-80df-82508eea1951"),
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
+		getExpectedSchema := func(withVector bool) map[string]interface{} {
+			fields := map[string]interface{}{
+				"name": "Luxury Parking Garage",
+				"location": &models.GeoCoordinates{
+					Latitude:  ptFloat32(48.864716),
+					Longitude: ptFloat32(2.349014),
+				},
+				"id": strfmt.UUID("a7e10b55-1ac4-464f-80df-82508eea1951"),
+			}
+			if withVector {
+				fields["vector"] = []float32{1, 2, 3, 4, 5, 6, 7}
+			}
+			return map[string]interface{}{
+				"name": "Car which is parked in a garage",
+				"id":   id,
+				"parkedAt": []interface{}{
+					search.LocalRef{
+						Class:  "MultiRefParkingGarage",
+						Fields: fields,
 					},
 				},
-			},
+			}
 		}
+
+		expectedSchemaWithRefs := getExpectedSchema(false)
+		expectedSchemaWithRefsWithVector := getExpectedSchema(true)
 
 		t.Run("asking for no refs", func(t *testing.T) {
 			res, err := repo.ObjectByID(context.Background(), id, nil, additional.Properties{})
@@ -283,6 +291,13 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 			require.Nil(t, err)
 
 			assert.Equal(t, expectedSchemaWithRefs, res.Schema)
+		})
+
+		t.Run("asking for refs of type garage with vector", func(t *testing.T) {
+			res, err := repo.ObjectByID(context.Background(), id, parkedAtGarageWithVector(true), additional.Properties{})
+			require.Nil(t, err)
+
+			assert.Equal(t, expectedSchemaWithRefsWithVector, res.Schema)
 		})
 
 		t.Run("asking for refs of type lot", func(t *testing.T) {
@@ -313,20 +328,28 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 			},
 		}
 
-		expectedSchemaWithRefs := map[string]interface{}{
-			"name": "Car which is parked in a lot",
-			"id":   id,
-			"parkedAt": []interface{}{
-				search.LocalRef{
-					Class: "MultiRefParkingLot",
-					Fields: map[string]interface{}{
-						"name":   "Fancy Parking Lot",
-						"id":     strfmt.UUID("1023967b-9512-475b-8ef9-673a110b695d"),
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
+		getSchemaWithRefs := func(withVector bool) map[string]interface{} {
+			fields := map[string]interface{}{
+				"name": "Fancy Parking Lot",
+				"id":   strfmt.UUID("1023967b-9512-475b-8ef9-673a110b695d"),
+			}
+			if withVector {
+				fields["vector"] = []float32{1, 2, 3, 4, 5, 6, 7}
+			}
+			return map[string]interface{}{
+				"name": "Car which is parked in a lot",
+				"id":   id,
+				"parkedAt": []interface{}{
+					search.LocalRef{
+						Class:  "MultiRefParkingLot",
+						Fields: fields,
 					},
 				},
-			},
+			}
 		}
+
+		expectedSchemaWithRefs := getSchemaWithRefs(false)
+		expectedSchemaWithRefsWithVector := getSchemaWithRefs(true)
 
 		t.Run("asking for no refs", func(t *testing.T) {
 			res, err := repo.ObjectByID(context.Background(), id, nil, additional.Properties{})
@@ -347,6 +370,13 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 			require.Nil(t, err)
 
 			assert.Equal(t, expectedSchemaWithRefs, res.Schema)
+		})
+
+		t.Run("asking for refs with vector of type lot", func(t *testing.T) {
+			res, err := repo.ObjectByID(context.Background(), id, parkedAtLotWithVector(), additional.Properties{})
+			require.Nil(t, err)
+
+			assert.Equal(t, expectedSchemaWithRefsWithVector, res.Schema)
 		})
 
 		t.Run("asking for refs of both types", func(t *testing.T) {
@@ -372,65 +402,88 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 				},
 			},
 		}
-
-		expectedSchemaWithLotRef := map[string]interface{}{
-			"name": "Car which is parked in two places at the same time (magic!)",
-			"id":   id,
-			"parkedAt": []interface{}{
-				search.LocalRef{
-					Class: "MultiRefParkingLot",
-					Fields: map[string]interface{}{
-						"name":   "Fancy Parking Lot",
-						"id":     strfmt.UUID("1023967b-9512-475b-8ef9-673a110b695d"),
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
+		getExpectedSchemaWithLotRef := func(withVector bool) map[string]interface{} {
+			fields := map[string]interface{}{
+				"name": "Fancy Parking Lot",
+				"id":   strfmt.UUID("1023967b-9512-475b-8ef9-673a110b695d"),
+			}
+			if withVector {
+				fields["vector"] = []float32{1, 2, 3, 4, 5, 6, 7}
+			}
+			return map[string]interface{}{
+				"name": "Car which is parked in two places at the same time (magic!)",
+				"id":   id,
+				"parkedAt": []interface{}{
+					search.LocalRef{
+						Class:  "MultiRefParkingLot",
+						Fields: fields,
 					},
 				},
-			},
+			}
 		}
-		expectedSchemaWithGarageRef := map[string]interface{}{
-			"name": "Car which is parked in two places at the same time (magic!)",
-			"id":   id,
-			"parkedAt": []interface{}{
-				search.LocalRef{
-					Class: "MultiRefParkingGarage",
-					Fields: map[string]interface{}{
-						"name": "Luxury Parking Garage",
-						"location": &models.GeoCoordinates{
-							Latitude:  ptFloat32(48.864716),
-							Longitude: ptFloat32(2.349014),
-						},
-						"id":     strfmt.UUID("a7e10b55-1ac4-464f-80df-82508eea1951"),
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
+		expectedSchemaWithLotRef := getExpectedSchemaWithLotRef(false)
+		expectedSchemaWithLotRefWithVector := getExpectedSchemaWithLotRef(true)
+		getExpectedSchemaWithGarageRef := func(withVector bool) map[string]interface{} {
+			fields := map[string]interface{}{
+				"name": "Luxury Parking Garage",
+				"location": &models.GeoCoordinates{
+					Latitude:  ptFloat32(48.864716),
+					Longitude: ptFloat32(2.349014),
+				},
+				"id": strfmt.UUID("a7e10b55-1ac4-464f-80df-82508eea1951"),
+			}
+			if withVector {
+				fields["vector"] = []float32{1, 2, 3, 4, 5, 6, 7}
+			}
+			return map[string]interface{}{
+				"name": "Car which is parked in two places at the same time (magic!)",
+				"id":   id,
+				"parkedAt": []interface{}{
+					search.LocalRef{
+						Class:  "MultiRefParkingGarage",
+						Fields: fields,
 					},
 				},
-			},
+			}
 		}
-		expectedSchemaWithAllRefs := map[string]interface{}{
-			"name": "Car which is parked in two places at the same time (magic!)",
-			"id":   id,
-			"parkedAt": []interface{}{
-				search.LocalRef{
-					Class: "MultiRefParkingLot",
-					Fields: map[string]interface{}{
-						"name":   "Fancy Parking Lot",
-						"id":     strfmt.UUID("1023967b-9512-475b-8ef9-673a110b695d"),
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
+		expectedSchemaWithGarageRef := getExpectedSchemaWithGarageRef(false)
+		expectedSchemaWithGarageRefWithVector := getExpectedSchemaWithGarageRef(true)
+		getExpectedSchemaWithAllRefs := func(withVector bool) map[string]interface{} {
+			fieldsParkingLot := map[string]interface{}{
+				"name": "Fancy Parking Lot",
+				"id":   strfmt.UUID("1023967b-9512-475b-8ef9-673a110b695d"),
+			}
+			if withVector {
+				fieldsParkingLot["vector"] = []float32{1, 2, 3, 4, 5, 6, 7}
+			}
+			fieldsParkingGarage := map[string]interface{}{
+				"name": "Luxury Parking Garage",
+				"location": &models.GeoCoordinates{
+					Latitude:  ptFloat32(48.864716),
+					Longitude: ptFloat32(2.349014),
+				},
+				"id": strfmt.UUID("a7e10b55-1ac4-464f-80df-82508eea1951"),
+			}
+			if withVector {
+				fieldsParkingGarage["vector"] = []float32{1, 2, 3, 4, 5, 6, 7}
+			}
+			return map[string]interface{}{
+				"name": "Car which is parked in two places at the same time (magic!)",
+				"id":   id,
+				"parkedAt": []interface{}{
+					search.LocalRef{
+						Class:  "MultiRefParkingLot",
+						Fields: fieldsParkingLot,
+					},
+					search.LocalRef{
+						Class:  "MultiRefParkingGarage",
+						Fields: fieldsParkingGarage,
 					},
 				},
-				search.LocalRef{
-					Class: "MultiRefParkingGarage",
-					Fields: map[string]interface{}{
-						"name": "Luxury Parking Garage",
-						"location": &models.GeoCoordinates{
-							Latitude:  ptFloat32(48.864716),
-							Longitude: ptFloat32(2.349014),
-						},
-						"id":     strfmt.UUID("a7e10b55-1ac4-464f-80df-82508eea1951"),
-						"vector": []float32{1, 2, 3, 4, 5, 6, 7},
-					},
-				},
-			},
+			}
 		}
+		expectedSchemaWithAllRefs := getExpectedSchemaWithAllRefs(false)
+		expectedSchemaWithAllRefsWithVector := getExpectedSchemaWithAllRefs(true)
 
 		t.Run("asking for no refs", func(t *testing.T) {
 			res, err := repo.ObjectByID(context.Background(), id, nil, additional.Properties{})
@@ -446,11 +499,25 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 			assert.Equal(t, expectedSchemaWithGarageRef, res.Schema)
 		})
 
+		t.Run("asking for refs with vector of type garage", func(t *testing.T) {
+			res, err := repo.ObjectByID(context.Background(), id, parkedAtGarageWithVector(true), additional.Properties{})
+			require.Nil(t, err)
+
+			assert.Equal(t, expectedSchemaWithGarageRefWithVector, res.Schema)
+		})
+
 		t.Run("asking for refs of type lot", func(t *testing.T) {
 			res, err := repo.ObjectByID(context.Background(), id, parkedAtLot(), additional.Properties{})
 			require.Nil(t, err)
 
 			assert.Equal(t, expectedSchemaWithLotRef, res.Schema)
+		})
+
+		t.Run("asking for refs with vector of type lot", func(t *testing.T) {
+			res, err := repo.ObjectByID(context.Background(), id, parkedAtLotWithVector(), additional.Properties{})
+			require.Nil(t, err)
+
+			assert.Equal(t, expectedSchemaWithLotRefWithVector, res.Schema)
 		})
 
 		t.Run("asking for refs of both types", func(t *testing.T) {
@@ -459,10 +526,21 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 
 			assert.Equal(t, expectedSchemaWithAllRefs, res.Schema)
 		})
+
+		t.Run("asking for refs with vectors of both types", func(t *testing.T) {
+			res, err := repo.ObjectByID(context.Background(), id, parkedAtEitherWithVector(), additional.Properties{})
+			require.Nil(t, err)
+
+			assert.Equal(t, expectedSchemaWithAllRefsWithVector, res.Schema)
+		})
 	})
 }
 
 func parkedAtGarage() search.SelectProperties {
+	return parkedAtGarageWithVector(false)
+}
+
+func parkedAtGarageWithVector(withVector bool) search.SelectProperties {
 	return search.SelectProperties{
 		search.SelectProperty{
 			Name:        "parkedAt",
@@ -475,6 +553,9 @@ func parkedAtGarage() search.SelectProperties {
 							Name:        "name",
 							IsPrimitive: true,
 						},
+					},
+					AdditionalProperties: additional.Properties{
+						Vector: withVector,
 					},
 				},
 			},
@@ -495,6 +576,29 @@ func parkedAtLot() search.SelectProperties {
 							Name:        "name",
 							IsPrimitive: true,
 						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func parkedAtLotWithVector() search.SelectProperties {
+	return search.SelectProperties{
+		search.SelectProperty{
+			Name:        "parkedAt",
+			IsPrimitive: false,
+			Refs: []search.SelectClass{
+				{
+					ClassName: "MultiRefParkingLot",
+					RefProperties: search.SelectProperties{
+						search.SelectProperty{
+							Name:        "name",
+							IsPrimitive: true,
+						},
+					},
+					AdditionalProperties: additional.Properties{
+						Vector: true,
 					},
 				},
 			},
@@ -524,6 +628,41 @@ func parkedAtEither() search.SelectProperties {
 							Name:        "name",
 							IsPrimitive: true,
 						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func parkedAtEitherWithVector() search.SelectProperties {
+	return search.SelectProperties{
+		search.SelectProperty{
+			Name:        "parkedAt",
+			IsPrimitive: false,
+			Refs: []search.SelectClass{
+				{
+					ClassName: "MultiRefParkingLot",
+					RefProperties: search.SelectProperties{
+						search.SelectProperty{
+							Name:        "name",
+							IsPrimitive: true,
+						},
+					},
+					AdditionalProperties: additional.Properties{
+						Vector: true,
+					},
+				},
+				{
+					ClassName: "MultiRefParkingGarage",
+					RefProperties: search.SelectProperties{
+						search.SelectProperty{
+							Name:        "name",
+							IsPrimitive: true,
+						},
+					},
+					AdditionalProperties: additional.Properties{
+						Vector: true,
 					},
 				},
 			},

--- a/adapters/repos/db/refcache/resolver.go
+++ b/adapters/repos/db/refcache/resolver.go
@@ -117,7 +117,8 @@ func (r *Resolver) parseRefs(input models.MultipleRef, prop string,
 	var refs []interface{}
 	for _, selectPropRef := range selectProp.Refs {
 		innerProperties := selectPropRef.RefProperties
-		perClass, err := r.resolveRefs(input, selectPropRef.ClassName, innerProperties)
+		additionalProperties := selectPropRef.AdditionalProperties
+		perClass, err := r.resolveRefs(input, selectPropRef.ClassName, innerProperties, additionalProperties)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve ref")
 		}
@@ -129,10 +130,11 @@ func (r *Resolver) parseRefs(input models.MultipleRef, prop string,
 
 func (r *Resolver) resolveRefs(input models.MultipleRef, desiredClass string,
 	innerProperties search.SelectProperties,
+	additionalProperties additional.Properties,
 ) ([]interface{}, error) {
 	var output []interface{}
 	for i, item := range input {
-		resolved, err := r.resolveRef(item, desiredClass, innerProperties)
+		resolved, err := r.resolveRef(item, desiredClass, innerProperties, additionalProperties)
 		if err != nil {
 			return nil, errors.Wrapf(err, "at position %d", i)
 		}
@@ -149,6 +151,7 @@ func (r *Resolver) resolveRefs(input models.MultipleRef, desiredClass string,
 
 func (r *Resolver) resolveRef(item *models.SingleRef, desiredClass string,
 	innerProperties search.SelectProperties,
+	additionalProperties additional.Properties,
 ) (*search.LocalRef, error) {
 	var out search.LocalRef
 
@@ -183,7 +186,9 @@ func (r *Resolver) resolveRef(item *models.SingleRef, desiredClass string,
 		return nil, errors.Wrap(err, "resolve nested ref")
 	}
 
-	nested["vector"] = res.Vector
+	if additionalProperties.Vector {
+		nested["vector"] = res.Vector
+	}
 	out.Fields = nested
 
 	return &out, nil

--- a/adapters/repos/db/refcache/resolver_test.go
+++ b/adapters/repos/db/refcache/resolver_test.go
@@ -73,6 +73,88 @@ func TestResolver(t *testing.T) {
 		assert.Equal(t, expected, res)
 	})
 
+	t.Run("with single ref with vector and matching select prop", func(t *testing.T) {
+		getInput := func() []search.Result {
+			return []search.Result{
+				{
+					ID:        "foo",
+					ClassName: "BestClass",
+					Schema: map[string]interface{}{
+						"refProp": models.MultipleRef{
+							&models.SingleRef{
+								Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/%s", id1)),
+							},
+						},
+					},
+				},
+			}
+		}
+		getResolver := func() *Resolver {
+			cacher := newFakeCacher()
+			r := NewResolver(cacher)
+			cacher.lookup[multi.Identifier{ID: id1, ClassName: "SomeClass"}] = search.Result{
+				ClassName: "SomeClass",
+				ID:        strfmt.UUID(id1),
+				Schema: map[string]interface{}{
+					"bar": "some string",
+				},
+				Vector: []float32{0.1, 0.2},
+			}
+			return r
+		}
+		getSelectProps := func(withVector bool) search.SelectProperties {
+			return search.SelectProperties{
+				search.SelectProperty{
+					Name: "refProp",
+					Refs: []search.SelectClass{
+						{
+							ClassName: "SomeClass",
+							RefProperties: search.SelectProperties{
+								search.SelectProperty{
+									Name:        "bar",
+									IsPrimitive: true,
+								},
+							},
+							AdditionalProperties: additional.Properties{
+								Vector: withVector,
+							},
+						},
+					},
+				},
+			}
+		}
+		getExpectedResult := func(withVector bool) []search.Result {
+			fields := map[string]interface{}{
+				"bar": "some string",
+			}
+			if withVector {
+				fields["vector"] = []float32{0.1, 0.2}
+			}
+			return []search.Result{
+				{
+					ID:        "foo",
+					ClassName: "BestClass",
+					Schema: map[string]interface{}{
+						"refProp": []interface{}{
+							search.LocalRef{
+								Class:  "SomeClass",
+								Fields: fields,
+							},
+						},
+					},
+				},
+			}
+		}
+		// ask for vector in ref property
+		res, err := getResolver().Do(context.Background(), getInput(), getSelectProps(true), additional.Properties{})
+		require.Nil(t, err)
+		assert.Equal(t, getExpectedResult(true), res)
+		// don't ask for vector in ref property
+		res, err = getResolver().Do(context.Background(), getInput(), getSelectProps(false), additional.Properties{})
+		require.Nil(t, err)
+		assert.Equal(t, getExpectedResult(false), res)
+	})
+
 	t.Run("with single ref and matching select prop", func(t *testing.T) {
 		cacher := newFakeCacher()
 		r := NewResolver(cacher)
@@ -122,8 +204,7 @@ func TestResolver(t *testing.T) {
 						search.LocalRef{
 							Class: "SomeClass",
 							Fields: map[string]interface{}{
-								"bar":    "some string",
-								"vector": []float32(nil),
+								"bar": "some string",
 							},
 						},
 					},
@@ -221,13 +302,11 @@ func TestResolver(t *testing.T) {
 										Beacon: strfmt.URI("weaviate://localhost/ignoreMe"),
 									},
 								},
-								"vector": []float32(nil),
 								"nestedRef": []interface{}{
 									search.LocalRef{
 										Class: "SomeNestedClass",
 										Fields: map[string]interface{}{
-											"name":   "John Doe",
-											"vector": []float32(nil),
+											"name": "John Doe",
 										},
 									},
 								},

--- a/test/acceptance/graphql_resolvers/local_get_with_additional_test.go
+++ b/test/acceptance/graphql_resolvers/local_get_with_additional_test.go
@@ -287,7 +287,7 @@ func gettingObjectsWithAdditionalProps(t *testing.T) {
 			}
 		}
 		`
-		result := AssertGraphQL(t, helper.RootAuth, query)
+		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
 		cities := result.Get("Get", "City").AsSlice()
 
 		vector := cities[0].(map[string]interface{})["inCountry"].([]interface{})[0].(map[string]interface{})["_additional"].(map[string]interface{})["vector"]

--- a/test/acceptance/objects/crefs_test.go
+++ b/test/acceptance/objects/crefs_test.go
@@ -106,9 +106,7 @@ func Test_CREFWithCardinalityMany_UsingPatch(t *testing.T) {
 
 	actualThunk := func() interface{} {
 		cityAfterFirstPatch := assertGetObject(t, cityID)
-		properties := cityAfterFirstPatch.Properties.(map[string]interface{})
-		delete(properties, "vector")
-		return properties
+		return cityAfterFirstPatch.Properties
 	}
 
 	testhelper.AssertEventuallyEqual(t, map[string]interface{}{
@@ -234,9 +232,7 @@ func Test_CREFWithCardinalityMany_UsingPostReference(t *testing.T) {
 
 	actualThunk := func() interface{} {
 		city := assertGetObject(t, cityID)
-		properties := city.Properties.(map[string]interface{})
-		delete(properties, "vector")
-		return properties
+		return city.Properties
 	}
 	t.Log("7. verify first cross ref was added")
 	testhelper.AssertEventuallyEqual(t, map[string]interface{}{

--- a/test/acceptance/objects/crefs_without_waiting_for_refresh_test.go
+++ b/test/acceptance/objects/crefs_without_waiting_for_refresh_test.go
@@ -86,9 +86,7 @@ func Test_AddingReferenceWithoutWaiting_UsingPostObjects(t *testing.T) {
 
 	actualThunk := func() interface{} {
 		city := assertGetObject(t, cityID)
-		properties := city.Properties.(map[string]interface{})
-		delete(properties, "vector")
-		return properties
+		return city.Properties
 	}
 	t.Log("7. verify first cross ref was added")
 	testhelper.AssertEventuallyEqual(t, map[string]interface{}{

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -393,7 +393,9 @@ func (e *Explorer) exctractAdditionalPropertiesFromRef(ref interface{},
 				if refClass.AdditionalProperties.Vector {
 					additionalProperties["vector"] = innerRef.Fields["vector"]
 				}
-				innerRef.Fields["_additional"] = additionalProperties
+				if len(additionalProperties) > 0 {
+					innerRef.Fields["_additional"] = additionalProperties
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What's being changed:

This PR introduces a capability to add vectors to reference properties in GraphQL response.

This change is co-authored-by: @danieldaeschle

### Review checklist

- [x] Chaos pipeline run or not necessary. Link to pipeline: https://app.travis-ci.com/github/semi-technologies/weaviate-chaos-engineering/builds/256715179
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
