### PR TITLE
Ignore hidden/nfs files in commit logger, fixes #2700

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -130,7 +130,7 @@ func getCommitFileNames(rootPath, name string) ([]string, error) {
 		return nil, errors.Wrap(err, "browse commit logger directory")
 	}
 
-	files = removeTmpScratchFiles(files)
+	files = removeTmpScratchOrHiddenFiles(files)
 	files, err = removeTmpCombiningFiles(dir, files)
 	if err != nil {
 		return nil, errors.Wrap(err, "remove temporary files")
@@ -177,7 +177,7 @@ func getCurrentCommitLogFileName(dirPath string) (string, bool, error) {
 		return "", false, nil
 	}
 
-	files = removeTmpScratchFiles(files)
+	files = removeTmpScratchOrHiddenFiles(files)
 	files, err = removeTmpCombiningFiles(dirPath, files)
 	if err != nil {
 		return "", false, errors.Wrap(err, "clean up tmp combining files")
@@ -203,11 +203,15 @@ func getCurrentCommitLogFileName(dirPath string) (string, bool, error) {
 	return files[0].Name(), true, nil
 }
 
-func removeTmpScratchFiles(in []os.DirEntry) []os.DirEntry {
+func removeTmpScratchOrHiddenFiles(in []os.DirEntry) []os.DirEntry {
 	out := make([]os.DirEntry, len(in))
 	i := 0
 	for _, info := range in {
 		if strings.HasSuffix(info.Name(), ".scratch.tmp") {
+			continue
+		}
+
+		if strings.HasPrefix(info.Name(), ".") {
 			continue
 		}
 

--- a/adapters/repos/db/vector/hnsw/commit_logger_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_test.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	_ "fmt"
+	"os"
+	"testing"
+)
+
+type MockDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (d MockDirEntry) Name() string {
+	return d.name
+}
+
+func (d MockDirEntry) IsDir() bool {
+	return d.isDir
+}
+
+func (d MockDirEntry) Type() os.FileMode {
+	return os.ModePerm
+}
+
+func (d MockDirEntry) Info() (os.FileInfo, error) {
+	return nil, nil
+}
+
+func TestRemoveTmpScratchOrHiddenFiles(t *testing.T) {
+	entries := []os.DirEntry{
+		MockDirEntry{name: "1682473161", isDir: false},
+		MockDirEntry{name: ".nfs6b46801cd962afbc00000005", isDir: false},
+		MockDirEntry{name: ".mystery-folder", isDir: false},
+		MockDirEntry{name: "1682473161.condensed", isDir: false},
+		MockDirEntry{name: "1682473161.scratch.tmp", isDir: false},
+	}
+
+	expected := []os.DirEntry{
+		MockDirEntry{name: "1682473161", isDir: false},
+		MockDirEntry{name: "1682473161.condensed", isDir: false},
+	}
+
+	result := removeTmpScratchOrHiddenFiles(entries)
+
+	if len(result) != len(expected) {
+		t.Errorf("Expected %d entries, got %d", len(expected), len(result))
+	}
+
+	for i, entry := range result {
+		if entry.Name() != expected[i].Name() {
+			t.Errorf("Expected entry %d to be %s, got %s", i, expected[i].Name(), entry.Name())
+		}
+	}
+}


### PR DESCRIPTION
### What's being changed:

Hidden `.nfsXXX` files in the hnsw commit log folder cause errors. These are being created by EFS on AWS ref https://weaviate.slack.com/archives/C03G62T1N9H/p1682464063920939. I've changed `removeTmpScratchFiles` to `removeTmpScratchOrHiddenFiles` to now also exclude any hidden files starting with a period.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
