### PR TITLE
Better Debug Tooling: Human-Readable Schema Differ

### DIFF
--- a/usecases/schema/schema_comparison.go
+++ b/usecases/schema/schema_comparison.go
@@ -1,0 +1,206 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// Diff creates human-readable information about the difference in two schemas,
+// returns a len=0 slice if schemas are identical
+func Diff(
+	leftLabel string, left *State,
+	rightLabel string, right *State,
+) []string {
+	var msgs []string
+
+	if len(left.ObjectSchema.Classes) != len(right.ObjectSchema.Classes) {
+		msg := fmt.Sprintf("%s has %d classes, but %s has %d classes",
+			leftLabel, len(left.ObjectSchema.Classes),
+			rightLabel, len(right.ObjectSchema.Classes))
+		msgs = append(msgs, msg)
+	}
+
+	leftClasses := map[string]*models.Class{}
+	rightClasses := map[string]*models.Class{}
+
+	for _, class := range left.ObjectSchema.Classes {
+		leftClasses[class.Class] = class
+	}
+
+	for _, class := range right.ObjectSchema.Classes {
+		rightClasses[class.Class] = class
+	}
+
+	for className, classLeft := range leftClasses {
+		if classRight, ok := rightClasses[className]; !ok {
+			msg := fmt.Sprintf("class %s exists in %s, but not in %s",
+				className, leftLabel, rightLabel)
+			msgs = append(msgs, msg)
+		} else {
+			cc := classComparison{
+				left:       classLeft,
+				right:      classRight,
+				leftLabel:  leftLabel,
+				rightLabel: rightLabel,
+			}
+			msgs = append(msgs, cc.diff()...)
+		}
+	}
+
+	for className := range rightClasses {
+		if _, ok := leftClasses[className]; !ok {
+			msg := fmt.Sprintf("class %s exists in %s, but not in %s",
+				className, rightLabel, leftLabel)
+			msgs = append(msgs, msg)
+		}
+	}
+
+	return msgs
+}
+
+type classComparison struct {
+	left, right           *models.Class
+	leftLabel, rightLabel string
+	msgs                  []string
+}
+
+func (cc *classComparison) addMsg(msg ...string) {
+	cc.msgs = append(cc.msgs, msg...)
+}
+
+func (cc *classComparison) diff() []string {
+	lj, _ := json.Marshal(cc.left)
+	rj, _ := json.Marshal(cc.right)
+
+	if bytes.Equal(lj, rj) {
+		// classes are identical, we are done
+		return nil
+	}
+
+	// classes are not identical, log this fact, then dig deeper to find the diff
+	msg := fmt.Sprintf("class %s exists in both, but is not identical: "+
+		"size %d vs %d", cc.left.Class, len(lj), len(rj))
+	cc.addMsg(msg)
+
+	pc := propsComparison{
+		left:       cc.left.Properties,
+		right:      cc.right.Properties,
+		leftLabel:  cc.leftLabel,
+		rightLabel: cc.rightLabel,
+		className:  cc.left.Class,
+	}
+	cc.addMsg(pc.diff()...)
+
+	ccc := classConfigComparison{
+		left:       cc.left,
+		right:      cc.right,
+		leftLabel:  cc.leftLabel,
+		rightLabel: cc.rightLabel,
+		className:  cc.left.Class,
+	}
+	cc.addMsg(ccc.diff()...)
+
+	return cc.msgs
+}
+
+type propsComparison struct {
+	left, right           []*models.Property
+	leftLabel, rightLabel string
+	className             string
+	msgs                  []string
+}
+
+func (cc *propsComparison) addMsg(msg ...string) {
+	cc.msgs = append(cc.msgs, msg...)
+}
+
+func (pc *propsComparison) diff() []string {
+	containedLeft := map[string]*models.Property{}
+	containedRight := map[string]*models.Property{}
+
+	for _, prop := range pc.left {
+		containedLeft[prop.Name] = prop
+	}
+	for _, prop := range pc.right {
+		if leftProp, ok := containedLeft[prop.Name]; !ok {
+			msg := fmt.Sprintf("class %s: property %s exists in %s, but not in %s",
+				pc.className, prop.Name, pc.rightLabel, pc.leftLabel)
+			pc.addMsg(msg)
+		} else {
+			pc.compareProp(leftProp, prop)
+		}
+		containedRight[prop.Name] = prop
+	}
+
+	for _, prop := range pc.left {
+		containedLeft[prop.Name] = prop
+		if _, ok := containedRight[prop.Name]; !ok {
+			msg := fmt.Sprintf("class %s: property %s exists in %s, but not in %s",
+				pc.className, prop.Name, pc.leftLabel, pc.rightLabel)
+			pc.addMsg(msg)
+		}
+	}
+
+	return pc.msgs
+}
+
+func (pc *propsComparison) compareProp(left, right *models.Property) {
+	lj, _ := json.Marshal(left)
+	rj, _ := json.Marshal(right)
+
+	if bytes.Equal(lj, rj) {
+		return
+	}
+
+	msg := fmt.Sprintf("class %s: property %s: mismatch: %s has %s, but %s has %s",
+		pc.className, left.Name, pc.leftLabel, lj, pc.rightLabel, rj)
+	pc.addMsg(msg)
+}
+
+type classConfigComparison struct {
+	left, right           *models.Class
+	leftLabel, rightLabel string
+	className             string
+	msgs                  []string
+}
+
+func (ccc *classConfigComparison) addMsg(msg ...string) {
+	ccc.msgs = append(ccc.msgs, msg...)
+}
+
+func (ccc *classConfigComparison) diff() []string {
+	ccc.compare(ccc.left.Description, ccc.right.Description, "description")
+	ccc.compare(ccc.left.InvertedIndexConfig,
+		ccc.right.InvertedIndexConfig, "inverted index config")
+	ccc.compare(ccc.left.ModuleConfig,
+		ccc.right.ModuleConfig, "module config")
+	ccc.compare(ccc.left.ReplicationConfig,
+		ccc.right.ReplicationConfig, "replication config")
+	ccc.compare(ccc.left.ShardingConfig,
+		ccc.right.ShardingConfig, "sharding config")
+	ccc.compare(ccc.left.VectorIndexConfig,
+		ccc.right.VectorIndexConfig, "vector index config")
+	ccc.compare(ccc.left.VectorIndexType,
+		ccc.right.VectorIndexType, "vector index type")
+	ccc.compare(ccc.left.Vectorizer,
+		ccc.right.Vectorizer, "vectorizer")
+	return ccc.msgs
+}
+
+func (ccc *classConfigComparison) compare(
+	left, right any, label string,
+) {
+	lj, _ := json.Marshal(left)
+	rj, _ := json.Marshal(right)
+
+	if bytes.Equal(lj, rj) {
+		return
+	}
+
+	msg := fmt.Sprintf("class %s: %s mismatch: %s has %s, but %s has %s",
+		ccc.className, label, ccc.leftLabel, lj, ccc.rightLabel, rj)
+	ccc.addMsg(msg)
+}

