### PR TITLE
Check consistency for GQL search results

### DIFF
--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -147,8 +147,8 @@ func (f *fakeClusterState) ClusterHealthScore() int {
 	return 0
 }
 
-func (f *fakeClusterState) ResolveParentNodes(string, string) ([]string, []string, error) {
-	return nil, nil, nil
+func (f *fakeClusterState) ResolveParentNodes(string, string) (map[string]string, error) {
+	return nil, nil
 }
 
 func (f *fakeClusterState) NodeHostname(nodeName string) (string, bool) {

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -158,8 +158,8 @@ func (f *fakeSchemaManager) ClusterHealthScore() int {
 }
 
 func (f *fakeSchemaManager) ResolveParentNodes(_ string, shard string,
-) ([]string, []string, error) {
-	return nil, nil, nil
+) (map[string]string, error) {
+	return nil, nil
 }
 
 type nodeResolver struct {

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -58,9 +58,8 @@ func (f *fakeSchemaGetter) ClusterHealthScore() int {
 	return 0
 }
 
-func (f fakeSchemaGetter) ResolveParentNodes(_ string, shard string,
-) ([]string, []string, error) {
-	return nil, nil, nil
+func (f fakeSchemaGetter) ResolveParentNodes(_ string, shard string) (map[string]string, error) {
+	return nil, nil
 }
 
 func singleShardState() *sharding.State {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -876,8 +876,8 @@ func (i *Index) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 		if replProps == nil {
 			replProps = defaultConsistency(replica.One)
 		}
-		outObjects, outScores, err = i.replicator.CheckConsistency(ctx,
-			replica.ConsistencyLevel(replProps.ConsistencyLevel), outObjects, outScores)
+		l := replica.ConsistencyLevel(replProps.ConsistencyLevel)
+		err = i.replicator.CheckConsistency(ctx, l, outObjects)
 		if err != nil {
 			return nil, nil, fmt.Errorf(
 				"failed to check consistency of search results: %w", err)

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -39,7 +39,9 @@ type Object struct {
 	VectorLen         int           `json:"-"`
 	BelongsToNode     string        `json:"-"`
 	BelongsToShard    string        `json:"-"`
-	docID             uint64
+	IsConsistent      bool          `json:"-"`
+
+	docID uint64
 }
 
 func New(docID uint64) *Object {

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -56,7 +56,7 @@ func (f *fakeSchemaGetter) ClusterHealthScore() int {
 }
 
 func (f *fakeSchemaGetter) ResolveParentNodes(string, string,
-) ([]string, []string, error) {
+) (map[string]string, error) {
 	panic("not implemented")
 }
 

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -57,7 +57,7 @@ func (f *fakeSchemaGetter) ClusterHealthScore() int {
 }
 
 func (f *fakeSchemaGetter) ResolveParentNodes(string, string,
-) ([]string, []string, error) {
+) (map[string]string, error) {
 	panic("not implemented")
 }
 

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -63,8 +63,8 @@ func (m *fakeSchemaGetter) ClusterHealthScore() int {
 }
 
 func (m *fakeSchemaGetter) ResolveParentNodes(_ string, shard string,
-) ([]string, []string, error) {
-	return nil, nil, nil
+) (map[string]string, error) {
+	return nil, nil
 }
 
 func singleShardState() *sharding.State {

--- a/usecases/replica/batch.go
+++ b/usecases/replica/batch.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"sort"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// indexedBatch holds an indexed list of objects
+type indexedBatch struct {
+	Data []*storobj.Object
+	// Index is z-index used to maintain object's order
+	Index []int
+}
+
+// createBatch creates indexedBatch from xs
+func createBatch(xs []*storobj.Object) indexedBatch {
+	var bi indexedBatch
+	bi.Data = xs
+	bi.Index = make([]int, len(xs))
+	for i := 0; i < len(xs); i++ {
+		bi.Index[i] = i
+	}
+	return bi
+}
+
+// cluster data object by shard
+func cluster(bi indexedBatch) []shardPart {
+	index := bi.Index
+	data := bi.Data
+	sort.Slice(index, func(i, j int) bool {
+		return data[index[i]].BelongsToShard < data[index[j]].BelongsToShard
+	})
+	clusters := make([]shardPart, 0, 16)
+	// partition
+	cur := data[index[0]]
+	j := 0
+	for i := 1; i < len(index); i++ {
+		if data[index[i]].BelongsToShard == cur.BelongsToShard {
+			continue
+		}
+		clusters = append(clusters, shardPart{
+			Shard: cur.BelongsToShard,
+			Node:  cur.BelongsToNode, Data: data,
+			Index: index[j:i],
+		})
+		j = i
+		cur = data[index[j]]
+
+	}
+	clusters = append(clusters, shardPart{
+		Shard: cur.BelongsToShard,
+		Node:  cur.BelongsToNode, Data: data,
+		Index: index[j:],
+	})
+	return clusters
+}
+
+// shardPart represents a data partition belonging to a physical shard
+type shardPart struct {
+	Shard string // one-to-one mapping between Shard and Node
+	Node  string
+
+	Data  []*storobj.Object
+	Index []int // index for data
+}
+
+func (b *shardPart) ObjectIDs() []strfmt.UUID {
+	xs := make([]strfmt.UUID, len(b.Index))
+	for i, idx := range b.Index {
+		xs[i] = b.Data[idx].ID()
+	}
+	return xs
+}
+
+func (b *shardPart) Extract() ([]objects.Replica, []strfmt.UUID) {
+	xs := make([]objects.Replica, len(b.Index))
+	ys := make([]strfmt.UUID, len(b.Index))
+
+	for i, idx := range b.Index {
+		p := b.Data[idx]
+		xs[i] = objects.Replica{ID: p.ID(), Deleted: false, Object: p}
+		ys[i] = p.ID()
+	}
+	return xs, ys
+}

--- a/usecases/replica/batch_test.go
+++ b/usecases/replica/batch_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+func TestBatchInput(t *testing.T) {
+	var (
+		N    = 9
+		ids  = make([]strfmt.UUID, N)
+		data = make([]*storobj.Object, N)
+	)
+	for i := 0; i < N; i++ {
+		uuid := strfmt.UUID(strconv.Itoa(i))
+		ids[i] = uuid
+		data[i] = objectEx(uuid, 1, "S1", "N1")
+	}
+	parts := cluster(createBatch(data))
+	assert.Len(t, parts, 1)
+	assert.Equal(t, parts[0], shardPart{
+		Shard: "S1",
+		Node:  "N1",
+		Data:  data,
+		Index: []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+	})
+	assert.Equal(t, parts[0].ObjectIDs(), ids)
+
+	data[0].BelongsToShard = "S2"
+	data[0].BelongsToNode = "N2"
+	data[2].BelongsToShard = "S2"
+	data[2].BelongsToNode = "N2"
+	data[3].BelongsToShard = "S2"
+	data[4].BelongsToNode = "N2"
+	data[5].BelongsToShard = "S2"
+	data[5].BelongsToNode = "N2"
+
+	parts = cluster(createBatch(data))
+	sort.Slice(parts, func(i, j int) bool { return len(parts[i].Index) < len(parts[j].Index) })
+	assert.Len(t, parts, 2)
+	assert.ElementsMatch(t, parts[0].ObjectIDs(), []strfmt.UUID{ids[0], ids[2], ids[3], ids[5]})
+	assert.Equal(t, parts[0].Shard, "S2")
+	assert.Equal(t, parts[0].Node, "N2")
+
+	assert.ElementsMatch(t, parts[1].ObjectIDs(), []strfmt.UUID{ids[1], ids[4], ids[6], ids[7], ids[8]})
+	assert.Equal(t, parts[1].Shard, "S1")
+	assert.Equal(t, parts[1].Node, "N1")
+}
+
+func genInputs(node, shard string, updateTime int64, ids []strfmt.UUID) ([]*storobj.Object, []RepairResponse) {
+	xs := make([]*storobj.Object, len(ids))
+	digestR := make([]RepairResponse, len(ids))
+	for i, id := range ids {
+		xs[i] = &storobj.Object{
+			Object: models.Object{
+				ID:                 id,
+				LastUpdateTimeUnix: updateTime,
+			},
+			BelongsToShard: shard,
+			BelongsToNode:  node,
+		}
+		digestR[i] = RepairResponse{ID: ids[i].String(), UpdateTime: updateTime}
+	}
+	return xs, digestR
+}
+
+func setObjectsConsistency(xs []*storobj.Object, isConsistent bool) []*storobj.Object {
+	want := make([]*storobj.Object, len(xs))
+	for i, x := range xs {
+		cp := *x
+		cp.IsConsistent = isConsistent
+		want[i] = &cp
+	}
+	return want
+}
+
+func objectEx(id strfmt.UUID, lastTime int64, shard, node string) *storobj.Object {
+	return &storobj.Object{
+		Object: models.Object{
+			ID:                 id,
+			LastUpdateTimeUnix: lastTime,
+		},
+		BelongsToShard: shard,
+		BelongsToNode:  node,
+	}
+}

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -53,7 +53,7 @@ func TestFinderReplicaNotFound(t *testing.T) {
 	var (
 		f      = newFakeFactory("C1", "S", []string{})
 		ctx    = context.Background()
-		finder = f.newFinder()
+		finder = f.newFinder("A")
 	)
 	_, err := finder.GetOne(ctx, "ONE", "S", "id", nil, additional.Properties{})
 	assert.ErrorIs(t, err, errReplicas)
@@ -63,9 +63,8 @@ func TestFinderReplicaNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, errReplicas)
 	f.assertLogErrorContains(t, errNoReplicaFound.Error())
 
-	_, err = finder.GetAll(ctx, "ONE", "S", []strfmt.UUID{"uuid1"})
-	assert.ErrorIs(t, err, errReplicas)
-	f.assertLogErrorContains(t, errNoReplicaFound.Error())
+	finder.CheckConsistency(ctx, All, []*storobj.Object{objectEx("1", 1, "S", "N")})
+	f.assertLogErrorContains(t, errReplicas.Error())
 }
 
 func TestFinderNodeObject(t *testing.T) {
@@ -82,14 +81,14 @@ func TestFinderNodeObject(t *testing.T) {
 
 	t.Run("Unresolved", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
-		finder := f.newFinder()
+		finder := f.newFinder("A")
 		_, err := finder.NodeObject(ctx, "N", "S", "id", nil, additional.Properties{})
 		assert.Contains(t, err.Error(), "N")
 	})
 
 	t.Run("Success", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
-		finder := f.newFinder()
+		finder := f.newFinder("A")
 		for _, n := range nodes {
 			f.RClient.On("FetchObject", anyVal, n, cls, shard, id, proj, adds).Return(r, nil)
 		}
@@ -115,7 +114,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 	t.Run("AllButOne", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
@@ -135,7 +134,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
@@ -152,7 +151,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			// obj       = object(id, 3)
 			digestR = []RepairResponse{{ID: id.String(), UpdateTime: 0}}
@@ -183,7 +182,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 	t.Run("AllButOne", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
@@ -201,7 +200,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
@@ -218,7 +217,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			// obj       = object(id, 3)
 			digestR = []RepairResponse{{ID: id.String(), UpdateTime: 0}}
@@ -249,7 +248,7 @@ func TestFinderGetOneWithConsistencyLevelOne(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
 		var (
 			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
+			finder = f.newFinder("A")
 			// obj    = objects.Replica{ID: id, Object: object(id, 3)
 		)
 		for _, n := range nodes {
@@ -265,10 +264,10 @@ func TestFinderGetOneWithConsistencyLevelOne(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
+			finder = f.newFinder(nodes[2])
 			item   = objects.Replica{ID: id, Object: object(id, 3)}
 		)
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
 		got, err := finder.GetOne(ctx, One, shard, id, proj, adds)
 		assert.Nil(t, err)
 		assert.Equal(t, item.Object, got)
@@ -277,314 +276,13 @@ func TestFinderGetOneWithConsistencyLevelOne(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
+			finder = f.newFinder("A")
 		)
 		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(emptyItem, nil)
 
 		got, err := finder.GetOne(ctx, One, shard, id, proj, adds)
 		assert.Nil(t, err)
 		assert.Equal(t, nilObject, got)
-	})
-}
-
-func TestFinderGetAllWithConsistencyLevelAll(t *testing.T) {
-	var (
-		ids   = []strfmt.UUID{"10", "20", "30"}
-		cls   = "C1"
-		shard = "SH1"
-		nodes = []string{"A", "B", "C"}
-		ctx   = context.Background()
-	)
-
-	t.Run("AllButOne", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 1, false),
-				replica(ids[1], 2, false),
-				replica(ids[2], 3, false),
-			}
-			digestR = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 3},
-			}
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, errAny)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, nil)
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRead)
-		assert.ErrorContains(t, err, msgCLevel)
-		f.assertLogContains(t, "replica", nodes[1])
-		f.assertLogErrorContains(t, errAny.Error())
-		assert.Nil(t, got)
-	})
-
-	t.Run("Success", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 1, false),
-				replica(ids[1], 2, false),
-				replica(ids[2], 3, false),
-			}
-			digestR = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 3},
-			}
-			want = fromReplicas(directR)
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, nil)
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
-	t.Run("OneOutOfThreeObjectsExists", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{{}, replica(ids[1], 2, false), {}}
-			digestR = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 0},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 0},
-			}
-			want = fromReplicas(directR)
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, nil)
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("DirectReadReturnsLessResults", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			ids     = []strfmt.UUID{"1", "2", "3"}
-			directR = []objects.Replica{ // has 2 instead of 3 objects
-				replica(ids[0], 2, false),
-				// replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
-			}
-			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 3}, // latest
-				{ID: ids[2].String(), UpdateTime: 1},
-			}
-			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 4}, // latest
-			}
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).
-			Return(directR, nil).
-			Once()
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).
-			Return(digestR2, nil).
-			Once()
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).
-			Return(digestR3, nil).
-			Once()
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.NotNil(t, err)
-		assert.Equal(t, []*storobj.Object(nil), got)
-		assert.ErrorContains(t, err, nodes[0])
-	})
-
-	t.Run("DigestReadReturnLessResults", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			ids     = []strfmt.UUID{"1", "2", "3"}
-			directR = []objects.Replica{
-				replica(ids[0], 2, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
-			}
-			digestR2 = []RepairResponse{ // has 2 instead of 3 objects
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 3}, // latest
-				//{ID: ids[2].String(), UpdateTime: 1},
-			}
-			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 4}, // latest
-			}
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).
-			Return(directR, nil).
-			Once()
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).
-			Return(digestR2, nil).
-			Once()
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).
-			Return(digestR3, nil).
-			Once()
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.NotNil(t, err)
-		assert.Equal(t, []*storobj.Object(nil), got)
-		assert.ErrorContains(t, err, nodes[0])
-	})
-}
-
-func TestFinderGetAllWithConsistencyLevelQuorum(t *testing.T) {
-	var (
-		ids   = []strfmt.UUID{"10", "20", "30"}
-		cls   = "C1"
-		shard = "SH1"
-		nodes = []string{"A", "B", "C"}
-		ctx   = context.Background()
-	)
-
-	t.Run("AllButOne", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 1, false),
-				replica(ids[1], 2, false),
-				replica(ids[2], 3, false),
-			}
-			digestR = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 3},
-			}
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, errAny)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, errAny)
-
-		got, err := finder.GetAll(ctx, Quorum, shard, ids)
-		assert.ErrorIs(t, err, errRead)
-		assert.ErrorContains(t, err, msgCLevel)
-		f.assertLogErrorContains(t, errAny.Error())
-		assert.Nil(t, got)
-	})
-
-	t.Run("Success", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 1, false),
-				replica(ids[1], 2, false),
-				replica(ids[2], 3, false),
-			}
-			digestR = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 3},
-			}
-			want = fromReplicas(directR)
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, errAny)
-
-		got, err := finder.GetAll(ctx, Quorum, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("OneOutOfThreeObjectsExists", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				{},
-				replica(ids[1], 2, false),
-				{},
-			}
-			digestR = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 0},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 0},
-			}
-			want = fromReplicas(directR)
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, errAny)
-
-		got, err := finder.GetAll(ctx, Quorum, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
-}
-
-func TestFinderGetAllWithConsistencyLevelOne(t *testing.T) {
-	var (
-		ids      = []strfmt.UUID{"10", "20", "30"}
-		cls      = "C1"
-		shard    = "SH1"
-		nodes    = []string{"A", "B", "C"}
-		ctx      = context.Background()
-		nilItems = []objects.Replica(nil)
-	)
-
-	t.Run("All", func(t *testing.T) {
-		var (
-			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
-		)
-		for _, n := range nodes {
-			f.RClient.On("FetchObjects", anyVal, n, cls, shard, ids).Return(nilItems, errAny)
-		}
-
-		got, err := finder.GetAll(ctx, One, shard, ids)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.ErrorIs(t, err, errRead)
-		assert.Nil(t, got)
-	})
-
-	t.Run("Success", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 1, false),
-				replica(ids[1], 2, false),
-				replica(ids[2], 3, false),
-			}
-			want = fromReplicas(directR)
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-
-		got, err := finder.GetAll(ctx, One, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("OneOutOfThreeObjectsExists", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{{}, replica(ids[1], 2, false), {}}
-			want    = fromReplicas(directR)
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, errAny)
-		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, ids).Return(directR, nil)
-
-		got, err := finder.GetAll(ctx, One, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
 	})
 }
 
