### PR TITLE
[Performance] Restructure hnsw connection list pooling

### DIFF
--- a/adapters/repos/db/vector/hnsw/pools.go
+++ b/adapters/repos/db/vector/hnsw/pools.go
@@ -26,7 +26,6 @@ type pools struct {
 	pqHeuristic  *pqMinWithIndexPool
 	pqResults    *pqMaxPool
 	pqCandidates *pqMinPool
-	connList     *connList
 }
 
 func newPools(maxConnectionsLayerZero int) *pools {
@@ -41,7 +40,6 @@ func newPools(maxConnectionsLayerZero int) *pools {
 		pqHeuristic:  newPqMinWithIndexPool(maxConnectionsLayerZero),
 		pqResults:    newPqMaxPool(maxConnectionsLayerZero),
 		pqCandidates: newPqMinPool(maxConnectionsLayerZero),
-		connList:     newConnList(maxConnectionsLayerZero),
 	}
 }
 
@@ -130,29 +128,4 @@ func (pqh *pqMaxPool) GetMax(capacity int) *priorityqueue.Queue {
 
 func (pqh *pqMaxPool) Put(pq *priorityqueue.Queue) {
 	pqh.pool.Put(pq)
-}
-
-func newConnList(capacity int) *connList {
-	return &connList{
-		pool: &sync.Pool{
-			New: func() interface{} {
-				l := make([]uint64, 0, capacity)
-				return &l
-			},
-		},
-	}
-}
-
-type connList struct {
-	pool *sync.Pool
-}
-
-func (cl *connList) Get(length int) *[]uint64 {
-	list := cl.pool.Get().(*[]uint64)
-	*list = (*list)[:length]
-	return list
-}
-
-func (cl *connList) Put(list *[]uint64) {
-	cl.pool.Put(list)
 }


### PR DESCRIPTION
### What's being changed:
* the connection list used a pool before, but it actually led to more overhead and more allocations
* instead we're now allocating the slice once outside of a loop and then reusing it inside the loop
* with high recall settings `ef=1024` this slightly improves single-threaded QPS (SIFT) from 168 to 170 on average on my machine.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
