### PR TITLE
Reduce prometheus metrics

### DIFF
--- a/tools/dev/grafana/dashboards/importing.json
+++ b/tools/dev/grafana/dashboards/importing.json
@@ -105,7 +105,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "rate(batch_durations_ms_sum{class_name=\"n/a\"}[5s])/rate(batch_durations_ms_count{class_name=\"n/a\"}[5s])",
+          "expr": "rate(batch_durations_ms_sum{class_name=\"n/a\"}[$__interval])/rate(batch_durations_ms_count{class_name=\"n/a\"}[$__interval])",
           "interval": "",
           "legendFormat": "{{operation}}",
           "refId": "A"
@@ -350,7 +350,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "rate(batch_durations_ms_sum{operation=\"object_storage\"}[5s])/rate(batch_durations_ms_count{operation=\"object_storage\"}[5s])",
+          "expr": "rate(batch_durations_ms_sum{operation=\"object_storage\"}[$__interval])/rate(batch_durations_ms_count{operation=\"object_storage\"}[$__interval])",
           "interval": "",
           "legendFormat": "Object Storage ({{class_name}} - {{shard_name}})",
           "refId": "A"
@@ -361,7 +361,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "rate(batch_durations_ms_sum{operation=\"vector_storage\"}[5s])/rate(batch_durations_ms_count{operation=\"vector_storage\"}[5s])",
+          "expr": "rate(batch_durations_ms_sum{operation=\"vector_storage\"}[$__interval])/rate(batch_durations_ms_count{operation=\"vector_storage\"}[$__interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "Vector Storage ({{class_name}} - {{shard_name}})",

--- a/tools/dev/grafana/dashboards/lsm.json
+++ b/tools/dev/grafana/dashboards/lsm.json
@@ -476,7 +476,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(lsm_bloom_filters_duration_ms_sum{strategy=\"replace\"}[5s])/rate(lsm_bloom_filters_duration_ms_count{strategy=\"replace\"}[5s])",
+          "expr": "rate(lsm_bloom_filters_duration_ms_sum{strategy=\"replace\"}[$__interval])/rate(lsm_bloom_filters_duration_ms_count{strategy=\"replace\"}[$__interval])",
           "legendFormat": "{{operation}} ({{class_name}}/{{shard_name}})",
           "range": true,
           "refId": "A"

--- a/tools/dev/grafana/dashboards/objects.json
+++ b/tools/dev/grafana/dashboards/objects.json
@@ -39,6 +39,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -95,7 +97,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -109,7 +112,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(objects_durations_ms_sum{operation=\"put\"}[5s])/rate(objects_durations_ms_count{operation=\"put\"}[5s])",
+          "expr": "rate(objects_durations_ms_sum{operation=\"put\"}[$__interval])/rate(objects_durations_ms_count{operation=\"put\"}[$__interval])",
           "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
           "range": true,
           "refId": "A"
@@ -119,126 +122,202 @@
       "type": "timeseries"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateGreens",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"
       },
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 0
       },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
       "id": 4,
-      "legend": {
-        "show": false
-      },
       "maxDataPoints": 25,
-      "reverseYBuckets": false,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(objects_durations_ms_bucket{step=\"total\"}[$__interval])) by (le)",
-          "format": "heatmap",
+          "expr": "rate(objects_durations_ms_sum{step=\"total\"}[$__interval]) / rate(objects_durations_ms_count{step=\"total\"}[$__interval])",
+          "format": "time_series",
           "interval": "",
-          "legendFormat": "{{le}}",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
           "refId": "A"
         }
       ],
       "title": "PUT Object (Total)",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "decimals": 2,
-        "format": "ms",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
+      "type": "timeseries"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateBlues",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"
       },
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 7
       },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
       "id": 5,
-      "legend": {
-        "show": false
-      },
       "maxDataPoints": 25,
-      "reverseYBuckets": false,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(objects_durations_ms_bucket{step=\"upsert_object_store\"}[$__interval])) by (le)",
-          "format": "heatmap",
+          "expr": "rate(objects_durations_ms_sum{step=\"upsert_object_store\"}[$__interval]) / rate(objects_durations_ms_count{step=\"upsert_object_store\"}[$__interval])",
+          "format": "time_series",
           "interval": "",
-          "legendFormat": "{{le}}",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
           "refId": "A"
         }
       ],
       "title": "PUT Object (Upsert Object)",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "decimals": 2,
-        "format": "ms",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -251,6 +330,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -307,10 +388,12 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -330,69 +413,107 @@
       "type": "timeseries"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"
       },
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 15
       },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
       "id": 6,
-      "legend": {
-        "show": false
-      },
       "maxDataPoints": 25,