@@ -601,7 +299,7 @@ func TestFinderExistsWithConsistencyLevelALL(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
 		)
@@ -618,7 +316,7 @@ func TestFinderExistsWithConsistencyLevelALL(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
 		)
@@ -634,7 +332,7 @@ func TestFinderExistsWithConsistencyLevelALL(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
 		)
@@ -661,7 +359,7 @@ func TestFinderExistsWithConsistencyLevelQuorum(t *testing.T) {
 	t.Run("AllButOne", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
 		)
@@ -678,7 +376,7 @@ func TestFinderExistsWithConsistencyLevelQuorum(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
 		)
@@ -694,7 +392,7 @@ func TestFinderExistsWithConsistencyLevelQuorum(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
 		)
@@ -720,7 +418,7 @@ func TestFinderExistsWithConsistencyLevelOne(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
 		)
@@ -735,7 +433,7 @@ func TestFinderExistsWithConsistencyLevelOne(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			digestR   = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
 		)
@@ -745,4 +443,260 @@ func TestFinderExistsWithConsistencyLevelOne(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, false, got)
 	})
+}
+
+func TestFinderCheckConsistencyALL(t *testing.T) {
+	var (
+		ids    = []strfmt.UUID{"0", "1", "2", "3", "4", "5"}
+		cls    = "C1"
+		shards = []string{"S1", "S2", "S3"}
+		nodes  = []string{"A", "B", "C"}
+		ctx    = context.Background()
+	)
+
+	t.Run("ExceptOne", func(t *testing.T) {
+		var (
+			shard       = shards[0]
+			f           = newFakeFactory("C1", shard, nodes)
+			finder      = f.newFinder("A")
+			xs, digestR = genInputs("A", shard, 1, ids)
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, errAny)
+
+		err := finder.CheckConsistency(ctx, All, xs)
+		want := setObjectsConsistency(xs, false)
+		assert.ErrorIs(t, err, errRead)
+		assert.ElementsMatch(t, want, xs)
+		f.assertLogErrorContains(t, errRead.Error())
+	})
+
+	t.Run("OneShard", func(t *testing.T) {
+		var (
+			shard       = shards[0]
+			f           = newFakeFactory("C1", shard, nodes)
+			finder      = f.newFinder("A")
+			xs, digestR = genInputs("A", shard, 2, ids)
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, nil)
+
+		want := setObjectsConsistency(xs, true)
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, want, xs)
+	})
+
+	t.Run("TwoShards", func(t *testing.T) {
+		var (
+			f             = newFakeFactory("C1", shards[0], nodes)
+			finder        = f.newFinder("A")
+			idSet1        = ids[:3]
+			idSet2        = ids[3:6]
+			xs1, digestR1 = genInputs("A", shards[0], 1, idSet1)
+			xs2, digestR2 = genInputs("B", shards[1], 2, idSet2)
+		)
+		xs := make([]*storobj.Object, 0, len(xs1)+len(xs2))
+		for i := 0; i < 3; i++ {
+			xs = append(xs, xs1[i])
+			xs = append(xs, xs2[i])
+		}
+		// first shard
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shards[0], idSet1).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[0], idSet1).Return(digestR1, nil)
+
+		// second shard
+		f.AddShard(shards[1], nodes)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shards[1], idSet2).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[1], idSet2).Return(digestR2, nil)
+
+		want := setObjectsConsistency(xs, true)
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, want, xs)
+	})
+
+	t.Run("ThreeShard", func(t *testing.T) {
+		var (
+			f             = newFakeFactory("C1", shards[0], nodes)
+			finder        = f.newFinder("A")
+			ids1          = ids[:2]
+			ids2          = ids[2:4]
+			ids3          = ids[4:]
+			xs1, digestR1 = genInputs("A", shards[0], 1, ids1)
+			xs2, digestR2 = genInputs("B", shards[1], 2, ids2)
+			xs3, digestR3 = genInputs("C", shards[2], 3, ids3)
+		)
+		xs := make([]*storobj.Object, 0, len(xs1)+len(xs2))
+		for i := 0; i < 2; i++ {
+			xs = append(xs, xs1[i])
+			xs = append(xs, xs2[i])
+			xs = append(xs, xs3[i])
+		}
+		// first shard
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shards[0], ids1).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[0], ids1).Return(digestR1, nil)
+
+		// second shard
+		f.AddShard(shards[1], nodes)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shards[1], ids2).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[1], ids2).Return(digestR2, nil)
+
+		// third shard
+		f.AddShard(shards[2], nodes)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shards[2], ids3).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shards[2], ids3).Return(digestR3, nil)
+
+		want := setObjectsConsistency(xs, true)
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, want, xs)
+	})
+
+	t.Run("TwoShardSingleNode", func(t *testing.T) {
+		var (
+			f             = newFakeFactory("C1", shards[0], nodes)
+			finder        = f.newFinder("A")
+			ids1          = ids[:2]
+			ids2          = ids[2:4]
+			ids3          = ids[4:]
+			xs1, digestR1 = genInputs("A", shards[0], 1, ids1)
+			xs2, digestR2 = genInputs("B", shards[1], 1, ids2)
+			xs3, digestR3 = genInputs("A", shards[2], 2, ids3)
+		)
+		xs := make([]*storobj.Object, 0, len(xs1)+len(xs2))
+		for i := 0; i < 2; i++ {
+			xs = append(xs, xs1[i])
+			xs = append(xs, xs2[i])
+			xs = append(xs, xs3[i])
+		}
+		// first shard
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shards[0], ids1).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[0], ids1).Return(digestR1, nil)
+
+		// second shard
+		f.AddShard(shards[1], nodes)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shards[1], ids2).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[1], ids2).Return(digestR2, nil)
+
+		// third shard
+		f.AddShard(shards[2], nodes)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shards[2], ids3).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shards[2], ids3).Return(digestR3, nil)
+
+		want := setObjectsConsistency(xs, true)
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, want, xs)
+	})
+}
+
+func TestFinderCheckConsistencyQuorum(t *testing.T) {
+	var (
+		ids   = []strfmt.UUID{"10", "20", "30"}
+		cls   = "C1"
+		shard = "SH1"
+		nodes = []string{"A", "B", "C"}
+		ctx   = context.Background()
+	)
+
+	t.Run("MalformedInputs", func(t *testing.T) {
+		var (
+			ids    = []strfmt.UUID{"10", "20", "30"}
+			shard  = "SH1"
+			nodes  = []string{"A", "B", "C"}
+			ctx    = context.Background()
+			f      = newFakeFactory("C1", shard, nodes)
+			finder = f.newFinder("A")
+			xs1    = []*storobj.Object{
+				objectEx(ids[0], 4, shard, "A"),
+				nil,
+				objectEx(ids[2], 6, shard, "A"),
+			}
+			// BelongToShard and BelongToNode are empty
+			xs2 = []*storobj.Object{
+				objectEx(ids[0], 4, shard, "A"),
+				{Object: models.Object{ID: ids[1]}},
+				objectEx(ids[2], 6, shard, "A"),
+			}
+		)
+
+		assert.Nil(t, finder.CheckConsistency(ctx, Quorum, nil))
+
+		err := finder.CheckConsistency(ctx, Quorum, xs1)
+		assert.NotNil(t, err)
+
+		err = finder.CheckConsistency(ctx, Quorum, xs2)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("None", func(t *testing.T) {
+		var (
+			f      = newFakeFactory("C1", shard, nodes)
+			finder = f.newFinder("A")
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 1, shard, "A"),
+				objectEx(ids[1], 2, shard, "A"),
+				objectEx(ids[2], 3, shard, "A"),
+			}
+			digestR = []RepairResponse{
+				{ID: ids[0].String(), UpdateTime: 1},
+				{ID: ids[1].String(), UpdateTime: 2},
+				{ID: ids[2].String(), UpdateTime: 3},
+			}
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, errAny)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, errAny)
+
+		err := finder.CheckConsistency(ctx, All, xs)
+		want := setObjectsConsistency(xs, false)
+		assert.ErrorIs(t, err, errRead)
+		assert.ElementsMatch(t, want, xs)
+		f.assertLogErrorContains(t, errRead.Error())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		var (
+			f      = newFakeFactory("C1", shard, nodes)
+			finder = f.newFinder("A")
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 1, shard, "A"),
+				objectEx(ids[1], 2, shard, "A"),
+				objectEx(ids[2], 3, shard, "A"),
+			}
+			digestR = []RepairResponse{
+				{ID: ids[0].String(), UpdateTime: 1},
+				{ID: ids[1].String(), UpdateTime: 2},
+				{ID: ids[2].String(), UpdateTime: 3},
+			}
+			want = setObjectsConsistency(xs, true)
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR, errAny)
+
+		err := finder.CheckConsistency(ctx, Quorum, xs)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, want, xs)
+	})
+}
+
+func TestFinderCheckConsistencyOne(t *testing.T) {
+	var (
+		ids    = []strfmt.UUID{"10", "20", "30"}
+		shard  = "SH1"
+		nodes  = []string{"A", "B", "C"}
+		ctx    = context.Background()
+		f      = newFakeFactory("C1", shard, nodes)
+		finder = f.newFinder("A")
+		xs     = []*storobj.Object{
+			objectEx(ids[0], 4, shard, "A"),
+			objectEx(ids[1], 5, shard, "A"),
+			objectEx(ids[2], 6, shard, "A"),
+		}
+		want = setObjectsConsistency(xs, true)
+	)
+
+	err := finder.CheckConsistency(ctx, One, xs)
+	assert.Nil(t, err)
+	assert.Equal(t, want, xs)
 }