--- a/usecases/schema/schema_comparison_test.go
+++ b/usecases/schema/schema_comparison_test.go
@@ -1,0 +1,212 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func Test_SchemaComparison_Identical(t *testing.T) {
+	left := &State{
+		ShardingState: map[string]*sharding.State{
+			"Foo": {
+				IndexID: "Foo",
+			},
+		},
+
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "Foo",
+					Properties: []*models.Property{
+						{
+							DataType: []string{"int"},
+							Name:     "prop_1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	right := &State{
+		ShardingState: map[string]*sharding.State{
+			"Foo": {
+				IndexID: "Foo",
+			},
+		},
+
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "Foo",
+					Properties: []*models.Property{
+						{
+							DataType: []string{"int"},
+							Name:     "prop_1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Len(t, Diff("left schema", left, "right schema", right), 0)
+}
+
+func Test_SchemaComparison_MismatchInClasses(t *testing.T) {
+	left := &State{
+		ShardingState: map[string]*sharding.State{
+			"Foo": {
+				IndexID: "Foo",
+			},
+		},
+
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "Foo",
+					Properties: []*models.Property{
+						{
+							DataType: []string{"int"},
+							Name:     "prop_1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	right := &State{
+		ShardingState: map[string]*sharding.State{
+			"Foo": {
+				IndexID: "Foo",
+			},
+		},
+
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{},
+		},
+	}
+
+	msgs := Diff("left schema", left, "right schema", right)
+	assert.Greater(t, len(msgs), 0)
+	assert.Contains(t, msgs, "class Foo exists in left schema, but not in right schema")
+}
+
+func Test_SchemaComparison_ClassesMatchButPropertiesDont(t *testing.T) {
+	left := &State{
+		ShardingState: map[string]*sharding.State{
+			"Foo": {
+				IndexID: "Foo",
+			},
+		},
+
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "Foo",
+					Properties: []*models.Property{
+						{
+							DataType: []string{"int"},
+							Name:     "prop_1",
+						},
+						{
+							DataType: []string{"text"},
+							Name:     "prop_2",
+						},
+						{
+							DataType: []string{"string"},
+							Name:     "prop_4",
+						},
+					},
+					Description: "foo",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexPropertyLength: true,
+					},
+					ModuleConfig: "bar",
+					ReplicationConfig: &models.ReplicationConfig{
+						Factor: 7,
+					},
+					ShardingConfig: map[string]interface{}{
+						"desiredCount": 7,
+					},
+					VectorIndexConfig: map[string]interface{}{
+						"ef": 1000,
+					},
+					VectorIndexType: "age-n-ass-double-u",
+				},
+			},
+		},
+	}
+
+	right := &State{
+		ShardingState: map[string]*sharding.State{
+			"Foo": {
+				IndexID: "Foo",
+			},
+		},
+
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "Foo",
+					Properties: []*models.Property{
+						{
+							DataType: []string{"int"},
+							Name:     "prop_1",
+						},
+						{
+							DataType: []string{"bool"},
+							Name:     "prop_3",
+						},
+						{
+							DataType: []string{"text"},
+							Name:     "prop_4",
+						},
+					},
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexTimestamps: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{
+						Factor: 8,
+					},
+					Vectorizer: "gpt-9",
+				},
+			},
+		},
+	}
+
+	actual := Diff("L", left, "R", right)
+
+	expected := []string{
+		"class Foo: property prop_2 exists in L, but not in R",
+		"class Foo: property prop_3 exists in R, but not in L",
+		"class Foo: property prop_4: mismatch: " +
+			"L has {\"dataType\":[\"string\"],\"name\":\"prop_4\"}, but " +
+			"R has {\"dataType\":[\"text\"],\"name\":\"prop_4\"}",
+		"class Foo: description mismatch: " +
+			"L has \"foo\", but R has \"\"",
+		"class Foo: inverted index config mismatch: " +
+			"L has {\"indexPropertyLength\":true}, " +
+			"but R has {\"indexTimestamps\":true}",
+		"class Foo: module config mismatch: " +
+			"L has \"bar\", but R has null",
+		"class Foo: replication config mismatch: " +
+			"L has {\"factor\":7}, but R has {\"factor\":8}",
+		"class Foo: sharding config mismatch: " +
+			"L has {\"desiredCount\":7}, but R has null",
+		"class Foo: vector index config mismatch: " +
+			"L has {\"ef\":1000}, but R has null",
+		"class Foo: vector index type mismatch: " +
+			"L has \"age-n-ass-double-u\", but R has \"\"",
+		"class Foo: vectorizer mismatch: " +
+			"L has \"\", but R has \"gpt-9\"",
+	}
+
+	for _, exp := range expected {
+		assert.Contains(t, actual, exp)
+	}
+}

