### PR TITLE
reranker-transformers

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -46,6 +46,7 @@ import (
 	modstgfs "github.com/weaviate/weaviate/modules/backup-filesystem"
 	modstggcs "github.com/weaviate/weaviate/modules/backup-gcs"
 	modstgs3 "github.com/weaviate/weaviate/modules/backup-s3"
+	modcrossrankertransformers "github.com/weaviate/weaviate/modules/cross-ranker-transformers"
 	modgenerativeopenai "github.com/weaviate/weaviate/modules/generative-openai"
 	modimage "github.com/weaviate/weaviate/modules/img2vec-neural"
 	modclip "github.com/weaviate/weaviate/modules/multi2vec-clip"
@@ -475,6 +476,14 @@ func registerModules(appState *state.State) error {
 		appState.Logger.
 			WithField("action", "startup").
 			WithField("module", "text2vec-transformers").
+			Debug("enabled module")
+	}
+
+	if _, ok := enabledModules["cross-ranker-transformers"]; ok {
+		appState.Modules.Register(modcrossrankertransformers.New())
+		appState.Logger.
+			WithField("action", "startup").
+			WithField("module", "cross-ranker-transformers").
 			Debug("enabled module")
 	}
 

--- a/modules/cross-ranker-transformers/additional/models/models.go
+++ b/modules/cross-ranker-transformers/additional/models/models.go
@@ -1,0 +1,18 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package models
+
+// Answer used in qna module to represent
+// the answer to a given question
+type RankResult struct {
+	Score *float64 `json:"score,omitempty"`
+}

--- a/modules/cross-ranker-transformers/additional/provider.go
+++ b/modules/cross-ranker-transformers/additional/provider.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package additional
+
+import (
+	"context"
+
+	"github.com/tailor-inc/graphql"
+	"github.com/tailor-inc/graphql/language/ast"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+type AdditionalProperty interface {
+	AdditionalPropertyFn(ctx context.Context,
+		in []search.Result, params interface{}, limit *int,
+		argumentModuleParams map[string]interface{}, cfg moduletools.ClassConfig) ([]search.Result, error)
+	ExtractAdditionalFn(param []*ast.Argument) interface{}
+	AdditionalPropertyDefaultValue() interface{}
+	AdditionalFieldFn(classname string) *graphql.Field
+}
+
+type GraphQLAdditionalArgumentsProvider struct {
+	CrossRankerProvider AdditionalProperty
+}
+
+func New(CrossRankerProvider AdditionalProperty) *GraphQLAdditionalArgumentsProvider {
+	return &GraphQLAdditionalArgumentsProvider{CrossRankerProvider}
+}
+
+func (p *GraphQLAdditionalArgumentsProvider) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {
+	additionalProperties := map[string]modulecapabilities.AdditionalProperty{}
+	additionalProperties["crossrank"] = p.getCrossRanker()
+	return additionalProperties
+}
+
+func (p *GraphQLAdditionalArgumentsProvider) getCrossRanker() modulecapabilities.AdditionalProperty {
+	return modulecapabilities.AdditionalProperty{
+		GraphQLNames:           []string{"crossrank"},
+		GraphQLFieldFunction:   p.CrossRankerProvider.AdditionalFieldFn,
+		GraphQLExtractFunction: p.CrossRankerProvider.ExtractAdditionalFn,
+		SearchFunctions: modulecapabilities.AdditionalSearch{
+			ExploreGet:  p.CrossRankerProvider.AdditionalPropertyFn,
+			ExploreList: p.CrossRankerProvider.AdditionalPropertyFn,
+		},
+	}
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank.go
@@ -25,7 +25,7 @@ import (
 //const maximumNumberOfGoroutines = 10
 
 type CrossRankerClient interface {
-	Rank(ctx context.Context, property string, query string) (*ent.RankResult, error)
+	Rank(ctx context.Context, rankpropertyValue string, query string) (*ent.RankResult, error)
 }
 
 type CrossRankerProvider struct {

--- a/modules/cross-ranker-transformers/additional/rank/rank.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank.go
@@ -1,0 +1,59 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tailor-inc/graphql"
+	"github.com/tailor-inc/graphql/language/ast"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
+)
+
+//const maximumNumberOfGoroutines = 10
+
+type CrossRankerClient interface {
+	Rank(ctx context.Context, property string, query string) (*ent.RankResult, error)
+}
+
+type CrossRankerProvider struct {
+	client CrossRankerClient
+}
+
+func New(crossranker CrossRankerClient) *CrossRankerProvider {
+	return &CrossRankerProvider{crossranker}
+}
+
+func (p *CrossRankerProvider) AdditionalPropertyDefaultValue() interface{} {
+	return &Params{}
+}
+
+func (p *CrossRankerProvider) ExtractAdditionalFn(param []*ast.Argument) interface{} {
+	return p.parseCrossRankerArguments(param)
+}
+
+func (p *CrossRankerProvider) AdditionalFieldFn(classname string) *graphql.Field {
+	return p.additionalCrossRankerField(classname)
+}
+
+func (p *CrossRankerProvider) AdditionalPropertyFn(ctx context.Context,
+	in []search.Result, params interface{}, limit *int,
+	argumentModuleParams map[string]interface{}, cfg moduletools.ClassConfig,
+) ([]search.Result, error) {
+	if parameters, ok := params.(*Params); ok {
+		return p.getScore(ctx, in, parameters)
+	}
+	return nil, errors.New("wrong parameters")
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank.go
@@ -22,8 +22,7 @@ import (
 	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
 )
 
-//const maximumNumberOfGoroutines = 10
-
+// const maximumNumberOfGoroutines = 10
 type CrossRankerClient interface {
 	Rank(ctx context.Context, rankpropertyValue string, query string) (*ent.RankResult, error)
 }

--- a/modules/cross-ranker-transformers/additional/rank/rank_graphql_field.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_graphql_field.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"fmt"
+
+	"github.com/tailor-inc/graphql"
+)
+
+func (p *CrossRankerProvider) additionalCrossRankerField(classname string) *graphql.Field {
+	return &graphql.Field{
+		Args: graphql.FieldConfigArgument{
+			"query": &graphql.ArgumentConfig{
+				Description:  "Properties which contains text",
+				Type:         graphql.String,
+				DefaultValue: nil,
+			},
+			"property": &graphql.ArgumentConfig{
+				Description:  "Property to rank from",
+				Type:         graphql.String,
+				DefaultValue: nil,
+			},
+		},
+		Type: graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+			Name: fmt.Sprintf("%sAdditionalSummary", classname),
+			Fields: graphql.Fields{
+				"score": &graphql.Field{Type: graphql.Float},
+			},
+		})),
+	}
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_graphql_field_test.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_graphql_field_test.go
@@ -1,0 +1,43 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tailor-inc/graphql"
+)
+
+func Test_additionalCrossRankerField(t *testing.T) {
+	// given
+	crossRankerProvider := &CrossRankerProvider{}
+	classname := "Class"
+
+	// when
+	crossRanker := crossRankerProvider.additionalCrossRankerField(classname)
+
+	assert.NotNil(t, crossRanker)
+	assert.Equal(t, "ClassAdditionalSummary", crossRanker.Type.Name())
+	assert.NotNil(t, crossRanker.Type)
+	crossRankerObjectList, crossRankerObjectListOK := crossRanker.Type.(*graphql.List)
+	assert.True(t, crossRankerObjectListOK)
+	crossRankerObject, crossRankerObjectOK := crossRankerObjectList.OfType.(*graphql.Object)
+	assert.True(t, crossRankerObjectOK)
+	assert.Equal(t, 1, len(crossRankerObject.Fields()))
+	assert.NotNil(t, crossRankerObject.Fields()["score"])
+
+	assert.NotNil(t, crossRanker.Args)
+	assert.Equal(t, 2, len(crossRanker.Args))
+	assert.NotNil(t, crossRanker.Args["query"])
+	assert.NotNil(t, crossRanker.Args["property"])
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_params.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_params.go
@@ -1,0 +1,25 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+type Params struct {
+	Property *string
+	Query    *string
+}
+
+func (n Params) GetQuery() string {
+	return *n.Query
+}
+
+func (n Params) GetProperty() string {
+	return *n.Property
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_params.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_params.go
@@ -17,9 +17,15 @@ type Params struct {
 }
 
 func (n Params) GetQuery() string {
-	return *n.Query
+	if n.Query != nil {
+		return *n.Query
+	}
+	return ""
 }
 
 func (n Params) GetProperty() string {
-	return *n.Property
+	if n.Property != nil {
+		return *n.Property
+	}
+	return ""
 }

--- a/modules/cross-ranker-transformers/additional/rank/rank_params_extractor.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_params_extractor.go
@@ -1,0 +1,20 @@
+package rank
+
+import (
+	"github.com/tailor-inc/graphql/language/ast"
+)
+
+func (p *CrossRankerProvider) parseCrossRankerArguments(args []*ast.Argument) *Params {
+	out := &Params{}
+
+	for _, arg := range args {
+		switch arg.Name.Value {
+		case "query":
+			out.Query = &arg.Value.(*ast.StringValue).Value
+		case "property":
+			out.Property = &arg.Value.(*ast.StringValue).Value
+		}
+	}
+
+	return out
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_params_extractor.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_params_extractor.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package rank
 
 import (

--- a/modules/cross-ranker-transformers/additional/rank/rank_params_extractor_test.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_params_extractor_test.go
@@ -1,0 +1,102 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/tailor-inc/graphql/language/ast"
+	"reflect"
+	"testing"
+)
+
+func Test_parseCrossRankerArguments(t *testing.T) {
+	type args struct {
+		args []*ast.Argument
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Params
+	}{
+		{
+			name: "Should create with no params",
+			args: args{},
+			want: &Params{},
+		},
+		{
+			name: "Should create with query param",
+			args: args{
+				args: []*ast.Argument{
+					createStringArg("query", "sample query"),
+				},
+			},
+			want: &Params{
+				Query: strPtr("sample query"),
+			},
+		},
+		{
+			name: "Should create with property param",
+			args: args{
+				args: []*ast.Argument{
+					createStringArg("property", "sample property"),
+				},
+			},
+			want: &Params{
+				Property: strPtr("sample property"),
+			},
+		},
+		{
+			name: "Should create with all params",
+			args: args{
+				args: []*ast.Argument{
+					createStringArg("query", "sample query"),
+					createStringArg("property", "sample property"),
+				},
+			},
+			want: &Params{
+				Query:    strPtr("sample query"),
+				Property: strPtr("sample property"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &CrossRankerProvider{}
+			if got := p.parseCrossRankerArguments(tt.args.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseCrossRankerArguments() = %v, want %v", got, tt.want)
+			}
+			actual := p.parseCrossRankerArguments(tt.args.args)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}
+
+func createStringArg(name, value string) *ast.Argument {
+	n := ast.Name{
+		Value: name,
+	}
+	val := ast.StringValue{
+		Kind:  "Kind",
+		Value: value,
+	}
+	arg := ast.Argument{
+		Name:  ast.NewName(&n),
+		Kind:  "Kind",
+		Value: &val,
+	}
+	a := ast.NewArgument(&arg)
+	return a
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_params_extractor_test.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_params_extractor_test.go
@@ -12,10 +12,11 @@
 package rank
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/tailor-inc/graphql/language/ast"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tailor-inc/graphql/language/ast"
 )
 
 func Test_parseCrossRankerArguments(t *testing.T) {

--- a/modules/cross-ranker-transformers/additional/rank/rank_result.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_result.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+	crossrankmodels "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional/models"
+)
+
+func (p *CrossRankerProvider) getScore(ctx context.Context,
+	in []search.Result, params *Params,
+) ([]search.Result, error) {
+	if len(in) == 0 {
+		return nil, nil
+	} else {
+		if params == nil {
+			return nil, fmt.Errorf("no params provided")
+		}
+
+		rankProperty := params.GetProperty()
+		query := params.GetQuery()
+
+		// check if user parameter values are valid
+		if len(rankProperty) == 0 {
+			return in, errors.New("no properties provided")
+		}
+
+		for i := range in { // for each result of the general GraphQL Query
+			// get text property
+			var rankPropertyValue = ""
+			schema := in[i].Object().Properties.(map[string]interface{})
+			for property, value := range schema {
+				if valueString, ok := value.(string); ok {
+					if property == rankProperty {
+						rankPropertyValue = valueString
+					}
+				}
+			}
+
+			ap := in[i].AdditionalProperties
+			if ap == nil {
+				ap = models.AdditionalProperties{}
+			}
+
+			result, _ := p.client.Rank(ctx, rankPropertyValue, query) // didn't implement error yet
+			ap["crossrank"] = []*crossrankmodels.RankResult{
+				{
+					Score: &result.Score,
+				},
+			}
+			in[i].AdditionalProperties = ap
+		}
+	}
+	//sort the list
+	sort.Slice(in, func(i, j int) bool {
+		apI := in[i].AdditionalProperties["crossrank"].([]*crossrankmodels.RankResult)
+		apJ := in[j].AdditionalProperties["crossrank"].([]*crossrankmodels.RankResult)
+
+		// Sort in descending order, based on Score values
+		return *apI[0].Score > *apJ[0].Score
+	})
+	return in, nil
+}
+
+func (p *CrossRankerProvider) containsProperty(property string, properties []string) bool {
+	if len(properties) == 0 {
+		return true
+	}
+	for i := range properties {
+		if properties[i] == property {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_result.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_result.go
@@ -42,7 +42,7 @@ func (p *CrossRankerProvider) getScore(ctx context.Context,
 
 		for i := range in { // for each result of the general GraphQL Query
 			// get text property
-			var rankPropertyValue = ""
+			rankPropertyValue := ""
 			schema := in[i].Object().Properties.(map[string]interface{})
 			for property, value := range schema {
 				if valueString, ok := value.(string); ok {
@@ -66,7 +66,7 @@ func (p *CrossRankerProvider) getScore(ctx context.Context,
 			in[i].AdditionalProperties = ap
 		}
 	}
-	//sort the list
+	// sort the list
 	sort.Slice(in, func(i, j int) bool {
 		apI := in[i].AdditionalProperties["crossrank"].([]*crossrankmodels.RankResult)
 		apJ := in[j].AdditionalProperties["crossrank"].([]*crossrankmodels.RankResult)
@@ -75,16 +75,4 @@ func (p *CrossRankerProvider) getScore(ctx context.Context,
 		return *apI[0].Score > *apJ[0].Score
 	})
 	return in, nil
-}
-
-func (p *CrossRankerProvider) containsProperty(property string, properties []string) bool {
-	if len(properties) == 0 {
-		return true
-	}
-	for i := range properties {
-		if properties[i] == property {
-			return true
-		}
-	}
-	return false
 }

--- a/modules/cross-ranker-transformers/additional/rank/rank_test.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_test.go
@@ -1,0 +1,124 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"context"
+	crossrankmodels "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional/models"
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+func TestAdditionalAnswerProvider(t *testing.T) {
+	t.Run("should fail with empty content", func(t *testing.T) {
+		// given
+		rankClient := &fakeRankClient{}
+		rankProvider := New(rankClient)
+		in := []search.Result{
+			{
+				ID: "some-uuid",
+			},
+		}
+		fakeParams := &Params{}
+		limit := 1
+		argumentModuleParams := map[string]interface{}{}
+
+		// when
+		out, err := rankProvider.AdditionalPropertyFn(context.Background(), in, fakeParams, &limit, argumentModuleParams, nil)
+
+		// then
+		require.NotNil(t, err)
+		require.NotEmpty(t, out)
+		assert.Error(t, err, "empty schema content")
+	})
+
+	t.Run("should fail with empty params", func(t *testing.T) {
+		// given
+		rankClient := &fakeRankClient{}
+		rankProvider := New(rankClient)
+		in := []search.Result{
+			{
+				ID: "some-uuid",
+				Schema: map[string]interface{}{
+					"content": "content",
+				},
+			},
+		}
+		fakeParams := &Params{}
+		limit := 1
+		argumentModuleParams := map[string]interface{}{}
+
+		// when
+		out, err := rankProvider.AdditionalPropertyFn(context.Background(), in, fakeParams, &limit, argumentModuleParams, nil)
+
+		// then
+		require.NotNil(t, err)
+		require.NotEmpty(t, out)
+		assert.Error(t, err, "empty params")
+	})
+
+	t.Run("should rank", func(t *testing.T) {
+		rankClient := &fakeRankClient{}
+		rankProvider := New(rankClient)
+		in := []search.Result{
+			{
+				ID: "some-uuid",
+				Schema: map[string]interface{}{
+					"content": "this is the content",
+				},
+			},
+		}
+		property := "content"
+		query := "this is the query"
+		fakeParams := &Params{Property: &property, Query: &query}
+		limit := 1
+		argumentModuleParams := map[string]interface{}{}
+
+		// when
+		out, err := rankProvider.AdditionalPropertyFn(context.Background(), in, fakeParams, &limit, argumentModuleParams, nil)
+		// then
+		require.Nil(t, err)
+		require.NotEmpty(t, out)
+		assert.Equal(t, 1, len(in))
+		answer, answerOK := in[0].AdditionalProperties["crossrank"]
+		assert.True(t, answerOK)
+		assert.NotNil(t, answer)
+		answerAdditional, _ := answer.(ent.RankResult)
+		//assert.True(t, answerAdditionalOK)
+		assert.Equal(t, float64(0), answerAdditional.Score)
+	})
+}
+
+type fakeRankClient struct{}
+
+func (c *fakeRankClient) Rank(ctx context.Context, rankpropertyValue string, query string,
+) (*ent.RankResult, error) {
+	score := 0.15
+	//rankResult := c.getRank(rankpropertyValue, query)
+	returnResult := ent.RankResult{
+		Score:             score,
+		Query:             query,
+		RankPropertyValue: rankpropertyValue,
+	}
+	return &returnResult, nil
+}
+
+func (c *fakeRankClient) getRank(rankpropertyValue string, query string) crossrankmodels.RankResult {
+	score := 0.15
+	return crossrankmodels.RankResult{
+		Score: &score,
+	}
+}

--- a/modules/cross-ranker-transformers/additional/rank/rank_test.go
+++ b/modules/cross-ranker-transformers/additional/rank/rank_test.go
@@ -13,9 +13,9 @@ package rank
 
 import (
 	"context"
-	crossrankmodels "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional/models"
-	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
 	"testing"
+
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -97,7 +97,7 @@ func TestAdditionalAnswerProvider(t *testing.T) {
 		assert.True(t, answerOK)
 		assert.NotNil(t, answer)
 		answerAdditional, _ := answer.(ent.RankResult)
-		//assert.True(t, answerAdditionalOK)
+		// assert.True(t, answerAdditionalOK)
 		assert.Equal(t, float64(0), answerAdditional.Score)
 	})
 }
@@ -107,18 +107,11 @@ type fakeRankClient struct{}
 func (c *fakeRankClient) Rank(ctx context.Context, rankpropertyValue string, query string,
 ) (*ent.RankResult, error) {
 	score := 0.15
-	//rankResult := c.getRank(rankpropertyValue, query)
+	// rankResult := c.getRank(rankpropertyValue, query)
 	returnResult := ent.RankResult{
 		Score:             score,
 		Query:             query,
 		RankPropertyValue: rankpropertyValue,
 	}
 	return &returnResult, nil
-}
-
-func (c *fakeRankClient) getRank(rankpropertyValue string, query string) crossrankmodels.RankResult {
-	score := 0.15
-	return crossrankmodels.RankResult{
-		Score: &score,
-	}
 }

--- a/modules/cross-ranker-transformers/clients/ranker.go
+++ b/modules/cross-ranker-transformers/clients/ranker.go
@@ -28,11 +28,11 @@ func New(origin string, logger logrus.FieldLogger) *client {
 }
 
 func (v *client) Rank(ctx context.Context,
-	property string, query string,
+	rankpropertyValue string, query string,
 ) (*ent.RankResult, error) {
 	body, err := json.Marshal(RankInput{
-		Property: property,
-		Query:    query,
+		RankPropertyValue: rankpropertyValue,
+		Query:             query,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshal body")
@@ -66,9 +66,9 @@ func (v *client) Rank(ctx context.Context,
 	}
 
 	return &ent.RankResult{
-		Property: resBody.Property,
-		Query:    resBody.Query,
-		Score:    resBody.Score,
+		RankPropertyValue: resBody.RankPropertyValue,
+		Query:             resBody.Query,
+		Score:             resBody.Score,
 	}, nil
 }
 
@@ -77,13 +77,13 @@ func (v *client) url(path string) string {
 }
 
 type RankInput struct {
-	Property string `json:"Property"`
-	Query    string `json:"Query"`
+	RankPropertyValue string `json:"RankPropertyValue"`
+	Query             string `json:"Query"`
 }
 
 type RankResponse struct {
-	Property string  `json:"Property"`
-	Query    string  `json:"Query"`
-	Score    float64 `json:"Score"`
-	Error    string  `json:"Error"`
+	RankPropertyValue string  `json:"RankPropertyValue"`
+	Query             string  `json:"Query"`
+	Score             float64 `json:"Score"`
+	Error             string  `json:"Error"`
 }

--- a/modules/cross-ranker-transformers/clients/ranker.go
+++ b/modules/cross-ranker-transformers/clients/ranker.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
+)
+
+type client struct {
+	origin     string
+	httpClient *http.Client
+	logger     logrus.FieldLogger
+}
+
+func New(origin string, logger logrus.FieldLogger) *client {
+	return &client{
+		origin:     origin,
+		httpClient: &http.Client{},
+		logger:     logger,
+	}
+}
+
+func (v *client) Rank(ctx context.Context,
+	property string, query string,
+) (*ent.RankResult, error) {
+	body, err := json.Marshal(RankInput{
+		Property: property,
+		Query:    query,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshal body")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", v.url("/crossrank"),
+		bytes.NewReader(body))
+	if err != nil {
+		return nil, errors.Wrap(err, "create POST request")
+	}
+
+	res, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "send POST request")
+	}
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read response body")
+	}
+
+	var resBody RankResponse
+	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
+		return nil, errors.Wrap(err, "unmarshal response body")
+	}
+
+	if res.StatusCode > 399 {
+		return nil, errors.Errorf("fail with status %d: %s", res.StatusCode,
+			resBody.Error)
+	}
+
+	return &ent.RankResult{
+		Property: resBody.Property,
+		Query:    resBody.Query,
+		Score:    resBody.Score,
+	}, nil
+}
+
+func (v *client) url(path string) string {
+	return fmt.Sprintf("%s%s", v.origin, path)
+}
+
+type RankInput struct {
+	Property string `json:"Property"`
+	Query    string `json:"Query"`
+}
+
+type RankResponse struct {
+	Property string  `json:"Property"`
+	Query    string  `json:"Query"`
+	Score    float64 `json:"Score"`
+	Error    string  `json:"Error"`
+}

--- a/modules/cross-ranker-transformers/clients/ranker.go
+++ b/modules/cross-ranker-transformers/clients/ranker.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package client
 
 import (

--- a/modules/cross-ranker-transformers/clients/ranker_meta.go
+++ b/modules/cross-ranker-transformers/clients/ranker_meta.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func (s *client) MetaInfo() (map[string]interface{}, error) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", s.url("/meta"), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "create GET meta request")
+	}
+
+	res, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "send GET meta request")
+	}
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read meta response body")
+	}
+
+	var resBody map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
+		return nil, errors.Wrap(err, "unmarshal meta response body")
+	}
+	return resBody, nil
+}

--- a/modules/cross-ranker-transformers/clients/ranker_meta.go
+++ b/modules/cross-ranker-transformers/clients/ranker_meta.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package client
 
 import (

--- a/modules/cross-ranker-transformers/clients/ranker_meta_test.go
+++ b/modules/cross-ranker-transformers/clients/ranker_meta_test.go
@@ -1,0 +1,156 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMeta(t *testing.T) {
+	t.Run("when the server is providing meta", func(t *testing.T) {
+		server := httptest.NewServer(&testMetaHandler{t: t})
+		defer server.Close()
+		c := New(server.URL, nullLogger())
+		meta, err := c.MetaInfo()
+
+		assert.Nil(t, err)
+		assert.NotNil(t, meta)
+		metaModel := meta["model"]
+		assert.True(t, metaModel != nil)
+		model, modelOK := metaModel.(map[string]interface{})
+		assert.True(t, modelOK)
+		assert.True(t, model["_name_or_path"] != nil)
+		assert.True(t, model["architectures"] != nil)
+	})
+}
+
+type testMetaHandler struct {
+	t *testing.T
+	// the test handler will report as not ready before the time has passed
+	readyTime time.Time
+}
+
+func (f *testMetaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	assert.Equal(f.t, "/meta", r.URL.String())
+	assert.Equal(f.t, http.MethodGet, r.Method)
+
+	if time.Since(f.readyTime) < 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	w.Write([]byte(f.metaInfo()))
+}
+
+func (f *testMetaHandler) metaInfo() string {
+	return `{
+		"model": {
+		"_name_or_path": "dbmdz/bert-large-cased-finetuned-conll03-english",
+		"_num_labels": 9,
+		"add_cross_attention": false,
+		"architectures": [
+		"BertForTokenClassification"
+		],
+		"attention_probs_dropout_prob": 0.1,
+		"bad_words_ids": null,
+		"bos_token_id": null,
+		"chunk_size_feed_forward": 0,
+		"decoder_start_token_id": null,
+		"directionality": "bidi",
+		"diversity_penalty": 0,
+		"do_sample": false,
+		"early_stopping": false,
+		"encoder_no_repeat_ngram_size": 0,
+		"eos_token_id": null,
+		"finetuning_task": null,
+		"forced_bos_token_id": null,
+		"forced_eos_token_id": null,
+		"gradient_checkpointing": false,
+		"hidden_act": "gelu",
+		"hidden_dropout_prob": 0.1,
+		"hidden_size": 1024,
+		"id2label": {
+		"0": "O",
+		"1": "B-MISC",
+		"2": "I-MISC",
+		"3": "B-PER",
+		"4": "I-PER",
+		"5": "B-ORG",
+		"6": "I-ORG",
+		"7": "B-LOC",
+		"8": "I-LOC"
+		},
+		"initializer_range": 0.02,
+		"intermediate_size": 4096,
+		"is_decoder": false,
+		"is_encoder_decoder": false,
+		"label2id": {
+		"B-LOC": 7,
+		"B-MISC": 1,
+		"B-ORG": 5,
+		"B-PER": 3,
+		"I-LOC": 8,
+		"I-MISC": 2,
+		"I-ORG": 6,
+		"I-PER": 4,
+		"O": 0
+		},
+		"layer_norm_eps": 1e-12,
+		"length_penalty": 1,
+		"max_length": 20,
+		"max_position_embeddings": 512,
+		"min_length": 0,
+		"model_type": "bert",
+		"no_repeat_ngram_size": 0,
+		"num_attention_heads": 16,
+		"num_beam_groups": 1,
+		"num_beams": 1,
+		"num_hidden_layers": 24,
+		"num_return_sequences": 1,
+		"output_attentions": false,
+		"output_hidden_states": false,
+		"output_scores": false,
+		"pad_token_id": 0,
+		"pooler_fc_size": 768,
+		"pooler_num_attention_heads": 12,
+		"pooler_num_fc_layers": 3,
+		"pooler_size_per_head": 128,
+		"pooler_type": "first_token_transform",
+		"position_embedding_type": "absolute",
+		"prefix": null,
+		"problem_type": null,
+		"pruned_heads": {},
+		"remove_invalid_values": false,
+		"repetition_penalty": 1,
+		"return_dict": true,
+		"return_dict_in_generate": false,
+		"sep_token_id": null,
+		"task_specific_params": null,
+		"temperature": 1,
+		"tie_encoder_decoder": false,
+		"tie_word_embeddings": true,
+		"tokenizer_class": null,
+		"top_k": 50,
+		"top_p": 1,
+		"torchscript": false,
+		"transformers_version": "4.6.1",
+		"type_vocab_size": 2,
+		"use_bfloat16": false,
+		"use_cache": true,
+		"vocab_size": 28996
+		}
+		}`
+}

--- a/modules/cross-ranker-transformers/clients/ranker_test.go
+++ b/modules/cross-ranker-transformers/clients/ranker_test.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
+)
+
+func TestGetScore(t *testing.T) {
+	t.Run("when the server has a successful answer", func(t *testing.T) {
+		server := httptest.NewServer(&testCrossRankerHandler{
+			t: t,
+			res: RankResponse{
+				RankPropertyValue: "I work at Apple",
+				Query:             "Where do I work?",
+				Score:             0.15,
+			},
+		})
+		defer server.Close()
+		c := New(server.URL, nullLogger())
+		res, err := c.Rank(context.Background(), "prop", "I work at Apple")
+
+		assert.Nil(t, err)
+		assert.Equal(t, ent.RankResult{
+			Query:             "Where do I work?",
+			RankPropertyValue: "I work at Apple",
+			Score:             0.15,
+		}, *res)
+	})
+
+	t.Run("when the server has an error", func(t *testing.T) {
+		server := httptest.NewServer(&testCrossRankerHandler{
+			t: t,
+			res: RankResponse{
+				Error: "some error from the server",
+			},
+		})
+		defer server.Close()
+		c := New(server.URL, nullLogger())
+		_, err := c.Rank(context.Background(), "prop",
+			"I work at Apple")
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "some error from the server")
+	})
+}
+
+type testCrossRankerHandler struct {
+	t *testing.T
+	// the test handler will report as not ready before the time has passed
+	res RankResponse
+}
+
+func (f *testCrossRankerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	assert.Equal(f.t, "/crossrank", r.URL.String())
+	assert.Equal(f.t, http.MethodPost, r.Method)
+
+	if f.res.Error != "" {
+		w.WriteHeader(500)
+	}
+
+	jsonBytes, _ := json.Marshal(f.res)
+	w.Write(jsonBytes)
+}

--- a/modules/cross-ranker-transformers/clients/startup.go
+++ b/modules/cross-ranker-transformers/clients/startup.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func (c *client) WaitForStartup(initCtx context.Context,
+	interval time.Duration,
+) error {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	expired := initCtx.Done()
+	var lastErr error
+	for {
+		select {
+		case <-t.C:
+			lastErr = c.checkReady(initCtx)
+			if lastErr == nil {
+				return nil
+			}
+			c.logger.
+				WithField("action", "crossranktransformers_remote_wait_for_startup").
+				WithError(lastErr).Warnf("crossranktransformers remote service not ready")
+		case <-expired:
+			return errors.Wrapf(lastErr, "init context expired before remote was ready")
+		}
+	}
+}
+
+func (c *client) checkReady(initCtx context.Context) error {
+	// spawn a new context (derived on the overall context) which is used to
+	// consider an individual request timed out
+	requestCtx, cancel := context.WithTimeout(initCtx, 500*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet,
+		c.url("/.well-known/ready"), nil)
+	if err != nil {
+		return errors.Wrap(err, "create check ready request")
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "send check ready request")
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode > 299 {
+		return errors.Errorf("not ready: status %d", res.StatusCode)
+	}
+
+	return nil
+}

--- a/modules/cross-ranker-transformers/clients/startup.go
+++ b/modules/cross-ranker-transformers/clients/startup.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package client
 
 import (

--- a/modules/cross-ranker-transformers/clients/startup_test.go
+++ b/modules/cross-ranker-transformers/clients/startup_test.go
@@ -1,0 +1,98 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForStartup(t *testing.T) {
+	t.Run("when the server is immediately ready", func(t *testing.T) {
+		server := httptest.NewServer(&testReadyHandler{t: t})
+		defer server.Close()
+		c := New(server.URL, nullLogger())
+		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("when the server is down", func(t *testing.T) {
+		c := New("http://nothing-running-at-this-url", nullLogger())
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		err := c.WaitForStartup(ctx, 150*time.Millisecond)
+
+		require.NotNil(t, err, nullLogger())
+		assert.Contains(t, err.Error(), "expired before remote was ready")
+	})
+
+	t.Run("when the server is alive, but not ready", func(t *testing.T) {
+		server := httptest.NewServer(&testReadyHandler{
+			t:         t,
+			readyTime: time.Now().Add(1 * time.Minute),
+		})
+		c := New(server.URL, nullLogger())
+		defer server.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		err := c.WaitForStartup(ctx, 50*time.Millisecond)
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "expired before remote was ready")
+	})
+
+	t.Run("when the server is initially not ready, but then becomes ready",
+		func(t *testing.T) {
+			server := httptest.NewServer(&testReadyHandler{
+				t:         t,
+				readyTime: time.Now().Add(100 * time.Millisecond),
+			})
+			c := New(server.URL, nullLogger())
+			defer server.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			err := c.WaitForStartup(ctx, 50*time.Millisecond)
+
+			require.Nil(t, err)
+		})
+}
+
+type testReadyHandler struct {
+	t *testing.T
+	// the test handler will report as not ready before the time has passed
+	readyTime time.Time
+}
+
+func (f *testReadyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	assert.Equal(f.t, "/.well-known/ready", r.URL.String())
+	assert.Equal(f.t, http.MethodGet, r.Method)
+
+	if time.Since(f.readyTime) < 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func nullLogger() logrus.FieldLogger {
+	l, _ := test.NewNullLogger()
+	return l
+}

--- a/modules/cross-ranker-transformers/config.go
+++ b/modules/cross-ranker-transformers/config.go
@@ -1,0 +1,27 @@
+package modcrossrankertransformers
+
+import (
+	"context"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func (m *CrossRankerModule) ClassConfigDefaults() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *CrossRankerModule) PropertyConfigDefaults(
+	dt *schema.DataType,
+) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *CrossRankerModule) ValidateClass(ctx context.Context,
+	class *models.Class, cfg moduletools.ClassConfig,
+) error {
+	return nil
+}
+
+var _ = modulecapabilities.ClassConfigurator(New())

--- a/modules/cross-ranker-transformers/config.go
+++ b/modules/cross-ranker-transformers/config.go
@@ -1,7 +1,19 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package modcrossrankertransformers
 
 import (
 	"context"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"

--- a/modules/cross-ranker-transformers/ent/rank_result.go
+++ b/modules/cross-ranker-transformers/ent/rank_result.go
@@ -1,0 +1,18 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package ent
+
+type RankResult struct {
+	Query    string
+	Property string
+	Score    float64
+}

--- a/modules/cross-ranker-transformers/ent/rank_result.go
+++ b/modules/cross-ranker-transformers/ent/rank_result.go
@@ -12,7 +12,7 @@
 package ent
 
 type RankResult struct {
-	Query    string
-	Property string
-	Score    float64
+	Query             string
+	RankPropertyValue string
+	Score             float64
 }

--- a/modules/cross-ranker-transformers/module.go
+++ b/modules/cross-ranker-transformers/module.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modcrossrankertransformers
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	crossrankeradditional "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional"
+	crossrankeradditionalrank "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional/rank"
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/clients"
+	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
+	"net/http"
+	"os"
+	"time"
+)
+
+const Name = "cross-ranker-transformers"
+
+func New() *CrossRankerModule {
+	return &CrossRankerModule{}
+}
+
+type CrossRankerModule struct {
+	crossranker                  CrossRankerClient
+	additionalPropertiesProvider modulecapabilities.AdditionalProperties
+}
+
+type CrossRankerClient interface {
+	Rank(ctx context.Context, property string, query string) (*ent.RankResult, error)
+	MetaInfo() (map[string]interface{}, error)
+}
+
+func (m *CrossRankerModule) Name() string {
+	return Name
+}
+
+func (m *CrossRankerModule) Type() modulecapabilities.ModuleType {
+	return modulecapabilities.Text2Text
+}
+
+func (m *CrossRankerModule) Init(ctx context.Context,
+	params moduletools.ModuleInitParams,
+) error {
+	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+		return errors.Wrap(err, "init cross encoder")
+	}
+
+	return nil
+}
+
+func (m *CrossRankerModule) initAdditional(ctx context.Context,
+	logger logrus.FieldLogger,
+) error {
+	uri := os.Getenv("CROSSRANKER_INFERENCE_API")
+	if uri == "" {
+		return nil
+	}
+
+	client := client.New(uri, logger)
+
+	m.crossranker = client
+	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
+		return errors.Wrap(err, "init remote sum module")
+	}
+
+	crossrankerProvider := crossrankeradditionalrank.New(m.crossranker)
+	m.additionalPropertiesProvider = crossrankeradditional.New(crossrankerProvider)
+	return nil
+}
+
+func (m *CrossRankerModule) MetaInfo() (map[string]interface{}, error) {
+	return m.crossranker.MetaInfo()
+}
+
+func (m *CrossRankerModule) RootHandler() http.Handler {
+	// TODO: remove once this is a capability interface
+	return nil
+}
+
+func (m *CrossRankerModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {
+	return m.additionalPropertiesProvider.AdditionalProperties()
+}
+
+// verify we implement the modules.Module interface
+var (
+	_ = modulecapabilities.Module(New())
+	_ = modulecapabilities.AdditionalProperties(New())
+	_ = modulecapabilities.MetaProvider(New())
+)

--- a/modules/cross-ranker-transformers/module.go
+++ b/modules/cross-ranker-transformers/module.go
@@ -13,17 +13,18 @@ package modcrossrankertransformers
 
 import (
 	"context"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	crossrankeradditional "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional"
 	crossrankeradditionalrank "github.com/weaviate/weaviate/modules/cross-ranker-transformers/additional/rank"
-	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/clients"
+	client "github.com/weaviate/weaviate/modules/cross-ranker-transformers/clients"
 	"github.com/weaviate/weaviate/modules/cross-ranker-transformers/ent"
-	"net/http"
-	"os"
-	"time"
 )
 
 const Name = "cross-ranker-transformers"

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -42,7 +42,7 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups" \
-      ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
+      ENABLE_MODULES="text2vec-contextionary,cross-ranker-transformers" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \


### PR DESCRIPTION
### What's being changed:

Cross Encoder Rankers in Weaviate!

## To configure:

CROSSRANKER_INFERENCE_API: 'inference api host'

ENABLE_MODULES: 'cross-ranker-transformers'

## To query:

```graphql
{
  Get {
    Product(limit:50){
      content
      _additional {
        crossrank(
          property: “content”
          query: “what is ref2vec?”
        ){
        score
        }
      }
  }
}
```

## Python Inference App

This is a local inference module, to run it the code is here:

https://github.com/weaviate/cross-ranker-transformers

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