--- a/usecases/replica/repairer_test.go
+++ b/usecases/replica/repairer_test.go
@@ -40,7 +40,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("GetContentFromDirectRead", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
@@ -65,7 +65,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("ChangedObject", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
@@ -79,7 +79,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 		updates := []*objects.VObject{{
 			LatestObject:    &item.Object.Object,
 			StaleUpdateTime: 2,
-			Version:         0, // todo set when implemented
+			Version:         0,
 		}}
 		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR4, nil)
 
@@ -94,7 +94,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("GetContentFromIndirectRead", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item2     = objects.Replica{ID: id, Object: object(id, 2)}
 			item3     = objects.Replica{ID: id, Object: object(id, 3)}
@@ -123,7 +123,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("OverwriteError", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
@@ -136,7 +136,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 		updates := []*objects.VObject{{
 			LatestObject:    &item.Object.Object,
 			StaleUpdateTime: 2,
-			Version:         0, // todo set when implemented
+			Version:         0,
 		}}
 		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
@@ -150,7 +150,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("CannotGetMostRecentObject", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item1     = objects.Replica{ID: id, Object: object(id, 1)}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
@@ -171,7 +171,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("MostRecentObjectChanged", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item1     = objects.Replica{ID: id, Object: object(id, 1)}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
@@ -195,7 +195,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("CreateMissingObject", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: object(id, 3)}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: false}}
@@ -219,7 +219,7 @@ func TestRepairerOneWithALL(t *testing.T) {
 	t.Run("ConflictDeletedObject", func(t *testing.T) {
 		var (
 			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
+			finder    = f.newFinder("A")
 			digestIDs = []strfmt.UUID{id}
 			item      = objects.Replica{ID: id, Object: nil, Deleted: true}
 			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
@@ -236,39 +236,457 @@ func TestRepairerOneWithALL(t *testing.T) {
 	})
 }
 
-func TestRepairerAllWithAll(t *testing.T) {
+func TestRepairerExistsWithALL(t *testing.T) {
 	var (
-		ids        = []strfmt.UUID{"10", "20", "30"}
-		cls        = "C1"
-		shard      = "SH1"
-		nodes      = []string{"A", "B", "C"}
-		ctx        = context.Background()
-		nilObjects = []*storobj.Object(nil)
+		id        = strfmt.UUID("123")
+		cls       = "C1"
+		shard     = "SH1"
+		nodes     = []string{"A", "B", "C"}
+		ctx       = context.Background()
+		adds      = additional.Properties{}
+		proj      = search.SelectProperties{}
+		emptyItem = objects.Replica{}
 	)
-	t.Run("DirectRead", func(t *testing.T) {
+
+	t.Run("ChangedObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item      = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+			digestR4  = []RepairResponse{{ID: id.String(), UpdateTime: 4, Err: "conflict"}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+		// repair
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
+
+		updates := []*objects.VObject{{
+			LatestObject:    &item.Object.Object,
+			StaleUpdateTime: 2,
+			Version:         0,
+		}}
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR4, nil).RunFn = func(a mock.Arguments) {
+			updates := a[4].([]*objects.VObject)[0]
+			assert.Equal(t, int64(2), updates.StaleUpdateTime)
+			assert.Equal(t, &item.Object.Object, updates.LatestObject)
+		}
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+
+		f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
+		f.assertLogErrorContains(t, "conflict")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item3     = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[1], cls, shard, id, proj, adds).Return(item3, nil)
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item3, nil)
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
+			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
+			updates := a[4].([]*objects.VObject)[0]
+			assert.Equal(t, int64(2), updates.StaleUpdateTime)
+			assert.Equal(t, &item3.Object.Object, updates.LatestObject)
+		}
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.Nil(t, err)
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("OverwriteError", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item      = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
+
+		updates := []*objects.VObject{{
+			LatestObject:    &item.Object.Object,
+			StaleUpdateTime: 2,
+			Version:         0,
+		}}
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+
+		f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
+		f.assertLogErrorContains(t, errAny.Error())
+	})
+
+	t.Run("CannotGetMostRecentObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(emptyItem, errAny)
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+
+		f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
+		f.assertLogErrorContains(t, errAny.Error())
+	})
+	t.Run("MostRecentObjectChanged", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item1     = objects.Replica{ID: id, Object: object(id, 1)}
+			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item1, nil)
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+		f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
+		f.assertLogErrorContains(t, errConflictObjectChanged.Error())
+	})
+
+	t.Run("CreateMissingObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item      = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2, Deleted: false}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+
+		// it can fetch object from the first or third node
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
+			updates := a[4].([]*objects.VObject)[0]
+			assert.Equal(t, int64(2), updates.StaleUpdateTime)
+			assert.Equal(t, &item.Object.Object, updates.LatestObject)
+		}
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.Nil(t, err)
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("ConflictDeletedObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+
+			digestR0 = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
+			digestR2 = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
+			digestR3 = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR0, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+
+		got, err := finder.Exists(ctx, All, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+		f.assertLogErrorContains(t, errConflictExistOrDeleted.Error())
+	})
+}
+
+func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
+	var (
+		id        = strfmt.UUID("123")
+		cls       = "C1"
+		shard     = "SH1"
+		nodes     = []string{"A", "B", "C"}
+		ctx       = context.Background()
+		adds      = additional.Properties{}
+		proj      = search.SelectProperties{}
+		emptyItem = objects.Replica{}
+	)
+
+	t.Run("ChangedObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item      = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+			digestR4  = []RepairResponse{{ID: id.String(), UpdateTime: 4, Err: "conflict"}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR2, errAny)
+
+		// repair
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+
+		updates := []*objects.VObject{{
+			LatestObject:    &item.Object.Object,
+			StaleUpdateTime: 2,
+			Version:         0,
+		}}
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR4, nil).RunFn = func(a mock.Arguments) {
+			updates := a[4].([]*objects.VObject)[0]
+			assert.Equal(t, int64(2), updates.StaleUpdateTime)
+			assert.Equal(t, &item.Object.Object, updates.LatestObject)
+		}
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+		f.assertLogContains(t, "msg", "A:3", "B:2")
+		f.assertLogErrorContains(t, "conflict")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes[:2])
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item3     = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR2, errAny)
+
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[1], cls, shard, id, proj, adds).Return(item3, nil)
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
+			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
+			updates := a[4].([]*objects.VObject)[0]
+			assert.Equal(t, int64(2), updates.StaleUpdateTime)
+			assert.Equal(t, &item3.Object.Object, updates.LatestObject)
+		}
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.Nil(t, err)
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("OverwriteError", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes[:2])
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item      = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR2, errAny)
+
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+
+		updates := []*objects.VObject{{
+			LatestObject:    &item.Object.Object,
+			StaleUpdateTime: 2,
+			Version:         0,
+		}}
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+		f.assertLogContains(t, "msg", "A:3", "B:2")
+		f.assertLogErrorContains(t, errAny.Error())
+	})
+
+	t.Run("CannotGetMostRecentObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, errAny)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(emptyItem, errAny)
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+		f.assertLogContains(t, "msg", "A:1", "C:3")
+		f.assertLogErrorContains(t, errAny.Error())
+	})
+	t.Run("MostRecentObjectChanged", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes)
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item1     = objects.Replica{ID: id, Object: object(id, 1)}
+			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
+		)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR1, errAny)
+		// called during reparation to fetch the most recent object
+		f.RClient.On("FetchObject", anyVal, nodes[1], cls, shard, id, proj, adds).Return(item1, nil)
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		assert.Equal(t, false, got)
+
+		f.assertLogContains(t, "msg", "A:1", "B:3")
+		f.assertLogErrorContains(t, errConflictObjectChanged.Error())
+	})
+
+	t.Run("CreateMissingObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes[:2])
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+			item      = objects.Replica{ID: id, Object: object(id, 3)}
+			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2, Deleted: false}}
+			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+
+		// it can fetch object from the first or third node
+		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
+			updates := a[4].([]*objects.VObject)[0]
+			assert.Equal(t, int64(2), updates.StaleUpdateTime)
+			assert.Equal(t, &item.Object.Object, updates.LatestObject)
+		}
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.Nil(t, err)
+		assert.Equal(t, true, got)
+	})
+
+	t.Run("ConflictDeletedObject", func(t *testing.T) {
+		var (
+			f         = newFakeFactory("C1", shard, nodes[:2])
+			finder    = f.newFinder("A")
+			digestIDs = []strfmt.UUID{id}
+
+			digestR0 = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
+			digestR2 = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
+		)
+		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR0, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
+
+		got, err := finder.Exists(ctx, Quorum, shard, id)
+		assert.ErrorIs(t, err, errRepair)
+		assert.ErrorContains(t, err, msgCLevel)
+		f.assertLogErrorContains(t, errConflictExistOrDeleted.Error())
+		assert.Equal(t, false, got)
+	})
+}
+
+func TestRepairerCheckConsistencyAll(t *testing.T) {
+	var (
+		ids   = []strfmt.UUID{"01", "02", "03"}
+		cls   = "C1"
+		shard = "S1"
+		nodes = []string{"A", "B", "C"}
+		ctx   = context.Background()
+	)
+	t.Run("GotMostRecentContent", func(t *testing.T) {
 		var (
 			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 4, false),
-				replica(ids[1], 5, false),
-				replica(ids[2], 6, false),
+			finder  = f.newFinder("A")
+			directR = []*storobj.Object{
+				objectEx(ids[0], 4, shard, "A"),
+				objectEx(ids[1], 5, shard, "A"),
+				objectEx(ids[2], 6, shard, "A"),
 			}
 			digestR2 = []RepairResponse{
 				{ID: ids[0].String(), UpdateTime: 4},
 				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 3},
+				{ID: ids[2].String(), UpdateTime: 0}, // doesn't exist
 			}
 			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
+				{ID: ids[0].String(), UpdateTime: 0}, // doesn't exist
 				{ID: ids[1].String(), UpdateTime: 5},
 				{ID: ids[2].String(), UpdateTime: 3},
 			}
-			want = fromReplicas(directR)
+			want = setObjectsConsistency(directR, true)
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
+
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, anyVal).Return(digestR2, nil)
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, anyVal).Return(digestR3, nil)
 
 		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
 			Return(digestR2, nil).
