### PR TITLE
[docs:update] refs to vec search engine to vec db

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Weaviate is an **open source ​vector search engine** that is robust, scalable, cloud-native, and fast. 
+Weaviate is an **open source ​vector database** that is robust, scalable, cloud-native, and fast.
 
 If you just want to get started, great! Try:
 - the [quickstart tutorial](https://weaviate.io/developers/weaviate/quickstart) if you are looking to use Weaviate, or
@@ -31,23 +31,23 @@ Weaviate typically performs a 10-NN neighbor search out of millions of objects i
 
 ### Flexibility
 
-You can use Weaviate to conveniently **vectorize your data at import time**, or alternatively you can **upload your own vectors**. 
+You can use Weaviate to conveniently **vectorize your data at import time**, or alternatively you can **upload your own vectors**.
 
 These vectorization options are enabled by Weaviate modules. Modules enable use of popular services and model hubs such as [OpenAI](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai), [Cohere](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere) or [HuggingFace](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface) and much more, including use of local and custom models.
 
 ### Production-readiness
 
-Weaviate is designed to take you from **rapid prototyping** all the way to **production at scale**. 
+Weaviate is designed to take you from **rapid prototyping** all the way to **production at scale**.
 
-To this end, Weaviate is built with [scaling](https://weaviate.io/developers/weaviate/concepts/cluster), [replication](https://weaviate.io/developers/weaviate/concepts/replication-architecture), and [security](https://weaviate.io/developers/weaviate/configuration/authentication) in mind, among others. 
+To this end, Weaviate is built with [scaling](https://weaviate.io/developers/weaviate/concepts/cluster), [replication](https://weaviate.io/developers/weaviate/concepts/replication-architecture), and [security](https://weaviate.io/developers/weaviate/configuration/authentication) in mind, among others.
 
 ### Beyond search
 
-Weaviate is a search engine that is capable of much more. Some of its other superpowers include **recommendation**, **summarization**, and **integrations with neural search frameworks**.
+Weaviate powers lightning-fast vector searches, but it is capable of much more. Some of its other superpowers include **recommendation**, **summarization**, and **integrations with neural search frameworks**.
 
 ## What can you build with Weaviate?
 
-For starters, you can build vector search engines with text, images, or a combination of both. 
+For starters, you can build vector databases with text, images, or a combination of both.
 
 You can also build question and answer extraction, summarization and classification systems.
 
@@ -59,9 +59,9 @@ You can find [code examples here](https://github.com/weaviate/weaviate-examples)
 
 ## Weaviate content
 
-Speaking of content - we love connecting with our community through these. We love helping amazing people build cool things with Weaviate, and we love getting to know them as well as talking to them about their passions. 
+Speaking of content - we love connecting with our community through these. We love helping amazing people build cool things with Weaviate, and we love getting to know them as well as talking to them about their passions.
 
-To this end, our team does an amazing job with our [blog](https://weaviate.io/blog) and [podcast](https://weaviate.io/podcast). 
+To this end, our team does an amazing job with our [blog](https://weaviate.io/blog) and [podcast](https://weaviate.io/podcast).
 
 Some of our past favorites include:
 
@@ -84,7 +84,7 @@ Both our [📝 blogs](https://weaviate.io/blog) and [🎙️ podcasts](https://w
 Also, we invite you to join our [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) community. There, you can meet other Weaviate users and members of the Weaviate team to talk all things Weaviate and AI (and other topics!).
 
 You can also say hi to us below:
-- [Twitter](https://twitter.com/weaviate_io) 
+- [Twitter](https://twitter.com/weaviate_io)
 - [LinkedIn](https://www.linkedin.com/company/weaviate-io)
 
 Or connect to us via:
@@ -95,7 +95,7 @@ Or connect to us via:
 
 ## Weaviate helps ...
 
-1. **Software Engineers** ([docs](https://weaviate.io/developers/weaviate/current/)) - Who use Weaviate as an ML-first database for your applications. 
+1. **Software Engineers** ([docs](https://weaviate.io/developers/weaviate/current/)) - Who use Weaviate as an ML-first database for your applications.
     * Out-of-the-box modules for: NLP/semantic search, automatic classification and image similarity search.
     * Easy to integrate into your current architecture, with full CRUD support like you're used to from other OSS databases.
     * Cloud-native, distributed, runs well on Kubernetes and scales with your workloads.

--- a/adapters/handlers/rest/doc.go
+++ b/adapters/handlers/rest/doc.go
@@ -13,7 +13,7 @@
 
 // Package rest Weaviate
 //
-//	Cloud-native, modular vector search engine
+//	Cloud-native, modular vector database
 //	Schemes:
 //	  https
 //	Host: localhost

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -41,7 +41,7 @@ func init() {
   ],
   "swagger": "2.0",
   "info": {
-    "description": "Cloud-native, modular vector search engine",
+    "description": "Cloud-native, modular vector database",
     "title": "Weaviate",
     "contact": {
       "name": "Weaviate",
@@ -4323,7 +4323,7 @@ func init() {
   ],
   "swagger": "2.0",
   "info": {
-    "description": "Cloud-native, modular vector search engine",
+    "description": "Cloud-native, modular vector database",
     "title": "Weaviate",
     "contact": {
       "name": "Weaviate",

--- a/adapters/handlers/rest/operations/weaviate_api.go
+++ b/adapters/handlers/rest/operations/weaviate_api.go
@@ -207,7 +207,7 @@ func NewWeaviateAPI(spec *loads.Document) *WeaviateAPI {
 	}
 }
 
-/*WeaviateAPI Cloud-native, modular vector databases */
+/*WeaviateAPI Cloud-native, modular vector database */
 type WeaviateAPI struct {
 	spec            *loads.Document
 	context         *middleware.Context

--- a/adapters/handlers/rest/operations/weaviate_api.go
+++ b/adapters/handlers/rest/operations/weaviate_api.go
@@ -207,7 +207,7 @@ func NewWeaviateAPI(spec *loads.Document) *WeaviateAPI {
 	}
 }
 
-/*WeaviateAPI Cloud-native, modular vector search engine */
+/*WeaviateAPI Cloud-native, modular vector databases */
 type WeaviateAPI struct {
 	spec            *loads.Document
 	context         *middleware.Context

--- a/cmd/weaviate-server/main.go
+++ b/cmd/weaviate-server/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	parser := flags.NewParser(server, flags.Default)
 	parser.ShortDescription = "Weaviate"
-	parser.LongDescription = "Cloud-native, modular vector search engine"
+	parser.LongDescription = "Cloud-native, modular vector database"
 	server.ConfigureFlags()
 	for _, optsGroup := range api.CommandLineOptionsGroups {
 		_, err := parser.AddGroup(optsGroup.ShortDescription, optsGroup.LongDescription, optsGroup.Options)

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1620,7 +1620,7 @@
       "name": "Weaviate",
       "url": "https://github.com/weaviate"
     },
-    "description": "Cloud-native, modular vector search engine",
+    "description": "Cloud-native, modular vector database",
     "title": "Weaviate",
     "version": "1.19.0-prealpha"
   },


### PR DESCRIPTION
### What's being changed:

Doc changes only: Change references to vector search engine to vector database.
