### PR TITLE
Add option to Group metrics, Fix broken Vector Add metric

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -398,6 +398,8 @@ func startupRoutine(ctx context.Context) *state.State {
 		logger.Exit(1)
 	}
 
+	monitoring.Init(serverConfig.Config.Monitoring)
+
 	if serverConfig.Config.DisableGraphQL {
 		logger.WithFields(logrus.Fields{
 			"action":          "startup",

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -40,11 +40,18 @@ type Metrics struct {
 	memtableDurations    prometheus.ObserverVec
 	memtableSize         *prometheus.GaugeVec
 	DimensionSum         *prometheus.GaugeVec
+
+	groupClasses bool
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	shardName string,
 ) *Metrics {
+	if promMetrics.GroupClasses {
+		className = "_grouped"
+		shardName = "_grouped"
+	}
+
 	replace := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
 		"operation":  "compact_lsm_segments_stratreplace",
 		"class_name": className,
@@ -70,6 +77,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	})
 
 	return &Metrics{
+		groupClasses:         promMetrics.GroupClasses,
 		CompactionReplace:    replace,
 		CompactionSet:        set,
 		CompactionMap:        stratMap,
@@ -138,6 +146,10 @@ func (m *Metrics) MemtableOpObserver(path, strategy, op string) NsObserver {
 		return noOpNsObserver
 	}
 
+	if m.groupClasses {
+		path = "_grouped"
+	}
+
 	curried := m.memtableDurations.With(prometheus.Labels{
 		"operation": op,
 		"path":      path,
@@ -151,7 +163,9 @@ func (m *Metrics) MemtableOpObserver(path, strategy, op string) NsObserver {
 }
 
 func (m *Metrics) MemtableSizeSetter(path, strategy string) Setter {
-	if m == nil {
+	if m == nil || m.groupClasses {
+		// this metric would set absolute values, that's not possible in
+		// grouped mode, each call would essentially overwrite the last
 		return noOpSetter
 	}
 

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -32,7 +32,8 @@ type Metrics struct {
 	filteredVectorSort    prometheus.Observer
 }
 
-func NewMetrics(logger logrus.FieldLogger, prom *monitoring.PrometheusMetrics,
+func NewMetrics(
+	logger logrus.FieldLogger, prom *monitoring.PrometheusMetrics,
 	className, shardName string,
 ) *Metrics {
 	m := &Metrics{
@@ -41,6 +42,11 @@ func NewMetrics(logger logrus.FieldLogger, prom *monitoring.PrometheusMetrics,
 
 	if prom == nil {
 		return m
+	}
+
+	if prom.GroupClasses {
+		className = "_grouped"
+		shardName = "_grouped"
 	}
 
 	m.monitoring = true

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -37,6 +37,14 @@ func (s *Shard) Dimensions() int {
 
 func (s *Shard) sendVectorDimensionsMetric(count int) {
 	if s.promMetrics != nil {
+		// Important: Never group classes/shards for this metric. We need the
+		// granularity here as this tracks an absolute value per shard that changes
+		// independently over time.
+		//
+		// If we need to reduce metrics further, an alternative could be to not
+		// make dimension tracking shard-centric, but rather make it node-centric.
+		// Then have a single metric that aggregates all dimensions first, then
+		// observes only the sum
 		metric, err := s.promMetrics.VectorDimensionsSum.
 			GetMetricWithLabelValues(s.index.Config.ClassName.String(), s.name)
 		if err == nil {

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -41,6 +41,11 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		return &Metrics{enabled: false}
 	}
 
+	if prom.GroupClasses {
+		className = "_grouped"
+		shardName = "_grouped"
+	}
+
 	tombstones := prom.VectorIndexTombstones.With(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -169,9 +169,10 @@ type Contextionary struct {
 }
 
 type Monitoring struct {
-	Enabled bool   `json:"enabled" yaml:"enabled"`
-	Tool    string `json:"tool" yaml:"tool"`
-	Port    int    `json:"port" yaml:"port"`
+	Enabled      bool   `json:"enabled" yaml:"enabled"`
+	Tool         string `json:"tool" yaml:"tool"`
+	Port         int    `json:"port" yaml:"port"`
+	GroupClasses bool   `json:"group_classes" yaml:"group_classes"`
 }
 
 type GRPC struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -30,6 +30,10 @@ func FromEnv(config *Config) error {
 		config.Monitoring.Enabled = true
 		config.Monitoring.Tool = "prometheus"
 		config.Monitoring.Port = 2112
+
+		if enabled(os.Getenv("PROMETHEUS_MONITORING_GROUP_CLASSES")) {
+			config.Monitoring.GroupClasses = true
+		}
 	}
 
 	if enabled(os.Getenv("TRACK_VECTOR_DIMENSIONS")) {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -406,3 +406,36 @@ func TestEnvironmentDisableGraphQL(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentPrometheusGroupClasses(t *testing.T) {
+	factors := []struct {
+		name        string
+		value       []string
+		expected    bool
+		expectedErr bool
+	}{
+		{"Valid: true", []string{"true"}, true, false},
+		{"Valid: false", []string{"false"}, false, false},
+		{"Valid: 1", []string{"1"}, true, false},
+		{"Valid: 0", []string{"0"}, false, false},
+		{"Valid: on", []string{"on"}, true, false},
+		{"Valid: off", []string{"off"}, false, false},
+		{"not given", []string{}, false, false},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PROMETHEUS_MONITORING_ENABLED", "true")
+			if len(tt.value) == 1 {
+				t.Setenv("PROMETHEUS_MONITORING_GROUP_CLASSES", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.Monitoring.GroupClasses)
+			}
+		})
+	}
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 type PrometheusMetrics struct {
@@ -56,6 +57,8 @@ type PrometheusMetrics struct {
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.SummaryVec
 	StartupDiskIO    *prometheus.SummaryVec
+
+	GroupClasses bool
 }
 
 var (
@@ -63,16 +66,17 @@ var (
 	metrics   *PrometheusMetrics = nil
 )
 
-func init() {
-	metrics = newPrometheusMetrics()
+func Init(cfg config.Monitoring) {
+	metrics = newPrometheusMetrics(cfg)
 }
 
 func GetMetrics() *PrometheusMetrics {
 	return metrics
 }
 
-func newPrometheusMetrics() *PrometheusMetrics {
+func newPrometheusMetrics(cfg config.Monitoring) *PrometheusMetrics {
 	return &PrometheusMetrics{
+		GroupClasses: cfg.GroupClasses,
 		BatchTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "batch_durations_ms",
 			Help:    "Duration in ms of a single batch",


### PR DESCRIPTION
### What's being changed:

#### Group Metrics
* In multi-tenancy situations (whether pre-v1.20 with classes or post-v1.20 with the designated feature), it's not viable to track metrics with shard-level (or even finer) granularity as the amount of metrics explodes
* A new environment variable `PROMETHEUS_MONITORING_GROUP_CLASSES` to turn on grouping mode. If not set, the old behavior is not changed.
* This PR replaces all shard and class labels with the fixed string `_grouped`. This way it does not introduce breaking changes, the labels still exist, they will simply all have the same value
* The dimension tracking metrics are exempt from this because they set absolute values in regular intervals. Here we must know the exact number of dimension at any time, otherwise the resulting reports aren't correct
* For metrics inside the LSM store that were tracked with very high granularity (e.g. file path) that set an absolute value, they are ignored completely. This is not feasible in grouped mode, as each new call would override the previously set value. 

#### Fix Vector Durations metric in Batch operation
* fixes #3015, see issue for details

An example screenshot for both changes:
<img width="825" alt="image" src="https://github.com/weaviate/weaviate/assets/8974479/83e0efc8-08d3-4f37-9145-7d2fab04151e">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
