### PR TITLE
Prevent adding duplicate props, fix duplicate props on startup (if broken)

### DIFF
--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"context"
+	"strings"
 
 	"github.com/weaviate/weaviate/entities/schema"
 
@@ -48,7 +49,7 @@ func (m *Manager) addClassProperty(ctx context.Context,
 
 	existingPropertyNames := map[string]bool{}
 	for _, existingProperty := range class.Properties {
-		existingPropertyNames[existingProperty.Name] = true
+		existingPropertyNames[strings.ToLower(existingProperty.Name)] = true
 	}
 	if err := m.validateProperty(prop, className, existingPropertyNames, false); err != nil {
 		return err

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -627,6 +627,46 @@ func TestAddClass(t *testing.T) {
 		assert.Contains(t, err.Error(), "conflict for property")
 	})
 
+	t.Run("trying to add an identical prop later", func(t *testing.T) {
+		mgr := newSchemaManager()
+
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{
+				Class: "NewClass",
+				Properties: []*models.Property{
+					{
+						Name:     "my_prop",
+						DataType: []string{"text"},
+					},
+					{
+						Name:     "otherProp",
+						DataType: []string{"text"},
+					},
+				},
+			})
+		require.Nil(t, err)
+
+		attempts := []string{
+			"my_prop",   // lowercase, same casing
+			"my_Prop",   // lowercase, different casing
+			"otherProp", // mixed case, same casing
+			"otherprop", // mixed case, all lower
+			"OtHerProP", // mixed case, other casing
+		}
+
+		for _, propName := range attempts {
+			t.Run(propName, func(t *testing.T) {
+				err = mgr.AddClassProperty(context.Background(), nil, "NewClass",
+					&models.Property{
+						Name:     propName,
+						DataType: []string{"int"},
+					})
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), "conflict for property")
+			})
+		}
+	})
+
 	// To prevent a regression on
 	// https://github.com/semi-technologies/weaviate/issues/2530
 	t.Run("with two props that are identical when ignoring casing", func(t *testing.T) {

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -206,6 +206,15 @@ func (m *Manager) loadOrInitializeSchema(ctx context.Context) error {
 		return fmt.Errorf("migrate schema: %w", err)
 	}
 
+	// There was a bug that allowed adding the same prop multiple times. This
+	// leads to a race at startup. If an instance is already affected by this,
+	// this step can remove the duplicate ones.
+	//
+	// See https://github.com/weaviate/weaviate/issues/2609
+	if err := m.removeDuplicatePropsIfPresent(ctx); err != nil {
+		return fmt.Errorf("remove duplicate props: %w", err)
+	}
+
 	// make sure that all migrations have completed before checking sync,
 	// otherwise two identical schemas might fail the check based on form rather
 	// than content

--- a/usecases/schema/remove_duplicate_props.go
+++ b/usecases/schema/remove_duplicate_props.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package schema
 
 import (

--- a/usecases/schema/remove_duplicate_props.go
+++ b/usecases/schema/remove_duplicate_props.go
@@ -1,0 +1,52 @@
+package schema
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func (m *Manager) removeDuplicatePropsIfPresent(ctx context.Context) error {
+	for _, c := range m.state.ObjectSchema.Classes {
+		if hasDuplicateProps(c.Properties) {
+			c.Properties = m.deduplicateProps(c.Properties)
+		}
+	}
+
+	return nil
+}
+
+func hasDuplicateProps(props []*models.Property) bool {
+	counts := map[string]int{}
+
+	for _, prop := range props {
+		counts[prop.Name]++
+	}
+
+	for _, count := range counts {
+		if count > 1 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Manager) deduplicateProps(orig []*models.Property) []*models.Property {
+	out := make([]*models.Property, len(orig))
+	seen := map[string]struct{}{}
+
+	i := 0
+
+	for _, prop := range orig {
+		if _, ok := seen[prop.Name]; ok {
+			continue
+		}
+
+		out[i] = prop
+		seen[prop.Name] = struct{}{}
+		i++
+	}
+
+	return out[:i]
+}

--- a/usecases/schema/remove_duplicate_props.go
+++ b/usecases/schema/remove_duplicate_props.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
@@ -29,16 +30,14 @@ func (m *Manager) removeDuplicatePropsIfPresent(ctx context.Context) error {
 }
 
 func hasDuplicateProps(props []*models.Property) bool {
-	counts := map[string]int{}
+	found := map[string]struct{}{}
 
 	for _, prop := range props {
-		counts[prop.Name]++
-	}
-
-	for _, count := range counts {
-		if count > 1 {
+		if _, ok := found[strings.ToLower(prop.Name)]; ok {
 			return true
 		}
+
+		found[strings.ToLower(prop.Name)] = struct{}{}
 	}
 
 	return false
@@ -53,12 +52,12 @@ func (m *Manager) deduplicateProps(orig []*models.Property,
 	i := 0
 
 	for _, prop := range orig {
-		if _, ok := seen[prop.Name]; ok {
+		if _, ok := seen[strings.ToLower(prop.Name)]; ok {
 			m.logger.WithFields(logrus.Fields{
 				"action": "startup_repair_schema",
 				"prop":   prop.Name,
 				"class":  className,
-			}).Warningf("removing duplicate proprty %s", prop.Name)
+			}).Warningf("removing duplicate property %s", prop.Name)
 			continue
 		}
 

--- a/usecases/schema/remove_duplicate_props_test.go
+++ b/usecases/schema/remove_duplicate_props_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package schema
 
 import (

--- a/usecases/schema/remove_duplicate_props_test.go
+++ b/usecases/schema/remove_duplicate_props_test.go
@@ -49,6 +49,10 @@ func TestStartupWithDuplicateProps(t *testing.T) {
 							DataType: []string{"Ref"},
 						},
 						{
+							Name:     "prOP_2",
+							DataType: []string{"Ref"},
+						},
+						{
 							Name:     "prop_4",
 							DataType: []string{"boolean"},
 						},

--- a/usecases/schema/remove_duplicate_props_test.go
+++ b/usecases/schema/remove_duplicate_props_test.go
@@ -1,0 +1,82 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestStartupWithDuplicateProps(t *testing.T) {
+	sch := State{
+		ObjectSchema: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class:           "MyClass",
+					VectorIndexType: "hnsw",
+					Properties: []*models.Property{
+						{
+							Name:     "prop_1",
+							DataType: []string{"int"},
+						},
+						{
+							Name:     "prop_2",
+							DataType: []string{"Ref"},
+						},
+						{
+							Name:     "prop_2",
+							DataType: []string{"Ref"},
+						},
+						{
+							Name:     "prop_3",
+							DataType: []string{"Ref"},
+						},
+						{
+							Name:     "prop_2",
+							DataType: []string{"Ref"},
+						},
+						{
+							Name:     "prop_4",
+							DataType: []string{"boolean"},
+						},
+					},
+				},
+			},
+		},
+	}
+	m, err := newManagerWithClusterAndTx(t, &fakeClusterState{
+		hosts: []string{"node1"},
+	},
+		&fakeTxClient{}, &sch)
+	require.Nil(t, err)
+
+	actual, err := m.GetClass(context.Background(), nil, "MyClass")
+	require.Nil(t, err)
+
+	expected := &models.Class{
+		Class:           "MyClass",
+		VectorIndexType: "hnsw",
+		Properties: []*models.Property{
+			{
+				Name:     "prop_1",
+				DataType: []string{"int"},
+			},
+			{
+				Name:     "prop_2",
+				DataType: []string{"Ref"},
+			},
+			{
+				Name:     "prop_3",
+				DataType: []string{"Ref"},
+			},
+			{
+				Name:     "prop_4",
+				DataType: []string{"boolean"},
+			},
+		},
+	}
+
+	assert.Equal(t, expected.Properties, actual.Properties)
+}


### PR DESCRIPTION
### What's being changed:
* prevent adding duplicate props through better validation
* add missing tests for ⬆️ 
* if there are duplicate props at startup, de-duplicate them before trying to init the same prop twice

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
