### PR TITLE
Creates missing RBM inverted index for text/text[] props on v1.18 to 1.19 migration 

### DIFF
--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -218,3 +218,7 @@ func (n *NilMigrator) RecalculateVectorDimensions(ctx context.Context) error {
 func (n *NilMigrator) InvertedReindex(ctx context.Context, taskNames ...string) error {
 	return nil
 }
+
+func (n *NilMigrator) AdjustFilterablePropSettings(ctx context.Context) error {
+	return nil
+}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -296,16 +296,25 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	setupNodesHandlers(api, schemaManager, repo, appState)
 
 	reindexCtx, reindexCtxCancel := context.WithCancel(context.Background())
-	reindexFinished := make(chan error)
+	reindexFinished := make(chan error, 1)
+	// FIXME to avoid import cycles, tasks are passed as strings
+	reindexTaskNames := []string{}
+
 	if appState.ServerConfig.Config.ReindexSetToRoaringsetAtStartup {
+		reindexTaskNames = append(reindexTaskNames, "ShardInvertedReindexTaskSetToRoaringSet")
+	}
+	if appState.ServerConfig.Config.IndexMissingTextFilterableAtStartup {
+		reindexTaskNames = append(reindexTaskNames, "ShardInvertedReindexTaskMissingTextFilterable")
+	}
+	if len(reindexTaskNames) > 0 {
 		// start reindexing inverted indexes (if requested by user) in the background
 		// allowing db to complete api configuration and start handling requests
 		go func() {
 			appState.Logger.
 				WithField("action", "startup").
-				Info("Reindexing sets to roaring sets")
+				Info("Reindexing inverted indexes")
 			// FIXME to avoid import cycles tasks are passed as strings
-			reindexFinished <- migrator.InvertedReindex(reindexCtx, "ShardInvertedReindexTaskSetToRoaringSet")
+			reindexFinished <- migrator.InvertedReindex(reindexCtx, reindexTaskNames...)
 		}()
 	}
 

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -33,17 +33,18 @@ type vectorIndex interface {
 }
 
 type Aggregator struct {
-	logger           logrus.FieldLogger
-	store            *lsmkv.Store
-	params           aggregation.Params
-	getSchema        schemaUC.SchemaGetter
-	invertedRowCache *inverted.RowCacher
-	classSearcher    inverted.ClassSearcher // to support ref-filters
-	deletedDocIDs    inverted.DeletedDocIDChecker
-	vectorIndex      vectorIndex
-	stopwords        stopwords.StopwordDetector
-	shardVersion     uint16
-	propLengths      *inverted.JsonPropertyLengthTracker
+	logger                 logrus.FieldLogger
+	store                  *lsmkv.Store
+	params                 aggregation.Params
+	getSchema              schemaUC.SchemaGetter
+	invertedRowCache       *inverted.RowCacher
+	classSearcher          inverted.ClassSearcher // to support ref-filters
+	deletedDocIDs          inverted.DeletedDocIDChecker
+	vectorIndex            vectorIndex
+	stopwords              stopwords.StopwordDetector
+	shardVersion           uint16
+	propLengths            *inverted.JsonPropertyLengthTracker
+	isFallbackToSearchable inverted.IsFallbackToSearchable
 }
 
 func New(store *lsmkv.Store, params aggregation.Params,
@@ -51,20 +52,21 @@ func New(store *lsmkv.Store, params aggregation.Params,
 	classSearcher inverted.ClassSearcher,
 	deletedDocIDs inverted.DeletedDocIDChecker, stopwords stopwords.StopwordDetector,
 	shardVersion uint16, vectorIndex vectorIndex, logger logrus.FieldLogger,
-	propLengths *inverted.JsonPropertyLengthTracker,
+	propLengths *inverted.JsonPropertyLengthTracker, isFallbackToSearchable inverted.IsFallbackToSearchable,
 ) *Aggregator {
 	return &Aggregator{
-		logger:           logger,
-		store:            store,
-		params:           params,
-		getSchema:        getSchema,
-		invertedRowCache: cache,
-		classSearcher:    classSearcher,
-		deletedDocIDs:    deletedDocIDs,
-		stopwords:        stopwords,
-		shardVersion:     shardVersion,
-		vectorIndex:      vectorIndex,
-		propLengths:      propLengths,
+		logger:                 logger,
+		store:                  store,
+		params:                 params,
+		getSchema:              getSchema,
+		invertedRowCache:       cache,
+		classSearcher:          classSearcher,
+		deletedDocIDs:          deletedDocIDs,
+		stopwords:              stopwords,
+		shardVersion:           shardVersion,
+		vectorIndex:            vectorIndex,
+		propLengths:            propLengths,
+		isFallbackToSearchable: isFallbackToSearchable,
 	}
 }
 

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -91,7 +91,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 	if a.params.Filters != nil {
 		s := a.getSchema.GetSchemaSkipAuth()
 		allow, err = inverted.NewSearcher(a.logger, a.store, s, a.invertedRowCache,
-			nil, a.classSearcher, a.deletedDocIDs, a.stopwords, a.shardVersion).
+			nil, a.classSearcher, a.deletedDocIDs, a.stopwords, a.shardVersion, a.isFallbackToSearchable).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},
 				a.params.ClassName)
 		if err != nil {

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -87,5 +87,5 @@ func TempBucketFromBucketName(bucketName string) string {
 }
 
 func BucketSearchableFromPropNameLSM(propName string) string {
-	return fmt.Sprintf("property_searchable_%s", propName)
+	return BucketFromPropNameLSM(propName + "_searchable")
 }

--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -17,9 +17,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+type IsFallbackToSearchable func() bool
 
 type Countable struct {
 	Data          []byte
@@ -35,7 +36,7 @@ type Property struct {
 }
 
 type Analyzer struct {
-	stopwords stopwords.StopwordDetector
+	isFallbackToSearchable IsFallbackToSearchable
 }
 
 // Text tokenizes given input according to selected tokenization,
@@ -212,6 +213,9 @@ func (a *Analyzer) Ref(in models.MultipleRef) ([]Countable, error) {
 	return out, nil
 }
 
-func NewAnalyzer(stopwords stopwords.StopwordDetector) *Analyzer {
-	return &Analyzer{stopwords: stopwords}
+func NewAnalyzer(isFallbackToSearchable IsFallbackToSearchable) *Analyzer {
+	if isFallbackToSearchable == nil {
+		isFallbackToSearchable = func() bool { return false }
+	}
+	return &Analyzer{isFallbackToSearchable: isFallbackToSearchable}
 }

--- a/adapters/repos/db/inverted/analyzer_test.go
+++ b/adapters/repos/db/inverted/analyzer_test.go
@@ -19,12 +19,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
 func TestAnalyzer(t *testing.T) {
-	a := NewAnalyzer(fakeStopwordDetector{})
+	a := NewAnalyzer(nil)
 
 	countable := func(data []string, freq []int) []Countable {
 		countable := make([]Countable, len(data))
@@ -330,7 +329,7 @@ func TestAnalyzer_DefaultEngPreset(t *testing.T) {
 		return countable
 	}
 
-	a := newTestAnalyzer(t, models.StopwordConfig{Preset: "en"})
+	a := NewAnalyzer(nil)
 	input := "Hello you-beautiful_World"
 
 	t.Run("with text", func(t *testing.T) {
@@ -456,11 +455,4 @@ type fakeStopwordDetector struct{}
 
 func (fsd fakeStopwordDetector) IsStopword(word string) bool {
 	return false
-}
-
-func newTestAnalyzer(t *testing.T, cfg models.StopwordConfig) *Analyzer {
-	sd, err := stopwords.NewDetectorFromConfig(cfg)
-	require.Nil(t, err)
-
-	return NewAnalyzer(sd)
 }

--- a/adapters/repos/db/inverted/cached_filters_integration_test.go
+++ b/adapters/repos/db/inverted/cached_filters_integration_test.go
@@ -91,7 +91,7 @@ func Test_CachedFilters_String(t *testing.T) {
 
 	rowCacher := newRowCacherSpy()
 	searcher := NewSearcher(logger, store, createSchema(), rowCacher,
-		nil, nil, nil, fakeStopwordDetector{}, 2)
+		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false })
 
 	type test struct {
 		name                     string
@@ -417,7 +417,7 @@ func Test_CachedFilters_Int(t *testing.T) {
 
 	rowCacher := newRowCacherSpy()
 	searcher := NewSearcher(logger, store, createSchema(), rowCacher,
-		nil, nil, nil, fakeStopwordDetector{}, 2)
+		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false })
 
 	type test struct {
 		name                     string
@@ -713,7 +713,7 @@ func Test_DuplicateEntriesInAnd_String(t *testing.T) {
 
 	rowCacher := newRowCacherSpy()
 	searcher := NewSearcher(logger, store, createSchema(), rowCacher,
-		nil, nil, nil, fakeStopwordDetector{}, 2)
+		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false })
 
 	type test struct {
 		name                     string

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -205,9 +205,12 @@ func (a *Analyzer) extendPropertiesWithPrimitive(properties *[]Property,
 
 func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Property, error) {
 	var items []Countable
-	dt := schema.DataType(prop.DataType[0])
-	switch dt {
+	isFilterable := IsFilterable(prop)
+	isSearchable := IsSearchable(prop)
+
+	switch dt := schema.DataType(prop.DataType[0]); dt {
 	case schema.DataTypeTextArray:
+		isFilterable = isFilterable && !a.isFallbackToSearchable()
 		in, err := stringsFromValues(prop, values)
 		if err != nil {
 			return nil, err
@@ -322,8 +325,8 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		Name:         prop.Name,
 		Items:        items,
 		Length:       len(values),
-		IsFilterable: IsFilterable(prop),
-		IsSearchable: IsSearchable(prop),
+		IsFilterable: isFilterable,
+		IsSearchable: isSearchable,
 	}, nil
 }
 
@@ -342,9 +345,12 @@ func stringsFromValues(prop *models.Property, values []any) ([]string, error) {
 func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Property, error) {
 	var items []Countable
 	propertyLength := -1 // will be overwritten for string/text, signals not to add the other types.
-	dt := schema.DataType(prop.DataType[0])
-	switch dt {
+	isFilterable := IsFilterable(prop)
+	isSearchable := IsSearchable(prop)
+
+	switch dt := schema.DataType(prop.DataType[0]); dt {
 	case schema.DataTypeText:
+		isFilterable = isFilterable && !a.isFallbackToSearchable()
 		asString, ok := value.(string)
 		if !ok {
 			return nil, fmt.Errorf("expected property %s to be of type string, but got %T", prop.Name, value)
@@ -442,8 +448,8 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 		Name:         prop.Name,
 		Items:        items,
 		Length:       propertyLength,
-		IsFilterable: IsFilterable(prop),
-		IsSearchable: IsSearchable(prop),
+		IsFilterable: isFilterable,
+		IsSearchable: isSearchable,
 	}, nil
 }
 

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestAnalyzeObject(t *testing.T) {
-	a := NewAnalyzer(fakeStopwordDetector{})
+	a := NewAnalyzer(nil)
 
 	t.Run("with multiple properties", func(t *testing.T) {
 		id1 := uuid.New()

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -238,14 +238,9 @@ func (s *Searcher) docBitmapGeo(ctx context.Context, pv *propValuePair) (docBitm
 
 // TODO move to some helper/utils?
 func (s *Searcher) getHashBucket(pv *propValuePair) (*lsmkv.Bucket, error) {
-	propName := pv.prop
-	if pv.operator == filters.OperatorIsNull {
-		propName += filters.InternalNullIndex
-	}
-
-	hashBucket := s.store.Bucket(helpers.HashBucketFromPropNameLSM(propName))
+	hashBucket := s.store.Bucket(helpers.HashBucketFromPropNameLSM(pv.prop))
 	if hashBucket == nil {
-		return nil, errors.Errorf("no hash bucket for prop '%s' found", propName)
+		return nil, errors.Errorf("no hash bucket for prop '%s' found", pv.prop)
 	}
 	return hashBucket, nil
 }

--- a/adapters/repos/db/inverted_migrator_filter_to_search.go
+++ b/adapters/repos/db/inverted_migrator_filter_to_search.go
@@ -1,0 +1,403 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/models"
+	ucschema "github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/usecases/schema"
+	"golang.org/x/sync/errgroup"
+)
+
+type filterableToSearchableMigrator struct {
+	logger       logrus.FieldLogger
+	files        *filterableToSearchableMigrationFiles
+	schemaGetter schema.SchemaGetter
+	indexes      map[string]*Index
+}
+
+func newFilterableToSearchableMigrator(migrator *Migrator) *filterableToSearchableMigrator {
+	return &filterableToSearchableMigrator{
+		logger:       migrator.logger,
+		files:        newFilterableToSearchableMigrationFiles(migrator.db.config.RootPath),
+		schemaGetter: migrator.db.schemaGetter,
+		indexes:      migrator.db.indices,
+	}
+}
+
+func (m *filterableToSearchableMigrator) migrate(ctx context.Context) error {
+	// only properties with both Filterable and Searchable indexing enabled
+	// filterable bucket has map strategy (when it should have roaring set stategy)
+	// searchable bucket does not exist (in fact weaviate will create empty one with map strategy)
+
+	// if flag exists, no class/property needs fixing
+	if m.files.existsMigrationSkipFlag() {
+		m.log().Debug("migration skip flag set, skipping migration")
+		return nil
+	}
+
+	migrationState, err := m.files.loadMigrationState()
+	if err != nil {
+		m.log().WithError(err).Error("loading migrated state")
+		return errors.Wrap(err, "loading migrated state")
+	}
+
+	migrationStateUpdated := false
+	updateLock := new(sync.Mutex)
+	sch := m.schemaGetter.GetSchemaSkipAuth().Objects
+
+	m.log().Debug("starting migration")
+
+	errgrp := &errgroup.Group{}
+	errgrp.SetLimit(50)
+	for _, index := range m.indexes {
+		index := index
+
+		errgrp.Go(func() error {
+			migratedProps, err := m.migrateClass(ctx, index, sch)
+			if err != nil {
+				m.logIndex(index).WithError(err).Error("failed migrating class")
+				return errors.Wrap(err, "failed migrating class")
+			}
+			if len(migratedProps) == 0 {
+				return nil
+			}
+
+			updateLock.Lock()
+			defer updateLock.Unlock()
+
+			migrationState.MissingFilterableClass2Props[index.Config.ClassName.String()] = migratedProps
+			migrationStateUpdated = true
+			return nil
+		})
+	}
+
+	err = errgrp.Wait()
+	if err != nil {
+		m.log().WithError(err).Error("failed migrating classes")
+	}
+
+	// save state regardless of previous error
+	if migrationStateUpdated {
+		m.log().Debug("saving migration state")
+		if err := m.files.saveMigrationState(migrationState); err != nil {
+			m.log().WithError(err).Error("failed saving migration state")
+			return errors.Wrap(err, "failed saving migration state")
+		}
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "failed migrating classes")
+	}
+
+	if err := m.files.createMigrationSkipFlag(); err != nil {
+		m.log().WithError(err).Error("failed creating migration skip flag")
+		return errors.Wrap(err, "failed creating migration skip flag")
+	}
+
+	m.log().Debug("finished migration")
+	return nil
+}
+
+func (m *filterableToSearchableMigrator) switchShardsToFallbackMode(ctx context.Context) error {
+	m.log().Debug("starting switching fallback mode")
+
+	migrationState, err := m.files.loadMigrationState()
+	if err != nil {
+		m.log().WithError(err).Error("loading migrated state")
+		return errors.Wrap(err, "loading migrated state")
+	}
+
+	if len(migrationState.MissingFilterableClass2Props) == 0 {
+		m.log().Debug("no missing filterable indexes, fallback mode skipped")
+		return nil
+	}
+
+	for _, index := range m.indexes {
+		if _, ok := migrationState.MissingFilterableClass2Props[index.Config.ClassName.String()]; !ok {
+			continue
+		}
+
+		for _, shard := range index.Shards {
+			m.logShard(shard).Debug("setting fallback mode for shard")
+			shard.fallbackToSearchable = true
+		}
+	}
+
+	m.log().Debug("finished switching fallback mode")
+	return nil
+}
+
+func (m *filterableToSearchableMigrator) migrateClass(ctx context.Context, index *Index,
+	sch *models.Schema,
+) (map[string]struct{}, error) {
+	m.logIndex(index).Debug("started migration of index")
+
+	className := index.Config.ClassName.String()
+	class, err := ucschema.GetClassByName(sch, className)
+	if err != nil {
+		return nil, err
+	}
+
+	shard2PropsToFix := map[string]map[string]struct{}{}
+	uniquePropsToFix := map[string]struct{}{}
+	for _, prop := range class.Properties {
+		if !(inverted.IsFilterable(prop) && inverted.IsSearchable(prop)) {
+			continue
+		}
+
+		for _, shard := range index.Shards {
+			if toFix, err := m.isPropToFix(prop, shard); toFix {
+				if _, ok := shard2PropsToFix[shard.name]; !ok {
+					shard2PropsToFix[shard.name] = map[string]struct{}{}
+				}
+				shard2PropsToFix[shard.name][prop.Name] = struct{}{}
+				uniquePropsToFix[prop.Name] = struct{}{}
+			} else if err != nil {
+				m.logShard(shard).WithError(err).Error("failed discovering props to fix")
+				return nil, errors.Wrap(err, "failed discovering props to fix")
+			}
+		}
+	}
+
+	m.logIndex(index).
+		WithField("number_of_props", len(uniquePropsToFix)).
+		WithField("props", m.uniquePropsToSlice(uniquePropsToFix)).
+		Debug("found properties to fix")
+
+	if len(uniquePropsToFix) == 0 {
+		return nil, nil
+	}
+
+	errgrp := &errgroup.Group{}
+	for shardName, props := range shard2PropsToFix {
+		shard := index.Shards[shardName]
+		props := props
+
+		errgrp.Go(func() error {
+			if err := m.migrateShard(ctx, shard, props); err != nil {
+				m.logShard(shard).WithError(err).Error("failed migrating shard")
+				return errors.Wrap(err, "failed migrating shard")
+			}
+			return nil
+		})
+	}
+	if err := errgrp.Wait(); err != nil {
+		return nil, err
+	}
+
+	m.logIndex(index).Debug("finished migration of index")
+	return uniquePropsToFix, nil
+}
+
+func (m *filterableToSearchableMigrator) migrateShard(ctx context.Context, shard *Shard,
+	props map[string]struct{},
+) error {
+	m.logShard(shard).Debug("started migration of shard")
+
+	m.pauseStoreActivity(ctx, shard)
+	defer m.resumeStoreActivity(ctx, shard)
+
+	for propName := range props {
+		srcBucketName := helpers.BucketFromPropNameLSM(propName)
+		dstBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
+
+		m.logShard(shard).
+			WithField("bucketSrc", srcBucketName).
+			WithField("bucketDst", dstBucketName).
+			WithField("prop", propName).
+			Debug("replacing buckets")
+
+		if err := shard.store.ReplaceBuckets(ctx, dstBucketName, srcBucketName); err != nil {
+			return err
+		}
+	}
+
+	m.logShard(shard).Debug("finished migration of shard")
+	return nil
+}
+
+func (m *filterableToSearchableMigrator) isPropToFix(prop *models.Property, shard *Shard) (bool, error) {
+	bucketFilterable := shard.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
+	if bucketFilterable != nil &&
+		bucketFilterable.Strategy() == lsmkv.StrategyMapCollection &&
+		bucketFilterable.DesiredStrategy() == lsmkv.StrategyRoaringSet {
+
+		bucketSearchable := shard.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop.Name))
+		if bucketSearchable != nil &&
+			bucketSearchable.Strategy() == lsmkv.StrategyMapCollection {
+
+			if m.isEmptyMapBucket(bucketSearchable) {
+				return true, nil
+			}
+			return false, fmt.Errorf("searchable bucket is not empty")
+		} else {
+			return false, fmt.Errorf("searchable bucket should have map strategy")
+		}
+	}
+	return false, nil
+}
+
+func (m *filterableToSearchableMigrator) isEmptyMapBucket(bucket *lsmkv.Bucket) bool {
+	cur := bucket.MapCursorKeyOnly()
+	defer cur.Close()
+
+	key, _ := cur.First()
+	return key == nil
+}
+
+func (m *filterableToSearchableMigrator) pauseStoreActivity(
+	ctx context.Context, shard *Shard,
+) error {
+	m.logShard(shard).Debug("pausing store activity")
+
+	if err := shard.store.PauseCompaction(ctx); err != nil {
+		return errors.Wrapf(err, "failed pausing compaction for shard '%s'", shard.ID())
+	}
+	if err := shard.store.FlushMemtables(ctx); err != nil {
+		return errors.Wrapf(err, "failed flushing memtables for shard '%s'", shard.ID())
+	}
+	shard.store.UpdateBucketsStatus(storagestate.StatusReadOnly)
+
+	m.logShard(shard).Debug("paused store activity")
+	return nil
+}
+
+func (m *filterableToSearchableMigrator) resumeStoreActivity(
+	ctx context.Context, shard *Shard,
+) error {
+	m.logShard(shard).Debug("resuming store activity")
+
+	if err := shard.store.ResumeCompaction(ctx); err != nil {
+		return errors.Wrapf(err, "failed resuming compaction for shard '%s'", shard.ID())
+	}
+	shard.store.UpdateBucketsStatus(storagestate.StatusReady)
+
+	m.logShard(shard).Debug("resumed store activity")
+	return nil
+}
+
+func (m *filterableToSearchableMigrator) log() *logrus.Entry {
+	return m.logger.WithField("action", "inverted filter2search migration")
+}
+
+func (m *filterableToSearchableMigrator) logIndex(index *Index) *logrus.Entry {
+	return m.log().WithField("index", index.ID())
+}
+
+func (m *filterableToSearchableMigrator) logShard(shard *Shard) *logrus.Entry {
+	return m.logIndex(shard.index).WithField("shard", shard.ID())
+}
+
+func (m *filterableToSearchableMigrator) uniquePropsToSlice(uniqueProps map[string]struct{}) []string {
+	props := make([]string, 0, len(uniqueProps))
+	for prop := range uniqueProps {
+		props = append(props, prop)
+	}
+	return props
+}
+
+type filterableToSearchableMigrationState struct {
+	MissingFilterableClass2Props map[string]map[string]struct{}
+	CreatedFilterableClass2Props map[string]map[string]struct{}
+}
+
+type filterableToSearchableMigrationFiles struct {
+	flagFileName  string
+	stateFileName string
+}
+
+func newFilterableToSearchableMigrationFiles(rootPath string) *filterableToSearchableMigrationFiles {
+	return &filterableToSearchableMigrationFiles{
+		flagFileName:  path.Join(rootPath, "migration1.19.filter2search.skip.flag"),
+		stateFileName: path.Join(rootPath, "migration1.19.filter2search.state"),
+	}
+}
+
+func (mf *filterableToSearchableMigrationFiles) loadMigrationState() (*filterableToSearchableMigrationState, error) {
+	f, err := os.OpenFile(mf.stateFileName, os.O_RDWR|os.O_CREATE, 0o666)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(f); err != nil {
+		return nil, err
+	}
+	bytes := buf.Bytes()
+
+	state := filterableToSearchableMigrationState{
+		MissingFilterableClass2Props: map[string]map[string]struct{}{},
+		CreatedFilterableClass2Props: map[string]map[string]struct{}{},
+	}
+
+	if len(bytes) > 0 {
+		if err := json.Unmarshal(bytes, &state); err != nil {
+			return nil, err
+		}
+	}
+	return &state, nil
+}
+
+func (mf *filterableToSearchableMigrationFiles) saveMigrationState(state *filterableToSearchableMigrationState) error {
+	bytes, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	fileNameTemp := mf.stateFileName + ".temp"
+	f, err := os.Create(fileNameTemp)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(bytes)
+	f.Close()
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(fileNameTemp, mf.stateFileName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (mf *filterableToSearchableMigrationFiles) existsMigrationSkipFlag() bool {
+	_, err := os.Stat(mf.flagFileName)
+	return err == nil
+}
+
+func (mf *filterableToSearchableMigrationFiles) createMigrationSkipFlag() error {
+	f, err := os.Create(mf.flagFileName)
+	if err != nil {
+		return err
+	}
+	f.Close()
+	return nil
+}

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -20,14 +20,12 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 type ShardInvertedReindexTask interface {
-	GetPropertiesToReindex(ctx context.Context, store *lsmkv.Store, indexConfig IndexConfig,
-		invertedIndexConfig schema.InvertedIndexConfig, logger logrus.FieldLogger,
+	GetPropertiesToReindex(ctx context.Context, shard *Shard,
 	) ([]ReindexableProperty, error)
 }
 
@@ -66,8 +64,7 @@ func (r *ShardInvertedReindexer) Do(ctx context.Context) error {
 }
 
 func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedReindexTask) error {
-	reindexProperties, err := task.GetPropertiesToReindex(ctx, r.shard.store,
-		r.shard.index.Config, r.shard.index.invertedIndexConfig, r.logger)
+	reindexProperties, err := task.GetPropertiesToReindex(ctx, r.shard)
 	if err != nil {
 		r.logError(err, "failed getting reindex properties")
 		return errors.Wrapf(err, "failed getting reindex properties")

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -95,7 +95,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 			return err
 		}
 
-		if !IsIndexTypeSupportedByStrategy(reindexProperty.IndexType, reindexProperty.DesiredStrategy) {
+		if !isIndexTypeSupportedByStrategy(reindexProperty.IndexType, reindexProperty.DesiredStrategy) {
 			err := fmt.Errorf("strategy '%s' is not supported for given index type '%d",
 				reindexProperty.DesiredStrategy, reindexProperty.IndexType)
 			r.logError(err, "invalid strategy")
@@ -429,7 +429,7 @@ func (r *ShardInvertedReindexer) handleNilProperty(ctx context.Context, checker 
 }
 
 func (r *ShardInvertedReindexer) bucketName(propName string, indexType PropertyIndexType) string {
-	CheckSupportedPropertyIndexType(indexType)
+	checkSupportedPropertyIndexType(indexType)
 
 	switch indexType {
 	case IndexTypePropValue:

--- a/adapters/repos/db/inverted_reindexer_index_types.go
+++ b/adapters/repos/db/inverted_reindexer_index_types.go
@@ -24,7 +24,7 @@ const (
 	IndexTypeHashPropNull
 )
 
-func IsSupportedPropertyIndexType(indexType PropertyIndexType) bool {
+func isSupportedPropertyIndexType(indexType PropertyIndexType) bool {
 	switch indexType {
 	case IndexTypePropValue,
 		IndexTypePropLength,
@@ -38,15 +38,15 @@ func IsSupportedPropertyIndexType(indexType PropertyIndexType) bool {
 	}
 }
 
-func CheckSupportedPropertyIndexType(indexType PropertyIndexType) {
-	if !IsSupportedPropertyIndexType(indexType) {
+func checkSupportedPropertyIndexType(indexType PropertyIndexType) {
+	if !isSupportedPropertyIndexType(indexType) {
 		panic("unsupported property index type")
 	}
 }
 
 // Some index types are supported by specific strategies only
 // Method ensures both index type and strategy work together
-func IsIndexTypeSupportedByStrategy(indexType PropertyIndexType, strategy string) bool {
+func isIndexTypeSupportedByStrategy(indexType PropertyIndexType, strategy string) bool {
 	switch indexType {
 	case IndexTypeHashPropValue,
 		IndexTypeHashPropLength,

--- a/adapters/repos/db/inverted_reindexer_index_types.go
+++ b/adapters/repos/db/inverted_reindexer_index_types.go
@@ -22,6 +22,7 @@ const (
 	IndexTypeHashPropValue
 	IndexTypeHashPropLength
 	IndexTypeHashPropNull
+	IndexTypePropSearchableValue
 )
 
 func isSupportedPropertyIndexType(indexType PropertyIndexType) bool {
@@ -31,7 +32,8 @@ func isSupportedPropertyIndexType(indexType PropertyIndexType) bool {
 		IndexTypePropNull,
 		IndexTypeHashPropValue,
 		IndexTypeHashPropLength,
-		IndexTypeHashPropNull:
+		IndexTypeHashPropNull,
+		IndexTypePropSearchableValue:
 		return true
 	default:
 		return false
@@ -53,10 +55,11 @@ func isIndexTypeSupportedByStrategy(indexType PropertyIndexType, strategy string
 		IndexTypeHashPropNull:
 		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategyReplace)
 	case IndexTypePropLength,
-		IndexTypePropNull:
+		IndexTypePropNull,
+		IndexTypePropValue:
 		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
-	case IndexTypePropValue:
-		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet, lsmkv.StrategyMapCollection)
+	case IndexTypePropSearchableValue:
+		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategyMapCollection)
 	}
 	return false
 }

--- a/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
+++ b/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
@@ -1,0 +1,114 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+)
+
+type shardInvertedReindexTaskMissingTextFilterable struct {
+	logger    logrus.FieldLogger
+	files     *filterableToSearchableMigrationFiles
+	stateLock *sync.RWMutex
+
+	migrationState *filterableToSearchableMigrationState
+}
+
+func newShardInvertedReindexTaskMissingTextFilterable(migrator *Migrator,
+) *shardInvertedReindexTaskMissingTextFilterable {
+	return &shardInvertedReindexTaskMissingTextFilterable{
+		logger:    migrator.logger,
+		files:     newFilterableToSearchableMigrationFiles(migrator.db.config.RootPath),
+		stateLock: new(sync.RWMutex),
+	}
+}
+
+func (t *shardInvertedReindexTaskMissingTextFilterable) init() error {
+	migrationState, err := t.files.loadMigrationState()
+	if err != nil {
+		return errors.Wrap(err, "failed loading migration state")
+	}
+
+	t.migrationState = migrationState
+	return nil
+}
+
+func (t *shardInvertedReindexTaskMissingTextFilterable) GetPropertiesToReindex(ctx context.Context,
+	shard *Shard,
+) ([]ReindexableProperty, error) {
+	reindexableProperties := []ReindexableProperty{}
+
+	t.stateLock.RLock()
+	className := shard.index.Config.ClassName.String()
+	props, ok := t.migrationState.MissingFilterableClass2Props[className]
+	t.stateLock.RUnlock()
+
+	if !ok || len(props) == 0 {
+		return reindexableProperties, nil
+	}
+
+	bucketOptions := []lsmkv.BucketOption{
+		lsmkv.WithIdleThreshold(time.Duration(shard.index.Config.MemtablesFlushIdleAfter) * time.Second),
+	}
+
+	for propName := range props {
+		bucketNameSearchable := helpers.BucketSearchableFromPropNameLSM(propName)
+		bucketNameFilterable := helpers.BucketFromPropNameLSM(propName)
+
+		bucketSearchable := shard.store.Bucket(bucketNameSearchable)
+		bucketFilterable := shard.store.Bucket(bucketNameFilterable)
+
+		// exists bucket searchable of strategy map and either of
+		// - exists empty filterable bucket of strategy roaring set
+		//   (weaviate was restrated after filterable to searchable migration)
+		// - filterable bucket does not exist
+		//   (indexing comes right after filterable to searchable migration)
+		if bucketSearchable != nil &&
+			bucketSearchable.Strategy() == lsmkv.StrategyMapCollection {
+
+			if bucketFilterable == nil {
+				reindexableProperties = append(reindexableProperties, ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropValue,
+					DesiredStrategy: lsmkv.StrategyRoaringSet,
+					NewIndex:        true,
+					BucketOptions:   bucketOptions,
+				})
+			} else if bucketFilterable.Strategy() == lsmkv.StrategyRoaringSet {
+				reindexableProperties = append(reindexableProperties, ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropValue,
+					DesiredStrategy: lsmkv.StrategyRoaringSet,
+					BucketOptions:   bucketOptions,
+				})
+			}
+		}
+	}
+
+	return reindexableProperties, nil
+}
+
+func (t *shardInvertedReindexTaskMissingTextFilterable) updateMigrationStateAndSave(classCreatedFilterable string) error {
+	t.stateLock.Lock()
+	defer t.stateLock.Unlock()
+
+	t.migrationState.CreatedFilterableClass2Props[classCreatedFilterable] = t.migrationState.MissingFilterableClass2Props[classCreatedFilterable]
+	delete(t.migrationState.MissingFilterableClass2Props, classCreatedFilterable)
+	return t.files.saveMigrationState(t.migrationState)
+}

--- a/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
+++ b/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
@@ -112,3 +112,9 @@ func (t *shardInvertedReindexTaskMissingTextFilterable) updateMigrationStateAndS
 	delete(t.migrationState.MissingFilterableClass2Props, classCreatedFilterable)
 	return t.files.saveMigrationState(t.migrationState)
 }
+
+func (t *shardInvertedReindexTaskMissingTextFilterable) OnPostResumeStore(ctx context.Context, shard *Shard) error {
+	// turn off fallback mode immediately after creating filterable index and resuming store's activity
+	shard.fallbackToSearchable = false
+	return nil
+}

--- a/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
+++ b/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
@@ -88,3 +88,7 @@ func (t *ShardInvertedReindexTaskSetToRoaringSet) GetPropertiesToReindex(ctx con
 
 	return reindexableProperties, nil
 }
+
+func (t *ShardInvertedReindexTaskSetToRoaringSet) OnPostResumeStore(ctx context.Context, shard *Shard) error {
+	return nil
+}

--- a/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
+++ b/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
@@ -15,24 +15,21 @@ import (
 	"context"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 type ShardInvertedReindexTaskSetToRoaringSet struct{}
 
 func (t *ShardInvertedReindexTaskSetToRoaringSet) GetPropertiesToReindex(ctx context.Context,
-	store *lsmkv.Store, indexConfig IndexConfig, invertedIndexConfig schema.InvertedIndexConfig,
-	logger logrus.FieldLogger,
+	shard *Shard,
 ) ([]ReindexableProperty, error) {
 	reindexableProperties := []ReindexableProperty{}
 
 	bucketOptions := []lsmkv.BucketOption{
-		lsmkv.WithIdleThreshold(time.Duration(indexConfig.MemtablesFlushIdleAfter) * time.Second),
+		lsmkv.WithIdleThreshold(time.Duration(shard.index.Config.MemtablesFlushIdleAfter) * time.Second),
 	}
 
-	for name, bucket := range store.GetBucketsByName() {
+	for name, bucket := range shard.store.GetBucketsByName() {
 		if bucket.Strategy() == lsmkv.StrategySetCollection &&
 			bucket.DesiredStrategy() == lsmkv.StrategyRoaringSet {
 

--- a/adapters/repos/db/inverted_reindexer_utils.go
+++ b/adapters/repos/db/inverted_reindexer_utils.go
@@ -33,6 +33,10 @@ func GetPropNameAndIndexTypeFromBucketName(bucketName string) (string, PropertyI
 			helpers.BucketFromPropNameLengthLSM,
 		},
 		{
+			IndexTypePropSearchableValue,
+			helpers.BucketSearchableFromPropNameLSM,
+		},
+		{
 			IndexTypePropValue,
 			helpers.BucketFromPropNameLSM,
 		},

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -353,11 +353,6 @@ func (m *Migrator) doInvertedIndexMissingTextFilterable(ctx context.Context, tas
 			m.logMissingFilterableIndex(index).
 				Info("finished filterable indexing on index")
 
-			for _, shard := range index.Shards {
-				m.logMissingFilterableShard(shard).Info("disabling fallback mode for shard")
-				shard.fallbackToSearchable = false
-			}
-
 			return nil
 		})
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -222,6 +223,13 @@ func (m *Migrator) RecalculateVectorDimensions(ctx context.Context) error {
 }
 
 func (m *Migrator) InvertedReindex(ctx context.Context, taskNames ...string) error {
+	var errs errorcompounder.ErrorCompounder
+	errs.Add(m.doInvertedReindex(ctx, taskNames...))
+	errs.Add(m.doInvertedIndexMissingTextFilterable(ctx, taskNames...))
+	return errs.ToError()
+}
+
+func (m *Migrator) doInvertedReindex(ctx context.Context, taskNames ...string) error {
 	tasksProviders := map[string]func() ShardInvertedReindexTask{
 		"ShardInvertedReindexTaskSetToRoaringSet": func() ShardInvertedReindexTask {
 			return &ShardInvertedReindexTaskSetToRoaringSet{}
@@ -242,26 +250,177 @@ func (m *Migrator) InvertedReindex(ctx context.Context, taskNames ...string) err
 	errgrp := &errgroup.Group{}
 	for _, index := range m.db.indices {
 		for _, shard := range index.Shards {
-			func(shard *Shard) {
-				errgrp.Go(func() error {
-					reindexer := NewShardInvertedReindexer(shard, m.logger)
-					for taskName, task := range tasks {
-						reindexer.AddTask(task)
-						m.logger.
-							WithField("action", "inverted reindex").
-							WithField("task", taskName).
-							WithField("shard", shard.name).
-							Info("About to start inverted reindexing, this may take a while")
-					}
-					res := reindexer.Do(ctx)
-					m.logger.
-						WithField("action", "inverted reindex").
-						WithField("shard", shard.name).
-						Info("Finished inverted reindexing")
-					return res
-				})
-			}(shard)
+			shard := shard
+
+			errgrp.Go(func() error {
+				reindexer := NewShardInvertedReindexer(shard, m.logger)
+				for taskName, task := range tasks {
+					reindexer.AddTask(task)
+					m.logInvertedReindexShard(shard).
+						WithField("task", taskName).
+						Info("About to start inverted reindexing, this may take a while")
+				}
+				if err := reindexer.Do(ctx); err != nil {
+					m.logInvertedReindexShard(shard).
+						WithError(err).
+						Error("failed reindexing")
+					return errors.Wrapf(err, "failed reindexing shard '%s'", shard.ID())
+				}
+				m.logInvertedReindexShard(shard).
+					Info("Finished inverted reindexing")
+				return nil
+			})
 		}
 	}
 	return errgrp.Wait()
+}
+
+func (m *Migrator) doInvertedIndexMissingTextFilterable(ctx context.Context, taskNames ...string) error {
+	taskName := "ShardInvertedReindexTaskMissingTextFilterable"
+	taskFound := false
+	for _, name := range taskNames {
+		if name == taskName {
+			taskFound = true
+			break
+		}
+	}
+	if !taskFound {
+		return nil
+	}
+
+	task := newShardInvertedReindexTaskMissingTextFilterable(m)
+	if err := task.init(); err != nil {
+		m.logMissingFilterable().WithError(err).Error("failed init missing text filterable task")
+		return errors.Wrap(err, "failed init missing text filterable task")
+	}
+
+	if len(task.migrationState.MissingFilterableClass2Props) == 0 {
+		m.logMissingFilterable().Info("no classes to create filterable index, skipping")
+		return nil
+	}
+
+	m.logMissingFilterable().Info("staring missing text filterable task")
+
+	errgrpIndexes := &errgroup.Group{}
+	errgrpIndexes.SetLimit(50)
+	for _, index := range m.db.indices {
+		index := index
+		className := index.Config.ClassName.String()
+
+		if _, ok := task.migrationState.MissingFilterableClass2Props[className]; !ok {
+			continue
+		}
+
+		errgrpIndexes.Go(func() error {
+			errgrpShards := &errgroup.Group{}
+			for _, shard := range index.Shards {
+				shard := shard
+
+				errgrpShards.Go(func() error {
+					m.logMissingFilterableShard(shard).
+						Info("starting filterable indexing on shard, this may take a while")
+
+					reindexer := NewShardInvertedReindexer(shard, m.logger)
+					reindexer.AddTask(task)
+
+					if err := reindexer.Do(ctx); err != nil {
+						m.logMissingFilterableShard(shard).
+							WithError(err).
+							Error("failed filterable indexing on shard")
+						return errors.Wrapf(err, "failed filterable indexing for shard '%s' of index '%s'",
+							shard.ID(), index.ID())
+					}
+					m.logMissingFilterableShard(shard).
+						Info("finished filterable indexing on shard")
+					return nil
+				})
+			}
+
+			if err := errgrpShards.Wait(); err != nil {
+				m.logMissingFilterableIndex(index).
+					WithError(err).
+					Error("failed filterable indexing on index")
+				return errors.Wrapf(err, "failed filterable indexing of index '%s'", index.ID())
+			}
+
+			if err := task.updateMigrationStateAndSave(className); err != nil {
+				m.logMissingFilterableIndex(index).
+					WithError(err).
+					Error("failed updating migration state file")
+				return errors.Wrapf(err, "failed updating migration state file for class '%s'", className)
+			}
+
+			m.logMissingFilterableIndex(index).
+				Info("finished filterable indexing on index")
+
+			for _, shard := range index.Shards {
+				m.logMissingFilterableShard(shard).Info("disabling fallback mode for shard")
+				shard.fallbackToSearchable = false
+			}
+
+			return nil
+		})
+	}
+
+	if err := errgrpIndexes.Wait(); err != nil {
+		m.logMissingFilterable().
+			WithError(err).
+			Error("failed missing text filterable task")
+		return errors.Wrap(err, "failed missing text filterable task")
+	}
+
+	m.logMissingFilterable().Info("finished missing text filterable task")
+	return nil
+}
+
+func (m *Migrator) logInvertedReindex() *logrus.Entry {
+	return m.logger.WithField("action", "inverted_reindex")
+}
+
+func (m *Migrator) logInvertedReindexShard(shard *Shard) *logrus.Entry {
+	return m.logInvertedReindex().
+		WithField("index", shard.index.ID()).
+		WithField("shard", shard.ID())
+}
+
+func (m *Migrator) logMissingFilterable() *logrus.Entry {
+	return m.logger.WithField("action", "ii_missing_text_filterable")
+}
+
+func (m *Migrator) logMissingFilterableIndex(index *Index) *logrus.Entry {
+	return m.logMissingFilterable().WithField("index", index.ID())
+}
+
+func (m *Migrator) logMissingFilterableShard(shard *Shard) *logrus.Entry {
+	return m.logMissingFilterableIndex(shard.index).WithField("shard", shard.ID())
+}
+
+// As of v1.19 property's IndexInverted setting is replaced with IndexFilterable
+// and IndexSearchable
+// Filterable buckets use roaring set strategy and searchable ones use map strategy
+// (therefore are applicabe just for text/text[])
+// Since both type of buckets can coexist for text/text[] props they need to be
+// distinguished by their name: searchable bucket has "searchable" suffix.
+// Up until v1.19 default text/text[]/string/string[] (string/string[] deprecated since v1.19)
+// strategy for buckets was map, migrating from pre v1.19 to v1.19 needs to properly
+// handle existing text/text[] buckets of map strategy having filterable bucket name.
+//
+// Enabled InvertedIndex translates in v1.19 to both InvertedFilterable and InvertedSearchable
+// enabled, but since only searchable bucket exist (with filterable name), it has to be renamed
+// to searchable bucket.
+// Though IndexFilterable setting is enabled filterable index does not exists,
+// therefore shards are switched into fallback mode, to use searchable buckets instead of
+// filterable ones whenever filtered are expected.
+// Fallback mode efectivelly sets IndexFilterable to false, although it stays enabled according
+// to schema.
+//
+// If filterable indexes will be created (that is up to user to decide whether missing indexes
+// should be created later on), shards will not be working in fallback mode, and actual filterable index
+// will be used when needed.
+func (m *Migrator) AdjustFilterablePropSettings(ctx context.Context) error {
+	f2sm := newFilterableToSearchableMigrator(m)
+	if err := f2sm.migrate(ctx); err != nil {
+		return err
+	}
+	return f2sm.switchShardsToFallbackMode(ctx)
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -70,6 +70,17 @@ type Shard struct {
 	docIdLock []sync.Mutex
 	// replication
 	replicationMap pendingReplicaTasks
+
+	// Indicates whether searchable buckets should be used
+	// when filterable buckets are missing for text/text[] properties
+	// This can happen for db created before v1.19, where
+	// only map (now called searchable) buckets were created as inverted
+	// indexes for text/text[] props.
+	// Now roaring set (filterable) and map (searchable) buckets can
+	// coexists for text/text[] props, and by default both are enabled.
+	// So despite property's IndexFilterable and IndexSearchable settings
+	// being enabled, only searchable bucket exists
+	fallbackToSearchable bool
 }
 
 func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
@@ -619,4 +630,8 @@ func (s *Shard) objectCount() int {
 	}
 
 	return b.Count()
+}
+
+func (s *Shard) isFallbackToSearchable() bool {
+	return s.fallbackToSearchable
 }

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -23,6 +23,6 @@ func (s *Shard) aggregate(ctx context.Context,
 ) (*aggregation.Result, error) {
 	return aggregator.New(s.store, params, s.index.getSchema, s.invertedRowCache,
 		s.index.classSearcher, s.deletedDocIDs, s.index.stopwords, s.versioner.Version(),
-		s.vectorIndex, s.index.logger, s.propLengths).
+		s.vectorIndex, s.index.logger, s.propLengths, s.isFallbackToSearchable).
 		Do(ctx)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -188,7 +188,7 @@ func (s *Shard) objectSearch(ctx context.Context, limit int,
 			objs, err = inverted.NewSearcher(s.index.logger, s.store,
 				s.index.getSchema.GetSchemaSkipAuth(), s.invertedRowCache,
 				s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
-				s.index.stopwords, s.versioner.Version()).
+				s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
 			if err != nil {
 				return nil, nil, err
@@ -230,7 +230,7 @@ func (s *Shard) objectSearch(ctx context.Context, limit int,
 	objs, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(), s.invertedRowCache,
 		s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
-		s.index.stopwords, s.versioner.Version()).
+		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName)
 	return objs, nil, err
 }
@@ -395,7 +395,7 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 	list, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(), s.invertedRowCache,
 		s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
-		s.index.stopwords, s.versioner.Version()).
+		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)
 	if err != nil {
 		return nil, errors.Wrap(err, "build inverted filter allow list")

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -151,7 +151,7 @@ func (s *Shard) findDocIDs(ctx context.Context,
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(), s.invertedRowCache, nil,
 		s.index.classSearcher, s.deletedDocIDs, s.index.stopwords,
-		s.versioner.version).
+		s.versioner.version, s.isFallbackToSearchable).
 		DocIDsPreventCaching(ctx, filters, additional.Properties{}, s.index.Config.ClassName)
 	if err != nil {
 		return nil, err

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -85,6 +85,6 @@ func (s *Shard) analyzeObject(object *storobj.Object) ([]inverted.Property, []ni
 		schemaMap[filters.InternalPropLastUpdateTimeUnix] = object.Object.LastUpdateTimeUnix
 	}
 
-	props, err := inverted.NewAnalyzer(s.index.stopwords).Object(schemaMap, c.Properties, object.ID())
+	props, err := inverted.NewAnalyzer(s.isFallbackToSearchable).Object(schemaMap, c.Properties, object.ID())
 	return props, nilProps, err
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -71,30 +71,31 @@ type Flags struct {
 
 // Config outline of the config file
 type Config struct {
-	Name                             string         `json:"name" yaml:"name"`
-	Debug                            bool           `json:"debug" yaml:"debug"`
-	QueryDefaults                    QueryDefaults  `json:"query_defaults" yaml:"query_defaults"`
-	QueryMaximumResults              int64          `json:"query_maximum_results" yaml:"query_maximum_results"`
-	Contextionary                    Contextionary  `json:"contextionary" yaml:"contextionary"`
-	Authentication                   Authentication `json:"authentication" yaml:"authentication"`
-	Authorization                    Authorization  `json:"authorization" yaml:"authorization"`
-	Origin                           string         `json:"origin" yaml:"origin"`
-	Persistence                      Persistence    `json:"persistence" yaml:"persistence"`
-	DefaultVectorizerModule          string         `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
-	DefaultVectorDistanceMetric      string         `json:"default_vector_distance_metric" yaml:"default_vector_distance_metric"`
-	EnableModules                    string         `json:"enable_modules" yaml:"enable_modules"`
-	ModulesPath                      string         `json:"modules_path" yaml:"modules_path"`
-	AutoSchema                       AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
-	Cluster                          cluster.Config `json:"cluster" yaml:"cluster"`
-	Monitoring                       Monitoring     `json:"monitoring" yaml:"monitoring"`
-	GRPC                             GRPC           `json:"grpc" yaml:"grpc"`
-	Profiling                        Profiling      `json:"profiling" yaml:"profiling"`
-	ResourceUsage                    ResourceUsage  `json:"resource_usage" yaml:"resource_usage"`
-	MaxImportGoroutinesFactor        float64        `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
-	MaximumConcurrentGetRequests     int            `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
-	TrackVectorDimensions            bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
-	ReindexVectorDimensionsAtStartup bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
-	ReindexSetToRoaringsetAtStartup  bool           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
+	Name                                string         `json:"name" yaml:"name"`
+	Debug                               bool           `json:"debug" yaml:"debug"`
+	QueryDefaults                       QueryDefaults  `json:"query_defaults" yaml:"query_defaults"`
+	QueryMaximumResults                 int64          `json:"query_maximum_results" yaml:"query_maximum_results"`
+	Contextionary                       Contextionary  `json:"contextionary" yaml:"contextionary"`
+	Authentication                      Authentication `json:"authentication" yaml:"authentication"`
+	Authorization                       Authorization  `json:"authorization" yaml:"authorization"`
+	Origin                              string         `json:"origin" yaml:"origin"`
+	Persistence                         Persistence    `json:"persistence" yaml:"persistence"`
+	DefaultVectorizerModule             string         `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
+	DefaultVectorDistanceMetric         string         `json:"default_vector_distance_metric" yaml:"default_vector_distance_metric"`
+	EnableModules                       string         `json:"enable_modules" yaml:"enable_modules"`
+	ModulesPath                         string         `json:"modules_path" yaml:"modules_path"`
+	AutoSchema                          AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
+	Cluster                             cluster.Config `json:"cluster" yaml:"cluster"`
+	Monitoring                          Monitoring     `json:"monitoring" yaml:"monitoring"`
+	GRPC                                GRPC           `json:"grpc" yaml:"grpc"`
+	Profiling                           Profiling      `json:"profiling" yaml:"profiling"`
+	ResourceUsage                       ResourceUsage  `json:"resource_usage" yaml:"resource_usage"`
+	MaxImportGoroutinesFactor           float64        `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
+	MaximumConcurrentGetRequests        int            `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
+	TrackVectorDimensions               bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
+	ReindexVectorDimensionsAtStartup    bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
+	ReindexSetToRoaringsetAtStartup     bool           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
+	IndexMissingTextFilterableAtStartup bool           `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 }
 
 type moduleProvider interface {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -46,6 +46,10 @@ func FromEnv(config *Config) error {
 		config.ReindexSetToRoaringsetAtStartup = true
 	}
 
+	if enabled(os.Getenv("INDEX_MISSING_TEXT_FILTERABLE_AT_STARTUP")) {
+		config.IndexMissingTextFilterableAtStartup = true
+	}
+
 	if v := os.Getenv("PROMETHEUS_MONITORING_PORT"); v != "" {
 		asInt, err := strconv.Atoi(v)
 		if err != nil {

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -92,6 +92,10 @@ func (n *NilMigrator) InvertedReindex(ctx context.Context, taskNames ...string) 
 	return nil
 }
 
+func (n *NilMigrator) AdjustFilterablePropSettings(ctx context.Context) error {
+	return nil
+}
+
 var schemaTests = []struct {
 	name string
 	fn   func(*testing.T, *Manager)

--- a/usecases/schema/migrate/migrator.go
+++ b/usecases/schema/migrate/migrator.go
@@ -43,5 +43,7 @@ type Migrator interface {
 	UpdateInvertedIndexConfig(ctx context.Context, className string,
 		updated *models.InvertedIndexConfig) error
 	RecalculateVectorDimensions(ctx context.Context) error
+
 	InvertedReindex(ctx context.Context, taskNames ...string) error
+	AdjustFilterablePropSettings(ctx context.Context) error
 }


### PR DESCRIPTION
### What's being changed:
Addresses https://github.com/weaviate/weaviate/issues/2751

Allows migration of text/text[] inverted indexes from v1.18 to v1.19.
Existing text/text[] indexes in v1.18 need to have different name in v1.19, due to property's IndexInverted to IndexFilterable+IndexSearchable settings migration.
Introduced feature renames existing text/text[] inverted indexes to searchable ones and creates missing RBM (filterable) inverted indexes on startup (only if `INDEX_MISSING_TEXT_FILTERABLE_AT_STARTUP` env variable is set).
Until filterable indexes are created (if at all), searchable indexes are used as fallback for filtering use cases.

Migration of text/text[] indexes from v1.18 to v1.19 is a multi step process:
1. property's `IndexInverted` setting is migrated to `IndexFilterable` and `IndexSearchable` settings. Both have the same value as `IndexInverted`. By default `IndexInverted` is enabled and so are `IndexFilterable` and `IndexSearchable`
2. Existing text/text[] buckets are renamed, as old names are used now by filterable (RBM set) buckets, while searchable (map) buckets have `searchable` suffix. Different names allow distinguish filterable and searchable buckets, as both of them can coexist for text/text[] props. List of properties and classes stored in renamed buckets is saved to file for further use. Separate, empty flag file is created to indicate in this step can be omitted on following db startups.
3. Shards containing buckets with classes/properties listed in created earlier file are set to fallback mode. Since text/text[] props by default should have both filterable and searchable indexes, yet only searchable existed in v1.18, searchable index will be used for search and filter related use cases. So even if property's IndexFilterable is enabled, due to fallback mode it is effectively disabled preventing read from and writes to filterable bucket. 
4. (optional) By setting `INDEX_MISSING_TEXT_FILTERABLE_AT_STARTUP` env variable, weaviate can be forced to create missing filterable indexes and disable fallback mode. Indexes are created at startup, for every class/property listed in the file. While index is being build shards are working in READ ONLY mode. Once all properties of class are indexed on every shard, fallback mode is turned off and class removed from the file, to prevent shards entering into fallback mode on following startups.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/69
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
