### PR TITLE
`backup-gcs:` add `BACKUP_GCS_USE_AUTH` env var to allow other forms of authentication

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
@@ -34,7 +35,11 @@ type gcsClient struct {
 
 func newClient(ctx context.Context, config *clientConfig, dataPath string) (*gcsClient, error) {
 	options := []option.ClientOption{}
-	if len(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")) > 0 {
+	useAuth, err := strconv.ParseBool(os.Getenv("BACKUP_GCS_USE_AUTH"))
+	if err != nil {
+		return nil, errors.Wrap(err, "get env")
+	}
+	if useAuth {
 		scopes := []string{
 			"https://www.googleapis.com/auth/devstorage.read_write",
 		}

--- a/test/docker/gcs.go
+++ b/test/docker/gcs.go
@@ -64,6 +64,7 @@ func startGCS(ctx context.Context, networkName string) (*DockerContainer, error)
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	envSettings["GOOGLE_CLOUD_PROJECT"] = projectID
 	envSettings["STORAGE_EMULATOR_HOST"] = fmt.Sprintf("%s:%s", GCS, "9090")
+	envSettings["BACKUP_GCS_USE_AUTH"] = "false"
 	return &DockerContainer{GCS, endpoint, container, envSettings}, nil
 }
 

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -61,6 +61,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 	projectID := "project-id"
 	endpoint := os.Getenv(envGCSEndpoint)
 	metadataFilename := "backup.json"
+	gcsUseAuth := "false"
 
 	t.Run("setup env", func(t *testing.T) {
 		require.Nil(t, os.Setenv(envGCSEndpoint, endpoint))
@@ -68,6 +69,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 		require.Nil(t, os.Setenv(envGCSCredentials, ""))
 		require.Nil(t, os.Setenv(envGCSProjectID, projectID))
 		require.Nil(t, os.Setenv(envGCSBucket, bucketName))
+		require.Nil(t, os.Setenv(envGCSUseAuth, gcsUseAuth))
 
 		moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
 	})
@@ -142,6 +144,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 	bucketName := "bucket"
 	projectID := "project-id"
 	endpoint := os.Getenv(envGCSEndpoint)
+	gcsUseAuth := "false"
 
 	t.Run("setup env", func(t *testing.T) {
 		require.Nil(t, os.Setenv(envGCSEndpoint, endpoint))
@@ -149,6 +152,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 		require.Nil(t, os.Setenv(envGCSCredentials, ""))
 		require.Nil(t, os.Setenv(envGCSProjectID, projectID))
 		require.Nil(t, os.Setenv(envGCSBucket, bucketName))
+		require.Nil(t, os.Setenv(envGCSUseAuth, gcsUseAuth))
 
 		moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
 	})
@@ -182,6 +186,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 	bucketName := "backet"
 	projectID := "project-id"
 	endpoint := os.Getenv(envGCSEndpoint)
+	gcsUseAuth := "false"
 
 	t.Run("setup env", func(t *testing.T) {
 		require.Nil(t, os.Setenv(envGCSEndpoint, endpoint))
@@ -189,6 +194,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 		require.Nil(t, os.Setenv(envGCSCredentials, ""))
 		require.Nil(t, os.Setenv(envGCSProjectID, projectID))
 		require.Nil(t, os.Setenv(envGCSBucket, bucketName))
+		require.Nil(t, os.Setenv(envGCSUseAuth, gcsUseAuth))
 
 		moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
 	})

--- a/test/modules/backup-gcs/backup_journey_test.go
+++ b/test/modules/backup-gcs/backup_journey_test.go
@@ -30,6 +30,7 @@ const (
 	envGCSCredentials         = "GOOGLE_APPLICATION_CREDENTIALS"
 	envGCSProjectID           = "GOOGLE_CLOUD_PROJECT"
 	envGCSBucket              = "BACKUP_GCS_BUCKET"
+	envGCSUseAuth             = "BACKUP_GCS_USE_AUTH"
 
 	gcsBackupJourneyClassName          = "GcsBackup"
 	gcsBackupJourneyBackupIDSingleNode = "gcs-backup-single-node"


### PR DESCRIPTION
fixes #2619 

### What's being changed:
- `backup-gcs`:
    - adds `BACKUP_GCS_USE_AUTH` env var to allow other forms of authentication eg workload identity
    - remove check for `GOOGLE_APPLICATION_CREDENTIALS`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
