### PR TITLE
Github Action workflow to add precompiled binaries to a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+name: Create Release Draft with Binaries
+on:
+  push:
+    branches:
+      # Change this to master (using release-worflow branch for testing the workflow)
+      - release-workflow
+jobs:
+  create-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Build Binaries (Linux arm64)
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          GOOS=linux GOARCH=arm64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-linux-arm64 cmd/weaviate-server/main.go
+      - name: Build Binaries (Linux amd64)
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          GOOS=linux GOARCH=amd64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-linux-amd64 cmd/weaviate-server/main.go
+      - name: Build Binaries (MacOS arm64)
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          GOOS=darwin GOARCH=arm64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-darwin-arm64 cmd/weaviate-server/main.go
+      - name: Build Binaries (MacOS amd64)
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          GOOS=darwin GOARCH=amd64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-darwin-amd64 cmd/weaviate-server/main.go
+      - name: Upload artifacts/weaviate-server-linux-arm64
+        uses: actions/upload-artifact@v2
+        with:
+          name: weaviate-server-linux-arm64
+          path: artifacts/weaviate-server-linux-arm64
+      - name: Upload artifacts/weaviate-server-linux-amd64
+        uses: actions/upload-artifact@v2
+        with:
+          name: weaviate-server-linux-amd64
+          path: artifacts/weaviate-server-linux-amd64
+      - name: Upload artifacts/weaviate-server-darwin-arm64
+        uses: actions/upload-artifact@v2
+        with:
+          name: weaviate-server-darwin-arm64
+          path: artifacts/weaviate-server-darwin-arm64
+      - name: Upload artifacts/weaviate-server-darwin-amd64
+        uses: actions/upload-artifact@v2
+        with:
+          name: weaviate-server-darwin-amd64
+          path: artifacts/weaviate-server-darwin-amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,52 +1,31 @@
-name: Create Release Draft with Binaries
+name: Generate release assets
+
 on:
-  push:
-    branches:
-      # Change this to master (using release-worflow branch for testing the workflow)
-      - release-workflow
+  release:
+    types: [published]
+
+env:
+  CGO_ENABLED: 0
+
+permissions:
+  contents: write
+
 jobs:
-  create-release-draft:
+  releases-matrix:
+    name: Release precompiled binaries
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [amd64, arm64]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: wangyoucao577/go-release-action@882378b5884e3254db31f1bdbf0f600188f617ae
         with:
-          go-version: 1.19
-      - name: Build Binaries (Linux arm64)
-        run: |
-          GIT_HASH=$(git rev-parse --short HEAD)
-          GOOS=linux GOARCH=arm64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-linux-arm64 cmd/weaviate-server/main.go
-      - name: Build Binaries (Linux amd64)
-        run: |
-          GIT_HASH=$(git rev-parse --short HEAD)
-          GOOS=linux GOARCH=amd64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-linux-amd64 cmd/weaviate-server/main.go
-      - name: Build Binaries (MacOS arm64)
-        run: |
-          GIT_HASH=$(git rev-parse --short HEAD)
-          GOOS=darwin GOARCH=arm64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-darwin-arm64 cmd/weaviate-server/main.go
-      - name: Build Binaries (MacOS amd64)
-        run: |
-          GIT_HASH=$(git rev-parse --short HEAD)
-          GOOS=darwin GOARCH=amd64 go build $EXTRA_BUILD_ARGS -ldflags '-w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'' -o artifacts/weaviate-server-darwin-amd64 cmd/weaviate-server/main.go
-      - name: Upload artifacts/weaviate-server-linux-arm64
-        uses: actions/upload-artifact@v2
-        with:
-          name: weaviate-server-linux-arm64
-          path: artifacts/weaviate-server-linux-arm64
-      - name: Upload artifacts/weaviate-server-linux-amd64
-        uses: actions/upload-artifact@v2
-        with:
-          name: weaviate-server-linux-amd64
-          path: artifacts/weaviate-server-linux-amd64
-      - name: Upload artifacts/weaviate-server-darwin-arm64
-        uses: actions/upload-artifact@v2
-        with:
-          name: weaviate-server-darwin-arm64
-          path: artifacts/weaviate-server-darwin-arm64
-      - name: Upload artifacts/weaviate-server-darwin-amd64
-        uses: actions/upload-artifact@v2
-        with:
-          name: weaviate-server-darwin-amd64
-          path: artifacts/weaviate-server-darwin-amd64
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: "1.19"
+          project_path: "./cmd/weaviate-server"
+          extra_files: LICENSE README.md
+          ldflags: -w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'


### PR DESCRIPTION
### What's being changed:

Introduces an Action workflow which is triggered when a release is published. Once triggered, the action will compile linux amd64/arm64 binaries for the target release tag, and attach them as assets to the release.

This workflow is triggered when pre-releases are published as well.

Eventually it would be great to support darwin executables as well, but we first need to find a way to add Mac code-signing into the mix.

This workflow has been [tested on this fork](https://github.com/parkerduckworth/weaviate/actions/runs/4315130433) and the resulting release with attached asset can be found [here](https://github.com/parkerduckworth/weaviate/releases/tag/v0.1.5).

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