-      "reverseYBuckets": false,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(objects_durations_ms_bucket{step=\"inverted_total\"}[$__interval])) by (le)",
-          "format": "heatmap",
+          "expr": "rate(objects_durations_ms_sum{step=\"inverted_total\"}[$__interval]) / rate(objects_durations_ms_count{step=\"inverted_total\"}[$__interval])",
+          "format": "time_series",
           "interval": "",
-          "legendFormat": "{{le}}",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
           "refId": "A"
         }
       ],
       "title": "PUT Object (Inverted Index)",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "decimals": 2,
-        "format": "ms",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 34,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/tools/dev/grafana/dashboards/querying.json
+++ b/tools/dev/grafana/dashboards/querying.json
@@ -32,6 +32,383 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
+      "description": "Average query latency per time interval for each class.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(queries_durations_ms_sum{}[$__interval]) / rate(queries_durations_ms_count{}[$__interval])",
+          "legendFormat": "{{class_name}} ",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Query Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Number of queries per second for each class",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-YlBl"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(queries_durations_ms_count{}[$__interval])",
+          "legendFormat": "{{class_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Query Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Note the percentiles are calculated from histogram buckets so have an associated error see https://prometheus.io/docs/practices/histograms/#errors-of-quantile-estimation",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-YlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(queries_durations_ms_bucket{}[$__interval])) by (le,class_name))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "90th Percentile Query Latency (Estimated)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Note the percentiles are calculated from histogram buckets so have an associated error see https://prometheus.io/docs/practices/histograms/#errors-of-quantile-estimation",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-YlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(queries_durations_ms_bucket{}[$__interval])) by (le,class_name))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "95th Percentile Query Latency (Estimated)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -39,6 +416,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
@@ -85,17 +464,18 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 17
       },
       "id": 2,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -166,6 +546,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
@@ -212,17 +594,18 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 17
       },
       "id": 3,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -347,7 +730,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -361,6 +744,6 @@
   "timezone": "",
   "title": "Querying",
   "uid": "ImxRLXe7z",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/tools/dev/grafana/dashboards/vectorindex.json
+++ b/tools/dev/grafana/dashboards/vectorindex.json
@@ -38,6 +38,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -70,7 +72,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -92,7 +95,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -116,18 +120,61 @@
       "type": "timeseries"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateInferno",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -135,44 +182,39 @@
         "x": 12,
         "y": 0
       },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
       "id": 4,
-      "legend": {
-        "show": false
-      },
       "maxDataPoints": 25,
-      "reverseYBuckets": false,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(vector_index_maintenance_durations_ms_bucket{}[$__interval])) by (le)",
-          "format": "heatmap",
+          "expr": "rate(vector_index_maintenance_durations_ms_sum{}[$__interval]) / rate(vector_index_maintenance_durations_ms_count{}[$__interval])",
+          "format": "time_series",
           "interval": "",
