### PR TITLE
Fix hardcoded CORS headers

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -91,6 +91,7 @@ type Config struct {
 	MaxImportGoroutinesFactor        float64        `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
 	TrackVectorDimensions            bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
 	ReindexVectorDimensionsAtStartup bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
+	CORS                             CORS           `json:"cors" yaml:"cors"`
 }
 
 type moduleProvider interface {
@@ -223,6 +224,18 @@ type ResourceUsage struct {
 	DiskUse DiskUse
 	MemUse  MemUse
 }
+
+type CORS struct {
+	AllowOrigin  string `json:"allow_origin" yaml:"allow_origin"`
+	AllowMethods string `json:"allow_methods" yaml:"allow_methods"`
+	AllowHeaders string `json:"allow_headers" yaml:"allow_headers"`
+}
+
+const (
+	DefaultCORSAllowOrigin  = "*"
+	DefaultCORSAllowMethods = "*"
+	DefaultCORSAllowHeaders = "Content-Type,Authorization,Batch"
+)
 
 func (r ResourceUsage) Validate() error {
 	if err := r.DiskUse.Validate(); err != nil {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -107,6 +107,10 @@ func FromEnv(config *Config) error {
 		return err
 	}
 
+	if err := config.parseCORSConfig(); err != nil {
+		return err
+	}
+
 	if v := os.Getenv("ORIGIN"); v != "" {
 		config.Origin = v
 	}
@@ -205,6 +209,28 @@ func FromEnv(config *Config) error {
 		}
 
 		config.Profiling.MutexProfileFraction = asInt
+	}
+
+	return nil
+}
+
+func (c *Config) parseCORSConfig() error {
+	if v := os.Getenv("CORS_ALLOW_ORIGIN"); v != "" {
+		c.CORS.AllowOrigin = v
+	} else {
+		c.CORS.AllowOrigin = DefaultCORSAllowOrigin
+	}
+
+	if v := os.Getenv("CORS_ALLOW_METHODS"); v != "" {
+		c.CORS.AllowMethods = v
+	} else {
+		c.CORS.AllowMethods = DefaultCORSAllowMethods
+	}
+
+	if v := os.Getenv("CORS_ALLOW_HEADERS"); v != "" {
+		c.CORS.AllowHeaders = v
+	} else {
+		c.CORS.AllowHeaders = DefaultCORSAllowHeaders
 	}
 
 	return nil

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -310,3 +310,87 @@ func TestEnvironmentSetDefaultVectorDistanceMetric(t *testing.T) {
 		require.Equal(t, "l2-squared", conf.DefaultVectorDistanceMetric)
 	})
 }
+
+func TestEnvironmentCORS_Origin(t *testing.T) {
+	factors := []struct {
+		name        string
+		value       []string
+		expected    string
+		expectedErr bool
+	}{
+		{"Valid", []string{"http://foo.com"}, "http://foo.com", false},
+		{"not given", []string{}, DefaultCORSAllowOrigin, false},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.value) == 1 {
+				os.Setenv("CORS_ALLOW_ORIGIN", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.CORS.AllowOrigin)
+			}
+		})
+	}
+}
+
+func TestEnvironmentCORS_Methods(t *testing.T) {
+	factors := []struct {
+		name        string
+		value       []string
+		expected    string
+		expectedErr bool
+	}{
+		{"Valid", []string{"POST"}, "POST", false},
+		{"not given", []string{}, DefaultCORSAllowMethods, false},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.value) == 1 {
+				os.Setenv("CORS_ALLOW_METHODS", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.CORS.AllowMethods)
+			}
+		})
+	}
+}
+
+func TestEnvironmentCORS_Headers(t *testing.T) {
+	factors := []struct {
+		name        string
+		value       []string
+		expected    string
+		expectedErr bool
+	}{
+		{"Valid", []string{"Authorization"}, "Authorization", false},
+		{"not given", []string{}, DefaultCORSAllowHeaders, false},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.value) == 1 {
+				os.Setenv("CORS_ALLOW_HEADERS", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.CORS.AllowHeaders)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

fixes #2486 

Allows overriding all CORS defaults using:

```
CORS_ALLOW_ORIGIN  # defaults to "*"
CORS_ALLOW_METHODS # defaults to "*"
CORS_ALLOW_HEADERS # defaults to "Content-Type, Authorization, Batch"
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
