### PR TITLE
[WIP] Go 1.20

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48
+          version: v1.51
           args: --timeout=3m

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Run Swagger
         run: ./tools/gen-code-from-swagger.sh
@@ -37,7 +37,7 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@v0.0.8
         with:
-          go-version: 1.20
+          go-version: "1.20"
           vulncheck-version: latest
           package: ./...
           fail-on-vuln: true
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh --acceptance-module-tests-only
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh --acceptance-only

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Run Swagger
         run: ./tools/gen-code-from-swagger.sh
@@ -37,7 +37,7 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@v0.0.8
         with:
-          go-version: 1.19
+          go-version: 1.20
           vulncheck-version: latest
           package: ./...
           fail-on-vuln: true
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh --acceptance-module-tests-only
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh --acceptance-only

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 ###############################################################################
 # Base build image
-FROM golang:1.19-alpine AS build_base
+FROM golang:1.20rc3-alpine3.17 AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -126,4 +126,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.20


### PR DESCRIPTION
### What's being changed:
* the motivation of this PR is to provide a build-image that's using go 1.20. 
* in order to get this ready to be merged, we should
  * wait until Go1.20 is officially released - this build uses a pre-release
  * also updated to go version used in the linter, vulnecheker, etc. Speaking from past experience this can be a bit buggy in the initial release days and stabilized within a week or so after the release. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
