### PR TITLE
Fixes merging results of filtered query

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -143,6 +143,11 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 		dbms[i] = dbm
 	}
 
+	if pv.cacheable() && checksumsIdenticalBM(dbms) {
+		// all children are identical, no need to merge, simply return the first
+		return dbms[0], nil
+	}
+
 	mergeRes := dbms[0].docIDs.Clone()
 	mergeFn := mergeRes.And
 	if pv.operator == filters.OperatorOr {

--- a/adapters/repos/db/inverted/prop_value_pairs_hashes.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_hashes.go
@@ -23,12 +23,6 @@ import (
 )
 
 func (pv *propValuePair) cacheable() bool {
-	for _, child := range pv.children {
-		if !child.cacheable() {
-			return false
-		}
-	}
-
 	switch pv.operator {
 	case filters.OperatorEqual, filters.OperatorAnd, filters.OperatorOr,
 		filters.OperatorNotEqual, filters.OperatorLike:
@@ -36,8 +30,15 @@ func (pv *propValuePair) cacheable() bool {
 		// ref-filter queries. For those queries, just checking the large amount of
 		// hashes has a very signifcant cost - even if they all turn out to be
 		// cache misses
-		return len(pv.children) < 10000
-
+		if len(pv.children) >= 10000 {
+			return false
+		}
+		for _, child := range pv.children {
+			if !child.cacheable() {
+				return false
+			}
+		}
+		return true
 	default:
 		return false
 	}

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -16,92 +16,209 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/roaringset"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
-func TestPropValuePairs_MergeAnd(t *testing.T) {
-	pv := &propValuePair{
-		operator: filters.OperatorAnd,
-		children: []*propValuePair{
-			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(7, 8, 9, 10, 11),
-					checksum: []byte{0x01},
-				},
-				operator: filters.OperatorEqual,
-			},
-			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
-					checksum: []byte{0x02},
-				},
-				operator: filters.OperatorEqual,
-			},
-			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(1, 3, 5, 7, 9),
-					checksum: []byte{0x03},
-				},
-				operator: filters.OperatorEqual,
-			},
-			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(1, 3, 5, 7),
-					checksum: []byte{0x04},
-				},
-				operator: filters.OperatorEqual,
-			},
-		},
-	}
+func TestPropValuePairs_Merging(t *testing.T) {
+	t.Run("uses checksums", func(t *testing.T) {
+		type testCase struct {
+			name string
 
-	expectedIds := []uint64{7}
+			bitmaps   []*sroar.Bitmap
+			checksums [][]byte
+			operator  filters.Operator
 
-	dbm, err := pv.mergeDocIDs()
+			expectedIds         []uint64
+			expectedChecksum    []byte
+			expectedFirstBitmap bool
+		}
 
-	require.Nil(t, err)
-	assert.ElementsMatch(t, expectedIds, dbm.IDs())
-}
-
-func TestPropValuePairs_MergeOr(t *testing.T) {
-	pv := &propValuePair{
-		operator: filters.OperatorOr,
-		children: []*propValuePair{
+		testCases := []testCase{
 			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(7, 8, 9, 10, 11),
-					checksum: []byte{0x01},
+				name: "AND; merging; new bitmap and calculated checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9),
 				},
-				operator: filters.OperatorEqual,
+				checksums: [][]byte{
+					{0x01}, {0x02}, {0x03},
+				},
+				operator: filters.OperatorAnd,
+
+				expectedIds:         []uint64{7, 9},
+				expectedChecksum:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xd1, 0xc0, 0xfa},
+				expectedFirstBitmap: false,
 			},
 			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
-					checksum: []byte{0x02},
+				name: "OR; merging; new bitmap and calculated checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9),
 				},
-				operator: filters.OperatorEqual,
+				checksums: [][]byte{
+					{0x01}, {0x02}, {0x03},
+				},
+				operator: filters.OperatorOr,
+
+				expectedIds:         []uint64{1, 3, 5, 7, 8, 9, 10, 11},
+				expectedChecksum:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xd1, 0x50, 0xf3},
+				expectedFirstBitmap: false,
 			},
 			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(1, 3, 5, 7, 9),
-					checksum: []byte{0x03},
+				name: "AND; optimization; first bitmap and checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
 				},
-				operator: filters.OperatorEqual,
+				checksums: [][]byte{
+					{0x01}, {0x01}, {0x01},
+				},
+				operator: filters.OperatorAnd,
+
+				expectedIds:         []uint64{7, 8, 9, 10, 11},
+				expectedChecksum:    []byte{0x01},
+				expectedFirstBitmap: true,
 			},
 			{
-				docIDs: docBitmap{
-					docIDs:   roaringset.NewBitmap(1, 3, 5, 7),
-					checksum: []byte{0x04},
+				name: "OR; optimization; first bitmap and checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
 				},
-				operator: filters.OperatorEqual,
+				checksums: [][]byte{
+					{0x01}, {0x01}, {0x01},
+				},
+				operator: filters.OperatorOr,
+
+				expectedIds:         []uint64{7, 8, 9, 10, 11},
+				expectedChecksum:    []byte{0x01},
+				expectedFirstBitmap: true,
 			},
-		},
-	}
+		}
 