@@ -277,12 +695,12 @@ func TestRepairerAllWithAll(t *testing.T) {
 			got := a[4].([]*objects.VObject)
 			want := []*objects.VObject{
 				{
-					LatestObject:    &directR[1].Object.Object,
+					LatestObject:    &directR[1].Object,
 					StaleUpdateTime: 2,
 				},
 				{
-					LatestObject:    &directR[2].Object.Object,
-					StaleUpdateTime: 3,
+					LatestObject:    &directR[2].Object,
+					StaleUpdateTime: 0,
 				},
 			}
 
@@ -295,168 +713,40 @@ func TestRepairerAllWithAll(t *testing.T) {
 			got := a[4].([]*objects.VObject)
 			want := []*objects.VObject{
 				{
-					LatestObject:    &directR[0].Object.Object,
-					StaleUpdateTime: 1,
+					LatestObject:    &directR[0].Object,
+					StaleUpdateTime: 0,
 				},
 				{
-					LatestObject:    &directR[2].Object.Object,
+					LatestObject:    &directR[2].Object,
 					StaleUpdateTime: 3,
 				},
 			}
 			assert.ElementsMatch(t, want, got)
 		}
 
-		got, err := finder.GetAll(ctx, All, shard, ids)
+		err := finder.CheckConsistency(ctx, All, directR)
 		assert.Nil(t, err)
-		assert.Equal(t, want, got)
+		assert.Equal(t, want, directR)
 	})
 
