### PR TITLE
Use different tokenisation for text and string

### DIFF
--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -141,7 +141,7 @@ func TestBM25FJourney(t *testing.T) {
 	require.NotNil(t, idx)
 
 	// Check basic search with one property
-	kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description"}, Query: "journey"}
+	kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description", "stringField"}, Query: "journey"}
 	addit := additional.Properties{}
 	res, _, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
 	require.Nil(t, err)
@@ -159,6 +159,30 @@ func TestBM25FJourney(t *testing.T) {
 		// Check explainScore
 		require.Contains(t, res[0].Object.Additional["explainScore"], "BM25F")
 	})
+
+
+	// Check basic search on string field
+	kwrStringField := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description", "stringField"}, Query: "*&^$@#$%^&*()(offtopic!!!!"}
+	addit = additional.Properties{}
+	resStringField, _, err := idx.objectSearch(context.TODO(), 1000, nil, kwrStringField, nil, addit)
+	require.Nil(t, err)
+
+	// Print results
+	fmt.Println("--- Start results for stringField search ---")
+	for _, r := range res {
+		fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+	}
+	t.Run("bm25f journey", func(t *testing.T) {
+		// Check results in correct order
+		require.Equal(t, uint64(7), resStringField[0].DocID())
+		
+
+		// Check explainScore
+		require.Contains(t, resStringField[0].Object.Additional["explainScore"], "BM25F")
+	})
+
+
+
 	// Check basic search WITH CAPS
 	kwr = &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description"}, Query: "JOURNEY"}
 	addit = additional.Properties{}

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -200,7 +200,6 @@ func TestBM25FJourney(t *testing.T) {
 
 		// Check results in correct order
 		require.Equal(t, uint64(8), resStringField[0].DocID())
-
 	})
 
 	// Check basic text search WITH CAPS
