### PR TITLE
Fix NullState/PropLength for props with disabled II

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -143,7 +143,10 @@ func (m *Migrator) AddProperty(ctx context.Context, className string, prop *mode
 		return errors.Errorf("cannot add property to a non-existing index for %s", className)
 	}
 
-	return m.addPropertiesAndNullAndLength(ctx, prop, idx)
+	if prop.IndexInverted == nil || *prop.IndexInverted {
+		return m.addPropertiesAndNullAndLength(ctx, prop, idx)
+	}
+	return nil
 }
 
 // DropProperty is ignored, API compliant change

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -63,8 +63,12 @@ func (s *Shard) analyzeObject(object *storobj.Object) ([]inverted.Property, []ni
 			if dt == schema.DataTypeGeoCoordinates || dt == schema.DataTypePhoneNumber || dt == schema.DataTypeBlob {
 				continue
 			}
+
+			// Add props as nil props if
+			// 1. They are not in the schema map ( == nil)
+			// 2. Their inverted index is enabled (either nil or true)
 			_, ok := schemaMap[prop.Name]
-			if !ok {
+			if !ok && !(prop.IndexInverted != nil && !*prop.IndexInverted) {
 				nilProps = append(nilProps, nilProp{
 					Name:                prop.Name,
 					AddToPropertyLength: isPropertyForLength(dt),


### PR DESCRIPTION
### What's being changed:
Fixes two bugs:

a) Buckets are created for properties without II on Update (everything seems fine for initial props)
b) When adding objects, for props without II the nullstate and prop length are still written, returning an error. But due to a) that only happens with initial props not updated ones


### Review checklist
- [x] All new code is covered by tests where it is reasonable.