--- a/usecases/schema/schema_comparison_test.go
+++ b/usecases/schema/schema_comparison_test.go
@@ -96,11 +96,21 @@ func Test_SchemaComparison_MismatchInClasses(t *testing.T) {
 	assert.Contains(t, msgs, "class Foo exists in left schema, but not in right schema")
 }
 
-func Test_SchemaComparison_ClassesMatchButPropertiesDont(t *testing.T) {
+func Test_SchemaComparison_VariousMismatches(t *testing.T) {
 	left := &State{
 		ShardingState: map[string]*sharding.State{
 			"Foo": {
 				IndexID: "Foo",
+			},
+			"Foo2": {
+				Physical: map[string]sharding.Physical{
+					"abcd": {},
+				},
+			},
+			"Foo4": {
+				Physical: map[string]sharding.Physical{
+					"abcd": {},
+				},
 			},
 		},
 
@@ -138,6 +148,9 @@ func Test_SchemaComparison_ClassesMatchButPropertiesDont(t *testing.T) {
 					},
 					VectorIndexType: "age-n-ass-double-u",
 				},
+				{Class: "Foo2"},
+				{Class: "Foo3"},
+				{Class: "Foo4"},
 			},
 		},
 	}
@@ -146,6 +159,16 @@ func Test_SchemaComparison_ClassesMatchButPropertiesDont(t *testing.T) {
 		ShardingState: map[string]*sharding.State{
 			"Foo": {
 				IndexID: "Foo",
+			},
+			"Foo2": {
+				Physical: map[string]sharding.Physical{
+					"xyz": {},
+				},
+			},
+			"Foo3": {
+				Physical: map[string]sharding.Physical{
+					"abcd": {},
+				},
 			},
 		},
 
@@ -175,6 +198,9 @@ func Test_SchemaComparison_ClassesMatchButPropertiesDont(t *testing.T) {
 					},
 					Vectorizer: "gpt-9",
 				},
