### PR TITLE
Fix Object count can temporarily be incorrect when a memtable with recent deletes is flushed

### DIFF
--- a/adapters/repos/db/lsmkv/binary_search_tree.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree.go
@@ -87,6 +87,34 @@ type countStats struct {
 	tombstonedKeys [][]byte
 }
 
+func (c *countStats) hasUpsert(needle []byte) bool {
+	if c == nil {
+		return false
+	}
+
+	for _, hay := range c.upsertKeys {
+		if bytes.Equal(needle, hay) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *countStats) hasTombstone(needle []byte) bool {
+	if c == nil {
+		return false
+	}
+
+	for _, hay := range c.tombstonedKeys {
+		if bytes.Equal(needle, hay) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (t *binarySearchTree) countStats() *countStats {
 	stats := &countStats{}
 	if t.root == nil {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -635,11 +635,22 @@ func (b *Bucket) Count() int {
 		panic("Count() called on strategy other than 'replace'")
 	}
 
-	memtableCount := b.memtableNetCount(b.active.countStats())
-	if b.flushing != nil {
-		memtableCount += b.memtableNetCount(b.flushing.countStats())
+	memtableCount := 0
+	if b.flushing == nil {
+		// only consider active
+		memtableCount += b.memtableNetCount(b.active.countStats(), nil)
+	} else {
+		flushingCountStats := b.flushing.countStats()
+		activeCountStats := b.active.countStats()
+		deltaActive := b.memtableNetCount(activeCountStats, flushingCountStats)
+		deltaFlushing := b.memtableNetCount(flushingCountStats, nil)
+
+		fmt.Printf("active=%d, flushing=%d\n", deltaActive, deltaFlushing)
+		memtableCount = deltaActive + deltaFlushing
 	}
+
 	diskCount := b.disk.count()
+	fmt.Printf("disk=%d\n", diskCount)
 
 	if b.monitorCount {
 		b.metrics.ObjectCount(memtableCount + diskCount)
@@ -647,29 +658,36 @@ func (b *Bucket) Count() int {
 	return memtableCount + diskCount
 }
 
-func (b *Bucket) memtableNetCount(stats *countStats) int {
+func (b *Bucket) memtableNetCount(stats *countStats, previousMemtable *countStats) int {
 	netCount := 0
 
 	// TODO: this uses regular get, given that this may be called quite commonly,
 	// we might consider building a pure Exists(), which skips reading the value
 	// and only checks for tombstones, etc.
 	for _, key := range stats.upsertKeys {
-		v, _ := b.disk.get(key) // current implementation can't error
-		if v == nil {
-			// this key didn't exist before
+		if !b.existsOnDiskAndPreviousMemtable(previousMemtable, key) {
 			netCount++
 		}
 	}
 
 	for _, key := range stats.tombstonedKeys {
-		v, _ := b.disk.get(key) // current implementation can't error
-		if v != nil {
-			// this key existed before
+		if b.existsOnDiskAndPreviousMemtable(previousMemtable, key) {
 			netCount--
 		}
 	}
 
 	return netCount
+}
+
+func (b *Bucket) existsOnDiskAndPreviousMemtable(previous *countStats, key []byte) bool {
+	v, _ := b.disk.get(key) // current implementation can't error
+	if v == nil {
+		// not on disk, but it could still be in the previous memtable
+		return previous.hasUpsert(key)
+	}
+
+	// it exists on disk ,but it could still have been deleted in the previous memtable
+	return !previous.hasTombstone(key)
 }
 
 func (b *Bucket) Shutdown(ctx context.Context) error {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -645,12 +645,10 @@ func (b *Bucket) Count() int {
 		deltaActive := b.memtableNetCount(activeCountStats, flushingCountStats)
 		deltaFlushing := b.memtableNetCount(flushingCountStats, nil)
 
-		fmt.Printf("active=%d, flushing=%d\n", deltaActive, deltaFlushing)
 		memtableCount = deltaActive + deltaFlushing
 	}
 
 	diskCount := b.disk.count()
-	fmt.Printf("disk=%d\n", diskCount)
 
 	if b.monitorCount {
 		b.metrics.ObjectCount(memtableCount + diskCount)


### PR DESCRIPTION
### What's being changed:
* fixes #2863 
* Most of the time, there is only one memtable. When a memtable is currently being flushed, there are two memtables. The flushing one is read-only (but can still be queried, otherwise the data would disappear). The active one accepts new incoming writes
* The net count logic already took the flushing memtable into account, so the flushing count was correct
* However, it did not consider that when calculating net count additions, you need to take the entire history into account: A delete only removes an object if it existed before. An upsert only increases the count if it did not exist before. When calculating the memtable net count, the logic would only look at all disk segments as history. However, while a flushing memtable is present, that flushing memtable needs to be part of that history.
* The new logic does that now

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
