### PR TITLE
Recount properties for all objects

### DIFF
--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -219,7 +219,6 @@ func (n *NilMigrator) RecountProperties(ctx context.Context) error {
 	return nil
 }
 
-
 func (n *NilMigrator) InvertedReindex(ctx context.Context, taskNames ...string) error {
 	return nil
 }

--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -215,6 +215,11 @@ func (n *NilMigrator) RecalculateVectorDimensions(ctx context.Context) error {
 	return nil
 }
 
+func (n *NilMigrator) RecountProperties(ctx context.Context) error {
+	return nil
+}
+
+
 func (n *NilMigrator) InvertedReindex(ctx context.Context, taskNames ...string) error {
 	return nil
 }

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -368,9 +368,6 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	// Add recount properties of all the objects in the database, if requested by the user
 	if appState.ServerConfig.Config.RecountPropertiesAtStartup {
-		appState.Logger.
-			WithField("action", "startup").
-			Info("Recounting properties")
 		migrator.RecountProperties(ctx)
 	}
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -366,13 +366,13 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		migrator.RecalculateVectorDimensions(ctx)
 	}
 
-		// Add recount properties of all the objects in the database, if requested by the user
-		if appState.ServerConfig.Config.RecountPropertiesAtStartup {
-			appState.Logger.
-				WithField("action", "startup").
-				Info("Recounting properties")
-			migrator.RecountProperties(ctx)
-		}
+	// Add recount properties of all the objects in the database, if requested by the user
+	if appState.ServerConfig.Config.RecountPropertiesAtStartup {
+		appState.Logger.
+			WithField("action", "startup").
+			Info("Recounting properties")
+		migrator.RecountProperties(ctx)
+	}
 
 	setupGrpc(appState)
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -366,6 +366,14 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		migrator.RecalculateVectorDimensions(ctx)
 	}
 
+		// Add recount properties of all the objects in the database, if requested by the user
+		if appState.ServerConfig.Config.RecountPropertiesAtStartup {
+			appState.Logger.
+				WithField("action", "startup").
+				Info("Recounting properties")
+			migrator.RecountProperties(ctx)
+		}
+
 	setupGrpc(appState)
 
 	return setupGlobalMiddleware(api.Serve(setupMiddlewares))

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -437,10 +437,16 @@ func TestBM25FSingleProp(t *testing.T) {
 	idx := repo.GetIndex("MyClass")
 	require.NotNil(t, idx)
 
+
+
 	// Check boosted
 	kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"description"}, Query: "journey"}
 	addit := additional.Properties{}
 	res, _, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, nil, addit, nil)
+	t.Log("--- Start results for singleprop search ---")
+	for _, r := range res {
+		t.Logf("Result id: %v, score: %v, title: %v, description: %v, additional %+v\n", r.DocID(), r.Score(), r.Object.Properties.(map[string]interface{})["title"], r.Object.Properties.(map[string]interface{})["description"], r.Object.Additional)
+	}
 	require.Nil(t, err)
 	// Check results in correct order
 	require.Equal(t, uint64(3), res[0].DocID())

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -437,8 +437,6 @@ func TestBM25FSingleProp(t *testing.T) {
 	idx := repo.GetIndex("MyClass")
 	require.NotNil(t, idx)
 
-
-
 	// Check boosted
 	kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"description"}, Query: "journey"}
 	addit := additional.Properties{}

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -157,7 +157,6 @@ func TestUpdateJourney(t *testing.T) {
 				additional.Properties{})
 			require.Nil(t, err)
 
-			// time.Sleep(20*time.Second)
 			err = repo.PutObject(context.Background(), old.Object(), updatedVec, nil)
 			require.Nil(t, err)
 
