### PR TITLE
IndexFilterable & IndexSearchable UX improvements

### DIFF
--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -137,8 +137,9 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		})
 
 		require.NotNil(t, err)
-		assert.Contains(t, err.Error(),
-			"bucket for prop hiddenStringProp not found - is it indexed?")
+		assert.Contains(t, err.Error(), "Filtering by property 'hiddenStringProp' requires inverted index. "+
+			"Is `indexFilterable` option of property 'hiddenStringProp' enabled? "+
+			"Set it to `true` or leave empty")
 	})
 
 	t.Run("class search on timestamp prop with no timestamp indexing error", func(t *testing.T) {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/priorityqueue"
 
+	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/models"
 
 	"github.com/pkg/errors"
@@ -80,7 +81,7 @@ func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList
 	// WEAVIATE-471 - If a property is not searchable, return an error
 	for _, property := range keywordRanking.Properties {
 		if !PropertyHasSearchableIndex(b.schema.Objects, string(className), property) {
-			return nil, nil, errors.New("Property " + property + " is not indexed.  Please choose another property or add an index to this property")
+			return nil, nil, inverted.NewMissingSearchableIndexError(property)
 		}
 	}
 	class, err := schema.GetClassByName(b.schema.Objects, string(className))

--- a/entities/inverted/errors.go
+++ b/entities/inverted/errors.go
@@ -1,0 +1,40 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import "fmt"
+
+type MissingIndexError struct {
+	message string
+}
+
+func NewMissingFilterableIndexError(propName string) error {
+	return MissingIndexError{message: fmt.Sprintf("Filtering by property '%s' requires inverted index. "+
+		"Is `indexFilterable` option of property '%s' enabled? "+
+		"Set it to `true` or leave empty", propName, propName)}
+}
+
+func NewMissingSearchableIndexError(propName string) error {
+	return MissingIndexError{message: fmt.Sprintf("Searching by property '%s' requires inverted index. "+
+		"Is `indexSearchable` option of property '%s' enabled? "+
+		"Set it to `true` or leave empty", propName, propName)}
+}
+
+func NewMissingFilterableMetaCountIndexError(propName string) error {
+	return MissingIndexError{message: fmt.Sprintf("Searching by property '%s' count requires inverted index. "+
+		"Is `indexFilterable` option of property '%s' enabled? "+
+		"Set it to `true` or leave empty", propName, propName)}
+}
+
+func (e MissingIndexError) Error() string {
+	return e.message
+}

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -260,9 +260,11 @@ func (m *Manager) setPropertyDefaultIndexing(prop *models.Property) {
 	}
 	if prop.IndexSearchable == nil {
 		switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
-		// string/string[] are migrated into text/text[] later,
-		// at this point they are still valid data type, therefore should be handled here
-		case schema.DataTypeString, schema.DataTypeStringArray, schema.DataTypeText, schema.DataTypeTextArray:
+		case schema.DataTypeString, schema.DataTypeStringArray:
+			// string/string[] are migrated to text/text[] later,
+			// at this point they are still valid data types, therefore should be handled here
+			fallthrough
+		case schema.DataTypeText, schema.DataTypeTextArray:
 			prop.IndexSearchable = &vTrue
 		default:
 			vFalse := false
@@ -388,7 +390,11 @@ func (m *Manager) validateProperty(
 		return fmt.Errorf("property '%s': invalid dataType: %v", property.Name, err)
 	}
 
-	if err := validatePropertyTokenization(property.Tokenization, propertyDataType); err != nil {
+	if err := m.validatePropertyTokenization(property.Tokenization, propertyDataType); err != nil {
+		return err
+	}
+
+	if err := m.validatePropertyIndexing(property); err != nil {
 		return err
 	}
 

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -441,8 +441,8 @@ func TestAddClass(t *testing.T) {
 	})
 }
 
-func TestAddClass_Migrate(t *testing.T) {
-	t.Run("migrate string|stringArray datatype and tokenization", func(t *testing.T) {
+func TestAddClass_DefaultsAndMigration(t *testing.T) {
+	t.Run("set defaults and migrate string|stringArray datatype and tokenization", func(t *testing.T) {
 		type testCase struct {
 			propName     string
 			dataType     schema.DataType
@@ -571,13 +571,14 @@ func TestAddClass_Migrate(t *testing.T) {
 		})
 	})
 
-	t.Run("migrate IndexInverted to IndexFilterable + IndexSearchable", func(t *testing.T) {
+	t.Run("set defaults and migrate IndexInverted to IndexFilterable + IndexSearchable", func(t *testing.T) {
 		vFalse := false
 		vTrue := true
 		allBoolPtrs := []*bool{nil, &vFalse, &vTrue}
 
 		type testCase struct {
 			propName        string
+			dataType        schema.DataType
 			indexInverted   *bool
 			indexFilterable *bool
 			indexSearchable *bool
@@ -593,9 +594,9 @@ func TestAddClass_Migrate(t *testing.T) {
 			}
 			return fmt.Sprintf("%v", *ptr)
 		}
-		propName := func(inverted, filterable, searchable *bool) string {
-			return fmt.Sprintf("inverted_%s_filterable_%s_searchable_%s",
-				boolPtrToStr(inverted), boolPtrToStr(filterable), boolPtrToStr(searchable))
+		propName := func(dt schema.DataType, inverted, filterable, searchable *bool) string {
+			return fmt.Sprintf("%s_inverted_%s_filterable_%s_searchable_%s",
+				dt.String(), boolPtrToStr(inverted), boolPtrToStr(filterable), boolPtrToStr(searchable))
 		}
 
 		mgr := newSchemaManager()
@@ -603,12 +604,16 @@ func TestAddClass_Migrate(t *testing.T) {
 		className := "MigrationClass"
 
 		testCases := []testCase{}
+
 		for _, inverted := range allBoolPtrs {
 			for _, filterable := range allBoolPtrs {
 				for _, searchable := range allBoolPtrs {
-					if filterable == nil && searchable == nil {
+					dataType := schema.DataTypeText
+
+					if filterable == nil && searchable == nil && inverted != nil {
 						testCases = append(testCases, testCase{
-							propName:           propName(inverted, filterable, searchable),
+							propName:           propName(dataType, inverted, filterable, searchable),
+							dataType:           dataType,
 							indexInverted:      inverted,
 							indexFilterable:    filterable,
 							indexSearchable:    searchable,
@@ -617,14 +622,59 @@ func TestAddClass_Migrate(t *testing.T) {
 							expectedSearchable: inverted,
 						})
 					} else {
+						expectedFilterable := filterable
+						if filterable == nil {
+							expectedFilterable = &vTrue
+						}
+						expectedSearchable := searchable
+						if searchable == nil {
+							expectedSearchable = &vTrue
+						}
+
 						testCases = append(testCases, testCase{
-							propName:           propName(inverted, filterable, searchable),
+							propName:           propName(dataType, inverted, filterable, searchable),
+							dataType:           dataType,
 							indexInverted:      inverted,
 							indexFilterable:    filterable,
 							indexSearchable:    searchable,
 							expectedInverted:   nil,
-							expectedFilterable: filterable,
-							expectedSearchable: searchable,
+							expectedFilterable: expectedFilterable,
+							expectedSearchable: expectedSearchable,
+						})
+					}
+
+					dataType = schema.DataTypeInt
+
+					if filterable == nil && searchable == nil && inverted != nil {
+						testCases = append(testCases, testCase{
+							propName:           propName(dataType, inverted, filterable, searchable),
+							dataType:           dataType,
+							indexInverted:      inverted,
+							indexFilterable:    filterable,
+							indexSearchable:    searchable,
+							expectedInverted:   nil,
+							expectedFilterable: inverted,
+							expectedSearchable: &vFalse,
+						})
+					} else {
+						expectedFilterable := filterable
+						if filterable == nil {
+							expectedFilterable = &vTrue
+						}
+						expectedSearchable := searchable
+						if searchable == nil {
+							expectedSearchable = &vFalse
+						}
+
+						testCases = append(testCases, testCase{
+							propName:           propName(dataType, inverted, filterable, searchable),
+							dataType:           dataType,
+							indexInverted:      inverted,
+							indexFilterable:    filterable,
+							indexSearchable:    searchable,
+							expectedInverted:   nil,
+							expectedFilterable: expectedFilterable,
+							expectedSearchable: expectedSearchable,
 						})
 					}
 				}
@@ -636,8 +686,7 @@ func TestAddClass_Migrate(t *testing.T) {
 			for _, tc := range testCases {
 				properties = append(properties, &models.Property{
 					Name:            "created_" + tc.propName,
-					DataType:        schema.DataTypeText.PropString(),
-					Tokenization:    models.PropertyTokenizationWord,
+					DataType:        tc.dataType.PropString(),
 					IndexInverted:   tc.indexInverted,
 					IndexFilterable: tc.indexFilterable,
 					IndexSearchable: tc.indexSearchable,
@@ -660,8 +709,7 @@ func TestAddClass_Migrate(t *testing.T) {
 				t.Run("added_"+tc.propName, func(t *testing.T) {
 					err := mgr.addClassProperty(ctx, className, &models.Property{
 						Name:            "added_" + tc.propName,
-						DataType:        schema.DataTypeText.PropString(),
-						Tokenization:    models.PropertyTokenizationWord,
+						DataType:        tc.dataType.PropString(),
 						IndexInverted:   tc.indexInverted,
 						IndexFilterable: tc.indexFilterable,
 						IndexSearchable: tc.indexSearchable,

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -605,77 +605,92 @@ func TestAddClass_DefaultsAndMigration(t *testing.T) {
 
 		testCases := []testCase{}
 
-		for _, inverted := range allBoolPtrs {
-			for _, filterable := range allBoolPtrs {
-				for _, searchable := range allBoolPtrs {
-					dataType := schema.DataTypeText
-
-					if filterable == nil && searchable == nil && inverted != nil {
-						testCases = append(testCases, testCase{
-							propName:           propName(dataType, inverted, filterable, searchable),
-							dataType:           dataType,
-							indexInverted:      inverted,
-							indexFilterable:    filterable,
-							indexSearchable:    searchable,
-							expectedInverted:   nil,
-							expectedFilterable: inverted,
-							expectedSearchable: inverted,
-						})
-					} else {
-						expectedFilterable := filterable
-						if filterable == nil {
-							expectedFilterable = &vTrue
-						}
-						expectedSearchable := searchable
-						if searchable == nil {
-							expectedSearchable = &vTrue
+		for _, dataType := range []schema.DataType{schema.DataTypeText, schema.DataTypeInt} {
+			for _, inverted := range allBoolPtrs {
+				for _, filterable := range allBoolPtrs {
+					for _, searchable := range allBoolPtrs {
+						if inverted != nil {
+							if filterable != nil || searchable != nil {
+								// invalid combination, indexInverted can not be set
+								// together with indexFilterable or indexSearchable
+								continue
+							}
 						}
 
-						testCases = append(testCases, testCase{
-							propName:           propName(dataType, inverted, filterable, searchable),
-							dataType:           dataType,
-							indexInverted:      inverted,
-							indexFilterable:    filterable,
-							indexSearchable:    searchable,
-							expectedInverted:   nil,
-							expectedFilterable: expectedFilterable,
-							expectedSearchable: expectedSearchable,
-						})
-					}
-
-					dataType = schema.DataTypeInt
-
-					if filterable == nil && searchable == nil && inverted != nil {
-						testCases = append(testCases, testCase{
-							propName:           propName(dataType, inverted, filterable, searchable),
-							dataType:           dataType,
-							indexInverted:      inverted,
-							indexFilterable:    filterable,
-							indexSearchable:    searchable,
-							expectedInverted:   nil,
-							expectedFilterable: inverted,
-							expectedSearchable: &vFalse,
-						})
-					} else {
-						expectedFilterable := filterable
-						if filterable == nil {
-							expectedFilterable = &vTrue
-						}
-						expectedSearchable := searchable
-						if searchable == nil {
-							expectedSearchable = &vFalse
+						if searchable != nil && *searchable {
+							if dataType != schema.DataTypeText {
+								// invalid combination, indexSearchable can not be enabled
+								// for non text/text[] data type
+								continue
+							}
 						}
 
-						testCases = append(testCases, testCase{
-							propName:           propName(dataType, inverted, filterable, searchable),
-							dataType:           dataType,
-							indexInverted:      inverted,
-							indexFilterable:    filterable,
-							indexSearchable:    searchable,
-							expectedInverted:   nil,
-							expectedFilterable: expectedFilterable,
-							expectedSearchable: expectedSearchable,
-						})
+						switch dataType {
+						case schema.DataTypeText:
+							if inverted != nil {
+								testCases = append(testCases, testCase{
+									propName:           propName(dataType, inverted, filterable, searchable),
+									dataType:           dataType,
+									indexInverted:      inverted,
+									indexFilterable:    filterable,
+									indexSearchable:    searchable,
+									expectedInverted:   nil,
+									expectedFilterable: inverted,
+									expectedSearchable: inverted,
+								})
+							} else {
+								expectedFilterable := filterable
+								if filterable == nil {
+									expectedFilterable = &vTrue
+								}
+								expectedSearchable := searchable
+								if searchable == nil {
+									expectedSearchable = &vTrue
+								}
+								testCases = append(testCases, testCase{
+									propName:           propName(dataType, inverted, filterable, searchable),
+									dataType:           dataType,
+									indexInverted:      inverted,
+									indexFilterable:    filterable,
+									indexSearchable:    searchable,
+									expectedInverted:   nil,
+									expectedFilterable: expectedFilterable,
+									expectedSearchable: expectedSearchable,
+								})
+							}
+						default:
+							if inverted != nil {
+								testCases = append(testCases, testCase{
+									propName:           propName(dataType, inverted, filterable, searchable),
+									dataType:           dataType,
+									indexInverted:      inverted,
+									indexFilterable:    filterable,
+									indexSearchable:    searchable,
+									expectedInverted:   nil,
+									expectedFilterable: inverted,
+									expectedSearchable: &vFalse,
+								})
+							} else {
+								expectedFilterable := filterable
+								if filterable == nil {
+									expectedFilterable = &vTrue
+								}
+								expectedSearchable := searchable
+								if searchable == nil {
+									expectedSearchable = &vFalse
+								}
+								testCases = append(testCases, testCase{
+									propName:           propName(dataType, inverted, filterable, searchable),
+									dataType:           dataType,
+									indexInverted:      inverted,
+									indexFilterable:    filterable,
+									indexSearchable:    searchable,
+									expectedInverted:   nil,
+									expectedFilterable: expectedFilterable,
+									expectedSearchable: expectedSearchable,
+								})
+							}
+						}
 					}
 				}
 			}

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -40,6 +41,8 @@ func TestFailedCommits(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	vTrue := true
+	vFalse := false
 
 	tests := []test{
 		{
@@ -84,15 +87,17 @@ func TestFailedCommits(t *testing.T) {
 			action: func(t *testing.T, sm *Manager) {
 				err := sm.AddClassProperty(ctx, nil, "MyClass", &models.Property{
 					Name:     "prop_1",
-					DataType: []string{"int"},
+					DataType: schema.DataTypeInt.PropString(),
 				})
 				assert.Nil(t, err)
 			},
 			expSchema: []*models.Class{
 				classWithDefaultsWithProps(t, "MyClass", []*models.Property{
 					{
-						Name:     "prop_1",
-						DataType: []string{"int"},
+						Name:            "prop_1",
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
 					},
 				}),
 			},

--- a/usecases/schema/remove_duplicate_props_test.go
+++ b/usecases/schema/remove_duplicate_props_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 )
 
 func TestStartupWithDuplicateProps(t *testing.T) {
@@ -30,7 +31,7 @@ func TestStartupWithDuplicateProps(t *testing.T) {
 					Properties: []*models.Property{
 						{
 							Name:     "prop_1",
-							DataType: []string{"int"},
+							DataType: schema.DataTypeInt.PropString(),
 						},
 						{
 							Name:     "prop_2",
@@ -54,7 +55,7 @@ func TestStartupWithDuplicateProps(t *testing.T) {
 						},
 						{
 							Name:     "prop_4",
-							DataType: []string{"boolean"},
+							DataType: schema.DataTypeBoolean.PropString(),
 						},
 					},
 				},
@@ -70,25 +71,35 @@ func TestStartupWithDuplicateProps(t *testing.T) {
 	actual, err := m.GetClass(context.Background(), nil, "MyClass")
 	require.Nil(t, err)
 
+	vTrue := true
+	vFalse := false
 	expected := &models.Class{
 		Class:           "MyClass",
 		VectorIndexType: "hnsw",
 		Properties: []*models.Property{
 			{
-				Name:     "prop_1",
-				DataType: []string{"int"},
+				Name:            "prop_1",
+				DataType:        schema.DataTypeInt.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
 			},
 			{
-				Name:     "prop_2",
-				DataType: []string{"Ref"},
+				Name:            "prop_2",
+				DataType:        []string{"Ref"},
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
 			},
 			{
-				Name:     "prop_3",
-				DataType: []string{"Ref"},
+				Name:            "prop_3",
+				DataType:        []string{"Ref"},
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
 			},
 			{
-				Name:     "prop_4",
-				DataType: []string{"boolean"},
+				Name:            "prop_4",
+				DataType:        schema.DataTypeBoolean.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
 			},
 		},
 	}

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -44,7 +44,7 @@ func (m *Manager) validateClassName(ctx context.Context, className string) error
 	return err
 }
 
-func validatePropertyTokenization(tokenization string, propertyDataType schema.PropertyDataType) error {
+func (m *Manager) validatePropertyTokenization(tokenization string, propertyDataType schema.PropertyDataType) error {
 	if propertyDataType.IsPrimitive() {
 		primitiveDataType := propertyDataType.AsPrimitive()
 
@@ -74,6 +74,32 @@ func validatePropertyTokenization(tokenization string, propertyDataType schema.P
 		return nil
 	}
 	return fmt.Errorf("Tokenization is not allowed for reference data type")
+}
+
+func (m *Manager) validatePropertyIndexing(prop *models.Property) error {
+	if prop.IndexInverted != nil {
+		if prop.IndexFilterable != nil || prop.IndexSearchable != nil {
+			return fmt.Errorf("`indexInverted` is deprecated and can not be set together with `indexFilterable` or `indexSearchable`.")
+		}
+	}
+
+	if prop.IndexSearchable != nil {
+		switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
+		case schema.DataTypeString, schema.DataTypeStringArray:
+			// string/string[] are migrated to text/text[] later,
+			// at this point they are still valid data types, therefore should be handled here
+			fallthrough
+		case schema.DataTypeText, schema.DataTypeTextArray:
+			// true or false allowed
+		default:
+			if *prop.IndexSearchable {
+				return fmt.Errorf("`indexSearchable` is allowed only for text/text[] data types. " +
+					"For other data types set false or leave empty")
+			}
+		}
+	}
+
+	return nil
 }
 
 func (m *Manager) validateVectorSettings(ctx context.Context, class *models.Class) error {

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
@@ -156,6 +157,10 @@ func (e *Explorer) getClassKeywordBased(ctx context.Context, params dto.GetParam
 
 	res, err := e.search.ClassSearch(ctx, params)
 	if err != nil {
+		var e inverted.MissingIndexError
+		if errors.As(err, &e) {
+			return nil, e
+		}
 		return nil, errors.Errorf("explorer: get class: vector search: %v", err)
 	}
 
@@ -308,6 +313,10 @@ func (e *Explorer) getClassList(ctx context.Context,
 	} else {
 		res, err = e.search.ClassSearch(ctx, params)
 		if err != nil {
+			var e inverted.MissingIndexError
+			if errors.As(err, &e) {
+				return nil, e
+			}
 			return nil, errors.Errorf("explorer: list class: search: %v", err)
 		}
 	}


### PR DESCRIPTION
### What's being changed:
- IndexFilterable + IndexSearchable have default values set before persisting schema
- human friendly error messages on missing filterable / searchable indexes (addresses https://github.com/weaviate/weaviate/issues/2974)
- IndexInverted + IndexFilterable + IndexSearchable validation (mixing IndexInverted with IndexFilterable or IndexSearchable not allowed, IndexSearchable disabled for non text/text[] data types)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
