### PR TITLE
Group all vector deletes in batches to reduce lock contention

### DIFF
--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -134,6 +134,7 @@ func (b *objectsBatcher) Objects(ctx context.Context,
 
 	b.init(objects)
 	b.storeInObjectStore(ctx)
+	b.markDeletedInVectorStorage(ctx)
 	b.storeAdditionalStorageWithWorkers(ctx)
 	b.flushWALs(ctx)
 	return b.errs
@@ -231,6 +232,28 @@ func (b *objectsBatcher) setStatusForID(status objectInsertStatus, id strfmt.UUI
 	b.statuses[id] = status
 }
 
+func (b *objectsBatcher) markDeletedInVectorStorage(ctx context.Context) {
+	var docIDsToDelete []uint64
+	var positions []int
+	for pos, object := range b.objects {
+		status := b.statuses[object.ID()]
+		if status.docIDChanged {
+			docIDsToDelete = append(docIDsToDelete, status.oldDocID)
+			positions = append(positions, pos)
+		}
+	}
+
+	if len(docIDsToDelete) == 0 {
+		return
+	}
+
+	if err := b.shard.vectorIndex.Delete(docIDsToDelete...); err != nil {
+		for _, pos := range positions {
+			b.setErrorAtIndex(err, pos)
+		}
+	}
+}
+
 // storeAdditionalStorageWithWorkers stores the object in all non-key-value
 // stores, such as the main vector index as well as the property-specific
 // indices, such as the geo-index.
@@ -287,9 +310,8 @@ func (b *objectsBatcher) storeSingleObjectInAdditionalStorage(ctx context.Contex
 	}
 
 	if object.Vector != nil {
-		// vector is now optional as of
-		// https://github.com/weaviate/weaviate/issues/1800
-		if err := b.shard.updateVectorIndex(object.Vector, status); err != nil {
+		// TODO: explain ignore delete
+		if err := b.shard.updateVectorIndexIgnoreDelete(object.Vector, status); err != nil {
 			b.setErrorAtIndex(errors.Wrap(err, "insert to vector index"), index)
 			return
 		}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -76,6 +76,25 @@ func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object)
 	return nil
 }
 
+// as the name implies this method only performs the insertions, but completely
+// ingores any deletes. It thus assumes that the caller has already taken care
+// of all the deletes in another way
+func (s *Shard) updateVectorIndexIgnoreDelete(vector []float32,
+	status objectInsertStatus,
+) error {
+	// vector is now optional as of
+	// https://github.com/weaviate/weaviate/issues/1800
+	if len(vector) == 0 {
+		return nil
+	}
+
+	if err := s.vectorIndex.Add(status.docID, vector); err != nil {
+		return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
+	}
+
+	return nil
+}
+
 func (s *Shard) updateVectorIndex(vector []float32,
 	status objectInsertStatus,
 ) error {

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -42,7 +42,7 @@ type vectorIndex interface {
 	Add(id uint64, vector []float32) error
 	KnnSearchByVectorMaxDist(query []float32, dist float32, ef int,
 		allowList helpers.AllowList) ([]uint64, error)
-	Delete(id uint64) error
+	Delete(id ...uint64) error
 	Dump(...string)
 	Drop(ctx context.Context) error
 	PostStartup()

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -26,7 +26,7 @@ type breakCleanUpTombstonedNodesFunc func() bool
 
 // Delete attaches a tombstone to an item so it can be periodically cleaned up
 // later and the edges reassigned
-func (h *hnsw) Delete(id uint64) error {
+func (h *hnsw) Delete(ids ...uint64) error {
 	h.deleteVsInsertLock.Lock()
 	defer h.deleteVsInsertLock.Unlock()
 
@@ -36,44 +36,47 @@ func (h *hnsw) Delete(id uint64) error {
 	before := time.Now()
 	defer h.metrics.TrackDelete(before, "total")
 
-	h.metrics.DeleteVector()
-	if err := h.addTombstone(id); err != nil {
+	if err := h.addTombstones(ids); err != nil {
 		return err
 	}
 
-	h.cache.delete(context.TODO(), id)
+	for _, id := range ids {
+		h.metrics.DeleteVector()
+		h.cache.delete(context.TODO(), id)
 
-	// Adding a tombstone might not be enough in some cases, if the tombstoned
-	// entry was the entrypoint this might lead to issues for following inserts:
-	// On a nearly empty graph the entrypoint might be the only viable element to
-	// connect to, however, because the entrypoint itself is tombstones
-	// connections to it are impossible. So, unless we find a new entrypoint,
-	// subsequent inserts might end up isolated (without edges) in the graph.
-	// This is especially true if the tombstoned entrypoint is the only node in
-	// the graph. In this case we must reset the graph, so it acts like an empty
-	// one. Otherwise we'd insert the next id and have only one possible node to
-	// connect it to (the entrypoint). With that one being tombstoned, the new
-	// node would be guaranteed to have zero edges
+		// Adding a tombstone might not be enough in some cases, if the tombstoned
+		// entry was the entrypoint this might lead to issues for following inserts:
+		// On a nearly empty graph the entrypoint might be the only viable element to
+		// connect to, however, because the entrypoint itself is tombstones
+		// connections to it are impossible. So, unless we find a new entrypoint,
+		// subsequent inserts might end up isolated (without edges) in the graph.
+		// This is especially true if the tombstoned entrypoint is the only node in
+		// the graph. In this case we must reset the graph, so it acts like an empty
+		// one. Otherwise we'd insert the next id and have only one possible node to
+		// connect it to (the entrypoint). With that one being tombstoned, the new
+		// node would be guaranteed to have zero edges
 
-	node := h.nodeByID(id)
-	if node == nil {
-		// node was already deleted/cleaned up
-		return nil
-	}
+		node := h.nodeByID(id)
+		if node == nil {
+			// node was already deleted/cleaned up
+			continue
+		}
 
-	if h.getEntrypoint() == id {
-		beforeDeleteEP := time.Now()
-		defer h.metrics.TrackDelete(beforeDeleteEP, "delete_entrypoint")
+		if h.getEntrypoint() == id {
+			beforeDeleteEP := time.Now()
+			defer h.metrics.TrackDelete(beforeDeleteEP, "delete_entrypoint")
 
-		denyList := h.tombstonesAsDenyList()
-		if onlyNode, err := h.resetIfOnlyNode(node, denyList); err != nil {
-			return errors.Wrap(err, "reset index")
-		} else if !onlyNode {
-			if err := h.deleteEntrypoint(node, denyList); err != nil {
-				return errors.Wrap(err, "delete entrypoint")
+			denyList := h.tombstonesAsDenyList()
+			if onlyNode, err := h.resetIfOnlyNode(node, denyList); err != nil {
+				return errors.Wrap(err, "reset index")
+			} else if !onlyNode {
+				if err := h.deleteEntrypoint(node, denyList); err != nil {
+					return errors.Wrap(err, "delete entrypoint")
+				}
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -534,6 +537,21 @@ func (h *hnsw) addTombstone(id uint64) error {
 	h.tombstones[id] = struct{}{}
 	h.tombstoneLock.Unlock()
 	return h.commitLog.AddTombstone(id)
+}
+
+// same as addTombstones, but for a list. Obtains all locks just once
+func (h *hnsw) addTombstones(ids []uint64) error {
+	h.tombstoneLock.Lock()
+	defer h.tombstoneLock.Unlock()
+
+	for _, id := range ids {
+		h.metrics.AddTombstone()
+		h.tombstones[id] = struct{}{}
+		if err := h.commitLog.AddTombstone(id); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakCleanUpTombstonedNodes breakCleanUpTombstonedNodesFunc) (ok bool, err error) {

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -36,7 +36,7 @@ func (h *hnsw) Delete(ids ...uint64) error {
 	before := time.Now()
 	defer h.metrics.TrackDelete(before, "total")
 
-	if err := h.addTombstones(ids); err != nil {
+	if err := h.addTombstone(ids...); err != nil {
 		return err
 	}
 
@@ -531,16 +531,7 @@ func (h *hnsw) hasTombstone(id uint64) bool {
 	return ok
 }
 
-func (h *hnsw) addTombstone(id uint64) error {
-	h.metrics.AddTombstone()
-	h.tombstoneLock.Lock()
-	h.tombstones[id] = struct{}{}
-	h.tombstoneLock.Unlock()
-	return h.commitLog.AddTombstone(id)
-}
-
-// same as addTombstones, but for a list. Obtains all locks just once
-func (h *hnsw) addTombstones(ids []uint64) error {
+func (h *hnsw) addTombstone(ids ...uint64) error {
 	h.tombstoneLock.Lock()
 	defer h.tombstoneLock.Unlock()
 

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -32,7 +32,7 @@ func (i *Index) Add(id uint64, vector []float32) error {
 	return nil
 }
 
-func (i *Index) Delete(id uint64) error {
+func (i *Index) Delete(id ...uint64) error {
 	// silently ignore
 	return nil
 }

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -23,7 +23,7 @@ import (
 type VectorIndex interface {
 	Dump(labels ...string)
 	Add(id uint64, vector []float32) error
-	Delete(id uint64) error
+	Delete(id ...uint64) error
 	SearchByVector(vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error)
 	SearchByVectorDistance(vector []float32, dist float32,
 		maxLimit int64, allow helpers.AllowList) ([]uint64, []float32, error)


### PR DESCRIPTION
This reduces lock contention, as every single delete would try to obtain a costly RWMutex.Lock() before which would drain all readers.

## Evaluation

SIFT1M was imported then, the last 100k objects were imported multiple times for a total of 1.3M writes resulting in 1M net objects.

### Before
![image](https://user-images.githubusercontent.com/8974479/223411677-4a943974-47d7-4bbe-a896-5c3e1c37da65.png)

### Afer
![image](https://user-images.githubusercontent.com/8974479/223411714-711f78c0-aed0-4f8f-8ec5-60419f968614.png)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: [replication pipeline failed because it is no longer compatible with v1.17 - others are green](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4352912181)
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
