### PR TITLE
Fix crash with many geo props

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -77,17 +77,6 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 		}
 	}
 
-	for _, prop := range class.Properties {
-		if prop.IndexInverted != nil && !*prop.IndexInverted {
-			continue
-		}
-
-		errProps := m.addPropertiesAndNullAndLength(ctx, prop, idx)
-		if errProps != nil {
-			return errors.Wrapf(errProps, "add prop and null state and property length '%v'", prop)
-		}
-	}
-
 	if m.db.config.TrackVectorDimensions {
 		if err := idx.addDimensionsProperty(context.TODO()); err != nil {
 			return errors.Wrap(err, "init id property")


### PR DESCRIPTION
### What's being changed:
* it seems we had accidentally initialized each property twice when a new class was added. The `NewShard()` constructor would already call `initProperties`, but the migrator.AddClass which in turn calls `NewShard()`, also explicitly iterated over all properties and called `shard.addProperty` again. This doesn't seem to matter for LSM Bucket props, but the geo prop which is HNSW based can't be initialized twice. We ended up with a race between two competing maintenance loops which both tried to write into the same files.
* fixes #2539
* This is tested through a new chaos pipeline, here is [an example of a failure with v1.17.1](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4008711822/jobs/6883217761#step:4:116), and an example of a [passed run with the preview build from this PR](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4008757393/jobs/6883317144).
* Please also review this related PR in the chaos pipeline repo.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: see links above (both failed and successful examples)
- [x] All new code is covered by tests where it is reasonable: tested exclusively with a new chaos pipeline, see above
- [ ] Performance tests have been run or not necessary.
