### PR TITLE
[Performance][grpc] Small performance improvements for id-only queries 

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -148,6 +148,10 @@ func searchParamsFromProto(req *pb.SearchRequest) (dto.GetParams, error) {
 				IsPrimitive: isPrimitive,
 			})
 		}
+	} else {
+		// This is a pure-ID query without any props. Indicate this to the DB, so
+		// it can optimize accordingly
+		out.AdditionalProperties.NoProps = true
 	}
 
 	if req.AdditionalProperties != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -991,11 +991,9 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 	shardingState := i.getSchema.ShardingState(i.Config.ClassName.String())
 	shardNames := shardingState.AllPhysicalShards()
 
-	if len(shardNames) == 1 {
-		if shardingState.IsShardLocal(shardNames[0]) {
-			return i.singleLocalShardObjectVectorSearch(ctx, searchVector, dist, limit, filters,
-				sort, additional, shardNames[0])
-		}
+	if len(shardNames) == 1 && shardingState.IsShardLocal(shardNames[0]) {
+		return i.singleLocalShardObjectVectorSearch(ctx, searchVector, dist, limit, filters,
+			sort, additional, shardNames[0])
 	}
 
 	// a limit of -1 is used to signal a search by distance. if that is

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -970,15 +970,26 @@ func (i *Index) sort(objects []*storobj.Object, scores []float32,
 		Sort(objects, scores, limit, sort)
 }
 
+func (i *Index) singleShardObjectVectorSearch(ctx context.Context, searchVector []float32,
+	dist float32, limit int, filters *filters.LocalFilter,
+	sort []filters.Sort, additional additional.Properties, shardName string,
+) ([]*storobj.Object, []float32, error) {
+	shard := i.Shards[shardName]
+	res, resDists, err := shard.objectVectorSearch(
+		ctx, searchVector, dist, limit, filters, sort, additional)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "shard %s", shard.ID())
+	}
+
+	return res, resDists, nil
+}
+
 func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 	dist float32, limit int, filters *filters.LocalFilter,
 	sort []filters.Sort, additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
-	shardNames := i.getSchema.ShardingState(i.Config.ClassName.String()).
-		AllPhysicalShards()
-
-	errgrp := &errgroup.Group{}
-	m := &sync.Mutex{}
+	shardingState := i.getSchema.ShardingState(i.Config.ClassName.String())
+	shardNames := shardingState.AllPhysicalShards()
 
 	// a limit of -1 is used to signal a search by distance. if that is
 	// the case we have to adjust how we calculate the output capacity
@@ -989,14 +1000,22 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 		shardCap = len(shardNames) * limit
 	}
 
+	if len(shardNames) == 1 {
+		if shardingState.IsShardLocal(shardNames[0]) {
+			return i.singleShardObjectVectorSearch(ctx, searchVector, dist, shardCap, filters,
+				sort, additional, shardNames[0])
+		}
+	}
+
+	errgrp := &errgroup.Group{}
+	m := &sync.Mutex{}
+
 	out := make([]*storobj.Object, 0, shardCap)
 	dists := make([]float32, 0, shardCap)
 	for _, shardName := range shardNames {
 		shardName := shardName
 		errgrp.Go(func() error {
-			local := i.getSchema.
-				ShardingState(i.Config.ClassName.String()).
-				IsShardLocal(shardName)
+			local := shardingState.IsShardLocal(shardName)
 
 			var res []*storobj.Object
 			var resDists []float32

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -319,6 +319,12 @@ func (db *DB) objectSearch(ctx context.Context, offset, limit int,
 func (db *DB) ResolveReferences(ctx context.Context, objs search.Results,
 	props search.SelectProperties, additional additional.Properties,
 ) (search.Results, error) {
+	if additional.NoProps {
+		// If we have no props, there also can't be refs among them, so we can skip
+		// the refcache resolver
+		return objs, nil
+	}
+
 	res, err := refcache.NewResolver(refcache.NewCacher(db, db.logger)).
 		Do(ctx, objs, props, additional)
 	if err != nil {

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -289,10 +289,7 @@ func (s *Shard) objectVectorSearch(ctx context.Context,
 		}
 	}
 
-	var beforeObjects time.Time
-	if filters != nil {
-		beforeObjects = time.Now()
-	}
+	beforeObjects := time.Now()
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	objs, err := storobj.ObjectsByDocID(bucket, ids, additional)

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -289,7 +289,10 @@ func (s *Shard) objectVectorSearch(ctx context.Context,
 		}
 	}
 
-	beforeObjects := time.Now()
+	var beforeObjects time.Time
+	if filters != nil {
+		beforeObjects = time.Now()
+	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	objs, err := storobj.ObjectsByDocID(bucket, ids, additional)

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -35,6 +35,10 @@ type Properties struct {
 	ExplainScore       bool                   `json:"explainScore"`
 	IsConsistent       bool                   `json:"isConsistent"`
 
+	// The User is not interested in returning props, we can skip any costly
+	// operation that isn't required.
+	NoProps bool `json:"noProps"`
+
 	// ReferenceQuery is used to indicate that a search
 	// is being conducted on behalf of a referenced
 	// property. for example: this is relevant when a


### PR DESCRIPTION
### What's being changed:

* in low-recall/low-latency situations the overhead is reduced
* for single-threaded (SIFT) `m=16, ef=16` we went from `2385` QPS to `2649` on my M1 Macbook

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
