### PR TITLE
Bm25: only add additonal explanations when requested

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/resolver.go
+++ b/adapters/handlers/graphql/local/aggregate/resolver.go
@@ -124,7 +124,7 @@ func makeResolveClass(modulesProvider ModulesProvider, class *models.Class) grap
 		// refactored
 		var hybridParams *searchparams.HybridSearch
 		if hybrid, ok := p.Args["hybrid"]; ok {
-			p, err := common_filters.ExtractHybridSearch(hybrid.(map[string]interface{}))
+			p, err := common_filters.ExtractHybridSearch(hybrid.(map[string]interface{}), false)
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract hybrid params: %w", err)
 			}

--- a/adapters/handlers/graphql/local/common_filters/bm25.go
+++ b/adapters/handlers/graphql/local/common_filters/bm25.go
@@ -31,6 +31,13 @@ func ExtractBM25(source map[string]interface{}) searchparams.KeywordRanking {
 		args.Query = query.(string)
 	}
 
+	addExplanations, ok := source["additionalExplanations"]
+	if ok {
+		args.AdditionalExplanations = addExplanations.(bool)
+	} else {
+		args.AdditionalExplanations = false
+	}
+
 	args.Type = "bm25"
 
 	return args

--- a/adapters/handlers/graphql/local/common_filters/bm25.go
+++ b/adapters/handlers/graphql/local/common_filters/bm25.go
@@ -14,7 +14,7 @@ package common_filters
 import "github.com/weaviate/weaviate/entities/searchparams"
 
 // ExtractBM25
-func ExtractBM25(source map[string]interface{}) searchparams.KeywordRanking {
+func ExtractBM25(source map[string]interface{}, explainScore bool) searchparams.KeywordRanking {
 	var args searchparams.KeywordRanking
 
 	p, ok := source["properties"]
@@ -31,9 +31,8 @@ func ExtractBM25(source map[string]interface{}) searchparams.KeywordRanking {
 		args.Query = query.(string)
 	}
 
-	addExplanations, ok := source["additionalExplanations"]
-	if ok {
-		args.AdditionalExplanations = addExplanations.(bool)
+	if explainScore {
+		args.AdditionalExplanations = explainScore
 	} else {
 		args.AdditionalExplanations = false
 	}

--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -18,7 +18,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-func ExtractHybridSearch(source map[string]interface{}) (*searchparams.HybridSearch, error) {
+func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*searchparams.HybridSearch, error) {
 	var subsearches []interface{}
 	operands_i := source["operands"]
 	if operands_i != nil {
@@ -36,7 +36,7 @@ func ExtractHybridSearch(source map[string]interface{}) (*searchparams.HybridSea
 		switch {
 		case subsearch["sparseSearch"] != nil:
 			bm25 := subsearch["sparseSearch"].(map[string]interface{})
-			arguments := ExtractBM25(bm25)
+			arguments := ExtractBM25(bm25, explainScore)
 
 			weightedSearchResults = append(weightedSearchResults, searchparams.WeightedSearchResult{
 				SearchParams: arguments,

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -369,11 +369,10 @@ func (r *resolver) makeResolveGetClass(className string) graphql.FieldResolveFn 
 			}
 		}
 
-		var keywordRankingParams *searchparams.KeywordRanking
-
 		// extracts bm25 (sparseSearch) from the query
+		var keywordRankingParams *searchparams.KeywordRanking
 		if bm25, ok := p.Args["bm25"]; ok {
-			p := common_filters.ExtractBM25(bm25.(map[string]interface{}))
+			p := common_filters.ExtractBM25(bm25.(map[string]interface{}), additional.ExplainScore)
 			keywordRankingParams = &p
 		}
 
@@ -382,7 +381,7 @@ func (r *resolver) makeResolveGetClass(className string) graphql.FieldResolveFn 
 		// refactored
 		var hybridParams *searchparams.HybridSearch
 		if hybrid, ok := p.Args["hybrid"]; ok {
-			p, err := common_filters.ExtractHybridSearch(hybrid.(map[string]interface{}))
+			p, err := common_filters.ExtractHybridSearch(hybrid.(map[string]interface{}), additional.ExplainScore)
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract hybrid params: %w", err)
 			}

--- a/adapters/handlers/graphql/local/get/sparse_search.go
+++ b/adapters/handlers/graphql/local/get/sparse_search.go
@@ -39,9 +39,5 @@ func bm25Fields(prefix string) graphql.InputObjectConfigFieldMap {
 			Description: "The properties to search in",
 			Type:        graphql.NewList(graphql.String),
 		},
-		"additionalExplanations": &graphql.InputObjectFieldConfig{
-			Description: "Return additional explanations for the BM25 results. False by default",
-			Type:        graphql.Boolean,
-		},
 	}
 }

--- a/adapters/handlers/graphql/local/get/sparse_search.go
+++ b/adapters/handlers/graphql/local/get/sparse_search.go
@@ -39,5 +39,9 @@ func bm25Fields(prefix string) graphql.InputObjectConfigFieldMap {
 			Description: "The properties to search in",
 			Type:        graphql.NewList(graphql.String),
 		},
+		"additionalExplanations": &graphql.InputObjectFieldConfig{
+			Description: "Return additional explanations for the BM25 results. False by default",
+			Type:        graphql.Boolean,
+		},
 	}
 }

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -225,8 +225,9 @@ func TestBM25FJourney(t *testing.T) {
 		require.Equal(t, uint64(4), res[0].DocID())
 		require.Equal(t, uint64(5), res[1].DocID())
 
-		// Check explainScore
-		require.Contains(t, res[0].Object.Additional["explainScore"], "BM25F")
+		// Without additionalExplanations no explainScore entry should be present
+		require.Contains(t, res[0].Object.Additional, "score")
+		require.NotContains(t, res[0].Object.Additional, "explainScore")
 	})
 
 	// Check non-alpha search on string field
@@ -246,9 +247,6 @@ func TestBM25FJourney(t *testing.T) {
 
 		// Check results in correct order
 		require.Equal(t, uint64(7), resStringField[0].DocID())
-
-		// Check explainScore
-		require.Contains(t, resStringField[0].Object.Additional["explainScore"], "BM25F")
 	})
 
 	// String and text fields are indexed differently, so this checks the string indexing and searching.  In particular,
@@ -367,6 +365,17 @@ func TestBM25FJourney(t *testing.T) {
 		require.Equal(t, uint64(0), res[1].DocID())
 		require.Equal(t, uint64(8), res[2].DocID())
 		require.Len(t, res, 3)
+	})
+
+	t.Run("Include additional explanations", func(t *testing.T) {
+		kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"description"}, Query: "journey", AdditionalExplanations: true}
+		res, _, err := idx.objectSearch(context.TODO(), 5, nil, kwr, nil, nil, addit)
+		require.Nil(t, err)
+
+		// With additionalExplanations explainScore entry should be present
+		require.Contains(t, res[0].Object.Additional, "score")
+		require.Contains(t, res[0].Object.Additional, "explainScore")
+		require.Contains(t, res[0].Object.Additional["explainScore"], "BM25")
 	})
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -849,16 +849,17 @@ func (i *Index) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 					oo.Object.Additional = make(map[string]interface{})
 				}
 				oo.Object.Additional["score"] = os
