### PR TITLE
Set unable consistency for replicated writes

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -285,7 +285,7 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object) error {
 	}
 
 	if i.replicationEnabled() {
-		err = i.replicator.PutObject(ctx, shardName, object)
+		err = i.replicator.PutObject(ctx, shardName, object, replica.All)
 		if err != nil {
 			return fmt.Errorf("failed to relay object put across replicas: %w", err)
 		}
@@ -454,7 +454,7 @@ func (i *Index) putObjectBatch(ctx context.Context,
 			defer wg.Done()
 			var errs []error
 			if i.replicationEnabled() {
-				errs = i.replicator.PutObjects(ctx, shardName, group.objects)
+				errs = i.replicator.PutObjects(ctx, shardName, group.objects, replica.All)
 			} else if !i.isLocalShard(shardName) {
 				errs = i.remote.BatchPutObjects(ctx, shardName, group.objects)
 			} else {
@@ -540,7 +540,7 @@ func (i *Index) addReferencesBatch(ctx context.Context,
 	for shardName, group := range byShard {
 		var errs []error
 		if i.replicationEnabled() {
-			errs = i.replicator.AddReferences(ctx, shardName, group.refs)
+			errs = i.replicator.AddReferences(ctx, shardName, group.refs, replica.All)
 		} else if i.isLocalShard(shardName) {
 			shard := i.Shards[shardName]
 			errs = shard.addReferencesBatch(ctx, group.refs)
@@ -993,7 +993,7 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID) error {
 	}
 
 	if i.replicationEnabled() {
-		err = i.replicator.DeleteObject(ctx, shardName, id)
+		err = i.replicator.DeleteObject(ctx, shardName, id, replica.All)
 		if err != nil {
 			return fmt.Errorf("failed to relay object delete across replicas: %w", err)
 		}
@@ -1043,7 +1043,7 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument) er
 	}
 
 	if i.replicationEnabled() {
-		err = i.replicator.MergeObject(ctx, shardName, &merge)
+		err = i.replicator.MergeObject(ctx, shardName, &merge, replica.All)
 		if err != nil {
 			return fmt.Errorf("failed to relay object patch across replicas: %w", err)
 		}
@@ -1297,7 +1297,7 @@ func (i *Index) batchDeleteObjects(ctx context.Context,
 
 			var objs objects.BatchSimpleObjects
 			if i.replicationEnabled() {
-				objs = i.replicator.DeleteObjects(ctx, shardName, docIDs, dryRun)
+				objs = i.replicator.DeleteObjects(ctx, shardName, docIDs, dryRun, replica.All)
 			} else if i.isLocalShard(shardName) {
 				shard := i.Shards[shardName]
 				objs = shard.deleteObjectBatch(ctx, docIDs, dryRun)

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -14,111 +14,107 @@ package replica
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
 
-// readyOp asks a replica to be read to second phase commit
+// readyOp asks a replica if it is ready to commit
 type readyOp func(ctx context.Context, host, requestID string) error
 
 // readyOp asks a replica to execute the actual operation
 type commitOp[T any] func(ctx context.Context, host, requestID string) (T, error)
 
-// coordinator coordinates replication of write request
+// coordinator coordinates replication of write requests
 type coordinator[T any] struct {
-	Client              // needed to commit and abort operation
-	resolver  *resolver // host names of replicas
-	class     string
-	shard     string
-	requestID string
-	// responses collect all responses of batch job
-	responses []T
-	nodes     []string
+	Client
+	Resolver *resolver // node-name -> host-address
+	Class    string
+	Shard    string
+	TID      string // transaction ID
 }
 
 func newCoordinator[T any](r *Replicator, shard, requestID string) *coordinator[T] {
 	return &coordinator[T]{
 		Client: r.client,
-		resolver: &resolver{
+		Resolver: &resolver{
 			schema:       r.stateGetter,
 			nodeResolver: r.resolver,
 			class:        r.class,
 		},
-		class:     r.class,
-		shard:     shard,
-		requestID: requestID,
+		Class: r.class,
+		Shard: shard,
+		TID:   requestID,
 	}
 }
 
 // broadcast sends write request to all replicas (first phase of a two-phase commit)
-func (c *coordinator[T]) broadcast(ctx context.Context, replicas []string, op readyOp) error {
+func (c *coordinator[T]) broadcast(ctx context.Context, replicas []string, op readyOp, level int) ([]string, error) {
 	errs := make([]error, len(replicas))
+	activeReplicas := make([]string, 0, len(replicas))
 	var g errgroup.Group
 	for i, replica := range replicas {
 		i, replica := i, replica
 		g.Go(func() error {
-			errs[i] = op(ctx, replica, c.requestID)
-			return nil
+			errs[i] = op(ctx, replica, c.TID)
+			return errs[i]
 		})
 	}
-	g.Wait()
-	var err error
-	for _, err = range errs {
-		if err != nil {
-			break
+	firstErr := g.Wait()
+	for i, err := range errs {
+		if err == nil {
+			activeReplicas = append(activeReplicas, replicas[i])
 		}
 	}
+	if len(activeReplicas) < level {
+		firstErr = fmt.Errorf("not enough active replicas found: %w", firstErr)
+	} else {
+		firstErr = nil
+	}
 
-	if err != nil {
+	if firstErr != nil {
 		for _, node := range replicas {
-			c.Abort(ctx, node, c.class, c.shard, c.requestID)
+			c.Abort(ctx, node, c.Class, c.Shard, c.TID)
 		}
 	}
 
-	return err
+	return activeReplicas, firstErr
 }
 
 // commitAll tells replicas to commit pending updates related to a specific request
 // (second phase of a two-phase commit)
-func (c *coordinator[T]) commitAll(ctx context.Context, replicas []string, op commitOp[T]) error {
-	var g errgroup.Group
-	c.responses = make([]T, len(replicas))
-	errs := make([]error, len(replicas))
-	for i, replica := range replicas {
-		i, replica := i, replica
-		g.Go(func() error {
-			resp, err := op(ctx, replica, c.requestID)
-			c.responses[i], errs[i] = resp, err
-			return nil
-		})
-	}
-	g.Wait()
-	var err error
-	for _, err = range errs {
-		if err != nil {
-			return err
+func (c *coordinator[T]) commitAll(ctx context.Context, replicas []string, op commitOp[T]) <-chan simpleResult[T] {
+	replyCh := make(chan simpleResult[T], len(replicas))
+	go func() {
+		wg := sync.WaitGroup{}
+		wg.Add(len(replicas))
+		for _, replica := range replicas {
+			go func(replica string) {
+				defer wg.Done()
+				resp, err := op(ctx, replica, c.TID)
+				replyCh <- simpleResult[T]{resp, err}
+			}(replica)
 		}
-	}
+		wg.Wait()
+		close(replyCh)
+	}()
 
-	return nil
+	return replyCh
 }
 
 // Replicate writes on all replicas of specific shard
-func (c *coordinator[T]) Replicate(ctx context.Context, ask readyOp, com commitOp[T]) error {
-	state, err := c.resolver.State(c.shard)
+func (c *coordinator[T]) Replicate(ctx context.Context, cl ConsistencyLevel, ask readyOp, com commitOp[T]) (<-chan simpleResult[T], int, error) {
+	state, err := c.Resolver.State(c.Shard)
+	level := 0
 	if err == nil {
-		_, err = state.ConsistencyLevel(All)
+		level, err = state.ConsistencyLevel(cl)
 	}
-	c.nodes = state.Hosts
-	const msg = "replication with consistency level 'ALL'"
 	if err != nil {
-		return fmt.Errorf("%s: %w : class %q shard %q", msg, err, c.class, c.shard)
+		return nil, level, fmt.Errorf("%w : class %q shard %q", err, c.Class, c.Shard)
 	}
-	if err := c.broadcast(ctx, c.nodes, ask); err != nil {
-		return fmt.Errorf("%s: broadcast: %w", msg, err)
+	nodes, err := c.broadcast(ctx, state.Hosts, ask, level)
+	if err != nil {
+		return nil, level, fmt.Errorf("broadcast: %w", err)
 	}
-	if err := c.commitAll(context.Background(), c.nodes, com); err != nil {
-		return fmt.Errorf("%s commit: %w", msg, err)
-	}
-	return nil
+	return c.commitAll(context.Background(), nodes, com), level, nil
 }

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -67,7 +67,7 @@ func NewReplicator(className string,
 }
 
 func (r *Replicator) PutObject(ctx context.Context, shard string,
-	obj *storobj.Object,
+	obj *storobj.Object, cl ConsistencyLevel,
 ) error {
 	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opPutObject))
 	op := func(ctx context.Context, host, requestID string) error {
@@ -80,29 +80,15 @@ func (r *Replicator) PutObject(ctx context.Context, shard string,
 		}
 		return nil
 	}
-	return coord.Replicate(ctx, op, r.simpleCommit(shard))
-}
-
-func (r *Replicator) PutObjects(ctx context.Context, shard string,
-	objs []*storobj.Object,
-) []error {
-	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opPutObjects))
-	op := func(ctx context.Context, host, requestID string) error {
-		resp, err := r.client.PutObjects(ctx, host, r.class, shard, requestID, objs)
-		if err == nil {
-			err = resp.FirstError()
-		}
-		if err != nil {
-			return fmt.Errorf("%q: %w", host, err)
-		}
-		return nil
+	replyCh, level, err := coord.Replicate(ctx, cl, op, r.simpleCommit(shard))
+	if err != nil {
+		return err
 	}
-	err := coord.Replicate(ctx, op, r.simpleCommit(shard))
-	return errorsFromSimpleResponses(len(objs), coord.responses, err)
+	return readSimpleResponses(1, level, replyCh)[0]
 }
 
 func (r *Replicator) MergeObject(ctx context.Context, shard string,
-	mergeDoc *objects.MergeDocument,
+	mergeDoc *objects.MergeDocument, cl ConsistencyLevel,
 ) error {
 	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opMergeObject))
 	op := func(ctx context.Context, host, requestID string) error {
@@ -115,7 +101,58 @@ func (r *Replicator) MergeObject(ctx context.Context, shard string,
 		}
 		return nil
 	}
-	return coord.Replicate(ctx, op, r.simpleCommit(shard))
+	replyCh, level, err := coord.Replicate(ctx, cl, op, r.simpleCommit(shard))
+	if err != nil {
+		return err
+	}
+	return readSimpleResponses(1, level, replyCh)[0]
+}
+
+func (r *Replicator) PutObjects(ctx context.Context, shard string,
+	objs []*storobj.Object, cl ConsistencyLevel,
+) []error {
+	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opPutObjects))
+	op := func(ctx context.Context, host, requestID string) error {
+		resp, err := r.client.PutObjects(ctx, host, r.class, shard, requestID, objs)
+		if err == nil {
+			err = resp.FirstError()
+		}
+		if err != nil {
+			return fmt.Errorf("%q: %w", host, err)
+		}
+		return nil
+	}
+
+	replyCh, level, err := coord.Replicate(ctx, cl, op, r.simpleCommit(shard))
+	if err != nil {
+		errs := make([]error, len(objs))
+		for i := 0; i < len(objs); i++ {
+			errs[i] = err
+		}
+		return errs
+	}
+	return readSimpleResponses(len(objs), level, replyCh)
+}
+
+func (r *Replicator) DeleteObject(ctx context.Context, shard string,
+	id strfmt.UUID, cl ConsistencyLevel,
+) error {
+	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opDeleteObject))
+	op := func(ctx context.Context, host, requestID string) error {
+		resp, err := r.client.DeleteObject(ctx, host, r.class, shard, requestID, id)
+		if err == nil {
+			err = resp.FirstError()
+		}
+		if err != nil {
+			return fmt.Errorf("%q: %w", host, err)
+		}
+		return nil
+	}
+	replyCh, level, err := coord.Replicate(ctx, cl, op, r.simpleCommit(shard))
+	if err != nil {
+		return err
+	}
+	return readSimpleResponses(1, level, replyCh)[0]
 }
 
 func (r *Replicator) simpleCommit(shard string) commitOp[SimpleResponse] {
@@ -132,25 +169,8 @@ func (r *Replicator) simpleCommit(shard string) commitOp[SimpleResponse] {
 	}
 }
 
-func (r *Replicator) DeleteObject(ctx context.Context, shard string,
-	id strfmt.UUID,
-) error {
-	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opDeleteObject))
-	op := func(ctx context.Context, host, requestID string) error {
-		resp, err := r.client.DeleteObject(ctx, host, r.class, shard, requestID, id)
-		if err == nil {
-			err = resp.FirstError()
-		}
-		if err != nil {
-			return fmt.Errorf("%q: %w", host, err)
-		}
-		return nil
-	}
-	return coord.Replicate(ctx, op, r.simpleCommit(shard))
-}
-
 func (r *Replicator) DeleteObjects(ctx context.Context, shard string,
-	docIDs []uint64, dryRun bool,
+	docIDs []uint64, dryRun bool, cl ConsistencyLevel,
 ) []objects.BatchSimpleObject {
 	coord := newCoordinator[DeleteBatchResponse](r, shard, r.requestID(opDeleteObjects))
 	op := func(ctx context.Context, host, requestID string) error {
@@ -176,12 +196,19 @@ func (r *Replicator) DeleteObjects(ctx context.Context, shard string,
 		return resp, err
 	}
 
-	err := coord.Replicate(ctx, op, commit)
-	return resultsFromDeletionResponses(len(docIDs), coord.responses, err)
+	replyCh, level, err := coord.Replicate(ctx, cl, op, commit)
+	if err != nil {
+		errs := make([]objects.BatchSimpleObject, len(docIDs))
+		for i := 0; i < len(docIDs); i++ {
+			errs[i].Err = err
+		}
+		return errs
+	}
+	return readDeletionResponses(len(docIDs), level, replyCh)
 }
 
 func (r *Replicator) AddReferences(ctx context.Context, shard string,
-	refs []objects.BatchReference,
+	refs []objects.BatchReference, cl ConsistencyLevel,
 ) []error {
 	coord := newCoordinator[SimpleResponse](r, shard, r.requestID(opAddReferences))
 	op := func(ctx context.Context, host, requestID string) error {
@@ -194,8 +221,15 @@ func (r *Replicator) AddReferences(ctx context.Context, shard string,
 		}
 		return nil
 	}
-	err := coord.Replicate(ctx, op, r.simpleCommit(shard))
-	return errorsFromSimpleResponses(len(refs), coord.responses, err)
+	replyCh, level, err := coord.Replicate(ctx, cl, op, r.simpleCommit(shard))
+	if err != nil {
+		errs := make([]error, len(refs))
+		for i := 0; i < len(refs); i++ {
+			errs[i] = err
+		}
+		return errs
+	}
+	return readSimpleResponses(len(refs), level, replyCh)
 }
 
 func errorsFromSimpleResponses(batchSize int, rs []SimpleResponse, defaultErr error) []error {
@@ -255,4 +289,50 @@ func (r *Replicator) requestID(op opID) string {
 		op,
 		time.Now().UnixMilli(),
 		r.requestCounter.Add(1))
+}
+
+type simpleResult[T any] struct {
+	Response T
+	Err      error
+}
+
+func readSimpleResponses(batchSize int, level int, ch <-chan simpleResult[SimpleResponse]) []error {
+	urs := make([]SimpleResponse, 0, level)
+	var firstError error
+	for x := range ch {
+		if x.Err != nil {
+			urs = append(urs, x.Response)
+			if len(x.Response.Errors) == 0 && firstError == nil {
+				firstError = x.Err
+			}
+		} else {
+			level--
+			if level == 0 {
+				return make([]error, batchSize)
+			}
+		}
+	}
+	return errorsFromSimpleResponses(batchSize, urs, firstError)
+}
+
+func readDeletionResponses(batchSize int, level int, ch <-chan simpleResult[DeleteBatchResponse]) []objects.BatchSimpleObject {
+	rs := make([]DeleteBatchResponse, 0, level)
+	urs := make([]DeleteBatchResponse, 0, level)
+	var firstError error
+	for x := range ch {
+		if x.Err != nil {
+			urs = append(urs, x.Response)
+			if len(x.Response.Batch) == 0 && firstError == nil {
+				firstError = x.Err
+			}
+		} else {
+			level--
+			rs = append(rs, x.Response)
+			if level == 0 {
+				return resultsFromDeletionResponses(batchSize, rs, nil)
+			}
+		}
+	}
+	urs = append(urs, rs...)
+	return resultsFromDeletionResponses(batchSize, urs, nil)
 }

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -31,7 +31,7 @@ var (
 func TestReplicatorReplicaNotFound(t *testing.T) {
 	f := newFakeFactory("C1", "S", []string{})
 	rep := f.newReplicator()
-	err := rep.PutObject(context.Background(), "S", nil)
+	err := rep.PutObject(context.Background(), "S", nil, All)
 	assert.ErrorIs(t, err, errNoReplicaFound)
 }
 
@@ -43,7 +43,8 @@ func TestReplicatorPutObject(t *testing.T) {
 		ctx   = context.Background()
 		obj   = &storobj.Object{}
 	)
-	t.Run("Success", func(t *testing.T) {
+	t.Run("SuccessWithConsistencyLevelAll", func(t *testing.T) {
+		nodes := []string{"A", "B", "C"}
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
@@ -51,7 +52,41 @@ func TestReplicatorPutObject(t *testing.T) {
 			f.Client.On("PutObject", ctx, n, cls, shard, anyVal, obj).Return(resp, nil)
 			f.Client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
 		}
-		err := rep.PutObject(ctx, shard, obj)
+		err := rep.PutObject(ctx, shard, obj, All)
+		assert.Nil(t, err)
+	})
+	t.Run("SuccessWithConsistencyLevelOne", func(t *testing.T) {
+		nodes := []string{"A", "B", "C"}
+		f := newFakeFactory("C1", shard, nodes)
+		rep := f.newReplicator()
+		resp := SimpleResponse{}
+
+		f.Client.On("PutObject", ctx, "A", cls, shard, anyVal, obj).Return(resp, errAny)
+		f.Client.On("Abort", ctx, "A", cls, shard, anyVal).Return(resp, nil)
+
+		f.Client.On("PutObject", ctx, "B", cls, shard, anyVal, obj).Return(resp, nil)
+		f.Client.On("Commit", ctx, "B", cls, shard, anyVal, anyVal).Return(errAny)
+
+		f.Client.On("PutObject", ctx, "C", cls, shard, anyVal, obj).Return(resp, nil)
+		f.Client.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil)
+		err := rep.PutObject(ctx, shard, obj, One)
+		assert.Nil(t, err)
+	})
+	t.Run("SuccessWithConsistencyLevelQuorum", func(t *testing.T) {
+		nodes := []string{"A", "B", "C"}
+		f := newFakeFactory("C1", shard, nodes)
+		rep := f.newReplicator()
+		resp := SimpleResponse{}
+		for _, n := range nodes[:2] {
+			f.Client.On("PutObject", ctx, n, cls, shard, anyVal, obj).Return(resp, nil)
+			f.Client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
+		}
+		f.Client.On("PutObject", ctx, "C", cls, shard, anyVal, obj).Return(resp, nil)
+		f.Client.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+			resp := a[5].(*SimpleResponse)
+			*resp = SimpleResponse{Errors: []Error{{Msg: "e3"}}}
+		}
+		err := rep.PutObject(ctx, shard, obj, Quorum)
 		assert.Nil(t, err)
 	})
 
@@ -64,7 +99,7 @@ func TestReplicatorPutObject(t *testing.T) {
 		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
-		err := rep.PutObject(ctx, shard, obj)
+		err := rep.PutObject(ctx, shard, obj, All)
 		assert.ErrorIs(t, err, errAny)
 	})
 
@@ -78,7 +113,7 @@ func TestReplicatorPutObject(t *testing.T) {
 		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
-		err := rep.PutObject(ctx, shard, obj)
+		err := rep.PutObject(ctx, shard, obj, All)
 		want := &Error{}
 		assert.ErrorAs(t, err, &want)
 		assert.ErrorContains(t, err, errAny.Error())
@@ -94,7 +129,7 @@ func TestReplicatorPutObject(t *testing.T) {
 		f.Client.On("Commit", ctx, nodes[0], "C1", shard, anyVal, anyVal).Return(nil)
 		f.Client.On("Commit", ctx, nodes[1], "C1", shard, anyVal, anyVal).Return(errAny)
 
-		err := rep.PutObject(ctx, shard, obj)
+		err := rep.PutObject(ctx, shard, obj, All)
 		assert.ErrorIs(t, err, errAny)
 	})
 }
@@ -116,7 +151,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 			f.Client.On("MergeObject", ctx, n, cls, shard, anyVal, merge).Return(resp, nil)
 			f.Client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
 		}
-		err := rep.MergeObject(ctx, shard, merge)
+		err := rep.MergeObject(ctx, shard, merge, All)
 		assert.Nil(t, err)
 	})
 
@@ -129,7 +164,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 		f.Client.On("Abort", ctx, nodes[0], cls, shard, anyVal).Return(resp, nil)
 		f.Client.On("Abort", ctx, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
-		err := rep.MergeObject(ctx, shard, merge)
+		err := rep.MergeObject(ctx, shard, merge, All)
 		assert.ErrorIs(t, err, errAny)
 	})
 
@@ -143,7 +178,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 		f.Client.On("Abort", ctx, nodes[0], cls, shard, anyVal).Return(resp, nil)
 		f.Client.On("Abort", ctx, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
-		err := rep.MergeObject(ctx, shard, merge)
+		err := rep.MergeObject(ctx, shard, merge, All)
 		want := &Error{}
 		assert.ErrorAs(t, err, &want)
 		assert.ErrorContains(t, err, errAny.Error())
@@ -159,29 +194,104 @@ func TestReplicatorMergeObject(t *testing.T) {
 		f.Client.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil)
 		f.Client.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)
 
-		err := rep.MergeObject(ctx, shard, merge)
+		err := rep.MergeObject(ctx, shard, merge, All)
 		assert.ErrorIs(t, err, errAny)
 	})
 }
 
 func TestReplicatorDeleteObject(t *testing.T) {
 	var (
-		cls     = "C1"
-		shard   = "SH1"
-		nodes   = []string{"A", "B"}
-		ctx     = context.Background()
-		factory = newFakeFactory("C1", shard, nodes)
-		client  = factory.Client
+		cls   = "C1"
+		shard = "SH1"
+		nodes = []string{"A", "B", "C"}
+		uuid  = strfmt.UUID("1234")
+		ctx   = context.Background()
 	)
-	rep := factory.newReplicator()
-	uuid := strfmt.UUID("1234")
-	resp := SimpleResponse{}
-	for _, n := range nodes {
-		client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
-		client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
-	}
-	err := rep.DeleteObject(ctx, shard, uuid)
-	assert.Nil(t, err)
+	t.Run("PhaseOneConnectionError", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		resp := SimpleResponse{Errors: make([]Error, 1)}
+		for _, n := range nodes[:2] {
+			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
+		}
+		client.On("DeleteObject", ctx, "C", cls, shard, anyVal, uuid).Return(SimpleResponse{}, errAny)
+		for _, n := range nodes {
+			client.On("Abort", ctx, n, "C1", shard, anyVal).Return(resp, nil)
+		}
+
+		err := rep.DeleteObject(ctx, shard, uuid, All)
+		assert.NotNil(t, err)
+		assert.ErrorIs(t, err, errAny)
+	})
+
+	t.Run("SuccessWithConsistencyLevelAll", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		resp := SimpleResponse{Errors: make([]Error, 1)}
+		for _, n := range nodes {
+			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
+		}
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, All))
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, Quorum))
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, One))
+	})
+	t.Run("SuccessWithConsistencyQuorum", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		resp := SimpleResponse{Errors: make([]Error, 1)}
+		for _, n := range nodes[:2] {
+			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+				resp := a[5].(*SimpleResponse)
+				*resp = SimpleResponse{
+					Errors: []Error{{}},
+				}
+			}
+		}
+		client.On("DeleteObject", ctx, "C", cls, shard, anyVal, uuid).Return(resp, nil)
+		client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+			resp := a[5].(*SimpleResponse)
+			*resp = SimpleResponse{
+				Errors: []Error{{Msg: "e3"}},
+			}
+		}
+
+		assert.NotNil(t, rep.DeleteObject(ctx, shard, uuid, All))
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, Quorum))
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, One))
+	})
+
+	t.Run("SuccessWithConsistencyQuorum", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		resp := SimpleResponse{Errors: make([]Error, 1)}
+		for _, n := range nodes[:2] {
+			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+				resp := a[5].(*SimpleResponse)
+				*resp = SimpleResponse{
+					Errors: []Error{{}},
+				}
+			}
+		}
+		client.On("DeleteObject", ctx, "C", cls, shard, anyVal, uuid).Return(resp, nil)
+		client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+			resp := a[5].(*SimpleResponse)
+			*resp = SimpleResponse{
+				Errors: []Error{{Msg: "e3"}},
+			}
+		}
+
+		assert.NotNil(t, rep.DeleteObject(ctx, shard, uuid, All))
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, Quorum))
+		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, One))
+	})
 }
 
 func TestReplicatorDeleteObjects(t *testing.T) {
@@ -192,6 +302,22 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		ctx   = context.Background()
 	)
 
