### PR TITLE
Fix selection of unique replicas when scaling up classes

### DIFF
--- a/usecases/cluster/iterator.go
+++ b/usecases/cluster/iterator.go
@@ -12,7 +12,7 @@
 package cluster
 
 import (
-	"errors"
+	"fmt"
 	"math/rand"
 )
 
@@ -32,21 +32,20 @@ type HostnameSource interface {
 	AllNames() []string
 }
 
-func NewNodeIterator(source HostnameSource,
+func NewNodeIterator(nodeNames []string,
 	strategy NodeIterationStrategy,
 ) (*NodeIterator, error) {
 	if strategy != StartRandom && strategy != StartAfter {
-		return nil, errors.New("unsupported strategy")
+		return nil, fmt.Errorf("unsupported strategy: %v", strategy)
 	}
 
-	hostnames := source.AllNames()
 	startState := 0
 	if strategy == StartRandom {
-		startState = rand.Intn(len(hostnames))
+		startState = rand.Intn(len(nodeNames))
 	}
 
 	return &NodeIterator{
-		hostnames: hostnames,
+		hostnames: nodeNames,
 		state:     startState,
 	}, nil
 }

--- a/usecases/cluster/iterator_test.go
+++ b/usecases/cluster/iterator_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestNodeIteration(t *testing.T) {
-	source := fakeNodeSource{[]string{"node1", "node2", "node3", "node4"}}
+	source := []string{"node1", "node2", "node3", "node4"}
 	it, err := NewNodeIterator(source, StartRandom)
 	require.Nil(t, err)
 
@@ -38,7 +38,7 @@ func TestNodeIteration(t *testing.T) {
 }
 
 func TestNodeIterationStartAfter(t *testing.T) {
-	source := fakeNodeSource{[]string{"node1", "node2", "node3", "node4"}}
+	source := []string{"node1", "node2", "node3", "node4"}
 	it, err := NewNodeIterator(source, StartAfter)
 	it.SetStartNode("node2")
 	require.Nil(t, err)
@@ -52,12 +52,4 @@ func TestNodeIterationStartAfter(t *testing.T) {
 
 	expected := []string{"node3", "node4", "node1"}
 	assert.Equal(t, expected, found)
-}
-
-type fakeNodeSource struct {
-	hostnames []string
-}
-
-func (f fakeNodeSource) AllNames() []string {
-	return f.hostnames
 }

--- a/usecases/scaler/scaler.go
+++ b/usecases/scaler/scaler.go
@@ -100,7 +100,7 @@ func (s *Scaler) Scale(ctx context.Context, className string,
 	// make changes
 	ssBefore := s.schema.ShardingState(className)
 	if ssBefore == nil {
-		return nil, errors.Errorf("no sharding state for class %q", className)
+		return nil, fmt.Errorf("no sharding state for class %q", className)
 	}
 	if newReplFactor > prevReplFactor {
 		return s.scaleOut(ctx, className, ssBefore, updated, newReplFactor)
@@ -131,7 +131,9 @@ func (s *Scaler) scaleOut(ctx context.Context, className string, ssBefore *shard
 	// Identify all shards of the class and adjust the replicas. After this is
 	// done, the affected shards now belong to more nodes than they did before.
 	for name, shard := range ssAfter.Physical {
-		shard.AdjustReplicas(int(replFactor), s.cluster)
+		if err := shard.AdjustReplicas(int(replFactor), s.cluster); err != nil {
+			return nil, err
+		}
 		ssAfter.Physical[name] = shard
 	}
 	lDist, nodeDist := distributions(ssBefore, &ssAfter)
@@ -210,5 +212,5 @@ func (s *Scaler) LocalScaleOut(ctx context.Context,
 func (s *Scaler) scaleIn(ctx context.Context, className string,
 	updated sharding.Config,
 ) (*sharding.State, error) {
-	return nil, errors.Errorf("scaling in (reducing replica count) not supported yet")
+	return nil, errors.Errorf("scaling in not supported yet")
 }

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -142,9 +142,6 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	if err != nil {
 		return nil, err
 	}
-	if f, n := class.ReplicationConfig.Factor, int64(m.clusterState.NodeCount()); f > n {
-		return nil, fmt.Errorf("not enough replicas: found %d want %d", n, f)
-	}
 
 	shardState, err := sharding.InitState(class.Class,
 		class.ShardingConfig.(sharding.Config),

--- a/usecases/sharding/state_test.go
+++ b/usecases/sharding/state_test.go
@@ -86,11 +86,12 @@ func (f fakeNodes) LocalName() string {
 	return f.nodes[0]
 }
 
-func TestInitShardWithReplicas(t *testing.T) {
+func TestInitState(t *testing.T) {
 	type test struct {
 		nodes             []string
 		replicationFactor int
 		shards            int
+		ok                bool
 	}
 
 	// this tests asserts that nodes are assigned evenly with various
@@ -101,36 +102,48 @@ func TestInitShardWithReplicas(t *testing.T) {
 			nodes:             []string{"node1", "node2", "node3"},
 			replicationFactor: 1,
 			shards:            3,
+			ok:                true,
 		},
 		{
 			nodes:             []string{"node1", "node2", "node3"},
 			replicationFactor: 2,
 			shards:            3,
+			ok:                true,
 		},
 		{
 			nodes:             []string{"node1", "node2", "node3"},
 			replicationFactor: 3,
 			shards:            1,
+			ok:                true,
 		},
 		{
 			nodes:             []string{"node1", "node2", "node3"},
 			replicationFactor: 3,
 			shards:            3,
+			ok:                true,
 		},
 		{
 			nodes:             []string{"node1", "node2", "node3"},
 			replicationFactor: 3,
 			shards:            2,
+			ok:                true,
 		},
 		{
 			nodes:             []string{"node1", "node2", "node3", "node4", "node5", "node6"},
 			replicationFactor: 4,
 			shards:            6,
+			ok:                true,
+		},
+		{
+			nodes:             []string{"node1", "node2"},
+			replicationFactor: 4,
+			shards:            4,
+			ok:                false,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("shards=%d, rf=%d", test.shards, test.replicationFactor),
+		t.Run(fmt.Sprintf("Shards=%d_RF=%d", test.shards, test.replicationFactor),
 			func(t *testing.T) {
 				nodes := fakeNodes{test.nodes}
 				cfg, err := ParseConfig(map[string]interface{}{
@@ -140,22 +153,23 @@ func TestInitShardWithReplicas(t *testing.T) {
 				require.Nil(t, err)
 
 				state, err := InitState("my-index", cfg, nodes, int64(test.replicationFactor))
+				if !test.ok {
+					require.NotNil(t, err)
+					return
+				}
 				require.Nil(t, err)
 
 				nodeCounter := map[string]int{}
-
+				actual := 0
 				for _, shard := range state.Physical {
 					for _, node := range shard.BelongsToNodes {
 						nodeCounter[node]++
+						actual++
 					}
 				}
 
 				// assert that total no of associations is correct
 				desired := test.shards * test.replicationFactor
-				actual := 0
-				for _, count := range nodeCounter {
-					actual += count
-				}
 				assert.Equal(t, desired, actual, "correct number of node associations")
 
 				// assert that shards are hit evenly
@@ -168,47 +182,53 @@ func TestInitShardWithReplicas(t *testing.T) {
 }
 
 func TestAdjustReplicas(t *testing.T) {
-	t.Run("scaling up from 1 to 3", func(t *testing.T) {
-		nodes := fakeNodes{nodes: []string{"node1", "node2", "node3"}}
-		shard := Physical{BelongsToNodes: []string{"node1"}}
-		expected := Physical{BelongsToNodes: []string{"node1", "node2", "node3"}}
+	t.Run("1->3", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5"}}
+		shard := Physical{BelongsToNodes: []string{"N1"}}
+		expected := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
 
 		require.Nil(t, shard.AdjustReplicas(3, nodes))
 		assert.Equal(t, expected, shard)
 	})
 
-	t.Run("scaling up from 2 to 3", func(t *testing.T) {
-		nodes := fakeNodes{nodes: []string{"node1", "node2", "node3"}}
-		shard := Physical{BelongsToNodes: []string{"node2", "node3"}}
-		expected := Physical{BelongsToNodes: []string{"node2", "node3", "node1"}}
+	t.Run("2->3", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5"}}
+		shard := Physical{BelongsToNodes: []string{"N2", "N3"}}
+		expected := Physical{BelongsToNodes: []string{"N2", "N3", "N1"}}
 
 		require.Nil(t, shard.AdjustReplicas(3, nodes))
 		assert.Equal(t, expected, shard)
 	})
 
-	t.Run("scaling from 3 to 3 - no change required", func(t *testing.T) {
-		nodes := fakeNodes{nodes: []string{"node1", "node2", "node3"}}
-		shard := Physical{BelongsToNodes: []string{"node1", "node2", "node3"}}
-		expected := Physical{BelongsToNodes: []string{"node1", "node2", "node3"}}
+	t.Run("3->3", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5"}}
+		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
+		expected := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
 
 		require.Nil(t, shard.AdjustReplicas(3, nodes))
 		assert.Equal(t, expected, shard)
 	})
 
-	t.Run("scaling down from 3 to 2", func(t *testing.T) {
-		nodes := fakeNodes{nodes: []string{"node1", "node2", "node3"}}
-		shard := Physical{BelongsToNodes: []string{"node1", "node2", "node3"}}
-		expected := Physical{BelongsToNodes: []string{"node1", "node2"}}
+	t.Run("3->2", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
+		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
+		expected := Physical{BelongsToNodes: []string{"N1", "N2"}}
 
 		require.Nil(t, shard.AdjustReplicas(2, nodes))
 		assert.Equal(t, expected, shard)
 	})
 
-	t.Run("attempting to scale to a negative value", func(t *testing.T) {
-		nodes := fakeNodes{nodes: []string{"node1", "node2", "node3"}}
-		shard := Physical{BelongsToNodes: []string{"node1", "node2", "node3"}}
+	t.Run("Min", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
+		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
 
-		require.NotNil(t, shard.AdjustReplicas(-22, nodes))
+		require.NotNil(t, shard.AdjustReplicas(-1, nodes))
+	})
+	t.Run("Max", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
+		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
+
+		require.NotNil(t, shard.AdjustReplicas(4, nodes))
 	})
 }
 

--- a/usecases/sharding/state_test.go
+++ b/usecases/sharding/state_test.go
@@ -185,50 +185,47 @@ func TestAdjustReplicas(t *testing.T) {
 	t.Run("1->3", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5"}}
 		shard := Physical{BelongsToNodes: []string{"N1"}}
-		expected := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
-
 		require.Nil(t, shard.AdjustReplicas(3, nodes))
-		assert.Equal(t, expected, shard)
+		assert.ElementsMatch(t, []string{"N1", "N2", "N3"}, shard.BelongsToNodes)
 	})
 
 	t.Run("2->3", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5"}}
 		shard := Physical{BelongsToNodes: []string{"N2", "N3"}}
-		expected := Physical{BelongsToNodes: []string{"N2", "N3", "N1"}}
-
 		require.Nil(t, shard.AdjustReplicas(3, nodes))
-		assert.Equal(t, expected, shard)
+		assert.ElementsMatch(t, []string{"N1", "N2", "N3"}, shard.BelongsToNodes)
 	})
 
 	t.Run("3->3", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5"}}
 		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
-		expected := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
-
 		require.Nil(t, shard.AdjustReplicas(3, nodes))
-		assert.Equal(t, expected, shard)
+		assert.ElementsMatch(t, []string{"N1", "N2", "N3"}, shard.BelongsToNodes)
 	})
 
 	t.Run("3->2", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
 		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
-		expected := Physical{BelongsToNodes: []string{"N1", "N2"}}
-
 		require.Nil(t, shard.AdjustReplicas(2, nodes))
-		assert.Equal(t, expected, shard)
+		assert.ElementsMatch(t, []string{"N1", "N2"}, shard.BelongsToNodes)
 	})
 
 	t.Run("Min", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
 		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
-
 		require.NotNil(t, shard.AdjustReplicas(-1, nodes))
 	})
 	t.Run("Max", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
 		shard := Physical{BelongsToNodes: []string{"N1", "N2", "N3"}}
-
 		require.NotNil(t, shard.AdjustReplicas(4, nodes))
+	})
+	t.Run("Bug", func(t *testing.T) {
+		names := []string{"N1", "N2", "N3", "N4"}
+		nodes := fakeNodes{nodes: names} // bug
+		shard := Physical{BelongsToNodes: []string{"N1", "N1", "N1", "N2", "N2"}}
+		require.Nil(t, shard.AdjustReplicas(4, nodes)) // correct
+		require.ElementsMatch(t, names, shard.BelongsToNodes)
 	})
 }
 


### PR DESCRIPTION
### What's being changed:
The bug might result in same replica selected twice.
This PR makes sure that selected replicas are unique.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