-				// Collect all keys starting with "BM25F" and add them to the Additional
-				explainScore := ""
-				for k, v := range oo.Object.Additional {
-					if strings.HasPrefix(k, "BM25F") {
 
-						explainScore = fmt.Sprintf("%v, %v:%v", explainScore, k, v)
-						delete(oo.Object.Additional, k)
+				// Collect all keys starting with "BM25F" and add them to the Additional
+				if keywordRanking.AdditionalExplanations {
+					explainScore := ""
+					for k, v := range oo.Object.Additional {
+						if strings.HasPrefix(k, "BM25F") {
+
+							explainScore = fmt.Sprintf("%v, %v:%v", explainScore, k, v)
+							delete(oo.Object.Additional, k)
+						}
 					}
-				}
-				if len(explainScore) > 0 {
 					oo.Object.Additional["explainScore"] = explainScore
 				}
 			}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -858,7 +858,9 @@ func (i *Index) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 						delete(oo.Object.Additional, k)
 					}
 				}
-				oo.Object.Additional["explainScore"] = explainScore
+				if len(explainScore) > 0 {
+					oo.Object.Additional["explainScore"] = explainScore
+				}
 			}
 		}
 	}

--- a/entities/searchparams/retrieval.go
+++ b/entities/searchparams/retrieval.go
@@ -19,9 +19,10 @@ type NearVector struct {
 }
 
 type KeywordRanking struct {
-	Type       string   `json:"type"`
-	Properties []string `json:"properties"`
-	Query      string   `json:"query"`
+	Type                   string   `json:"type"`
+	Properties             []string `json:"properties"`
+	Query                  string   `json:"query"`
+	AdditionalExplanations bool     `json:"additionalExplanations"`
 }
 
 type WeightedSearchResult struct {

--- a/test/benchmark_bm25/cmd/import.go
+++ b/test/benchmark_bm25/cmd/import.go
@@ -80,7 +80,7 @@ var importCmd = &cobra.Command{
 				props[key] = value
 			}
 
-			batch.WithObject(&models.Object{
+			batch.WithObjects(&models.Object{
 				ID:         strfmt.UUID(id),
 				Class:      lib.ClassNameFromDatasetID(datasets.Datasets[0].ID),
 				Properties: props,


### PR DESCRIPTION
### What's being changed:

Skip some expensive computations if "explainScore" is not part of `_additional{}`.

-----Benchmark-----

old:
```
Min:    1.856917ms
Mean: 556.972387ms
Max:  1.408237916s
p50:  651.758666ms
p90:  1.025386916s
p99:  1.387304041s
```

new:
```
Min:       3.473ms
Mean: 217.437607ms
Max:  930.479709ms
p50:     234.578ms
p90:  376.472667ms
p99:  834.601375ms
```

msmarco first 200 queries

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
