### PR TITLE
Transfer backup files between S3, GCS, and Weaviate without loading their content into memory

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -139,22 +139,35 @@ func (g *gcsClient) PutFile(ctx context.Context, backupID, key, srcPath string) 
 		return fmt.Errorf("find bucket: %w", err)
 	}
 
+	// open source file
 	filePath := path.Join(g.dataPath, srcPath)
 	file, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("os.Open %s: %v", filePath, err)
+		return fmt.Errorf("os.Open %q: %w", filePath, err)
 	}
 	defer file.Close()
 
-	writer := bucket.Object(g.makeObjectName(backupID, key)).NewWriter(ctx)
+	// create a new writer
+	object := g.makeObjectName(backupID, key)
+	writer := bucket.Object(object).NewWriter(ctx)
 	writer.ContentType = "application/octet-stream"
 	writer.Metadata = map[string]string{"backup-id": backupID}
+
+	// if we return early make sure writer is closed
+	closeWriter := true
+	defer func() {
+		if closeWriter {
+			writer.Close()
+		}
+	}()
+
 	nBytes, err := io.Copy(writer, file)
 	if err != nil {
-		return fmt.Errorf("io.Copy %s: %v", filePath, err)
+		return fmt.Errorf("io.Copy %q %q: %w", object, filePath, err)
 	}
+	closeWriter = false
 	if err := writer.Close(); err != nil {
-		return fmt.Errorf("Writer.Close %s: %v", filePath, err)
+		return fmt.Errorf("Writer.Close %q: %w", filePath, err)
 	}
 	metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.GetMetricWithLabelValues("backup-gcs", "class")
 	if err == nil {
@@ -211,19 +224,57 @@ func (g *gcsClient) Initialize(ctx context.Context, backupID string) error {
 	return nil
 }
 
-func (g *gcsClient) WriteToFile(ctx context.Context, backupID, key, destPath string) error {
-	obj, err := g.GetObject(ctx, backupID, key)
+// WriteToFile downloads an object and store its content in destPath
+// The file destPath will be created if it doesn't exit
+func (g *gcsClient) WriteToFile(ctx context.Context, backupID, key, destPath string) (err error) {
+	bucket, err := g.findBucket(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "get object '%s'", key)
+		return fmt.Errorf("find bucket: %w", err)
 	}
 
+	// validate destination path
+	if st, err := os.Stat(destPath); err == nil {
+		if st.IsDir() {
+			return fmt.Errorf("file is a directory")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	// create empty file
 	dir := path.Dir(destPath)
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "make dir '%s'", dir)
+		return fmt.Errorf("os.MkdirAll %q: %w", dir, err)
+	}
+	file, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("os.Create %q: %w", destPath, err)
 	}
 
-	if err := os.WriteFile(destPath, obj, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "write file '%s'", destPath)
+	// make sure to close and delete in case we return early
+	closeAndRemove := true
+	defer func() {
+		if closeAndRemove {
+			file.Close()
+			os.Remove(destPath)
+		}
+	}()
+
+	// create reader
+	object := g.makeObjectName(backupID, key)
+	rc, err := bucket.Object(object).NewReader(ctx)
+	if err != nil {
+		return fmt.Errorf("Object(%q).NewReader: %v", object, err)
+	}
+	defer rc.Close()
+
+	// transfer content to the file
+	if _, err := io.Copy(file, rc); err != nil {
+		return fmt.Errorf("io.Copy:%q %q: %w", destPath, object, err)
+	}
+	closeAndRemove = false
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("f.Close %q: %w", destPath, err)
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:
The GCS and S3 backup modules might crash the app when manipulating big backup files because they load file contents into memory before transferring them from/into GCS or S3.

This fix makes sure that files are streamed to object store directly from/to original files

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4314986686/jobs/7528744124
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
