### PR TITLE
Add sha256 checksums to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,3 +29,4 @@ jobs:
           project_path: "./cmd/weaviate-server"
           extra_files: LICENSE README.md
           ldflags: -w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'
+          sha256sum: true


### PR DESCRIPTION
### What's being changed:

There are only md5 checksums for current releases which is not recommended to use anymore. This PR adds sha256