@@ -222,7 +221,6 @@ func TestUpdateJourney(t *testing.T) {
 			require.Nil(t, err)
 
 			old.Schema.(map[string]interface{})["intProp"] = int64(21)
-			// time.Sleep(20*time.Second)
 			err = repo.PutObject(context.Background(), old.Object(), updatedVec, nil)
 			require.Nil(t, err)
 

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -258,9 +258,9 @@ func TestUpdateJourney(t *testing.T) {
 
 		sum, count, mean, err := tracker.PropertyTally("name")
 		require.Nil(t, err)
-		assert.Equal(t, 54, sum) // FIXME updates are not tracked in the proplengths tracker
+		assert.Equal(t, 6, sum) // FIXME updates are not tracked in the proplengths tracker, the old count isn't deleted
 		assert.Equal(t, 6, count)
-		assert.InEpsilon(t, 9, mean, 0.1)
+		assert.InEpsilon(t, 1, mean, 0.1)
 
 		tracker.Clear()
 		sum, count, mean, err = tracker.PropertyTally("name")
@@ -275,9 +275,9 @@ func TestUpdateJourney(t *testing.T) {
 
 		sum, count, mean, err = tracker.PropertyTally("name")
 		require.Nil(t, err)
-		assert.Equal(t, 36, sum)
+		assert.Equal(t, 4, sum)
 		assert.Equal(t, 4, count)
-		assert.Equal(t, float64(9), mean)
+		assert.Equal(t, float64(1), mean)
 	})
 }
 

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -19,11 +19,11 @@ import (
 	"math/rand"
 	"testing"
 	"time"
-	
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -32,7 +32,6 @@ import (
 	libschema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 )
 
 // Updates are non trivial, because vector indices are built under the
@@ -83,7 +82,7 @@ func TestUpdateJourney(t *testing.T) {
 
 		sum, count, mean, err := tracker.PropertyTally("name")
 		require.Nil(t, err)
-		assert.Equal(t, 4, sum) 
+		assert.Equal(t, 4, sum)
 		assert.Equal(t, 4, count)
 		assert.InEpsilon(t, 1, mean, 0.1)
 	})
@@ -158,18 +157,17 @@ func TestUpdateJourney(t *testing.T) {
 				additional.Properties{})
 			require.Nil(t, err)
 
-			//time.Sleep(20*time.Second)
+			// time.Sleep(20*time.Second)
 			err = repo.PutObject(context.Background(), old.Object(), updatedVec, nil)
 			require.Nil(t, err)
-		
 
 			tracker := getTracker(repo, "UpdateTestClass")
 
 			require.Nil(t, err)
-	
+
 			sum, count, mean, err := tracker.PropertyTally("name")
 			require.Nil(t, err)
-			assert.Equal(t, 4, sum) 
+			assert.Equal(t, 4, sum)
 			assert.Equal(t, 4, count)
 			assert.InEpsilon(t, 1, mean, 0.1)
 		})
@@ -224,17 +222,17 @@ func TestUpdateJourney(t *testing.T) {
 			require.Nil(t, err)
 
 			old.Schema.(map[string]interface{})["intProp"] = int64(21)
-			//time.Sleep(20*time.Second)
+			// time.Sleep(20*time.Second)
 			err = repo.PutObject(context.Background(), old.Object(), updatedVec, nil)
 			require.Nil(t, err)
 
 			tracker := getTracker(repo, "UpdateTestClass")
 
 			require.Nil(t, err)
-	
+
 			sum, count, mean, err := tracker.PropertyTally("name")
 			require.Nil(t, err)
-			assert.Equal(t, 4, sum) 
+			assert.Equal(t, 4, sum)
 			assert.Equal(t, 4, count)
 			assert.InEpsilon(t, 1, mean, 0.1)
 		})
@@ -279,20 +277,14 @@ func TestUpdateJourney(t *testing.T) {
 		assert.ElementsMatch(t, expectedInAnyOrder, searchInv(t, filters.OperatorEqual, 30))
 	})
 
-
-
-
-
 	t.Run("test recount", func(t *testing.T) {
-
-
 		tracker := getTracker(repo, "UpdateTestClass")
 
 		require.Nil(t, err)
 
 		sum, count, mean, err := tracker.PropertyTally("name")
 		require.Nil(t, err)
-		assert.Equal(t, 4, sum) 
+		assert.Equal(t, 4, sum)
 		assert.Equal(t, 4, count)
 		assert.InEpsilon(t, 1, mean, 0.1)
 
@@ -389,7 +381,6 @@ func extractPropValues(in search.Results, propName string) []interface{} {
 	return out
 }
 
-
 func getTracker(repo *DB, className string) *inverted.JsonPropertyLengthTracker {
 	shards := repo.GetIndex("UpdateTestClass").Shards
 	var shard *Shard
@@ -398,9 +389,6 @@ func getTracker(repo *DB, className string) *inverted.JsonPropertyLengthTracker 
 	}
 
 	tracker := shard.propLengths
-
-	
-
 
 	return tracker
 }

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -245,9 +245,8 @@ func TestUpdateJourney(t *testing.T) {
 		assert.ElementsMatch(t, expectedInAnyOrder, searchInv(t, filters.OperatorEqual, 30))
 	})
 
