### PR TITLE
Reject Objects with different vector length

### DIFF
--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -10,7 +10,6 @@
 //
 
 //go:build integrationTest
-// +build integrationTest
 
 package db
 
@@ -1774,7 +1773,7 @@ func Test_PutPatchRestart(t *testing.T) {
 				Properties: map[string]interface{}{
 					"description": fmt.Sprintf("test object, put #%d", i+1),
 				},
-			}, testVec)
+			}, nil)
 			require.Nil(t, err)
 
 			err = repo.Merge(ctx, objects.MergeDocument{

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -2053,17 +2053,31 @@ func TestIndexDifferentVectorLength(t *testing.T) {
 		Vector: []float32{1, 2, 3},
 	}
 
-	obj2 := &models.Object{
-		ID:     "b71ffac8-6534-4368-9718-5410ca89ce16",
-		Class:  class.Class,
-		Vector: []float32{1, 2, 3, 4},
-	}
 	require.Nil(t, repo.PutObject(context.Background(), obj1, obj1.Vector))
-	require.NotNil(t, repo.PutObject(context.Background(), obj2, obj2.Vector))
 
 	t.Run("Add object with different vector length", func(t *testing.T) {
+		obj2 := &models.Object{
+			ID:     "b71ffac8-6534-4368-9718-5410ca89ce16",
+			Class:  class.Class,
+			Vector: []float32{1, 2, 3, 4},
+		}
+		require.NotNil(t, repo.PutObject(context.Background(), obj2, obj2.Vector))
 		found, err := repo.Object(context.Background(), class.Class, obj2.ID, nil, additional.Properties{}, nil)
 		require.Nil(t, err)
 		require.Nil(t, found)
+	})
+
+	t.Run("Update object with different vector length", func(t *testing.T) {
+		err = repo.Merge(context.Background(), objects.MergeDocument{
+			ID:              obj1.ID,
+			Class:           class.Class,
+			PrimitiveSchema: map[string]interface{}{},
+			Vector:          []float32{1, 2, 3, 4},
+			UpdateTime:      time.Now().UnixNano() / int64(time.Millisecond),
+		})
+		require.NotNil(t, err)
+		found, err := repo.Object(context.Background(), class.Class, obj1.ID, nil, additional.Properties{}, nil)
+		require.Nil(t, err)
+		require.Len(t, found.Vector, 3)
 	})
 }

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -28,6 +28,14 @@ func (s *Shard) mergeObject(ctx context.Context, merge objects.MergeDocument) er
 		return storagestate.ErrStatusReadOnly
 	}
 
+	if merge.Vector != nil {
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere inbetween.
+		err := s.vectorIndex.ValidateBeforeInsert(merge.Vector)
+		if err != nil {
+			return errors.Wrapf(err, "Validate vector index for update of %v", merge.ID)
+		}
+	}
+
 	idBytes, err := uuid.MustParse(merge.ID.String()).MarshalBinary()
 	if err != nil {
 		return err

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -29,7 +29,7 @@ func (s *Shard) mergeObject(ctx context.Context, merge objects.MergeDocument) er
 	}
 
 	if merge.Vector != nil {
-		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere inbetween.
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
 		err := s.vectorIndex.ValidateBeforeInsert(merge.Vector)
 		if err != nil {
 			return errors.Wrapf(err, "Validate vector index for update of %v", merge.ID)

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -41,7 +41,7 @@ func (s *Shard) putObject(ctx context.Context, object *storobj.Object) error {
 
 func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object) error {
 	if object.Vector != nil {
-		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere inbetween.
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
 		err := s.vectorIndex.ValidateBeforeInsert(object.Vector)
 		if err != nil {
 			return errors.Wrapf(err, "Validate vector index for %v", uuid)

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -40,6 +40,12 @@ func (s *Shard) putObject(ctx context.Context, object *storobj.Object) error {
 }
 
 func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object) error {
+	// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere inbetween.
+	err := s.vectorIndex.ValidateBeforeInsert(object.Vector)
+	if err != nil {
+		return errors.Wrapf(err, "Validate vector index for %v", uuid)
+	}
+
 	status, err := s.putObjectLSM(object, uuid, false)
 	if err != nil {
 		return errors.Wrap(err, "store object in LSM store")

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -40,10 +40,12 @@ func (s *Shard) putObject(ctx context.Context, object *storobj.Object) error {
 }
 
 func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object) error {
-	// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere inbetween.
-	err := s.vectorIndex.ValidateBeforeInsert(object.Vector)
-	if err != nil {
-		return errors.Wrapf(err, "Validate vector index for %v", uuid)
+	if object.Vector != nil {
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere inbetween.
+		err := s.vectorIndex.ValidateBeforeInsert(object.Vector)
+		if err != nil {
+			return errors.Wrapf(err, "Validate vector index for %v", uuid)
+		}
 	}
 
 	status, err := s.putObjectLSM(object, uuid, false)

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -33,7 +33,7 @@ func (h *hnsw) ValidateBeforeInsert(vector []float32) error {
 
 	if len(existingNodeVector) != len(vector) {
 		return fmt.Errorf("new node has a vector with length %v. "+
-			"Existing nodes have vectors with lenght %v", len(vector), len(existingNodeVector))
+			"Existing nodes have vectors with length %v", len(vector), len(existingNodeVector))
 	}
 
 	return nil

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -12,12 +12,32 @@
 package hnsw
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
+
+func (h *hnsw) ValidateBeforeInsert(vector []float32) error {
+	if h.isEmpty() {
+		return nil
+	}
+	// check if vector length is the same as existing nodes
+	existingNodeVector, err := h.cache.get(context.Background(), h.entryPointID)
+	if err != nil {
+		return err
+	}
+
+	if len(existingNodeVector) != len(vector) {
+		return fmt.Errorf("new node has a vector with length %v. "+
+			"Existing nodes have vectors with lenght %v", len(vector), len(existingNodeVector))
+	}
+
+	return nil
+}
 
 func (h *hnsw) Add(id uint64, vector []float32) error {
 	before := time.Now()

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -76,6 +76,10 @@ func (i *Index) ResumeMaintenance(context.Context) error {
 	return nil
 }
 
+func (i *Index) ValidateBeforeInsert(vector []float32) error {
+	return nil
+}
+
 func (i *Index) PostStartup() {
 }
 

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -36,4 +36,5 @@ type VectorIndex interface {
 	ListFiles(ctx context.Context) ([]string, error)
 	ResumeMaintenance(ctx context.Context) error
 	PostStartup()
+	ValidateBeforeInsert(vector []float32) error
 }


### PR DESCRIPTION
### What's being changed:

Closes https://github.com/weaviate/weaviate/issues/2443

Ensures that Objects added/updated with vectors that have a different length are not added. Before weavaite returned an error when adding the object, but it was still added to the object store.

Nil Vectors can still be added/updated

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

