### PR TITLE
Allow cleaning up an inconsistent schema by force-deleting a class

### DIFF
--- a/adapters/handlers/rest/clusterapi/schema_component_test.go
+++ b/adapters/handlers/rest/clusterapi/schema_component_test.go
@@ -80,7 +80,7 @@ func TestComponentCluster(t *testing.T) {
 		err := localManager.AddClass(ctx, nil, testClass())
 		require.Nil(t, err)
 
-		err = localManager.DeleteClass(ctx, nil, testClass().Class)
+		err = localManager.DeleteClass(ctx, nil, testClass().Class, false)
 		require.Nil(t, err)
 
 		localSchema, err := localManager.GetSchema(nil)

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2294,6 +2294,11 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "name": "force",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6505,6 +6510,11 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "name": "force",
+            "in": "query"
           }
         ],
         "responses": {

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -88,7 +88,11 @@ func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
 }
 
 func (s *schemaHandlers) deleteClass(params schema.SchemaObjectsDeleteParams, principal *models.Principal) middleware.Responder {
-	err := s.manager.DeleteClass(params.HTTPRequest.Context(), principal, params.ClassName)
+	force := false
+	if params.Force != nil {
+		force = *params.Force
+	}
+	err := s.manager.DeleteClass(params.HTTPRequest.Context(), principal, params.ClassName, force)
 	if err != nil {
 		switch err.(type) {
 		case errors.Forbidden:

--- a/adapters/handlers/rest/operations/schema/schema_objects_delete_parameters.go
+++ b/adapters/handlers/rest/operations/schema/schema_objects_delete_parameters.go
@@ -20,8 +20,10 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewSchemaObjectsDeleteParams creates a new SchemaObjectsDeleteParams object
@@ -45,6 +47,10 @@ type SchemaObjectsDeleteParams struct {
 	  In: path
 	*/
 	ClassName string
+	/*
+	  In: query
+	*/
+	Force *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -56,8 +62,15 @@ func (o *SchemaObjectsDeleteParams) BindRequest(r *http.Request, route *middlewa
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
 	rClassName, rhkClassName, _ := route.Params.GetOK("className")
 	if err := o.bindClassName(rClassName, rhkClassName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qForce, qhkForce, _ := qs.GetOK("force")
+	if err := o.bindForce(qForce, qhkForce, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +91,28 @@ func (o *SchemaObjectsDeleteParams) bindClassName(rawData []string, hasKey bool,
 	// Parameter is provided by construction from the route
 
 	o.ClassName = raw
+
+	return nil
+}
+
+// bindForce binds and validates parameter Force from query.
+func (o *SchemaObjectsDeleteParams) bindForce(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("force", "query", "bool", raw)
+	}
+	o.Force = &value
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/schema/schema_objects_delete_urlbuilder.go
+++ b/adapters/handlers/rest/operations/schema/schema_objects_delete_urlbuilder.go
@@ -21,11 +21,15 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
+
+	"github.com/go-openapi/swag"
 )
 
 // SchemaObjectsDeleteURL generates an URL for the schema objects delete operation
 type SchemaObjectsDeleteURL struct {
 	ClassName string
+
+	Force *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -65,6 +69,18 @@ func (o *SchemaObjectsDeleteURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var forceQ string
+	if o.Force != nil {
+		forceQ = swag.FormatBool(*o.Force)
+	}
+	if forceQ != "" {
+		qs.Set("force", forceQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/client/schema/schema_objects_delete_parameters.go
+++ b/client/schema/schema_objects_delete_parameters.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewSchemaObjectsDeleteParams creates a new SchemaObjectsDeleteParams object
@@ -74,6 +75,8 @@ type SchemaObjectsDeleteParams struct {
 
 	/*ClassName*/
 	ClassName string
+	/*Force*/
+	Force *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -124,6 +127,17 @@ func (o *SchemaObjectsDeleteParams) SetClassName(className string) {
 	o.ClassName = className
 }
 
+// WithForce adds the force to the schema objects delete params
+func (o *SchemaObjectsDeleteParams) WithForce(force *bool) *SchemaObjectsDeleteParams {
+	o.SetForce(force)
+	return o
+}
+
+// SetForce adds the force to the schema objects delete params
+func (o *SchemaObjectsDeleteParams) SetForce(force *bool) {
+	o.Force = force
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *SchemaObjectsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -135,6 +149,22 @@ func (o *SchemaObjectsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg 
 	// path param className
 	if err := r.SetPathParam("className", o.ClassName); err != nil {
 		return err
+	}
+
+	if o.Force != nil {
+
+		// query param force
+		var qrForce bool
+		if o.Force != nil {
+			qrForce = *o.Force
+		}
+		qForce := swag.FormatBool(qrForce)
+		if qForce != "" {
+			if err := r.SetQueryParam("force", qForce); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3428,6 +3428,12 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -74,7 +74,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:       "DeleteClass",
-			additionalArgs:   []interface{}{"somename"},
+			additionalArgs:   []interface{}{"somename", false},
 			expectedVerb:     "delete",
 			expectedResource: "schema/objects",
 		},

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -20,21 +20,21 @@ import (
 )
 
 // DeleteClass from the schema
-func (m *Manager) DeleteClass(ctx context.Context, principal *models.Principal, class string) error {
+func (m *Manager) DeleteClass(ctx context.Context, principal *models.Principal, class string, force bool) error {
 	err := m.authorizer.Authorize(principal, "delete", "schema/objects")
 	if err != nil {
 		return err
 	}
 
-	return m.deleteClass(ctx, class)
+	return m.deleteClass(ctx, class, force)
 }
 
-func (m *Manager) deleteClass(ctx context.Context, className string) error {
+func (m *Manager) deleteClass(ctx context.Context, className string, force bool) error {
 	m.Lock()
 	defer m.Unlock()
 
 	tx, err := m.cluster.BeginTransaction(ctx, DeleteClass,
-		DeleteClassPayload{className}, DefaultTxTTL)
+		DeleteClassPayload{className, force}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
 		// the up for a schema transaction) or concurrent transactions from other
@@ -46,32 +46,54 @@ func (m *Manager) deleteClass(ctx context.Context, className string) error {
 		return errors.Wrap(err, "commit cluster-wide transaction")
 	}
 
-	return m.deleteClassApplyChanges(ctx, className)
+	return m.deleteClassApplyChanges(ctx, className, force)
 }
 
-func (m *Manager) deleteClassApplyChanges(ctx context.Context, className string) error {
-	semanticSchema := m.state.ObjectSchema
+func (m *Manager) deleteClassApplyChanges(ctx context.Context,
+	className string, force bool,
+) error {
+	sch := m.state.ObjectSchema
 	classIdx := -1
-	for idx, class := range semanticSchema.Classes {
+	for idx, class := range sch.Classes {
 		if class.Class == className {
 			classIdx = idx
 			break
 		}
 	}
 
-	if classIdx == -1 {
+	if classIdx == -1 && !force {
 		return fmt.Errorf("could not find class '%s'", className)
 	}
 
-	semanticSchema.Classes[classIdx] = semanticSchema.Classes[len(semanticSchema.Classes)-1]
-	semanticSchema.Classes[len(semanticSchema.Classes)-1] = nil // to prevent leaking this pointer.
-	semanticSchema.Classes = semanticSchema.Classes[:len(semanticSchema.Classes)-1]
+	if classIdx > -1 {
+		// make sure not to delete another class if the force flag is set, but the class does not exist
+		sch.Classes[classIdx] = sch.Classes[len(sch.Classes)-1]
+		sch.Classes[len(sch.Classes)-1] = nil // to prevent leaking this pointer.
+		sch.Classes = sch.Classes[:len(sch.Classes)-1]
+	}
 
 	err := m.saveSchema(ctx)
 	if err != nil {
 		return err
 	}
 
-	return m.migrator.DropClass(ctx, className)
-	// TODO gh-846: rollback state update if migration fails
+	err = m.migrator.DropClass(ctx, className)
+	if err != nil {
+		if !force {
+			return err
+		}
+
+		m.logger.WithError(err).
+			Errorf("ignoring class delete error because force is set")
+	}
+
+	m.shardingStateLock.Lock()
+	delete(m.state.ShardingState, className)
+	m.shardingStateLock.Unlock()
+	err = m.saveSchema(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/usecases/schema/force_delete_test.go
+++ b/usecases/schema/force_delete_test.go
@@ -1,0 +1,136 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestForceDelete(t *testing.T) {
+	type test struct {
+		name           string
+		existingSchema []*models.Class
+		classToDelete  string
+		force          bool
+		expErr         bool
+		expErrMsg      string
+		expSchema      []*models.Class
+	}
+
+	tests := []test{
+		{
+			name:  "class exists, regular delete",
+			force: false,
+			existingSchema: []*models.Class{
+				{Class: "MyClass", VectorIndexType: "hnsw"},
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			classToDelete: "MyClass",
+			expSchema: []*models.Class{
+				classWithDefaultsSet(t, "OtherClass"),
+			},
+			expErr: false,
+		},
+		{
+			name:  "class does not exist, regular delete",
+			force: false,
+			existingSchema: []*models.Class{
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			classToDelete: "MyClass",
+			expSchema: []*models.Class{
+				classWithDefaultsSet(t, "OtherClass"),
+			},
+			expErr:    true,
+			expErrMsg: "could not find class",
+		},
+		{
+			name:  "class exists, force delete",
+			force: true,
+			existingSchema: []*models.Class{
+				{Class: "MyClass", VectorIndexType: "hnsw"},
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			classToDelete: "MyClass",
+			expSchema: []*models.Class{
+				classWithDefaultsSet(t, "OtherClass"),
+			},
+			expErr: false,
+		},
+		{
+			name:  "class does not exist, force delete",
+			force: true,
+			existingSchema: []*models.Class{
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			classToDelete: "MyClass",
+			expSchema: []*models.Class{
+				classWithDefaultsSet(t, "OtherClass"),
+			},
+			expErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clusterState := &fakeClusterState{
+				hosts: []string{"node1"},
+			}
+
+			txClient := &fakeTxClient{}
+
+			initialSchema := &State{
+				ObjectSchema: &models.Schema{
+					Classes: test.existingSchema,
+				},
+			}
+
+			sm, err := newManagerWithClusterAndTx(t, clusterState, txClient, initialSchema)
+			require.Nil(t, err)
+			err = sm.DeleteClass(context.Background(), nil, test.classToDelete, test.force)
+
+			if test.expErr {
+				require.NotNil(t, err, "opeartion should have errord")
+				assert.Contains(t, err.Error(), test.expErrMsg)
+			} else {
+				require.Nil(t, err)
+			}
+
+			assert.ElementsMatch(t, test.expSchema, sm.GetSchemaSkipAuth().Objects.Classes)
+
+			if len(sm.state.ShardingState) != len(test.expSchema) {
+				t.Errorf("sharding state entries != schema: %d vs %d",
+					len(sm.state.ShardingState), len(test.expSchema))
+			}
+		})
+	}
+}
+
+func classWithDefaultsSet(t *testing.T, name string) *models.Class {
+	class := &models.Class{Class: name, VectorIndexType: "hnsw"}
+
+	sc, err := sharding.ParseConfig(map[string]interface{}{}, 1)
+	require.Nil(t, err)
+
+	class.ShardingConfig = sc
+
+	class.VectorIndexConfig = fakeVectorConfig{}
+	class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+
+	return class
+}

--- a/usecases/schema/incoming_commit.go
+++ b/usecases/schema/incoming_commit.go
@@ -111,7 +111,7 @@ func (m *Manager) handleDeleteClassCommit(ctx context.Context,
 			tx.Payload)
 	}
 
-	return m.deleteClassApplyChanges(ctx, pl.ClassName)
+	return m.deleteClassApplyChanges(ctx, pl.ClassName, pl.Force)
 }
 
 func (m *Manager) handleUpdateClassCommit(ctx context.Context,

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -271,7 +271,7 @@ func testRemoveObjectClass(t *testing.T, lsm *Manager) {
 	assert.Contains(t, objectClasses, "Car")
 
 	// Now delete the class
-	err = lsm.DeleteClass(context.Background(), nil, "Car")
+	err = lsm.DeleteClass(context.Background(), nil, "Car", false)
 	assert.Nil(t, err)
 
 	objectClasses = testGetClassNames(lsm)

--- a/usecases/schema/startup_cluster_sync.go
+++ b/usecases/schema/startup_cluster_sync.go
@@ -50,7 +50,6 @@ func (m *Manager) startupClusterSync(ctx context.Context,
 	}
 
 	return m.validateSchemaCorruption(ctx, localSchema)
-	// return nil
 }
 
 // startupHandleSingleNode deals with the case where there is only a single

--- a/usecases/schema/startup_cluster_sync.go
+++ b/usecases/schema/startup_cluster_sync.go
@@ -50,6 +50,7 @@ func (m *Manager) startupClusterSync(ctx context.Context,
 	}
 
 	return m.validateSchemaCorruption(ctx, localSchema)
+	// return nil
 }
 
 // startupHandleSingleNode deals with the case where there is only a single

--- a/usecases/schema/transactions.go
+++ b/usecases/schema/transactions.go
@@ -46,6 +46,7 @@ type AddPropertyPayload struct {
 
 type DeleteClassPayload struct {
 	ClassName string `json:"className"`
+	Force     bool   `json:"force"`
 }
 
 type UpdateClassPayload struct {


### PR DESCRIPTION
### What's being changed:
* If you manage to get your schema out of sync or run with an old state where a schema already was out of sync, currently there is no way to clean it up
* This adds a `?force=true` option to `DELETE /v1/schema/<className>` to allow cleaning it up.
* The force option ignores validation and deletes any remnants of the class, even if they are just partial, such as only the sharding state, or only the index state

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