-
 	t.Run("test recount", func(t *testing.T) {
-		shards :=  repo.GetIndex("UpdateTestClass").Shards
+		shards := repo.GetIndex("UpdateTestClass").Shards
 		var shard *Shard
 		for _, shardv := range shards {
 			shard = shardv
@@ -257,11 +256,9 @@ func TestUpdateJourney(t *testing.T) {
 
 		require.Nil(t, err)
 
-		
-
 		sum, count, mean, err := tracker.PropertyTally("name")
 		require.Nil(t, err)
-		assert.Equal(t, 54, sum)  //FIXME updates are not tracked in the proplengths tracker
+		assert.Equal(t, 54, sum) // FIXME updates are not tracked in the proplengths tracker
 		assert.Equal(t, 6, count)
 		assert.InEpsilon(t, 9, mean, 0.1)
 
@@ -281,11 +278,7 @@ func TestUpdateJourney(t *testing.T) {
 		assert.Equal(t, 36, sum)
 		assert.Equal(t, 4, count)
 		assert.Equal(t, float64(9), mean)
-
 	})
-
-
-
 }
 
 func updateTestClass() *models.Class {

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -244,6 +244,48 @@ func TestUpdateJourney(t *testing.T) {
 		expectedInAnyOrder = []interface{}{"element-3"}
 		assert.ElementsMatch(t, expectedInAnyOrder, searchInv(t, filters.OperatorEqual, 30))
 	})
+
+
+	t.Run("test recount", func(t *testing.T) {
+		shards :=  repo.GetIndex("UpdateTestClass").Shards
+		var shard *Shard
+		for _, shardv := range shards {
+			shard = shardv
+		}
+
+		tracker := shard.propLengths
+
+		require.Nil(t, err)
+
+		
+
+		sum, count, mean, err := tracker.PropertyTally("name")
+		require.Nil(t, err)
+		assert.Equal(t, 54, sum)  //FIXME updates are not tracked in the proplengths tracker
+		assert.Equal(t, 6, count)
+		assert.InEpsilon(t, 9, mean, 0.1)
+
+		tracker.Clear()
+		sum, count, mean, err = tracker.PropertyTally("name")
+		require.Nil(t, err)
+		assert.Equal(t, 0, sum)
+		assert.Equal(t, 0, count)
+		assert.Equal(t, float64(0), mean)
+
+		logger := logrus.New()
+		migrator := NewMigrator(repo, logger)
+		migrator.RecountProperties(context.Background())
+
+		sum, count, mean, err = tracker.PropertyTally("name")
+		require.Nil(t, err)
+		assert.Equal(t, 36, sum)
+		assert.Equal(t, 4, count)
+		assert.Equal(t, float64(9), mean)
+
+	})
+
+
+
 }
 
 func updateTestClass() *models.Class {

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -258,7 +258,7 @@ func TestUpdateJourney(t *testing.T) {
 
 		sum, count, mean, err := tracker.PropertyTally("name")
 		require.Nil(t, err)
-		assert.Equal(t, 6, sum) // FIXME updates are not tracked in the proplengths tracker, the old count isn't deleted
+		assert.Equal(t, 4, sum) // FIXME updates are not tracked in the proplengths tracker, the old count isn't deleted
 		assert.Equal(t, 6, count)
 		assert.InEpsilon(t, 1, mean, 0.1)
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -148,6 +148,7 @@ func NewIndex(ctx context.Context, config IndexConfig,
 	return index, nil
 }
 
+// Iterate over all objects in the index, applying the callback function to each one.  Adding or removing objects during iteration is not supported.
 func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard *Shard, object *storobj.Object) error) error {
 	for _, shard := range i.Shards {
 		wrapper := func(object *storobj.Object) error {
@@ -161,6 +162,7 @@ func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard 
 	return nil
 }
 
+// Iterate over all objects in the shard, applying the callback function to each one.  Adding or removing objects during iteration is not supported.
 func (i *Index) IterateShards(ctx context.Context, cb func(index *Index, shard *Shard) error) error {
 	for _, shard := range i.Shards {
 		if err := cb(i, shard); err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -161,6 +161,17 @@ func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard 
 	return nil
 }
 
+func (i *Index) IterateShards(ctx context.Context, cb func(index *Index, shard *Shard) error) error {
+	for _, shard := range i.Shards {
+		
+		if err :=cb(i, shard) ; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+
 func (i *Index) addProperty(ctx context.Context, prop *models.Property) error {
 	eg := &errgroup.Group{}
 	for _, shard := range i.Shards {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -163,14 +163,12 @@ func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard 
 
 func (i *Index) IterateShards(ctx context.Context, cb func(index *Index, shard *Shard) error) error {
 	for _, shard := range i.Shards {
-		
-		if err :=cb(i, shard) ; err != nil {
+		if err := cb(i, shard); err != nil {
 			return err
 		}
 	}
 	return nil
 }
-
 
 func (i *Index) addProperty(ctx context.Context, prop *models.Property) error {
 	eg := &errgroup.Group{}

--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -30,7 +30,7 @@ type PropLenData struct {
 
 type JsonPropertyLengthTracker struct {
 	path string
-	data PropLenData
+	data *PropLenData
 	sync.Mutex
 	UnlimitedBuckets bool
 }
@@ -62,7 +62,7 @@ type JsonPropertyLengthTracker struct {
 // NewJsonPropertyLengthTracker creates a new tracker and loads the data from the given path.  If the file is in the old format, it will be converted to the new format.
 func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker, error) {
 	t := &JsonPropertyLengthTracker{
-		data:             PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)},
+		data:             &PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)},
 		path:             path,
 		UnlimitedBuckets: false,
 	}
@@ -115,14 +115,14 @@ func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker, erro
 					data.CountData[name] = data.CountData[name] + int(count)
 				}
 			}
-			t.data = data
+			t.data = &data
 			t.Flush(true)
 			plt.Close()
 			plt.Drop()
 			t.Flush(false)
 		}
 	}
-	t.data = data
+	t.data = &data
 
 	return t, nil
 }
@@ -131,7 +131,7 @@ func (t *JsonPropertyLengthTracker) Clear() {
 	t.Lock()
 	defer t.Unlock()
 
-	t.data = PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)}
+	t.data = &PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)}
 }
 
 // Path to the file on disk

