### PR TITLE
Switch all BM25 callers to new interface

### DIFF
--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -19,7 +19,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/docid"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
-	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -122,12 +121,10 @@ func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.
 		class = s.GetClass(fa.params.ClassName)
 		cfg   = inverted.ConfigFromModel(class.InvertedIndexConfig)
 	)
-
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, s,
 		fa.invertedRowCache, propertyspecific.Indices{}, fa.classSearcher,
 		nil, fa.propLengths, fa.logger, fa.shardVersion,
-	).Objects(ctx, nil, *fa.params.ObjectLimit, *kw, fa.params.Filters,
-		nil, additional.Properties{}, fa.params.ClassName)
+	).BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
 	}

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
-	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -55,8 +54,7 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, s,
 		a.invertedRowCache, propertyspecific.Indices{}, a.classSearcher,
 		nil, a.propLengths, a.logger, a.shardVersion,
-	).Objects(ctx, nil, *a.params.ObjectLimit, *kw, a.params.Filters,
-		nil, additional.Properties{Vector: true}, a.params.ClassName)
+	).BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
 	}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -34,8 +34,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
-	"github.com/weaviate/weaviate/entities/additional"
-	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -80,8 +78,6 @@ func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store, schema schema
 
 func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList, className schema.ClassName, limit int,
 	keywordRanking searchparams.KeywordRanking,
-	filter *filters.LocalFilter, sort []filters.Sort, additional additional.Properties,
-	objectByIndexID func(index uint64) *storobj.Object,
 ) ([]*storobj.Object, []float32, error) {
 	// WEAVIATE-471 - If a property is not searchable, return an error
 	for _, property := range keywordRanking.Properties {
@@ -100,30 +96,6 @@ func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList
 	}
 
 	return objs, scores, nil
-}
-
-// Objects returns a list of full objects
-func (b *BM25Searcher) Objects(ctx context.Context, filterDocIds helpers.AllowList, limit int,
-	keywordRanking searchparams.KeywordRanking,
-	filter *filters.LocalFilter, sort []filters.Sort, additional additional.Properties,
-	className schema.ClassName,
-) ([]*storobj.Object, []float32, error) {
-	class, err := schema.GetClassByName(b.schema.Objects, string(className))
-	if err != nil {
-		return nil, []float32{}, errors.Wrap(err, "get class by name")
-	}
-	property := keywordRanking.Properties[0]
-	p, err := schema.GetPropertyByName(class, property)
-	if err != nil {
-		return nil, []float32{}, errors.Wrap(err, "read property from class")
-	}
-
-	if IsSearchable(p) {
-		keywordRanking.Properties = keywordRanking.Properties[:1]
-		return b.wand(ctx, filterDocIds, class, keywordRanking, limit)
-	} else {
-		return []*storobj.Object{}, []float32{}, nil
-	}
 }
 
 func (b *BM25Searcher) wand(

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -197,26 +197,11 @@ func (s *Shard) objectSearch(ctx context.Context, limit int,
 			filterDocIds = objs
 		}
 
-		searchFunc := func(index uint64) *storobj.Object {
-			v, _ := s.objectByIndexID(ctx, index, false)
-			return v
-		}
-
-		if keywordRanking.Type == "bm25" {
-			className := s.index.Config.ClassName
-			bm25objs, bm25count, err = bm25searcher.BM25F(ctx,
-				filterDocIds, className, limit, *keywordRanking,
-				filters, sort, additional, searchFunc)
-			if err != nil {
-				return nil, nil, err
-			}
-		} else {
-			bm25objs, bm25count, err = bm25searcher.Objects(ctx,
-				filterDocIds, limit, *keywordRanking, filters,
-				sort, additional, s.index.Config.ClassName)
-			if err != nil {
-				return nil, nil, err
-			}
+		className := s.index.Config.ClassName
+		bm25objs, bm25count, err = bm25searcher.BM25F(ctx,
+			filterDocIds, className, limit, *keywordRanking)
+		if err != nil {
+			return nil, nil, err
 		}
 
 		return bm25objs, bm25count, nil


### PR DESCRIPTION
### What's being changed:

BM25 offered an old interface that would only search the first property. This switches the remaining callers to the new interface that can search all properties.
