### PR TITLE
Allow 3rd-party Module API key headers in CORS preflight config

### DIFF
--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -144,7 +144,8 @@ func addPreflight(next http.Handler) http.Handler {
 		if r.Method == "OPTIONS" {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "*")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Batch")
+			w.Header().Set("Access-Control-Allow-Headers",
+				"Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Cohere-Api-Key, X-Huggingface-Api-Key")
 			return
 		}
 


### PR DESCRIPTION
### What's being changed:
* title says it all
* for now all 3 known 3rd-party modules are hard-coded, should be made dynamic in the future

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
