### PR TITLE
Enable gcs auth by default

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -17,7 +17,7 @@ import (
 	"io"
 	"os"
 	"path"
-	"strconv"
+	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
@@ -36,10 +36,7 @@ type gcsClient struct {
 
 func newClient(ctx context.Context, config *clientConfig, dataPath string) (*gcsClient, error) {
 	options := []option.ClientOption{}
-	useAuth, err := strconv.ParseBool(os.Getenv("BACKUP_GCS_USE_AUTH"))
-	if err != nil {
-		return nil, errors.Wrap(err, "get env")
-	}
+	useAuth := strings.ToLower(os.Getenv("BACKUP_GCS_USE_AUTH")) != "false"
 	if useAuth {
 		scopes := []string{
 			"https://www.googleapis.com/auth/devstorage.read_write",

--- a/test/modules/backup-azure/backup_journey_test.go
+++ b/test/modules/backup-azure/backup_journey_test.go
@@ -33,7 +33,6 @@ const (
 	azureBackupJourneyClassName          = "AzureBackup"
 	azureBackupJourneyBackupIDSingleNode = "azure-backup-single-node"
 	azureBackupJourneyBackupIDCluster    = "azure-backup-cluster"
-	azureBackupJourneyProjectID          = "azure-backup-journey"
 	azureBackupJourneyContainerName      = "backups"
 )
 


### PR DESCRIPTION
### What's being changed:

Currently, when using the GCS backup module, and `BACKUP_GCS_USE_AUTH` is not set, the following error is logged on server startup:

```
{"action":"startup","error":"init modules: init module 1 (\"backup-gcs\"): init gcs client: get env: strconv.ParseBool: parsing \"\": invalid syntax","level":"fatal","msg":"modules didn't initialize","time":"2023-03-08T19:17:34Z"}
```

Instead of failing to start in this case, this PR makes the change that `BACKUP_GCS_USE_AUTH` should be set to `true` by default.

If wanting to use the GCS backup module with a local GCS emulator, and auth is not necessary, `BACKUP_GCS_USE_AUTH` can be explicitly set to `false`.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
         https://github.com/weaviate/weaviate-io/pull/515
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
