### PR TITLE
Report to log when contextionary can't be contacted

### DIFF
--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -1274,7 +1274,6 @@ func TestCRUD(t *testing.T) {
 			assert.Equal(t, expected, res)
 		})
 	})
-
 }
 
 func TestCRUD_Query(t *testing.T) {
@@ -1518,6 +1517,7 @@ func TestCRUD_Query(t *testing.T) {
 		}
 	})
 }
+
 func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 	total := 100
 	individual := total / 4

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -149,8 +149,6 @@ func searchResultsFromProto(input []*pb.SchemaSearchResult) []traverser.SearchRe
 	return output
 }
 
-
-
 func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, error) {
 	res, err := c.grpcClient.VectorForWord(ctx, &pb.Word{Word: word})
 	if err != nil {

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -42,6 +42,7 @@ func NewClient(uri string, logger logrus.FieldLogger) (*Client, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*48)))
 	if err != nil {
+
 		return nil, fmt.Errorf("couldn't connect to remote contextionary gRPC server: %s", err)
 	}
 
@@ -56,6 +57,9 @@ func NewClient(uri string, logger logrus.FieldLogger) (*Client, error) {
 func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordStopword(ctx, &pb.Word{Word: word})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return false, err
 	}
 
@@ -66,6 +70,9 @@ func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordPresent(ctx, &pb.Word{Word: word})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return false, err
 	}
 
@@ -76,6 +83,9 @@ func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 func (c *Client) SafeGetSimilarWordsWithCertainty(ctx context.Context, word string, certainty float32) ([]string, error) {
 	res, err := c.grpcClient.SafeGetSimilarWordsWithCertainty(ctx, &pb.SimilarWordsParams{Word: word, Certainty: certainty})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return nil, err
 	}
 
@@ -98,6 +108,9 @@ func (c *Client) SchemaSearch(ctx context.Context, params traverser.SearchParams
 
 	res, err := c.grpcClient.SchemaSearch(ctx, pbParams)
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Error("module uncontactable")
+		}
 		return traverser.SearchResults{}, err
 	}
 
@@ -148,6 +161,9 @@ func searchResultsFromProto(input []*pb.SchemaSearchResult) []traverser.SearchRe
 func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, error) {
 	res, err := c.grpcClient.VectorForWord(ctx, &pb.Word{Word: word})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return nil, fmt.Errorf("could not get vector from remote: %v", err)
 	}
 	v, _, _ := vectorFromProto(res)
@@ -164,6 +180,9 @@ func (c *Client) MultiVectorForWord(ctx context.Context, words []string) ([][]fl
 
 	res, err := c.grpcClient.MultiVectorForWord(ctx, &pb.WordList{Words: wordParams})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return nil, err
 	}
 
@@ -193,6 +212,9 @@ func (c *Client) MultiNearestWordsByVector(ctx context.Context, vectors [][]floa
 
 	res, err := c.grpcClient.MultiNearestWordsByVector(ctx, &pb.VectorNNParamsList{Params: searchParams})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return nil, err
 	}
 
@@ -239,6 +261,9 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 	overrides := overridesFromMap(overridesMap)
 	res, err := c.grpcClient.VectorForCorpi(ctx, &pb.Corpi{Corpi: corpi, Overrides: overrides})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		st, ok := status.FromError(err)
 		if !ok || st.Code() != codes.InvalidArgument {
 			return nil, nil, fmt.Errorf("could not get vector from remote: %v", err)
@@ -262,6 +287,9 @@ func (c *Client) NearestWordsByVector(ctx context.Context, vector []float32, n i
 		Vector: vectorToProto(vector),
 	})
 	if err != nil {
+		if strings.Contains(fmt.Sprintf("%v", err), "") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		}
 		return nil, nil, fmt.Errorf("could not get nearest words by vector: %v", err)
 	}
 

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -161,7 +161,7 @@ func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, err
 	return v, nil
 }
 
