### PR TITLE
Fix memwatch from blocking everything

### DIFF
--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -50,12 +50,16 @@ func (m *Monitor) Ratio() float64 {
 		// in case a few more entries have been added
 		// since the call to MemProfile.
 		p = make([]runtime.MemProfileRecord, n+50)
-		n, ok := m.memProfiler(p, true)
+
+		// use different var name and explicitly overwrite
+		// otherwise n from the outside is shadowed and not overwritten
+		n2, ok := m.memProfiler(p, true)
 		if ok {
-			p = p[0:n]
+			p = p[0:n2]
 			break
 		}
 		// Profile grew; try again.
+		n = n2
 	}
 
 	var sum int64


### PR DESCRIPTION
### What's being changed:
Memwatch grows its buffer when the current buffer is not big enough. However, due to a coding error, the variable containing the size was shaddowed and the buffer never grew => Endless loop that contiously allocated memory that the GC had to clear => everything locked up

This seems to happen when
1. The memcheck is running (it starts every 30 secs)
2. There are a lot of goroutines

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