-	t.Run("DirectRead3", func(t *testing.T) {
+	t.Run("GetMostRecentContent", func(t *testing.T) {
 		var (
-			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
-			ids    = []strfmt.UUID{"1", "2", "3"}
-			result = []*storobj.Object{
-				object(ids[0], 2),
-				object(ids[1], 3),
-				object(ids[2], 4), // latest
-
-			}
-			directR = []objects.Replica{
-				replica(ids[0], 2, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
-			}
-
-			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 3}, // latest
-				{ID: ids[2].String(), UpdateTime: 1},
-			}
-			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 4}, // latest
-			}
-			directR2 = []objects.Replica{
-				replica(ids[1], 3, false),
-			}
-			directR3 = []objects.Replica{
-				replica(ids[2], 4, false),
-			}
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
-
-		// fetch most recent objects
-		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).Return(directR2, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]strfmt.UUID)
-			assert.ElementsMatch(t, ids[1:2], got)
-		}
-		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).Return(directR3, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]strfmt.UUID)
-			assert.ElementsMatch(t, ids[2:], got)
-		}
-
-		// repair
-		var (
-			repairR1 = []RepairResponse{
-				{ID: ids[1].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 1},
-			}
-
-			repairR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 1},
-			}
-			repairR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
-			}
-		)
-		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
-			Return(repairR1, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &result[1].Object,
-					StaleUpdateTime: 1,
-				},
-				{
-					LatestObject:    &result[2].Object,
-					StaleUpdateTime: 1,
-				},
-			}
-
-			assert.ElementsMatch(t, want, got)
-		}
-
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
-			Return(repairR2, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &result[0].Object,
-					StaleUpdateTime: 1,
-				},
-				{
-					LatestObject:    &result[2].Object,
-					StaleUpdateTime: 1,
-				},
-			}
-
-			assert.ElementsMatch(t, want, got)
-		}
-		f.RClient.On("OverwriteObjects", anyVal, nodes[2], cls, shard, anyVal).
-			Return(repairR3, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &result[0].Object,
-					StaleUpdateTime: 1,
-				},
-				{
-					LatestObject:    &result[1].Object,
-					StaleUpdateTime: 1,
-				},
-			}
-			assert.ElementsMatch(t, want, got)
-		}
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.Nil(t, err)
-		assert.Equal(t, result, got)
-	})
-
-	t.Run("DigestRead6", func(t *testing.T) {
-		var (
-			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
+			f      = newFakeFactory(cls, shard, nodes)
+			finder = f.newFinder("A")
 			ids    = []strfmt.UUID{"1", "2", "3", "4", "5"}
 			result = []*storobj.Object{
-				object(ids[0], 2),
-				object(ids[1], 2),
-				object(ids[2], 3),
-				object(ids[3], 4), // latest
-				object(ids[4], 3),
+				objectEx(ids[0], 2, shard, "A"),
+				objectEx(ids[1], 2, shard, "A"),
+				objectEx(ids[2], 3, shard, "A"),
+				objectEx(ids[3], 4, shard, "A"),
+				objectEx(ids[4], 3, shard, "A"),
 			}
-			directR = []objects.Replica{
-				replica(ids[0], 1, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 2, false),
-				replica(ids[3], 4, false), // latest
-				replica(ids[4], 2, false),
+			xs = []*storobj.Object{
+				objectEx(ids[0], 1, shard, "A"),
+				objectEx(ids[1], 1, shard, "A"),
+				objectEx(ids[2], 2, shard, "A"),
+				objectEx(ids[3], 4, shard, "A"), // latest
+				objectEx(ids[4], 2, shard, "A"),
 			}
 			digestR2 = []RepairResponse{
 				{ID: ids[0].String(), UpdateTime: 2}, // latest
@@ -480,8 +770,8 @@ func TestRepairerAllWithAll(t *testing.T) {
 				replica(ids[2], 3, false),
 				replica(ids[4], 3, false),
 			}
+			want = setObjectsConsistency(result, true)
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
 		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
 		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
 
@@ -589,19 +879,19 @@ func TestRepairerAllWithAll(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		got, err := finder.GetAll(ctx, All, shard, ids)
+		err := finder.CheckConsistency(ctx, All, xs)
 		assert.Nil(t, err)
-		assert.Equal(t, result, got)
+		assert.Equal(t, want, xs)
 	})
 
-	t.Run("ChangedObject", func(t *testing.T) {
+	t.Run("OverwriteChangedObject", func(t *testing.T) {
 		var (
 			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
-			result = []objects.Replica{
-				replica(ids[0], 4, false),
-				replica(ids[1], 5, false),
-				replica(ids[2], 6, false),
+			finder = f.newFinder("A")
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 4, shard, "A"),
+				objectEx(ids[1], 5, shard, "A"),
+				objectEx(ids[2], 6, shard, "A"),
 			}
 			digestR2 = []RepairResponse{
 				{ID: ids[0].String(), UpdateTime: 4},
@@ -613,28 +903,29 @@ func TestRepairerAllWithAll(t *testing.T) {
 				{ID: ids[1].String(), UpdateTime: 5},
 				{ID: ids[2].String(), UpdateTime: 3},
 			}
-			digestR4 = []RepairResponse{
+			directR2 = []RepairResponse{
 				{ID: ids[0].String(), UpdateTime: 4},
 				{ID: ids[1].String(), UpdateTime: 2},
 				{ID: ids[2].String(), UpdateTime: 1, Err: "conflict"}, // this one
 			}
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(result, nil)
+		want := setObjectsConsistency(xs, true)
+		want[2].IsConsistent = false
 		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
 		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
 
 		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
-			Return(digestR4, nil).
+			Return(directR2, nil).
 			Once().
 			RunFn = func(a mock.Arguments) {
 			got := a[4].([]*objects.VObject)
 			want := []*objects.VObject{
 				{
-					LatestObject:    &result[1].Object.Object,
+					LatestObject:    &xs[1].Object,
 					StaleUpdateTime: 2,
 				},
 				{
-					LatestObject:    &result[2].Object.Object,
+					LatestObject:    &xs[2].Object,
 					StaleUpdateTime: 3,
 				},
 			}
@@ -648,33 +939,31 @@ func TestRepairerAllWithAll(t *testing.T) {
 			got := a[4].([]*objects.VObject)
 			want := []*objects.VObject{
 				{
-					LatestObject:    &result[0].Object.Object,
+					LatestObject:    &xs[0].Object,
 					StaleUpdateTime: 1,
 				},
 				{
-					LatestObject:    &result[2].Object.Object,
+					LatestObject:    &xs[2].Object,
 					StaleUpdateTime: 3,
 				},
 			}
 			assert.ElementsMatch(t, want, got)
 		}
 
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, nilObjects, got)
-		f.assertLogErrorContains(t, nodes[1], "conflict")
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.Equal(t, want, xs)
 	})
 
 	t.Run("OverwriteError", func(t *testing.T) {
 		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			ids     = []strfmt.UUID{"1", "2", "3"}
-			directR = []objects.Replica{
-				replica(ids[0], 2, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
+			f      = newFakeFactory("C1", shard, nodes)
+			finder = f.newFinder("A")
+			ids    = []strfmt.UUID{"1", "2", "3"}
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 2, shard, "A"),
+				objectEx(ids[1], 3, shard, "A"),
+				objectEx(ids[2], 1, shard, "A"),
 			}
 
 			digestR2 = []RepairResponse{
@@ -694,9 +983,16 @@ func TestRepairerAllWithAll(t *testing.T) {
 				replica(ids[2], 4, false),
 			}
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).
-			Return(directR, nil).
-			Once()
+
+		want := setObjectsConsistency([]*storobj.Object{
+			xs[0],
+			directR2[0].Object,
+			xs[2],
+		}, false)
+		want[1].IsConsistent = true
+		want[1].BelongsToNode = "A"
+		want[1].BelongsToShard = shard
+
 		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).
 			Return(digestR2, nil).
 			Once()
@@ -735,75 +1031,30 @@ func TestRepairerAllWithAll(t *testing.T) {
 			Return(repairR3, nil).
 			Once()
 
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		f.assertLogErrorContains(t, nodes[1], errAny.Error())
-		assert.Equal(t, []*storobj.Object(nil), got)
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.Equal(t, want, xs)
 	})
 
-	t.Run("FetchMostRecentObjectsError", func(t *testing.T) {
+	t.Run("DirectReadEmptyResponse", func(t *testing.T) {
 		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			ids     = []strfmt.UUID{"1", "2", "3"}
-			directR = []objects.Replica{
-				replica(ids[0], 2, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
+			f      = newFakeFactory("C1", shard, nodes)
+			finder = f.newFinder("A")
+			ids    = []strfmt.UUID{"1", "2", "3"}
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 2, shard, "A"),
+				objectEx(ids[1], 3, shard, "A"),
+				objectEx(ids[2], 1, shard, "A"),
 			}
 
 			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
+				{ID: ids[0].String(), UpdateTime: 2},
 				{ID: ids[1].String(), UpdateTime: 3}, // latest
 				{ID: ids[2].String(), UpdateTime: 1},
 			}
 			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 4}, // latest
-			}
-			directR2 = []objects.Replica{
-				replica(ids[1], 3, false),
-			}
-			directR3 = []objects.Replica{
-				replica(ids[2], 4, false),
-			}
-		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
-
-		// fetch most recent objects
-		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).Return(directR2, nil)
-		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).Return(directR3, errAny)
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		f.assertLogErrorContains(t, errAny.Error())
-		assert.Equal(t, []*storobj.Object(nil), got)
-	})
-
-	t.Run("FetchMostRecentObjectsEmptyResponse", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			ids     = []strfmt.UUID{"1", "2", "3"}
-			directR = []objects.Replica{
-				replica(ids[0], 2, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
-			}
-
-			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 3}, // latest
-				{ID: ids[2].String(), UpdateTime: 1},
-			}
-			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
+				{ID: ids[0].String(), UpdateTime: 2},
+				{ID: ids[1].String(), UpdateTime: 3},
 				{ID: ids[2].String(), UpdateTime: 4}, // latest
 			}
 			directR2 = []objects.Replica{
@@ -811,654 +1062,227 @@ func TestRepairerAllWithAll(t *testing.T) {
 			}
 			directR3 = []objects.Replica{}
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
+
+		want := setObjectsConsistency(xs, true)
+		want[2].IsConsistent = false
+
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).
+			Return(digestR2, nil).
+			Once()
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).
+			Return(digestR3, nil).
+			Once()
 
 		// fetch most recent objects
-		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).Return(directR2, nil)
-		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).Return(directR3, nil)
+		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(directR2, nil).
+			Once()
+		// response must at leas contain one item
+		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).
+			Return(directR3, nil).
+			Once()
+		// repair
+		var (
+			repairR1 = []RepairResponse{
+				{ID: ids[1].String(), UpdateTime: 1},
+				{ID: ids[2].String(), UpdateTime: 1},
+			}
 
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, []*storobj.Object(nil), got)
+			repairR2 = []RepairResponse(nil)
+		)
+		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
+			Return(repairR1, nil).
+			Once()
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(repairR2, nil).
+			Once()
+
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.Equal(t, want, xs)
 	})
 
