### PR TITLE
Remove obsolete warning about weaviate config file

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -269,8 +269,6 @@ func (f *WeaviateConfig) LoadConfig(flags *swag.CommandLineOptionsGroup, logger 
 	// Set default if not given
 	if configFileName == "" {
 		configFileName = DefaultConfigFile
-		logger.WithField("action", "config_load").WithField("config_file_path", DefaultConfigFile).
-			Info("no config file specified, using default or environment based")
 	}
 
 	// Read config file


### PR DESCRIPTION
### What's being changed:

removes `{"action":"config_load","config_file_path":"./weaviate.conf.json","level":"info","msg":"no config file specified, using default or environment based","time":"2023-03-14T09:31:02+01:00"}
`