+	t.Run("PhaseOneConnectionError", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		docIDs := []uint64{1, 2}
+		client.On("DeleteObjects", ctx, nodes[0], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
+		client.On("DeleteObjects", ctx, nodes[1], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, errAny)
+		for _, n := range nodes {
+			client.On("Abort", ctx, n, "C1", shard, anyVal).Return(SimpleResponse{}, nil)
+		}
+		result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, false, All)
+		assert.Equal(t, len(result), 2)
+		for _, r := range result {
+			assert.ErrorIs(t, r.Err, errAny)
+		}
+	})
+
 	t.Run("PhaseTwoDecodingError", func(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.Client
@@ -200,7 +326,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
 			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(errAny)
 		}
-		result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, false)
+		result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, false, All)
 		assert.Equal(t, len(result), 2)
 	})
 	t.Run("PartialSuccess", func(t *testing.T) {
@@ -218,10 +344,77 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 				}
 			}
 		}
-		result := rep.DeleteObjects(ctx, shard, docIDs, false)
+		result := rep.DeleteObjects(ctx, shard, docIDs, false, All)
 		assert.Equal(t, len(result), 2)
 		assert.Equal(t, objects.BatchSimpleObject{UUID: "1", Err: nil}, result[0])
 		assert.Equal(t, objects.BatchSimpleObject{UUID: "2", Err: &Error{Msg: "e1"}}, result[1])
