### PR TITLE
gh-2576 optionally provided Huggingface endpoint URL/path

### DIFF
--- a/modules/text2vec-huggingface/clients/url.go
+++ b/modules/text2vec-huggingface/clients/url.go
@@ -16,17 +16,29 @@ import "fmt"
 type huggingFaceUrlBuilder struct {
 	origin   string
 	pathMask string
+	customOrigin string
+	customPathMask string
 }
 
-func newHuggingFaceUrlBuilder() *huggingFaceUrlBuilder {
+func newHuggingFaceUrlBuilder(customOrigin string, customPathMask string) *huggingFaceUrlBuilder {
 	return &huggingFaceUrlBuilder{
 		origin:   "https://api-inference.huggingface.co",
 		pathMask: "/pipeline/feature-extraction/%s",
+		customOrigin: customOrigin,
+		customPathMask: customPathMask,
 	}
 }
 
 func (o *huggingFaceUrlBuilder) url(model string) string {
-	return fmt.Sprintf("%s%s", o.origin, o.getPath(model))
+	origin := o.origin
+	pathMask := o.getPath(model)
+	if o.customOrigin != "" {
+		origin = o.customOrigin
+	}
+	if o.customPathMask != "" {
+		pathMask = o.customPathMask
+	}
+	return fmt.Sprintf("%s%s", origin, pathMask)
 }
 
 func (o *huggingFaceUrlBuilder) getPath(model string) string {


### PR DESCRIPTION
Fixes #2576
### What's being changed:
Optionally provided Huggingface endpoint URL/path in `text2vec-huggingface`. Users can now provide custom origins and paths based on their convenience. If neither is provided, the default origin and path value are used. 

### Note for Reviewer:
I am not aware of how to go about testing my changes, since I am new to this. I would like to know if there is anything else to be added or if resolves the issue successfully. 