-          "legendFormat": "{{le}}",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
           "refId": "A"
         }
       ],
       "title": "Vector Index Maintenance Operations (Sync & Async)",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "format": "dtdurationms",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -185,6 +227,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -240,7 +284,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -253,10 +298,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(vector_index_durations_ms_sum{operation=\"create\"}[5s])/rate(vector_index_durations_ms_count{operation=\"create\"}[5s])",
+          "expr": "rate(vector_index_durations_ms_sum{operation=\"create\"}[$__interval])/rate(vector_index_durations_ms_count{operation=\"create\"}[$__interval])",
           "interval": "",
           "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
           "refId": "A"
         },
         {
@@ -287,6 +334,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -319,7 +368,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -341,7 +391,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -354,10 +405,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(vector_index_durations_ms_sum{operation=\"delete\"}[5s])/rate(vector_index_durations_ms_count{operation=\"delete\"}[5s])",
+          "expr": "rate(vector_index_durations_ms_sum{operation=\"delete\"}[$__interval])/rate(vector_index_durations_ms_count{operation=\"delete\"}[$__interval])",
           "interval": "",
           "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -365,7 +418,7 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -20,45 +20,45 @@ import (
 
 type PrometheusMetrics struct {
 	BatchTime                          *prometheus.HistogramVec
-	BatchDeleteTime                    *prometheus.HistogramVec
-	ObjectsTime                        *prometheus.HistogramVec
-	LSMBloomFilters                    *prometheus.HistogramVec
+	BatchDeleteTime                    *prometheus.SummaryVec
+	ObjectsTime                        *prometheus.SummaryVec
+	LSMBloomFilters                    *prometheus.SummaryVec
 	AsyncOperations                    *prometheus.GaugeVec
 	LSMSegmentCount                    *prometheus.GaugeVec
 	LSMSegmentCountByLevel             *prometheus.GaugeVec
 	LSMSegmentObjects                  *prometheus.GaugeVec
 	LSMSegmentSize                     *prometheus.GaugeVec
 	LSMMemtableSize                    *prometheus.GaugeVec
-	LSMMemtableDurations               *prometheus.HistogramVec
+	LSMMemtableDurations               *prometheus.SummaryVec
 	VectorIndexTombstones              *prometheus.GaugeVec
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
 	VectorIndexOperations              *prometheus.GaugeVec
-	VectorIndexDurations               *prometheus.HistogramVec
+	VectorIndexDurations               *prometheus.SummaryVec
 	VectorIndexSize                    *prometheus.GaugeVec
-	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
+	VectorIndexMaintenanceDurations    *prometheus.SummaryVec
 	ObjectCount                        *prometheus.GaugeVec
 	QueriesCount                       *prometheus.GaugeVec
 	QueriesDurations                   *prometheus.HistogramVec
 	QueryDimensions                    *prometheus.CounterVec
 	GoroutinesCount                    *prometheus.GaugeVec
-	BackupRestoreDurations             *prometheus.HistogramVec
-	BackupStoreDurations               *prometheus.HistogramVec
-	BucketPauseDurations               *prometheus.HistogramVec
-	BackupRestoreClassDurations        *prometheus.HistogramVec
-	BackupRestoreBackupInitDurations   *prometheus.HistogramVec
-	BackupRestoreFromStorageDurations  *prometheus.HistogramVec
+	BackupRestoreDurations             *prometheus.SummaryVec
+	BackupStoreDurations               *prometheus.SummaryVec
+	BucketPauseDurations               *prometheus.SummaryVec
+	BackupRestoreClassDurations        *prometheus.SummaryVec
+	BackupRestoreBackupInitDurations   *prometheus.SummaryVec
+	BackupRestoreFromStorageDurations  *prometheus.SummaryVec
 	BackupRestoreDataTransferred       *prometheus.CounterVec
 	BackupStoreDataTransferred         *prometheus.CounterVec
 	VectorDimensionsSum                *prometheus.GaugeVec
 
 	StartupProgress  *prometheus.GaugeVec
-	StartupDurations *prometheus.HistogramVec
-	StartupDiskIO    *prometheus.HistogramVec
+	StartupDurations *prometheus.SummaryVec
+	StartupDiskIO    *prometheus.SummaryVec
 }
 
 var (
-	msBuckets                    = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000}
+	msBuckets                    = []float64{10, 50, 100, 500, 1000, 5000}
 	metrics   *PrometheusMetrics = nil
 )
 
@@ -75,18 +75,16 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		BatchTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "batch_durations_ms",
 			Help:    "Duration in ms of a single batch",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+			Buckets: msBuckets,
 		}, []string{"operation", "class_name", "shard_name"}),
-		BatchDeleteTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "batch_delete_durations_ms",
-			Help:    "Duration in ms of a single delete batch",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BatchDeleteTime: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "batch_delete_durations_ms",
+			Help: "Duration in ms of a single delete batch",
 		}, []string{"operation", "class_name", "shard_name"}),
 
-		ObjectsTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "objects_durations_ms",
-			Help:    "Duration of an individual object operation. Also as part of batches.",
-			Buckets: prometheus.ExponentialBuckets(1, 1.8, 12),
+		ObjectsTime: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "objects_durations_ms",
+			Help: "Duration of an individual object operation. Also as part of batches.",
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		ObjectCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "object_count",
@@ -101,7 +99,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		QueriesDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "queries_durations_ms",
 			Help:    "Duration of queries in milliseconds",
-			Buckets: []float64{1, 10, 25, 50, 75, 100, 250, 500, 1000, 2500, 5000, 10000},
+			Buckets: msBuckets,
 		}, []string{"class_name", "query_type"}),
 
 		GoroutinesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -118,10 +116,9 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "lsm_active_segments",
 			Help: "Number of currently present segments per shard",
 		}, []string{"strategy", "class_name", "shard_name", "path"}),
-		LSMBloomFilters: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "lsm_bloom_filters_duration_ms",
-			Help:    "Duration of bloom filter operations",
-			Buckets: prometheus.ExponentialBuckets(1, 1.8, 12),
+		LSMBloomFilters: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "lsm_bloom_filters_duration_ms",
+			Help: "Duration of bloom filter operations",
 		}, []string{"operation", "strategy", "class_name", "shard_name"}),
 		LSMSegmentObjects: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_segment_objects",
@@ -139,10 +136,9 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "lsm_memtable_size",
 			Help: "Size of memtable by path",
 		}, []string{"strategy", "class_name", "shard_name", "path"}),
