### PR TITLE
Govulncheck action update

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -35,10 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Scan for Vulnerabilities in Code
-        uses: Templum/govulncheck-action@v0.0.8
+        uses: Templum/govulncheck-action@v0.10.0
         with:
           go-version: 1.19
-          vulncheck-version: latest
           package: ./...
           fail-on-vuln: true
   Unit-Tests:


### PR DESCRIPTION
### What's being changed:
Udpates GH's govulncheck-action to 0.10.0 and latest working with it govulncheck (therefore `vulncheck-version` entry is removed)
See https://github.com/Templum/govulncheck-action/releases/tag/v0.10.0


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
