### PR TITLE
Improve error when no classes to backup

### DIFF
--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -682,6 +682,8 @@ func TestManagerCoordinatedBackup(t *testing.T) {
 		ch := fakeBackupDescriptor(genClassDescriptions(cls, cls2)...)
 		sourcer.On("BackupDescriptors", any, backupID, mock.Anything).Return(ch).RunFn = func(a mock.Arguments) {
 			m.OnAbort(ctx, &AbortRequest{OpCreate, req.ID, backendName})
+			// give the abort request time to propagate
+			time.Sleep(time.Millisecond)
 		}
 		sourcer.On("ReleaseBackup", ctx, backupID, mock.Anything).Return(nil)
 

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -218,6 +218,10 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 	classes := req.Include
 	if len(classes) == 0 {
 		classes = s.backupper.selector.ListClasses(ctx)
+		// no classes exist in the DB
+		if len(classes) == 0 {
+			return nil, fmt.Errorf("no available classes to backup, there's nothing to do here")
+		}
 	}
 	if classes = filterClasses(classes, req.Exclude); len(classes) == 0 {
 		return nil, fmt.Errorf("empty class list: please choose from : %v", classes)


### PR DESCRIPTION
### What's being changed:

- Makes it more obvious to user when there are no classes found to backup
- Fix a flaky backupper unit test

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