-		LSMMemtableDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "lsm_memtable_durations_ms",
-			Help:    "Time in ms for a bucket operation to complete",
-			Buckets: msBuckets,
+		LSMMemtableDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "lsm_memtable_durations_ms",
+			Help: "Time in ms for a bucket operation to complete",
 		}, []string{"strategy", "class_name", "shard_name", "path", "operation"}),
 
 		VectorIndexTombstones: promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -165,15 +161,13 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "vector_index_size",
 			Help: "The size of the vector index. Typically larger than number of vectors, as it grows proactively.",
 		}, []string{"class_name", "shard_name"}),
-		VectorIndexMaintenanceDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "vector_index_maintenance_durations_ms",
-			Help:    "Duration of a sync or async vector index maintenance operation",
-			Buckets: prometheus.ExponentialBuckets(1, 1.8, 12),
+		VectorIndexMaintenanceDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "vector_index_maintenance_durations_ms",
+			Help: "Duration of a sync or async vector index maintenance operation",
 		}, []string{"operation", "class_name", "shard_name"}),
-		VectorIndexDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "vector_index_durations_ms",
-			Help:    "Duration of typical vector index operations (insert, delete)",
-			Buckets: prometheus.ExponentialBuckets(0.1, 1.8, 12),
+		VectorIndexDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "vector_index_durations_ms",
+			Help: "Duration of typical vector index operations (insert, delete)",
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		VectorDimensionsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_dimensions_sum",
@@ -184,50 +178,42 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "startup_progress",
 			Help: "A ratio (percentage) of startup progress for a particular component in a shard",
 		}, []string{"operation", "class_name", "shard_name"}),
-		StartupDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "startup_durations_ms",
-			Help:    "Duration of individual startup operations in ms",
-			Buckets: prometheus.ExponentialBuckets(100, 1.8, 12),
+		StartupDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "startup_durations_ms",
+			Help: "Duration of individual startup operations in ms",
 		}, []string{"operation", "class_name", "shard_name"}),
-		StartupDiskIO: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "startup_diskio_throughput",
-			Help:    "Disk I/O throuhput in bytes per second",
-			Buckets: prometheus.ExponentialBuckets(1, 2, 12),
+		StartupDiskIO: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "startup_diskio_throughput",
+			Help: "Disk I/O throuhput in bytes per second",
 		}, []string{"operation", "class_name", "shard_name"}),
 		QueryDimensions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "query_dimensions_total",
 			Help: "The vector dimensions used by any read-query that involves vectors",
 		}, []string{"query_type", "operation", "class_name"}),
 
-		BackupRestoreDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "backup_restore_ms",
-			Help:    "Duration of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BackupRestoreDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "backup_restore_ms",
+			Help: "Duration of a backup restore",
 		}, []string{"backend_name", "class_name"}),
-		BackupRestoreClassDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "backup_restore_class_ms",
-			Help:    "Duration restoring class",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BackupRestoreClassDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "backup_restore_class_ms",
+			Help: "Duration restoring class",
 		}, []string{"class_name"}),
-		BackupRestoreBackupInitDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "backup_restore_init_ms",
-			Help:    "startup phase of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BackupRestoreBackupInitDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "backup_restore_init_ms",
+			Help: "startup phase of a backup restore",
 		}, []string{"backend_name", "class_name"}),
-		BackupRestoreFromStorageDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "backup_restore_from_backend_ms",
-			Help:    "file transfer stage of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BackupRestoreFromStorageDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "backup_restore_from_backend_ms",
+			Help: "file transfer stage of a backup restore",
 		}, []string{"backend_name", "class_name"}),
-		BackupStoreDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "backup_store_to_backend_ms",
-			Help:    "file transfer stage of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BackupStoreDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "backup_store_to_backend_ms",
+			Help: "file transfer stage of a backup restore",
 		}, []string{"backend_name", "class_name"}),
-		BucketPauseDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "bucket_pause_durations_ms",
-			Help:    "bucket pause durations",
-			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
+		BucketPauseDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "bucket_pause_durations_ms",
+			Help: "bucket pause durations",
 		}, []string{"bucket_dir"}),
 		BackupRestoreDataTransferred: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "backup_restore_data_transferred",


### PR DESCRIPTION
### What's being changed:

- Histograms are swapped for Summaries https://prometheus.io/docs/practices/histograms/
- With 20 Classes this lead to a 6-7x reduction in number of metrics
- Only two histograms kept for batch latency and query latency
- Dashboards modified to use time series instead of heatmaps. The time series are more readable as the heatmaps were averaging over all classes.
- Improvements to querying dashboard 

<img width="1624" alt="Screen Shot 2023-02-10 at 12 07 54 pm" src="https://user-images.githubusercontent.com/2173919/217982675-6dc797c3-bdd8-418c-9a15-c6193d86bbcc.png">

<img width="1624" alt="Screen Shot 2023-02-10 at 12 07 49 pm" src="https://user-images.githubusercontent.com/2173919/217982694-62db1a27-a6e6-437a-9e55-860e6c5e1f6b.png">

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
