### PR TITLE
Improve conflict detection when a target object has been already updated to most recent state

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -54,7 +54,7 @@ func (c *replicationClient) FetchObject(ctx context.Context, host, index,
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
-	err = c.doCustomMarshal(c.timeoutUnit*90, req, nil, &resp)
+	err = c.doCustomMarshal(c.timeoutUnit*20, req, nil, &resp)
 	return resp, err
 }
 
@@ -72,7 +72,7 @@ func (c *replicationClient) DigestObjects(ctx context.Context,
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
-	err = c.do(c.timeoutUnit*90, req, body, &resp)
+	err = c.do(c.timeoutUnit*20, req, body, &resp)
 	return resp, err
 }
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -349,12 +349,12 @@ func (i *Index) overwriteObjects(ctx context.Context,
 			continue
 		}
 		// valid update
-		r := replica.RepairResponse{ID: data.ID.String(), UpdateTime: u.StaleUpdateTime}
 		found, err := s.objectByID(ctx, data.ID, nil, additional.Properties{})
 		var curUpdateTime int64 // 0 means object doesn't exist on this node
 		if found != nil {
 			curUpdateTime = found.LastUpdateTimeUnix()
 		}
+		r := replica.RepairResponse{ID: data.ID.String(), UpdateTime: curUpdateTime}
 		switch {
 		case err != nil:
 			r.Err = "not found: " + err.Error()
@@ -367,7 +367,7 @@ func (i *Index) overwriteObjects(ctx context.Context,
 			}
 		case curUpdateTime != data.LastUpdateTimeUnix:
 			// object changed and its state differs from recent known state
-			r.UpdateTime, r.Err = curUpdateTime, "conflict"
+			r.Err = "conflict"
 		}
 
 		if r.Err != "" { // include only unsuccessful responses

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -333,48 +333,45 @@ func (db *DB) OverwriteObjects(ctx context.Context,
 // It returns nil if all object have been successfully overwritten
 // and otherwise a list of failed operations.
 func (i *Index) overwriteObjects(ctx context.Context,
-	shard string, list []*objects.VObject,
+	shard string, updates []*objects.VObject,
 ) ([]replica.RepairResponse, error) {
-	result := make([]replica.RepairResponse, 0, len(list)/2)
+	result := make([]replica.RepairResponse, 0, len(updates)/2)
 	s := i.Shards[shard]
 	if s == nil {
 		return nil, fmt.Errorf("shard %q not found locally", shard)
 	}
-	for _, update := range list {
-		id := update.LatestObject.ID
-		found, err := s.objectByID(ctx, id, nil, additional.Properties{})
+	for i, u := range updates {
+		// Just in case but this should not happen
+		data := u.LatestObject
+		if data == nil || data.ID == "" {
+			msg := fmt.Sprintf("received nil object or empty uuid at position %d", i)
+			result = append(result, replica.RepairResponse{Err: msg})
+			continue
+		}
+		// valid update
+		r := replica.RepairResponse{ID: data.ID.String(), UpdateTime: u.StaleUpdateTime}
+		found, err := s.objectByID(ctx, data.ID, nil, additional.Properties{})
 		var curUpdateTime int64 // 0 means object doesn't exist on this node
 		if found != nil {
 			curUpdateTime = found.LastUpdateTimeUnix()
 		}
-		if err != nil {
-			result = append(result, replica.RepairResponse{
-				ID:  id.String(),
-				Err: "not found",
-			})
-			continue
-		}
-		// the stored object is not the most recent version. in
-		// this case, we overwrite it with the more recent one.
-		if curUpdateTime == update.StaleUpdateTime {
-			err := s.putObject(ctx, storobj.FromObject(update.LatestObject, update.LatestObject.Vector))
+		switch {
+		case err != nil:
+			r.Err = "not found: " + err.Error()
+		case curUpdateTime == u.StaleUpdateTime:
+			// the stored object is not the most recent version. in
+			// this case, we overwrite it with the more recent one.
+			err := s.putObject(ctx, storobj.FromObject(data, data.Vector))
 			if err != nil {
-				result = append(result, replica.RepairResponse{
-					ID:         id.String(),
-					UpdateTime: curUpdateTime,
-					// Version: , todo
-					Err: fmt.Sprintf("overwrite stale object: %v", err),
-				})
-				continue
+				r.Err = fmt.Sprintf("overwrite stale object: %v", err)
 			}
-		} else {
-			// todo set version once implemented
-			result = append(result, replica.RepairResponse{
-				ID:         id.String(),
-				UpdateTime: curUpdateTime,
-				// Version: , todo
-				Err: "conflict",
-			})
+		case curUpdateTime != data.LastUpdateTimeUnix:
+			// object changed and its state differs from recent known state
+			r.UpdateTime, r.Err = curUpdateTime, "conflict"
+		}
+
+		if r.Err != "" { // include only unsuccessful responses
+			result = append(result, r)
 		}
 	}
 	if len(result) == 0 {

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -302,7 +302,7 @@ func (f *Finder) repairOne(ctx context.Context, shard string, id strfmt.UUID, vo
 			if err != nil {
 				return fmt.Errorf("node %q could not repair object: %w", vote.sender, err)
 			}
-			if len(resp) > 0 && resp[0].Err != "" && resp[0].UpdateTime != lastUTime {
+			if len(resp) > 0 && resp[0].Err != "" {
 				return fmt.Errorf("overwrite %w %s: %s", errConflictObjectChanged, vote.sender, resp[0].Err)
 			}
 			return nil
@@ -605,7 +605,7 @@ func (f *Finder) repairExist(ctx context.Context, shard string, id strfmt.UUID, 
 			if err != nil {
 				return fmt.Errorf("node %q could not repair object: %w", vote.sender, err)
 			}
-			if len(resp) > 0 && resp[0].Err != "" && resp[0].UpdateTime != lastUTime {
+			if len(resp) > 0 && resp[0].Err != "" {
 				return fmt.Errorf("overwrite %w %s: %s", errConflictObjectChanged, vote.sender, resp[0].Err)
 			}
 			return nil


### PR DESCRIPTION
### What's being changed:

1. This might happen if another node was faster to update the object.
2. Prevent from nil updates
3. Change timeouts for the endpoints (FetchObject and DigestObject) of the replication client to shorter ones. This prevents from client blocking when fetching objects and a node is down

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
