### PR TITLE
test: use `t.Setenv` to set env vars

### DIFF
--- a/test/modules/backup-filesystem/backup_backend_test.go
+++ b/test/modules/backup-filesystem/backup_backend_test.go
@@ -45,9 +45,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 	backupID := "backup_id"
 	metadataFilename := "backup.json"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv("BACKUP_FILESYSTEM_PATH", backupDir))
-	})
+	t.Setenv("BACKUP_FILESYSTEM_PATH", backupDir)
 
 	t.Run("store backup meta in fs", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
@@ -105,9 +103,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 	key := "moduleLevelCopyObjects"
 	backupID := "backup_id"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv("BACKUP_FILESYSTEM_PATH", backupDir))
-	})
+	t.Setenv("BACKUP_FILESYSTEM_PATH", backupDir)
 
 	t.Run("copy objects", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
@@ -140,9 +136,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 	key := "moduleLevelCopyFiles"
 	backupID := "backup_id"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv("BACKUP_FILESYSTEM_PATH", backupDir))
-	})
+	t.Setenv("BACKUP_FILESYSTEM_PATH", backupDir)
 
 	t.Run("copy files", func(t *testing.T) {
 		fpaths := moduleshelper.CreateTestFiles(t, dataDir)

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -39,7 +39,7 @@ func Test_GCSBackend_Backup(t *testing.T) {
 		t.Fatal(errors.Wrapf(err, "cannot start"))
 	}
 
-	require.Nil(t, os.Setenv(envGCSEndpoint, compose.GetGCS().URI()))
+	t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
 
 	t.Run("store backup meta", moduleLevelStoreBackupMeta)
 	t.Run("copy objects", moduleLevelCopyObjects)
@@ -63,19 +63,17 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 	metadataFilename := "backup.json"
 	gcsUseAuth := "false"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envGCSEndpoint, endpoint))
