### PR TITLE
Speedup BM25 + filter

### DIFF
--- a/test/benchmark_bm25/cmd/query.go
+++ b/test/benchmark_bm25/cmd/query.go
@@ -102,7 +102,7 @@ var queryCmd = &cobra.Command{
 				return err
 			}
 			if i%1000 == 0 && i > 0 {
-				log.Printf("completed %d/%d queries. nDCG score: %v", i, len(q), scores.CurrentNDCG())
+				log.Printf("completed %d/%d queries. nDCG score: %.04f", i, len(q), scores.CurrentNDCG())
 			}
 		}
 

--- a/test/benchmark_bm25/cmd/query.go
+++ b/test/benchmark_bm25/cmd/query.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.AddCommand(queryCmd)
 	queryCmd.PersistentFlags().IntVarP(&BatchSize, "batch-size", "b", DefaultBatchSize, "number of objects in a single import batch")
 	queryCmd.PersistentFlags().IntVarP(&QueriesCount, "count", "c", DefaultQueriesCount, "run only the specified amount of queries, negative numbers mean unlimited")
-	queryCmd.PersistentFlags().BoolVarP(&FilterProperties, "filter", "f", DefaultFilterProperties, "filter results")
+	queryCmd.PersistentFlags().IntVarP(&FilterObjectPercentage, "filter", "f", DefaultFilterObjectPercentage, "The given percentage of objects are filtered out. Off by default, use <=0 to disable")
 }
 
 var queryCmd = &cobra.Command{
@@ -80,11 +80,11 @@ var queryCmd = &cobra.Command{
 			bm25Query := client.GraphQL().Get().WithClassName(lib.ClassNameFromDatasetID(ds.ID)).
 				WithLimit(100).WithBM25(bm25).WithFields(graphql.Field{Name: "_additional { id }"}, graphql.Field{Name: propNameWithId})
 
-			if FilterProperties {
+			if FilterObjectPercentage > 0 {
 				filter := filters.Where()
-				filter.WithPath([]string{"modulo_10"})
-				filter.WithOperator(filters.NotEqual)
-				filter.WithValueInt(0)
+				filter.WithPath([]string{"modulo_100"})
+				filter.WithOperator(filters.GreaterThan)
+				filter.WithValueInt(int64(FilterObjectPercentage))
 				bm25Query = bm25Query.WithWhere(filter)
 			}
 

--- a/test/benchmark_bm25/cmd/root.go
+++ b/test/benchmark_bm25/cmd/root.go
@@ -19,21 +19,21 @@ import (
 )
 
 var (
-	Origin             string
-	DatasetConfigPath  string
-	BatchSize          int
-	QueriesCount       int
-	MultiplyProperties int
-	FilterProperties   bool
+	Origin                 string
+	DatasetConfigPath      string
+	BatchSize              int
+	QueriesCount           int
+	MultiplyProperties     int
+	FilterObjectPercentage int
 )
 
 const (
-	DefaultOrigin             = "http://localhost:8080"
-	DefaultDatasetConfigPath  = "datasets.yml"
-	DefaultBatchSize          = 100
-	DefaultQueriesCount       = -1
-	DefaultMultiplyProperties = 1
-	DefaultFilterProperties   = false
+	DefaultOrigin                 = "http://localhost:8080"
+	DefaultDatasetConfigPath      = "datasets.yml"
+	DefaultBatchSize              = 100
+	DefaultQueriesCount           = -1
+	DefaultMultiplyProperties     = 1
+	DefaultFilterObjectPercentage = 0
 )
 
 var rootCmd = &cobra.Command{

--- a/test/benchmark_bm25/cmd/root.go
+++ b/test/benchmark_bm25/cmd/root.go
@@ -24,6 +24,7 @@ var (
 	BatchSize          int
 	QueriesCount       int
 	MultiplyProperties int
+	FilterProperties   bool
 )
 
 const (
@@ -32,6 +33,7 @@ const (
 	DefaultBatchSize          = 100
 	DefaultQueriesCount       = -1
 	DefaultMultiplyProperties = 1
+	DefaultFilterProperties   = false
 )
 
 var rootCmd = &cobra.Command{

--- a/test/benchmark_bm25/datasets_default.yml
+++ b/test/benchmark_bm25/datasets_default.yml
@@ -19,6 +19,18 @@ datasets:
         - _id 
     queries:
       property: text
+  - id: fiqa
+    path: ./datasets/fiqa
+    corpus:
+      indexed_properties:
+        - title
+        - text
+      unindexed_properties:
+        - _id
+    queries:
+      property: query
+      matching_results: original_matchingDocIDs
+      property_with_id: _id
   - id: quora
     path: ./datasets/quora
     corpus:

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/spf13/cobra v1.6.1
 	github.com/weaviate/weaviate v1.18.1-0.20230307173515-39ef7cc0c9ff
-	github.com/weaviate/weaviate-go-client/v4 v4.6.3-0.20230307175645-1e6af74af18b
+	github.com/weaviate/weaviate-go-client/v4 v4.6.3
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -862,8 +862,8 @@ github.com/weaviate/contextionary v1.2.0/go.mod h1:nIEM3Gq1BzTZLuY+Pl7t8hD3eR6VA
 github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d/go.mod h1:bJUcu8a/7XKOeaCWZtSjuBogUGReUiwJTyGSvcAjDzQ=
 github.com/weaviate/weaviate v1.18.1-0.20230307173515-39ef7cc0c9ff h1:r+NrRkES/Z2/towIiSbmbHsrvrBw1dUjjsNYwauW+yM=
 github.com/weaviate/weaviate v1.18.1-0.20230307173515-39ef7cc0c9ff/go.mod h1:uCOsdblsybZcY7kNCXr1B0KCBfgvwuu/yKdXP3cPvEY=
-github.com/weaviate/weaviate-go-client/v4 v4.6.3-0.20230307175645-1e6af74af18b h1:z0SYcFPr9unrTDICox+eGRrferMRcf0kGxLtjgveLrk=
-github.com/weaviate/weaviate-go-client/v4 v4.6.3-0.20230307175645-1e6af74af18b/go.mod h1:ACWAFaKt1TNlMcr42Tlb2pPPKPWvUUOSx47F/uB9Eow=
+github.com/weaviate/weaviate-go-client/v4 v4.6.3 h1:GjC3EgPgvhCxG6AZOmB03imyU3P57lzVidFDxh2ShxM=
+github.com/weaviate/weaviate-go-client/v4 v4.6.3/go.mod h1:ACWAFaKt1TNlMcr42Tlb2pPPKPWvUUOSx47F/uB9Eow=
 github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=

--- a/test/benchmark_bm25/lib/dataset_queries.go
+++ b/test/benchmark_bm25/lib/dataset_queries.go
@@ -17,9 +17,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
-type Queries []string
+type Query struct {
+	Query       string
+	MatchingIds []int
+}
+
+type Queries []Query
 
 func ParseQueries(ds Dataset, limit int) (Queries, error) {
 	p := filepath.Join(ds.Path, "queries.jsonl")
@@ -49,7 +55,37 @@ func ParseQueries(ds Dataset, limit int) (Queries, error) {
 				ds.Queries.Property, obj[ds.Queries.Property])
 		}
 
-		q = append(q, queryStr)
+		var matchingIds []int
+		if ds.Queries.MatchingResults != "" {
+			matchingIdsInterface, ok := obj[ds.Queries.MatchingResults].([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("property %s is not a []interface{}]: %T",
+					ds.Queries.MatchingResults, obj[ds.Queries.MatchingResults])
+			}
+			matchingIds = make([]int, len(matchingIdsInterface))
+			for i, val := range matchingIdsInterface {
+				// docIds can be provided as strings
+				valStr, ok := val.(string)
+				if ok {
+					valInt, err := strconv.Atoi(valStr)
+					if err != nil {
+						return nil, err
+					}
+					matchingIds[i] = valInt
+
+				} else {
+					valFloat, ok := val.(float64)
+					if !ok {
+						return nil, fmt.Errorf("matching Id %v is not a float: %v", i, matchingIdsInterface)
+					}
+					matchingIds[i] = int(valFloat)
+				}
+
+			}
+
+		}
+
+		q = append(q, Query{Query: queryStr, MatchingIds: matchingIds})
 	}
 
 	return q, nil

--- a/test/benchmark_bm25/lib/dataset_queries.go
+++ b/test/benchmark_bm25/lib/dataset_queries.go
@@ -64,7 +64,7 @@ func ParseQueries(ds Dataset, limit int) (Queries, error) {
 			}
 			matchingIds = make([]int, len(matchingIdsInterface))
 			for i, val := range matchingIdsInterface {
-				// docIds can be provided as strings
+				// docIds can be provided as strings or float arrays
 				valStr, ok := val.(string)
 				if ok {
 					valInt, err := strconv.Atoi(valStr)

--- a/test/benchmark_bm25/lib/datasets.go
+++ b/test/benchmark_bm25/lib/datasets.go
@@ -34,7 +34,9 @@ type DatasetCorpus struct {
 }
 
 type DatasetQueries struct {
-	Property string `yaml:"property"`
+	Property        string `yaml:"property"`
+	MatchingResults string `yaml:"matching_results"`
+	PropertyWithId  string `yaml:"property_with_id"`
 }
 
 func ParseDatasetConfig(filename string) (DatasetCfg, error) {


### PR DESCRIPTION
### What's being changed:
A bit smarter method of keeping track how many unique documents there are.
Note has the commits from the BM25 benchmark with filtering PR

Fiqa, first 1000queries with a filter of 10%.
Before:
```
Min:    2.660833ms
Mean:   21.10613ms
Max:   63.336667ms
p50:   19.731458ms
p90:       31.18ms
p99:   43.788458ms
```

After:
```
Min:    2.683334ms
Mean:  19.060891ms
Max:    62.70525ms
p50:   18.223333ms
p90:   27.700417ms
p99:      38.537ms
```
