### PR TITLE
Always use newest openssl and ca-certificates in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 FROM alpine AS weaviate
 ENTRYPOINT ["/bin/weaviate"]
 COPY --from=server_builder /weaviate-server /bin/weaviate
-COPY --from=build_base /etc/ssl/certs /etc/ssl/certs
+RUN apk add --no-cache --upgrade ca-certificates openssl
 RUN mkdir ./modules
 CMD [ "--host", "0.0.0.0", "--port", "8080", "--scheme", "http"]


### PR DESCRIPTION
### What's being changed:

Change to upgrade `openssl` and `ca-certificates` in final stage image. Although golang uses its own TLS library, scans of base image will show vulnerabilities until `alpine:latest` is released which is approximately every 2-3 months.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