-		require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, endpoint))
-		require.Nil(t, os.Setenv(envGCSCredentials, ""))
-		require.Nil(t, os.Setenv(envGCSProjectID, projectID))
-		require.Nil(t, os.Setenv(envGCSBucket, bucketName))
-		require.Nil(t, os.Setenv(envGCSUseAuth, gcsUseAuth))
-
-		moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
-	})
+	t.Log("setup env")
+	t.Setenv(envGCSEndpoint, endpoint)
+	t.Setenv(envGCSStorageEmulatorHost, endpoint)
+	t.Setenv(envGCSCredentials, "")
+	t.Setenv(envGCSProjectID, projectID)
+	t.Setenv(envGCSBucket, bucketName)
+	t.Setenv(envGCSUseAuth, gcsUseAuth)
+	moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
 
 	t.Run("store backup meta in gcs", func(t *testing.T) {
-		require.Nil(t, os.Setenv("BACKUP_GCS_BUCKET", bucketName))
+		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
 		gcs := mod.New()
 		err := gcs.Init(testCtx, newFakeModuleParams(dataDir))
 		require.Nil(t, err)
@@ -146,19 +144,17 @@ func moduleLevelCopyObjects(t *testing.T) {
 	endpoint := os.Getenv(envGCSEndpoint)
 	gcsUseAuth := "false"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envGCSEndpoint, endpoint))
-		require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, endpoint))
-		require.Nil(t, os.Setenv(envGCSCredentials, ""))
-		require.Nil(t, os.Setenv(envGCSProjectID, projectID))
-		require.Nil(t, os.Setenv(envGCSBucket, bucketName))
-		require.Nil(t, os.Setenv(envGCSUseAuth, gcsUseAuth))
-
-		moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
-	})
+	t.Log("setup env")
+	t.Setenv(envGCSEndpoint, endpoint)
+	t.Setenv(envGCSStorageEmulatorHost, endpoint)
+	t.Setenv(envGCSCredentials, "")
+	t.Setenv(envGCSProjectID, projectID)
+	t.Setenv(envGCSBucket, bucketName)
+	t.Setenv(envGCSUseAuth, gcsUseAuth)
+	moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
 
 	t.Run("copy objects", func(t *testing.T) {
-		require.Nil(t, os.Setenv("BACKUP_GCS_BUCKET", bucketName))
+		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
 		gcs := mod.New()
 		err := gcs.Init(testCtx, newFakeModuleParams(dataDir))
 		require.Nil(t, err)
@@ -188,16 +184,14 @@ func moduleLevelCopyFiles(t *testing.T) {
 	endpoint := os.Getenv(envGCSEndpoint)
 	gcsUseAuth := "false"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envGCSEndpoint, endpoint))
-		require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, endpoint))
-		require.Nil(t, os.Setenv(envGCSCredentials, ""))
-		require.Nil(t, os.Setenv(envGCSProjectID, projectID))
-		require.Nil(t, os.Setenv(envGCSBucket, bucketName))
-		require.Nil(t, os.Setenv(envGCSUseAuth, gcsUseAuth))
-
-		moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
-	})
+	t.Log("setup env")
+	t.Setenv(envGCSEndpoint, endpoint)
+	t.Setenv(envGCSStorageEmulatorHost, endpoint)
+	t.Setenv(envGCSCredentials, "")
+	t.Setenv(envGCSProjectID, projectID)
+	t.Setenv(envGCSBucket, bucketName)
+	t.Setenv(envGCSUseAuth, gcsUseAuth)
+	moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
 
 	t.Run("copy files", func(t *testing.T) {
 		fpaths := moduleshelper.CreateTestFiles(t, dataDir)
@@ -206,7 +200,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, expectedContents)
 
-		require.Nil(t, os.Setenv("BACKUP_GCS_BUCKET", bucketName))
+		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
 		gcs := mod.New()
 		err = gcs.Init(testCtx, newFakeModuleParams(dataDir))
 		require.Nil(t, err)

--- a/test/modules/backup-gcs/backup_journey_test.go
+++ b/test/modules/backup-gcs/backup_journey_test.go
@@ -13,7 +13,6 @@ package test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -44,11 +43,10 @@ func Test_BackupJourney(t *testing.T) {
 	defer cancel()
 
 	t.Run("single node", func(t *testing.T) {
-		t.Run("pre-instance env setup", func(t *testing.T) {
-			require.Nil(t, os.Setenv(envGCSCredentials, ""))
-			require.Nil(t, os.Setenv(envGCSProjectID, gcsBackupJourneyProjectID))
-			require.Nil(t, os.Setenv(envGCSBucket, gcsBackupJourneyBucketName))
-		})
+		t.Log("pre-instance env setup")
+		t.Setenv(envGCSCredentials, "")
+		t.Setenv(envGCSProjectID, gcsBackupJourneyProjectID)
+		t.Setenv(envGCSBucket, gcsBackupJourneyBucketName)
 
 		compose, err := docker.New().
 			WithBackendGCS(gcsBackupJourneyBucketName).
@@ -62,13 +60,11 @@ func Test_BackupJourney(t *testing.T) {
 			}
 		}()
 
-		t.Run("post-instance env setup", func(t *testing.T) {
-			require.Nil(t, os.Setenv(envGCSEndpoint, compose.GetGCS().URI()))
-			require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI()))
-
-			moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
-			helper.SetupClient(compose.GetWeaviate().URI())
-		})
+		t.Log("post-instance env setup")
+		t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
+		t.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI())
+		moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+		helper.SetupClient(compose.GetWeaviate().URI())
 
 		t.Run("backup-gcs", func(t *testing.T) {
 			journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
@@ -77,11 +73,10 @@ func Test_BackupJourney(t *testing.T) {
 	})
 
 	t.Run("multiple node", func(t *testing.T) {
-		t.Run("pre-instance env setup", func(t *testing.T) {
-			require.Nil(t, os.Setenv(envGCSCredentials, ""))
-			require.Nil(t, os.Setenv(envGCSProjectID, gcsBackupJourneyProjectID))
-			require.Nil(t, os.Setenv(envGCSBucket, gcsBackupJourneyBucketName))
-		})
+		t.Log("pre-instance env setup")
+		t.Setenv(envGCSCredentials, "")
+		t.Setenv(envGCSProjectID, gcsBackupJourneyProjectID)
+		t.Setenv(envGCSBucket, gcsBackupJourneyBucketName)
 
 		compose, err := docker.New().
 			WithBackendGCS(gcsBackupJourneyBucketName).
@@ -95,13 +90,11 @@ func Test_BackupJourney(t *testing.T) {
 			}
 		}()
 
-		t.Run("post-instance env setup", func(t *testing.T) {
-			require.Nil(t, os.Setenv(envGCSEndpoint, compose.GetGCS().URI()))
-			require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI()))
-
-			moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
-			helper.SetupClient(compose.GetWeaviate().URI())
-		})
+		t.Log("post-instance env setup")
+		t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
+		t.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI())
+		moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+		helper.SetupClient(compose.GetWeaviate().URI())
 
 		t.Run("backup-gcs", func(t *testing.T) {
 			journey.BackupJourneyTests_Cluster(t, "gcs", gcsBackupJourneyClassName,

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -39,7 +39,7 @@ func Test_S3Backend_Backup(t *testing.T) {
 		t.Fatal(errors.Wrapf(err, "cannot start"))
 	}
 
-	require.Nil(t, os.Setenv(envMinioEndpoint, compose.GetMinIO().URI()))
+	t.Setenv(envMinioEndpoint, compose.GetMinIO().URI())
 
 	t.Run("store backup meta", moduleLevelStoreBackupMeta)
 	t.Run("copy objects", moduleLevelCopyObjects)
@@ -62,18 +62,16 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 	endpoint := os.Getenv(envMinioEndpoint)
 	metadataFilename := "backup.json"
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envAwsRegion, region))
-		require.Nil(t, os.Setenv(envS3AccessKey, "aws_access_key"))
-		require.Nil(t, os.Setenv(envS3SecretKey, "aws_secret_key"))
-		require.Nil(t, os.Setenv(envS3Bucket, bucketName))
-
-		createBucket(testCtx, t, endpoint, region, bucketName)
-	})
+	t.Log("setup env")
+	t.Setenv(envAwsRegion, region)
+	t.Setenv(envS3AccessKey, "aws_access_key")
+	t.Setenv(envS3SecretKey, "aws_secret_key")
+	t.Setenv(envS3Bucket, bucketName)
+	createBucket(testCtx, t, endpoint, region, bucketName)
 
 	t.Run("store backup meta in s3", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envS3UseSSL, "false"))
