### PR TITLE
Only enable compressed cache if compression is enabled

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -48,6 +48,7 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 	uc.EFConstruction = efConstruction
 	uc.EF = ef
 	uc.VectorCacheMaxObjects = 10e12
+	uc.PQ = ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "title", Distribution: "normal"}}
 
 	index, _ := hnsw.New(
 		hnsw.Config{

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -91,14 +91,24 @@ func (h *hnsw) UpdateUserConfig(updated schema.VectorIndexConfig, callback func(
 	atomic.StoreInt64(&h.efFactor, int64(parsed.DynamicEFFactor))
 	atomic.StoreInt64(&h.flatSearchCutoff, int64(parsed.FlatSearchCutoff))
 
-	if parsed.PQ.Enabled && h.compressed.Load() {
-		h.compressedVectorsCache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))
+	if !parsed.PQ.Enabled {
+		callback()
+		return nil
+	}
+
+	// compression got enabled in this update
+	if h.compressedVectorsCache == (*compressedShardedLockCache)(nil) {
+		h.compressedVectorsCache = newCompressedShardedLockCache(parsed.VectorCacheMaxObjects, h.logger)
 	} else {
-		h.cache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))
+		if h.compressed.Load() {
+			h.compressedVectorsCache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))
+		} else {
+			h.cache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))
+		}
 	}
 
 	// ToDo: check atomic operation
-	if !h.compressed.Load() && parsed.PQ.Enabled {
+	if !h.compressed.Load() {
 		// the compression will fire the callback once it's complete
 		h.turnOnCompression(parsed, callback)
 	} else {

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -91,7 +91,7 @@ func (h *hnsw) UpdateUserConfig(updated schema.VectorIndexConfig, callback func(
 	atomic.StoreInt64(&h.efFactor, int64(parsed.DynamicEFFactor))
 	atomic.StoreInt64(&h.flatSearchCutoff, int64(parsed.FlatSearchCutoff))
 
-	if h.compressed.Load() {
+	if parsed.PQ.Enabled && h.compressed.Load() {
 		h.compressedVectorsCache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))
 	} else {
 		h.cache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -513,7 +513,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "title", Distribution: "normal"}},
+		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "tile", Distribution: "normal"}},
 	}
 
 	t.Run("import the test vectors", func(t *testing.T) {
@@ -640,7 +640,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "title", Distribution: "normal"}},
+		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "tile", Distribution: "normal"}},
 	}
 
 	t.Run("import the test vectors", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -513,6 +513,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
+		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "title", Distribution: "normal"}},
 	}
 
 	t.Run("import the test vectors", func(t *testing.T) {
@@ -541,9 +542,6 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 			err := vectorIndex.Add(uint64(i), vec)
 			require.Nil(t, err)
 		}
-		userConfig.PQ.Enabled = true
-		userConfig.PQ.Encoder.Type = "tile"
-		userConfig.PQ.Encoder.Distribution = "normal"
 		index.Compress(0, 256, false, int(ssdhelpers.UseTileEncoder), int(ssdhelpers.LogNormalEncoderDistribution))
 	})
 
@@ -642,6 +640,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
+		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "title", Distribution: "normal"}},
 	}
 
 	t.Run("import the test vectors", func(t *testing.T) {
@@ -670,9 +669,6 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 			err := vectorIndex.Add(uint64(i), vec)
 			require.Nil(t, err)
 		}
-		userConfig.PQ.Enabled = true
-		userConfig.PQ.Encoder.Type = "tile"
-		userConfig.PQ.Encoder.Distribution = "normal"
 		index.Compress(0, 256, false, int(ssdhelpers.UseTileEncoder), int(ssdhelpers.LogNormalEncoderDistribution))
 		for i := len(vectors); i < 1000; i++ {
 			err := vectorIndex.Add(uint64(i), vectors[i%len(vectors)])

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -214,7 +214,11 @@ func New(cfg Config, uc ent.UserConfig) (*hnsw, error) {
 	vectorCache := newShardedLockCache(cfg.VectorForIDThunk, uc.VectorCacheMaxObjects,
 		cfg.Logger, normalizeOnRead, defaultDeletionInterval)
 
-	compressedVectorsCache := newCompressedShardedLockCache(uc.VectorCacheMaxObjects, cfg.Logger)
+	var compressedVectorsCache *compressedShardedLockCache
+	if uc.PQ.Enabled {
+		compressedVectorsCache = newCompressedShardedLockCache(uc.VectorCacheMaxObjects, cfg.Logger)
+	}
+
 	resetCtx, resetCtxCancel := context.WithCancel(context.Background())
 	index := &hnsw{
 		maximumConnections: uc.MaxConnections,


### PR DESCRIPTION
### What's being changed:

Closes https://github.com/weaviate/weaviate/issues/2988

Only enable compressed cache if compression is enabled

[before](https://user-images.githubusercontent.com/5353192/237022968-441e135a-94e8-4ac3-b496-79585418e591.png)
[after](https://user-images.githubusercontent.com/5353192/237023011-c41dcb52-d051-421e-8523-ee49b4f634ef.png)
