### PR TITLE
fix premature callback fire issue

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -496,7 +496,10 @@ func (s *Shard) updateVectorIndexConfig(ctx context.Context,
 		return storagestate.ErrStatusReadOnly
 	}
 
-	s.updateStatus(storagestate.StatusReadOnly.String())
+	err := s.updateStatus(storagestate.StatusReadOnly.String())
+	if err != nil {
+		return fmt.Errorf("attempt to mark read-only: %w", err)
+	}
 	return s.vectorIndex.UpdateUserConfig(updated, func() {
 		s.updateStatus(storagestate.StatusReady.String())
 	})


### PR DESCRIPTION
### What's being changed:
* fixes #2998, previously the callback was fired prematurely
* refactor code a bit to (split up functions) to make it easier to reason about what's going on
* this PR adds no new tests, however this whole flow will be tested in an upcoming e2e pipeline for compression


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
