### PR TITLE
Change readiness prob endpoint  to check for DB-startup completion and member-list health

### DIFF
--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -96,7 +96,7 @@ func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Ha
 			handler = makeAddMonitoring(appState.Metrics)(handler)
 		}
 		handler = addPreflight(handler)
-		handler = addLiveAndReadyness(handler)
+		handler = addLiveAndReadyness(appState, handler)
 		handler = addHandleRoot(handler)
 		handler = makeAddModuleHandlers(appState.Modules)(handler)
 		handler = addInjectHeadersIntoContext(handler)
@@ -171,7 +171,7 @@ func addInjectHeadersIntoContext(next http.Handler) http.Handler {
 	})
 }
 
-func addLiveAndReadyness(next http.Handler) http.Handler {
+func addLiveAndReadyness(state *state.State, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() == "/v1/.well-known/live" {
 			w.WriteHeader(http.StatusOK)
@@ -179,7 +179,11 @@ func addLiveAndReadyness(next http.Handler) http.Handler {
 		}
 
 		if r.URL.String() == "/v1/.well-known/ready" {
-			w.WriteHeader(http.StatusOK)
+			code := http.StatusServiceUnavailable
+			if state.DB.StartupComplete() && state.Cluster.ClusterHealthScore() == 0 {
+				code = http.StatusOK
+			}
+			w.WriteHeader(code)
 			return
 		}
 


### PR DESCRIPTION
This will prevent k8s from sending traffic to the pod while DB is not ready

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