+				{Class: "Foo2"},
+				{Class: "Foo3"},
+				{Class: "Foo4"},
 			},
 		},
 	}
@@ -204,6 +230,11 @@ func Test_SchemaComparison_ClassesMatchButPropertiesDont(t *testing.T) {
 			"L has \"age-n-ass-double-u\", but R has \"\"",
 		"class Foo: vectorizer mismatch: " +
 			"L has \"\", but R has \"gpt-9\"",
+		"class Foo3: missing sharding state in L",
+		"class Foo4: missing sharding state in R",
+		"class Foo2: sharding state mismatch: " +
+			"L has {\"indexID\":\"\",\"config\":{\"virtualPerPhysical\":0,\"desiredCount\":0,\"actualCount\":0,\"desiredVirtualCount\":0,\"actualVirtualCount\":0,\"key\":\"\",\"strategy\":\"\",\"function\":\"\"},\"physical\":{\"abcd\":{\"name\":\"\",\"ownsVirtual\":null,\"ownsPercentage\":0,\"belongsToNodes\":null}},\"virtual\":null}, " +
+			"but R has {\"indexID\":\"\",\"config\":{\"virtualPerPhysical\":0,\"desiredCount\":0,\"actualCount\":0,\"desiredVirtualCount\":0,\"actualVirtualCount\":0,\"key\":\"\",\"strategy\":\"\",\"function\":\"\"},\"physical\":{\"xyz\":{\"name\":\"\",\"ownsVirtual\":null,\"ownsPercentage\":0,\"belongsToNodes\":null}},\"virtual\":null}",
 	}
 
 	for _, exp := range expected {


### PR DESCRIPTION
### What's being changed:
* whenever Weaviate decides that two schemas don't match, it would previously log a json dump of both schemas. This lead to a 14MB (!) log entry in production on a cluster that has many schemas
* Instead – with this PR –, if Weaviate concludes that a schema does not match, it goes through both schemas and compares them. Finally, it only prints the diffs in as small chunks as possible.
* Example: <img width="852" alt="Screen Shot 2023-02-12 at 1 32 02 PM" src="https://user-images.githubusercontent.com/8974479/218311508-b9d77072-1a68-493a-93dc-eda260c25a24.png">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