-	expectedPointers := []uint64{1, 3, 5, 7, 8, 9, 10, 11}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				pv := &propValuePair{
+					operator: tc.operator,
+					children: make([]*propValuePair, len(tc.bitmaps)),
+				}
+				for i := range tc.bitmaps {
+					pv.children[i] = &propValuePair{
+						operator: filters.OperatorEqual,
+						docIDs: docBitmap{
+							docIDs:   tc.bitmaps[i],
+							checksum: tc.checksums[i],
+						},
+					}
+				}
 
-	dbm, err := pv.mergeDocIDs()
+				dbm, err := pv.mergeDocIDs(true)
 
-	require.Nil(t, err)
-	assert.ElementsMatch(t, expectedPointers, dbm.IDs())
+				require.Nil(t, err)
+				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())
+				assert.Equal(t, tc.expectedChecksum, dbm.checksum)
+				assert.Equal(t, tc.expectedFirstBitmap, tc.bitmaps[0] == dbm.docIDs)
+				assert.False(t, tc.bitmaps[1] == dbm.docIDs)
+				assert.False(t, tc.bitmaps[2] == dbm.docIDs)
+			})
+		}
+	})
+
+	t.Run("does not use checksums", func(t *testing.T) {
+		type testCase struct {
+			name string
+
+			bitmaps  []*sroar.Bitmap
+			operator filters.Operator
+
+			expectedIds []uint64
+		}
+
+		testCases := []testCase{
+			{
+				name: "AND; merging; new bitmap without checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9),
+				},
+				operator: filters.OperatorAnd,
+
+				expectedIds: []uint64{7, 9},
+			},
+			{
+				name: "OR; merging; new bitmap without checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
+					roaringset.NewBitmap(1, 3, 5, 7, 9),
+				},
+				operator: filters.OperatorOr,
+
+				expectedIds: []uint64{1, 3, 5, 7, 8, 9, 10, 11},
+			},
+			{
+				name: "AND; no optimization; new bitmap without checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+				},
+				operator: filters.OperatorAnd,
+
+				expectedIds: []uint64{7, 8, 9, 10, 11},
+			},
+			{
+				name: "OR; no optimization; new bitmap without checksum",
+
+				bitmaps: []*sroar.Bitmap{
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+					roaringset.NewBitmap(7, 8, 9, 10, 11),
+				},
+				operator: filters.OperatorOr,
+
+				expectedIds: []uint64{7, 8, 9, 10, 11},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				pv := &propValuePair{
+					operator: tc.operator,
+					children: make([]*propValuePair, len(tc.bitmaps)),
+				}
+				for i := range tc.bitmaps {
+					pv.children[i] = &propValuePair{
+						operator: filters.OperatorEqual,
+						docIDs: docBitmap{
+							docIDs: tc.bitmaps[i],
+						},
+					}
+				}
+
+				dbm, err := pv.mergeDocIDs(false)
+
+				require.Nil(t, err)
+				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())
+				assert.Nil(t, dbm.checksum)
+				assert.False(t, tc.bitmaps[0] == dbm.docIDs)
+				assert.False(t, tc.bitmaps[1] == dbm.docIDs)
+				assert.False(t, tc.bitmaps[2] == dbm.docIDs)
+			})
+		}
+	})
 }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -85,11 +85,12 @@ func (s *Searcher) Objects(ctx context.Context, limit int,
 		return nil, err
 	}
 
-	if err := pv.fetchDocIDs(s, limit, !pv.cacheable()); err != nil {
+	cacheable := pv.cacheable()
+	if err := pv.fetchDocIDs(s, limit, !cacheable); err != nil {
 		return nil, errors.Wrap(err, "fetch doc ids for prop/value pair")
 	}
 
-	dbm, err := pv.mergeDocIDs()
+	dbm, err := pv.mergeDocIDs(cacheable)
 	if err != nil {
 		return nil, errors.Wrap(err, "merge doc ids by operator")
 	}
@@ -206,11 +207,11 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 		}
 	}
 
-	if err := pv.fetchDocIDs(s, 0, !pv.cacheable()); err != nil {
+	if err := pv.fetchDocIDs(s, 0, !cacheable); err != nil {
 		return nil, errors.Wrap(err, "fetch doc ids for prop/value pair")
 	}
 
-	dbm, err := pv.mergeDocIDs()
+	dbm, err := pv.mergeDocIDs(cacheable)
 	if err != nil {
 		return nil, errors.Wrap(err, "merge doc ids by operator")
 	}

--- a/adapters/repos/db/inverted/searcher_checksum.go
+++ b/adapters/repos/db/inverted/searcher_checksum.go
@@ -112,3 +112,22 @@ func docPointerChecksum(pointers []uint64) ([]byte, error) {
 
 // 	return true
 // }
+
+func checksumsIdenticalBM(docBitmaps []*docBitmap) bool {
+	if len(docBitmaps) == 0 {
+		return false
+	}
+
+	if len(docBitmaps) == 1 {
+		return true
+	}
+
+	firstChecksum := docBitmaps[0].checksum
+	for _, docBitmap := range docBitmaps {
+		if !bytes.Equal(docBitmap.checksum, firstChecksum) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
### What's being changed:
Fixes merging results of filtered query.

Root cause of invalid (incomplete) results of filtered query was merging optimization skipping merging of identical result subsets. Identity of subsets was verified based on checksum values calculated for each subset. Due to recently added new requirement to consider subset (non-)cacheable (number of children < 10k), checksums calculations were skipped for children >= 10k, yet they still may have been used in optimized merging process, falsely considering subsets as equal, therefore only first subset of results was returned instead of merged of all subsets.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/59
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
