### PR TITLE
Adds support for properties field for groupedResult, in order to limit the amount of tokens used in a request

### DIFF
--- a/modules/generative-openai/additional/generate/generate_graphql_field.go
+++ b/modules/generative-openai/additional/generate/generate_graphql_field.go
@@ -42,6 +42,11 @@ func (p *GenerateProvider) additionalGenerateField(classname string) *graphql.Fi
 							Description: "task",
 							Type:        graphql.String,
 						},
+						"properties": &graphql.InputObjectFieldConfig{
+							Description:  "Properties used for the generation",
+							Type:         graphql.NewList(graphql.String),
+							DefaultValue: nil,
+						},
 					},
 				}),
 				DefaultValue: nil,

--- a/modules/generative-openai/additional/generate/generate_params.go
+++ b/modules/generative-openai/additional/generate/generate_params.go
@@ -12,8 +12,9 @@
 package generate
 
 type Params struct {
-	Prompt *string
-	Task   *string
+	Prompt     *string
+	Task       *string
+	Properties []string
 }
 
 func (n Params) GetPrompt() string {
@@ -22,4 +23,8 @@ func (n Params) GetPrompt() string {
 
 func (n Params) GetTask() string {
 	return *n.Task
+}
+
+func (n Params) GetProperties() []string {
+	return n.Properties
 }

--- a/modules/generative-openai/additional/generate/generate_params_extractor.go
+++ b/modules/generative-openai/additional/generate/generate_params_extractor.go
@@ -27,7 +27,19 @@ func (p *GenerateProvider) parseGenerateArguments(args []*ast.Argument) *Params 
 			out.Prompt = &obj[0].Value.(*ast.StringValue).Value
 		case "groupedResult":
 			obj := arg.Value.(*ast.ObjectValue).Fields
-			out.Task = &obj[0].Value.(*ast.StringValue).Value
+			for _, field := range obj {
+				switch field.Name.Value {
+				case "task":
+					out.Task = &field.Value.(*ast.StringValue).Value
+				case "properties":
+					inp := field.Value.GetValue().([]ast.Value)
+					out.Properties = make([]string, len(inp))
+
+					for i, value := range inp {
+						out.Properties[i] = value.(*ast.StringValue).Value
+					}
+				}
+			}
 
 		default:
 			// ignore what we don't recognize

--- a/modules/generative-openai/additional/generate/generate_result.go
+++ b/modules/generative-openai/additional/generate/generate_result.go
@@ -30,10 +30,11 @@ func (p *GenerateProvider) generateResult(ctx context.Context, in []search.Resul
 	}
 	prompt := params.Prompt
 	task := params.Task
+	properties := params.Properties
 	var err error
 
 	if task != nil {
-		_, err = p.generateForAllSearchResults(ctx, in, *task, cfg)
+		_, err = p.generateForAllSearchResults(ctx, in, *task, properties, cfg)
 	}
 	if prompt != nil {
 		prompt, err = validatePrompt(prompt)
@@ -63,7 +64,7 @@ func (p *GenerateProvider) generatePerSearchResult(ctx context.Context, in []sea
 	sem := make(chan struct{}, p.maximumNumberOfGoroutines)
 	for i, result := range in {
 		wg.Add(1)
-		textProperties := p.getTextProperties(result)
+		textProperties := p.getTextProperties(result, nil)
 		go func(result search.Result, textProperties map[string]string, i int) {
 			sem <- struct{}{}
 			defer wg.Done()
@@ -76,22 +77,30 @@ func (p *GenerateProvider) generatePerSearchResult(ctx context.Context, in []sea
 	return in, nil
 }
 
-func (p *GenerateProvider) generateForAllSearchResults(ctx context.Context, in []search.Result, task string, cfg moduletools.ClassConfig) ([]search.Result, error) {
+func (p *GenerateProvider) generateForAllSearchResults(ctx context.Context, in []search.Result, task string, properties []string, cfg moduletools.ClassConfig) ([]search.Result, error) {
 	var propertiesForAllDocs []map[string]string
 	for _, res := range in {
-		propertiesForAllDocs = append(propertiesForAllDocs, p.getTextProperties(res))
+		propertiesForAllDocs = append(propertiesForAllDocs, p.getTextProperties(res, properties))
 	}
 	generateResult, err := p.client.GenerateAllResults(ctx, propertiesForAllDocs, task, cfg)
 	p.setCombinedResult(in, 0, generateResult, err)
 	return in, nil
 }
 
-func (p *GenerateProvider) getTextProperties(result search.Result) map[string]string {
+func (p *GenerateProvider) getTextProperties(result search.Result, properties []string) map[string]string {
 	textProperties := map[string]string{}
 	schema := result.Object().Properties.(map[string]interface{})
 	for property, value := range schema {
-		if valueString, ok := value.(string); ok {
-			textProperties[property] = valueString
+		if properties != nil {
+			if p.containsProperty(property, properties) {
+				if valueString, ok := value.(string); ok {
+					textProperties[property] = valueString
+				}
+			}
+		} else {
+			if valueString, ok := value.(string); ok {
+				textProperties[property] = valueString
+			}
 		}
 	}
 	return textProperties
@@ -141,4 +150,16 @@ func (p *GenerateProvider) setIndividualResult(in []search.Result, i int, genera
 	}
 
 	in[i].AdditionalProperties = ap
+}
+
+func (p *GenerateProvider) containsProperty(property string, properties []string) bool {
+	if len(properties) == 0 {
+		return true
+	}
+	for i := range properties {
+		if properties[i] == property {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/generative-openai/additional/generate/generate_result.go
+++ b/modules/generative-openai/additional/generate/generate_result.go
@@ -91,7 +91,7 @@ func (p *GenerateProvider) getTextProperties(result search.Result, properties []
 	textProperties := map[string]string{}
 	schema := result.Object().Properties.(map[string]interface{})
 	for property, value := range schema {
-		if properties != nil {
+		if len(properties) > 0 {
 			if p.containsProperty(property, properties) {
 				if valueString, ok := value.(string); ok {
 					textProperties[property] = valueString
@@ -153,9 +153,6 @@ func (p *GenerateProvider) setIndividualResult(in []search.Result, i int, genera
 }
 
 func (p *GenerateProvider) containsProperty(property string, properties []string) bool {
-	if len(properties) == 0 {
-		return true
-	}
 	for i := range properties {
 		if properties[i] == property {
 			return true


### PR DESCRIPTION
This will expose a new field `properties` for `groupedResult` which allows users to narrow the scope of data sent to OpenAI in the prompt:

```
{
  Get {
    CLASS_NAME {
      _additional {
        generate(groupedResult: {
          task: "Run a task", 
          properties: ["title", "content"]
        })
      }
    }
  }
}

```

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
