### PR TITLE
Reset vector cache counter only if deletion happens

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -200,7 +200,7 @@ func New(cfg Config, uc ent.UserConfig) (*hnsw, error) {
 	}
 
 	vectorCache := newShardedLockCache(cfg.VectorForIDThunk, uc.VectorCacheMaxObjects,
-		cfg.Logger, normalizeOnRead)
+		cfg.Logger, normalizeOnRead, defaultDeletionInterval)
 
 	resetCtx, resetCtxCancel := context.WithCancel(context.Background())
 	index := &hnsw{

--- a/adapters/repos/db/vector/hnsw/vector_cache_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_test.go
@@ -1,0 +1,74 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheCleanup(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	var vecForId VectorForID = nil
+
+	maxSize := 10
+	batchSize := maxSize - 1
+	deletionInterval := 200 * time.Millisecond // overwrite default deletionInterval of 3s
+	sleepMs := deletionInterval + 50*time.Millisecond
+
+	t.Run("count is not reset on unnecessary deletion", func(t *testing.T) {
+		shardedLockCache := newShardedLockCache(vecForId, maxSize, logger, false, deletionInterval)
+
+		for i := 0; i < batchSize; i++ {
+			shardedLockCache.preload(uint64(i), []float32{float32(i), float32(i)})
+		}
+		time.Sleep(sleepMs) // wait for deletion to fire
+
+		assert.Equal(t, batchSize, int(shardedLockCache.countVectors()))
+		assert.Equal(t, batchSize, countCached(shardedLockCache))
+
+		shardedLockCache.drop()
+
+		assert.Equal(t, 0, int(shardedLockCache.count))
+		assert.Equal(t, 0, countCached(shardedLockCache))
+	})
+
+	t.Run("deletion clears cache and counter when maxSize exceeded", func(t *testing.T) {
+		shardedLockCache := newShardedLockCache(vecForId, maxSize, logger, false, deletionInterval)
+
+		for b := 0; b < 2; b++ {
+			for i := 0; i < batchSize; i++ {
+				id := b*batchSize + i
+				shardedLockCache.preload(uint64(id), []float32{float32(id), float32(id)})
+			}
+			time.Sleep(sleepMs) // wait for deletion to fire, 2nd should clean the cache
+		}
+
+		assert.Equal(t, 0, int(shardedLockCache.countVectors()))
+		assert.Equal(t, 0, countCached(shardedLockCache))
+
+		shardedLockCache.drop()
+	})
+}
+
+func countCached(c *shardedLockCache) int {
+	count := 0
+	for _, vec := range c.cache {
+		if vec != nil {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
### What's being changed:

Vector cache is checked for cleanup every 3 seconds. If its size is >= given max size it is emptied. Counter holding number of elements in cache was reset on every cleanup attempt regardless of deletion took place or not.
Now reset occurs only if cleanup happened.

### Review checklist

- [ ] ~~Documentation has been updated, if necessary. Link to changed documentation:~~
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] ~~Performance tests have been run or not necessary.~~