+	})
+	t.Run("SuccessWithConsistencyLevelAll", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		docIDs := []uint64{1, 2}
+		resp1 := SimpleResponse{}
+		for _, n := range nodes {
+			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
+				resp := args[5].(*DeleteBatchResponse)
+				*resp = DeleteBatchResponse{
+					Batch: []UUID2Error{{UUID: "1"}, {UUID: "2"}},
+				}
+			}
+		}
+		result := rep.DeleteObjects(ctx, shard, docIDs, false, All)
+		assert.Equal(t, len(result), 2)
+		assert.Equal(t, objects.BatchSimpleObject{UUID: "1", Err: nil}, result[0])
+		assert.Equal(t, objects.BatchSimpleObject{UUID: "2", Err: nil}, result[1])
+	})
+
+	t.Run("SuccessWithConsistencyLevelOne", func(t *testing.T) {
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		docIDs := []uint64{1, 2}
+		resp1 := SimpleResponse{}
+		client.On("DeleteObjects", ctx, nodes[0], cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+		client.On("DeleteObjects", ctx, nodes[1], cls, shard, anyVal, docIDs, false).Return(resp1, errAny)
+		client.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
+			resp := args[5].(*DeleteBatchResponse)
+			*resp = DeleteBatchResponse{
+				Batch: []UUID2Error{{UUID: "1"}, {UUID: "2"}},
+			}
+		}
+		result := rep.DeleteObjects(ctx, shard, docIDs, false, One)
+		assert.Equal(t, len(result), 2)
+		assert.Equal(t, []objects.BatchSimpleObject{{UUID: "1"}, {UUID: "2"}}, result)
+	})
+	t.Run("SuccessWithConsistencyQuorum", func(t *testing.T) {
+		nodes = []string{"A", "B", "C"}
+		factory := newFakeFactory("C1", shard, nodes)
+		client := factory.Client
+		rep := factory.newReplicator()
+		docIDs := []uint64{1, 2}
+		resp1 := SimpleResponse{}
+		for _, n := range nodes {
+			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+		}
+		for _, n := range nodes[:2] {
+			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
+				resp := args[5].(*DeleteBatchResponse)
+				*resp = DeleteBatchResponse{
+					Batch: []UUID2Error{{UUID: "1"}, {UUID: "2"}},
+				}
+			}
+		}
+		client.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
+			resp := args[5].(*DeleteBatchResponse)
+			*resp = DeleteBatchResponse{
+				Batch: []UUID2Error{{UUID: "1"}, {UUID: "2", Error: Error{Msg: "e2"}}},
+			}
+		}
+		result := rep.DeleteObjects(ctx, shard, docIDs, false, Quorum)
+		assert.Equal(t, len(result), 2)
+		assert.Equal(t, []objects.BatchSimpleObject{{UUID: "1"}, {UUID: "2"}}, result)
 	})
 }
 
