### PR TITLE
Fix updating objects with null values

### DIFF
--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -34,7 +34,7 @@ import (
 func (db *DB) Aggregate(ctx context.Context,
 	params aggregation.Params,
 ) (*aggregation.Result, error) {
-	idx := db.GetIndex(schema.ClassName(params.ClassName))
+	idx := db.GetIndex(params.ClassName)
 	if idx == nil {
 		return nil, fmt.Errorf("tried to browse non-existing index for %s", params.ClassName)
 	}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -217,8 +217,13 @@ func mergeProps(previous *storobj.Object,
 		properties = map[string]interface{}{}
 	}
 
+	// remove properties from object that have been set to nil
+	for _, propToDelete := range merge.PropertiesToDelete {
+		delete(properties, propToDelete)
+	}
+
 	for propName, value := range merge.PrimitiveSchema {
-		// for primtive props, we simply need to overwrite
+		// for primitive props, we simply need to overwrite
 		properties[propName] = value
 	}
 

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -131,7 +131,7 @@ func TestAutoschemaCasingUpdateProps(t *testing.T) {
 			require.Nil(t, err)
 
 			updater := c.Data().Updater()
-			err = updater.WithClassName(className).WithID(objId).WithProperties(map[string]string{tt.prop1: "other"}).Do(ctx)
+			err = updater.WithClassName(className).WithID(objId).WithProperties(map[string]string{tt.prop2: "other"}).Do(ctx)
 			require.Nil(t, err)
 
 			// two objects should have been added (with one update

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
+
 	"github.com/stretchr/testify/require"
 
 	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
@@ -59,10 +61,6 @@ func TestAutoschemaCasingProps(t *testing.T) {
 	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
 
 	className := "RandomGreenBike"
-	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
-	creator := c.Data().Creator()
-	_, err := creator.WithClassName(className).Do(ctx)
-	require.Nil(t, err)
 
 	upperPropName := "SomeProp"
 	lowerPropName := "someProp"
@@ -77,13 +75,73 @@ func TestAutoschemaCasingProps(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.prop1+" "+tt.prop2, func(t *testing.T) {
+			c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+			creator := c.Data().Creator()
+			_, err := creator.WithClassName(className).Do(ctx)
+			require.Nil(t, err)
+
 			creator1 := c.Data().Creator()
-			_, err := creator1.WithClassName(className).WithProperties(map[string]string{tt.prop1: "something"}).Do(ctx)
+			_, err = creator1.WithClassName(className).WithProperties(map[string]string{tt.prop1: "something"}).Do(ctx)
 			require.Nil(t, err)
 
 			creator2 := c.Data().Creator()
-			_, err = creator2.WithClassName(className).WithProperties(map[string]string{tt.prop2: "overwrite value"}).Do(ctx)
+			_, err = creator2.WithClassName(className).WithProperties(map[string]string{tt.prop2: "other value"}).Do(ctx)
 			require.Nil(t, err)
+
+			// three objects should have been added
+			result, err := c.GraphQL().Aggregate().WithClassName(className).WithFields(graphql.Field{
+				Name: "meta", Fields: []graphql.Field{
+					{Name: "count"},
+				},
+			}).Do(ctx)
+			require.Nil(t, err)
+			require.Equal(t, result.Data["Aggregate"].(map[string]interface{})[className].([]interface{})[0].(map[string]interface{})["meta"].(map[string]interface{})["count"], 3.)
+
+			require.Nil(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
+		})
+	}
+}
+
+func TestAutoschemaCasingUpdateProps(t *testing.T) {
+	ctx := context.Background()
+	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
+
+	objId := "67b79643-cf8b-4b22-b206-6e63dbb4e57a"
+	upperPropName := "SomeProp"
+	lowerPropName := "someProp"
+	cases := []struct {
+		prop1 string
+		prop2 string
+	}{
+		{prop1: upperPropName, prop2: upperPropName},
+		{prop1: lowerPropName, prop2: lowerPropName},
+		{prop1: upperPropName, prop2: lowerPropName},
+		{prop1: lowerPropName, prop2: upperPropName},
+	}
+	for _, tt := range cases {
+		t.Run(tt.prop1+" "+tt.prop2, func(t *testing.T) {
+			className := "RandomOliveTree"
+			c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+			creator := c.Data().Creator()
+			_, err := creator.WithClassName(className).Do(ctx)
+			require.Nil(t, err)
+
+			creator1 := c.Data().Creator()
+			_, err = creator1.WithClassName(className).WithID(objId).WithProperties(map[string]string{tt.prop1: "something"}).Do(ctx)
+			require.Nil(t, err)
+
+			updater := c.Data().Updater()
+			err = updater.WithClassName(className).WithID(objId).WithProperties(map[string]string{tt.prop1: "other"}).Do(ctx)
+			require.Nil(t, err)
+
+			// two objects should have been added (with one update
+			result, err := c.GraphQL().Aggregate().WithClassName(className).WithFields(graphql.Field{
+				Name: "meta", Fields: []graphql.Field{
+					{Name: "count"},
+				},
+			}).Do(ctx)
+			require.Nil(t, err)
+			require.Equal(t, result.Data["Aggregate"].(map[string]interface{})[className].([]interface{})[0].(map[string]interface{})["meta"].(map[string]interface{})["count"], 2.)
 
 			require.Nil(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
 		})

--- a/test/acceptance_with_go_client/endpoint_test.go
+++ b/test/acceptance_with_go_client/endpoint_test.go
@@ -1,0 +1,72 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestUpdatingPropertiesWithNil(t *testing.T) {
+	ctx := context.Background()
+	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
+	className := "RandomPinkFlower"
+	upperPropName := "SomeProp"
+	lowerPropName := "someProp"
+	cases := []struct {
+		prop1 string
+		prop2 string
+	}{
+		{prop1: upperPropName, prop2: upperPropName},
+		{prop1: lowerPropName, prop2: lowerPropName},
+		{prop1: upperPropName, prop2: lowerPropName},
+		{prop1: lowerPropName, prop2: upperPropName},
+	}
+	for _, tt := range cases {
+		t.Run(tt.prop1+" "+tt.prop2, func(t *testing.T) {
+			c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+			defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+			classCreator := c.Schema().ClassCreator()
+			class := models.Class{
+				Class: className,
+				Properties: []*models.Property{{
+					Name:     tt.prop1,
+					DataType: []string{string(schema.DataTypeString)},
+				}},
+			}
+			require.Nil(t, classCreator.WithClass(&class).Do(ctx))
+
+			obj, err := c.Data().Creator().WithClassName(className).WithProperties(
+				map[string]interface{}{tt.prop1: "SomeText"},
+			).WithID("0a21ae23-3f22-4f34-b04a-199e701886ef").Do(ctx)
+			require.Nil(t, err)
+
+			require.Nil(t, c.Data().Updater().WithClassName(className).WithProperties(map[string]interface{}{tt.prop2: nil}).WithID(string(obj.Object.ID)).WithMerge().Do(ctx))
+
+			// update should have cleared the object
+			getter := c.Data().ObjectsGetter()
+			objAfterUpdate, err := getter.WithID(string(obj.Object.ID)).WithClassName(className).Do(ctx)
+			require.Nil(t, err)
+			require.Len(t, objAfterUpdate[0].Properties, 0)
+
+			// Property is still part of the class
+			schemaClass, err := c.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.Nil(t, err)
+			require.Len(t, schemaClass.Properties, 1)
+		})
+	}
+}

--- a/test/acceptance_with_go_client/schema_test.go
+++ b/test/acceptance_with_go_client/schema_test.go
@@ -1,0 +1,73 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+
+	"github.com/stretchr/testify/require"
+
+	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
+)
+
+func TestSchemaCasingClass(t *testing.T) {
+	ctx := context.Background()
+	c := client.New(client.Config{Scheme: "http", Host: "localhost:8080"})
+
+	upperClassName := "RandomGreenCar"
+	lowerClassName := "randomGreenCar"
+
+	cases := []struct {
+		className1 string
+		className2 string
+	}{
+		{className1: upperClassName, className2: upperClassName},
+		{className1: lowerClassName, className2: lowerClassName},
+		{className1: upperClassName, className2: lowerClassName},
+		{className1: lowerClassName, className2: upperClassName},
+	}
+	for _, tt := range cases {
+		t.Run(tt.className1+" "+tt.className2, func(t *testing.T) {
+			c.Schema().ClassDeleter().WithClassName(tt.className1).Do(ctx)
+			c.Schema().ClassDeleter().WithClassName(tt.className2).Do(ctx)
+			class := &models.Class{Class: tt.className1, Vectorizer: "none"}
+			require.Nil(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+			// try to create class again lowercase. This should fail as it already exists
+			class2 := &models.Class{Class: tt.className2, Vectorizer: "none"}
+			require.NotNil(t, c.Schema().ClassCreator().WithClass(class2).Do(ctx))
+
+			// create object with lower and upper case class names. Both should succeed
+			_, err := c.Data().Creator().WithClassName(tt.className1).Do(ctx)
+			require.Nil(t, err)
+			_, err = c.Data().Creator().WithClassName(tt.className2).Do(ctx)
+			require.Nil(t, err)
+
+			// two objects should have been added
+			result, err := c.GraphQL().Aggregate().WithClassName(upperClassName).WithFields(graphql.Field{
+				Name: "meta", Fields: []graphql.Field{
+					{Name: "count"},
+				},
+			}).Do(ctx)
+			require.Nil(t, err)
+			require.Equal(t, result.Data["Aggregate"].(map[string]interface{})[upperClassName].([]interface{})[0].(map[string]interface{})["meta"].(map[string]interface{})["count"], 2.)
+
+			// class exists only once in Uppercase, so lowercase delete has to fail
+			require.Nil(t, c.Schema().ClassDeleter().WithClassName(upperClassName).Do(ctx))
+			require.NotNil(t, c.Schema().ClassDeleter().WithClassName(lowerClassName).Do(ctx))
+		})
+	}
+}

--- a/test/acceptance_with_go_client/schema_test.go
+++ b/test/acceptance_with_go_client/schema_test.go
@@ -46,11 +46,11 @@ func TestSchemaCasingClass(t *testing.T) {
 			class := &models.Class{Class: tt.className1, Vectorizer: "none"}
 			require.Nil(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
 
-			// try to create class again lowercase. This should fail as it already exists
+			// try to create class again with other casing. This should fail as it already exists
 			class2 := &models.Class{Class: tt.className2, Vectorizer: "none"}
 			require.NotNil(t, c.Schema().ClassCreator().WithClass(class2).Do(ctx))
 
-			// create object with lower and upper case class names. Both should succeed
+			// create object with both casing as class name. Both should succeed
 			_, err := c.Data().Creator().WithClassName(tt.className1).Do(ctx)
 			require.Nil(t, err)
 			_, err = c.Data().Creator().WithClassName(tt.className2).Do(ctx)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -97,7 +97,7 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}
 
-	err = m.validateObject(ctx, principal, object, repl)
+	err = m.validateObjectAndNormalizeNames(ctx, principal, object, repl)
 	if err != nil {
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}
@@ -125,7 +125,7 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	return object, nil
 }
 
-func (m *Manager) validateObject(ctx context.Context,
+func (m *Manager) validateObjectAndNormalizeNames(ctx context.Context,
 	principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) error {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -33,6 +33,7 @@ type MergeDocument struct {
 	Vector               []float32                   `json:"vector"`
 	UpdateTime           int64                       `json:"updateTime"`
 	AdditionalProperties models.AdditionalProperties `json:"additionalProperties"`
+	PropertiesToDelete   []string                    `json:"propertiesToDelete"`
 }
 
 func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
@@ -50,9 +51,19 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	m.metrics.MergeObjectInc()
 	defer m.metrics.MergeObjectDec()
 
-	if err := m.validateObject(ctx, principal, updates, repl); err != nil {
+	var propertiesToDelete []string
+	if updates.Properties != nil {
+		for key, val := range updates.Properties.(map[string]interface{}) {
+			if val == nil {
+				propertiesToDelete = append(propertiesToDelete, schema.LowercaseFirstLetter(key))
+			}
+		}
+	}
+
+	if err := m.validateObjectAndNormalizeNames(ctx, principal, updates, repl); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
+
 	if updates.Properties == nil {
 		updates.Properties = map[string]interface{}{}
 	}
@@ -63,12 +74,12 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if obj == nil {
 		return &Error{"not found", StatusNotFound, err}
 	}
-	return m.patchObject(ctx, principal, obj, updates, repl)
+	return m.patchObject(ctx, principal, obj, updates, repl, propertiesToDelete)
 }
 
 // patchObject patches an existing object obj with updates
 func (m *Manager) patchObject(ctx context.Context, principal *models.Principal,
-	obj *search.Result, updates *models.Object, repl *additional.ReplicationProperties,
+	obj *search.Result, updates *models.Object, repl *additional.ReplicationProperties, propertiesToDelete []string,
 ) *Error {
 	cls, id := updates.Class, updates.ID
 	primitive, refs := m.splitPrimitiveAndRefs(updates.Properties.(map[string]interface{}), cls, id)
@@ -78,12 +89,13 @@ func (m *Manager) patchObject(ctx context.Context, principal *models.Principal,
 		return &Error{"merge and vectorize", StatusInternalServerError, err}
 	}
 	mergeDoc := MergeDocument{
-		Class:           cls,
-		ID:              id,
-		PrimitiveSchema: primitive,
-		References:      refs,
-		Vector:          objWithVec.Vector,
-		UpdateTime:      m.timeSource.Now(),
+		Class:              cls,
+		ID:                 id,
+		PrimitiveSchema:    primitive,
+		References:         refs,
+		Vector:             objWithVec.Vector,
+		UpdateTime:         m.timeSource.Now(),
+		PropertiesToDelete: propertiesToDelete,
 	}
 
 	if objWithVec.Additional != nil {

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -67,7 +67,7 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context, principa
 		WithField("id", id).
 		Debug("received update kind request")
 
-	err = m.validateObject(ctx, principal, updates, repl)
+	err = m.validateObjectAndNormalizeNames(ctx, principal, updates, repl)
 	if err != nil {
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -21,7 +21,7 @@ import (
 // ValidateObject without adding it to the database. Can be used in UIs for
 // async validation before submitting
 func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principal,
-	class *models.Object, repl *additional.ReplicationProperties,
+	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
 	err := m.authorizer.Authorize(principal, "validate", "objects")
 	if err != nil {
@@ -34,7 +34,7 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	}
 	defer unlock()
 
-	err = m.validateObject(ctx, principal, class, repl)
+	err = m.validateObjectAndNormalizeNames(ctx, principal, obj, repl)
 	if err != nil {
 		return NewErrInvalidUserInput("invalid object: %v", err)
 	}


### PR DESCRIPTION
### What's being changed:

Closes https://github.com/weaviate/weaviate/issues/2607

- First two commits add more acceptance tests around schema casing. Both worked without any further changes.
- When sending an update with an explicit null value it was ignored. Now it is removed from the object
- Adds an acceptance test using the go client

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

