### PR TITLE
Assign shards and replicas to new classes based on the amount of free disk space

### DIFF
--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -130,6 +130,10 @@ func (f *fakeClusterState) AllNames() []string {
 	return f.hosts
 }
 
+func (f *fakeClusterState) Candidates() []string {
+	return f.hosts
+}
+
 func (f *fakeClusterState) LocalName() string {
 	return f.hosts[0]
 }

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -397,7 +397,7 @@ func startupRoutine(ctx context.Context) *state.State {
 	logger.WithField("action", "startup").WithField("startup_time_left", timeTillDeadline(ctx)).
 		Debug("initialized schema")
 
-	clusterState, err := cluster.Init(serverConfig.Config.Cluster, logger)
+	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Persistence.DataPath, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).
 			Error("could not init cluster state")

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -121,7 +121,7 @@ type fakeNodes struct {
 	nodes []string
 }
 
-func (f fakeNodes) AllNames() []string {
+func (f fakeNodes) Candidates() []string {
 	return f.nodes
 }
 
@@ -171,6 +171,10 @@ type nodeResolver struct {
 
 func (r nodeResolver) AllNames() []string {
 	panic("node resolving not implemented yet")
+}
+
+func (r nodeResolver) Candidates() []string {
+	return nil
 }
 
 func (r nodeResolver) LocalName() string {

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -114,7 +114,7 @@ type fakeNodes struct {
 	nodes []string
 }
 
-func (f fakeNodes) AllNames() []string {
+func (f fakeNodes) Candidates() []string {
 	return f.nodes
 }
 

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -326,7 +326,7 @@ type fakeNodes struct {
 	nodes []string
 }
 
-func (f fakeNodes) AllNames() []string {
+func (f fakeNodes) Candidates() []string {
 	return f.nodes
 }
 

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -1,0 +1,247 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hashicorp/memberlist"
+)
+
+// _OpCode represents the type of supported operation
+type _OpCode uint8
+
+const (
+	// _ProtoVersion internal protocol version for exchanging messages
+	_ProtoVersion uint8 = 1
+	// _OpCodeDisk operation code for getting disk space
+	_OpCodeDisk _OpCode = 1
+	// _ProtoTTL used to decide when to update the cache
+	_ProtoTTL = time.Second * 20
+)
+
+// spaceMsg is used to notify other nodes about current disk usage
+type spaceMsg struct {
+	header
+	DiskUsage
+	Node string // node space
+}
+
+// header of an operation
+type header struct {
+	// OpCode operation code
+	OpCode _OpCode
+	// ProtoVersion protocol we will speak
+	ProtoVersion uint8
+}
+
+// DiskUsage contains total and available space in B
+type DiskUsage struct {
+	// Total disk space
+	Total uint64
+	// Total available space
+	Available uint64
+}
+
+// NodeInfo disk space
+type NodeInfo struct {
+	DiskUsage
+	LastTimeMilli int64 // last update time in milli seconds
+}
+
+func (d *spaceMsg) marshal() (data []byte, err error) {
+	buf := bytes.NewBuffer(make([]byte, 0, 20+len(d.Node)))
+	if err := binary.Write(buf, binary.BigEndian, d.header); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, d.DiskUsage); err != nil {
+		return nil, err
+	}
+	_, err = buf.Write([]byte(d.Node))
+	return buf.Bytes(), err
+}
+
+func (d *spaceMsg) unmarshal(data []byte) error {
+	rd := bytes.NewReader(data)
+	if err := binary.Read(rd, binary.BigEndian, &d.header); err != nil {
+		return err
+	}
+	if err := binary.Read(rd, binary.BigEndian, &d.DiskUsage); err != nil {
+		return err
+	}
+	d.Node = string(data[len(data)-rd.Len():])
+	return nil
+}
+
+// delegate implements the memberList delegate interface
+type delegate struct {
+	Name     string
+	dataPath string
+	sync.Mutex
+	diskUsage func(path string) (DiskUsage, error)
+	Cache     map[string]NodeInfo
+}
+
+// init must be called first to initialize the cache
+func (d *delegate) init() error {
+	d.Cache = make(map[string]NodeInfo, 32)
+	d.diskUsage = diskSpace
+	space, err := diskSpace(d.dataPath)
+	if err != nil {
+		return fmt.Errorf("disk_space: %w", err)
+	}
+
+	d.set(d.Name, NodeInfo{space, time.Now().UnixMilli()}) // cache
+	return nil
+}
+
+// NodeMeta is used to retrieve meta-data about the current node
+// when broadcasting an alive message. It's length is limited to
+// the given byte size. This metadata is available in the Node structure.
+func (d *delegate) NodeMeta(limit int) (meta []byte) {
+	return nil
+}
+
+// LocalState is used for a TCP Push/Pull. This is sent to
+// the remote side in addition to the membership information. Any
+// data can be sent here. See MergeRemoteState as well. The `join`
+// boolean indicates this is for a join instead of a push/pull.
+func (d *delegate) LocalState(join bool) []byte {
+	prv, _ := d.get(d.Name) // value from cache
+	var (
+		info NodeInfo = prv
+		err  error
+	)
+	// renew cached value if ttl expires
+	if prv.Available == 0 || time.Since(time.UnixMilli(prv.LastTimeMilli)) >= _ProtoTTL {
+		info.DiskUsage, err = d.diskUsage(d.dataPath)
+		if err != nil {
+			return nil
+		}
+		info.LastTimeMilli = time.Now().UnixMilli()
+	}
+
+	if prv.LastTimeMilli != info.LastTimeMilli {
+		d.set(d.Name, info) // cache new value
+	}
+
+	x := spaceMsg{
+		header{OpCode: _OpCodeDisk, ProtoVersion: _ProtoVersion},
+		info.DiskUsage,
+		d.Name,
+	}
+	bytes, err := x.marshal()
+	if err != nil {
+		return nil
+	}
+	return bytes
+}
+
+// MergeRemoteState is invoked after a TCP Push/Pull. This is the
+// state received from the remote side and is the result of the
+// remote side's LocalState call. The 'join'
+// boolean indicates this is for a join instead of a push/pull.
+func (d *delegate) MergeRemoteState(data []byte, join bool) {
+	var x spaceMsg
+	if err := x.unmarshal(data); err != nil || x.Node == "" {
+		return
+	}
+	info := NodeInfo{x.DiskUsage, time.Now().UnixMilli()}
+	d.set(x.Node, info)
+}
+
+func (d *delegate) NotifyMsg(data []byte) {}
+
+func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
+	return nil
+}
+
+// get returns info about about a specific node in the cluster
+func (d *delegate) get(node string) (NodeInfo, bool) {
+	d.Lock()
+	defer d.Unlock()
+	x, ok := d.Cache[node]
+	return x, ok
+}
+
+func (d *delegate) set(node string, x NodeInfo) {
+	d.Lock()
+	defer d.Unlock()
+	d.Cache[node] = x
+}
+
+// delete key from the cache
+func (d *delegate) delete(node string) {
+	d.Lock()
+	defer d.Unlock()
+	delete(d.Cache, node)
+}
+
+// sortCandidates by the amount of free space in descending order
+//
+// Two nodes are considered equivalent if the difference between their
+// free spaces is less than 4KB.
+// The free space is just an rough estimate of the actual amount.
+// The Lower bound 4KB helps to mitigate the risk of selecting same set of nodes
+// when selections happens concurrently on different initiator nodes.
+func (d *delegate) sortCandidates(names []string) []string {
+	d.Lock()
+	defer d.Unlock()
+	m := d.Cache
+	sort.Slice(names, func(i, j int) bool {
+		return (m[names[j]].Available >> 12) < (m[names[i]].Available >> 12)
+	})
+	return names
+}
+
+// events implement memberlist.EventDelegate interface
+// EventDelegate is a simpler delegate that is used only to receive
+// notifications about members joining and leaving. The methods in this
+// delegate may be called by multiple goroutines, but never concurrently.
+// This allows you to reason about ordering.
+type events struct {
+	d *delegate
+}
+
+// NotifyJoin is invoked when a node is detected to have joined.
+// The Node argument must not be modified.
+func (e events) NotifyJoin(*memberlist.Node) {}
+
+// NotifyLeave is invoked when a node is detected to have left.
+// The Node argument must not be modified.
+func (e events) NotifyLeave(node *memberlist.Node) {
+	e.d.delete(node.Name)
+}
+
+// NotifyUpdate is invoked when a node is detected to have
+// updated, usually involving the meta data. The Node argument
+// must not be modified.
+func (e events) NotifyUpdate(*memberlist.Node) {}
+
+// diskSpace return the disk space usage
+func diskSpace(path string) (DiskUsage, error) {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return DiskUsage{}, err
+	}
+	return DiskUsage{
+		Total:     fs.Blocks * uint64(fs.Bsize),
+		Available: fs.Bavail * uint64(fs.Bsize),
+	}, nil
+}

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -32,7 +32,7 @@ const (
 	// _OpCodeDisk operation code for getting disk space
 	_OpCodeDisk _OpCode = 1
 	// _ProtoTTL used to decide when to update the cache
-	_ProtoTTL = time.Second * 20
+	_ProtoTTL = time.Second * 3
 )
 
 // spaceMsg is used to notify other nodes about current disk usage

--- a/usecases/cluster/delegate_test.go
+++ b/usecases/cluster/delegate_test.go
@@ -1,0 +1,188 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/memberlist"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiskSpace(t *testing.T) {
+	for _, name := range []string{"", "host-12:1", "2", "00", "-jhd"} {
+		want := spaceMsg{
+			header{
+				ProtoVersion: uint8(1),
+				OpCode:       _OpCode(2),
+			},
+			DiskUsage{
+				Total:     256,
+				Available: 3,
+			},
+			name,
+		}
+		bytes, err := want.marshal()
+		assert.Nil(t, err)
+		got := spaceMsg{}
+		err = got.unmarshal(bytes)
+		assert.Nil(t, err)
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestDelegateGetSet(t *testing.T) {
+	now := time.Now().UnixMilli() - 1
+	st := State{
+		delegate: delegate{
+			Name:     "ABC",
+			dataPath: ".",
+			Cache:    make(map[string]NodeInfo, 32),
+		},
+	}
+	st.delegate.NotifyMsg(nil)
+	st.delegate.GetBroadcasts(0, 0)
+	st.delegate.NodeMeta(0)
+	spaces := make([]spaceMsg, 32)
+	for i := range spaces {
+		spaces[i] = spaceMsg{
+			Node: fmt.Sprintf("N-%d", i+1),
+			DiskUsage: DiskUsage{
+				uint64(i + 1),
+				uint64(i),
+			},
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for _, x := range spaces {
+			bytes, _ := x.marshal()
+			st.delegate.MergeRemoteState(bytes, false)
+		}
+		done <- struct{}{}
+	}()
+
+	_, ok := st.delegate.get("X")
+	assert.False(t, ok)
+
+	for _, x := range spaces {
+		space, ok := st.NodeInfo(x.Node)
+		if ok {
+			assert.Equal(t, x.DiskUsage, space)
+		}
+	}
+	<-done
+	for _, x := range spaces {
+		info, ok := st.NodeInfo(x.Node)
+		assert.Greater(t, info.LastTimeMilli, now)
+		want := NodeInfo{x.DiskUsage, info.LastTimeMilli}
+		assert.Equal(t, want, info)
+		assert.True(t, ok)
+		st.delegate.delete(x.Node)
+
+	}
+	assert.Empty(t, st.delegate.Cache)
+	st.delegate.init()
+	assert.Equal(t, 1, len(st.delegate.Cache))
+
+	st.delegate.MergeRemoteState(st.delegate.LocalState(false), false)
+	space, ok := st.NodeInfo(st.delegate.Name)
+	assert.True(t, ok)
+	assert.Greater(t, space.Total, space.Available)
+}
+
+func TestDelegateSort(t *testing.T) {
+	now := time.Now().UnixMilli()
+	GB := uint64(1) << 30
+	delegate := delegate{
+		Name:     "ABC",
+		dataPath: ".",
+		Cache:    make(map[string]NodeInfo, 32),
+	}
+
+	delegate.set("N1", NodeInfo{DiskUsage{Available: GB}, now})
+	delegate.set("N2", NodeInfo{DiskUsage{Available: 3 * GB}, now})
+	delegate.set("N3", NodeInfo{DiskUsage{Available: 2 * GB}, now})
+	delegate.set("N4", NodeInfo{DiskUsage{Available: 4 * GB}, now})
+	got := delegate.sortCandidates([]string{"N1", "N0", "N2", "N4", "N3"})
+	assert.Equal(t, []string{"N4", "N2", "N3", "N1", "N0"}, got)
+
+	delegate.set("N1", NodeInfo{DiskUsage{Available: GB - 10}, now})
+	// insert equivalent nodes "N2" and "N3"
+	delegate.set("N2", NodeInfo{DiskUsage{Available: GB + 128}, now})
+	delegate.set("N3", NodeInfo{DiskUsage{Available: GB + 512}, now})
+	// one block more
+	delegate.set("N4", NodeInfo{DiskUsage{Available: GB + 4096}, now})
+	got = delegate.sortCandidates([]string{"N1", "N0", "N2", "N3", "N4"})
+	if got[1] == "N2" {
+		assert.Equal(t, []string{"N4", "N2", "N3", "N1", "N0"}, got)
+	} else {
+		assert.Equal(t, []string{"N4", "N3", "N2", "N1", "N0"}, got)
+	}
+}
+
+func TestDelegateCleanUp(t *testing.T) {
+	st := State{
+		delegate: delegate{
+			Name:     "N0",
+			dataPath: ".",
+		},
+	}
+	st.delegate.init()
+	_, ok := st.delegate.get("N0")
+	assert.True(t, ok, "N0 must exist")
+	st.delegate.set("N1", NodeInfo{LastTimeMilli: 1})
+	st.delegate.set("N2", NodeInfo{LastTimeMilli: 2})
+	handler := events{&st.delegate}
+	handler.NotifyJoin(nil)
+	handler.NotifyUpdate(nil)
+	handler.NotifyLeave(&memberlist.Node{Name: "N0"})
+	handler.NotifyLeave(&memberlist.Node{Name: "N1"})
+	handler.NotifyLeave(&memberlist.Node{Name: "N2"})
+	assert.Empty(t, st.delegate.Cache)
+}
+
+func TestDelegateLocalState(t *testing.T) {
+	now := time.Now().UnixMilli() - 1
+	errAny := errors.New("any error")
+	d := delegate{
+		Name:      "N0",
+		dataPath:  ".",
+		Cache:     map[string]NodeInfo{},
+		diskUsage: func(path string) (DiskUsage, error) { return DiskUsage{}, errAny },
+	}
+	// error reading disk space
+	d.LocalState(true)
+	assert.Empty(t, d.Cache)
+	d.diskUsage = func(path string) (DiskUsage, error) { return DiskUsage{5, 1}, nil }
+
+	// successful case
+	d.LocalState(true)
+	got, ok := d.get("N0")
+	assert.True(t, ok)
+	assert.Greater(t, got.LastTimeMilli, now)
+	assert.Equal(t, DiskUsage{5, 1}, got.DiskUsage)
+
+	// renew cache
+	got.LastTimeMilli = got.LastTimeMilli - _ProtoTTL.Milliseconds()
+	d.Cache["N0"] = got
+	d.diskUsage = func(path string) (DiskUsage, error) { return DiskUsage{6, 2}, nil }
+	d.LocalState(true)
+	got, ok = d.get("N0")
+	assert.True(t, ok)
+	assert.Greater(t, got.LastTimeMilli, now)
+	assert.Equal(t, DiskUsage{6, 2}, got.DiskUsage)
+}

--- a/usecases/cluster/delegate_test.go
+++ b/usecases/cluster/delegate_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/memberlist"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,9 +159,11 @@ func TestDelegateCleanUp(t *testing.T) {
 func TestDelegateLocalState(t *testing.T) {
 	now := time.Now().UnixMilli() - 1
 	errAny := errors.New("any error")
+	logger, _ := test.NewNullLogger()
 	d := delegate{
 		Name:      "N0",
 		dataPath:  ".",
+		log:       logger,
 		Cache:     map[string]NodeInfo{},
 		diskUsage: func(path string) (DiskUsage, error) { return DiskUsage{}, errAny },
 	}

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -38,10 +38,13 @@ type Config struct {
 func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *State, err error) {
 	cfg := memberlist.DefaultLANConfig()
 	cfg.LogOutput = newLogParser(logger)
+	if userConfig.Hostname != "" {
+		cfg.Name = userConfig.Hostname
+	}
 	state := State{
 		config: userConfig,
 		delegate: delegate{
-			Name:     userConfig.Hostname,
+			Name:     cfg.Name,
 			dataPath: dataPath,
 		},
 	}
@@ -50,10 +53,6 @@ func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *Sta
 	}
 	cfg.Delegate = &state.delegate
 	cfg.Events = events{&state.delegate}
-	if userConfig.Hostname != "" {
-		cfg.Name = userConfig.Hostname
-	}
-
 	if userConfig.GossipBindPort != 0 {
 		cfg.BindPort = userConfig.GossipBindPort
 	}

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -22,8 +22,9 @@ import (
 )
 
 type State struct {
-	config Config
-	list   *memberlist.Memberlist
+	config   Config
+	list     *memberlist.Memberlist
+	delegate delegate
 }
 
 type Config struct {
@@ -34,10 +35,21 @@ type Config struct {
 	IgnoreStartupSchemaSync bool   `json:"ignoreStartupSchemaSync" yaml:"ignoreStartupSchemaSync"`
 }
 
-func Init(userConfig Config, logger logrus.FieldLogger) (*State, error) {
+func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *State, err error) {
 	cfg := memberlist.DefaultLANConfig()
 	cfg.LogOutput = newLogParser(logger)
-
+	state := State{
+		config: userConfig,
+		delegate: delegate{
+			Name:     userConfig.Hostname,
+			dataPath: dataPath,
+		},
+	}
+	if err := state.delegate.init(); err != nil {
+		logger.WithField("action", "init_state.delete_init").Error(err)
+	}
+	cfg.Delegate = &state.delegate
+	cfg.Events = events{&state.delegate}
 	if userConfig.Hostname != "" {
 		cfg.Name = userConfig.Hostname
 	}
@@ -46,8 +58,7 @@ func Init(userConfig Config, logger logrus.FieldLogger) (*State, error) {
 		cfg.BindPort = userConfig.GossipBindPort
 	}
 
-	list, err := memberlist.Create(cfg)
-	if err != nil {
+	if state.list, err = memberlist.Create(cfg); err != nil {
 		logger.WithField("action", "memberlist_init").
 			WithField("hostname", userConfig.Hostname).
 			WithField("bind_port", userConfig.GossipBindPort).
@@ -71,7 +82,7 @@ func Init(userConfig Config, logger logrus.FieldLogger) (*State, error) {
 				Warn("specified hostname to join cluster cannot be resolved. This is fine" +
 					"if this is the first node of a new cluster, but problematic otherwise.")
 		} else {
-			_, err := list.Join(joinAddr)
+			_, err := state.list.Join(joinAddr)
 			if err != nil {
 				logger.WithField("action", "memberlist_init").
 					WithField("remote_hostname", joinAddr).
@@ -81,8 +92,7 @@ func Init(userConfig Config, logger logrus.FieldLogger) (*State, error) {
 			}
 		}
 	}
-
-	return &State{list: list, config: userConfig}, nil
+	return &state, nil
 }
 
 // Hostnames for all live members, except self. Use AllHostnames to include
@@ -131,6 +141,12 @@ func (s *State) AllNames() []string {
 	return out
 }
 
+// Candidates returns list of nodes (names) sorted by the
+// free amount of disk space in descending order
+func (s *State) Candidates() []string {
+	return s.delegate.sortCandidates(s.AllNames())
+}
+
 // All node names (not their hostnames!) for live members, including self.
 func (s *State) NodeCount() int {
 	return s.list.NumMembers()
@@ -158,4 +174,8 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 
 func (s *State) SchemaSyncIgnored() bool {
 	return s.config.IgnoreStartupSchemaSync
+}
+
+func (s *State) NodeInfo(node string) (NodeInfo, bool) {
+	return s.delegate.get(node)
 }

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -46,6 +46,7 @@ func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *Sta
 		delegate: delegate{
 			Name:     cfg.Name,
 			dataPath: dataPath,
+			log:      logger,
 		},
 	}
 	if err := state.delegate.init(); err != nil {

--- a/usecases/scaler/mocks_test.go
+++ b/usecases/scaler/mocks_test.go
@@ -121,7 +121,7 @@ func (r *fakeNodeResolver) NodeHostname(nodeName string) (string, bool) {
 	return host, ok
 }
 
-func (r *fakeNodeResolver) AllNames() []string {
+func (r *fakeNodeResolver) Candidates() []string {
 	xs := make([]string, 0, len(r.M))
 	for k := range r.M {
 		xs = append(xs, k)

--- a/usecases/scaler/scaler.go
+++ b/usecases/scaler/scaler.go
@@ -71,7 +71,7 @@ type BackUpper interface {
 // cluster is used by the scaler to query cluster
 type cluster interface {
 	// AllNames returns list of existing node in the cluster
-	AllNames() []string
+	Candidates() []string
 	// LocalName returns name of this node
 	LocalName() string
 	// NodeHostname return hosts address for a specific node name

--- a/usecases/scaler/scaler.go
+++ b/usecases/scaler/scaler.go
@@ -70,7 +70,7 @@ type BackUpper interface {
 
 // cluster is used by the scaler to query cluster
 type cluster interface {
-	// AllNames returns list of existing node in the cluster
+	// Candidates returns list of existing nodes in the cluster
 	Candidates() []string
 	// LocalName returns name of this node
 	LocalName() string

--- a/usecases/schema/helpers_for_test.go
+++ b/usecases/schema/helpers_for_test.go
@@ -132,6 +132,10 @@ func (f *fakeClusterState) AllNames() []string {
 	return f.hosts
 }
 
+func (f *fakeClusterState) Candidates() []string {
+	return f.hosts
+}
+
 func (f *fakeClusterState) LocalName() string {
 	return "node1"
 }

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -90,6 +90,7 @@ type clusterState interface {
 
 	// AllNames initializes shard distribution across nodes
 	AllNames() []string
+	Candidates() []string
 	LocalName() string
 	NodeCount() int
 	NodeHostname(nodeName string) (string, bool)

--- a/usecases/schema/restore_test.go
+++ b/usecases/schema/restore_test.go
@@ -92,7 +92,7 @@ type fakeNodes struct {
 	nodes []string
 }
 
-func (f fakeNodes) AllNames() []string {
+func (f fakeNodes) Candidates() []string {
 	return f.nodes
 }
 

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -94,7 +94,7 @@ func (p *Physical) AdjustReplicas(count int, nodes nodes) error {
 		return nil
 	}
 
-	names := nodes.AllNames()
+	names := nodes.Candidates()
 	if count > len(names) {
 		return fmt.Errorf("not enough replicas: found %d want %d", len(names), count)
 	}
@@ -114,13 +114,13 @@ func (p *Physical) AdjustReplicas(count int, nodes nodes) error {
 }
 
 type nodes interface {
-	AllNames() []string
+	Candidates() []string
 	LocalName() string
 }
 
 func InitState(id string, config Config, nodes nodes, replFactor int64) (*State, error) {
 	out := &State{Config: config, IndexID: id, localNodeName: nodes.LocalName()}
-	names := nodes.AllNames()
+	names := nodes.Candidates()
 	if f, n := replFactor, len(names); f > int64(n) {
 		return nil, fmt.Errorf("not enough replicas: found %d want %d", n, f)
 	}

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -222,10 +222,11 @@ func (s *State) IsShardLocal(name string) bool {
 // Shard 2: Node8, Node9, Node10, Node 11, Node 12
 // Shard 3: Node9, Node10, Node11, Node 12, Node 1
 func (s *State) initPhysical(names []string, replFactor int64) error {
-	it, err := cluster.NewNodeIterator(names, cluster.StartRandom)
+	it, err := cluster.NewNodeIterator(names, cluster.StartAfter)
 	if err != nil {
 		return err
 	}
+	it.SetStartNode(names[len(names)-1])
 
 	s.Physical = map[string]Physical{}
 

--- a/usecases/sharding/state_test.go
+++ b/usecases/sharding/state_test.go
@@ -78,7 +78,7 @@ type fakeNodes struct {
 	nodes []string
 }
 
-func (f fakeNodes) AllNames() []string {
+func (f fakeNodes) Candidates() []string {
 	return f.nodes
 }
 


### PR DESCRIPTION
### What's being changed:
This feature is related to new created classes
Nodes with the highest amount of free disk free spaces are selected as shards and replicas.
It uses the gossip protocol to spread the disk info into whole cluster
Two nodes are considered equivalent if space difference is less than 4KB

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
