### PR TITLE
Improve Ci and codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,0 @@
-codecov:
-    notify:
-        after_n_builds: 2

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
 codecov:
+    disable_default_path_fixes: true
     notify:
         after_n_builds: 2
+fixes:
+    - "github.com/weaviate/weaviate/::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,3 @@
 codecov:
-    disable_default_path_fixes: true
     notify:
         after_n_builds: 2
-fixes:
-    - "github.com/weaviate/weaviate/::"

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -52,14 +52,11 @@ jobs:
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
-      - name: Codecov Unit
-        if: ${{ (github.ref_type == 'branch') && (github.ref_name != 'master') }}
-        uses: codecov/codecov-action@v3
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
         with:
-          fail_ci_if_error: true
-          files: ./coverage-unit.txt
-          flags: unittests
-          verbose: true
+          name: coverage-report-unit
+          path: coverage-unit.txt
   Integration-Tests:
     runs-on: ubuntu-latest
     steps:
@@ -71,14 +68,11 @@ jobs:
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
-      - name: Codecov Integration
-        if: ${{ (github.ref_type == 'branch') && (github.ref_name != 'master') }}
-        uses: codecov/codecov-action@v3
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
         with:
-          fail_ci_if_error: true
-          files: ./coverage-integration.txt
-          flags: integration
-          verbose: true
+          name: coverage-report-integration
+          path: coverage-integration.txt
   Modules-Acceptance-Tests:
     runs-on: ubuntu-latest-8-cores
     steps:
@@ -104,6 +98,34 @@ jobs:
           WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
           WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}
         run: ./test/run.sh --acceptance-only
+  Codecov:
+    needs: [Unit-Tests, Integration-Tests]
+    runs-on: ubuntu-latest
+    if: ${{ (github.ref_type == 'branch') && (github.ref_name != 'master') }}
+    steps:
+      - name: Download coverage artifacts integration
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-report-unit
+      - name: Download coverage unit
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-report-integration
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          files: ./coverage-integration.txt
+          flags: integration
+          verbose: true
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          files: ./coverage-unit.txt
+          flags: unittests
+          verbose: true
+
   Push-Docker:
     needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]
     runs-on: ubuntu-latest-8-cores

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -42,7 +42,6 @@ jobs:
           package: ./...
           fail-on-vuln: true
   Unit-Tests:
-    needs: [Run-Swagger]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +61,6 @@ jobs:
           flags: unittests
           verbose: true
   Integration-Tests:
-    needs: [Run-Swagger]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +80,6 @@ jobs:
           flags: integration
           verbose: true
   Modules-Acceptance-Tests:
-    needs: [Run-Swagger]
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
@@ -94,7 +91,6 @@ jobs:
       - name: Acceptance tests (modules)
         run: ./test/run.sh --acceptance-module-tests-only
   Acceptance-Tests:
-    needs: [Run-Swagger]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -103,13 +99,13 @@ jobs:
         with:
           go-version: 1.19
           cache: true
-      - name: Acceptance tests (modules)
+      - name: Acceptance tests
         env:
           WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
           WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}
         run: ./test/run.sh --acceptance-only
   Push-Docker:
-    needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning]
+    needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]
     runs-on: ubuntu-latest-8-cores
     if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork
     steps:

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -112,23 +112,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage-report-integration
-      - name: Fix files
-        run: |
-          sed -i 's:github.com/weaviate/weaviate/::g' coverage-integration.txt
-          sed -i 's:github.com/weaviate/weaviate/::g' coverage-unit.txt
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
-          files: ./coverage-integration.txt
-          flags: integration
-          verbose: true
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          files: ./coverage-unit.txt
-          flags: unittests
+          files: ./coverage-integration.txt, ./coverage-unit.txt
           verbose: true
 
   Push-Docker:

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -111,6 +111,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage-report-integration
+      - name: Fix files
+        run: |
+          sed -i 's:github.com/weaviate/weaviate/::g' coverage-integration.txt
+          sed -i 's:github.com/weaviate/weaviate/::g' coverage-unit.txt
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -55,7 +55,6 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
-          name: coverage-report-unit
           path: coverage-unit.txt
   Integration-Tests:
     runs-on: ubuntu-latest
@@ -71,7 +70,6 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
-          name: coverage-report-integration
           path: coverage-integration.txt
   Modules-Acceptance-Tests:
     runs-on: ubuntu-latest-8-cores
@@ -105,12 +103,6 @@ jobs:
     steps:
       - name: Download coverage artifacts integration
         uses: actions/download-artifact@v3
-        with:
-          name: coverage-report-unit
-      - name: Download coverage unit
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage-report-integration
       - name: Fix files
         run: |
           sed -i 's:github.com/weaviate/weaviate/::g' coverage-integration.txt

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
+          name: coverage-report-unit
           path: coverage-unit.txt
   Integration-Tests:
     runs-on: ubuntu-latest
@@ -70,6 +71,7 @@ jobs:
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
+          name: coverage-report-integration
           path: coverage-integration.txt
   Modules-Acceptance-Tests:
     runs-on: ubuntu-latest-8-cores
@@ -101,8 +103,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.ref_type == 'branch') && (github.ref_name != 'master') }}
     steps:
+      - uses: actions/checkout@v3
       - name: Download coverage artifacts integration
         uses: actions/download-artifact@v3
+        with:
+          name: coverage-report-unit
+      - name: Download coverage unit
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-report-integration
       - name: Fix files
         run: |
           sed -i 's:github.com/weaviate/weaviate/::g' coverage-integration.txt


### PR DESCRIPTION
- Starts all tests immediately to save time (Some jobs were waiting on the result of swagger before)
- Move codecov into an extra job. Now the docker-image will be created, even if the codecov upload fails for whatever reason and rerunning does not rerun the complete job with tests, but only the codecov upload