@@ -327,7 +326,6 @@ func TestBM25FDifferentParamsJourney(t *testing.T) {
 }
 
 func EqualFloats(t *testing.T, expected, actual float32, significantFigures int) {
-
 	s1 := fmt.Sprintf("%v", expected)
 	s2 := fmt.Sprintf("%v", actual)
 	if len(s1) < 2 || len(s2) < 2 {

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -148,9 +148,9 @@ func TestBM25FJourney(t *testing.T) {
 	require.Nil(t, err)
 
 	// Print results
-	fmt.Println("--- Start results for basic search ---")
+	t.Log("--- Start results for basic search ---")
 	for _, r := range res {
-		fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+		t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 	}
 
 	t.Run("bm25f journey", func(t *testing.T) {
@@ -172,9 +172,9 @@ func TestBM25FJourney(t *testing.T) {
 		require.Nil(t, err)
 
 		// Print results
-		fmt.Println("--- Start results for stringField search ---")
+		t.Log("--- Start results for stringField search ---")
 		for _, r := range resStringField {
-			fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+			t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 		}
 
 		// Check results in correct order
@@ -193,9 +193,9 @@ func TestBM25FJourney(t *testing.T) {
 		require.Nil(t, err)
 
 		// Print results
-		fmt.Println("--- Start results for stringField caps search ---")
+		t.Log("--- Start results for stringField caps search ---")
 		for _, r := range resStringField {
-			fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+			t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 		}
 
 		// Check results in correct order
@@ -208,9 +208,9 @@ func TestBM25FJourney(t *testing.T) {
 		addit = additional.Properties{}
 		res, _, err = idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
 		// Print results
-		fmt.Println("--- Start results for search with caps ---")
+		t.Log("--- Start results for search with caps ---")
 		for _, r := range res {
-			fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+			t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 		}
 		require.Nil(t, err)
 
@@ -225,9 +225,9 @@ func TestBM25FJourney(t *testing.T) {
 
 	require.Nil(t, err)
 	// Print results
-	fmt.Println("--- Start results for boosted search ---")
+	t.Log("--- Start results for boosted search ---")
 	for _, r := range res {
-		fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+		t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 	}
 
 	t.Run("bm25f journey boosted", func(t *testing.T) {
@@ -250,7 +250,7 @@ func TestBM25FJourney(t *testing.T) {
 		require.Equal(t, uint64(6), res[3].DocID())
 		require.Equal(t, uint64(2), res[4].DocID())
 	})
-	fmt.Println("Search with no properties")
+	t.Log("Search with no properties")
 	// Check search with no properties (should include all properties)
 	kwr = &searchparams.KeywordRanking{Type: "bm25", Properties: []string{}, Query: "journey somewhere"}
 	res, _, err = idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
@@ -264,7 +264,7 @@ func TestBM25FJourney(t *testing.T) {
 		require.Equal(t, uint64(6), res[3].DocID())
 	})
 
-	fmt.Println("Search with non alphanums")
+	t.Log("Search with non alphanums")
 	// Check search with no properties (should include all properties)
 	kwr = &searchparams.KeywordRanking{Type: "bm25", Properties: []string{}, Query: "*&^$@#$%^&*()(Offtopic!!!!"}
 	res, _, err = idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
@@ -303,9 +303,9 @@ func TestBM25FDifferentParamsJourney(t *testing.T) {
 	res, _, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
 
 	// Print results
-	fmt.Println("--- Start results for boosted search ---")
+	t.Log("--- Start results for boosted search ---")
 	for _, r := range res {
-		fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+		t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 	}
 
 	require.Nil(t, err)
@@ -315,9 +315,9 @@ func TestBM25FDifferentParamsJourney(t *testing.T) {
 	require.Equal(t, uint64(1), res[3].DocID())
 
 	// Print results
-	fmt.Println("--- Start results for boosted search ---")
+	t.Log("--- Start results for boosted search ---")
 	for _, r := range res {
-		fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+		t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 	}
 
 	// Check scores
@@ -367,29 +367,29 @@ func TestBM25FCompare(t *testing.T) {
 
 	for _, shardName := range shardNames {
 		shard := idx.Shards[shardName]
-		fmt.Printf("------ BM25F --------\n")
+		t.Logf("------ BM25F --------\n")
 		kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title"}, Query: "journey"}
 		addit := additional.Properties{}
 
 		withBM25Fobjs, withBM25Fscores, err := shard.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
 
 		for i, r := range withBM25Fobjs {
-			fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), withBM25Fscores[i], r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+			t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), withBM25Fscores[i], r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 		}
 
-		fmt.Printf("------ BM25 --------\n")
+		t.Logf("------ BM25 --------\n")
 		kwr.Type = ""
 
 		objs, scores, err := shard.objectSearch(context.TODO(), 1000, nil, kwr, nil, addit)
 
 		for i, r := range objs {
-			fmt.Printf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), scores[i], r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+			t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), scores[i], r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
 		}
 
 		require.Nil(t, err)
 		require.Equal(t, len(withBM25Fobjs), len(objs))
 		for i := range objs {
-			fmt.Printf("%v: BM25F score: %v, BM25 score: %v", i, withBM25Fscores[i], scores[i])
+			t.Logf("%v: BM25F score: %v, BM25 score: %v", i, withBM25Fscores[i], scores[i])
 			EqualFloats(t, withBM25Fscores[i], scores[i], 9)
 		}
 

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -339,6 +339,7 @@ func TestBM25FCompare(t *testing.T) {
 		for i := range objs {
 			s1 := fmt.Sprintf("%v", withBM25Fscores[i])
 			s2 := fmt.Sprintf("%v", scores[i])
+			fmt.Printf("%v: BM25F score: %v, BM25 score: %v", i, s1[:9], s2[:9])
 			require.Equal(t, s1[:9], s2[:9])
 		}
 

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -160,7 +160,6 @@ func TestBM25FJourney(t *testing.T) {
 		require.Contains(t, res[0].Object.Additional["explainScore"], "BM25F")
 	})
 
-
 	// Check basic search on string field
 	kwrStringField := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description", "stringField"}, Query: "*&^$@#$%^&*()(offtopic!!!!"}
 	addit = additional.Properties{}
@@ -175,13 +174,10 @@ func TestBM25FJourney(t *testing.T) {
 	t.Run("bm25f journey", func(t *testing.T) {
 		// Check results in correct order
 		require.Equal(t, uint64(7), resStringField[0].DocID())
-		
 
 		// Check explainScore
 		require.Contains(t, resStringField[0].Object.Additional["explainScore"], "BM25F")
 	})
-
-
 
 	// Check basic search WITH CAPS
 	kwr = &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description"}, Query: "JOURNEY"}

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -391,10 +391,8 @@ func TestBM25FCompare(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, len(withBM25Fobjs), len(objs))
 		for i := range objs {
-			s1 := fmt.Sprintf("%v", withBM25Fscores[i])
-			s2 := fmt.Sprintf("%v", scores[i])
-			fmt.Printf("%v: BM25F score: %v, BM25 score: %v", i, s1[:9], s2[:9])
-			require.Equal(t, s1[:9], s2[:9])
+			fmt.Printf("%v: BM25F score: %v, BM25 score: %v", i, withBM25Fscores[i], scores[i])
+			EqualFloats(t, withBM25Fscores[i], scores[i], 9)
 		}
 
 		// Not all the scores are unique and the search is not stable, so pick ones that don't move

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -226,26 +226,25 @@ func (b *BM25Searcher) BM25F(ctx context.Context, className schema.ClassName, li
 	textTerms := helpers.TokenizeText(keywordRanking.Query)
 	stringTerms := helpers.TokenizeString(keywordRanking.Query)
 
-	idLists := []docPointersWithScore{}
-
-	for _, term := range textTerms {
+	idLists := make([]docPointersWithScore, len(textTerms)+len(stringTerms))
+	for i, term := range textTerms {
 
 		ids, err := b.retrieveForSingleTermMultipleProps(ctx, className, objectByIndexID, keywordRanking.Properties, term, "", keywordRanking.Query)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		idLists = append(idLists, ids)
+		idLists[i] = ids
 	}
 
-	for _, term := range stringTerms {
+	for i, term := range stringTerms {
 
 		ids, err := b.retrieveForSingleTermMultipleProps(ctx, className, objectByIndexID, keywordRanking.Properties, "", term, keywordRanking.Query)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		idLists = append(idLists, ids)
+		idLists[len(textTerms)+i] = ids
 	}
 
 	ids := mergeScores(idLists)
@@ -361,7 +360,6 @@ func (b *BM25Searcher) retrieveForSingleTermMultipleProps(ctx context.Context, c
 				} else if p.DataType[0] == "string" && stringTerm != "" {
 					ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, stringTerm)
 				}
-
 			} else {
 				ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, query)
 			}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -358,11 +358,10 @@ func (b *BM25Searcher) retrieveForSingleTermMultipleProps(ctx context.Context, c
 			if p.Tokenization == "word" {
 				if p.DataType[0] == "text" && textTerm != "" {
 					ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, textTerm)
-				} else {
-					if p.DataType[0] == "string" && stringTerm != "" {
-						ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, stringTerm)
-					}
+				} else if p.DataType[0] == "string" && stringTerm != "" {
+					ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, stringTerm)
 				}
+
 			} else {
 				ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, query)
 			}


### PR DESCRIPTION
### What's being changed:

Queries on string properties are only sometimes working correctly, because search queries are forced to lower case and string fields are not.

This patch ensures the correct tokenisation is used for each property

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
