### PR TITLE
Make schema changes considerably more resilient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile for development purposes.
 # Read docs/development.md for more information
-
 # vi: ft=dockerfile
 
 ###############################################################################

--- a/usecases/cluster/ideal_node_list.go
+++ b/usecases/cluster/ideal_node_list.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package cluster
 
 import (
@@ -79,10 +90,5 @@ func (ics *IdealClusterState) extendList(current []string) {
 	}
 
 	ics.memberNames = append(ics.memberNames, unknown...)
-	sort.Sort(sort.StringSlice(ics.memberNames))
-}
-
-type icsPersistence interface {
-	Store([]string) error
-	Load() ([]string, error)
+	sort.Strings(ics.memberNames)
 }

--- a/usecases/cluster/ideal_node_list.go
+++ b/usecases/cluster/ideal_node_list.go
@@ -1,0 +1,82 @@
+package cluster
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type IdealClusterState struct {
+	memberNames  []string
+	currentState MemberLister
+	persistence  icsPersistence
+	lock         sync.Mutex
+}
+
+func NewIdealClusterState(s MemberLister, p icsPersistence) *IdealClusterState {
+	ics := &IdealClusterState{currentState: s, persistence: p}
+	go ics.startPolling()
+	return ics
+}
+
+// Validate returns an error if the actual state does not match the assumed
+// ideal state, e.g. because a node has died, or left unexpectedly.
+func (ics *IdealClusterState) Validate() error {
+	ics.lock.Lock()
+	defer ics.lock.Unlock()
+
+	actual := map[string]struct{}{}
+	for _, name := range ics.currentState.AllNames() {
+		actual[name] = struct{}{}
+	}
+
+	var missing []string
+	for _, name := range ics.memberNames {
+		if _, ok := actual[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("node(s) %s unhealthy or unavailable",
+			strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func (ics *IdealClusterState) startPolling() {
+	t := time.NewTicker(1 * time.Second)
+	for {
+		<-t.C
+		current := ics.currentState.AllNames()
+		ics.extendList(current)
+	}
+}
+
+func (ics *IdealClusterState) extendList(current []string) {
+	ics.lock.Lock()
+	defer ics.lock.Unlock()
+
+	var unknown []string
+	known := map[string]struct{}{}
+	for _, name := range ics.memberNames {
+		known[name] = struct{}{}
+	}
+
+	for _, name := range current {
+		if _, ok := known[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+
+	ics.memberNames = append(ics.memberNames, unknown...)
+	sort.Sort(sort.StringSlice(ics.memberNames))
+}
+
+type icsPersistence interface {
+	Store([]string) error
+	Load() ([]string, error)
+}

--- a/usecases/cluster/ideal_node_list.go
+++ b/usecases/cluster/ideal_node_list.go
@@ -11,12 +11,11 @@ import (
 type IdealClusterState struct {
 	memberNames  []string
 	currentState MemberLister
-	persistence  icsPersistence
 	lock         sync.Mutex
 }
 
-func NewIdealClusterState(s MemberLister, p icsPersistence) *IdealClusterState {
-	ics := &IdealClusterState{currentState: s, persistence: p}
+func NewIdealClusterState(s MemberLister) *IdealClusterState {
+	ics := &IdealClusterState{currentState: s}
 	go ics.startPolling()
 	return ics
 }
@@ -45,6 +44,13 @@ func (ics *IdealClusterState) Validate() error {
 	}
 
 	return nil
+}
+
+func (ics *IdealClusterState) Members() []string {
+	ics.lock.Lock()
+	defer ics.lock.Unlock()
+
+	return ics.memberNames
 }
 
 func (ics *IdealClusterState) startPolling() {

--- a/usecases/cluster/transactions_broadcast.go
+++ b/usecases/cluster/transactions_broadcast.go
@@ -45,7 +45,7 @@ type MemberLister interface {
 }
 
 func NewTxBroadcaster(state MemberLister, client Client) *TxBroadcaster {
-	ideal := NewIdealClusterState(state, nil)
+	ideal := NewIdealClusterState(state)
 	return &TxBroadcaster{
 		state:  state,
 		client: client,

--- a/usecases/cluster/transactions_broadcast.go
+++ b/usecases/cluster/transactions_broadcast.go
@@ -23,6 +23,7 @@ type TxBroadcaster struct {
 	state       MemberLister
 	client      Client
 	consensusFn ConsensusFn
+	ideal       *IdealClusterState
 }
 
 // The Broadcaster is the link between the the current node and all other nodes
@@ -39,13 +40,16 @@ type Client interface {
 }
 
 type MemberLister interface {
+	AllNames() []string
 	Hostnames() []string
 }
 
 func NewTxBroadcaster(state MemberLister, client Client) *TxBroadcaster {
+	ideal := NewIdealClusterState(state, nil)
 	return &TxBroadcaster{
 		state:  state,
 		client: client,
+		ideal:  ideal,
 	}
 }
 
@@ -54,9 +58,11 @@ func (t *TxBroadcaster) SetConsensusFunction(fn ConsensusFn) {
 }
 
 func (t *TxBroadcaster) BroadcastTransaction(ctx context.Context, tx *Transaction) error {
-	// TODO health check
-	// it should be impossible to even attempt to open a transaction if we
-	// already know that the cluster is not healthy
+	if !tx.TolerateNodeFailures {
+		if err := t.ideal.Validate(); err != nil {
+			return fmt.Errorf("tx does not tolerate node failures: %w", err)
+		}
+	}
 
 	hosts := t.state.Hostnames()
 	resTx := make([]*Transaction, len(hosts))
@@ -114,6 +120,11 @@ func (t *TxBroadcaster) BroadcastAbortTransaction(ctx context.Context, tx *Trans
 }
 
 func (t *TxBroadcaster) BroadcastCommitTransaction(ctx context.Context, tx *Transaction) error {
+	if !tx.TolerateNodeFailures {
+		if err := t.ideal.Validate(); err != nil {
+			return fmt.Errorf("tx does not tolerate node failures: %w", err)
+		}
+	}
 	eg := &errgroup.Group{}
 	for _, host := range t.state.Hostnames() {
 		host := host // https://golang.org/doc/faq#closures_and_goroutines

--- a/usecases/cluster/transactions_broadcast_test.go
+++ b/usecases/cluster/transactions_broadcast_test.go
@@ -110,6 +110,10 @@ func (f *fakeState) Hostnames() []string {
 	return f.hosts
 }
 
+func (f *fakeState) AllNames() []string {
+	return f.hosts
+}
+
 type fakeClient struct {
 	sync.Mutex
 	openCalled   []string

--- a/usecases/cluster/transactions_broadcast_test.go
+++ b/usecases/cluster/transactions_broadcast_test.go
@@ -13,9 +13,11 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +25,7 @@ import (
 
 func TestBroadcastOpenTransaction(t *testing.T) {
 	client := &fakeClient{}
-	state := &fakeState{[]string{"host1", "host2", "host3"}}
+	state := &fakeState{hosts: []string{"host1", "host2", "host3"}}
 
 	bc := NewTxBroadcaster(state, client)
 
@@ -37,7 +39,7 @@ func TestBroadcastOpenTransaction(t *testing.T) {
 
 func TestBroadcastOpenTransactionWithReturnPayload(t *testing.T) {
 	client := &fakeClient{}
-	state := &fakeState{[]string{"host1", "host2", "host3"}}
+	state := &fakeState{hosts: []string{"host1", "host2", "host3"}}
 
 	bc := NewTxBroadcaster(state, client)
 	bc.SetConsensusFunction(func(ctx context.Context,
@@ -74,9 +76,51 @@ func TestBroadcastOpenTransactionWithReturnPayload(t *testing.T) {
 	}, results)
 }
 
+func TestBroadcastOpenTransactionAfterNodeHasDied(t *testing.T) {
+	client := &fakeClient{}
+	state := &fakeState{hosts: []string{"host1", "host2", "host3"}}
+	bc := NewTxBroadcaster(state, client)
+
+	waitUntilIdealStateHasReached(t, bc, 3, 4*time.Second)
+
+	// host2 is dead
+	state.updateHosts([]string{"host1", "host3"})
+
+	tx := &Transaction{ID: "foo"}
+
+	err := bc.BroadcastTransaction(context.Background(), tx)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "host2")
+
+	// no node is should have received an nopen
+	assert.ElementsMatch(t, []string{}, client.openCalled)
+}
+
+func waitUntilIdealStateHasReached(t *testing.T, bc *TxBroadcaster, goal int,
+	max time.Duration,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), max)
+	defer cancel()
+
+	interval := time.NewTicker(250 * time.Millisecond)
+	defer interval.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Error(fmt.Errorf("waiting to reach state goal %d: %w", goal, ctx.Err()))
+			return
+		case <-interval.C:
+			if len(bc.ideal.Members()) == goal {
+				return
+			}
+		}
+	}
+}
+
 func TestBroadcastAbortTransaction(t *testing.T) {
 	client := &fakeClient{}
-	state := &fakeState{[]string{"host1", "host2", "host3"}}
+	state := &fakeState{hosts: []string{"host1", "host2", "host3"}}
 
 	bc := NewTxBroadcaster(state, client)
 
@@ -90,7 +134,7 @@ func TestBroadcastAbortTransaction(t *testing.T) {
 
 func TestBroadcastCommitTransaction(t *testing.T) {
 	client := &fakeClient{}
-	state := &fakeState{[]string{"host1", "host2", "host3"}}
+	state := &fakeState{hosts: []string{"host1", "host2", "host3"}}
 
 	bc := NewTxBroadcaster(state, client)
 
@@ -102,15 +146,48 @@ func TestBroadcastCommitTransaction(t *testing.T) {
 	assert.ElementsMatch(t, []string{"host1", "host2", "host3"}, client.commitCalled)
 }
 
+func TestBroadcastCommitTransactionAfterNodeHasDied(t *testing.T) {
+	client := &fakeClient{}
+	state := &fakeState{hosts: []string{"host1", "host2", "host3"}}
+	bc := NewTxBroadcaster(state, client)
+
+	waitUntilIdealStateHasReached(t, bc, 3, 4*time.Second)
+
+	state.updateHosts([]string{"host1", "host3"})
+
+	tx := &Transaction{ID: "foo"}
+
+	err := bc.BroadcastCommitTransaction(context.Background(), tx)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "host2")
+
+	// no node should have received the commit
+	assert.ElementsMatch(t, []string{}, client.commitCalled)
+}
+
 type fakeState struct {
 	hosts []string
+	sync.Mutex
+}
+
+func (f *fakeState) updateHosts(newHosts []string) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.hosts = newHosts
 }
 
 func (f *fakeState) Hostnames() []string {
+	f.Lock()
+	defer f.Unlock()
+
 	return f.hosts
 }
 
 func (f *fakeState) AllNames() []string {
+	f.Lock()
+	defer f.Unlock()
+
 	return f.hosts
 }
 

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -171,8 +171,27 @@ func (c *TxManager) SetResponseFn(fn ResponseFn) {
 // in a ttl of 0. When choosing TTLs keep in mind that clocks might be slightly
 // skewed in the cluster, therefore set your TTL for desiredTTL +
 // toleratedClockSkew
+//
+// Regular transactions cannot be opened if the cluster is not considered
+// healthy.
 func (c *TxManager) BeginTransaction(ctx context.Context, trType TransactionType,
 	payload interface{}, ttl time.Duration,
+) (*Transaction, error) {
+	return c.beginTransaction(ctx, trType, payload, ttl, false)
+}
+
+// Begin a Transaction that does not require the whole cluster to be healthy.
+// This can be used for example in bootstrapping situations when not all nodes
+// are present yet, or in disaster recovery situations when a node needs to run
+// a transaction in order to re-join a cluster.
+func (c *TxManager) BeginTransactionTolerateNodeFailures(ctx context.Context, trType TransactionType,
+	payload interface{}, ttl time.Duration,
+) (*Transaction, error) {
+	return c.beginTransaction(ctx, trType, payload, ttl, true)
+}
+
+func (c *TxManager) beginTransaction(ctx context.Context, trType TransactionType,
+	payload interface{}, ttl time.Duration, tolerateNodeFailures bool,
 ) (*Transaction, error) {
 	c.Lock()
 
@@ -182,9 +201,10 @@ func (c *TxManager) BeginTransaction(ctx context.Context, trType TransactionType
 	}
 
 	tx := &Transaction{
-		Type:    trType,
-		ID:      uuid.New().String(),
-		Payload: payload,
+		Type:                 trType,
+		ID:                   uuid.New().String(),
+		Payload:              payload,
+		TolerateNodeFailures: tolerateNodeFailures,
 	}
 	if ttl > 0 {
 		tx.Deadline = time.Now().Add(ttl)
@@ -339,4 +359,9 @@ type Transaction struct {
 	Type     TransactionType
 	Payload  interface{}
 	Deadline time.Time
+
+	// If TolerateNodeFailures is false (the default) a transaction cannot be
+	// opened or committed if a node is confirmed dead. If a node is only
+	// suspected dead, the TxManager will try, but abort unless all nodes ACK.
+	TolerateNodeFailures bool
 }

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -160,9 +160,22 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	}
 
 	if err := m.cluster.CommitWriteTransaction(ctx, tx); err != nil {
-		// return nil, errors.Wrap(err, "commit cluster-wide transaction")
-		m.logger.WithError(err).Errorf("commit TODO")
+		// Only log the commit error, but do not abort the changes locally. Once
+		// we've told others to commit, we also need to commit ourselves!
+		//
+		// The idea is that if we abort our changes we are guaranteed to create an
+		// inconsistency as soon as any other node honored the commit. This would
+		// for example be the case in a 3-node cluster where node 1 is the
+		// coordinator, node 2 honored the commit and node 3 died during the commit
+		// phase.
+		//
+		// In this scenario it is far more desireable to make sure that node 1 and
+		// node 2 stay in sync, as node 3 - who may or may not have missed the
+		// update - can use a local WAL from the first TX phase to replay any
+		// missing changes once it's back.
+		m.logger.WithError(err).Errorf("not every node was able to commit")
 	}
+
 	if err := m.addClassApplyChanges(ctx, class, shardState); err != nil {
 		return nil, err
 	}
@@ -198,27 +211,7 @@ func (m *Manager) setClassDefaults(class *models.Class) {
 		}
 	}
 
-	if class.InvertedIndexConfig == nil {
-		class.InvertedIndexConfig = &models.InvertedIndexConfig{}
-	}
-
-	if class.InvertedIndexConfig.CleanupIntervalSeconds == 0 {
-		class.InvertedIndexConfig.CleanupIntervalSeconds = config.DefaultCleanupIntervalSeconds
-	}
-
-	if class.InvertedIndexConfig.Bm25 == nil {
-		class.InvertedIndexConfig.Bm25 = &models.BM25Config{
-			K1: config.DefaultBM25k1,
-			B:  config.DefaultBM25b,
-		}
-	}
-
-	if class.InvertedIndexConfig.Stopwords == nil {
-		class.InvertedIndexConfig.Stopwords = &models.StopwordConfig{
-			Preset: stopwords.EnglishPreset,
-		}
-	}
-
+	setInvertedConfigDefaults(class)
 	for _, prop := range class.Properties {
 		m.setPropertyDefaults(prop)
 	}
@@ -378,4 +371,27 @@ func lowerCaseFirstLetter(name string) string {
 	}
 
 	return strings.ToLower(string(name[0])) + name[1:]
+}
+
+func setInvertedConfigDefaults(class *models.Class) {
+	if class.InvertedIndexConfig == nil {
+		class.InvertedIndexConfig = &models.InvertedIndexConfig{}
+	}
+
+	if class.InvertedIndexConfig.CleanupIntervalSeconds == 0 {
+		class.InvertedIndexConfig.CleanupIntervalSeconds = config.DefaultCleanupIntervalSeconds
+	}
+
+	if class.InvertedIndexConfig.Bm25 == nil {
+		class.InvertedIndexConfig.Bm25 = &models.BM25Config{
+			K1: config.DefaultBM25k1,
+			B:  config.DefaultBM25b,
+		}
+	}
+
+	if class.InvertedIndexConfig.Stopwords == nil {
+		class.InvertedIndexConfig.Stopwords = &models.StopwordConfig{
+			Preset: stopwords.EnglishPreset,
+		}
+	}
 }

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -160,7 +160,8 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	}
 
 	if err := m.cluster.CommitWriteTransaction(ctx, tx); err != nil {
-		return nil, errors.Wrap(err, "commit cluster-wide transaction")
+		// return nil, errors.Wrap(err, "commit cluster-wide transaction")
+		m.logger.WithError(err).Errorf("commit TODO")
 	}
 	if err := m.addClassApplyChanges(ctx, class, shardState); err != nil {
 		return nil, err

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -169,7 +169,7 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 		// coordinator, node 2 honored the commit and node 3 died during the commit
 		// phase.
 		//
-		// In this scenario it is far more desireable to make sure that node 1 and
+		// In this scenario it is far more desirable to make sure that node 1 and
 		// node 2 stay in sync, as node 3 - who may or may not have missed the
 		// update - can use a local WAL from the first TX phase to replay any
 		// missing changes once it's back.

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -74,7 +74,7 @@ func (m *Manager) addClassProperty(ctx context.Context,
 		// coordinator, node 2 honored the commit and node 3 died during the commit
 		// phase.
 		//
-		// In this scenario it is far more desireable to make sure that node 1 and
+		// In this scenario it is far more desirable to make sure that node 1 and
 		// node 2 stay in sync, as node 3 - who may or may not have missed the
 		// update - can use a local WAL from the first TX phase to replay any
 		// missing changes once it's back.

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -65,8 +65,20 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	}
 
 	if err := m.cluster.CommitWriteTransaction(ctx, tx); err != nil {
-		// return errors.Wrap(err, "commit cluster-wide transaction")
-		m.logger.WithError(err).Errorf("commit TODO")
+		// Only log the commit error, but do not abort the changes locally. Once
+		// we've told others to commit, we also need to commit ourselves!
+		//
+		// The idea is that if we abort our changes we are guaranteed to create an
+		// inconsistency as soon as any other node honored the commit. This would
+		// for example be the case in a 3-node cluster where node 1 is the
+		// coordinator, node 2 honored the commit and node 3 died during the commit
+		// phase.
+		//
+		// In this scenario it is far more desireable to make sure that node 1 and
+		// node 2 stay in sync, as node 3 - who may or may not have missed the
+		// update - can use a local WAL from the first TX phase to replay any
+		// missing changes once it's back.
+		m.logger.WithError(err).Errorf("not every node was able to commit")
 	}
 
 	return m.addClassPropertyApplyChanges(ctx, className, prop)

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -65,7 +65,8 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	}
 
 	if err := m.cluster.CommitWriteTransaction(ctx, tx); err != nil {
-		return errors.Wrap(err, "commit cluster-wide transaction")
+		// return errors.Wrap(err, "commit cluster-wide transaction")
+		m.logger.WithError(err).Errorf("commit TODO")
 	}
 
 	return m.addClassPropertyApplyChanges(ctx, className, prop)

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package schema
 
 import (

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -67,7 +67,7 @@ func TestFailedCommits(t *testing.T) {
 				})
 			},
 			action: func(t *testing.T, sm *Manager) {
-				assert.Nil(t, sm.DeleteClass(ctx, nil, "MyClass"))
+				assert.Nil(t, sm.DeleteClass(ctx, nil, "MyClass", false))
 			},
 			expSchema: []*models.Class{
 				classWithDefaultsWithProps(t, "OtherClass", nil),

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -1,0 +1,150 @@
+package schema
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// This test makes sure that even when a commit fails, the coordinator still
+// honors the commit. This was introduced as part of
+// https://github.com/weaviate/weaviate/issues/2616, where a schema
+// inconsistency was guaranteed as soon as any node died in it's commit phase
+// because the coordinator would behave differently than other (alive) which it
+// told to commit.
+func TestFailedCommits(t *testing.T) {
+	type test struct {
+		name string
+		// prepare runs before any commit errors occur to build an initial state
+		prepare func(*testing.T, *Manager)
+		// action runs with commit errors
+		action    func(*testing.T, *Manager)
+		expSchema []*models.Class
+	}
+
+	ctx := context.Background()
+
+	tests := []test{
+		{
+			name: "Add a class",
+			action: func(t *testing.T, sm *Manager) {
+				sm.AddClass(ctx, nil, &models.Class{
+					Class:           "MyClass",
+					VectorIndexType: "hnsw",
+				})
+			},
+			expSchema: []*models.Class{
+				classWithDefaultsWithProps(t, "MyClass", nil),
+			},
+		},
+		{
+			name: "Delete a class",
+			prepare: func(t *testing.T, sm *Manager) {
+				sm.AddClass(ctx, nil, &models.Class{
+					Class:           "MyClass",
+					VectorIndexType: "hnsw",
+				})
+				sm.AddClass(ctx, nil, &models.Class{
+					Class:           "OtherClass",
+					VectorIndexType: "hnsw",
+				})
+			},
+			action: func(t *testing.T, sm *Manager) {
+				assert.Nil(t, sm.DeleteClass(ctx, nil, "MyClass"))
+			},
+			expSchema: []*models.Class{
+				classWithDefaultsWithProps(t, "OtherClass", nil),
+			},
+		},
+		{
+			name: "Extend a class with a property",
+			prepare: func(t *testing.T, sm *Manager) {
+				sm.AddClass(ctx, nil, &models.Class{
+					Class:           "MyClass",
+					VectorIndexType: "hnsw",
+				})
+			},
+			action: func(t *testing.T, sm *Manager) {
+				err := sm.AddClassProperty(ctx, nil, "MyClass", &models.Property{
+					Name:     "prop_1",
+					DataType: []string{"int"},
+				})
+				assert.Nil(t, err)
+			},
+			expSchema: []*models.Class{
+				classWithDefaultsWithProps(t, "MyClass", []*models.Property{
+					{
+						Name:     "prop_1",
+						DataType: []string{"int"},
+					},
+				}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clusterState := &fakeClusterState{
+				hosts: []string{"node1", "node2"},
+			}
+
+			// required for the startup sync
+			txJSON, _ := json.Marshal(ReadSchemaPayload{
+				Schema: &State{
+					ObjectSchema: &models.Schema{
+						Classes: []*models.Class{},
+					},
+				},
+			})
+
+			txClient := &fakeTxClient{
+				openInjectPayload: json.RawMessage(txJSON), // required for the startup sync
+			}
+
+			initialSchema := &State{
+				ObjectSchema:  &models.Schema{},
+				ShardingState: map[string]*sharding.State{},
+			}
+
+			sm, err := newManagerWithClusterAndTx(t, clusterState, txClient, initialSchema)
+			require.Nil(t, err)
+
+			if test.prepare != nil {
+				test.prepare(t, sm)
+			}
+
+			txClient.commitErr = fmt.Errorf("Oh I, I just died in your arms tonight")
+			test.action(t, sm)
+
+			assert.ElementsMatch(t, test.expSchema, sm.GetSchemaSkipAuth().Objects.Classes)
+		})
+	}
+}
+
+func classWithDefaultsWithProps(t *testing.T, name string,
+	props []*models.Property,
+) *models.Class {
+	class := &models.Class{Class: name, VectorIndexType: "hnsw"}
+	class.Vectorizer = "none"
+
+	sc, err := sharding.ParseConfig(map[string]interface{}{}, 1)
+	require.Nil(t, err)
+
+	class.ShardingConfig = sc
+
+	class.VectorIndexConfig = fakeVectorConfig{}
+	class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+
+	(&fakeModuleConfig{}).SetClassDefaults(class)
+	setInvertedConfigDefaults(class)
+
+	class.Properties = props
+
+	return class
+}

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -43,7 +43,8 @@ func (m *Manager) deleteClass(ctx context.Context, className string, force bool)
 	}
 
 	if err := m.cluster.CommitWriteTransaction(ctx, tx); err != nil {
-		return errors.Wrap(err, "commit cluster-wide transaction")
+		// return errors.Wrap(err, "commit cluster-wide transaction")
+		m.logger.WithError(err).Errorf("commit TODO")
 	}
 
 	return m.deleteClassApplyChanges(ctx, className, force)

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -37,14 +37,26 @@ func (m *Manager) deleteClass(ctx context.Context, className string, force bool)
 		DeleteClassPayload{className, force}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
-		// the up for a schema transaction) or concurrent transactions from other
+		// be up for a schema transaction) or concurrent transactions from other
 		// nodes
 		return errors.Wrap(err, "open cluster-wide transaction")
 	}
 
 	if err := m.cluster.CommitWriteTransaction(ctx, tx); err != nil {
-		// return errors.Wrap(err, "commit cluster-wide transaction")
-		m.logger.WithError(err).Errorf("commit TODO")
+		// Only log the commit error, but do not abort the changes locally. Once
+		// we've told others to commit, we also need to commit ourselves!
+		//
+		// The idea is that if we abort our changes we are guaranteed to create an
+		// inconsistency as soon as any other node honored the commit. This would
+		// for example be the case in a 3-node cluster where node 1 is the
+		// coordinator, node 2 honored the commit and node 3 died during the commit
+		// phase.
+		//
+		// In this scenario it is far more desireable to make sure that node 1 and
+		// node 2 stay in sync, as node 3 - who may or may not have missed the
+		// update - can use a local WAL from the first TX phase to replay any
+		// missing changes once it's back.
+		m.logger.WithError(err).Errorf("not every node was able to commit")
 	}
 
 	return m.deleteClassApplyChanges(ctx, className, force)

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -52,7 +52,7 @@ func (m *Manager) deleteClass(ctx context.Context, className string, force bool)
 		// coordinator, node 2 honored the commit and node 3 died during the commit
 		// phase.
 		//
-		// In this scenario it is far more desireable to make sure that node 1 and
+		// In this scenario it is far more desirable to make sure that node 1 and
 		// node 2 stay in sync, as node 3 - who may or may not have missed the
 		// update - can use a local WAL from the first TX phase to replay any
 		// missing changes once it's back.


### PR DESCRIPTION
### What's being changed:

* The schema is supposed to be CP, we cannot tolerate any inconsistencies, but it is fine if progress cannot be made when a node is down.
* However, the current implementation did not fully reflect that
* This fixes two short-comings in the the schema update logic:
  1. Due to the way memberlist removes members from the list once they are confirmed dead, we would happily send schema updates even when nodes are down without knowing so.
  2. There was a logic error that a coordinator node would not apply the update to itself if any of the commits failed. This is not consistent with a 2-phase-commit. Once the decision has been made to commit, the coordinator must assume that some nodes have honored the commit and applied the change. If it would not apply the change to itself, then there would be guaranteed inconsistency as soon as some nodes have honored the commit. The new logic now applies the changes to the coordinator as soon as it tells others to commit. This way, any alive members will be consistent. There is still a chance that the node that died during the commit could not apply the changes before it died. However, this is something that the dead node can fix itself using a Write-Ahead-Log.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
