### PR TITLE
Migration of inverted index buckets of collection set to roaring set strategy

### DIFF
--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -210,3 +210,7 @@ func (n *NilMigrator) UpdateInvertedIndexConfig(ctx context.Context, className s
 func (n *NilMigrator) RecalculateVectorDimensions(ctx context.Context) error {
 	return nil
 }
+
+func (n *NilMigrator) InvertedReindex(ctx context.Context, taskNames ...string) error {
+	return nil
+}

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -11,7 +11,11 @@
 
 package helpers
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/filters"
+)
 
 var (
 	ObjectsBucket              = []byte("objects")
@@ -44,4 +48,24 @@ func BucketFromPropNameLSM(propName string) string {
 // for the status information of a partiular prop in the inverted index
 func HashBucketFromPropNameLSM(propName string) string {
 	return fmt.Sprintf("hash_property_%s", propName)
+}
+
+func BucketFromPropNameLengthLSM(propName string) string {
+	return BucketFromPropNameLSM(propName + filters.InternalPropertyLength)
+}
+
+func HashBucketFromPropNameLengthLSM(propName string) string {
+	return HashBucketFromPropNameLSM(propName + filters.InternalPropertyLength)
+}
+
+func BucketFromPropNameNullLSM(propName string) string {
+	return BucketFromPropNameLSM(propName + filters.InternalNullIndex)
+}
+
+func HashBucketFromPropNameNullLSM(propName string) string {
+	return HashBucketFromPropNameLSM(propName + filters.InternalNullIndex)
+}
+
+func TempBucketFromBucketName(bucketName string) string {
+	return bucketName + "_temp"
 }

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -1,0 +1,430 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+type ShardInvertedReindexTask interface {
+	GetPropertiesToReindex(ctx context.Context, store *lsmkv.Store, indexConfig IndexConfig,
+		invertedIndexConfig schema.InvertedIndexConfig, logger logrus.FieldLogger,
+	) ([]ReindexableProperty, error)
+}
+
+type ReindexableProperty struct {
+	PropertyName    string
+	IndexType       PropertyIndexType
+	DesiredStrategy string
+	BucketOptions   []lsmkv.BucketOption
+}
+
+type ShardInvertedReindexer struct {
+	logger logrus.FieldLogger
+	shard  *Shard
+
+	tasks []ShardInvertedReindexTask
+}
+
+func NewShardInvertedReindexer(shard *Shard, logger logrus.FieldLogger) *ShardInvertedReindexer {
+	return &ShardInvertedReindexer{logger: logger, shard: shard, tasks: []ShardInvertedReindexTask{}}
+}
+
+func (r *ShardInvertedReindexer) AddTask(task ShardInvertedReindexTask) {
+	r.tasks = append(r.tasks, task)
+}
+
+func (r *ShardInvertedReindexer) Do(ctx context.Context) error {
+	for _, task := range r.tasks {
+		if err := r.doTask(ctx, task); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedReindexTask) error {
+	reindexProperties, err := task.GetPropertiesToReindex(ctx, r.shard.store,
+		r.shard.index.Config, r.shard.index.invertedIndexConfig, r.logger)
+	if err != nil {
+		r.logger.
+			WithField("action", "inverted reindex").
+			WithError(err).
+			Error("failed getting reindex properties")
+		return errors.Wrapf(err, "failed getting reindex properties")
+	}
+	if len(reindexProperties) == 0 {
+		r.logger.
+			WithField("action", "inverted reindex").
+			Debug("no properties to reindex")
+		return nil
+	}
+
+	if err := r.pauseStoreActivity(ctx); err != nil {
+		r.logger.
+			WithField("action", "inverted reindex").
+			WithError(err).
+			Error("failed pausing store activity")
+		return err
+	}
+
+	bucketsToReindex := make([]string, len(reindexProperties))
+	for i, reindexProperty := range reindexProperties {
+		if !IsIndexTypeSupportedByStrategy(reindexProperty.IndexType, reindexProperty.DesiredStrategy) {
+			err := fmt.Errorf("strategy '%s' is not supported for given index type '%d",
+				reindexProperty.DesiredStrategy, reindexProperty.IndexType)
+			r.logger.
+				WithField("action", "inverted reindex").
+				WithError(err).
+				Error("invalid strategy")
+			return err
+		}
+
+		bucketsToReindex[i] = r.bucketName(reindexProperty.PropertyName, reindexProperty.IndexType)
+		if err := r.createTempBucket(ctx, bucketsToReindex[i], reindexProperty.DesiredStrategy,
+			reindexProperty.BucketOptions...); err != nil {
+			r.logger.
+				WithField("action", "inverted reindex").
+				WithError(err).
+				Error("failed creating temporary bucket")
+			return err
+		}
+		r.logger.
+			WithField("action", "inverted reindex").
+			WithField("property", reindexProperty.PropertyName).
+			WithField("strategy", reindexProperty.DesiredStrategy).
+			WithField("index_type", reindexProperty.IndexType).
+			Debug("created temporary bucket")
+	}
+
+	if err := r.reindexProperties(ctx, reindexProperties); err != nil {
+		r.logger.
+			WithField("action", "inverted reindex").
+			WithError(err).
+			Errorf("failed reindexing properties on shard '%s'", r.shard.name)
+		return errors.Wrapf(err, "failed reindexing properties on shard '%s'", r.shard.name)
+	}
+
+	for i := range bucketsToReindex {
+		tempBucketName := helpers.TempBucketFromBucketName(bucketsToReindex[i])
+		tempBucket := r.shard.store.Bucket(tempBucketName)
+		tempBucket.FlushMemtable(ctx)
+		tempBucket.UpdateStatus(storagestate.StatusReadOnly)
+
+		if err := r.shard.store.ReplaceBuckets(ctx, bucketsToReindex[i], tempBucketName); err != nil {
+			r.logger.
+				WithField("action", "inverted reindex").
+				WithError(err).
+				Error("failed replacing buckets")
+			return err
+		}
+		r.logger.
+			WithField("action", "inverted reindex").
+			WithField("bucket", bucketsToReindex[i]).
+			WithField("temp_bucket", tempBucketName).
+			Debug("replaced buckets")
+	}
+
+	if err := r.resumeStoreActivity(ctx); err != nil {
+		r.logger.
+			WithField("action", "inverted reindex").
+			WithError(err).
+			Error("failed resuming store activity")
+		return err
+	}
+
+	return nil
+}
+
+func (r *ShardInvertedReindexer) pauseStoreActivity(ctx context.Context) error {
+	if err := r.shard.store.PauseCompaction(ctx); err != nil {
+		return errors.Wrapf(err, "failed pausing compaction for shard '%s'", r.shard.name)
+	}
+	if err := r.shard.store.FlushMemtables(ctx); err != nil {
+		return errors.Wrapf(err, "failed flushing memtables for shard '%s'", r.shard.name)
+	}
+	r.shard.store.UpdateBucketsStatus(storagestate.StatusReadOnly)
+
+	r.logger.
+		WithField("action", "inverted reindex").
+		WithField("shard", r.shard.name).
+		Debug("paused store activity")
+
+	return nil
+}
+
+func (r *ShardInvertedReindexer) resumeStoreActivity(ctx context.Context) error {
+	if err := r.shard.store.ResumeCompaction(ctx); err != nil {
+		return errors.Wrapf(err, "failed resuming compaction for shard '%s'", r.shard.name)
+	}
+	r.shard.store.UpdateBucketsStatus(storagestate.StatusReady)
+
+	r.logger.
+		WithField("action", "inverted reindex").
+		WithField("shard", r.shard.name).
+		Debug("resumed store activity")
+
+	return nil
+}
+
+func (r *ShardInvertedReindexer) createTempBucket(ctx context.Context, name string,
+	strategy string, options ...lsmkv.BucketOption,
+) error {
+	tempName := helpers.TempBucketFromBucketName(name)
+	bucketOptions := append(options, lsmkv.WithStrategy(strategy))
+
+	if err := r.shard.store.CreateBucket(ctx, tempName, bucketOptions...); err != nil {
+		return errors.Wrapf(err, "failed creating temp bucket '%s'", tempName)
+	}
+
+	// no point starting compaction until bucket successfully populated and plugged in
+	if err := r.shard.store.Bucket(tempName).PauseCompaction(ctx); err != nil {
+		return errors.Wrapf(err, "failed pausing compaction for temp bucket '%s'", tempName)
+	}
+	return nil
+}
+
+func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexableProperties []ReindexableProperty) error {
+	checker := newReindexablePropertyChecker(reindexableProperties)
+	objectsBucket := r.shard.store.Bucket(helpers.ObjectsBucketLSM)
+
+	r.logger.
+		WithField("action", "inverted reindex").
+		Debug("starting populating indexes")
+
+	return objectsBucket.IterateObjects(ctx, func(object *storobj.Object) error {
+		docID := object.DocID()
+		properties, nilProperties, err := r.shard.analyzeObject(object)
+		if err != nil {
+			return errors.Wrapf(err, "failed analyzying object")
+		}
+
+		for _, property := range properties {
+			if err := r.handleProperty(ctx, checker, docID, property); err != nil {
+				return errors.Wrapf(err, "failed reindexing property '%s' of object '%d'", property.Name, docID)
+			}
+		}
+		for _, nilProperty := range nilProperties {
+			if err := r.handleNilProperty(ctx, checker, docID, nilProperty); err != nil {
+				return errors.Wrapf(err, "failed reindexing property '%s' of object '%d'", nilProperty.Name, docID)
+			}
+		}
+		return nil
+	})
+}
+
+func (r *ShardInvertedReindexer) handleProperty(ctx context.Context, checker *reindexablePropertyChecker,
+	docID uint64, property inverted.Property,
+) error {
+	reindexableHashPropValue := checker.isReindexable(property.Name, IndexTypeHashPropValue)
+	reindexablePropValue := checker.isReindexable(property.Name, IndexTypePropValue)
+
+	if reindexableHashPropValue || reindexablePropValue {
+		var hashBucketValue, bucketValue *lsmkv.Bucket
+
+		if reindexableHashPropValue {
+			hashBucketValue = r.tempBucket(property.Name, IndexTypeHashPropValue)
+			if hashBucketValue == nil {
+				return fmt.Errorf("no hash bucket for prop '%s' value found", property.Name)
+			}
+		}
+		if reindexablePropValue {
+			bucketValue = r.tempBucket(property.Name, IndexTypePropValue)
+			if bucketValue == nil {
+				return fmt.Errorf("no bucket for prop '%s' value found", property.Name)
+			}
+		}
+
+		if property.HasFrequency {
+			propLen := float32(len(property.Items))
+			for _, item := range property.Items {
+				key := item.Data
+				if reindexableHashPropValue {
+					if err := r.shard.addToPropertyHashBucket(hashBucketValue, key); err != nil {
+						return errors.Wrapf(err, "failed adding to prop '%s' value hash bucket", property.Name)
+					}
+				}
+				if reindexablePropValue {
+					pair := r.shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+					if err := r.shard.addToPropertyMapBucket(bucketValue, pair, key); err != nil {
+						return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+					}
+				}
+			}
+		} else {
+			for _, item := range property.Items {
+				key := item.Data
+				if reindexableHashPropValue {
+					if err := r.shard.addToPropertyHashBucket(hashBucketValue, key); err != nil {
+						return errors.Wrapf(err, "failed adding to prop '%s' value hash bucket", property.Name)
+					}
+				}
+				if reindexablePropValue {
+					if err := r.shard.addToPropertySetBucket(bucketValue, docID, key); err != nil {
+						return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+					}
+				}
+			}
+		}
+	}
+
+	// add non-nil properties to the null-state inverted index,
+	// but skip internal properties (__meta_count, _id etc)
+	if isMetaCountProperty(property) || isInternalProperty(property) {
+		return nil
+	}
+
+	// properties where defining a length does not make sense (floats etc.) have a negative entry as length
+	if r.shard.index.invertedIndexConfig.IndexPropertyLength && property.Length >= 0 {
+		key, err := r.shard.keyPropertyLength(property.Length)
+		if err != nil {
+			return errors.Wrapf(err, "failed creating key for prop '%s' length", property.Name)
+		}
+		if checker.isReindexable(property.Name, IndexTypeHashPropLength) {
+			hashBucketLength := r.tempBucket(property.Name, IndexTypeHashPropLength)
+			if hashBucketLength == nil {
+				return fmt.Errorf("no hash bucket for prop '%s' length found", property.Name)
+			}
+			if err := r.shard.addToPropertyHashBucket(hashBucketLength, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' length hash bucket", property.Name)
+			}
+		}
+		if checker.isReindexable(property.Name, IndexTypePropLength) {
+			bucketLength := r.tempBucket(property.Name, IndexTypePropLength)
+			if bucketLength == nil {
+				return fmt.Errorf("no bucket for prop '%s' length found", property.Name)
+			}
+			if err := r.shard.addToPropertySetBucket(bucketLength, docID, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' length bucket", property.Name)
+			}
+		}
+	}
+
+	if r.shard.index.invertedIndexConfig.IndexNullState {
+		key, err := r.shard.keyPropertyNull(property.Length == 0)
+		if err != nil {
+			return errors.Wrapf(err, "failed creating key for prop '%s' null", property.Name)
+		}
+		if checker.isReindexable(property.Name, IndexTypeHashPropNull) {
+			hashBucketNull := r.tempBucket(property.Name, IndexTypeHashPropNull)
+			if hashBucketNull == nil {
+				return fmt.Errorf("no hash bucket for prop '%s' null found", property.Name)
+			}
+			if err := r.shard.addToPropertyHashBucket(hashBucketNull, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' null hash bucket", property.Name)
+			}
+		}
+		if checker.isReindexable(property.Name, IndexTypePropNull) {
+			bucketNull := r.tempBucket(property.Name, IndexTypePropNull)
+			if bucketNull == nil {
+				return fmt.Errorf("no bucket for prop '%s' null found", property.Name)
+			}
+			if err := r.shard.addToPropertySetBucket(bucketNull, docID, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' null bucket", property.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *ShardInvertedReindexer) handleNilProperty(ctx context.Context, checker *reindexablePropertyChecker,
+	docID uint64, nilProperty nilProp,
+) error {
+	if r.shard.index.invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
+		key, err := r.shard.keyPropertyLength(0)
+		if err != nil {
+			return errors.Wrapf(err, "failed creating key for prop '%s' length", nilProperty.Name)
+		}
+		if checker.isReindexable(nilProperty.Name, IndexTypeHashPropLength) {
+			hashBucketLength := r.tempBucket(nilProperty.Name, IndexTypeHashPropLength)
+			if hashBucketLength == nil {
+				return fmt.Errorf("no hash bucket for prop '%s' length found", nilProperty.Name)
+			}
+			if err := r.shard.addToPropertyHashBucket(hashBucketLength, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' length hash bucket", nilProperty.Name)
+			}
+		}
+		if checker.isReindexable(nilProperty.Name, IndexTypePropLength) {
+			bucketLength := r.tempBucket(nilProperty.Name, IndexTypePropLength)
+			if bucketLength == nil {
+				return fmt.Errorf("no bucket for prop '%s' length found", nilProperty.Name)
+			}
+			if err := r.shard.addToPropertySetBucket(bucketLength, docID, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' length bucket", nilProperty.Name)
+			}
+		}
+	}
+
+	if r.shard.index.invertedIndexConfig.IndexNullState {
+		key, err := r.shard.keyPropertyNull(true)
+		if err != nil {
+			return errors.Wrapf(err, "failed creating key for prop '%s' null", nilProperty.Name)
+		}
+		if checker.isReindexable(nilProperty.Name, IndexTypeHashPropNull) {
+			hashBucketNull := r.tempBucket(nilProperty.Name, IndexTypeHashPropNull)
+			if hashBucketNull == nil {
+				return fmt.Errorf("no hash bucket for prop '%s' null found", nilProperty.Name)
+			}
+			if err := r.shard.addToPropertyHashBucket(hashBucketNull, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' null hash bucket", nilProperty.Name)
+			}
+		}
+		if checker.isReindexable(nilProperty.Name, IndexTypePropNull) {
+			bucketNull := r.tempBucket(nilProperty.Name, IndexTypePropNull)
+			if bucketNull == nil {
+				return fmt.Errorf("no bucket for prop '%s' null found", nilProperty.Name)
+			}
+			if err := r.shard.addToPropertySetBucket(bucketNull, docID, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' null bucket", nilProperty.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *ShardInvertedReindexer) bucketName(propName string, indexType PropertyIndexType) string {
+	CheckSupportedPropertyIndexType(indexType)
+
+	switch indexType {
+	case IndexTypePropValue:
+		return helpers.BucketFromPropNameLSM(propName)
+	case IndexTypePropLength:
+		return helpers.BucketFromPropNameLengthLSM(propName)
+	case IndexTypePropNull:
+		return helpers.BucketFromPropNameNullLSM(propName)
+	case IndexTypeHashPropValue:
+		return helpers.HashBucketFromPropNameLSM(propName)
+	case IndexTypeHashPropLength:
+		return helpers.HashBucketFromPropNameLengthLSM(propName)
+	case IndexTypeHashPropNull:
+		return helpers.HashBucketFromPropNameNullLSM(propName)
+	default:
+		return ""
+	}
+}
+
+func (r *ShardInvertedReindexer) tempBucket(propName string, indexType PropertyIndexType) *lsmkv.Bucket {
+	tempBucketName := helpers.TempBucketFromBucketName(r.bucketName(propName, indexType))
+	return r.shard.store.Bucket(tempBucketName)
+}

--- a/adapters/repos/db/inverted_reindexer_index_types.go
+++ b/adapters/repos/db/inverted_reindexer_index_types.go
@@ -1,0 +1,62 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import "github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+
+type PropertyIndexType uint8
+
+const (
+	IndexTypePropValue PropertyIndexType = iota + 1
+	IndexTypePropLength
+	IndexTypePropNull
+	IndexTypeHashPropValue
+	IndexTypeHashPropLength
+	IndexTypeHashPropNull
+)
+
+func IsSupportedPropertyIndexType(indexType PropertyIndexType) bool {
+	switch indexType {
+	case IndexTypePropValue,
+		IndexTypePropLength,
+		IndexTypePropNull,
+		IndexTypeHashPropValue,
+		IndexTypeHashPropLength,
+		IndexTypeHashPropNull:
+		return true
+	default:
+		return false
+	}
+}
+
+func CheckSupportedPropertyIndexType(indexType PropertyIndexType) {
+	if !IsSupportedPropertyIndexType(indexType) {
+		panic("unsupported property index type")
+	}
+}
+
+// Some index types are supported by specific strategies only
+// Method ensures both index type and strategy work together
+func IsIndexTypeSupportedByStrategy(indexType PropertyIndexType, strategy string) bool {
+	switch indexType {
+	case IndexTypeHashPropValue,
+		IndexTypeHashPropLength,
+		IndexTypeHashPropNull:
+		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategyReplace)
+	case IndexTypePropLength,
+		IndexTypePropNull:
+		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
+	case IndexTypePropValue:
+		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet, lsmkv.StrategyMapCollection)
+	}
+	return false
+}

--- a/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
+++ b/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
@@ -1,0 +1,93 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+type ShardInvertedReindexTaskSetToRoaringSet struct{}
+
+func (t *ShardInvertedReindexTaskSetToRoaringSet) GetPropertiesToReindex(ctx context.Context,
+	store *lsmkv.Store, indexConfig IndexConfig, invertedIndexConfig schema.InvertedIndexConfig,
+	logger logrus.FieldLogger,
+) ([]ReindexableProperty, error) {
+	reindexableProperties := []ReindexableProperty{}
+
+	bucketOptions := []lsmkv.BucketOption{
+		lsmkv.WithIdleThreshold(time.Duration(indexConfig.MemtablesFlushIdleAfter) * time.Second),
+	}
+
+	for name, bucket := range store.GetBucketsByName() {
+		if bucket.Strategy() == lsmkv.StrategySetCollection &&
+			bucket.DesiredStrategy() == lsmkv.StrategyRoaringSet {
+
+			propName, indexType := GetPropNameAndIndexTypeFromBucketName(name)
+			switch indexType {
+			case IndexTypePropValue:
+				reindexableProperties = append(reindexableProperties,
+					ReindexableProperty{
+						PropertyName:    propName,
+						IndexType:       IndexTypePropValue,
+						DesiredStrategy: lsmkv.StrategyRoaringSet,
+						BucketOptions:   bucketOptions,
+					},
+					ReindexableProperty{
+						PropertyName:    propName,
+						IndexType:       IndexTypeHashPropValue,
+						DesiredStrategy: lsmkv.StrategyReplace,
+						BucketOptions:   bucketOptions,
+					},
+				)
+			case IndexTypePropLength:
+				reindexableProperties = append(reindexableProperties,
+					ReindexableProperty{
+						PropertyName:    propName,
+						IndexType:       IndexTypePropLength,
+						DesiredStrategy: lsmkv.StrategyRoaringSet,
+						BucketOptions:   bucketOptions,
+					},
+					ReindexableProperty{
+						PropertyName:    propName,
+						IndexType:       IndexTypeHashPropLength,
+						DesiredStrategy: lsmkv.StrategyReplace,
+						BucketOptions:   bucketOptions,
+					},
+				)
+			case IndexTypePropNull:
+				reindexableProperties = append(reindexableProperties,
+					ReindexableProperty{
+						PropertyName:    propName,
+						IndexType:       IndexTypePropNull,
+						DesiredStrategy: lsmkv.StrategyRoaringSet,
+						BucketOptions:   bucketOptions,
+					},
+					ReindexableProperty{
+						PropertyName:    propName,
+						IndexType:       IndexTypeHashPropNull,
+						DesiredStrategy: lsmkv.StrategyReplace,
+						BucketOptions:   bucketOptions,
+					},
+				)
+			default:
+				// skip remaining
+			}
+		}
+	}
+
+	return reindexableProperties, nil
+}

--- a/adapters/repos/db/inverted_reindexer_utils.go
+++ b/adapters/repos/db/inverted_reindexer_utils.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"regexp"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+)
+
+func GetPropNameAndIndexTypeFromBucketName(bucketName string) (string, PropertyIndexType) {
+	propRegexpGroup := "(?P<propName>.*)"
+
+	types := []struct {
+		indexType    PropertyIndexType
+		bucketNameFn func(string) string
+	}{
+		{
+			IndexTypePropNull,
+			helpers.BucketFromPropNameNullLSM,
+		},
+		{
+			IndexTypePropLength,
+			helpers.BucketFromPropNameLengthLSM,
+		},
+		{
+			IndexTypePropValue,
+			helpers.BucketFromPropNameLSM,
+		},
+		{
+			IndexTypeHashPropNull,
+			helpers.HashBucketFromPropNameNullLSM,
+		},
+		{
+			IndexTypeHashPropLength,
+			helpers.HashBucketFromPropNameLengthLSM,
+		},
+		{
+			IndexTypeHashPropValue,
+			helpers.HashBucketFromPropNameLSM,
+		},
+	}
+
+	for _, t := range types {
+		r, err := regexp.Compile("^" + t.bucketNameFn(propRegexpGroup) + "$")
+		if err != nil {
+			continue
+		}
+		matches := r.FindStringSubmatch(bucketName)
+		if len(matches) > 0 {
+			return matches[r.SubexpIndex("propName")], t.indexType
+		}
+	}
+	return "", 0
+}
+
+type reindexablePropertyChecker struct {
+	reindexables map[string]map[PropertyIndexType]struct{}
+}
+
+func newReindexablePropertyChecker(reindexableProperties []ReindexableProperty) *reindexablePropertyChecker {
+	reindexables := map[string]map[PropertyIndexType]struct{}{}
+	for _, property := range reindexableProperties {
+		if _, ok := reindexables[property.PropertyName]; !ok {
+			reindexables[property.PropertyName] = map[PropertyIndexType]struct{}{}
+		}
+		reindexables[property.PropertyName][property.IndexType] = struct{}{}
+	}
+	return &reindexablePropertyChecker{reindexables}
+}
+
+func (c *reindexablePropertyChecker) isReindexable(propName string, indexType PropertyIndexType) bool {
+	if _, ok := c.reindexables[propName]; !ok {
+		return false
+	} else if _, ok := c.reindexables[propName][indexType]; !ok {
+		return false
+	}
+	return true
+}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -707,7 +707,7 @@ func (b *Bucket) Shutdown(ctx context.Context) error {
 }
 
 func (b *Bucket) flushAndSwitchIfThresholdsMet(stopFunc cyclemanager.StopFunc) {
-	b.flushLock.Lock()
+	b.flushLock.RLock()
 
 	// to check the current size of the WAL to
 	// see if the threshold has been reached
@@ -734,12 +734,12 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(stopFunc cyclemanager.StopFunc) {
 			WithField("path", b.dir).
 			Warn("flush halted due to shard READONLY status")
 
-		b.flushLock.Unlock()
+		b.flushLock.RUnlock()
 		time.Sleep(time.Second)
 		return
 	}
 
-	b.flushLock.Unlock()
+	b.flushLock.RUnlock()
 	if shouldSwitch {
 		cycleLength := b.active.ActiveDuration()
 		if err := b.FlushAndSwitch(); err != nil {

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -36,7 +36,10 @@ func (l *Memtable) flush() error {
 		// this is an empty memtable, nothing to do
 		// however, we still have to cleanup the commit log, otherwise we will
 		// attempt to recover from it on the next cycle
-		return l.commitlog.delete()
+		if err := l.commitlog.delete(); err != nil {
+			return errors.Wrap(err, "delete commit log file")
+		}
+		return nil
 	}
 
 	f, err := os.Create(l.path + ".db")

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -12,6 +12,8 @@
 package lsmkv
 
 import (
+	"fmt"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 )
 
@@ -35,5 +37,24 @@ func SegmentStrategyFromString(in string) segmentindex.Strategy {
 		return segmentindex.StrategyRoaringSet
 	default:
 		panic("unsupported strategy")
+	}
+}
+
+func IsExpectedStrategy(strategy string, expectedStrategies ...string) bool {
+	if len(expectedStrategies) == 0 {
+		expectedStrategies = []string{StrategyReplace, StrategySetCollection, StrategyMapCollection, StrategyRoaringSet}
+	}
+
+	for _, s := range expectedStrategies {
+		if s == strategy {
+			return true
+		}
+	}
+	return false
+}
+
+func CheckExpectedStrategy(strategy string, expectedStrategies ...string) {
+	if !IsExpectedStrategy(strategy, expectedStrategies...) {
+		panic(fmt.Sprintf("one of strategies %v expected, strategy '%s' found", expectedStrategies, strategy))
 	}
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -98,20 +98,19 @@ func New(logger logrus.FieldLogger, config Config,
 }
 
 type Config struct {
-	RootPath                         string
-	QueryLimit                       int64
-	QueryMaximumResults              int64
-	ResourceUsage                    config.ResourceUsage
-	MaxImportGoroutinesFactor        float64
-	MemtablesFlushIdleAfter          int
-	MemtablesInitialSizeMB           int
-	MemtablesMaxSizeMB               int
-	MemtablesMinActiveSeconds        int
-	MemtablesMaxActiveSeconds        int
-	TrackVectorDimensions            bool
-	ReindexVectorDimensionsAtStartup bool
-	ServerVersion                    string
-	GitHash                          string
+	RootPath                  string
+	QueryLimit                int64
+	QueryMaximumResults       int64
+	ResourceUsage             config.ResourceUsage
+	MaxImportGoroutinesFactor float64
+	MemtablesFlushIdleAfter   int
+	MemtablesInitialSizeMB    int
+	MemtablesMaxSizeMB        int
+	MemtablesMinActiveSeconds int
+	MemtablesMaxActiveSeconds int
+	TrackVectorDimensions     bool
+	ServerVersion             string
+	GitHash                   string
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -42,11 +42,10 @@ func Benchmark_Migration(b *testing.B) {
 			logger := logrus.New()
 			schemaGetter := &fakeSchemaGetter{shardState: shardState}
 			repo := New(logger, Config{
-				RootPath:                         dirName,
-				QueryMaximumResults:              1000,
-				MaxImportGoroutinesFactor:        1,
-				TrackVectorDimensions:            true,
-				ReindexVectorDimensionsAtStartup: false,
+				RootPath:                  dirName,
+				QueryMaximumResults:       1000,
+				MaxImportGoroutinesFactor: 1,
+				TrackVectorDimensions:     true,
 			}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil)
 			repo.SetSchemaGetter(schemaGetter)
 			err := repo.WaitForStartup(testCtx())
@@ -89,7 +88,6 @@ func Benchmark_Migration(b *testing.B) {
 
 			fmt.Printf("Added vectors, now migrating\n")
 
-			repo.config.ReindexVectorDimensionsAtStartup = true
 			repo.config.TrackVectorDimensions = true
 			migrator.RecalculateVectorDimensions(context.TODO())
 			fmt.Printf("Benchmark complete")
@@ -106,11 +104,10 @@ func Test_Migration(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: shardState}
 	repo := New(logger, Config{
-		RootPath:                         dirName,
-		QueryMaximumResults:              1000,
-		MaxImportGoroutinesFactor:        1,
-		TrackVectorDimensions:            true,
-		ReindexVectorDimensionsAtStartup: false,
+		RootPath:                  dirName,
+		QueryMaximumResults:       1000,
+		MaxImportGoroutinesFactor: 1,
+		TrackVectorDimensions:     true,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -158,7 +155,6 @@ func Test_Migration(t *testing.T) {
 
 	dimBefore := GetDimensionsFromRepo(repo, "Test")
 	require.Equal(t, 0, dimBefore, "dimensions should not have been calculated")
-	repo.config.ReindexVectorDimensionsAtStartup = true
 	repo.config.TrackVectorDimensions = true
 	migrator.RecalculateVectorDimensions(context.TODO())
 	dimAfter := GetDimensionsFromRepo(repo, "Test")

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -27,48 +27,24 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []n
 	docID uint64,
 ) error {
 	for _, prop := range props {
-		b := s.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
-		if b == nil {
-			return errors.Errorf("no bucket for prop '%s' found", prop.Name)
-		}
-
-		hashBucket := s.store.Bucket(helpers.HashBucketFromPropNameLSM(prop.Name))
-		if hashBucket == nil {
-			return errors.Errorf("no hash bucket for prop '%s' found", prop.Name)
-		}
-
-		if prop.HasFrequency {
-			for _, item := range prop.Items {
-				if err := s.extendInvertedIndexItemWithFrequencyLSM(b, hashBucket, item,
-					docID, item.TermFrequency, float32(len(prop.Items))); err != nil {
-					return errors.Wrapf(err, "extend index with item '%s'",
-						string(item.Data))
-				}
-			}
-		} else {
-			for _, item := range prop.Items {
-				if err := s.extendInvertedIndexItemLSM(b, hashBucket, item, docID); err != nil {
-					return errors.Wrapf(err, "extend index with item '%s'",
-						string(item.Data))
-				}
-			}
+		if err := s.addToPropertyValueIndex(docID, prop); err != nil {
+			return err
 		}
 
 		// add non-nil properties to the null-state inverted index, but skip internal properties (__meta_count, _id etc)
-		if (len(prop.Name) > 12 && prop.Name[len(prop.Name)-12:] == "__meta_count") ||
-			prop.Name[0] == '_' {
+		if isMetaCountProperty(prop) || isInternalProperty(prop) {
 			continue
 		}
 
 		// properties where defining a length does not make sense (floats etc.) have a negative entry as length
 		if s.index.invertedIndexConfig.IndexPropertyLength && prop.Length >= 0 {
-			if err := s.addIndexedPropertyLengthToProps(docID, prop.Name, prop.Length); err != nil {
+			if err := s.addToPropertyLengthIndex(prop.Name, docID, prop.Length); err != nil {
 				return errors.Wrap(err, "add indexed property length")
 			}
 		}
 
 		if s.index.invertedIndexConfig.IndexNullState {
-			if err := s.addIndexedNullStateToProps(docID, prop.Name, prop.Length == 0); err != nil {
+			if err := s.addToPropertyNullIndex(prop.Name, docID, prop.Length == 0); err != nil {
 				return errors.Wrap(err, "add indexed null state")
 			}
 		}
@@ -76,118 +52,108 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []n
 
 	// add nil properties to the nullstate and property length inverted index
 	for _, nilProperty := range nilProps {
-		if s.index.invertedIndexConfig.IndexNullState {
-			if err := s.addIndexedNullStateToProps(docID, nilProperty.Name, true); err != nil {
-				return errors.Wrap(err, "add indexed null state")
-			}
-		}
-
 		if s.index.invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
-			if err := s.addIndexedPropertyLengthToProps(docID, nilProperty.Name, 0); err != nil {
+			if err := s.addToPropertyLengthIndex(nilProperty.Name, docID, 0); err != nil {
 				return errors.Wrap(err, "add indexed property length")
 			}
 		}
 
+		if s.index.invertedIndexConfig.IndexNullState {
+			if err := s.addToPropertyNullIndex(nilProperty.Name, docID, true); err != nil {
+				return errors.Wrap(err, "add indexed null state")
+			}
+		}
 	}
 
 	return nil
 }
 
-func (s *Shard) addIndexedPropertyLengthToProps(docID uint64, propName string, length int) error {
-	bLength := s.store.Bucket(helpers.BucketFromPropNameLSM(propName + filters.InternalPropertyLength))
-	if bLength == nil {
-		return errors.Errorf("no bucket prop '%s' found", propName+filters.InternalPropertyLength)
+func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property) error {
+	bucketValue := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
+	if bucketValue == nil {
+		return errors.Errorf("no bucket for prop '%s' found", property.Name)
 	}
 
-	if bLength.Strategy() != lsmkv.StrategySetCollection && bLength.Strategy() != lsmkv.StrategyRoaringSet {
-		panic("prop has no frequency, but bucket does not have 'Set' nor 'RoaringSet' strategy")
+	hashBucketValue := s.store.Bucket(helpers.HashBucketFromPropNameLSM(property.Name))
+	if hashBucketValue == nil {
+		return errors.Errorf("no hash bucket for prop '%s' found", property.Name)
 	}
 
-	hashBucketPropertyLength := s.store.Bucket(helpers.HashBucketFromPropNameLSM(propName + filters.InternalPropertyLength))
-	if hashBucketPropertyLength == nil {
-		return errors.Errorf("no hash bucket for prop '%s' found", propName+filters.InternalPropertyLength)
-	}
-
-	hash, err := s.generateRowHash()
-	if err != nil {
-		return err
-	}
-
-	key, err := inverted.LexicographicallySortableInt64(int64(length))
-	if err != nil {
-		return err
-	}
-
-	if err := hashBucketPropertyLength.Put(key, hash); err != nil {
-		return err
-	}
-
-	if bLength.Strategy() == lsmkv.StrategyRoaringSet {
-		return bLength.RoaringSetAddOne(key, docID)
-	}
-
-	docIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(docIDBytes, docID)
-
-	return bLength.SetAdd(key, [][]byte{docIDBytes})
-}
-
-func (s *Shard) addIndexedNullStateToProps(docID uint64, propName string, isNil bool) error {
-	bNullState := s.store.Bucket(helpers.BucketFromPropNameLSM(propName + filters.InternalNullIndex))
-	if bNullState == nil {
-		return errors.Errorf("no bucket for nil prop '%s' found", propName+filters.InternalNullIndex)
-	}
-
-	hashBucketNullState := s.store.Bucket(helpers.HashBucketFromPropNameLSM(propName + filters.InternalNullIndex))
-	if hashBucketNullState == nil {
-		return errors.Errorf("no nil-hash bucket for prop '%s' found", propName+filters.InternalNullIndex)
-	}
-
-	if bNullState.Strategy() != lsmkv.StrategySetCollection && bNullState.Strategy() != lsmkv.StrategyRoaringSet {
-		panic("prop has no frequency, but bucket does not have 'Set' nor 'RoaringSet' strategy")
-	}
-
-	hash, err := s.generateRowHash()
-	if err != nil {
-		return err
-	}
-
-	var key uint8
-	if isNil {
-		key = uint8(filters.InternalNullState)
+	if property.HasFrequency {
+		propLen := float32(len(property.Items))
+		for _, item := range property.Items {
+			key := item.Data
+			if err := s.addToPropertyHashBucket(hashBucketValue, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' value hash bucket", property.Name)
+			}
+			pair := s.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+			if err := s.addToPropertyMapBucket(bucketValue, pair, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+			}
+		}
 	} else {
-		key = uint8(filters.InternalNotNullState)
+		for _, item := range property.Items {
+			key := item.Data
+			if err := s.addToPropertyHashBucket(hashBucketValue, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' value hash bucket", property.Name)
+			}
+			if err := s.addToPropertySetBucket(bucketValue, docID, key); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+			}
+		}
 	}
-	if err := hashBucketNullState.Put([]byte{key}, hash); err != nil {
-		return err
-	}
-
-	if bNullState.Strategy() == lsmkv.StrategyRoaringSet {
-		return bNullState.RoaringSetAddOne([]byte{key}, docID)
-	}
-
-	docIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(docIDBytes, docID)
-
-	return bNullState.SetAdd([]byte{key}, [][]byte{docIDBytes})
+	return nil
 }
 
-func (s *Shard) extendInvertedIndexItemWithFrequencyLSM(b, hashBucket *lsmkv.Bucket,
-	item inverted.Countable, docID uint64, frequency float32, propLen float32,
-) error {
-	if b.Strategy() != lsmkv.StrategyMapCollection {
-		panic("prop has frequency, but bucket does not have 'Map' strategy")
+func (s *Shard) addToPropertyLengthIndex(propName string, docID uint64, length int) error {
+	bucketLength := s.store.Bucket(helpers.BucketFromPropNameLengthLSM(propName))
+	if bucketLength == nil {
+		return errors.Errorf("no bucket for prop '%s' length found", propName)
 	}
 
-	hash, err := s.generateRowHash()
+	hashBucketLength := s.store.Bucket(helpers.HashBucketFromPropNameLengthLSM(propName))
+	if hashBucketLength == nil {
+		return errors.Errorf("no hash bucket for prop '%s' length found", propName)
+	}
+
+	key, err := s.keyPropertyLength(length)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed creating key for prop '%s' length", propName)
+	}
+	if err := s.addToPropertyHashBucket(hashBucketLength, key); err != nil {
+		return errors.Wrapf(err, "failed adding to prop '%s' length hash bucket", propName)
+	}
+	if err := s.addToPropertySetBucket(bucketLength, docID, key); err != nil {
+		return errors.Wrapf(err, "failed adding to prop '%s' length bucket", propName)
+	}
+	return nil
+}
+
+func (s *Shard) addToPropertyNullIndex(propName string, docID uint64, isNull bool) error {
+	bucketNull := s.store.Bucket(helpers.BucketFromPropNameNullLSM(propName))
+	if bucketNull == nil {
+		return errors.Errorf("no bucket for prop '%s' null found", propName)
 	}
 
-	if err := hashBucket.Put(item.Data, hash); err != nil {
-		return err
+	hashBucketNull := s.store.Bucket(helpers.HashBucketFromPropNameNullLSM(propName))
+	if hashBucketNull == nil {
+		return errors.Errorf("no hash bucket for prop '%s' null found", propName)
 	}
 
+	key, err := s.keyPropertyNull(isNull)
+	if err != nil {
+		return errors.Wrapf(err, "failed creating key for prop '%s' null", propName)
+	}
+	if err := s.addToPropertyHashBucket(hashBucketNull, key); err != nil {
+		return errors.Wrapf(err, "failed adding to prop '%s' null hash bucket", propName)
+	}
+	if err := s.addToPropertySetBucket(bucketNull, docID, key); err != nil {
+		return errors.Wrapf(err, "failed adding to prop '%s' null bucket", propName)
+	}
+	return nil
+}
+
+func (s *Shard) pairPropertyWithFrequency(docID uint64, freq, propLen float32) lsmkv.MapPair {
 	// 8 bytes for doc id, 4 bytes for frequency, 4 bytes for prop term length
 	buf := make([]byte, 16)
 
@@ -198,41 +164,58 @@ func (s *Shard) extendInvertedIndexItemWithFrequencyLSM(b, hashBucket *lsmkv.Buc
 	} else {
 		binary.BigEndian.PutUint64(buf[0:8], docID)
 	}
-	binary.LittleEndian.PutUint32(buf[8:12], math.Float32bits(item.TermFrequency))
+	binary.LittleEndian.PutUint32(buf[8:12], math.Float32bits(freq))
 	binary.LittleEndian.PutUint32(buf[12:16], math.Float32bits(propLen))
 
-	pair := lsmkv.MapPair{
+	return lsmkv.MapPair{
 		Key:   buf[:8],
 		Value: buf[8:],
 	}
-
-	return b.MapSet(item.Data, pair)
 }
 
-func (s *Shard) extendInvertedIndexItemLSM(b, hashBucket *lsmkv.Bucket,
-	item inverted.Countable, docID uint64,
-) error {
-	if b.Strategy() != lsmkv.StrategySetCollection && b.Strategy() != lsmkv.StrategyRoaringSet {
-		panic("prop has no frequency, but bucket does not have 'Set' nor 'RoaringSet' strategy")
+func (s *Shard) keyPropertyLength(length int) ([]byte, error) {
+	return inverted.LexicographicallySortableInt64(int64(length))
+}
+
+func (s *Shard) keyPropertyNull(isNull bool) ([]byte, error) {
+	if isNull {
+		return []byte{uint8(filters.InternalNullState)}, nil
 	}
+	return []byte{uint8(filters.InternalNotNullState)}, nil
+}
+
+func (s *Shard) addToPropertyHashBucket(hashBucket *lsmkv.Bucket, key []byte) error {
+	lsmkv.CheckExpectedStrategy(hashBucket.Strategy(), lsmkv.StrategyReplace)
 
 	hash, err := s.generateRowHash()
 	if err != nil {
 		return err
 	}
 
-	if err := hashBucket.Put(item.Data, hash); err != nil {
+	if err := hashBucket.Put(key, hash); err != nil {
 		return err
 	}
 
-	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		return b.RoaringSetAddOne(item.Data, docID)
+	return nil
+}
+
+func (s *Shard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {
+	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
+
+	return bucket.MapSet(key, pair)
+}
+
+func (s *Shard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
+	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
+
+	if bucket.Strategy() == lsmkv.StrategySetCollection {
+		docIDBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(docIDBytes, docID)
+
+		return bucket.SetAdd(key, [][]byte{docIDBytes})
 	}
 
-	docIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(docIDBytes, docID)
-
-	return b.SetAdd(item.Data, [][]byte{docIDBytes})
+	return bucket.RoaringSetAddOne(key, docID)
 }
 
 func (s *Shard) batchExtendInvertedIndexItemsLSMNoFrequency(b, hashBucket *lsmkv.Bucket,
@@ -341,4 +324,12 @@ func (s *Shard) removeDimensionsLSM(
 	}
 
 	return b.MapSet(buf[0:4], pair)
+}
+
+func isMetaCountProperty(property inverted.Property) bool {
+	return len(property.Name) > 12 && property.Name[len(property.Name)-12:] == "__meta_count"
+}
+
+func isInternalProperty(property inverted.Property) bool {
+	return property.Name[0] == '_'
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -92,6 +92,7 @@ type Config struct {
 	MaximumConcurrentGetRequests     int            `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
 	TrackVectorDimensions            bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
 	ReindexVectorDimensionsAtStartup bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
+	ReindexSetToRoaringsetAtStartup  bool           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
 }
 
 type moduleProvider interface {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -41,6 +41,10 @@ func FromEnv(config *Config) error {
 		}
 	}
 
+	if enabled(os.Getenv("REINDEX_SET_TO_ROARINGSET_AT_STARTUP")) {
+		config.ReindexSetToRoaringsetAtStartup = true
+	}
+
 	if v := os.Getenv("PROMETHEUS_MONITORING_PORT"); v != "" {
 		asInt, err := strconv.Atoi(v)
 		if err != nil {

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -88,6 +88,10 @@ func (n *NilMigrator) RecalculateVectorDimensions(ctx context.Context) error {
 	return nil
 }
 
+func (n *NilMigrator) InvertedReindex(ctx context.Context, taskNames ...string) error {
+	return nil
+}
+
 var schemaTests = []struct {
 	name string
 	fn   func(*testing.T, *Manager)

--- a/usecases/schema/migrate/migrator.go
+++ b/usecases/schema/migrate/migrator.go
@@ -43,4 +43,5 @@ type Migrator interface {
 	UpdateInvertedIndexConfig(ctx context.Context, className string,
 		updated *models.InvertedIndexConfig) error
 	RecalculateVectorDimensions(ctx context.Context) error
+	InvertedReindex(ctx context.Context, taskNames ...string) error
 }


### PR DESCRIPTION
### What's being changed:
Runs at startup migration of inverted index buckets with strategy CollectionSet to strategy RoaringSet where required.
Migration is run for each shard separately, and shards are set to READONLY mode for the duration of migration.
New buckets are created aside of existing ones, so reading data should be supported for the whole migration process.
Once new buckets are successfully populated, they replace existing, old ones. Old ones are then shutdown and theirs files deleted. Shard then is put back to READY mode.

To run startup migration env variable `REINDEX_SET_TO_ROARINGSET_AT_STARTUP` has to be set.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
