### PR TITLE
Add `uuid` and `uuid[]` prop types (indexed with roaring bitmaps)

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/aggregate.go
+++ b/adapters/handlers/graphql/local/aggregate/aggregate.go
@@ -235,6 +235,9 @@ func classPropertyField(dataType schema.DataType, class *models.Class, property 
 		return makePropertyField(class, property, booleanPropertyFields)
 	case schema.DataTypeDateArray:
 		return makePropertyField(class, property, datePropertyFields)
+	case schema.DataTypeUUID, schema.DataTypeUUIDArray:
+		// not aggregatable
+		return nil, nil
 	default:
 		return nil, fmt.Errorf(schema.ErrorNoSuchDatatype+": %s", dataType)
 	}

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -128,6 +128,18 @@ func (b *classBuilder) primitiveField(propertyType schema.PropertyDataType,
 			Name:        property.Name,
 			Type:        graphql.NewList(graphql.String), // String since no graphql date datatype exists
 		}
+	case schema.DataTypeUUIDArray:
+		return &graphql.Field{
+			Description: property.Description,
+			Name:        property.Name,
+			Type:        graphql.NewList(graphql.String), // Always return UUID as string representation to the user
+		}
+	case schema.DataTypeUUID:
+		return &graphql.Field{
+			Description: property.Description,
+			Name:        property.Name,
+			Type:        graphql.String, // Always return UUID as string representation to the user
+		}
 	default:
 		panic(fmt.Sprintf("buildGetClass: unknown primitive type for %s.%s; %s",
 			className, property.Name, propertyType.AsPrimitive()))

--- a/adapters/handlers/graphql/test/helper/schema_fixtures.go
+++ b/adapters/handlers/graphql/test/helper/schema_fixtures.go
@@ -52,6 +52,14 @@ func CreateSimpleSchema(vectorizer string) schema.Schema {
 							DataType: []string{"int"},
 						},
 						{
+							Name:     "uuidField",
+							DataType: []string{"uuid"},
+						},
+						{
+							Name:     "uuidArrayField",
+							DataType: []string{"uuid[]"},
+						},
+						{
 							Name:     "location",
 							DataType: []string{"geoCoordinates"},
 						},

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -748,14 +748,12 @@ var carClass = &models.Class{
 			Tokenization: "field",
 		},
 		{
-			DataType:     []string{string(schema.DataTypeUUID)},
-			Name:         "manufacturerId",
-			Tokenization: "field",
+			DataType: []string{string(schema.DataTypeUUID)},
+			Name:     "manufacturerId",
 		},
 		{
-			DataType:     []string{string(schema.DataTypeUUIDArray)},
-			Name:         "availableAtDealerships",
-			Tokenization: "field",
+			DataType: []string{string(schema.DataTypeUUIDArray)},
+			Name:     "availableAtDealerships",
 		},
 	},
 }

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -469,6 +469,26 @@ func testPrimitiveProps(repo *DB) func(t *testing.T) {
 				filter:      buildFilter("len(colorArrayWord)", 0, eq, dtInt),
 				expectedIDs: []strfmt.UUID{carEmpty, carNilID},
 			},
+			{
+				name:        "made by Mercedes ... I mean manufacturer1",
+				filter:      buildFilter("manufacturerId", manufacturer1.String(), eq, dtString),
+				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID},
+			},
+			{
+				name:        "made by manufacturer2",
+				filter:      buildFilter("manufacturerId", manufacturer2.String(), eq, dtString),
+				expectedIDs: []strfmt.UUID{carPoloID},
+			},
+			{
+				name:        "available at the north dealership",
+				filter:      buildFilter("availableAtDealerships", dealershipNorth.String(), eq, dtString),
+				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID},
+			},
+			{
+				name:        "available at the south dealership",
+				filter:      buildFilter("availableAtDealerships", dealershipSouth.String(), eq, dtString),
+				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID},
+			},
 		}
 
 		for _, test := range tests {
@@ -727,6 +747,16 @@ var carClass = &models.Class{
 			Name:         "colorArrayField",
 			Tokenization: "field",
 		},
+		{
+			DataType:     []string{string(schema.DataTypeUUID)},
+			Name:         "manufacturerId",
+			Tokenization: "field",
+		},
+		{
+			DataType:     []string{string(schema.DataTypeUUIDArray)},
+			Name:         "availableAtDealerships",
+			Tokenization: "field",
+		},
 	},
 }
 
