### PR TITLE
Generative OpenAI - Adds support for GPT3.5-turbo and GPT4

### DIFF
--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -47,7 +48,7 @@ func New(apiKey string, logger logrus.FieldLogger) *openai {
 			Timeout: 60 * time.Second,
 		},
 		host:   "https://api.openai.com",
-		path:   "/v1/completions",
+		path:   "/v1/chat/completions",
 		logger: logger,
 	}
 }
@@ -71,22 +72,46 @@ func (v *openai) GenerateAllResults(ctx context.Context, textProperties []map[st
 func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string) (*ent.GenerateResult, error) {
 	settings := config.NewClassSettings(cfg)
 
-	body, err := json.Marshal(generateInput{
-		Prompt:           prompt,
-		Model:            settings.Model(),
-		MaxTokens:        settings.MaxTokens(),
-		Temperature:      settings.Temperature(),
-		FrequencyPenalty: settings.FrequencyPenalty(),
-		PresencePenalty:  settings.PresencePenalty(),
-		TopP:             settings.TopP(),
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "marshal body")
+	var body []byte
+	var err error
+	var oaiUrl string
+
+	if settings.IsLegacy() {
+		oaiUrl, err = url.JoinPath(v.host, "/v1/completions")
+		if err != nil {
+			return nil, errors.Wrap(err, "join OpenAI API host and path")
+		}
+		body, err = json.Marshal(generateInput{
+			Prompt:           prompt,
+			Model:            settings.Model(),
+			MaxTokens:        settings.MaxTokens(),
+			Temperature:      settings.Temperature(),
+			FrequencyPenalty: settings.FrequencyPenalty(),
+			PresencePenalty:  settings.PresencePenalty(),
+			TopP:             settings.TopP(),
+		})
+	} else {
+		oaiUrl, err = url.JoinPath(v.host, v.path)
+		if err != nil {
+			return nil, errors.Wrap(err, "join OpenAI API host and path")
+		}
+		tokens := determineTokens(settings.GetMaxTokensForModel(settings.Model()), settings.MaxTokens(), prompt)
+		body, err = json.Marshal(generateInput{
+			Messages: []message{{
+				Role:    "user",
+				Content: prompt,
+			}},
+			Model:            settings.Model(),
+			MaxTokens:        float64(tokens),
+			Temperature:      settings.Temperature(),
+			FrequencyPenalty: settings.FrequencyPenalty(),
+			PresencePenalty:  settings.PresencePenalty(),
+			TopP:             settings.TopP(),
+		})
 	}
 
-	oaiUrl, err := url.JoinPath(v.host, v.path)
 	if err != nil {
-		return nil, errors.Wrap(err, "join OpenAI API host and path")
+		return nil, errors.Wrapf(err, "marshal body")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", oaiUrl,
@@ -121,7 +146,13 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 		errorMessage := getErrorMessage(res.StatusCode, resBody.Error, "connection to OpenAI failed with status: %d error: %v")
 		return nil, errors.Errorf(errorMessage)
 	} else if res.StatusCode >= 400 {
-		errorMessage := getErrorMessage(res.StatusCode, resBody.Error, "failed with status: %d")
+		errorMessage := ""
+		if settings.IsLegacy() {
+			errorMessage = getErrorMessage(res.StatusCode, resBody.Error, "failed with status: %d")
+		} else {
+			errorMessage = getErrorMessage(res.StatusCode, resBody.Error, "failed with status: %d and message: %v")
+		}
+
 		return nil, errors.Errorf(errorMessage)
 	}
 
@@ -132,9 +163,28 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 			Result: &trimmedResponse,
 		}, nil
 	}
+
+	message := resBody.Choices[0].Message
+	if message != nil {
+		textResponse = message.Content
+		trimmedResponse := strings.Trim(textResponse, "\n")
+		return &ent.GenerateResult{
+			Result: &trimmedResponse,
+		}, nil
+	}
+
 	return &ent.GenerateResult{
 		Result: nil,
 	}, nil
+}
+
+func determineTokens(maxTokensSetting float64, classSetting float64, prompt string) int {
+	//nolint:gofumpt    //todo very naive approach here, but better than before ;)
+	tokens := float64(countWhitespace(prompt)+1) * 2.5
+	if tokens+classSetting > maxTokensSetting {
+		return int(maxTokensSetting - tokens)
+	}
+	return int(tokens)
 }
 
 func getErrorMessage(statusCode int, resBodyError *openAIApiError, errorTemplate string) string {
@@ -168,6 +218,19 @@ func (v *openai) generateForPrompt(textProperties map[string]string, prompt stri
 	return prompt, nil
 }
 
+func countWhitespace(s string) int {
+	count := 0
+	for {
+		idx := strings.IndexFunc(s, unicode.IsSpace)
+		if idx == -1 {
+			break
+		}
+		count++
+		s = s[idx+1:]
+	}
+	return count
+}
+
 func (v *openai) getApiKey(ctx context.Context) (string, error) {
 	if len(v.apiKey) > 0 {
 		return v.apiKey, nil
@@ -183,14 +246,20 @@ func (v *openai) getApiKey(ctx context.Context) (string, error) {
 }
 
 type generateInput struct {
-	Prompt           string   `json:"prompt"`
-	Model            string   `json:"model"`
-	MaxTokens        float64  `json:"max_tokens"`
-	Temperature      float64  `json:"temperature"`
-	Stop             []string `json:"stop"`
-	FrequencyPenalty float64  `json:"frequency_penalty"`
-	PresencePenalty  float64  `json:"presence_penalty"`
-	TopP             float64  `json:"top_p"`
+	Prompt           string    `json:"prompt,omitempty"`
+	Messages         []message `json:"messages,omitempty"`
+	Model            string    `json:"model"`
+	MaxTokens        float64   `json:"max_tokens"`
+	Temperature      float64   `json:"temperature"`
+	Stop             []string  `json:"stop"`
+	FrequencyPenalty float64   `json:"frequency_penalty"`
+	PresencePenalty  float64   `json:"presence_penalty"`
+	TopP             float64   `json:"top_p"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
 }
 
 type generateResponse struct {
@@ -202,7 +271,8 @@ type choice struct {
 	FinishReason string
 	Index        float32
 	Logprobs     string
-	Text         string
+	Text         string   `json:"text,omitempty"`
+	Message      *message `json:"message,omitempty"`
 }
 
 type openAIApiError struct {

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"path"
 	"regexp"
 	"strings"
@@ -73,16 +72,11 @@ func (v *openai) GenerateAllResults(ctx context.Context, textProperties []map[st
 func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string) (*ent.GenerateResult, error) {
 	settings := config.NewClassSettings(cfg)
 
-	var body []byte
-	var err error
 	var oaiUrl string
 	var input generateInput
 
 	if settings.IsLegacy() {
 		oaiUrl = path.Join(v.host, "/v1/completions")
-		if err != nil {
-			return nil, errors.Wrap(err, "join OpenAI API host and path")
-		}
 		input = generateInput{
 			Prompt:           prompt,
 			Model:            settings.Model(),
@@ -93,10 +87,7 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 			TopP:             settings.TopP(),
 		}
 	} else {
-		oaiUrl, err = url.JoinPath(v.host, v.path)
-		if err != nil {
-			return nil, errors.Wrap(err, "join OpenAI API host and path")
-		}
+		oaiUrl = path.Join(v.host, v.path)
 		tokens := determineTokens(settings.GetMaxTokensForModel(settings.Model()), settings.MaxTokens(), prompt)
 		input = generateInput{
 			Messages: []message{{
@@ -112,7 +103,7 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 		}
 	}
 
-	body, err = json.Marshal(input)
+	body, err := json.Marshal(input)
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshal body")
 	}

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -90,7 +90,7 @@ type testAnswerHandler struct {
 }
 
 func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	assert.Equal(f.t, "/v1/completions", r.URL.String())
+	assert.Equal(f.t, "/v1/chat/completions", r.URL.String())
 	assert.Equal(f.t, http.MethodPost, r.Method)
 
 	if f.answer.Error != nil && f.answer.Error.Message != "" {

--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -28,17 +28,33 @@ const (
 	topPProperty             = "topP"
 )
 
+var availableOpenAILegacyModels = []string{
+	"text-davinci-002",
+	"text-davinci-003",
+}
+
+var availableOpenAIModels = []string{
+	"gpt-3.5-turbo",
+	"gpt-4",
+	"gpt-4-32k",
+}
+
 var (
-	DefaultOpenAIModel                    = "text-davinci-003"
-	DefaultOpenAITemperature      float64 = 0.0
-	DefaultOpenAIMaxTokens        float64 = 1200
-	DefaultOpenAIFrequencyPenalty float64 = 0.0
-	DefaultOpenAIPresencePenalty  float64 = 0.0
-	DefaultOpenAITopP             float64 = 1.0
+	DefaultOpenAIModel            = "gpt-3.5-turbo"
+	DefaultOpenAITemperature      = 0.0
+	DefaultOpenAIMaxTokens        = defaultMaxTokens[DefaultOpenAIModel]
+	DefaultOpenAIFrequencyPenalty = 0.0
+	DefaultOpenAIPresencePenalty  = 0.0
+	DefaultOpenAITopP             = 1.0
 )
 
-var maxTokensForModel = map[string]float64{
-	"text-davinci-003": 1200,
+// todo Need to parse the tokenLimits in a smarter way, as the prompt defines the max length
+var defaultMaxTokens = map[string]float64{
+	"text-davinci-002": 4097,
+	"text-davinci-003": 4097,
+	"gpt-3.5-turbo":    4097,
+	"gpt-4":            8192,
+	"gpt-4-32k":        32768,
 }
 
 type classSettings struct {
@@ -55,13 +71,18 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		return errors.New("empty config")
 	}
 
+	model := ic.getStringProperty(modelProperty, DefaultOpenAIModel)
+	if model == nil || !ic.validateModel(*model) {
+		return errors.Errorf("wrong OpenAI model name, available model names are: %v", availableOpenAIModels)
+	}
+
 	temperature := ic.getFloatProperty(temperatureProperty, &DefaultOpenAITemperature)
 	if temperature == nil || (*temperature < 0 || *temperature > 1) {
 		return errors.Errorf("Wrong temperature configuration, values are between 0.0 and 1.0")
 	}
 
 	maxTokens := ic.getFloatProperty(maxTokensProperty, &DefaultOpenAIMaxTokens)
-	if maxTokens == nil || (*maxTokens < 0 || *maxTokens > getMaxTokensForModel(DefaultOpenAIModel)) {
+	if maxTokens == nil || (*maxTokens < 0 || *maxTokens > ic.GetMaxTokensForModel(DefaultOpenAIModel)) {
 		return errors.Errorf("Wrong maxTokens configuration, values are should have a minimal value of 1 and max is dependant on the model used")
 	}
 
@@ -133,8 +154,16 @@ func (ic *classSettings) getFloatProperty(name string, defaultValue *float64) *f
 	return nil
 }
 
-func getMaxTokensForModel(model string) float64 {
-	return maxTokensForModel[model]
+func (ic *classSettings) GetMaxTokensForModel(model string) float64 {
+	return defaultMaxTokens[model]
+}
+
+func (ic *classSettings) validateModel(model string) bool {
+	return Contains(availableOpenAIModels, model) || Contains(availableOpenAILegacyModels, model)
+}
+
+func (ic *classSettings) IsLegacy() bool {
+	return Contains(availableOpenAILegacyModels, ic.Model())
 }
 
 func (ic *classSettings) Model() string {
@@ -159,4 +188,13 @@ func (ic *classSettings) PresencePenalty() float64 {
 
 func (ic *classSettings) TopP() float64 {
 	return *ic.getFloatProperty(topPProperty, &DefaultOpenAITopP)
+}
+
+func Contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -159,11 +159,11 @@ func (ic *classSettings) GetMaxTokensForModel(model string) float64 {
 }
 
 func (ic *classSettings) validateModel(model string) bool {
-	return Contains(availableOpenAIModels, model) || Contains(availableOpenAILegacyModels, model)
+	return contains(availableOpenAIModels, model) || contains(availableOpenAILegacyModels, model)
 }
 
 func (ic *classSettings) IsLegacy() bool {
-	return Contains(availableOpenAILegacyModels, ic.Model())
+	return contains(availableOpenAILegacyModels, ic.Model())
 }
 
 func (ic *classSettings) Model() string {
@@ -190,7 +190,7 @@ func (ic *classSettings) TopP() float64 {
 	return *ic.getFloatProperty(topPProperty, &DefaultOpenAITopP)
 }
 
-func Contains[T comparable](s []T, e T) bool {
+func contains[T comparable](s []T, e T) bool {
 	for _, v := range s {
 		if v == e {
 			return true

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -36,8 +36,8 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{},
 			},
-			wantModel:            "text-davinci-003",
-			wantMaxTokens:        1200,
+			wantModel:            "gpt-3.5-turbo",
+			wantMaxTokens:        4097,
 			wantTemperature:      0.0,
 			wantTopP:             1,
 			wantFrequencyPenalty: 0.0,
@@ -46,6 +46,26 @@ func Test_classSettings_Validate(t *testing.T) {
 		},
 		{
 			name: "Everything non default configured",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":            "gpt-3.5-turbo",
+					"maxTokens":        4097,
+					"temperature":      0.5,
+					"topP":             3,
+					"frequencyPenalty": 0.1,
+					"presencePenalty":  0.9,
+				},
+			},
+			wantModel:            "gpt-3.5-turbo",
+			wantMaxTokens:        4097,
+			wantTemperature:      0.5,
+			wantTopP:             3,
+			wantFrequencyPenalty: 0.1,
+			wantPresencePenalty:  0.9,
+			wantErr:              nil,
+		},
+		{
+			name: "Legacy config",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"model":            "text-davinci-003",


### PR DESCRIPTION
### What's being changed:
Adds support for new models to the `generative-openai` module. Models supported:

- `text-davinci-002`
- `text-davinci-003`
- `gpt-3.5-turbo`
- `gpt-4`
- `gpt-4-32k`

## Important update
Also changes the default model from: `text-davinci-003`  to: `gpt-3.5-turbo`


Closes https://github.com/weaviate/weaviate/issues/2715

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
