### PR TITLE
Fix potential for incorrect And/Or filter merge results

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -143,10 +143,10 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 		dbms[i] = dbm
 	}
 
-	if pv.cacheable() && checksumsIdenticalBM(dbms) {
-		// all children are identical, no need to merge, simply return the first
-		return dbms[0], nil
-	}
+	// if pv.cacheable() && checksumsIdenticalBM(dbms) {
+	// 	// all children are identical, no need to merge, simply return the first
+	// 	return dbms[0], nil
+	// }
 
 	mergeRes := dbms[0].docIDs.Clone()
 	mergeFn := mergeRes.And

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -143,11 +143,6 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 		dbms[i] = dbm
 	}
 
-	// if pv.cacheable() && checksumsIdenticalBM(dbms) {
-	// 	// all children are identical, no need to merge, simply return the first
-	// 	return dbms[0], nil
-	// }
-
 	mergeRes := dbms[0].docIDs.Clone()
 	mergeFn := mergeRes.And
 	if pv.operator == filters.OperatorOr {

--- a/adapters/repos/db/inverted/searcher_checksum.go
+++ b/adapters/repos/db/inverted/searcher_checksum.go
@@ -112,22 +112,3 @@ func docPointerChecksum(pointers []uint64) ([]byte, error) {
 
 // 	return true
 // }
-
-func checksumsIdenticalBM(docBitmaps []*docBitmap) bool {
-	if len(docBitmaps) == 0 {
-		return false
-	}
-
-	if len(docBitmaps) == 1 {
-		return true
-	}
-
-	firstChecksum := docBitmaps[0].checksum
-	for _, docBitmap := range docBitmaps {
-		if !bytes.Equal(docBitmap.checksum, firstChecksum) {
-			return false
-		}
-	}
-
-	return true
-}


### PR DESCRIPTION
### What's being changed:
* This PR removes an optimization that no longer makes sense today, but can cause bugs
* There was a logic to skip merging of And/Or filters if each clause's results have the same hash
* With roaring bitmaps this optimization is no longer needed as this merge is trivially cheap
* However, this logic can introduce bugs when - for whatever reason - something goes wrong upstream and we end up with a false positive for identical hashes. In this case, the merge would be skipped incorrectly and we'd always end up with the leftmost clause. 

*Note: As of the time of this PR we do not yet know what needs to happen to have a false positive on identical hashes, but we can proof that a user ran into this situation. We will add new tests once we can reproduce that from scratch.*

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