--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -60,7 +60,7 @@ type JsonPropertyLengthTracker struct {
 // Note that some of the code in this file is forced by the need to be backwards-compatible with the old format.  Once we are confident that all users have migrated to the new format, we can remove the old format code and simplify this file.
 
 // NewJsonPropertyLengthTracker creates a new tracker and loads the data from the given path.  If the file is in the old format, it will be converted to the new format.
-func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker,  error) {
+func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker, error) {
 	t := &JsonPropertyLengthTracker{
 		data:             PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)},
 		path:             path,
@@ -132,7 +132,6 @@ func (t *JsonPropertyLengthTracker) Clear() {
 	defer t.Unlock()
 
 	t.data = PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)}
-
 }
 
 // Path to the file on disk

--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -60,7 +60,7 @@ type JsonPropertyLengthTracker struct {
 // Note that some of the code in this file is forced by the need to be backwards-compatible with the old format.  Once we are confident that all users have migrated to the new format, we can remove the old format code and simplify this file.
 
 // NewJsonPropertyLengthTracker creates a new tracker and loads the data from the given path.  If the file is in the old format, it will be converted to the new format.
-func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker, error) {
+func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker,  error) {
 	t := &JsonPropertyLengthTracker{
 		data:             PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)},
 		path:             path,
@@ -113,7 +113,6 @@ func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker, erro
 
 					data.SumData[name] = data.SumData[name] + int(value)*int(count)
 					data.CountData[name] = data.CountData[name] + int(count)
-
 				}
 			}
 			t.data = data
@@ -126,6 +125,14 @@ func NewJsonPropertyLengthTracker(path string) (*JsonPropertyLengthTracker, erro
 	t.data = data
 
 	return t, nil
+}
+
+func (t *JsonPropertyLengthTracker) Clear() {
+	t.Lock()
+	defer t.Unlock()
+
+	t.data = PropLenData{make(map[string]map[int]int), make(map[string]int), make(map[string]int)}
+
 }
 
 // Path to the file on disk

