### PR TITLE
Return error if list of classes to back up contains duplicates.

### DIFF
--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -90,6 +90,24 @@ func TestBackupStatus(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, want, got)
 	})
+
+	t.Run("ReadFromMetadataError", func(t *testing.T) {
+		backend := &fakeBackend{}
+		st := string(backup.Failed)
+		bytes := marshalMeta(backup.BackupDescriptor{Status: st, Error: "error1"})
+		want = &models.BackupCreateStatusResponse{
+			ID:      id,
+			Path:    path,
+			Status:  &st,
+			Backend: backendName,
+		}
+		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(bytes, nil)
+		backend.On("HomeDir", mock.Anything).Return(path)
+		m := createManager(nil, nil, backend, nil)
+		_, err := m.BackupStatus(ctx, nil, backendName, id)
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "error1")
+	})
 }
 
 func TestBackupOnStatus(t *testing.T) {

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -355,15 +355,21 @@ func filterClasses(classes, excludes []string) []string {
 	if len(excludes) == 0 {
 		return classes
 	}
-	cs := classes[:0]
-	xmap := make(map[string]struct{}, len(excludes))
-	for _, c := range excludes {
-		xmap[c] = struct{}{}
-	}
+	m := make(map[string]struct{}, len(classes))
 	for _, c := range classes {
-		if _, ok := xmap[c]; !ok {
-			cs = append(cs, c)
+		m[c] = struct{}{}
+	}
+	for _, x := range excludes {
+		delete(m, x)
+	}
+	if len(classes) != len(m) {
+		classes = classes[:len(m)]
+		i := 0
+		for k := range m {
+			classes[i] = k
+			i++
 		}
 	}
-	return cs
+
+	return classes
 }

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -52,10 +52,11 @@ func TestFilterClasses(t *testing.T) {
 		{in: []string{"a"}, xs: []string{"a"}, out: []string{}},
 		{in: []string{"1", "2", "3", "4"}, xs: []string{"2", "3"}, out: []string{"1", "4"}},
 		{in: []string{"1", "2", "3"}, xs: []string{"1", "3"}, out: []string{"2"}},
+		{in: []string{"1", "2", "1", "3", "1", "3"}, xs: []string{"2"}, out: []string{"1", "3"}},
 	}
 	for _, tc := range tests {
 		got := filterClasses(tc.in, tc.xs)
-		assert.Equal(t, tc.out, got)
+		assert.ElementsMatch(t, tc.out, got)
 	}
 }
 

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -125,7 +125,7 @@ func (c *shardSyncChan) OnCommit(ctx context.Context, req *StatusRequest) error 
 		c.coordChan <- *req
 		return nil
 	}
-	return fmt.Errorf("shard has abandon backup opeartion")
+	return fmt.Errorf("shard has abandon backup operation")
 }
 
 // Abort tells a node to abort the previous backup operation


### PR DESCRIPTION

### What's being changed:
Return error if list of classes to back up contains duplicates.
Deduplicate list of all classes which is returned internally when req.include is empty
Return appropriate error message when metadata has been found and backup has failed
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