-	t.Run("FetchMostRecentObjectsUnexpectedResponse", func(t *testing.T) {
+	t.Run("DirectReadEUnexpectedResponse", func(t *testing.T) {
 		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			ids     = []strfmt.UUID{"1", "2", "3"}
-			directR = []objects.Replica{
-				replica(ids[0], 2, false),
-				replica(ids[1], 1, false),
-				replica(ids[2], 1, false),
+			f      = newFakeFactory("C1", shard, nodes)
+			finder = f.newFinder("A")
+			ids    = []strfmt.UUID{"1", "2", "3"}
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 2, shard, "A"),
+				objectEx(ids[1], 3, shard, "A"),
+				objectEx(ids[2], 1, shard, "A"),
 			}
 
 			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
+				{ID: ids[0].String(), UpdateTime: 2},
 				{ID: ids[1].String(), UpdateTime: 3}, // latest
 				{ID: ids[2].String(), UpdateTime: 1},
 			}
 			digestR3 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 1},
+				{ID: ids[0].String(), UpdateTime: 2},
+				{ID: ids[1].String(), UpdateTime: 3},
 				{ID: ids[2].String(), UpdateTime: 4}, // latest
 			}
 			directR2 = []objects.Replica{
 				replica(ids[1], 3, false),
 			}
-			directR3 = []objects.Replica{
-				replica(ids[2], 3, false), // 3 instead of 4
-			}
+			// unexpected response UpdateTime  is 3 instead of 4
+			directR3 = []objects.Replica{replica(ids[2], 3, false)}
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
+
+		want := setObjectsConsistency(xs, true)
+		want[2].IsConsistent = false
+
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).
+			Return(digestR2, nil).
+			Once()
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).
+			Return(digestR3, nil).
+			Once()
 
 		// fetch most recent objects
-		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).Return(directR2, nil)
-		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).Return(directR3, nil)
+		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(directR2, nil).
+			Once()
+		// response must at leas contain one item
+		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).
+			Return(directR3, nil).
+			Once()
+		// repair
+		var (
+			repairR1 = []RepairResponse{
+				{ID: ids[1].String(), UpdateTime: 1},
+				{ID: ids[2].String(), UpdateTime: 1},
+			}
 
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, []*storobj.Object(nil), got)
+			repairR2 = []RepairResponse(nil)
+		)
+		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
+			Return(repairR1, nil).
+			Once()
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(repairR2, nil).
+			Once()
+
+		err := finder.CheckConsistency(ctx, All, xs)
+		assert.Nil(t, err)
+		assert.Equal(t, want, xs)
 	})
 