--- a/adapters/repos/db/inverted/prop_length_tracker_test.go
+++ b/adapters/repos/db/inverted/prop_length_tracker_test.go
@@ -12,6 +12,7 @@
 package inverted
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"path"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/schema/migrate"
 )
 
 func Test_PropertyLengthTracker(t *testing.T) {
@@ -124,6 +126,7 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		assert.Equal(t, 1, count)
 		assert.InEpsilon(t, 3, mean, 0.1)
 	})
+
 
 	t.Run("multiple properties (can all fit on one page)", func(t *testing.T) {
 		type prop struct {
@@ -620,3 +623,6 @@ func Test_PropertyLengthTracker_Overflow(t *testing.T) {
 	err = tracker.TrackProperty("OVERFLOW", float32(123))
 	require.NotNil(t, err)
 }
+
+
+

--- a/adapters/repos/db/inverted/prop_length_tracker_test.go
+++ b/adapters/repos/db/inverted/prop_length_tracker_test.go
@@ -12,7 +12,6 @@
 package inverted
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"path"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/usecases/schema/migrate"
 )
 
 func Test_PropertyLengthTracker(t *testing.T) {
@@ -126,7 +124,6 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		assert.Equal(t, 1, count)
 		assert.InEpsilon(t, 3, mean, 0.1)
 	})
-
 
 	t.Run("multiple properties (can all fit on one page)", func(t *testing.T) {
 		type prop struct {
@@ -623,6 +620,3 @@ func Test_PropertyLengthTracker_Overflow(t *testing.T) {
 	err = tracker.TrackProperty("OVERFLOW", float32(123))
 	require.NotNil(t, err)
 }
-
-
-

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -250,6 +250,8 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 				return nil
 			}
 
+			shard.propLengths.Flush(false)
+
 			return nil
 		})
 		if err != nil {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -245,10 +245,6 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 
 		// Iterate over all shards
 		err = index.IterateObjects(ctx, func(index *Index, shard *Shard, object *storobj.Object) error {
-			if _, ok := clearedShard[shard.name]; !ok {
-				shard.propLengths.Clear()
-				clearedShard[shard.name] = true
-			}
 			count = count + 1
 			props, _, err := shard.analyzeObject(object)
 			if err != nil {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -228,7 +228,6 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 		WithField("action", "recount").
 		Info("Recounting properties, this may take a while")
 
-
 	m.db.indexLock.Lock()
 	defer m.db.indexLock.Unlock()
 	// Iterate over all indexes

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -228,10 +228,16 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 		WithField("action", "recount").
 		Info("Recounting properties, this may take a while")
 
+		clearedShard := map[string]bool{}
+	
 	// Iterate over all indexes
 	for _, index := range m.db.indices {
 		// Iterate over all shards
 		err := index.IterateObjects(ctx, func(index *Index, shard *Shard, object *storobj.Object) error {
+			if _, ok := clearedShard[shard.name]; !ok {
+				shard.propLengths.Clear()
+				clearedShard[shard.name] = true
+			}
 			count = count + 1
 			props, _, err := shard.analyzeObject(object)
 			if err != nil {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -228,8 +228,8 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 		WithField("action", "recount").
 		Info("Recounting properties, this may take a while")
 
-		clearedShard := map[string]bool{}
-	
+	clearedShard := map[string]bool{}
+
 	// Iterate over all indexes
 	for _, index := range m.db.indices {
 		// Iterate over all shards
@@ -252,7 +252,6 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 
 			return nil
 		})
-
 		if err != nil {
 			m.logger.WithField("error", err).Error("could not iterate over objects")
 		}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -258,6 +258,14 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 			m.logger.WithField("error", err).Error("could not iterate over objects")
 		}
 
+		// Flush the propLengths to disk
+		err = index.IterateShards(ctx, func(index *Index, shard *Shard) error {
+			return shard.propLengths.Flush(false)
+		})
+		if err != nil {
+			m.logger.WithField("error", err).Error("could not flush prop lengths")
+		}
+
 	}
 	go func() {
 		for {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -234,11 +234,10 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 	for _, index := range m.db.indices {
 
 		// Clear the shards before counting
-		 index.IterateShards(ctx, func(index *Index, shard *Shard) error {
+		index.IterateShards(ctx, func(index *Index, shard *Shard) error {
 			shard.propLengths.Clear()
 			return nil
 		})
-
 
 		// Iterate over all shards
 		index.IterateObjects(ctx, func(index *Index, shard *Shard, object *storobj.Object) error {
@@ -258,7 +257,6 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 
 			return nil
 		})
-	
 
 		// Flush the propLengths to disk
 		err := index.IterateShards(ctx, func(index *Index, shard *Shard) error {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -228,7 +228,7 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 		WithField("action", "recount").
 		Info("Recounting properties, this may take a while")
 
-	clearedShard := map[string]bool{}
+
 	m.db.indexLock.Lock()
 	defer m.db.indexLock.Unlock()
 	// Iterate over all indexes

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -234,16 +234,14 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 	for _, index := range m.db.indices {
 
 		// Clear the shards before counting
-		err := index.IterateShards(ctx, func(index *Index, shard *Shard) error {
+		 index.IterateShards(ctx, func(index *Index, shard *Shard) error {
 			shard.propLengths.Clear()
 			return nil
 		})
-		if err != nil {
-			m.logger.WithField("error", err).Error("could not clear prop lengths")
-		}
+
 
 		// Iterate over all shards
-		err = index.IterateObjects(ctx, func(index *Index, shard *Shard, object *storobj.Object) error {
+		index.IterateObjects(ctx, func(index *Index, shard *Shard, object *storobj.Object) error {
 			count = count + 1
 			props, _, err := shard.analyzeObject(object)
 			if err != nil {
@@ -260,12 +258,10 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 
 			return nil
 		})
-		if err != nil {
-			m.logger.WithField("error", err).Error("could not iterate over objects")
-		}
+	
 
 		// Flush the propLengths to disk
-		err = index.IterateShards(ctx, func(index *Index, shard *Shard) error {
+		err := index.IterateShards(ctx, func(index *Index, shard *Shard) error {
 			return shard.propLengths.Flush(false)
 		})
 		if err != nil {

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -70,7 +70,6 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID) error {
 	// Remove each property from the property length tracker.
 	for _, propTypes := range class.Properties {
 		propName := strings.ToLower(propTypes.Name)
-		fmt.Println("Decrementing property length for", propName)
 		if properties.(map[string]interface{})[propName] != nil {
 			for _, propType := range propTypes.DataType {
 				switch propType {

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -14,7 +14,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -55,12 +54,6 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID) error {
 		return errors.Wrap(err, "get existing doc id from object binary")
 	}
 
-	obj, err := storobj.FromBinary(existing)
-	if err != nil {
-		return errors.Wrap(err, "get existing object from binary")
-	}
-
-	s.subtractPropLengths(obj *storobj.Object)
 
 	err = bucket.Delete(idBytes)
 	if err != nil {

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -54,7 +54,6 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID) error {
 		return errors.Wrap(err, "get existing doc id from object binary")
 	}
 
-
 	err = bucket.Delete(idBytes)
 	if err != nil {
 		return errors.Wrap(err, "delete object from bucket")

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -16,6 +16,7 @@ import (
 	"math"
 
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/storobj"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -282,6 +283,22 @@ func (s *Shard) addPropLengths(props []inverted.Property) error {
 	}
 
 	return nil
+}
+
+func (s *Shard) subtractPropLengths(props []inverted.Property) error {
+	for _, prop := range props {
+		if !prop.HasFrequency {
+			continue
+		}
+
+		if err := s.propLengths.UnTrackProperty(prop.Name, float32(len(prop.Items))); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+	
 }
 
 func (s *Shard) extendDimensionTrackerLSM(

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -279,14 +279,6 @@ func (s *Shard) addPropLengths(props []inverted.Property) error {
 			return err
 		}
 
-		/*
-				for _, item := range prop.Items {
-				if err := s.propLengths.TrackProperty(prop.Name, float32(len(item.Data))); err != nil {
-					return err
-				}
-
-			}
-		*/
 	}
 
 	return nil

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -275,10 +275,11 @@ func (s *Shard) addPropLengths(props []inverted.Property) error {
 			continue
 		}
 
-		if err := s.propLengths.TrackProperty(prop.Name, float32(prop.Length)); err != nil {
+		for _, item := range prop.Items {
+		if err := s.propLengths.TrackProperty(prop.Name, float32(len(item.Data))); err != nil {
 			return err
 		}
-
+	}
 	}
 
 	return nil

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -275,9 +275,10 @@ func (s *Shard) addPropLengths(props []inverted.Property) error {
 			continue
 		}
 
-		if err := s.propLengths.TrackProperty(prop.Name, float32(len(prop.Items))); err != nil {
+		if err := s.propLengths.TrackProperty(prop.Name, float32(prop.Length)); err != nil {
 			return err
 		}
+
 	}
 
 	return nil

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -275,11 +275,18 @@ func (s *Shard) addPropLengths(props []inverted.Property) error {
 			continue
 		}
 
-		for _, item := range prop.Items {
-		if err := s.propLengths.TrackProperty(prop.Name, float32(len(item.Data))); err != nil {
+		if err := s.propLengths.TrackProperty(prop.Name, float32(len(prop.Items))); err != nil {
 			return err
 		}
-	}
+
+		/*
+				for _, item := range prop.Items {
+				if err := s.propLengths.TrackProperty(prop.Name, float32(len(item.Data))); err != nil {
+					return err
+				}
+
+			}
+		*/
 	}
 
 	return nil

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -297,7 +297,6 @@ func (s *Shard) subtractPropLengths(props []inverted.Property) error {
 	}
 
 	return nil
-	
 }
 
 func (s *Shard) extendDimensionTrackerLSM(

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -286,7 +286,7 @@ func (s *Shard) addPropLengths(props []inverted.Property) error {
 
 func (s *Shard) subtractPropLengths(props []inverted.Property) error {
 	for _, prop := range props {
-		if !prop.HasFrequency {
+		if !prop.HasSearchableIndex {
 			continue
 		}
 

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -16,7 +16,6 @@ import (
 	"math"
 
 	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/storobj"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -164,7 +164,7 @@ func (s *Shard) putObjectLSM(object *storobj.Object, idBytes []byte,
 	if err := s.updateInvertedIndexLSM(object, status, previous_object_bytes); err != nil {
 		return status, errors.Wrap(err, "update inverted indices")
 	}
-	
+
 	s.metrics.PutObjectUpdateInverted(before)
 
 	return status, nil

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -258,6 +259,23 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "analyze next object")
 	}
 
+	
+
+	if status.docIDChanged {
+			oldObject, err := storobj.FromBinary(previous)
+			
+				oldProps, _, err := s.analyzeObject(oldObject)
+				if err != nil {
+					s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
+				}
+
+				if err := s.subtractPropLengths(oldProps); err != nil {
+					s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
+				}
+		
+	
+	}
+
 	// TODO: metrics
 	if err := s.updateInvertedIndexCleanupOldLSM(status, previous); err != nil {
 		return errors.Wrap(err, "analyze and cleanup previous")
@@ -278,6 +296,8 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "put inverted indices props")
 	}
 	s.metrics.InvertedExtend(before, len(props))
+
+
 
 	if err := s.addPropLengths(props); err != nil {
 		return errors.Wrap(err, "store field length values for props")

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -12,11 +12,11 @@
 package db
 
 import (
-
 	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -259,21 +259,18 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "analyze next object")
 	}
 
-	
-
 	if status.docIDChanged {
-			oldObject, err := storobj.FromBinary(previous)
-			
-				oldProps, _, err := s.analyzeObject(oldObject)
-				if err != nil {
-					s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
-				}
+		oldObject, err := storobj.FromBinary(previous)
 
-				if err := s.subtractPropLengths(oldProps); err != nil {
-					s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
-				}
-		
-	
+		oldProps, _, err := s.analyzeObject(oldObject)
+		if err != nil {
+			s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
+		}
+
+		if err := s.subtractPropLengths(oldProps); err != nil {
+			s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
+		}
+
 	}
 
 	// TODO: metrics
@@ -296,8 +293,6 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "put inverted indices props")
 	}
 	s.metrics.InvertedExtend(before, len(props))
-
-
 
 	if err := s.addPropLengths(props); err != nil {
 		return errors.Wrap(err, "store field length values for props")

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -261,16 +261,18 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 
 	if status.docIDChanged {
 		oldObject, err := storobj.FromBinary(previous)
-
-		oldProps, _, err := s.analyzeObject(oldObject)
 		if err != nil {
-			s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
-		}
 
-		if err := s.subtractPropLengths(oldProps); err != nil {
-			s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
-		}
+			oldProps, _, err := s.analyzeObject(oldObject)
+			if err != nil {
+				s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not analyse prop lengths")
+			}
 
+			if err := s.subtractPropLengths(oldProps); err != nil {
+				s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
+			}
+
+		}
 	}
 
 	// TODO: metrics

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -261,7 +261,7 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 
 	if status.docIDChanged {
 		oldObject, err := storobj.FromBinary(previous)
-		if err != nil {
+		if err == nil {
 
 			oldProps, _, err := s.analyzeObject(oldObject)
 			if err != nil {

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -2,10 +2,15 @@ module acceptance_tests_with_client
 
 go 1.19
 
+replace (
+        github.com/weaviate/weaviate v1.19.0 => ../..
+)
+
+
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
-	github.com/weaviate/weaviate v1.19.0-beta.1.0.20230424082040-b053defd25ee
+	github.com/weaviate/weaviate v1.19.0
 	github.com/weaviate/weaviate-go-client/v4 v4.7.1
 )
 

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -2,6 +2,10 @@ module github.com/weaviate/weaviate/test/benchmark_bm25
 
 go 1.19
 
+replace (
+	github.com/weaviate/weaviate => ../..
+)
+
 require (
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/google/uuid v1.3.0

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -94,6 +94,7 @@ type Config struct {
 	MaximumConcurrentGetRequests        int            `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
 	TrackVectorDimensions               bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
 	ReindexVectorDimensionsAtStartup    bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
+	RecountPropertiesAtStartup       bool           `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
 	ReindexSetToRoaringsetAtStartup     bool           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
 	IndexMissingTextFilterableAtStartup bool           `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -94,7 +94,7 @@ type Config struct {
 	MaximumConcurrentGetRequests        int            `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
 	TrackVectorDimensions               bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
 	ReindexVectorDimensionsAtStartup    bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
-	RecountPropertiesAtStartup       bool           `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
+	RecountPropertiesAtStartup          bool           `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
 	ReindexSetToRoaringsetAtStartup     bool           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
 	IndexMissingTextFilterableAtStartup bool           `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -42,6 +42,13 @@ func FromEnv(config *Config) error {
 		}
 	}
 
+	//Recount all property lengths at startup to support accurate BM25 scoring
+	if enabled(os.Getenv("RECOUNT_PROPERTIES_AT_STARTUP")) {
+		
+			config.RecountPropertiesAtStartup = true
+		
+	}
+
 	if enabled(os.Getenv("REINDEX_SET_TO_ROARINGSET_AT_STARTUP")) {
 		config.ReindexSetToRoaringsetAtStartup = true
 	}

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -42,11 +42,9 @@ func FromEnv(config *Config) error {
 		}
 	}
 
-	//Recount all property lengths at startup to support accurate BM25 scoring
+	// Recount all property lengths at startup to support accurate BM25 scoring
 	if enabled(os.Getenv("RECOUNT_PROPERTIES_AT_STARTUP")) {
-		
-			config.RecountPropertiesAtStartup = true
-		
+		config.RecountPropertiesAtStartup = true
 	}
 
 	if enabled(os.Getenv("REINDEX_SET_TO_ROARINGSET_AT_STARTUP")) {

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -96,6 +96,11 @@ func (n *NilMigrator) AdjustFilterablePropSettings(ctx context.Context) error {
 	return nil
 }
 
+func (n *NilMigrator) RecountProperties(ctx context.Context) error {
+	return nil
+}
+
+
 var schemaTests = []struct {
 	name string
 	fn   func(*testing.T, *Manager)

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -100,7 +100,6 @@ func (n *NilMigrator) RecountProperties(ctx context.Context) error {
 	return nil
 }
 
-
 var schemaTests = []struct {
 	name string
 	fn   func(*testing.T, *Manager)

--- a/usecases/schema/migrate/migrator.go
+++ b/usecases/schema/migrate/migrator.go
@@ -43,7 +43,7 @@ type Migrator interface {
 	UpdateInvertedIndexConfig(ctx context.Context, className string,
 		updated *models.InvertedIndexConfig) error
 	RecalculateVectorDimensions(ctx context.Context) error
-
+	RecountProperties(ctx context.Context) error
 	InvertedReindex(ctx context.Context, taskNames ...string) error
 	AdjustFilterablePropSettings(ctx context.Context) error
 }


### PR DESCRIPTION
### What's being changed:

This PR deletes all the length data caches for objects, then recounts every object.

This is useful if the data length caches become corrupted, and can improve BM25 searches if the current database was created using the old prop tracker.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
