### PR TITLE
BM25: Abort early when min score cannot be reached without exhausted terms

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -352,12 +352,11 @@ func (b *BM25Searcher) getTopKHeap(limit int, results terms, averagePropLength f
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	for {
-		results.pivot(worstDist)
-
-		id, score, ok := results.scoreNext(averagePropLength, b.config)
-		if !ok {
-			return topKHeap // nothing left to score
+		if results.completelyExhausted() || results.pivot(worstDist) {
+			return topKHeap
 		}
+
+		id, score := results.scoreNext(averagePropLength, b.config)
 
 		if topKHeap.Len() < limit || topKHeap.Top().Dist < float32(score) {
 			topKHeap.Insert(id, float32(score))
@@ -536,14 +535,27 @@ func (t *term) advanceAtLeast(minID uint64) {
 
 type terms []term
 
-func (t terms) pivot(minScore float64) {
-	minID, pivotPoint := t.findMinID(minScore)
+func (t terms) completelyExhausted() bool {
+	for i := range t {
+		if !t[i].exhausted {
+			return false
+		}
+	}
+	return true
+}
+
+func (t terms) pivot(minScore float64) bool {
+	minID, pivotPoint, abort := t.findMinID(minScore)
+	if abort {
+		return true
+	}
 	if pivotPoint == 0 {
-		return
+		return false
 	}
 
 	t.advanceAllAtLeast(minID)
 	sort.Sort(t)
+	return false
 }
 
 func (t terms) advanceAllAtLeast(minID uint64) {
@@ -552,17 +564,20 @@ func (t terms) advanceAllAtLeast(minID uint64) {
 	}
 }
 
-func (t terms) findMinID(minScore float64) (uint64, int) {
+func (t terms) findMinID(minScore float64) (uint64, int, bool) {
 	cumScore := float64(0)
 
 	for i, term := range t {
+		if term.exhausted {
+			continue
+		}
 		cumScore += term.idf
 		if cumScore >= minScore {
-			return term.idPointer, i
+			return term.idPointer, i, false
 		}
 	}
 
-	panic(fmt.Sprintf("score of %f is unreachable", minScore))
+	return 0, 0, true
 }
 
 func (t terms) findFirstNonExhausted() (int, bool) {
@@ -575,11 +590,11 @@ func (t terms) findFirstNonExhausted() (int, bool) {
 	return -1, false
 }
 
-func (t terms) scoreNext(averagePropLength float64, config schema.BM25Config) (uint64, float64, bool) {
+func (t terms) scoreNext(averagePropLength float64, config schema.BM25Config) (uint64, float64) {
 	pos, ok := t.findFirstNonExhausted()
 	if !ok {
 		// done, nothing left to score
-		return 0, 0, false
+		return 0, 0
 	}
 
 	id := t[pos].idPointer
@@ -594,7 +609,7 @@ func (t terms) scoreNext(averagePropLength float64, config schema.BM25Config) (u
 
 	sort.Sort(t) // pointer was advanced in scoreAndAdvance
 
-	return id, cumScore, true
+	return id, cumScore
 }
 
 // provide sort interface

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -362,9 +362,10 @@ func (b *BM25Searcher) getTopKHeap(limit int, results terms, averagePropLength f
 			topKHeap.Insert(id, float32(score))
 			for topKHeap.Len() > limit {
 				topKHeap.Pop()
-
-				// only update the worst distance when the queue is full, otherwise results can be missing if the first
-				// entry that is checked already has a very high score
+			}
+			// only update the worst distance when the queue is full, otherwise results can be missing if the first
+			// entry that is checked already has a very high score
+			if topKHeap.Len() >= limit {
 				worstDist = float64(topKHeap.Top().Dist)
 			}
 		}


### PR DESCRIPTION
### What's being changed:

Skip exhausted terms when calculating the approximate score. Then, WAND can be aborted when the minimum score cannot be reached anymore without the exhausted term.

with change
```
Min:    2.618417ms
Mean:   7.922193ms
Max:   31.536375ms
p50:    7.359542ms
p90:   11.975583ms
p99:    17.02675ms
```

without

```
Min:     2.62625ms
Mean:   8.270795ms
Max:   58.575958ms
p50:    7.610708ms
p90:   12.329666ms
p99:     18.1155ms
```