-		require.Nil(t, os.Setenv(envS3Endpoint, endpoint))
+		t.Setenv(envS3UseSSL, "false")
+		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
 		err := s3.Init(testCtx, newFakeModuleParams(dataDir))
 		require.Nil(t, err)
@@ -143,17 +141,15 @@ func moduleLevelCopyObjects(t *testing.T) {
 	region := "eu-west-1"
 	endpoint := os.Getenv(envMinioEndpoint)
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envAwsRegion, region))
-		require.Nil(t, os.Setenv(envS3AccessKey, "aws_access_key"))
-		require.Nil(t, os.Setenv(envS3SecretKey, "aws_secret_key"))
-		require.Nil(t, os.Setenv(envS3Bucket, bucketName))
-
-		createBucket(testCtx, t, endpoint, region, bucketName)
-	})
+	t.Log("setup env")
+	t.Setenv(envAwsRegion, region)
+	t.Setenv(envS3AccessKey, "aws_access_key")
+	t.Setenv(envS3SecretKey, "aws_secret_key")
+	t.Setenv(envS3Bucket, bucketName)
+	createBucket(testCtx, t, endpoint, region, bucketName)
 
 	t.Run("copy objects", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envS3Endpoint, endpoint))
+		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
 		err := s3.Init(testCtx, newFakeModuleParams(dataDir))
 		require.Nil(t, err)
