### PR TITLE
Reduce CPU usage for many-classes: Remove need for syscall in flush check, use more reasonable defaults

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -708,20 +708,10 @@ func (b *Bucket) Shutdown(ctx context.Context) error {
 
 func (b *Bucket) flushAndSwitchIfThresholdsMet(stopFunc cyclemanager.StopFunc) {
 	b.flushLock.RLock()
-
-	// to check the current size of the WAL to
-	// see if the threshold has been reached
-	stat, err := b.active.commitlog.file.Stat()
-	if err != nil {
-		b.logger.WithField("action", "lsm_wal_stat").
-			WithField("path", b.dir).
-			WithError(err).
-			Fatal("flush and switch failed")
-	}
-
+	commitLogSize := b.active.commitlog.Size()
 	memtableTooLarge := b.active.Size() >= b.memtableThreshold
-	walTooLarge := uint64(stat.Size()) >= b.walThreshold
-	dirtyButIdle := (b.active.Size() > 0 || stat.Size() > 0) &&
+	walTooLarge := uint64(commitLogSize) >= b.walThreshold
+	dirtyButIdle := (b.active.Size() > 0 || commitLogSize > 0) &&
 		b.active.IdleDuration() >= b.flushAfterIdle
 	shouldSwitch := memtableTooLarge || walTooLarge || dirtyButIdle
 

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -74,7 +74,13 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 					for i := range keys {
 						err := bucket.Put(keys[i], values[i])
 						assert.Nil(t, err)
-						time.Sleep(time.Millisecond)
+						// the pause was adjusted from 1ms to 10ms in this test as part of
+						// https://github.com/weaviate/weaviate/issues/2776 which also
+						// changed the cyclemanage's default flush interval from 100ms to
+						// 500ms. With the previous value the test was too fast. It would
+						// write all the data (and therefore cross the threshold) before
+						// the memtable could ever flush.
+						time.Sleep(10 * time.Millisecond)
 					}
 				}
 			}
@@ -210,7 +216,12 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 		})
 
 		t.Run("wait until idle threshold has passed", func(t *testing.T) {
-			time.Sleep(50 * time.Millisecond)
+			// This threshold was adjusted as part of
+			// https://github.com/weaviate/weaviate/issues/2776 because the interval
+			// to check thresholds is now 500ms (from previously 100ms). With the old
+			// sleep here, a cycle would never have run regardless of the setting.
+			// Now there's a buffer of 250ms.
+			time.Sleep(750 * time.Millisecond)
 		})
 
 		t.Run("assert no segments exist even after passing the idle threshold", func(t *testing.T) {
@@ -249,7 +260,12 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 		})
 
 		t.Run("wait until idle threshold has passed", func(t *testing.T) {
-			time.Sleep(500 * time.Millisecond)
+			// This threshold was adjusted as part of
+			// https://github.com/weaviate/weaviate/issues/2776 because the interval
+			// to check thresholds is now 500ms (from previously 100ms). With the old
+			// sleep here, a cycle would never have run regardless of the setting.
+			// Now there's a buffer of 250ms.
+			time.Sleep(750 * time.Millisecond)
 		})
 
 		t.Run("assert that a flush has occurred (and one segment exists)", func(t *testing.T) {

--- a/entities/cyclemanager/interval.go
+++ b/entities/cyclemanager/interval.go
@@ -15,5 +15,5 @@ import "time"
 
 const (
 	DefaultLSMCompactionInterval = 3 * time.Second
-	DefaultMemtableFlushInterval = 100 * time.Millisecond
+	DefaultMemtableFlushInterval = 500 * time.Millisecond
 )


### PR DESCRIPTION
### What's being changed:
* The LSM bucket commit logger now keeps track of how much it has previously written in memory, which eliminates the need for a syscall to check in the flush interval
* It also reduces the flush interval from 100ms to 500ms as we cannot see any negative UX effect from that, it was a bit too aggressive in the first place which really showed with 1,000s of classes.
* fixes #2776 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: See GH activity log
- [x] All new code is covered by tests where it is reasonable: Existing tests have been adapted
- [ ] Performance tests have been run or not necessary.