-	t.Run("MissingObject", func(t *testing.T) {
+	t.Run("OrphanObject", func(t *testing.T) {
 		var (
 			f      = newFakeFactory("C1", shard, nodes)
-			finder = f.newFinder()
-			ids    = []strfmt.UUID{"1", "2", "3", "4", "5"}
-			result = []*storobj.Object{
-				nil,
-				nil,
-				nil,
-				object(ids[3], 4), // latest
-				object(ids[4], 3),
+			finder = f.newFinder("A")
+			ids    = []strfmt.UUID{"1", "2", "3"}
+			xs     = []*storobj.Object{
+				objectEx(ids[0], 2, shard, "A"),
+				objectEx(ids[1], 3, shard, "A"),
+				objectEx(ids[2], 1, shard, "A"),
 			}
-			directR = []objects.Replica{
-				replica(ids[0], 0, true),
-				replica(ids[1], 1, false),
-				replica(ids[2], 2, false),
-				replica(ids[3], 4, false), // latest
-				replica(ids[4], 2, false),
-			}
+
 			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 2}, // latest
-				{ID: ids[1].String(), UpdateTime: 0, Deleted: true},
-				{ID: ids[2].String(), UpdateTime: 1},
-				{ID: ids[3].String(), UpdateTime: 1},
-				{ID: ids[4].String(), UpdateTime: 1},
+				{ID: ids[0].String(), UpdateTime: 1},
+				{ID: ids[1].String(), UpdateTime: 3}, // latest
+				{ID: ids[2].String(), UpdateTime: 1, Deleted: true},
 			}
 			digestR3 = []RepairResponse{
 				{ID: ids[0].String(), UpdateTime: 1},
 				{ID: ids[1].String(), UpdateTime: 1},
-				{ID: ids[2].String(), UpdateTime: 0, Deleted: true},
-				{ID: ids[3].String(), UpdateTime: 1},
-				{ID: ids[4].String(), UpdateTime: 3}, // latest
+				{ID: ids[2].String(), UpdateTime: 4, Deleted: true}, // latest
 			}
 			directR2 = []objects.Replica{
-				replica(ids[0], 2, false),
-			}
-			directR3 = []objects.Replica{
-				replica(ids[4], 3, false),
+				replica(ids[1], 3, false),
 			}
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
+
+		want := setObjectsConsistency(xs, true)
+		want[2].IsConsistent = false // orphan
+
+		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).
+			Return(digestR2, nil).
+			Once()
+		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).
+			Return(digestR3, nil).
+			Once()
 
 		// fetch most recent objects
-		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).Return(directR2, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]strfmt.UUID)
-			assert.ElementsMatch(t, ids[1:2], got)
-		}
-		f.RClient.On("FetchObjects", anyVal, nodes[2], cls, shard, anyVal).Return(directR3, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]strfmt.UUID)
-			assert.ElementsMatch(t, []strfmt.UUID{ids[4]}, got)
-		}
-
+		f.RClient.On("FetchObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(directR2, nil).
+			Once()
 		// repair
 		var (
-			overwriteR1 = []RepairResponse{
-				{ID: ids[4].String(), UpdateTime: 2},
-			}
-			overwriteR2 = []RepairResponse{
-				{ID: ids[3].String(), UpdateTime: 1},
-				{ID: ids[4].String(), UpdateTime: 1},
-			}
-			overwriteR3 = []RepairResponse{
-				{ID: ids[3].String(), UpdateTime: 1},
-			}
-		)
-		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
-			Return(overwriteR1, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &result[4].Object,
-					StaleUpdateTime: 2,
-				},
+			repairR2 = []RepairResponse{
+				{ID: ids[1].String(), UpdateTime: 1},
 			}
 
-			assert.ElementsMatch(t, want, got)
-		}
-
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
-			Return(overwriteR2, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &result[3].Object,
-					StaleUpdateTime: 1,
-				},
-				{
-					LatestObject:    &result[4].Object,
-					StaleUpdateTime: 1,
-				},
-			}
-
-			assert.ElementsMatch(t, want, got)
-		}
-		f.RClient.On("OverwriteObjects", anyVal, nodes[2], cls, shard, anyVal).
-			Return(overwriteR3, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &result[3].Object,
-					StaleUpdateTime: 1,
-				},
-			}
-			assert.ElementsMatch(t, want, got)
-		}
-
-		got, err := finder.GetAll(ctx, All, shard, ids)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		f.assertLogErrorContains(t, errConflictExistOrDeleted.Error())
-		assert.Equal(t, nilObjects, got)
-	})
-}
-
-func TestRepairerAllWithQuorum(t *testing.T) {
-	var (
-		ids   = []strfmt.UUID{"10", "20", "30"}
-		cls   = "C1"
-		shard = "SH1"
-		nodes = []string{"A", "B", "C"}
-		ctx   = context.Background()
-	)
-	t.Run("DirectRead", func(t *testing.T) {
-		var (
-			f       = newFakeFactory("C1", shard, nodes)
-			finder  = f.newFinder()
-			directR = []objects.Replica{
-				replica(ids[0], 4, false),
-				replica(ids[1], 5, false),
-				replica(ids[2], 6, false),
-			}
-			digestR2 = []RepairResponse{
-				{ID: ids[0].String(), UpdateTime: 4},
-				{ID: ids[1].String(), UpdateTime: 2},
-				{ID: ids[2].String(), UpdateTime: 3},
-			}
-			digestR3 = []RepairResponse{
+			repairR3 = []RepairResponse{
 				{ID: ids[0].String(), UpdateTime: 1},
-				{ID: ids[1].String(), UpdateTime: 5},
-				{ID: ids[2].String(), UpdateTime: 3},
+				{ID: ids[1].String(), UpdateTime: 1},
 			}
-			want = fromReplicas(directR)
 		)
-		f.RClient.On("FetchObjects", anyVal, nodes[0], cls, shard, ids).Return(directR, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, errAny)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
+
+		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
+			Return(repairR2, nil).
+			Once()
 		f.RClient.On("OverwriteObjects", anyVal, nodes[2], cls, shard, anyVal).
-			Return(digestR2, nil).
-			Once().
-			RunFn = func(a mock.Arguments) {
-			got := a[4].([]*objects.VObject)
-			want := []*objects.VObject{
-				{
-					LatestObject:    &directR[0].Object.Object,
-					StaleUpdateTime: 1,
-				},
-				{
-					LatestObject:    &directR[2].Object.Object,
-					StaleUpdateTime: 3,
-				},
-			}
-			assert.ElementsMatch(t, want, got)
-		}
+			Return(repairR3, nil).
+			Once()
 
-		got, err := finder.GetAll(ctx, Quorum, shard, ids)
+		err := finder.CheckConsistency(ctx, All, xs)
 		assert.Nil(t, err)
-		assert.Equal(t, want, got)
+		assert.Equal(t, want, xs)
 	})
 }
 
-func TestRepairerExistsWithALL(t *testing.T) {
+func TestRepairerCheckConsistencyQuorum(t *testing.T) {
 	var (
-		id        = strfmt.UUID("123")
-		cls       = "C1"
-		shard     = "SH1"
-		nodes     = []string{"A", "B", "C"}
-		ctx       = context.Background()
-		adds      = additional.Properties{}
-		proj      = search.SelectProperties{}
-		emptyItem = objects.Replica{}
+		ids    = []strfmt.UUID{"10", "20", "30"}
+		cls    = "C1"
+		shard  = "SH1"
+		nodes  = []string{"A", "B", "C"}
+		ctx    = context.Background()
+		f      = newFakeFactory("C1", shard, nodes)
+		finder = f.newFinder("A")
+		xs     = []*storobj.Object{
+			objectEx(ids[0], 4, shard, "A"),
+			objectEx(ids[1], 5, shard, "A"),
+			objectEx(ids[2], 6, shard, "A"),
+		}
+		digestR2 = []RepairResponse{
+			{ID: ids[0].String(), UpdateTime: 4},
+			{ID: ids[1].String(), UpdateTime: 2},
+			{ID: ids[2].String(), UpdateTime: 3},
+		}
+		digestR3 = []RepairResponse{
+			{ID: ids[0].String(), UpdateTime: 1},
+			{ID: ids[1].String(), UpdateTime: 5},
+			{ID: ids[2].String(), UpdateTime: 3},
+		}
+		want = setObjectsConsistency(xs, true)
 	)
-
-	t.Run("ChangedObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item      = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-			digestR4  = []RepairResponse{{ID: id.String(), UpdateTime: 4, Err: "conflict"}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-		// repair
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
-
-		updates := []*objects.VObject{{
-			LatestObject:    &item.Object.Object,
-			StaleUpdateTime: 2,
-			Version:         0, // todo set when implemented
-		}}
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR4, nil).RunFn = func(a mock.Arguments) {
-			updates := a[4].([]*objects.VObject)[0]
-			assert.Equal(t, int64(2), updates.StaleUpdateTime)
-			assert.Equal(t, &item.Object.Object, updates.LatestObject)
+	f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, ids).Return(digestR2, errAny)
+	f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, ids).Return(digestR3, nil)
+	f.RClient.On("OverwriteObjects", anyVal, nodes[2], cls, shard, anyVal).
+		Return(digestR2, nil).
+		Once().
+		RunFn = func(a mock.Arguments) {
+		got := a[4].([]*objects.VObject)
+		want := []*objects.VObject{
+			{
+				LatestObject:    &xs[0].Object,
+				StaleUpdateTime: 1,
+			},
+			{
+				LatestObject:    &xs[2].Object,
+				StaleUpdateTime: 3,
+			},
 		}
+		assert.ElementsMatch(t, want, got)
+	}
 
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-
-		f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
-		f.assertLogErrorContains(t, "conflict")
-	})
-
-	t.Run("Success", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item3     = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[1], cls, shard, id, proj, adds).Return(item3, nil)
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item3, nil)
-
-		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
-			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
-			updates := a[4].([]*objects.VObject)[0]
-			assert.Equal(t, int64(2), updates.StaleUpdateTime)
-			assert.Equal(t, &item3.Object.Object, updates.LatestObject)
-		}
-
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.Nil(t, err)
-		assert.Equal(t, true, got)
-	})
-
-	t.Run("OverwriteError", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item      = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
-
-		updates := []*objects.VObject{{
-			LatestObject:    &item.Object.Object,
-			StaleUpdateTime: 2,
-			Version:         0, // todo set when implemented
-		}}
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
-
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-
-		f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
-		f.assertLogErrorContains(t, errAny.Error())
-	})
-
-	t.Run("CannotGetMostRecentObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(emptyItem, errAny)
-
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-
-		f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
-		f.assertLogErrorContains(t, errAny.Error())
-	})
-	t.Run("MostRecentObjectChanged", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item1     = objects.Replica{ID: id, Object: object(id, 1)}
-			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item1, nil)
-
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-		f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
-		f.assertLogErrorContains(t, errConflictObjectChanged.Error())
-	})
-
-	t.Run("CreateMissingObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item      = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2, Deleted: false}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
-		)
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-
-		// it can fetch object from the first or third node
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(item, nil)
-
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
-			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
-			updates := a[4].([]*objects.VObject)[0]
-			assert.Equal(t, int64(2), updates.StaleUpdateTime)
-			assert.Equal(t, &item.Object.Object, updates.LatestObject)
-		}
-
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.Nil(t, err)
-		assert.Equal(t, true, got)
-	})
-
-	t.Run("ConflictDeletedObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-
-			digestR0 = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
-			digestR2 = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
-			digestR3 = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
-		)
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR0, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-
-		got, err := finder.Exists(ctx, All, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-		f.assertLogErrorContains(t, errConflictExistOrDeleted.Error())
-	})
-}
-
-func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
-	var (
-		id        = strfmt.UUID("123")
-		cls       = "C1"
-		shard     = "SH1"
-		nodes     = []string{"A", "B", "C"}
-		ctx       = context.Background()
-		adds      = additional.Properties{}
-		proj      = search.SelectProperties{}
-		emptyItem = objects.Replica{}
-	)
-
-	t.Run("ChangedObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item      = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-			digestR4  = []RepairResponse{{ID: id.String(), UpdateTime: 4, Err: "conflict"}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, errAny)
-		// repair
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-
-		updates := []*objects.VObject{{
-			LatestObject:    &item.Object.Object,
-			StaleUpdateTime: 2,
-			Version:         0, // todo set when implemented
-		}}
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR4, nil).RunFn = func(a mock.Arguments) {
-			updates := a[4].([]*objects.VObject)[0]
-			assert.Equal(t, int64(2), updates.StaleUpdateTime)
-			assert.Equal(t, &item.Object.Object, updates.LatestObject)
-		}
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-		f.assertLogContains(t, "msg", "A:3", "B:2")
-		f.assertLogErrorContains(t, "conflict")
-	})
-
-	t.Run("Success", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes[:2])
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item3     = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR2, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR3, nil)
-
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[1], cls, shard, id, proj, adds).Return(item3, nil)
-
-		f.RClient.On("OverwriteObjects", anyVal, nodes[0], cls, shard, anyVal).
-			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
-			updates := a[4].([]*objects.VObject)[0]
-			assert.Equal(t, int64(2), updates.StaleUpdateTime)
-			assert.Equal(t, &item3.Object.Object, updates.LatestObject)
-		}
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.Nil(t, err)
-		assert.Equal(t, true, got)
-	})
-
-	t.Run("OverwriteError", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes[:2])
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item      = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-
-		updates := []*objects.VObject{{
-			LatestObject:    &item.Object.Object,
-			StaleUpdateTime: 2,
-			Version:         0, // todo set when implemented
-		}}
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-		f.assertLogContains(t, "msg", "A:3", "B:2")
-		f.assertLogErrorContains(t, errAny.Error())
-	})
-
-	t.Run("CannotGetMostRecentObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, errAny)
-		f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs).Return(digestR3, nil)
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[2], cls, shard, id, proj, adds).Return(emptyItem, errAny)
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-		f.assertLogContains(t, "msg", "A:1", "C:3")
-		f.assertLogErrorContains(t, errAny.Error())
-	})
-	t.Run("MostRecentObjectChanged", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes)
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item1     = objects.Replica{ID: id, Object: object(id, 1)}
-			digestR1  = []RepairResponse{{ID: id.String(), UpdateTime: 1}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3}}
-		)
-
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR1, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR3, nil)
-		// called during reparation to fetch the most recent object
-		f.RClient.On("FetchObject", anyVal, nodes[1], cls, shard, id, proj, adds).Return(item1, nil)
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		assert.Equal(t, false, got)
-
-		f.assertLogContains(t, "msg", "A:1", "B:3")
-		f.assertLogErrorContains(t, errConflictObjectChanged.Error())
-	})
-
-	t.Run("CreateMissingObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes[:2])
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-			item      = objects.Replica{ID: id, Object: object(id, 3)}
-			digestR2  = []RepairResponse{{ID: id.String(), UpdateTime: 2, Deleted: false}}
-			digestR3  = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
-		)
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR3, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-
-		// it can fetch object from the first or third node
-		f.RClient.On("FetchObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(item, nil)
-
-		f.RClient.On("OverwriteObjects", anyVal, nodes[1], cls, shard, anyVal).
-			Return(digestR2, nil).RunFn = func(a mock.Arguments) {
-			updates := a[4].([]*objects.VObject)[0]
-			assert.Equal(t, int64(2), updates.StaleUpdateTime)
-			assert.Equal(t, &item.Object.Object, updates.LatestObject)
-		}
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.Nil(t, err)
-		assert.Equal(t, true, got)
-	})
-
-	t.Run("ConflictDeletedObject", func(t *testing.T) {
-		var (
-			f         = newFakeFactory("C1", shard, nodes[:2])
-			finder    = f.newFinder()
-			digestIDs = []strfmt.UUID{id}
-
-			digestR0 = []RepairResponse{{ID: id.String(), UpdateTime: 0, Deleted: true}}
-			digestR2 = []RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: false}}
-		)
-		f.RClient.On("DigestObjects", anyVal, nodes[0], cls, shard, digestIDs).Return(digestR0, nil)
-		f.RClient.On("DigestObjects", anyVal, nodes[1], cls, shard, digestIDs).Return(digestR2, nil)
-
-		got, err := finder.Exists(ctx, Quorum, shard, id)
-		assert.ErrorIs(t, err, errRepair)
-		assert.ErrorContains(t, err, msgCLevel)
-		f.assertLogErrorContains(t, errConflictExistOrDeleted.Error())
-		assert.Equal(t, false, got)
-	})
+	err := finder.CheckConsistency(ctx, Quorum, xs)
+	assert.Nil(t, err)
+	assert.Equal(t, want, xs)
 }