@@ -232,8 +425,9 @@ func TestReplicatorPutObjects(t *testing.T) {
 		nodes = []string{"A", "B"}
 		ctx   = context.Background()
 		objs  = []*storobj.Object{{}, {}, {}}
+		resp1 = SimpleResponse{[]Error{{}}}
 	)
-	t.Run("Success", func(t *testing.T) {
+	t.Run("SuccessWithConsistencyLevelAll", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{Errors: make([]Error, 3)}
@@ -241,20 +435,58 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp, nil)
 			f.Client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
 		}
-		errs := rep.PutObjects(ctx, shard, objs)
+		errs := rep.PutObjects(ctx, shard, objs, All)
+		assert.Equal(t, []error{nil, nil, nil}, errs)
+	})
+	t.Run("SuccessWithConsistencyLevelOne", func(t *testing.T) {
+		nodes := []string{"A", "B", "C"}
+		f := newFakeFactory("C1", shard, nodes)
+		rep := f.newReplicator()
+		for _, n := range nodes[:2] {
+			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
+			f.Client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+				resp := a[5].(*SimpleResponse)
+				*resp = SimpleResponse{Errors: []Error{{}, {}, {Msg: "e3"}}}
+			}
+		}
+		f.Client.On("PutObjects", ctx, "C", cls, shard, anyVal, objs).Return(resp1, nil)
+		f.Client.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+			resp := a[5].(*SimpleResponse)
+			*resp = SimpleResponse{Errors: make([]Error, 3)}
+		}
+		errs := rep.PutObjects(ctx, shard, objs, One)
+		assert.Equal(t, []error{nil, nil, nil}, errs)
+	})
+
+	t.Run("SuccessWithConsistencyLevelQuorum", func(t *testing.T) {
+		nodes := []string{"A", "B", "C"}
+		f := newFakeFactory("C1", shard, nodes)
+		rep := f.newReplicator()
+		for _, n := range nodes[:2] {
+			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
+			f.Client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+				resp := a[5].(*SimpleResponse)
+				*resp = SimpleResponse{Errors: []Error{{}}}
+			}
+		}
+		f.Client.On("PutObjects", ctx, "C", cls, shard, anyVal, objs).Return(resp1, nil)
+		f.Client.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
+			resp := a[5].(*SimpleResponse)
+			*resp = SimpleResponse{Errors: []Error{{Msg: "e3"}}}
+		}
+		errs := rep.PutObjects(ctx, shard, objs, Quorum)
 		assert.Equal(t, []error{nil, nil, nil}, errs)
 	})
 
 	t.Run("PhaseOneConnectionError", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
-		resp := SimpleResponse{}
-		f.Client.On("PutObjects", ctx, nodes[0], cls, shard, anyVal, objs).Return(resp, nil)
-		f.Client.On("PutObjects", ctx, nodes[1], cls, shard, anyVal, objs).Return(resp, errAny)
-		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
-		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
+		f.Client.On("PutObjects", ctx, nodes[0], cls, shard, anyVal, objs).Return(resp1, nil)
+		f.Client.On("PutObjects", ctx, nodes[1], cls, shard, anyVal, objs).Return(resp1, errAny)
+		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
+		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
 
-		errs := rep.PutObjects(ctx, shard, objs)
+		errs := rep.PutObjects(ctx, shard, objs, All)
 		assert.Equal(t, 3, len(errs))
 		assert.ErrorIs(t, errs[0], errAny)
 	})
