### PR TITLE
Use more reasonable shard sizing defaults

### DIFF
--- a/adapters/repos/db/vector/hnsw/commitlog/logger.go
+++ b/adapters/repos/db/vector/hnsw/commitlog/logger.go
@@ -53,7 +53,7 @@ func NewLogger(fileName string) *Logger {
 }
 
 func NewLoggerWithFile(file *os.File) *Logger {
-	return &Logger{file: file, bufw: NewWriterSize(file, 1024*1024)}
+	return &Logger{file: file, bufw: NewWriterSize(file, 32*1024)}
 }
 
 func (l *Logger) SetEntryPointWithMaxLayer(id uint64, level int) error {

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -87,16 +87,16 @@ func TestHnswIndexGrow(t *testing.T) {
 		id := uint64(5*initialSize + 1)
 		err := index.Add(id, vector)
 		require.Nil(t, err)
-		// index should grow to 150001
+		// index should grow to 5001
 		assert.Equal(t, int(id)+minimumIndexGrowthDelta, len(index.nodes))
 		assert.Equal(t, int32(id+2*minimumIndexGrowthDelta), index.cache.len())
-		// try to add a vector with id: 170001
+		// try to add a vector with id: 8001
 		id = uint64(6*initialSize + minimumIndexGrowthDelta + 1)
 		err = index.Add(id, vector)
 		require.Nil(t, err)
-		// index should grow to at least 170001
-		assert.GreaterOrEqual(t, len(index.nodes), 17001)
-		assert.GreaterOrEqual(t, index.cache.len(), int32(17001))
+		// index should grow to at least 8001
+		assert.GreaterOrEqual(t, len(index.nodes), 8001)
+		assert.GreaterOrEqual(t, index.cache.len(), int32(8001))
 	})
 
 	t.Run("should grow index", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/maintainance.go
+++ b/adapters/repos/db/vector/hnsw/maintainance.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	initialSize             = 25000
-	minimumIndexGrowthDelta = 25000
+	initialSize             = 1000
+	minimumIndexGrowthDelta = 2000
 	indexGrowthRate         = 1.25
 )
 

--- a/adapters/repos/db/vector/hnsw/maintainance_test.go
+++ b/adapters/repos/db/vector/hnsw/maintainance_test.go
@@ -104,10 +104,10 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 		{
 			name: "panic case",
 			args: args{
-				id:    uint64(2*initialSize + 1),
+				id:    uint64(initialSize + minimumIndexGrowthDelta + 1),
 				index: createVertexSlice(initialSize + 1),
 			},
-			wantIndexSize: 2*initialSize + 1 + minimumIndexGrowthDelta,
+			wantIndexSize: initialSize + 1 + 2*minimumIndexGrowthDelta,
 			changed:       true,
 		},
 	}


### PR DESCRIPTION
### What's being changed:

* Reduces size of buffered writer that was excessively large
* Reduces initial size of HNSW which was rather arbitrary
* Shard foot print reduced from ~3MB to ~500kB

Fixes #2949

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: see linked commits
- [x] All new code is covered by tests where it is reasonable: existing tests adapted
- [ ] Performance tests have been run or not necessary.
