### PR TITLE
Fix almost deadlock between class delete and batch add

### DIFF
--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -44,8 +44,9 @@ func (db *DB) BatchPutObjects(ctx context.Context, objects objects.BatchObjects,
 				continue
 			}
 			_, ok := byIndex[index]
-			if !ok { // only lock index once
+			if !ok { // only lock index once and initialize byIndex map
 				index.indexLock.RLock()
+				byIndex[index] = batchQueue{}
 			}
 			indexById[i] = index
 		}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -78,7 +78,7 @@ type Index struct {
 	// unlock db.indexLock
 	// Use the indices
 	// RUnlock all picked indices
-	indexLock sync.RWMutex
+	dropIndex sync.RWMutex
 
 	metrics         *Metrics
 	centralJobQueue chan job

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -66,6 +66,7 @@ type Index struct {
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
 
+	// This lock should be used together with the db indexLock
 	indexLock sync.RWMutex
 
 	metrics         *Metrics

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -66,7 +66,18 @@ type Index struct {
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
 
-	// This lock should be used together with the db indexLock
+	// This lock should be used together with the db indexLock.
+	//
+	// The db indexlock locks the map that contains all indices against changes and should be used while iterating.
+	// This lock protects this specific index form being deleted while in use. Use Rlock to signale that it is in use.
+	// This way many goroutines can use a specific index in parallel. The delete-routine will try to acquire a RWlock.
+	//
+	// Usage:
+	// Lock the whole db using db.indexLock
+	// pick the indices you want and Rlock them
+	// unlock db.indexLock
+	// Use the indices
+	// RUnlock all picked indices
 	indexLock sync.RWMutex
 
 	metrics         *Metrics

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -66,6 +66,8 @@ type Index struct {
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
 
+	indexLock sync.RWMutex
+
 	metrics         *Metrics
 	centralJobQueue chan job
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -173,8 +173,8 @@ func (d *DB) DeleteIndex(className schema.ClassName) error {
 	if !ok {
 		return errors.Errorf("exist index %s", id)
 	}
-	index.indexLock.Lock()
-	defer index.indexLock.Unlock()
+	index.dropIndex.Lock()
+	defer index.dropIndex.Unlock()
 	err := index.drop()
 	if err != nil {
 		return errors.Wrapf(err, "drop index %s", id)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -170,6 +170,8 @@ func (d *DB) DeleteIndex(className schema.ClassName) error {
 	if !ok {
 		return errors.Errorf("exist index %s", id)
 	}
+	index.indexLock.Lock()
+	defer index.indexLock.Unlock()
 	err := index.drop()
 	if err != nil {
 		return errors.Wrapf(err, "drop index %s", id)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -62,6 +62,9 @@ type DB struct {
 	//
 	//
 	// See also: https://github.com/weaviate/weaviate/issues/2351
+	//
+	// This lock should be used to avoid that the indices-map is changed while iterating over it. To
+	// mark a given index in use, lock that index directly.
 	indexLock sync.RWMutex
 
 	jobQueueCh          chan job


### PR DESCRIPTION
### What's being changed:

Changes how indices are locked.

- Use db.indexLock, to protect the indice-map against changes (eg additions and deletions).
- Pick the indices you need and lock those indices against deletions by using index.indexLock.Rlock()
- Unlock the big lock (db.indexLock)
- Use indices
- Unlock afterwards


Chaos pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/4563888504/jobs/8053090103