@@ -262,14 +494,13 @@ func TestReplicatorPutObjects(t *testing.T) {
 	t.Run("PhaseOneUnsuccessfulResponse", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
-		resp := SimpleResponse{}
-		f.Client.On("PutObjects", ctx, nodes[0], cls, shard, anyVal, objs).Return(resp, nil)
+		f.Client.On("PutObjects", ctx, nodes[0], cls, shard, anyVal, objs).Return(resp1, nil)
 		resp2 := SimpleResponse{[]Error{{Msg: "E1"}, {Msg: "E2"}}}
 		f.Client.On("PutObjects", ctx, nodes[1], cls, shard, anyVal, objs).Return(resp2, nil)
-		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
-		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
+		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
+		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
 
-		errs := rep.PutObjects(ctx, shard, objs)
+		errs := rep.PutObjects(ctx, shard, objs, All)
 		want := &Error{}
 		assert.Equal(t, 3, len(errs))
 		assert.ErrorAs(t, errs[0], &want)
@@ -278,9 +509,8 @@ func TestReplicatorPutObjects(t *testing.T) {
 	t.Run("PhaseTwoDecodingError", func(t *testing.T) {
 		f := newFakeFactory(cls, shard, nodes)
 		rep := f.newReplicator()
-		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp, nil)
+			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
 		}
 		f.Client.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
@@ -288,7 +518,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		}
 		f.Client.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)
 
-		errs := rep.PutObjects(ctx, shard, objs)
+		errs := rep.PutObjects(ctx, shard, objs, All)
 		assert.Equal(t, len(errs), 3)
 		assert.ErrorIs(t, errs[0], errAny)
 		assert.ErrorIs(t, errs[1], errAny)
@@ -298,10 +528,9 @@ func TestReplicatorPutObjects(t *testing.T) {
 	t.Run("PhaseTwoUnsuccessfulResponse", func(t *testing.T) {
 		f := newFakeFactory(cls, shard, nodes)
 		rep := f.newReplicator()
-		resp := SimpleResponse{}
 		node2Errs := []Error{{Msg: "E1"}, {}, {Msg: "E3"}}
 		for _, n := range nodes {
-			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp, nil)
+			f.Client.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
 		}
 		f.Client.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
@@ -312,7 +541,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			*resp = SimpleResponse{Errors: node2Errs}
 		}
 
-		errs := rep.PutObjects(ctx, shard, objs)
+		errs := rep.PutObjects(ctx, shard, objs, All)
 		assert.Equal(t, len(errs), len(objs))
 
 		wantError := []error{&node2Errs[0], nil, &node2Errs[2]}
@@ -336,7 +565,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 			f.Client.On("AddReferences", ctx, n, cls, shard, anyVal, refs).Return(resp, nil)
 			f.Client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
 		}
-		errs := rep.AddReferences(ctx, shard, refs)
+		errs := rep.AddReferences(ctx, shard, refs, All)
 		assert.Equal(t, []error{nil, nil}, errs)
 	})
 
@@ -349,7 +578,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
-		errs := rep.AddReferences(ctx, shard, refs)
+		errs := rep.AddReferences(ctx, shard, refs, All)
 		assert.Equal(t, 2, len(errs))
 		assert.ErrorIs(t, errs[0], errAny)
 	})
@@ -364,7 +593,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 		f.Client.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 		f.Client.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
-		errs := rep.AddReferences(ctx, shard, refs)
+		errs := rep.AddReferences(ctx, shard, refs, All)
 		want := &Error{}
 		assert.Equal(t, 2, len(errs))
 		assert.ErrorAs(t, errs[0], &want)
@@ -380,7 +609,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 		f.Client.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil)
 		f.Client.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)
 
-		errs := rep.AddReferences(ctx, shard, refs)
+		errs := rep.AddReferences(ctx, shard, refs, All)
 		assert.Equal(t, len(errs), 2)
 		assert.ErrorIs(t, errs[0], errAny)
 		assert.ErrorIs(t, errs[1], errAny)


### PR DESCRIPTION
### What's being changed:
Extend each write with unable consistency.
Writes default to consistency level All until the http endpoints has been implemented

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
