### PR TITLE
Fix: prevent panic when backup request contains case permutation of existing class

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -29,8 +29,9 @@ type BackupState struct {
 // Backupable returns whether all given class can be backed up.
 func (db *DB) Backupable(ctx context.Context, classes []string) error {
 	for _, c := range classes {
-		idx := db.GetIndex(schema.ClassName(c))
-		if idx == nil {
+		className := schema.ClassName(c)
+		idx := db.GetIndex(className)
+		if idx == nil || idx.Config.ClassName != className {
 			return fmt.Errorf("class %v doesn't exist", c)
 		}
 	}

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -80,6 +80,12 @@ func TestBackup_DBLevel(t *testing.T) {
 
 		classes := db.ListBackupable()
 
+		t.Run("doesn't fail on casing permutation of existing class", func(t *testing.T) {
+			err := db.Backupable(ctx, []string{"DBLeVELBackupClass"})
+			require.NotNil(t, err)
+			require.Equal(t, "class DBLeVELBackupClass doesn't exist", err.Error())
+		})
+
 		t.Run("create backup", func(t *testing.T) {
 			err := db.Backupable(ctx, classes)
 			assert.Nil(t, err)


### PR DESCRIPTION
### What's being changed:

Prevents a nil pointer panic that occurs when a backup request contains a casing permutation of an existing class name in the `include` property.

For example, if a class `SomeClass` exists, this request would cause a panic:
```
{
  "include": ["SOmeClass"]
}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