@@ -736,6 +766,13 @@ var (
 	carPoloID     strfmt.UUID = "b444e1d8-d73a-4d53-a417-8d6501c27f2e"
 	carNilID      strfmt.UUID = "b444e1d8-d73a-4d53-a417-8d6501c27f3e"
 	carEmpty      strfmt.UUID = "b444e1d8-d73a-4d53-a417-8d6501c27f4e"
+
+	// these UUIDs are not primary IDs of objects, but rather values for uuid and
+	// uuid[] fields
+	manufacturer1   = uuid.MustParse("11111111-2222-3333-4444-000000000001")
+	manufacturer2   = uuid.MustParse("11111111-2222-3333-4444-000000000002")
+	dealershipNorth = uuid.MustParse("99999999-9999-9999-9999-000000000001")
+	dealershipSouth = uuid.MustParse("99999999-9999-9999-9999-000000000002")
 )
 
 func mustParseTime(in string) time.Time {
@@ -759,12 +796,14 @@ var cars = []models.Object{
 				Latitude:  ptFloat32(34.052235),
 				Longitude: ptFloat32(-118.243683),
 			},
-			"contact":         "john@heavycars.example.com",
-			"description":     "This car resembles a large van that can still be driven with a regular license. Contact john@heavycars.example.com for details",
-			"colorWord":       "light grey",
-			"colorField":      "light grey",
-			"colorArrayWord":  []interface{}{"light grey"},
-			"colorArrayField": []interface{}{"light grey"},
+			"contact":                "john@heavycars.example.com",
+			"description":            "This car resembles a large van that can still be driven with a regular license. Contact john@heavycars.example.com for details",
+			"colorWord":              "light grey",
+			"colorField":             "light grey",
+			"colorArrayWord":         []interface{}{"light grey"},
+			"colorArrayField":        []interface{}{"light grey"},
+			"manufacturerId":         manufacturer1,
+			"availableAtDealerships": []uuid.UUID{dealershipNorth, dealershipSouth},
 		},
 	},
 	{
@@ -779,28 +818,32 @@ var cars = []models.Object{
 				Latitude:  ptFloat32(40.730610),
 				Longitude: ptFloat32(-73.935242),
 			},
-			"contact":         "jessica-世界@unicode.example.com",
-			"description":     "This car has a huge motor, but it's also not exactly lightweight.",
-			"colorWord":       "very light grey",
-			"colorField":      "very light grey",
-			"colorArrayWord":  []interface{}{"very light", "grey"},
-			"colorArrayField": []interface{}{"very light", "grey"},
+			"contact":                "jessica-世界@unicode.example.com",
+			"description":            "This car has a huge motor, but it's also not exactly lightweight.",
+			"colorWord":              "very light grey",
+			"colorField":             "very light grey",
+			"colorArrayWord":         []interface{}{"very light", "grey"},
+			"colorArrayField":        []interface{}{"very light", "grey"},
+			"manufacturerId":         manufacturer1,
+			"availableAtDealerships": []uuid.UUID{dealershipNorth},
 		},
 	},
 	{
 		Class: carClass.Class,
 		ID:    carPoloID,
 		Properties: map[string]interface{}{
-			"released":        mustParseTime("1975-01-01T10:12:00+02:00"),
-			"modelName":       "polo",
-			"horsepower":      int64(100),
-			"weight":          1200.0,
-			"contact":         "sandra@efficientcars.example.com",
-			"description":     "This small car has a small engine and unicode labels (ąę), but it's very light, so it feels fater than it is.",
-			"colorWord":       "dark grey",
-			"colorField":      "dark grey",
-			"colorArrayWord":  []interface{}{"dark", "grey"},
-			"colorArrayField": []interface{}{"dark", "grey"},
+			"released":               mustParseTime("1975-01-01T10:12:00+02:00"),
+			"modelName":              "polo",
+			"horsepower":             int64(100),
+			"weight":                 1200.0,
+			"contact":                "sandra@efficientcars.example.com",
+			"description":            "This small car has a small engine and unicode labels (ąę), but it's very light, so it feels fater than it is.",
+			"colorWord":              "dark grey",
+			"colorField":             "dark grey",
+			"colorArrayWord":         []interface{}{"dark", "grey"},
+			"colorArrayField":        []interface{}{"dark", "grey"},
+			"manufacturerId":         manufacturer2,
+			"availableAtDealerships": []uuid.UUID{dealershipSouth},
 		},
 	},
 	{

--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
+	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/models"
@@ -132,6 +133,28 @@ func (a *Analyzer) Int(in int64) ([]Countable, error) {
 			Data: data,
 		},
 	}, nil
