### PR TITLE
Fix autoschema casing

### DIFF
--- a/entities/schema/schema.go
+++ b/entities/schema/schema.go
@@ -65,3 +65,23 @@ func UpperCaseClassName(name string) string {
 
 	return strings.ToUpper(string(name[0])) + name[1:]
 }
+
+func LowerCaseAllPropertyNames(props []*models.Property) []*models.Property {
+	for i, prop := range props {
+		props[i].Name = LowerCaseFirstLetter(prop.Name)
+	}
+
+	return props
+}
+
+func LowerCaseFirstLetter(name string) string {
+	if len(name) < 1 {
+		return name
+	}
+
+	if len(name) == 1 {
+		return strings.ToLower(name)
+	}
+
+	return strings.ToLower(string(name[0])) + name[1:]
+}

--- a/entities/schema/schema.go
+++ b/entities/schema/schema.go
@@ -12,6 +12,8 @@
 package schema
 
 import (
+	"strings"
+
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -50,4 +52,16 @@ func Empty() Schema {
 // Return one of the semantic schema's
 func (s *Schema) SemanticSchemaFor() *models.Schema {
 	return s.Objects
+}
+
+func UpperCaseClassName(name string) string {
+	if len(name) < 1 {
+		return name
+	}
+
+	if len(name) == 1 {
+		return strings.ToUpper(name)
+	}
+
+	return strings.ToUpper(string(name[0])) + name[1:]
 }

--- a/entities/schema/schema.go
+++ b/entities/schema/schema.go
@@ -54,7 +54,7 @@ func (s *Schema) SemanticSchemaFor() *models.Schema {
 	return s.Objects
 }
 
-func UpperCaseClassName(name string) string {
+func UppercaseClassName(name string) string {
 	if len(name) < 1 {
 		return name
 	}
@@ -66,15 +66,15 @@ func UpperCaseClassName(name string) string {
 	return strings.ToUpper(string(name[0])) + name[1:]
 }
 
-func LowerCaseAllPropertyNames(props []*models.Property) []*models.Property {
+func LowercaseAllPropertyNames(props []*models.Property) []*models.Property {
 	for i, prop := range props {
-		props[i].Name = LowerCaseFirstLetter(prop.Name)
+		props[i].Name = LowercaseFirstLetter(prop.Name)
 	}
 
 	return props
 }
 
-func LowerCaseFirstLetter(name string) string {
+func LowercaseFirstLetter(name string) string {
 	if len(name) < 1 {
 		return name
 	}

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -1,0 +1,55 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
+)
+
+func TestAutoschemaCasingClass(t *testing.T) {
+	ctx := context.Background()
+	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
+
+	upperClassName := "RandomTestClass1234"
+	lowerClassName := "randomTestClass1234"
+
+	cases := []struct {
+		className1 string
+		className2 string
+	}{
+		{className1: upperClassName, className2: upperClassName},
+		{className1: lowerClassName, className2: lowerClassName},
+		{className1: upperClassName, className2: lowerClassName},
+		{className1: lowerClassName, className2: upperClassName},
+	}
+	for _, tt := range cases {
+		t.Run(tt.className1+" "+tt.className2, func(t *testing.T) {
+			c.Schema().ClassDeleter().WithClassName(tt.className1).Do(ctx)
+			c.Schema().ClassDeleter().WithClassName(tt.className2).Do(ctx)
+			creator := c.Data().Creator()
+			_, err := creator.WithClassName(tt.className1).Do(ctx)
+			require.Nil(t, err)
+
+			_, err = creator.WithClassName(tt.className2).Do(ctx)
+			require.Nil(t, err)
+
+			// class exists only once in Uppercase, so lowercase delete has to fail
+			require.Nil(t, c.Schema().ClassDeleter().WithClassName(upperClassName).Do(ctx))
+			require.NotNil(t, c.Schema().ClassDeleter().WithClassName(lowerClassName).Do(ctx))
+		})
+	}
+}

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -53,3 +53,39 @@ func TestAutoschemaCasingClass(t *testing.T) {
 		})
 	}
 }
+
+func TestAutoschemaCasingProps(t *testing.T) {
+	ctx := context.Background()
+	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
+
+	className := "RandomTestClass548468"
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	creator := c.Data().Creator()
+	_, err := creator.WithClassName(className).Do(ctx)
+	require.Nil(t, err)
+
+	upperPropName := "SomeProp"
+	lowerPropName := "someProp"
+	cases := []struct {
+		prop1 string
+		prop2 string
+	}{
+		{prop1: upperPropName, prop2: upperPropName},
+		{prop1: lowerPropName, prop2: lowerPropName},
+		{prop1: upperPropName, prop2: lowerPropName},
+		{prop1: lowerPropName, prop2: upperPropName},
+	}
+	for _, tt := range cases {
+		t.Run(tt.prop1+" "+tt.prop2, func(t *testing.T) {
+			creator1 := c.Data().Creator()
+			_, err := creator1.WithClassName(className).WithProperties(map[string]string{tt.prop1: "something"}).Do(ctx)
+			require.Nil(t, err)
+
+			creator2 := c.Data().Creator()
+			_, err = creator2.WithClassName(className).WithProperties(map[string]string{tt.prop2: "overwrite value"}).Do(ctx)
+			require.Nil(t, err)
+
+			require.Nil(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
+		})
+	}
+}

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -24,8 +24,8 @@ func TestAutoschemaCasingClass(t *testing.T) {
 	ctx := context.Background()
 	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
 
-	upperClassName := "RandomTestClass1234"
-	lowerClassName := "randomTestClass1234"
+	upperClassName := "RandomBlueTree"
+	lowerClassName := "randomBlueTree"
 
 	cases := []struct {
 		className1 string
@@ -58,7 +58,7 @@ func TestAutoschemaCasingProps(t *testing.T) {
 	ctx := context.Background()
 	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
 
-	className := "RandomTestClass548468"
+	className := "RandomGreenBike"
 	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 	creator := c.Data().Creator()
 	_, err := creator.WithClassName(className).Do(ctx)

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -116,7 +116,7 @@ func (m *autoSchemaManager) updateClass(ctx context.Context, principal *models.P
 	for _, prop := range properties {
 		found := false
 		for _, classProp := range existingProperties {
-			if classProp.Name == prop.Name {
+			if classProp.Name == schema.LowerCaseFirstLetter(prop.Name) {
 				found = true
 				break
 			}

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -70,7 +70,7 @@ func (m *autoSchemaManager) performAutoSchema(ctx context.Context, principal *mo
 		return fmt.Errorf(validation.ErrorMissingClass)
 	}
 
-	object.Class = schema.UpperCaseClassName(object.Class)
+	object.Class = schema.UppercaseClassName(object.Class)
 
 	schemaClass, err := m.getClass(principal, object)
 	if err != nil {
@@ -116,7 +116,7 @@ func (m *autoSchemaManager) updateClass(ctx context.Context, principal *models.P
 	for _, prop := range properties {
 		found := false
 		for _, classProp := range existingProperties {
-			if classProp.Name == schema.LowerCaseFirstLetter(prop.Name) {
+			if classProp.Name == schema.LowercaseFirstLetter(prop.Name) {
 				found = true
 				break
 			}

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -69,6 +69,9 @@ func (m *autoSchemaManager) performAutoSchema(ctx context.Context, principal *mo
 		// stop performing auto schema
 		return fmt.Errorf(validation.ErrorMissingClass)
 	}
+
+	object.Class = schema.UpperCaseClassName(object.Class)
+
 	schemaClass, err := m.getClass(principal, object)
 	if err != nil {
 		return err

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -57,6 +57,8 @@ const (
 	ErrorInvalidCRefType string = "'cref' type '%s' does not exists"
 	// ErrorNotFoundInDatabase message
 	ErrorNotFoundInDatabase string = "%s: no object with id %s found"
+	// ErrorInvalidProperties message
+	ErrorInvalidProperties string = "properties of object %v must be of type map[string]interface"
 )
 
 type Validator struct {

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -72,7 +72,7 @@ func (m *Manager) RestoreClass(ctx context.Context, d *backup.ClassDescriptor) e
 	}
 
 	class.Class = schema.UpperCaseClassName(class.Class)
-	class.Properties = lowerCaseAllPropertyNames(class.Properties)
+	class.Properties = schema.LowerCaseAllPropertyNames(class.Properties)
 	m.setClassDefaults(class)
 
 	err = m.validateCanAddClass(ctx, class, true)
@@ -120,7 +120,7 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	defer m.Unlock()
 
 	class.Class = schema.UpperCaseClassName(class.Class)
-	class.Properties = lowerCaseAllPropertyNames(class.Properties)
+	class.Properties = schema.LowerCaseAllPropertyNames(class.Properties)
 	m.setClassDefaults(class)
 
 	err := m.validateCanAddClass(ctx, class, false)
@@ -339,26 +339,6 @@ func (m *Manager) parseShardingConfig(ctx context.Context,
 	class.ShardingConfig = parsed
 
 	return nil
-}
-
-func lowerCaseAllPropertyNames(props []*models.Property) []*models.Property {
-	for i, prop := range props {
-		props[i].Name = lowerCaseFirstLetter(prop.Name)
-	}
-
-	return props
-}
-
-func lowerCaseFirstLetter(name string) string {
-	if len(name) < 1 {
-		return name
-	}
-
-	if len(name) == 1 {
-		return strings.ToLower(name)
-	}
-
-	return strings.ToLower(string(name[0])) + name[1:]
 }
 
 func setInvertedConfigDefaults(class *models.Class) {

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -71,7 +71,7 @@ func (m *Manager) RestoreClass(ctx context.Context, d *backup.ClassDescriptor) e
 		defer timer.ObserveDuration()
 	}
 
-	class.Class = upperCaseClassName(class.Class)
+	class.Class = schema.UpperCaseClassName(class.Class)
 	class.Properties = lowerCaseAllPropertyNames(class.Properties)
 	m.setClassDefaults(class)
 
@@ -119,7 +119,7 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	m.Lock()
 	defer m.Unlock()
 
-	class.Class = upperCaseClassName(class.Class)
+	class.Class = schema.UpperCaseClassName(class.Class)
 	class.Properties = lowerCaseAllPropertyNames(class.Properties)
 	m.setClassDefaults(class)
 
@@ -339,18 +339,6 @@ func (m *Manager) parseShardingConfig(ctx context.Context,
 	class.ShardingConfig = parsed
 
 	return nil
-}
-
-func upperCaseClassName(name string) string {
-	if len(name) < 1 {
-		return name
-	}
-
-	if len(name) == 1 {
-		return strings.ToUpper(name)
-	}
-
-	return strings.ToUpper(string(name[0])) + name[1:]
 }
 
 func lowerCaseAllPropertyNames(props []*models.Property) []*models.Property {

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -71,8 +71,8 @@ func (m *Manager) RestoreClass(ctx context.Context, d *backup.ClassDescriptor) e
 		defer timer.ObserveDuration()
 	}
 
-	class.Class = schema.UpperCaseClassName(class.Class)
-	class.Properties = schema.LowerCaseAllPropertyNames(class.Properties)
+	class.Class = schema.UppercaseClassName(class.Class)
+	class.Properties = schema.LowercaseAllPropertyNames(class.Properties)
 	m.setClassDefaults(class)
 
 	err = m.validateCanAddClass(ctx, class, true)
@@ -119,8 +119,8 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	m.Lock()
 	defer m.Unlock()
 
-	class.Class = schema.UpperCaseClassName(class.Class)
-	class.Properties = schema.LowerCaseAllPropertyNames(class.Properties)
+	class.Class = schema.UppercaseClassName(class.Class)
+	class.Properties = schema.LowercaseAllPropertyNames(class.Properties)
 	m.setClassDefaults(class)
 
 	err := m.validateCanAddClass(ctx, class, false)

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -44,7 +44,7 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	prop.Name = lowerCaseFirstLetter(prop.Name)
+	prop.Name = schema.LowerCaseFirstLetter(prop.Name)
 
 	if err := m.setNewPropDefaults(class, prop); err != nil {
 		return err

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -44,7 +44,7 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	prop.Name = schema.LowerCaseFirstLetter(prop.Name)
+	prop.Name = schema.LowercaseFirstLetter(prop.Name)
 
 	if err := m.setNewPropDefaults(class, prop); err != nil {
 		return err

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -229,7 +229,7 @@ func (m *Manager) updateClass(ctx context.Context, className string,
 
 	if class.Class != className {
 		// the name in the URI and body don't match, so we assume the user wants to rename
-		n := upperCaseClassName(class.Class)
+		n := schema.UpperCaseClassName(class.Class)
 		newName = &n
 	}
 

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -229,7 +229,7 @@ func (m *Manager) updateClass(ctx context.Context, className string,
 
 	if class.Class != className {
 		// the name in the URI and body don't match, so we assume the user wants to rename
-		n := schema.UpperCaseClassName(class.Class)
+		n := schema.UppercaseClassName(class.Class)
 		newName = &n
 	}
 


### PR DESCRIPTION
### What's being changed:

Closes https://github.com/weaviate/weaviate/issues/2720

Class and property names are now treated equally no matter how the first letter is cased, eg "Class" == "class". Some parts of the code already did this before, but autoschema was left out.

### Review checklist
- [x] All new code is covered by tests where it is reasonable.

