### PR TITLE
Add possibility to register module for a class without configuration if there's only one module of a given type enabled

### DIFF
--- a/entities/modulecapabilities/module.go
+++ b/entities/modulecapabilities/module.go
@@ -21,14 +21,17 @@ import (
 type ModuleType string
 
 const (
-	Backup        ModuleType = "Backup"
-	Extension     ModuleType = "Extension"
-	Img2Vec       ModuleType = "Img2Vec"
-	Multi2Vec     ModuleType = "Multi2Vec"
-	Ref2Vec       ModuleType = "Ref2Vec"
-	Text2MultiVec ModuleType = "Text2MultiVec"
-	Text2Text     ModuleType = "Text2Text"
-	Text2Vec      ModuleType = "Text2Vec"
+	Backup              ModuleType = "Backup"
+	Extension           ModuleType = "Extension"
+	Img2Vec             ModuleType = "Img2Vec"
+	Multi2Vec           ModuleType = "Multi2Vec"
+	Ref2Vec             ModuleType = "Ref2Vec"
+	Text2MultiVec       ModuleType = "Text2MultiVec"
+	Text2TextGenerative ModuleType = "Text2TextGenerative"
+	Text2TextSummarize  ModuleType = "Text2TextSummarize"
+	Text2TextNER        ModuleType = "Text2TextNER"
+	Text2TextQnA        ModuleType = "Text2TextQnA"
+	Text2Vec            ModuleType = "Text2Vec"
 )
 
 type Module interface {

--- a/modules/generative-cohere/module.go
+++ b/modules/generative-cohere/module.go
@@ -49,7 +49,7 @@ func (m *GenerativeCohereModule) Name() string {
 }
 
 func (m *GenerativeCohereModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextGenerative
 }
 
 func (m *GenerativeCohereModule) Init(ctx context.Context,

--- a/modules/generative-openai/module.go
+++ b/modules/generative-openai/module.go
@@ -49,7 +49,7 @@ func (m *GenerativeOpenAIModule) Name() string {
 }
 
 func (m *GenerativeOpenAIModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextGenerative
 }
 
 func (m *GenerativeOpenAIModule) Init(ctx context.Context,

--- a/modules/generative-palm/module.go
+++ b/modules/generative-palm/module.go
@@ -49,7 +49,7 @@ func (m *GenerativePaLMModule) Name() string {
 }
 
 func (m *GenerativePaLMModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextGenerative
 }
 
 func (m *GenerativePaLMModule) Init(ctx context.Context,

--- a/modules/ner-transformers/module.go
+++ b/modules/ner-transformers/module.go
@@ -46,7 +46,7 @@ func (m *NERModule) Name() string {
 }
 
 func (m *NERModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextNER
 }
 
 func (m *NERModule) Init(ctx context.Context,

--- a/modules/qna-openai/module.go
+++ b/modules/qna-openai/module.go
@@ -53,7 +53,7 @@ func (m *QnAModule) Name() string {
 }
 
 func (m *QnAModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextQnA
 }
 
 func (m *QnAModule) Init(ctx context.Context,

--- a/modules/qna-transformers/module.go
+++ b/modules/qna-transformers/module.go
@@ -53,7 +53,7 @@ func (m *QnAModule) Name() string {
 }
 
 func (m *QnAModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextQnA
 }
 
 func (m *QnAModule) Init(ctx context.Context,

--- a/modules/sum-transformers/module.go
+++ b/modules/sum-transformers/module.go
@@ -46,7 +46,7 @@ func (m *SUMModule) Name() string {
 }
 
 func (m *SUMModule) Type() modulecapabilities.ModuleType {
-	return modulecapabilities.Text2Text
+	return modulecapabilities.Text2TextSummarize
 }
 
 func (m *SUMModule) Init(ctx context.Context,

--- a/test/helper/sample-schema/books/books.go
+++ b/test/helper/sample-schema/books/books.go
@@ -29,6 +29,10 @@ func ClassContextionaryVectorizer() *models.Class {
 	return class(defaultClassName, "text2vec-contextionary")
 }
 
+func ClassContextionaryVectorizerWithName(className string) *models.Class {
+	return class(className, "text2vec-contextionary")
+}
+
 func ClassContextionaryVectorizerWithSumTransformers() *models.Class {
 	return class(defaultClassName, "text2vec-contextionary", "sum-transformers")
 }

--- a/test/modules/qna-transformers/qna_test.go
+++ b/test/modules/qna-transformers/qna_test.go
@@ -26,19 +26,32 @@ import (
 
 func Test_QnATransformers(t *testing.T) {
 	helper.SetupClient(os.Getenv(weaviateEndpoint))
+	// Contextionary with QnA module config present
 	booksClass := books.ClassContextionaryVectorizerWithQnATransformers()
 	helper.CreateClass(t, booksClass)
 	defer helper.DeleteClass(t, booksClass.Class)
-	// Text2VecTransformers
+	// Contextionary without QnA module config present
+	booksWithoutQnAConfig := "BooksWithoutConfig"
+	booksWithoutQnAConfigClass := books.ClassContextionaryVectorizerWithName(booksWithoutQnAConfig)
+	helper.CreateClass(t, booksWithoutQnAConfigClass)
+	defer helper.DeleteClass(t, booksWithoutQnAConfigClass.Class)
+	// Text2VecTransformers with QnA module config present
 	booksTransformers := "BooksTransformers"
 	booksTransformersClass := books.ClassTransformersVectorizerWithQnATransformersWithName(booksTransformers)
 	helper.CreateClass(t, booksTransformersClass)
 	defer helper.DeleteClass(t, booksTransformersClass.Class)
+	// Text2VecTransformers without QnA module config present
+	booksTransformersWithoutQnAConfig := "BooksTransformersWithoutConfig"
+	booksTransformersWithoutQnAConfigClass := books.ClassTransformersVectorizerWithName(booksTransformersWithoutQnAConfig)
+	helper.CreateClass(t, booksTransformersWithoutQnAConfigClass)
+	defer helper.DeleteClass(t, booksTransformersWithoutQnAConfigClass.Class)
 
 	t.Run("add data to Books schema", func(t *testing.T) {
 		bookObjects := []*models.Object{}
 		bookObjects = append(bookObjects, books.Objects()...)
+		bookObjects = append(bookObjects, books.ObjectsWithName(booksWithoutQnAConfig)...)
 		bookObjects = append(bookObjects, books.ObjectsWithName(booksTransformers)...)
+		bookObjects = append(bookObjects, books.ObjectsWithName(booksTransformersWithoutQnAConfig)...)
 		for _, book := range bookObjects {
 			helper.CreateObject(t, book)
 			helper.AssertGetObjectEventually(t, book.Class, book.ID)
@@ -46,7 +59,7 @@ func Test_QnATransformers(t *testing.T) {
 	})
 
 	t.Run("ask", func(t *testing.T) {
-		for _, class := range []*models.Class{booksClass, booksTransformersClass} {
+		for _, class := range []*models.Class{booksClass, booksWithoutQnAConfigClass, booksTransformersClass, booksTransformersWithoutQnAConfigClass} {
 			t.Run(class.Class, func(t *testing.T) {
 				query := `
 					{

--- a/test/modules/sum-transformers/sum_test.go
+++ b/test/modules/sum-transformers/sum_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/books"
@@ -23,53 +24,70 @@ import (
 
 func Test_SUMTransformers(t *testing.T) {
 	helper.SetupClient(os.Getenv(weaviateEndpoint))
-	booksClass := books.ClassContextionaryVectorizerWithSumTransformers()
-	helper.CreateClass(t, booksClass)
-	defer helper.DeleteClass(t, booksClass.Class)
+	tests := []struct {
+		name  string
+		class *models.Class
+	}{
+		{
+			name:  "with module config for sum-transformers module",
+			class: books.ClassContextionaryVectorizerWithSumTransformers(),
+		},
+		{
+			name:  "without module config",
+			class: books.ClassContextionaryVectorizer(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			booksClass := tt.class
+			helper.CreateClass(t, booksClass)
+			defer helper.DeleteClass(t, booksClass.Class)
 
-	t.Run("add data to Books schema", func(t *testing.T) {
-		for _, book := range books.Objects() {
-			helper.CreateObject(t, book)
-			helper.AssertGetObjectEventually(t, book.Class, book.ID)
-		}
-	})
+			t.Run("add data to Books schema", func(t *testing.T) {
+				for _, book := range books.Objects() {
+					helper.CreateObject(t, book)
+					helper.AssertGetObjectEventually(t, book.Class, book.ID)
+				}
+			})
 
-	t.Run("query Books data with nearText", func(t *testing.T) {
-		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
-			{
-				Get {
-					Books(where: {
-						operator: Equal
-						path:["title"]
-						valueText: "Dune"
-					}){
-						title
-						_additional {
-							summary (properties:["description"]) {
-								property
-								result
+			t.Run("query Books data with nearText", func(t *testing.T) {
+				result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
+					{
+						Get {
+							Books(where: {
+								operator: Equal
+								path:["title"]
+								valueText: "Dune"
+							}){
+								title
+								_additional {
+									summary (properties:["description"]) {
+										property
+										result
+									}
+								}
 							}
 						}
 					}
-				}
-			}
-		`)
-		books := result.Get("Get", "Books").AsSlice()
-		expected := []interface{}{
-			map[string]interface{}{
-				"title": "Dune",
-				"_additional": map[string]interface{}{
-					"summary": []interface{}{
-						map[string]interface{}{
-							"property": "description",
-							"result": "Dune is a 1965 epic science fiction novel by American author Frank Herbert." +
-								"It is the first novel in the Dune series by Frank Herbert, and the first in the \"Dune\" series of books." +
-								"It was published in the United States by Simon & Schuster in 1965.",
+				`)
+				books := result.Get("Get", "Books").AsSlice()
+				expected := []interface{}{
+					map[string]interface{}{
+						"title": "Dune",
+						"_additional": map[string]interface{}{
+							"summary": []interface{}{
+								map[string]interface{}{
+									"property": "description",
+									"result": "Dune is a 1965 epic science fiction novel by American author Frank Herbert." +
+										"It is the first novel in the Dune series by Frank Herbert, and the first in the \"Dune\" series of books." +
+										"It was published in the United States by Simon & Schuster in 1965.",
+								},
+							},
 						},
 					},
-				},
-			},
-		}
-		assert.ElementsMatch(t, expected, books)
-	})
+				}
+				assert.ElementsMatch(t, expected, books)
+			})
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:

This PR loosens module validation and enables registering a module for a class that has no `moduleConfig` present but only if there's just 1 type of a given module enabled.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