+}
+
+// UUID requires no analysis, so it's just dumping the raw binary representation
+func (a *Analyzer) UUID(in uuid.UUID) ([]Countable, error) {
+	return []Countable{
+		{
+			Data: in[:],
+		},
+	}, nil
+}
+
+// UUID array requires no analysis, so it's just dumping the raw binary
+// representation of each contained element
+func (a *Analyzer) UUIDArray(in []uuid.UUID) ([]Countable, error) {
+	out := make([]Countable, len(in))
+	for i := range in {
+		out[i] = Countable{
+			Data: in[i][:],
+		}
+	}
+
+	return out, nil
 }
 
 // Int array requires no analysis, so it's actually just a simple conversion to a

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -37,18 +37,18 @@ func (a *Analyzer) Object(input map[string]any, props []*models.Property,
 
 	properties, err := a.analyzeProps(propsMap, input)
 	if err != nil {
-		return nil, errors.Wrap(err, "analyze props")
+		return nil, fmt.Errorf("analyze props: %w", err)
 	}
 
 	idProp, err := a.analyzeIDProp(uuid)
 	if err != nil {
-		return nil, errors.Wrap(err, "analyze uuid prop")
+		return nil, fmt.Errorf("analyze uuid prop: %w", err)
 	}
 	properties = append(properties, *idProp)
 
 	tsProps, err := a.analyzeTimestampProps(input)
 	if err != nil {
-		return nil, errors.Wrap(err, "analyze timestamp props")
+		return nil, fmt.Errorf("analyze timestamp props: %w", err)
 	}
 	// tsProps will be nil here if weaviate is
 	// not setup to index by timestamps
@@ -97,7 +97,7 @@ func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 func (a *Analyzer) analyzeIDProp(id strfmt.UUID) (*Property, error) {
 	value, err := id.MarshalText()
 	if err != nil {
-		return nil, errors.Wrap(err, "marshal id prop")
+		return nil, fmt.Errorf("marshal id prop: %w", err)
 	}
 	return &Property{
 		Name:         filters.InternalPropID,
@@ -118,7 +118,7 @@ func (a *Analyzer) analyzeTimestampProps(input map[string]any) ([]Property, erro
 	if createTimeOK {
 		b, err := json.Marshal(createTime)
 		if err != nil {
-			return nil, errors.Wrap(err, "analyze create timestamp prop")
+			return nil, fmt.Errorf("analyze create timestamp prop: %w", err)
 		}
 		props = append(props, Property{
 			Name:  filters.InternalPropCreationTimeUnix,
@@ -129,7 +129,7 @@ func (a *Analyzer) analyzeTimestampProps(input map[string]any) ([]Property, erro
 	if updateTimeOK {
 		b, err := json.Marshal(updateTime)
 		if err != nil {
-			return nil, errors.Wrap(err, "analyze update timestamp prop")
+			return nil, fmt.Errorf("analyze update timestamp prop: %w", err)
 		}
 		props = append(props, Property{
 			Name:  filters.InternalPropLastUpdateTimeUnix,
@@ -163,7 +163,7 @@ func (a *Analyzer) extendPropertiesWithArrayType(properties *[]Property,
 
 	property, err := a.analyzeArrayProp(prop, values)
 	if err != nil {
-		return errors.Wrap(err, "analyze array prop")
+		return fmt.Errorf("analyze array prop: %w", err)
 	}
 	if property == nil {
 		return nil
@@ -188,7 +188,7 @@ func (a *Analyzer) extendPropertiesWithPrimitive(properties *[]Property,
 	}
 	property, err = a.analyzePrimitiveProp(prop, value)
 	if err != nil {
-		return errors.Wrap(err, "analyze primitive prop")
+		return fmt.Errorf("analyze primitive prop: %w", err)
 	}
 	if property == nil {
 		return nil
@@ -254,7 +254,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		var err error
 		items, err = a.IntArray(in)
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeNumberArray:
 		hasFrequency = HasFrequency(dt)
@@ -278,7 +278,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		var err error
 		items, err = a.FloatArray(in) // convert to int before analyzing
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeBooleanArray:
 		hasFrequency = HasFrequency(dt)
@@ -294,7 +294,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		var err error
 		items, err = a.BoolArray(in) // convert to int before analyzing
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeDateArray:
 		hasFrequency = HasFrequency(dt)
@@ -306,7 +306,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 			} else if asString, okString := value.(string); okString {
 				parsedTime, err := time.Parse(time.RFC3339Nano, asString)
 				if err != nil {
-					return nil, errors.Wrapf(err, "Time parsing")
+					return nil, fmt.Errorf("parse time: %w", err)
 				}
 				in[i] = parsedTime.UnixNano()
 			} else {
@@ -317,7 +317,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		var err error
 		items, err = a.IntArray(in)
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeUUIDArray:
 		hasFrequency = false
@@ -399,7 +399,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 		var err error
 		items, err = a.Int(asInt)
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeNumber:
 		hasFrequency = HasFrequency(dt)
@@ -411,7 +411,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 		var err error
 		items, err = a.Float(asFloat) // convert to int before analyzing
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeBoolean:
 		hasFrequency = HasFrequency(dt)
@@ -423,7 +423,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 		var err error
 		items, err = a.Bool(asBool) // convert to int before analyzing
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeDate:
 		hasFrequency = HasFrequency(dt)
@@ -432,7 +432,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 			// for example when patching the date may have been loaded as a string
 			value, err = time.Parse(time.RFC3339Nano, asString)
 			if err != nil {
-				return nil, errors.Wrap(err, "parse stringified timestamp")
+				return nil, fmt.Errorf("parse stringified timestamp: %w", err)
 			}
 		}
 		asTime, ok := value.(time.Time)
@@ -442,7 +442,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 
 		items, err = a.Int(asTime.UnixNano())
 		if err != nil {
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	case schema.DataTypeUUID:
 		var err error
@@ -452,7 +452,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 			// for example when patching the uuid may have been loaded as a string
 			value, err = uuid.Parse(asString)
 			if err != nil {
-				return nil, errors.Wrap(err, "parse stringified uuid")
+				return nil, fmt.Errorf("parse stringified uuid: %w", err)
 			}
 		}
 
@@ -463,8 +463,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 
 		items, err = a.UUID(asUUID)
 		if err != nil {
-			// TODO: use fmt.Errorf
-			return nil, errors.Wrapf(err, "analyze property %s", prop.Name)
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}
 	default:
 		// ignore unsupported prop type
@@ -510,7 +509,7 @@ func (a *Analyzer) extendPropertiesWithReference(properties *[]Property,
 
 	property, err := a.analyzeRefPropCount(prop, asRefs)
 	if err != nil {
-		return errors.Wrap(err, "ref count")
+		return fmt.Errorf("ref count: %w", err)
 	}
 
 	*properties = append(*properties, *property)
@@ -521,7 +520,7 @@ func (a *Analyzer) extendPropertiesWithReference(properties *[]Property,
 
 	property, err = a.analyzeRefProp(prop, asRefs)
 	if err != nil {
-		return errors.Wrap(err, "refs")
+		return fmt.Errorf("refs: %w", err)
 	}
 
 	*properties = append(*properties, *property)
@@ -533,7 +532,7 @@ func (a *Analyzer) analyzeRefPropCount(prop *models.Property,
 ) (*Property, error) {
 	items, err := a.RefCount(value)
 	if err != nil {
-		return nil, errors.Wrapf(err, "analyze ref-property %q", prop.Name)
+		return nil, fmt.Errorf("analyze ref-property %q: %w", prop.Name, err)
 	}
 
 	return &Property{
@@ -549,7 +548,7 @@ func (a *Analyzer) analyzeRefProp(prop *models.Property,
 ) (*Property, error) {
 	items, err := a.Ref(value)
 	if err != nil {
-		return nil, errors.Wrapf(err, "analyze ref-property %q", prop.Name)
+		return nil, fmt.Errorf("analyze ref-property %q: %w", prop.Name, err)
 	}
 
 	return &Property{

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -28,11 +29,17 @@ func TestAnalyzeObject(t *testing.T) {
 	a := NewAnalyzer(fakeStopwordDetector{})
 
 	t.Run("with multiple properties", func(t *testing.T) {
+		id1 := uuid.New()
+		id2 := uuid.New()
 		schema := map[string]interface{}{
 			"description": "I am great!",
 			"email":       "john@doe.com",
 			"about_me":    "I like reading sci-fi books",
 			"profession":  "Mechanical Engineer",
+			"id1":         id1,                 // correctly parsed
+			"id2":         id2.String(),        // untyped
+			"idArray1":    []uuid.UUID{id1},    // coorectly parsed
+			"idArray2":    []any{id2.String()}, // untyped
 		}
 
 		uuid := "2609f1bc-7693-48f3-b531-6ddc52cd2501"
@@ -55,6 +62,26 @@ func TestAnalyzeObject(t *testing.T) {
 			{
 				Name:         "profession",
 				DataType:     []string{"string"},
+				Tokenization: "field",
+			},
+			{
+				Name:         "id1",
+				DataType:     []string{"uuid"},
+				Tokenization: "field",
+			},
+			{
+				Name:         "id2",
+				DataType:     []string{"uuid"},
+				Tokenization: "field",
+			},
+			{
+				Name:         "idArray1",
+				DataType:     []string{"uuid[]"},
+				Tokenization: "field",
+			},
+			{
+				Name:         "idArray2",
+				DataType:     []string{"uuid[]"},
 				Tokenization: "field",
 			},
 		}
@@ -120,12 +147,44 @@ func TestAnalyzeObject(t *testing.T) {
 			},
 		}
 
-		require.Len(t, res, 5)
+		expectedID1 := []Countable{
+			{
+				Data:          []byte(id1[:]),
+				TermFrequency: 0,
+			},
+		}
+
+		expectedID2 := []Countable{
+			{
+				Data:          []byte(id2[:]),
+				TermFrequency: 0,
+			},
+		}
+
+		expectedIDArray1 := []Countable{
+			{
+				Data:          []byte(id1[:]),
+				TermFrequency: 0,
+			},
+		}
+
+		expectedIDArray2 := []Countable{
+			{
+				Data:          []byte(id2[:]),
+				TermFrequency: 0,
+			},
+		}
+
+		require.Len(t, res, 9)
 		var actualDescription []Countable
 		var actualEmail []Countable
 		var actualAboutMe []Countable
 		var actualProfession []Countable
 		var actualUUID []Countable
+		var actualID1 []Countable
+		var actualID2 []Countable
+		var actualIDArray1 []Countable
+		var actualIDArray2 []Countable
 
 		for _, elem := range res {
 			if elem.Name == "email" {
@@ -147,6 +206,22 @@ func TestAnalyzeObject(t *testing.T) {
 			if elem.Name == "_id" {
 				actualUUID = elem.Items
 			}
+
+			if elem.Name == "id1" {
+				actualID1 = elem.Items
+			}
+
+			if elem.Name == "id2" {
+				actualID2 = elem.Items
+			}
+
+			if elem.Name == "idArray1" {
+				actualIDArray1 = elem.Items
+			}
+
+			if elem.Name == "idArray2" {
+				actualIDArray2 = elem.Items
+			}
 		}
 
 		assert.ElementsMatch(t, expectedEmail, actualEmail, res)
@@ -154,6 +229,10 @@ func TestAnalyzeObject(t *testing.T) {
 		assert.ElementsMatch(t, expectedAboutMe, actualAboutMe, res)
 		assert.ElementsMatch(t, expectedProfession, actualProfession, res)
 		assert.ElementsMatch(t, expectedUUID, actualUUID, res)
+		assert.ElementsMatch(t, expectedID1, actualID1, res)
+		assert.ElementsMatch(t, expectedID2, actualID2, res)
+		assert.ElementsMatch(t, expectedIDArray1, actualIDArray1, res)
+		assert.ElementsMatch(t, expectedIDArray2, actualIDArray2, res)
 	})
 
 	t.Run("with refProps", func(t *testing.T) {

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -65,24 +65,20 @@ func TestAnalyzeObject(t *testing.T) {
 				Tokenization: "field",
 			},
 			{
-				Name:         "id1",
-				DataType:     []string{"uuid"},
-				Tokenization: "field",
+				Name:     "id1",
+				DataType: []string{"uuid"},
 			},
 			{
-				Name:         "id2",
-				DataType:     []string{"uuid"},
-				Tokenization: "field",
+				Name:     "id2",
+				DataType: []string{"uuid"},
 			},
 			{
-				Name:         "idArray1",
-				DataType:     []string{"uuid[]"},
-				Tokenization: "field",
+				Name:     "idArray1",
+				DataType: []string{"uuid[]"},
 			},
 			{
-				Name:         "idArray2",
-				DataType:     []string{"uuid[]"},
-				Tokenization: "field",
+				Name:     "idArray2",
+				DataType: []string{"uuid[]"},
 			},
 		}
 		res, err := a.Object(schema, props, strfmt.UUID(uuid))

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/sroar"
@@ -262,6 +263,11 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 			filter.Operator)
 	}
 
+	if s.onUUIDProp(className, props[0]) {
+		return s.extractUUIDFilter(props[0], filter.Value.Value, filter.Value.Type,
+			filter.Operator)
+	}
+
 	if s.onTokenizablePropValue(filter.Value.Type) {
 		property, err := s.schema.GetProperty(className, schema.PropertyName(props[0]))
 		if err != nil {
@@ -354,6 +360,33 @@ func (s *Searcher) extractGeoFilter(propName string, value interface{},
 		hasFrequency:  false,
 		prop:          propName,
 		operator:      operator,
+	}, nil
+}
+
+func (s *Searcher) extractUUIDFilter(propName string, value interface{},
+	valueType schema.DataType, operator filters.Operator,
+) (*propValuePair, error) {
+	if valueType != schema.DataTypeString {
+		return nil, fmt.Errorf("prop %q is of type uuid, the uuid to filter"+
+			"on must be specified as a string (e.g. valueString:<uuid>)", propName)
+	}
+
+	asStr, ok := value.(string)
+	if !ok {
+		return nil,
+			fmt.Errorf("expected to see uuid as string in filter, got %T", value)
+	}
+
+	parsed, err := uuid.Parse(asStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse uuid string: %w", err)
+	}
+
+	return &propValuePair{
+		value:        parsed[:],
+		hasFrequency: false,
+		prop:         propName,
+		operator:     operator,
 	}, nil
 }
 
@@ -504,6 +537,24 @@ func (s *Searcher) onGeoProp(className schema.ClassName, propName string) bool {
 	}
 
 	return schema.DataType(property.DataType[0]) == schema.DataTypeGeoCoordinates
+}
+
+// Note: A UUID prop is a user-specified prop of type UUID. This has nothing to
+// do with the primary ID of an object which happens to always be a UUID in
+// Weaviate v1
+//
+// TODO: repeated calls to on... aren't too efficient because we iterate over
+// the schema each time, might be smarter to have a single method that
+// determines the type and then we switch based on the result. However, the
+// effect of that should be very small unless the schema is absolutely massive.
+func (s *Searcher) onUUIDProp(className schema.ClassName, propName string) bool {
+	property, err := s.schema.GetProperty(className, schema.PropertyName(propName))
+	if err != nil {
+		return false
+	}
+
+	dt := schema.DataType(property.DataType[0])
+	return dt == schema.DataTypeUUID || dt == schema.DataTypeUUIDArray
 }
 
 func (s *Searcher) onInternalProp(propName string) bool {

--- a/entities/filters/sort_validator.go
+++ b/entities/filters/sort_validator.go
@@ -12,6 +12,8 @@
 package filters
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -62,6 +64,13 @@ func validateSortClause(sch schema.Schema, className schema.ClassName, sort Sort
 		if err != nil {
 			return err
 		}
+
+		if isUUIDType(prop.DataType[0]) {
+			return fmt.Errorf("prop %q is of type uuid/uuid[]: "+
+				"sorting by uuid is currently not supported - if you believe it should be, "+
+				"please open a feature request on github.com/weaviate/weaviate", prop.Name)
+		}
+
 		if schema.IsRefDataType(prop.DataType) {
 			return errors.Errorf("sorting by reference not supported, "+
 				"property %q is a ref prop to the class %q", propName, prop.DataType[0])

--- a/entities/filters/sort_validator_test.go
+++ b/entities/filters/sort_validator_test.go
@@ -1,0 +1,74 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestSortValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		prop  string
+		valid bool
+	}{
+		{
+			name:  "existing prop - string",
+			valid: true,
+			prop:  "modelName",
+		},
+		{
+			name:  "existing prop - int",
+			valid: true,
+			prop:  "horsepower",
+		},
+		{
+			name:  "invalid prop",
+			valid: false,
+			prop:  "idontexist",
+		},
+		{
+			name:  "uuid prop",
+			valid: false,
+			prop:  "my_id",
+		},
+		{
+			name:  "uuid[] prop",
+			valid: false,
+			prop:  "my_idz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sch := schema.Schema{Objects: &models.Schema{
+				Classes: []*models.Class{
+					{
+						Class: "Car",
+						Properties: []*models.Property{
+							{Name: "modelName", DataType: []string{"string"}},
+							{Name: "manufacturerName", DataType: []string{"string"}},
+							{Name: "horsepower", DataType: []string{"int"}},
+							{Name: "my_id", DataType: []string{"uuid"}},
+							{Name: "my_idz", DataType: []string{"uuid[]"}},
+						},
+					},
+				},
+			}}
+
+			sort := []Sort{{
+				Path:  []string{tt.prop},
+				Order: "asc",
+			}}
+
+			err := ValidateSort(sch, schema.ClassName("Car"), sort)
+			if tt.valid {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+			}
+		})
+	}
+}

--- a/entities/filters/sort_validator_test.go
+++ b/entities/filters/sort_validator_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package filters
 
 import (

--- a/entities/schema/backward_compat.go
+++ b/entities/schema/backward_compat.go
@@ -85,37 +85,7 @@ func GetValueDataTypeFromString(dt string) (*DataType, error) {
 	var returnDataType DataType
 
 	if IsValidValueDataType(dt) {
-		if dt == string(DataTypeBoolean) {
-			returnDataType = DataTypeBoolean
-		} else if dt == string(DataTypeInt) {
-			returnDataType = DataTypeInt
-		} else if dt == string(DataTypeDate) {
-			returnDataType = DataTypeDate
-		} else if dt == string(DataTypeNumber) {
-			returnDataType = DataTypeNumber
-		} else if dt == string(DataTypeString) {
-			returnDataType = DataTypeString
-		} else if dt == string(DataTypeText) {
-			returnDataType = DataTypeText
-		} else if dt == string(DataTypeGeoCoordinates) {
-			returnDataType = DataTypeGeoCoordinates
-		} else if dt == string(DataTypePhoneNumber) {
-			returnDataType = DataTypePhoneNumber
-		} else if dt == string(DataTypeBlob) {
-			returnDataType = DataTypeBlob
-		} else if dt == string(DataTypeStringArray) {
-			returnDataType = DataTypeStringArray
-		} else if dt == string(DataTypeTextArray) {
-			returnDataType = DataTypeTextArray
-		} else if dt == string(DataTypeIntArray) {
-			returnDataType = DataTypeIntArray
-		} else if dt == string(DataTypeNumberArray) {
-			returnDataType = DataTypeNumberArray
-		} else if dt == string(DataTypeBooleanArray) {
-			returnDataType = DataTypeBooleanArray
-		} else if dt == string(DataTypeDateArray) {
-			returnDataType = DataTypeDateArray
-		}
+		returnDataType = DataType(dt)
 	} else {
 		return nil, errors_.New(ErrorNoSuchDatatype)
 	}
@@ -136,6 +106,8 @@ func IsValidValueDataType(dt string) bool {
 		string(DataTypeGeoCoordinates),
 		string(DataTypePhoneNumber),
 		string(DataTypeBlob),
+		string(DataTypeUUID),
+		string(DataTypeUUIDArray),
 		string(DataTypeStringArray),
 		string(DataTypeTextArray),
 		string(DataTypeIntArray),
@@ -165,7 +137,8 @@ func IsArrayDataType(dt []string) bool {
 	for i := range dt {
 		switch DataType(dt[i]) {
 		case DataTypeStringArray, DataTypeTextArray, DataTypeIntArray,
-			DataTypeNumberArray, DataTypeBooleanArray, DataTypeDateArray:
+			DataTypeNumberArray, DataTypeBooleanArray, DataTypeDateArray,
+			DataTypeUUIDArray:
 			return true
 		default:
 			// move to the next loop

--- a/entities/schema/backward_compat_test.go
+++ b/entities/schema/backward_compat_test.go
@@ -78,6 +78,20 @@ func TestIsArrayDataType(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "is not uuid array",
+			args: args{
+				dt: []string{"uuid"},
+			},
+			want: false,
+		},
+		{
+			name: "is uuid array",
+			args: args{
+				dt: []string{"uuid[]"},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/entities/schema/data_types.go
+++ b/entities/schema/data_types.go
@@ -53,9 +53,21 @@ const (
 	DataTypeBooleanArray DataType = "boolean[]"
 	// DataTypeDateArray The data type is a value of type date array
 	DataTypeDateArray DataType = "date[]"
+	// DataTypeUUID is a native UUID data type. It is stored in it's raw byte
+	// representation and therefore takes up less space than storing a UUID as a
+	// string
+	DataTypeUUID DataType = "uuid"
+	// DataTypeUUIDArray is the array version of DataTypeUUID
+	DataTypeUUIDArray DataType = "uuid[]"
 )
 
-var PrimitiveDataTypes []DataType = []DataType{DataTypeString, DataTypeText, DataTypeInt, DataTypeNumber, DataTypeBoolean, DataTypeDate, DataTypeGeoCoordinates, DataTypePhoneNumber, DataTypeBlob, DataTypeStringArray, DataTypeTextArray, DataTypeIntArray, DataTypeNumberArray, DataTypeBooleanArray, DataTypeDateArray}
+var PrimitiveDataTypes []DataType = []DataType{
+	DataTypeString, DataTypeText, DataTypeInt, DataTypeNumber, DataTypeBoolean,
+	DataTypeDate, DataTypeGeoCoordinates, DataTypePhoneNumber, DataTypeBlob,
+	DataTypeStringArray, DataTypeTextArray, DataTypeIntArray,
+	DataTypeNumberArray, DataTypeBooleanArray, DataTypeDateArray,
+	DataTypeUUID, DataTypeUUIDArray,
+}
 
 type PropertyKind int
 
@@ -103,6 +115,8 @@ func IsArrayType(dt DataType) (DataType, bool) {
 		return DataTypeBoolean, true
 	case DataTypeDateArray:
 		return DataTypeDate, true
+	case DataTypeUUIDArray:
+		return DataTypeUUID, true
 
 	default:
 		return "", false
@@ -187,6 +201,7 @@ func (s *Schema) FindPropertyDataTypeWithRefs(
 				string(DataTypePhoneNumber), string(DataTypeBlob),
 				string(DataTypeStringArray), string(DataTypeTextArray),
 				string(DataTypeIntArray), string(DataTypeNumberArray),
+				string(DataTypeUUIDArray), string(DataTypeUUID),
 				string(DataTypeBooleanArray), string(DataTypeDateArray):
 				return &propertyDataType{
 					kind:          PropertyKindPrimitive,

--- a/entities/schema/data_types_test.go
+++ b/entities/schema/data_types_test.go
@@ -82,6 +82,7 @@ func TestGetPropertyDataType(t *testing.T) {
 		"string", "text", "int", "number", "boolean",
 		"date", "geoCoordinates", "phoneNumber", "blob", "Ref", "invalid",
 		"string[]", "text[]", "int[]", "number[]", "boolean[]", "date[]",
+		"uuid", "uuid[]",
 	}
 	class.Properties = make([]*models.Property, len(dataTypes))
 	for i, dtString := range dataTypes {
@@ -157,6 +158,14 @@ func TestGetPropertyDataType(t *testing.T) {
 		{
 			propName:         "date[]Prop",
 			expectedDataType: ptDataType(DataTypeDateArray),
+		},
+		{
+			propName:         "uuidProp",
+			expectedDataType: ptDataType(DataTypeUUID),
+		},
+		{
+			propName:         "uuid[]Prop",
+			expectedDataType: ptDataType(DataTypeUUIDArray),
 		},
 		{
 			propName:         "RefProp",

--- a/test/acceptance/graphql_resolvers/local_get_with_filter_test.go
+++ b/test/acceptance/graphql_resolvers/local_get_with_filter_test.go
@@ -208,6 +208,49 @@ func gettingObjectsWithFilters(t *testing.T) {
 		assert.Equal(t, expected, airport)
 	})
 
+	t.Run("with uuid filters applied", func(t *testing.T) {
+		query := `
+		{
+			Get {
+				Airport(where:{
+					operator:And
+					operands: [
+						{
+							operator: GreaterThan,
+							valueString: "00000000-0000-0000-0000-000000010000",
+							path:["airportId"]
+						},
+						{
+							operator: LessThan,
+							valueString: "00000000-0000-0000-0000-000000030000",
+							path:["airportId"]
+						},
+						{
+							operator: NotEqual,
+							valueString: "00000000-0000-0000-0000-000000040000",
+							path:["airportId"]
+						}
+					]
+				}){
+					code
+					airportId
+				}
+			}
+		}
+		`
+		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
+		airports := result.Get("Get", "Airport").AsSlice()
+
+		expected := []interface{}{
+			map[string]interface{}{
+				"code":      "20000",
+				"airportId": "00000000-0000-0000-0000-000000020000",
+			},
+		}
+
+		assert.ElementsMatch(t, expected, airports)
+	})
+
 	t.Run("filtering for ref counts", func(t *testing.T) {
 		// this is the journey test for gh-1101
 

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/entities/models"
 	sch "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
@@ -269,6 +270,10 @@ func addTestSchema(t *testing.T) {
 			{
 				Name:     "inCity",
 				DataType: []string{"City"},
+			},
+			{
+				Name:     "airportId",
+				DataType: []string{"uuid"},
 			},
 		},
 	})
@@ -620,7 +625,8 @@ func addTestDataCityAirport(t *testing.T) {
 		Class: "Airport",
 		ID:    airport1,
 		Properties: map[string]interface{}{
-			"code": "10000",
+			"code":      "10000",
+			"airportId": uuid.MustParse("00000000-0000-0000-0000-000000010000").String(),
 			"phone": map[string]interface{}{
 				"input": "+311234567",
 			},
@@ -635,7 +641,8 @@ func addTestDataCityAirport(t *testing.T) {
 		Class: "Airport",
 		ID:    airport2,
 		Properties: map[string]interface{}{
-			"code": "20000",
+			"code":      "20000",
+			"airportId": uuid.MustParse("00000000-0000-0000-0000-000000020000").String(),
 			"inCity": []interface{}{
 				map[string]interface{}{
 					"beacon": crossref.NewLocalhost("City", rotterdam).String(),
@@ -647,7 +654,8 @@ func addTestDataCityAirport(t *testing.T) {
 		Class: "Airport",
 		ID:    airport3,
 		Properties: map[string]interface{}{
-			"code": "30000",
+			"code":      "30000",
+			"airportId": uuid.MustParse("00000000-0000-0000-0000-000000030000").String(),
 			"inCity": []interface{}{
 				map[string]interface{}{
 					"beacon": crossref.NewLocalhost("City", dusseldorf).String(),
@@ -659,7 +667,8 @@ func addTestDataCityAirport(t *testing.T) {
 		Class: "Airport",
 		ID:    airport4,
 		Properties: map[string]interface{}{
-			"code": "40000",
+			"code":      "40000",
+			"airportId": uuid.MustParse("00000000-0000-0000-0000-000000040000").String(),
 			"inCity": []interface{}{
 				map[string]interface{}{
 					"beacon": crossref.NewLocalhost("City", berlin).String(),
@@ -667,15 +676,6 @@ func addTestDataCityAirport(t *testing.T) {
 			},
 		},
 	})
-
-	// wait for consistency
-	assertGetObjectEventually(t, airport1)
-	assertGetObjectEventually(t, airport2)
-	assertGetObjectEventually(t, airport3)
-	assertGetObjectEventually(t, airport4)
-
-	// give cache some time to become hot
-	time.Sleep(2 * time.Second)
 }
 
 func addTestDataCompanies(t *testing.T) {

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
@@ -114,6 +115,16 @@ func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName
 		if err != nil {
 			return nil, fmt.Errorf("invalid text property '%s' on class '%s': %s", propertyName, className, err)
 		}
+	case schema.DataTypeUUID:
+		asStr, err := stringVal(pv)
+		if err != nil {
+			return nil, fmt.Errorf("invalid uuid property '%s' on class '%s': %s", propertyName, className, err)
+		}
+
+		data, err = uuid.Parse(asStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid uuid property '%s' on class '%s': %s", propertyName, className, err)
+		}
 	case schema.DataTypeInt:
 		data, err = intVal(pv)
 		if err != nil {
@@ -178,6 +189,11 @@ func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName
 		data, err = dateArrayVal(pv)
 		if err != nil {
 			return nil, fmt.Errorf("invalid date array property '%s' on class '%s': %s", propertyName, className, err)
+		}
+	case schema.DataTypeUUIDArray:
+		data, err = ParseUUIDArray(pv)
+		if err != nil {
+			return nil, fmt.Errorf("invalid uuid array property '%s' on class '%s': %s", propertyName, className, err)
 		}
 
 	default:
@@ -539,4 +555,38 @@ func dateArrayVal(val interface{}) ([]interface{}, error) {
 	}
 
 	return typed, nil
+}
+
+func ParseUUIDArray(in any) ([]uuid.UUID, error) {
+	var err error
+
+	if parsed, ok := in.([]uuid.UUID); ok {
+		return parsed, nil
+	}
+
+	asSlice, ok := in.([]any)
+	if !ok {
+		return nil, fmt.Errorf("not a slice type: %T", in)
+	}
+
+	d := make([]uuid.UUID, len(asSlice))
+	for i, elem := range asSlice {
+		asUUID, ok := elem.(uuid.UUID)
+		if ok {
+			d[i] = asUUID
+			continue
+		}
+
+		asStr, ok := elem.(string)
+		if !ok {
+			return nil, fmt.Errorf("array element neither uuid.UUID nor str, but: %T", elem)
+		}
+
+		d[i], err = uuid.Parse(asStr)
+		if err != nil {
+			return nil, fmt.Errorf("at pos %d: %w", i, err)
+		}
+	}
+
+	return d, nil
 }


### PR DESCRIPTION
### What's being changed:
* This adds `uuid` and `uuid[]` property types. When indexed in the inverted indexed, those are not indexed as string representation (36 bytes), but as a 128-bit (16 byte) number
* The filterable index is served using `RoaringSet` (i.e. roaring bitmaps)
* It is currently not possible to Aggregate `uuid` or `uuid[]` types
* It is currently not possible to sort by `uuid` or `uuid[]` types
* closes #2734 

### Usage Example
<img width="1214" alt="Screen Shot 2023-03-09 at 10 57 42 AM" src="https://user-images.githubusercontent.com/8974479/224002301-b8a8f454-da3e-4e01-838f-cb2532e80053.png">


### Implementation checklist
* [x] add type definitions
* [x] parse at ingest time
* [x] serve when retrieving objects in GraphQL and REST
* [x] index as `RoaringSet` bucket
* [x] parse filter when uuid specified as `valueString`
* [x] add e2e tests
* [x] add appropriate error message when trying to sort 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