--- a/usecases/replica/resolver_test.go
+++ b/usecases/replica/resolver_test.go
@@ -26,28 +26,66 @@ func TestResolver(t *testing.T) {
 		"S4": {"D", "E", "F"},
 		"S5": {"A", "B", "C", "D", "E", "F"},
 	}
+	assertSameHosts := func(want, got rState, thisNode string) {
+		t.Helper()
+		if thisNode != "" {
+			assert.Equal(t, thisNode, got.Hosts[0])
+		}
+		assert.ElementsMatch(t, want.Hosts, got.Hosts, "match Hosts")
+		assert.Equal(t, want.NodeMap, got.NodeMap, "match NodeMap")
+		assert.Equal(t, want.CLevel, got.CLevel, "match CLevel")
+		assert.Equal(t, want.Level, got.Level, "match Level")
+	}
 
 	nr := newFakeNodeResolver([]string{"A", "B", "C"})
 	r := resolver{
 		nodeResolver: nr,
-		schema:       newFakeShardingState(ss, nr),
+		Class:        "C",
+		NodeName:     "A",
+		Schema:       newFakeShardingState("A", ss, nr),
 	}
 	t.Run("ShardingState", func(t *testing.T) {
-		_, err := r.State("Sx", One)
+		_, err := r.State("Sx", One, "")
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "sharding state")
 	})
 	t.Run("ALL", func(t *testing.T) {
-		got, err := r.State("S1", All)
+		r := resolver{
+			nodeResolver: nr,
+			Class:        "C",
+			NodeName:     "B",
+			Schema:       newFakeShardingState("B", ss, nr),
+		}
+		got, err := r.State("S1", All, "")
 		assert.Nil(t, err)
-		want := rState{All, len(ss["S1"]), ss["S1"], nil}
-		assert.Equal(t, want, got)
+		m := make(map[string]string, len(ss["S1"]))
+		for _, k := range ss["S1"] {
+			m[k] = nr.hosts[k]
+		}
+		want := rState{All, len(ss["S1"]), ss["S1"], m}
+		assertSameHosts(want, got, "B")
+	})
+
+	t.Run("ALLWithDirectCandidate", func(t *testing.T) {
+		got, err := r.State("S1", All, "B")
+		assert.Nil(t, err)
+		m := make(map[string]string, len(ss["S1"]))
+		for _, k := range ss["S1"] {
+			m[k] = nr.hosts[k]
+		}
+		want := rState{All, len(ss["S1"]), ss["S1"], m}
+		assertSameHosts(want, got, "B")
 	})
 	t.Run("Quorum", func(t *testing.T) {
-		got, err := r.State("S3", Quorum)
+		got, err := r.State("S3", Quorum, "")
 		assert.Nil(t, err)
-		want := rState{Quorum, len(ss["S1"]), ss["S1"], ss["S2"]}
-		assert.Equal(t, want, got)
+
+		m := make(map[string]string, len(ss["S1"]))
+		for _, k := range ss["S3"] {
+			m[k] = nr.hosts[k]
+		}
+		want := rState{Quorum, len(ss["S1"]), ss["S1"], m} // ss["S2"]}
+		assertSameHosts(want, got, "A")
 		_, err = got.ConsistencyLevel(All)
 		assert.ErrorIs(t, err, errUnresolvedName)
 		_, err = got.ConsistencyLevel(Quorum)
@@ -56,10 +94,15 @@ func TestResolver(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("NoQuorum", func(t *testing.T) {
-		got, err := r.State("S5", Quorum)
+		got, err := r.State("S5", Quorum, "")
 		assert.ErrorIs(t, err, errUnresolvedName)
-		want := rState{Quorum, 0, ss["S1"], ss["S4"]}
-		assert.Equal(t, want, got)
+		m := make(map[string]string, len(ss["S1"]))
+		for _, k := range ss["S5"] {
+			m[k] = nr.hosts[k]
+		}
+		want := rState{Quorum, 0, ss["S1"], m} // ss["S4"]}
+		assertSameHosts(want, got, "A")
+
 		_, err = got.ConsistencyLevel(All)
 		assert.ErrorIs(t, err, errUnresolvedName)
 		_, err = got.ConsistencyLevel(Quorum)

--- a/usecases/schema/helpers_for_test.go
+++ b/usecases/schema/helpers_for_test.go
@@ -149,8 +149,8 @@ func (f *fakeClusterState) ClusterHealthScore() int {
 }
 
 func (f *fakeClusterState) ResolveParentNodes(string, string,
-) ([]string, []string, error) {
-	return nil, nil, nil
+) (map[string]string, error) {
+	return nil, nil
 }
 
 func (f *fakeClusterState) NodeHostname(string) (string, bool) {

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -61,7 +61,7 @@ type SchemaGetter interface {
 	Nodes() []string
 	NodeName() string
 	ClusterHealthScore() int
-	ResolveParentNodes(string, string) ([]string, []string, error)
+	ResolveParentNodes(string, string) (map[string]string, error)
 }
 
 type VectorizerValidator interface {

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -259,7 +259,7 @@ func (f *fakeSchemaGetter) ClusterHealthScore() int {
 }
 
 func (f *fakeSchemaGetter) ResolveParentNodes(string, string,
-) ([]string, []string, error) {
+) (map[string]string, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
### What's being changed:
The search results are passed to the replica.Finder
The Finder check consistency depending on the consistency level
The finder detects and repairs inconsistencies if there are any

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
