### PR TITLE
Reject class name casing permutations

### DIFF
--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -30,6 +30,19 @@ func TestAddClass(t *testing.T) {
 		require.EqualError(t, err, "'' is not a valid class name")
 	})
 
+	t.Run("with permuted-casing class names", func(t *testing.T) {
+		mgr := newSchemaManager()
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: "NewClass"})
+		require.Nil(t, err)
+		err = mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: "NewCLASS"})
+		require.NotNil(t, err)
+		require.Equal(t,
+			"class name \"NewCLASS\" already exists as a permutation of: \"NewClass\". "+
+				"class names must be unique when lowercased", err.Error())
+	})
+
 	t.Run("with default BM25 params", func(t *testing.T) {
 		mgr := newSchemaManager()
 

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
@@ -23,8 +24,14 @@ import (
 
 func (m *Manager) validateClassNameUniqueness(className string) error {
 	for _, otherClass := range m.state.ObjectSchema.Classes {
-		if className == otherClass.Class {
-			return fmt.Errorf("Name '%s' already used as a name for an Object class", className)
+		if strings.EqualFold(className, otherClass.Class) {
+			if className != otherClass.Class {
+				// It's a permutation
+				return fmt.Errorf(
+					"class name %q already exists as a permutation of: %q. class names must be unique when lowercased",
+					className, otherClass.Class)
+			}
+			return fmt.Errorf("class name %q already exists", className)
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:

Disallow class names which are equal when case-folded. This can lead to unexpected side-effects, like the inaccessibility of a shard, due to a class' corresponding index name being stored as lower-case.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