@@ -182,14 +178,11 @@ func moduleLevelCopyFiles(t *testing.T) {
 	region := "eu-west-1"
 	endpoint := os.Getenv(envMinioEndpoint)
 
-	t.Run("setup env", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envAwsRegion, region))
-		require.Nil(t, os.Setenv(envS3AccessKey, "aws_access_key"))
-		require.Nil(t, os.Setenv(envS3SecretKey, "aws_secret_key"))
-		require.Nil(t, os.Setenv(envS3Bucket, bucketName))
-
-		createBucket(testCtx, t, endpoint, region, bucketName)
-	})
+	t.Setenv(envAwsRegion, region)
+	t.Setenv(envS3AccessKey, "aws_access_key")
+	t.Setenv(envS3SecretKey, "aws_secret_key")
+	t.Setenv(envS3Bucket, bucketName)
+	createBucket(testCtx, t, endpoint, region, bucketName)
 
 	t.Run("copy files", func(t *testing.T) {
 		fpaths := moduleshelper.CreateTestFiles(t, dataDir)
@@ -198,7 +191,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, expectedContents)
 
-		require.Nil(t, os.Setenv(envS3Endpoint, endpoint))
+		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
 		err = s3.Init(testCtx, newFakeModuleParams(dataDir))
 		require.Nil(t, err)

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -149,6 +149,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 	createBucket(testCtx, t, endpoint, region, bucketName)
 
 	t.Run("copy objects", func(t *testing.T) {
+		t.Setenv(envS3UseSSL, "false")
 		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
 		err := s3.Init(testCtx, newFakeModuleParams(dataDir))
@@ -178,6 +179,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 	region := "eu-west-1"
 	endpoint := os.Getenv(envMinioEndpoint)
 
+	t.Log("setup env")
 	t.Setenv(envAwsRegion, region)
 	t.Setenv(envS3AccessKey, "aws_access_key")
 	t.Setenv(envS3SecretKey, "aws_secret_key")
@@ -191,6 +193,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, expectedContents)
 
+		t.Setenv(envS3UseSSL, "false")
 		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
 		err = s3.Init(testCtx, newFakeModuleParams(dataDir))

--- a/test/modules/backup-s3/backup_journey_test.go
+++ b/test/modules/backup-s3/backup_journey_test.go
@@ -13,7 +13,6 @@ package test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -46,11 +45,10 @@ func Test_BackupJourney(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 
-		t.Run("pre-instance env setup", func(t *testing.T) {
-			require.Nil(t, os.Setenv(envS3AccessKey, s3BackupJourneyAccessKey))
-			require.Nil(t, os.Setenv(envS3SecretKey, s3BackupJourneySecretKey))
-			require.Nil(t, os.Setenv(envS3Bucket, s3BackupJourneyBucketName))
-		})
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+		t.Setenv(envS3Bucket, s3BackupJourneyBucketName)
 
 		compose, err := docker.New().
 			WithBackendS3(s3BackupJourneyBucketName).
@@ -79,11 +77,10 @@ func Test_BackupJourney(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 
-		t.Run("pre-instance env setup", func(t *testing.T) {
-			require.Nil(t, os.Setenv(envS3AccessKey, s3BackupJourneyAccessKey))
-			require.Nil(t, os.Setenv(envS3SecretKey, s3BackupJourneySecretKey))
-			require.Nil(t, os.Setenv(envS3Bucket, s3BackupJourneyBucketName))
-		})
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+		t.Setenv(envS3Bucket, s3BackupJourneyBucketName)
 
 		compose, err := docker.New().
 			WithBackendS3(s3BackupJourneyBucketName).

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -39,9 +39,8 @@ func TestEnvironmentImportGoroutineFactor(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.goroutineFactor) == 1 {
-				os.Setenv("MAX_IMPORT_GOROUTINES_FACTOR", tt.goroutineFactor[0])
+				t.Setenv("MAX_IMPORT_GOROUTINES_FACTOR", tt.goroutineFactor[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -70,9 +69,8 @@ func TestEnvironmentSetFlushAfter_BackwardCompatibility(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.flushAfter) == 1 {
-				os.Setenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", tt.flushAfter[0])
+				t.Setenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", tt.flushAfter[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -101,9 +99,8 @@ func TestEnvironmentSetFlushAfter_NewName(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.flushAfter) == 1 {
-				os.Setenv("PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS", tt.flushAfter[0])
+				t.Setenv("PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS", tt.flushAfter[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -121,8 +118,8 @@ func TestEnvironmentFlushConflictingValues(t *testing.T) {
 	// if both the old and new variable names are used the new variable name
 	// should be taken into consideration
 	os.Clearenv()
-	os.Setenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", "16")
-	os.Setenv("PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS", "17")
+	t.Setenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", "16")
+	t.Setenv("PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS", "17")
 	conf := Config{}
 	err := FromEnv(&conf)
 	require.Nil(t, err)
@@ -145,9 +142,8 @@ func TestEnvironmentMemtable_MaxSize(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.value) == 1 {
-				os.Setenv("PERSISTENCE_MEMTABLES_MAX_SIZE_MB", tt.value[0])
+				t.Setenv("PERSISTENCE_MEMTABLES_MAX_SIZE_MB", tt.value[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -176,9 +172,8 @@ func TestEnvironmentMemtable_MinDuration(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.value) == 1 {
-				os.Setenv("PERSISTENCE_MEMTABLES_MIN_ACTIVE_DURATION_SECONDS", tt.value[0])
+				t.Setenv("PERSISTENCE_MEMTABLES_MIN_ACTIVE_DURATION_SECONDS", tt.value[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -207,9 +202,8 @@ func TestEnvironmentMemtable_MaxDuration(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.value) == 1 {
-				os.Setenv("PERSISTENCE_MEMTABLES_MAX_ACTIVE_DURATION_SECONDS", tt.value[0])
+				t.Setenv("PERSISTENCE_MEMTABLES_MAX_ACTIVE_DURATION_SECONDS", tt.value[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -315,7 +309,7 @@ func TestEnvironmentSetDefaultVectorDistanceMetric(t *testing.T) {
 
 	t.Run("NonEmptyDefaultVectorDistanceMetric", func(t *testing.T) {
 		os.Clearenv()
-		os.Setenv("DEFAULT_VECTOR_DISTANCE_METRIC", "l2-squared")
+		t.Setenv("DEFAULT_VECTOR_DISTANCE_METRIC", "l2-squared")
 		conf := Config{}
 		FromEnv(&conf)
 		require.Equal(t, "l2-squared", conf.DefaultVectorDistanceMetric)
@@ -336,9 +330,8 @@ func TestEnvironmentMaxConcurrentGetRequests(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
 			if len(tt.value) == 1 {
-				os.Setenv("MAXIMUM_CONCURRENT_GET_REQUESTS", tt.value[0])
+				t.Setenv("MAXIMUM_CONCURRENT_GET_REQUESTS", tt.value[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)


### PR DESCRIPTION
### What's being changed:

Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
