### PR TITLE
Fix filter memory leak in inverted.Searcher / RowCacher

### DIFF
--- a/adapters/repos/db/inverted/row_cacher.go
+++ b/adapters/repos/db/inverted/row_cacher.go
@@ -36,7 +36,7 @@ func NewRowCacher(maxSize uint64) *RowCacher {
 type CacheEntry struct {
 	Type      CacheEntryType
 	Hash      []byte
-	Partial   *docPointers
+	Partial   docPointers
 	AllowList helpers.AllowList
 }
 

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -239,7 +239,7 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 		s.rowCache.Store(pv.docIDs.checksum, &CacheEntry{
 			Type:      CacheTypeAllowList,
 			AllowList: out,
-			Partial:   &pv.docIDs,
+			Partial:   pv.docIDs,
 			Hash:      pv.docIDs.checksum,
 		})
 	}


### PR DESCRIPTION
### What's being changed:
* fixes #1917 by turning a struct pointer into a copy
* a detailed explanation is inside the code
* There is a new chaos pipeline that reproduces the leak. A [failed pipeline with an OOM-kill](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4151087357/jobs/7181158573) can be seen here.
* A [successful pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4151708958) with the fix applied can be seen here. 
* Please also see the [PR for the new chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/pull/47).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: see description
- [x] All new code is covered by tests where it is reasonable: through new chaos pipeline
- [ ] Performance tests have been run or not necessary.
