### PR TITLE
Cross-ref filters: Build lookup strings in bulk

### DIFF
--- a/adapters/repos/db/inverted/searcher_ref_filter.go
+++ b/adapters/repos/db/inverted/searcher_ref_filter.go
@@ -180,24 +180,6 @@ func (r *refFilterExtractor) idToPropValuePairWithValue(v []byte) (*propValuePai
 	}, nil
 }
 
-func (r *refFilterExtractor) idToPropValuePairWithClass(p classUUIDPair) (*propValuePair, error) {
-	return &propValuePair{
-		prop:         lowercaseFirstLetter(r.filter.On.Property.String()),
-		hasFrequency: false,
-		value:        []byte(crossref.New("localhost", p.class, p.id).String()),
-		operator:     filters.OperatorEqual,
-	}, nil
-}
-
-func (r *refFilterExtractor) idToPropValuePairLegacyWithoutClass(p classUUIDPair) (*propValuePair, error) {
-	return &propValuePair{
-		prop:         lowercaseFirstLetter(r.filter.On.Property.String()),
-		hasFrequency: false,
-		value:        []byte(crossref.New("localhost", "", p.id).String()),
-		operator:     filters.OperatorEqual,
-	}, nil
-}
-
 // chain multiple alternatives using an OR operator
 func (r *refFilterExtractor) chainedIDsToPropValuePair(ids []classUUIDPair) (*propValuePair, error) {
 	children, err := r.idsToPropValuePairs(ids)

--- a/entities/schema/crossref/bulk_builder.go
+++ b/entities/schema/crossref/bulk_builder.go
@@ -22,7 +22,7 @@ import (
 // considerably faster when generating 100s of thousand of beacons strings. The
 // main intended use case for this is building propValuePairs in ref-filters.
 //
-// The BulkBuilder makes some estimations for how much memory will be necesary
+// The BulkBuilder makes some estimations for how much memory will be necessary
 // based on expected input params. If those requirements get exceeded, it will
 // still be safe to use, but will fallback to allocating dynamically.
 type BulkBuilder struct {

--- a/entities/schema/crossref/bulk_builder.go
+++ b/entities/schema/crossref/bulk_builder.go
@@ -1,0 +1,98 @@
+package crossref
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/strfmt"
+)
+
+// BulkBuilder is a low-alloc tool to build many beacon strings (as []byte). It
+// is optimized to allocate just once as opposed to once per ID. This makes it
+// considerably faster when generating 100s of thousand of beacons strings. The
+// main intended use case for this is building propValuePairs in ref-filters.
+//
+// The BulkBuilder makes some estimations for how much memory will be necesary
+// based on expected input params. If those requirements get exceeded, it will
+// still be safe to use, but will fallback to allocating dynamically.
+type BulkBuilder struct {
+	buf    []byte
+	prefix []byte
+	offset int
+}
+
+func NewBulkBuilderWithEstimates(expectedCount int, exampleClassName string,
+	overheadRatio float64,
+) *BulkBuilder {
+	prefix := []byte("weaviate://localhost/")
+
+	lenOfTypicalClassName := int(float64(len(exampleClassName)) * overheadRatio)
+	predictedSize := expectedCount * (len(prefix) + 1 + lenOfTypicalClassName + 36)
+
+	bb := &BulkBuilder{
+		buf:    make([]byte, predictedSize),
+		prefix: prefix,
+	}
+
+	return bb
+}
+
+func (bb *BulkBuilder) ClassAndID(className string,
+	id strfmt.UUID,
+) ([]byte, error) {
+	requiredSpace := len(bb.prefix) + len(className) + 1 + len(id)
+	if bb.offset+requiredSpace >= len(bb.buf) {
+		return nil, fmt.Errorf("fallback not implemented yet, %d vs %d", bb.offset+requiredSpace, len(bb.buf))
+	}
+
+	// copy the start pos, we will need this at the end to know what to return to
+	// the caller
+	start := bb.offset
+
+	copy(bb.buf[bb.offset:], bb.prefix)
+	bb.offset += len(bb.prefix)
+
+	// This is a safe way, in case a class-name ever contains non-ASCII
+	// characters. If we could be 100% sure that a class is ASCII-only, we could
+	// remove this allocation and instead use the same copy-by-rune approach that
+	// we use later on for the ID.
+	classNameBuf := []byte(className)
+	copy(bb.buf[bb.offset:], classNameBuf)
+	bb.offset += len(classNameBuf)
+
+	bb.buf[bb.offset] = '/' // The separating slash between class and ID
+	bb.offset += 1
+
+	for _, runeValue := range id {
+		// We know that the UUID-string never contains non-ASCII characters. This
+		// means it safe to convert the uint32-rune into a uint8. This allows us to
+		// copy char by char without any additional allocs
+		bb.buf[bb.offset] = uint8(runeValue)
+		bb.offset += 1
+	}
+
+	return bb.buf[start:bb.offset], nil
+}
+
+func (bb *BulkBuilder) LegacyIDOnly(id strfmt.UUID) ([]byte, error) {
+	requiredSpace := len(bb.prefix) + len(id)
+	if bb.offset+requiredSpace >= len(bb.buf) {
+		return nil, fmt.Errorf("fallback not implemented yet")
+	}
+
+	// copy the start pos, we will need this at the end to know what to return to
+	// the caller
+	start := bb.offset
+
+	copy(bb.buf[bb.offset:], bb.prefix)
+	bb.offset += len(bb.prefix)
+
+	for _, runeValue := range id {
+		// We know that the UUID-string never contains non-ASCII characters. This
+		// means it safe to convert the uint32-rune into a uint8. This allows us to
+		// copy char by char without any additional allocs
+		bb.buf[bb.offset] = uint8(runeValue)
+		bb.offset += 1
+	}
+
+	return bb.buf[start:bb.offset], nil
+}

--- a/entities/schema/crossref/bulk_builder_test.go
+++ b/entities/schema/crossref/bulk_builder_test.go
@@ -1,0 +1,67 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package crossref
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBulkBuilder_EnoughPreAllocation(t *testing.T) {
+	className := "MyClass"
+	bb := NewBulkBuilderWithEstimates(25, className, 1.00)
+
+	for i := 0; i < 25; i++ {
+		id := strfmt.UUID(uuid.New().String())
+		res := bb.ClassAndID(className, id)
+		expected := []byte(fmt.Sprintf("weaviate://localhost/MyClass/%s", id))
+		assert.Equal(t, expected, res)
+	}
+}
+
+func TestBulkBuilder_NotEnoughPreAllocation(t *testing.T) {
+	className := "MyClass"
+	bb := NewBulkBuilderWithEstimates(10, className, 1.00)
+
+	for i := 0; i < 25; i++ {
+		id := strfmt.UUID(uuid.New().String())
+		res := bb.ClassAndID(className, id)
+		expected := []byte(fmt.Sprintf("weaviate://localhost/MyClass/%s", id))
+		assert.Equal(t, expected, res)
+	}
+}
+
+func TestBulkBuilder_LegacyWithoutClassName_EnoughPreAllocation(t *testing.T) {
+	bb := NewBulkBuilderWithEstimates(25, "", 1.00)
+
+	for i := 0; i < 25; i++ {
+		id := strfmt.UUID(uuid.New().String())
+		res := bb.LegacyIDOnly(id)
+		expected := []byte(fmt.Sprintf("weaviate://localhost/%s", id))
+		assert.Equal(t, expected, res)
+	}
+}
+
+func TestBulkBuilder_LegacyWithoutClassName_NotEnoughPreAllocation(t *testing.T) {
+	bb := NewBulkBuilderWithEstimates(10, "", 1.00)
+
+	for i := 0; i < 25; i++ {
+		id := strfmt.UUID(uuid.New().String())
+		res := bb.LegacyIDOnly(id)
+		expected := []byte(fmt.Sprintf("weaviate://localhost/%s", id))
+		assert.Equal(t, expected, res)
+	}
+}

--- a/entities/schema/crossref/bulk_builder_test.go
+++ b/entities/schema/crossref/bulk_builder_test.go
@@ -98,10 +98,10 @@ func TestBulkBuilder(t *testing.T) {
 				id := uuid.New().String()
 				if tt.withClassName {
 					res := bb.ClassAndID(tt.className, strfmt.UUID(id))
-					assert.Equal(t, []byte(tt.expectedFn(id)), res)
+					assert.Equal(t, tt.expectedFn(id), string(res))
 				} else {
 					res := bb.LegacyIDOnly(strfmt.UUID(id))
-					assert.Equal(t, []byte(tt.expectedFn(id)), res)
+					assert.Equal(t, tt.expectedFn(id), string(res))
 				}
 			}
 		})


### PR DESCRIPTION
### What's being changed:

* Previously a cross-ref filter that would match 100s of thousands of refs would lose a lot of time (and waste allocations) building lookup-strings for inverted index retrieval
* Now those lookup values can be generated in bulk with far fewer allocations


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
