### PR TITLE
Switch queries filtered metrics to summaries

### DIFF
--- a/tools/dev/grafana/dashboards/querying.json
+++ b/tools/dev/grafana/dashboards/querying.json
@@ -409,28 +409,27 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "",
+      "description": "Break down of filtered query latency by operation",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMin": 0,
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 15,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "smooth",
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -440,7 +439,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -459,17 +458,18 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 17
       },
-      "id": 2,
+      "id": 11,
       "options": {
         "legend": {
           "calcs": [],
@@ -488,23 +488,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(concurrent_queries_count{query_type=\"aggregate\"})",
-          "interval": "",
-          "legendFormat": "Aggregate",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "exemplar": true,
-          "expr": "sum(concurrent_queries_count{query_type=\"get_graphql\"})",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Get (GraphQL)",
-          "refId": "B"
+          "expr": "rate(queries_filtered_vector_durations_ms_sum{operation=\"filter\"}[$__interval]) / rate(queries_filtered_vector_durations_ms_count{operation=\"filter\"}[$__interval])",
+          "legendFormat": "{{class_name}}/{{operation}}/{{shard_name}}",
+          "range": true,
+          "refId": "Filter"
         },
         {
           "datasource": {
@@ -512,11 +501,12 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(concurrent_queries_count{query_type=\"get_object\"})",
+          "exemplar": true,
+          "expr": "rate(queries_filtered_vector_durations_ms_sum{operation=\"sort\"}[$__interval]) / rate(queries_filtered_vector_durations_ms_count{operation=\"sort\"}[$__interval])",
           "hide": false,
-          "legendFormat": "Get (Objects)",
+          "legendFormat": "{{class_name}}/{{operation}}/{{shard_name}}",
           "range": true,
-          "refId": "C"
+          "refId": "Sort"
         },
         {
           "datasource": {
@@ -524,14 +514,28 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(concurrent_queries_count{query_type=\"head_object\"})",
+          "exemplar": true,
+          "expr": "rate(queries_filtered_vector_durations_ms_sum{operation=\"vector\"}[$__interval]) / rate(queries_filtered_vector_durations_ms_count{operation=\"vector\"}[$__interval])",
           "hide": false,
-          "legendFormat": "Head (Objects)",
+          "legendFormat": "{{class_name}}/{{operation}}/{{shard_name}}",
           "range": true,
-          "refId": "D"
+          "refId": "Vector"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(queries_filtered_vector_durations_ms_sum{operation=\"objects\"}[$__interval]) / rate(queries_filtered_vector_durations_ms_count{operation=\"objects\"}[$__interval])",
+          "hide": false,
+          "legendFormat": "{{class_name}}/{{operation}}/{{shard_name}}",
+          "range": true,
+          "refId": "Objects"
         }
       ],
-      "title": "Concurrent Read Requests",
+      "title": "Filtered Query Latency",
       "type": "timeseries"
     },
     {
@@ -733,24 +737,28 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMin": 0,
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 15,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -760,7 +768,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -779,8 +787,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ms"
+          }
         },
         "overrides": []
       },
@@ -788,14 +795,15 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 26
       },
-      "id": 5,
+      "id": 2,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -808,14 +816,50 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "editorMode": "code",
-          "expr": "rate(queries_filtered_vector_durations_ms_sum[5s]) / rate(queries_filtered_vector_durations_ms_count[5s])",
-          "legendFormat": "__auto",
-          "range": true,
+          "exemplar": true,
+          "expr": "sum(concurrent_queries_count{query_type=\"aggregate\"})",
+          "interval": "",
+          "legendFormat": "Aggregate",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(concurrent_queries_count{query_type=\"get_graphql\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get (GraphQL)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(concurrent_queries_count{query_type=\"get_object\"})",
+          "hide": false,
+          "legendFormat": "Get (Objects)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(concurrent_queries_count{query_type=\"head_object\"})",
+          "hide": false,
+          "legendFormat": "Head (Objects)",
+          "range": true,
+          "refId": "D"
         }
       ],
-      "title": "Filtered Vector Search",
+      "title": "Concurrent Read Requests",
       "type": "timeseries"
     }
   ],

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -40,7 +40,7 @@ type PrometheusMetrics struct {
 	ObjectCount                        *prometheus.GaugeVec
 	QueriesCount                       *prometheus.GaugeVec
 	QueriesDurations                   *prometheus.HistogramVec
-	QueriesFilteredVectorDurations     *prometheus.HistogramVec
+	QueriesFilteredVectorDurations     *prometheus.SummaryVec
 	QueryDimensions                    *prometheus.CounterVec
 	GoroutinesCount                    *prometheus.GaugeVec
 	BackupRestoreDurations             *prometheus.SummaryVec
@@ -103,10 +103,9 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Buckets: msBuckets,
 		}, []string{"class_name", "query_type"}),
 
-		QueriesFilteredVectorDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "queries_filtered_vector_durations_ms",
-			Help:    "Duration of queries in milliseconds",
-			Buckets: []float64{1, 10, 25, 50, 75, 100, 250, 500, 1000, 2500, 5000, 10000},
+		QueriesFilteredVectorDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "queries_filtered_vector_durations_ms",
+			Help: "Duration of queries in milliseconds",
 		}, []string{"class_name", "shard_name", "operation"}),
 
 		GoroutinesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Reason for switching is to reduce metrics in line with https://github.com/weaviate/weaviate/pull/2605

Also fix filter vector graph (was not editable before due to some issues with the grafana json).

<img width="1037" alt="Screen Shot 2023-02-28 at 9 51 10 pm" src="https://user-images.githubusercontent.com/2173919/221847784-c0005a2c-bb9a-4083-afb4-eab4536ff8b6.png">