-func logConnectionRefused(logger *logrus.Logger, err error) {
+func logConnectionRefused(logger logrus.FieldLogger, err error) {
 	if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 	}

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -56,7 +56,7 @@ func NewClient(uri string, logger logrus.FieldLogger) (*Client, error) {
 func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordStopword(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return false, err
@@ -69,7 +69,7 @@ func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordPresent(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return false, err
@@ -82,7 +82,7 @@ func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 func (c *Client) SafeGetSimilarWordsWithCertainty(ctx context.Context, word string, certainty float32) ([]string, error) {
 	res, err := c.grpcClient.SafeGetSimilarWordsWithCertainty(ctx, &pb.SimilarWordsParams{Word: word, Certainty: certainty})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, err
@@ -160,7 +160,7 @@ func searchResultsFromProto(input []*pb.SchemaSearchResult) []traverser.SearchRe
 func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, error) {
 	res, err := c.grpcClient.VectorForWord(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, fmt.Errorf("could not get vector from remote: %v", err)
@@ -179,7 +179,7 @@ func (c *Client) MultiVectorForWord(ctx context.Context, words []string) ([][]fl
 
 	res, err := c.grpcClient.MultiVectorForWord(ctx, &pb.WordList{Words: wordParams})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, err
@@ -211,7 +211,7 @@ func (c *Client) MultiNearestWordsByVector(ctx context.Context, vectors [][]floa
 
 	res, err := c.grpcClient.MultiNearestWordsByVector(ctx, &pb.VectorNNParamsList{Params: searchParams})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, err
@@ -286,7 +286,7 @@ func (c *Client) NearestWordsByVector(ctx context.Context, vector []float32, n i
 		Vector: vectorToProto(vector),
 	})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, nil, fmt.Errorf("could not get nearest words by vector: %v", err)

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -107,8 +107,8 @@ func (c *Client) SchemaSearch(ctx context.Context, params traverser.SearchParams
 
 	res, err := c.grpcClient.SchemaSearch(ctx, pbParams)
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
-			c.logger.WithError(err).WithField("module", "contextionary").Error("module uncontactable")
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return traverser.SearchResults{}, err
 	}

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -260,7 +260,7 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 	overrides := overridesFromMap(overridesMap)
 	res, err := c.grpcClient.VectorForCorpi(ctx, &pb.Corpi{Corpi: corpi, Overrides: overrides})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		st, ok := status.FromError(err)

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -42,7 +42,6 @@ func NewClient(uri string, logger logrus.FieldLogger) (*Client, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*48)))
 	if err != nil {
-
 		return nil, fmt.Errorf("couldn't connect to remote contextionary gRPC server: %s", err)
 	}
 

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -56,9 +56,7 @@ func NewClient(uri string, logger logrus.FieldLogger) (*Client, error) {
 func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordStopword(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return false, err
 	}
 
@@ -69,9 +67,7 @@ func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordPresent(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return false, err
 	}
 
@@ -82,9 +78,7 @@ func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 func (c *Client) SafeGetSimilarWordsWithCertainty(ctx context.Context, word string, certainty float32) ([]string, error) {
 	res, err := c.grpcClient.SafeGetSimilarWordsWithCertainty(ctx, &pb.SimilarWordsParams{Word: word, Certainty: certainty})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return nil, err
 	}
 
@@ -107,9 +101,7 @@ func (c *Client) SchemaSearch(ctx context.Context, params traverser.SearchParams
 
 	res, err := c.grpcClient.SchemaSearch(ctx, pbParams)
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return traverser.SearchResults{}, err
 	}
 
@@ -157,16 +149,22 @@ func searchResultsFromProto(input []*pb.SchemaSearchResult) []traverser.SearchRe
 	return output
 }
 
+
+
 func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, error) {
 	res, err := c.grpcClient.VectorForWord(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return nil, fmt.Errorf("could not get vector from remote: %v", err)
 	}
 	v, _, _ := vectorFromProto(res)
 	return v, nil
+}
+
+func logConnectionRefused(logger *logrus.Logger, err error) {
+	if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
+		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+	}
 }
 
 func (c *Client) MultiVectorForWord(ctx context.Context, words []string) ([][]float32, error) {
@@ -179,9 +177,7 @@ func (c *Client) MultiVectorForWord(ctx context.Context, words []string) ([][]fl
 
 	res, err := c.grpcClient.MultiVectorForWord(ctx, &pb.WordList{Words: wordParams})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return nil, err
 	}
 
@@ -211,9 +207,7 @@ func (c *Client) MultiNearestWordsByVector(ctx context.Context, vectors [][]floa
 
 	res, err := c.grpcClient.MultiNearestWordsByVector(ctx, &pb.VectorNNParamsList{Params: searchParams})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return nil, err
 	}
 
@@ -286,9 +280,7 @@ func (c *Client) NearestWordsByVector(ctx context.Context, vector []float32, n i
 		Vector: vectorToProto(vector),
 	})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
-		}
+		logConnectionRefused(c.logger, err)
 		return nil, nil, fmt.Errorf("could not get nearest words by vector: %v", err)
 	}
 

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -260,7 +260,7 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 	overrides := overridesFromMap(overridesMap)
 	res, err := c.grpcClient.VectorForCorpi(ctx, &pb.Corpi{Corpi: corpi, Overrides: overrides})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
+		if strings.Contains(err.Error(), "connect: connection refused") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		st, ok := status.FromError(err)

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -56,7 +56,7 @@ func NewClient(uri string, logger logrus.FieldLogger) (*Client, error) {
 func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordStopword(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return false, err
@@ -69,7 +69,7 @@ func (c *Client) IsStopWord(ctx context.Context, word string) (bool, error) {
 func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 	res, err := c.grpcClient.IsWordPresent(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return false, err
@@ -82,7 +82,7 @@ func (c *Client) IsWordPresent(ctx context.Context, word string) (bool, error) {
 func (c *Client) SafeGetSimilarWordsWithCertainty(ctx context.Context, word string, certainty float32) ([]string, error) {
 	res, err := c.grpcClient.SafeGetSimilarWordsWithCertainty(ctx, &pb.SimilarWordsParams{Word: word, Certainty: certainty})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, err
@@ -160,7 +160,7 @@ func searchResultsFromProto(input []*pb.SchemaSearchResult) []traverser.SearchRe
 func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, error) {
 	res, err := c.grpcClient.VectorForWord(ctx, &pb.Word{Word: word})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, fmt.Errorf("could not get vector from remote: %v", err)
@@ -179,7 +179,7 @@ func (c *Client) MultiVectorForWord(ctx context.Context, words []string) ([][]fl
 
 	res, err := c.grpcClient.MultiVectorForWord(ctx, &pb.WordList{Words: wordParams})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, err
@@ -211,7 +211,7 @@ func (c *Client) MultiNearestWordsByVector(ctx context.Context, vectors [][]floa
 
 	res, err := c.grpcClient.MultiNearestWordsByVector(ctx, &pb.VectorNNParamsList{Params: searchParams})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, err
@@ -286,7 +286,7 @@ func (c *Client) NearestWordsByVector(ctx context.Context, vector []float32, n i
 		Vector: vectorToProto(vector),
 	})
 	if err != nil {
-		if strings.Contains(fmt.Sprintf("%v", err), "") {
+		if strings.Contains(fmt.Sprintf("%v", err), "module uncontactable") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		return nil, nil, fmt.Errorf("could not get nearest words by vector: %v", err)


### PR DESCRIPTION
### What's being changed:

Add log messages to alert admin when contextionary disappears.   At the moment, if contextionary starts failing, no errors are raised.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
