### PR TITLE
Common cycle manager

### DIFF
--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -199,7 +199,7 @@ func TestBackup_BucketLevel(t *testing.T) {
 		objBucket := shard.store.Bucket("objects")
 		require.NotNil(t, objBucket)
 
-		err := objBucket.PauseCompaction(ctx)
+		err := shard.store.PauseCompaction(ctx)
 		require.Nil(t, err)
 
 		err = objBucket.FlushMemtable(ctx)
@@ -242,7 +242,7 @@ func TestBackup_BucketLevel(t *testing.T) {
 			assert.Contains(t, exts, ".bloom") // matches both bloom filters (primary+secondary)
 		})
 
-		err = objBucket.ResumeCompaction(ctx)
+		err = shard.store.ResumeCompaction(ctx)
 		require.Nil(t, err)
 	})
 

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -202,7 +202,7 @@ func TestBackup_BucketLevel(t *testing.T) {
 		err := shard.store.PauseCompaction(ctx)
 		require.Nil(t, err)
 
-		err = objBucket.FlushMemtable(ctx)
+		err = objBucket.FlushMemtable()
 		require.Nil(t, err)
 
 		files, err := objBucket.ListFiles(ctx)

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -144,7 +144,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 		}
 		tempBucketName := helpers.TempBucketFromBucketName(bucketsToReindex[i])
 		tempBucket := r.shard.store.Bucket(tempBucketName)
-		tempBucket.FlushMemtable(ctx)
+		tempBucket.FlushMemtable()
 		tempBucket.UpdateStatus(storagestate.StatusReadOnly)
 
 		if reindexProperties[i].NewIndex {

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -229,11 +229,6 @@ func (r *ShardInvertedReindexer) createTempBucket(ctx context.Context, name stri
 	if err := r.shard.store.CreateBucket(ctx, tempName, bucketOptions...); err != nil {
 		return errors.Wrapf(err, "failed creating temp bucket '%s'", tempName)
 	}
-
-	// no point starting compaction until bucket successfully populated and plugged in
-	if err := r.shard.store.Bucket(tempName).PauseCompaction(ctx); err != nil {
-		return errors.Wrapf(err, "failed pausing compaction for temp bucket '%s'", tempName)
-	}
 	return nil
 }
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -60,7 +60,7 @@ type Bucket struct {
 	// for backward compatibility
 	legacyMapSortingBeforeCompaction bool
 
-	flushCycle *cyclemanager.CycleManager
+	flushCycle cyclemanager.CycleManager
 
 	status     storagestate.Status
 	statusLock sync.RWMutex
@@ -82,7 +82,7 @@ type Bucket struct {
 // [Store]. In this case the [Store] can manage buckets for you, using methods
 // such as CreateOrLoadBucket().
 func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
-	metrics *Metrics, opts ...BucketOption,
+	metrics *Metrics, compactionCycle cyclemanager.CycleManager, opts ...BucketOption,
 ) (*Bucket, error) {
 	beforeAll := time.Now()
 	defaultMemTableThreshold := uint64(10 * 1024 * 1024)
@@ -116,7 +116,7 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 	}
 
 	sg, err := newSegmentGroup(dir, logger, b.legacyMapSortingBeforeCompaction,
-		metrics, b.strategy, b.monitorCount)
+		metrics, b.strategy, b.monitorCount, compactionCycle)
 	if err != nil {
 		return nil, errors.Wrap(err, "init disk segments")
 	}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -156,9 +156,8 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 		return nil, err
 	}
 
-	b.flushCycle = cyclemanager.New(
-		cyclemanager.MemtableFlushCycleTicker(),
-		b.flushAndSwitchIfThresholdsMet)
+	b.flushCycle = cyclemanager.NewMulti(cyclemanager.MemtableFlushCycleTicker())
+	b.flushCycle.Register(b.flushAndSwitchIfThresholdsMet)
 	b.flushCycle.Start()
 
 	b.metrics.TrackStartupBucket(beforeAll)

--- a/adapters/repos/db/lsmkv/bucket_backup.go
+++ b/adapters/repos/db/lsmkv/bucket_backup.go
@@ -25,20 +25,13 @@ import (
 //
 // This is a preparatory stage for creating backups.
 //
-// A timeout should be specified for the input context as some
-// flushes are long-running, in which case it may be better
-// to fail the backup attempt and retry later, than to block
-// indefinitely.
-func (b *Bucket) FlushMemtable(ctx context.Context) error {
+// Method should be run only if flushCycle is not running
+// (was not started, is stopped, or noop impl is provided)
+func (b *Bucket) FlushMemtable() error {
 	if b.isReadOnly() {
 		return errors.Wrap(storagestate.ErrStatusReadOnly, "flush memtable")
 	}
 
-	if err := b.flushCycle.StopAndWait(ctx); err != nil {
-		return errors.Wrap(ctx.Err(), "long-running memtable flush in progress")
-	}
-
-	defer b.flushCycle.Start()
 	// this lock does not currently _need_ to be
 	// obtained, as the only other place that
 	// grabs this lock is the flush cycle, which

--- a/adapters/repos/db/lsmkv/bucket_backup_test.go
+++ b/adapters/repos/db/lsmkv/bucket_backup_test.go
@@ -14,11 +14,8 @@ package lsmkv
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -28,73 +25,20 @@ import (
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
-func TestBackup_FlushMemtable(t *testing.T) {
-	t.Run("assert that context timeout works for long flushes", func(t *testing.T) {
-		ctx := context.Background()
-
-		dirName := makeTestDir(t)
-		defer removeTestDir(t, dirName)
-
-		b, err := NewBucket(ctx, dirName, "", logrus.New(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
-		require.Nil(t, err)
-
-		ctx, cancel := context.WithTimeout(ctx, time.Nanosecond)
-		defer cancel()
-
-		err = b.FlushMemtable(ctx)
-		require.NotNil(t, err)
-		assert.Equal(t, "long-running memtable flush in progress: context deadline exceeded", err.Error())
-
-		err = b.Shutdown(context.Background())
-		require.Nil(t, err)
-	})
-
-	t.Run("assert that flushes run successfully", func(t *testing.T) {
-		ctx := context.Background()
-
-		dirName := makeTestDir(t)
-		defer removeTestDir(t, dirName)
-
-		b, err := NewBucket(ctx, dirName, "", logrus.New(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
-		require.Nil(t, err)
-
-		t.Run("insert contents into bucket", func(t *testing.T) {
-			for i := 0; i < 10; i++ {
-				err := b.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
-				require.Nil(t, err)
-			}
-		})
-
-		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		defer cancel()
-
-		err = b.FlushMemtable(ctx)
-		assert.Nil(t, err)
-
-		err = b.Shutdown(context.Background())
-		require.Nil(t, err)
-	})
-
+func TestBucketBackup_FlushMemtable(t *testing.T) {
 	t.Run("assert that readonly bucket fails to flush", func(t *testing.T) {
 		ctx := context.Background()
+		dirName := t.TempDir()
 
-		dirName := makeTestDir(t)
-		defer removeTestDir(t, dirName)
-
-		b, err := NewBucket(ctx, dirName, "", logrus.New(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		b, err := NewBucket(ctx, dirName, dirName, logrus.New(), nil,
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		b.UpdateStatus(storagestate.StatusReadOnly)
 
-		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		defer cancel()
-
-		err = b.FlushMemtable(ctx)
+		err = b.FlushMemtable()
 		require.NotNil(t, err)
-
 		expectedErr := errors.Wrap(storagestate.ErrStatusReadOnly, "flush memtable")
 		assert.EqualError(t, expectedErr, err.Error())
 
@@ -103,14 +47,13 @@ func TestBackup_FlushMemtable(t *testing.T) {
 	})
 }
 
-func TestBackup_ListFiles(t *testing.T) {
+func TestBucketBackup_ListFiles(t *testing.T) {
 	ctx := context.Background()
+	dirName := t.TempDir()
 
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
-
-	b, err := NewBucket(ctx, dirName, "", logrus.New(), nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+	b, err := NewBucket(ctx, dirName, dirName, logrus.New(), nil,
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 
 	t.Run("insert contents into bucket", func(t *testing.T) {
@@ -118,7 +61,7 @@ func TestBackup_ListFiles(t *testing.T) {
 			err := b.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
 			require.Nil(t, err)
 		}
-		b.FlushMemtable(ctx) // flush memtable to generate .db files
+		b.FlushMemtable() // flush memtable to generate .db files
 	})
 
 	t.Run("assert expected bucket contents", func(t *testing.T) {
@@ -137,19 +80,4 @@ func TestBackup_ListFiles(t *testing.T) {
 
 	err = b.Shutdown(context.Background())
 	require.Nil(t, err)
-}
-
-func makeTestDir(t *testing.T) string {
-	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	if err := os.MkdirAll(dirName, 0o777); err != nil {
-		t.Fatalf("failed to make test dir '%s': %s", dirName, err)
-	}
-	return dirName
-}
-
-func removeTestDir(t *testing.T, dirName string) {
-	if err := os.RemoveAll(dirName); err != nil {
-		t.Errorf("failed to remove test dir '%s': %s", dirName, err)
-	}
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -25,7 +25,7 @@ func TestBucket_WasDeleted(t *testing.T) {
 	tmpDir := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	b, err := NewBucket(context.Background(), tmpDir, "", logger, nil,
-		cyclemanager.NewNoop())
+		cyclemanager.NewNoop(), cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	var (

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -18,12 +18,14 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestBucket_WasDeleted(t *testing.T) {
 	tmpDir := t.TempDir()
 	logger, _ := test.NewNullLogger()
-	b, err := NewBucket(context.Background(), tmpDir, "", logger, nil)
+	b, err := NewBucket(context.Background(), tmpDir, "", logger, nil,
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	var (

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 // This test ensures that the WAL threshold is being adhered to, and that a
@@ -40,6 +41,7 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 	tolerance := 4.
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(1024*1024*1024),
 		WithWalThreshold(walThreshold))
@@ -136,6 +138,7 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	tolerance := 4.
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(memtableThreshold))
 	require.Nil(t, err)
@@ -223,6 +226,7 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 		dirName := t.TempDir()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -261,6 +265,7 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 		dirName := t.TempDir()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -303,6 +308,7 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 		dirName := t.TempDir()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -40,8 +40,11 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 	walThreshold := uint64(4096)
 	tolerance := 4.
 
+	flushCycle := cyclemanager.NewMulti(cyclemanager.MemtableFlushCycleTicker())
+	flushCycle.Start()
+
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), flushCycle,
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(1024*1024*1024),
 		WithWalThreshold(walThreshold))
@@ -120,6 +123,7 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 	defer cancel()
 
 	require.Nil(t, bucket.Shutdown(ctx))
+	require.Nil(t, flushCycle.StopAndWait(ctx))
 }
 
 // This test ensures that the Memtable threshold is being adhered to, and
@@ -137,8 +141,11 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	memtableThreshold := uint64(4096)
 	tolerance := 4.
 
+	flushCycle := cyclemanager.NewMulti(cyclemanager.MemtableFlushCycleTicker())
+	flushCycle.Start()
+
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), flushCycle,
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(memtableThreshold))
 	require.Nil(t, err)
@@ -215,6 +222,7 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	defer cancel()
 
 	require.Nil(t, bucket.Shutdown(ctx))
+	require.Nil(t, flushCycle.StopAndWait(ctx))
 }
 
 func isSizeWithinTolerance(t *testing.T, detectedSize uint64, threshold uint64, tolerance float64) bool {
@@ -225,8 +233,11 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 	t.Run("an empty memtable is not flushed", func(t *testing.T) {
 		dirName := t.TempDir()
 
+		flushCycle := cyclemanager.NewMulti(cyclemanager.MemtableFlushCycleTicker())
+		flushCycle.Start()
+
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), flushCycle,
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -258,14 +269,18 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			require.Nil(t, bucket.Shutdown(ctx))
+			require.Nil(t, flushCycle.StopAndWait(ctx))
 		})
 	})
 
 	t.Run("a dirty memtable is flushed once the idle period is over", func(t *testing.T) {
 		dirName := t.TempDir()
 
+		flushCycle := cyclemanager.NewMulti(cyclemanager.MemtableFlushCycleTicker())
+		flushCycle.Start()
+
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), flushCycle,
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -301,14 +316,18 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			require.Nil(t, bucket.Shutdown(ctx))
+			require.Nil(t, flushCycle.StopAndWait(ctx))
 		})
 	})
 
 	t.Run("a dirty memtable is not flushed as long as the next write occurs before the idle threshold", func(t *testing.T) {
 		dirName := t.TempDir()
 
+		flushCycle := cyclemanager.NewMulti(cyclemanager.MemtableFlushCycleTicker())
+		flushCycle.Start()
+
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), flushCycle,
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -365,6 +384,7 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 			require.Nil(t, bucket.Shutdown(ctx))
+			require.Nil(t, flushCycle.StopAndWait(ctx))
 		})
 	})
 }

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -135,7 +135,8 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -346,7 +347,7 @@ func Test_CompactionReplaceStrategy_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -462,7 +463,8 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryDeletes(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -555,7 +557,8 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryUpdates(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -818,7 +821,8 @@ func Test_CompactionSetStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -937,7 +941,8 @@ func Test_CompactionSetStrategy_RemoveUnnecessary(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1283,7 +1288,8 @@ func Test_CompactionMapStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1408,7 +1414,8 @@ func Test_CompactionMapStrategy_RemoveUnnecessary(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1525,7 +1532,8 @@ func Test_CompactionReplaceStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1593,7 +1601,7 @@ func Test_Compaction_FrequentPutDeleteOperations_WithSecondaryKeys(t *testing.T)
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewNoop(),
+					cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 					WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 				require.Nil(t, err)
 
@@ -1669,7 +1677,8 @@ func Test_CompactionSetStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+					cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+					WithStrategy(StrategySetCollection))
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test
@@ -1756,7 +1765,8 @@ func Test_CompactionMapStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+					cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+					WithStrategy(StrategyMapCollection))
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func testCtx() context.Context {
@@ -134,7 +135,7 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -345,6 +346,7 @@ func Test_CompactionReplaceStrategy_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -460,7 +462,7 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryDeletes(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -553,7 +555,7 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryUpdates(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -816,7 +818,7 @@ func Test_CompactionSetStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -935,7 +937,7 @@ func Test_CompactionSetStrategy_RemoveUnnecessary(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1281,7 +1283,7 @@ func Test_CompactionMapStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1406,7 +1408,7 @@ func Test_CompactionMapStrategy_RemoveUnnecessary(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1523,7 +1525,7 @@ func Test_CompactionReplaceStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1591,6 +1593,7 @@ func Test_Compaction_FrequentPutDeleteOperations_WithSecondaryKeys(t *testing.T)
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+					cyclemanager.NewNoop(),
 					WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 				require.Nil(t, err)
 
@@ -1666,7 +1669,7 @@ func Test_CompactionSetStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					WithStrategy(StrategySetCollection))
+					cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test
@@ -1753,7 +1756,7 @@ func Test_CompactionMapStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					WithStrategy(StrategyMapCollection))
+					cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -15,7 +15,6 @@
 package lsmkv
 
 import (
-	"context"
 	"encoding/binary"
 	"math/rand"
 	"testing"
@@ -24,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func Test_CompactionRoaringSet(t *testing.T) {
@@ -40,11 +40,10 @@ func Test_CompactionRoaringSet(t *testing.T) {
 	control := controlFromInstructions(instr, maxID)
 
 	b, err := NewBucket(testCtx(), t.TempDir(), "", nullLogger(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyRoaringSet))
 	require.Nil(t, err)
 
-	// stop default compaction to run one manually
-	b.disk.compactionCycle.StopAndWait(context.Background())
 	defer b.Shutdown(testCtx())
 
 	// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -40,7 +40,7 @@ func Test_CompactionRoaringSet(t *testing.T) {
 	control := controlFromInstructions(instr, maxID)
 
 	b, err := NewBucket(testCtx(), t.TempDir(), "", nullLogger(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyRoaringSet))
 	require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func BenchmarkConcurrentReading(b *testing.B) {
@@ -63,6 +64,7 @@ func prepareBucket(b *testing.B) (bucket *Bucket, cleanup func()) {
 	}()
 
 	bucket, err := NewBucket(testCtxB(), dirName, "", nullLoggerB(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(b, err)

--- a/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
@@ -64,7 +64,7 @@ func prepareBucket(b *testing.B) (bucket *Bucket, cleanup func()) {
 	}()
 
 	bucket, err := NewBucket(testCtxB(), dirName, "", nullLoggerB(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(b, err)

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 // This test continuously writes into a bucket with a small memtable threshold,
@@ -43,6 +44,7 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 	values := make([][]byte, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -135,6 +137,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 	values := make([][][]byte, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategySetCollection),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -225,6 +228,7 @@ func TestConcurrentWriting_Map(t *testing.T) {
 	values := make([][]MapPair, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -44,7 +44,7 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 	values := make([][]byte, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -137,7 +137,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 	values := make([][][]byte, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategySetCollection),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -228,7 +228,7 @@ func TestConcurrentWriting_Map(t *testing.T) {
 	values := make([][]MapPair, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
@@ -37,7 +38,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -71,7 +72,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 			// then recreate bucket
 			var err error
 			b, err = NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-				WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 		})
 
@@ -156,7 +157,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -191,7 +192,7 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 	t.Run("without previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -298,7 +299,7 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -338,7 +339,7 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -437,7 +438,7 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				WithStrategy(StrategySetCollection))
+				cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -479,7 +480,7 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -616,7 +617,7 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				WithStrategy(StrategyMapCollection))
+				cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -38,7 +38,8 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -72,7 +73,8 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 			// then recreate bucket
 			var err error
 			b, err = NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 		})
 
@@ -157,7 +159,8 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -192,7 +195,8 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 	t.Run("without previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -299,7 +303,8 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -339,7 +344,8 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -438,7 +444,8 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -480,7 +487,8 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -617,7 +625,8 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -31,14 +31,14 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -50,7 +50,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	assert.True(t, ok)
 
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -73,14 +73,14 @@ func TestCreateBloomInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	for _, ext := range []string{".secondary.0.bloom", ".bloom"} {
 		files, err := os.ReadDir(dirName)
@@ -101,7 +101,8 @@ func TestCreateBloomInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is re-created on init
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -120,12 +121,13 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -138,7 +140,8 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -154,14 +157,14 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -174,7 +177,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestCreateBloomOnFlush(t *testing.T) {
@@ -30,8 +31,8 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		WithStrategy(StrategyReplace),
-		WithSecondaryIndices(1))
+		cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -49,8 +50,8 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	assert.True(t, ok)
 
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		WithStrategy(StrategyReplace),
-		WithSecondaryIndices(1))
+		cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -72,8 +73,8 @@ func TestCreateBloomInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		WithStrategy(StrategyReplace),
-		WithSecondaryIndices(1))
+		cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -99,7 +100,8 @@ func TestCreateBloomInit(t *testing.T) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
-	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -117,7 +119,8 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -134,7 +137,8 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
-	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -150,8 +154,8 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		WithStrategy(StrategyReplace),
-		WithSecondaryIndices(1))
+		cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -170,6 +174,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -38,7 +38,7 @@ type SegmentGroup struct {
 
 	strategy string
 
-	compactionCycle *cyclemanager.CycleManager
+	unregisterCompaction cyclemanager.UnregisterFunc
 
 	logger logrus.FieldLogger
 
@@ -58,7 +58,7 @@ type SegmentGroup struct {
 
 func newSegmentGroup(dir string, logger logrus.FieldLogger,
 	mapRequiresSorting bool, metrics *Metrics, strategy string,
-	monitorCount bool,
+	monitorCount bool, compactionCycleManager cyclemanager.CycleManager,
 ) (*SegmentGroup, error) {
 	list, err := os.ReadDir(dir)
 	if err != nil {
@@ -131,9 +131,7 @@ func newSegmentGroup(dir string, logger logrus.FieldLogger,
 		out.metrics.ObjectCount(out.count())
 	}
 
-	out.compactionCycle = cyclemanager.NewMulti(cyclemanager.CompactionCycleTicker())
-	out.compactionCycle.Register(out.compactIfLevelsMatch)
-	out.compactionCycle.Start()
+	out.unregisterCompaction = compactionCycleManager.Register(out.compactIfLevelsMatch)
 
 	return out, nil
 }
@@ -321,7 +319,7 @@ func (sg *SegmentGroup) count() int {
 }
 
 func (sg *SegmentGroup) shutdown(ctx context.Context) error {
-	if err := sg.compactionCycle.StopAndWait(ctx); err != nil {
+	if err := sg.unregisterCompaction(ctx); err != nil {
 		return errors.Wrap(ctx.Err(), "long-running compaction in progress")
 	}
 

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -131,9 +131,8 @@ func newSegmentGroup(dir string, logger logrus.FieldLogger,
 		out.metrics.ObjectCount(out.count())
 	}
 
-	out.compactionCycle = cyclemanager.New(
-		cyclemanager.CompactionCycleTicker(),
-		out.compactIfLevelsMatch)
+	out.compactionCycle = cyclemanager.NewMulti(cyclemanager.CompactionCycleTicker())
+	out.compactionCycle.Register(out.compactIfLevelsMatch)
 	out.compactionCycle.Start()
 
 	return out, nil

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestCreateCNAOnFlush(t *testing.T) {
@@ -31,7 +32,8 @@ func TestCreateCNAOnFlush(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -53,7 +55,8 @@ func TestCreateCNAInit(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -76,7 +79,8 @@ func TestCreateCNAInit(t *testing.T) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
-	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -94,7 +98,8 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -111,7 +116,8 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
-	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -33,12 +33,13 @@ func TestCreateCNAOnFlush(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -56,12 +57,13 @@ func TestCreateCNAInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -80,7 +82,8 @@ func TestCreateCNAInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is re-created on init
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -99,12 +102,13 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -117,7 +121,8 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestPrecomputeSegmentMeta_Replace(t *testing.T) {
@@ -35,8 +36,8 @@ func TestPrecomputeSegmentMeta_Replace(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		WithStrategy(StrategyReplace),
-		WithSecondaryIndices(1))
+		cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -98,7 +99,7 @@ func TestPrecomputeSegmentMeta_Set(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		WithStrategy(StrategySetCollection))
+		cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -36,14 +36,14 @@ func TestPrecomputeSegmentMeta_Replace(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(),
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	for _, ext := range []string{".secondary.0.bloom", ".bloom", ".cna"} {
 		files, err := os.ReadDir(dirName)
@@ -99,13 +99,14 @@ func TestPrecomputeSegmentMeta_Set(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategySetCollection))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
 	err = b.SetAdd([]byte("greetings"), [][]byte{[]byte("hello"), []byte("hola")})
 	require.Nil(t, err)
-	require.Nil(t, b.FlushMemtable(ctx))
+	require.Nil(t, b.FlushMemtable())
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
@@ -28,11 +29,12 @@ import (
 // Store groups multiple buckets together, it "owns" one folder on the file
 // system
 type Store struct {
-	dir           string
-	rootDir       string
-	bucketsByName map[string]*Bucket
-	logger        logrus.FieldLogger
-	metrics       *Metrics
+	dir             string
+	rootDir         string
+	bucketsByName   map[string]*Bucket
+	logger          logrus.FieldLogger
+	metrics         *Metrics
+	compactionCycle cyclemanager.CycleManager
 
 	// Prevent concurrent manipulations to the bucketsByNameMap, most notably
 	// when initializing buckets in parallel
@@ -46,11 +48,12 @@ func New(dir, rootDir string, logger logrus.FieldLogger,
 	metrics *Metrics,
 ) (*Store, error) {
 	s := &Store{
-		dir:           dir,
-		rootDir:       rootDir,
-		bucketsByName: map[string]*Bucket{},
-		logger:        logger,
-		metrics:       metrics,
+		dir:             dir,
+		rootDir:         rootDir,
+		bucketsByName:   map[string]*Bucket{},
+		logger:          logger,
+		metrics:         metrics,
+		compactionCycle: cyclemanager.NewMulti(cyclemanager.CompactionCycleTicker()),
 	}
 
 	return s, s.init()
@@ -89,7 +92,7 @@ func (s *Store) init() error {
 	if err := os.MkdirAll(s.dir, 0o700); err != nil {
 		return err
 	}
-
+	s.compactionCycle.Start()
 	return nil
 }
 
@@ -115,7 +118,8 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
 		return nil
 	}
 
-	b, err := NewBucket(ctx, s.bucketDir(bucketName), s.rootDir, s.logger, s.metrics, opts...)
+	b, err := NewBucket(ctx, s.bucketDir(bucketName), s.rootDir, s.logger, s.metrics,
+		s.compactionCycle, opts...)
 	if err != nil {
 		return err
 	}
@@ -175,19 +179,6 @@ type jobFunc func(context.Context, *Bucket) (interface{}, error)
 
 type rollbackFunc func(context.Context, *Bucket) error
 
-func (s *Store) PauseCompaction(ctx context.Context) error {
-	pauseCompaction := func(ctx context.Context, b *Bucket) (interface{}, error) {
-		return nil, b.PauseCompaction(ctx)
-	}
-
-	resumeCompaction := func(ctx context.Context, b *Bucket) error {
-		return b.ResumeCompaction(ctx)
-	}
-
-	_, err := s.runJobOnBuckets(ctx, pauseCompaction, resumeCompaction)
-	return err
-}
-
 func (s *Store) FlushMemtables(ctx context.Context) error {
 	flushMemtable := func(ctx context.Context, b *Bucket) (interface{}, error) {
 		return nil, b.FlushMemtable(ctx)
@@ -213,19 +204,6 @@ func (s *Store) ListFiles(ctx context.Context) ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (s *Store) ResumeCompaction(ctx context.Context) error {
-	resumeCompaction := func(ctx context.Context, b *Bucket) (interface{}, error) {
-		return nil, b.ResumeCompaction(ctx)
-	}
-
-	pauseCompaction := func(ctx context.Context, b *Bucket) error {
-		return b.PauseCompaction(ctx)
-	}
-
-	_, err := s.runJobOnBuckets(ctx, resumeCompaction, pauseCompaction)
-	return err
 }
 
 // runJobOnBuckets applies a jobFunc to each bucket in the store in parallel.
@@ -312,7 +290,8 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 		return errors.Wrapf(err, "failed removing bucket %s files", bucketName)
 	}
 
-	b, err := NewBucket(ctx, bucketDir, s.rootDir, s.logger, s.metrics, opts...)
+	b, err := NewBucket(ctx, bucketDir, s.rootDir, s.logger, s.metrics,
+		s.compactionCycle, opts...)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -1,0 +1,59 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// PauseCompaction waits for all ongoing compactions to finish,
+// then makes sure that no new compaction can be started.
+//
+// This is a preparatory stage for creating backups.
+//
+// A timeout should be specified for the input context as some
+// compactions are long-running, in which case it may be better
+// to fail the backup attempt and retry later, than to block
+// indefinitely.
+func (s *Store) PauseCompaction(ctx context.Context) error {
+	if err := s.compactionCycle.StopAndWait(ctx); err != nil {
+		return errors.Wrap(err, "long-running compaction in progress")
+	}
+
+	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
+	for _, b := range s.bucketsByName {
+		if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(b.dir); err == nil {
+			b.pauseTimer = prometheus.NewTimer(metric)
+		}
+	}
+
+	return nil
+}
+
+// ResumeCompaction starts the compaction cycle again.
+// It errors if compactions were not paused
+func (s *Store) ResumeCompaction(ctx context.Context) error {
+	s.compactionCycle.Start()
+
+	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
+	for _, b := range s.bucketsByName {
+		if b.pauseTimer != nil {
+			b.pauseTimer.ObserveDuration()
+		}
+	}
+
+	return nil
+}

--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -57,3 +57,25 @@ func (s *Store) ResumeCompaction(ctx context.Context) error {
 
 	return nil
 }
+
+// FlushMemtable flushes any active memtable and returns only once the memtable
+// has been fully flushed and a stable state on disk has been reached.
+//
+// This is a preparatory stage for creating backups.
+//
+// A timeout should be specified for the input context as some
+// flushes are long-running, in which case it may be better
+// to fail the backup attempt and retry later, than to block
+// indefinitely.
+func (s *Store) FlushMemtables(ctx context.Context) error {
+	if err := s.flushCycle.StopAndWait(ctx); err != nil {
+		return errors.Wrap(err, "long-running memtable flush in progress")
+	}
+	defer s.flushCycle.Start()
+
+	flushMemtable := func(ctx context.Context, b *Bucket) (interface{}, error) {
+		return nil, b.FlushMemtable()
+	}
+	_, err := s.runJobOnBuckets(ctx, flushMemtable, nil)
+	return err
+}

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -1,0 +1,112 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackup_PauseCompaction(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	t.Run("assert that context timeout works for long compactions", func(t *testing.T) {
+		dirName := t.TempDir()
+
+		store, err := New(dirName, "", logger, nil)
+		require.Nil(t, err)
+
+		err = store.CreateOrLoadBucket(ctx, "test_bucket")
+		require.Nil(t, err)
+
+		canceledCtx, cancel := context.WithTimeout(ctx, time.Nanosecond)
+		defer cancel()
+
+		err = store.PauseCompaction(canceledCtx)
+		require.NotNil(t, err)
+		assert.Equal(t, "long-running compaction in progress: context deadline exceeded", err.Error())
+
+		err = store.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+
+	t.Run("assert compaction is successfully paused", func(t *testing.T) {
+		dirName := t.TempDir()
+
+		store, err := New(dirName, "", logger, nil)
+		require.Nil(t, err)
+
+		err = store.CreateOrLoadBucket(ctx, "test_bucket")
+		require.Nil(t, err)
+
+		cancelableCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		t.Run("insert contents into bucket", func(t *testing.T) {
+			bucket := store.Bucket("test_bucket")
+			for i := 0; i < 10; i++ {
+				err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+				require.Nil(t, err)
+			}
+		})
+
+		err = store.PauseCompaction(cancelableCtx)
+		assert.Nil(t, err)
+
+		err = store.Shutdown(context.Background())
+		require.Nil(t, err)
+	})
+}
+
+func TestBackup_ResumeCompaction(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	t.Run("assert compaction restarts after pausing", func(t *testing.T) {
+		dirName := t.TempDir()
+
+		store, err := New(dirName, "", logger, nil)
+		require.Nil(t, err)
+
+		err = store.CreateOrLoadBucket(ctx, "test_bucket")
+		require.Nil(t, err)
+
+		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		t.Run("insert contents into bucket", func(t *testing.T) {
+			bucket := store.Bucket("test_bucket")
+			for i := 0; i < 10; i++ {
+				err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+				require.Nil(t, err)
+			}
+		})
+
+		err = store.PauseCompaction(cancelableCtx)
+		require.Nil(t, err)
+
+		err = store.ResumeCompaction(ctx)
+		require.Nil(t, err)
+
+		assert.True(t, store.compactionCycle.Running())
+
+		err = store.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+}

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -17,19 +17,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
-func TestBackup_PauseCompaction(t *testing.T) {
+func TestStoreBackup_PauseCompaction(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
 	t.Run("assert that context timeout works for long compactions", func(t *testing.T) {
 		dirName := t.TempDir()
 
-		store, err := New(dirName, "", logger, nil)
+		store, err := New(dirName, dirName, logger, nil)
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(ctx, "test_bucket")
@@ -49,7 +51,7 @@ func TestBackup_PauseCompaction(t *testing.T) {
 	t.Run("assert compaction is successfully paused", func(t *testing.T) {
 		dirName := t.TempDir()
 
-		store, err := New(dirName, "", logger, nil)
+		store, err := New(dirName, dirName, logger, nil)
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(ctx, "test_bucket")
@@ -74,21 +76,18 @@ func TestBackup_PauseCompaction(t *testing.T) {
 	})
 }
 
-func TestBackup_ResumeCompaction(t *testing.T) {
+func TestStoreBackup_ResumeCompaction(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
 	t.Run("assert compaction restarts after pausing", func(t *testing.T) {
 		dirName := t.TempDir()
 
-		store, err := New(dirName, "", logger, nil)
+		store, err := New(dirName, dirName, logger, nil)
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(ctx, "test_bucket")
 		require.Nil(t, err)
-
-		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
 
 		t.Run("insert contents into bucket", func(t *testing.T) {
 			bucket := store.Bucket("test_bucket")
@@ -98,6 +97,9 @@ func TestBackup_ResumeCompaction(t *testing.T) {
 			}
 		})
 
+		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
 		err = store.PauseCompaction(cancelableCtx)
 		require.Nil(t, err)
 
@@ -105,6 +107,81 @@ func TestBackup_ResumeCompaction(t *testing.T) {
 		require.Nil(t, err)
 
 		assert.True(t, store.compactionCycle.Running())
+
+		err = store.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+}
+
+func TestStoreBackup_FlushMemtable(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	t.Run("assert that context timeout works for long flushes", func(t *testing.T) {
+		dirName := t.TempDir()
+
+		store, err := New(dirName, dirName, logger, nil)
+		require.Nil(t, err)
+
+		err = store.CreateOrLoadBucket(ctx, "test_bucket")
+		require.Nil(t, err)
+
+		canceledCtx, cancel := context.WithTimeout(ctx, time.Nanosecond)
+		defer cancel()
+
+		err = store.FlushMemtables(canceledCtx)
+		require.NotNil(t, err)
+		assert.Equal(t, "long-running memtable flush in progress: context deadline exceeded", err.Error())
+
+		err = store.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+
+	t.Run("assert that flushes run successfully", func(t *testing.T) {
+		dirName := t.TempDir()
+
+		store, err := New(dirName, dirName, logger, nil)
+		require.Nil(t, err)
+
+		err = store.CreateOrLoadBucket(ctx, "test_bucket")
+		require.Nil(t, err)
+
+		t.Run("insert contents into bucket", func(t *testing.T) {
+			bucket := store.Bucket("test_bucket")
+			for i := 0; i < 10; i++ {
+				err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+				require.Nil(t, err)
+			}
+		})
+
+		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err = store.FlushMemtables(cancelableCtx)
+		assert.Nil(t, err)
+
+		err = store.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+
+	t.Run("assert that readonly bucket fails to flush", func(t *testing.T) {
+		dirName := t.TempDir()
+
+		store, err := New(dirName, dirName, logger, nil)
+		require.Nil(t, err)
+
+		err = store.CreateOrLoadBucket(ctx, "test_bucket")
+		require.Nil(t, err)
+
+		store.UpdateBucketsStatus(storagestate.StatusReadOnly)
+
+		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err = store.FlushMemtables(cancelableCtx)
+		require.NotNil(t, err)
+		expectedErr := errors.Wrap(storagestate.ErrStatusReadOnly, "flush memtable")
+		assert.EqualError(t, expectedErr, err.Error())
 
 		err = store.Shutdown(ctx)
 		require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
@@ -29,50 +30,70 @@ func TestStoreBackup_PauseCompaction(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("assert that context timeout works for long compactions", func(t *testing.T) {
-		dirName := t.TempDir()
+		for _, buckets := range [][]string{
+			{"test_bucket"},
+			{"test_bucket1", "test_bucket2"},
+			{"test_bucket1", "test_bucket2", "test_bucket3", "test_bucket4", "test_bucket5"},
+		} {
+			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
+				dirName := t.TempDir()
 
-		store, err := New(dirName, dirName, logger, nil)
-		require.Nil(t, err)
+				store, err := New(dirName, dirName, logger, nil)
+				require.Nil(t, err)
 
-		err = store.CreateOrLoadBucket(ctx, "test_bucket")
-		require.Nil(t, err)
+				for _, bucket := range buckets {
+					err = store.CreateOrLoadBucket(ctx, bucket)
+					require.Nil(t, err)
+				}
 
-		canceledCtx, cancel := context.WithTimeout(ctx, time.Nanosecond)
-		defer cancel()
+				expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
+				defer cancel()
 
-		err = store.PauseCompaction(canceledCtx)
-		require.NotNil(t, err)
-		assert.Equal(t, "long-running compaction in progress: context deadline exceeded", err.Error())
+				err = store.PauseCompaction(expiredCtx)
+				require.NotNil(t, err)
+				assert.Equal(t, "long-running compaction in progress: context deadline exceeded", err.Error())
 
-		err = store.Shutdown(ctx)
-		require.Nil(t, err)
+				err = store.Shutdown(ctx)
+				require.Nil(t, err)
+			})
+		}
 	})
 
 	t.Run("assert compaction is successfully paused", func(t *testing.T) {
-		dirName := t.TempDir()
+		for _, buckets := range [][]string{
+			{"test_bucket"},
+			{"test_bucket1", "test_bucket2"},
+			{"test_bucket1", "test_bucket2", "test_bucket3", "test_bucket4", "test_bucket5"},
+		} {
+			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
+				dirName := t.TempDir()
 
-		store, err := New(dirName, dirName, logger, nil)
-		require.Nil(t, err)
-
-		err = store.CreateOrLoadBucket(ctx, "test_bucket")
-		require.Nil(t, err)
-
-		cancelableCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-		defer cancel()
-
-		t.Run("insert contents into bucket", func(t *testing.T) {
-			bucket := store.Bucket("test_bucket")
-			for i := 0; i < 10; i++ {
-				err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+				store, err := New(dirName, dirName, logger, nil)
 				require.Nil(t, err)
-			}
-		})
 
-		err = store.PauseCompaction(cancelableCtx)
-		assert.Nil(t, err)
+				for _, bucket := range buckets {
+					err = store.CreateOrLoadBucket(ctx, bucket)
+					require.Nil(t, err)
 
-		err = store.Shutdown(context.Background())
-		require.Nil(t, err)
+					t.Run("insert contents into bucket", func(t *testing.T) {
+						bucket := store.Bucket(bucket)
+						for i := 0; i < 10; i++ {
+							err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+							require.Nil(t, err)
+						}
+					})
+				}
+
+				expirableCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+				defer cancel()
+
+				err = store.PauseCompaction(expirableCtx)
+				assert.Nil(t, err)
+
+				err = store.Shutdown(context.Background())
+				require.Nil(t, err)
+			})
+		}
 	})
 }
 
@@ -81,35 +102,45 @@ func TestStoreBackup_ResumeCompaction(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("assert compaction restarts after pausing", func(t *testing.T) {
-		dirName := t.TempDir()
+		for _, buckets := range [][]string{
+			{"test_bucket"},
+			{"test_bucket1", "test_bucket2"},
+			{"test_bucket1", "test_bucket2", "test_bucket3", "test_bucket4", "test_bucket5"},
+		} {
+			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
+				dirName := t.TempDir()
 
-		store, err := New(dirName, dirName, logger, nil)
-		require.Nil(t, err)
-
-		err = store.CreateOrLoadBucket(ctx, "test_bucket")
-		require.Nil(t, err)
-
-		t.Run("insert contents into bucket", func(t *testing.T) {
-			bucket := store.Bucket("test_bucket")
-			for i := 0; i < 10; i++ {
-				err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+				store, err := New(dirName, dirName, logger, nil)
 				require.Nil(t, err)
-			}
-		})
 
-		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
+				for _, bucket := range buckets {
+					err = store.CreateOrLoadBucket(ctx, bucket)
+					require.Nil(t, err)
 
-		err = store.PauseCompaction(cancelableCtx)
-		require.Nil(t, err)
+					t.Run("insert contents into bucket", func(t *testing.T) {
+						bucket := store.Bucket(bucket)
+						for i := 0; i < 10; i++ {
+							err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+							require.Nil(t, err)
+						}
+					})
+				}
 
-		err = store.ResumeCompaction(ctx)
-		require.Nil(t, err)
+				expirableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
 
-		assert.True(t, store.compactionCycle.Running())
+				err = store.PauseCompaction(expirableCtx)
+				require.Nil(t, err)
 
-		err = store.Shutdown(ctx)
-		require.Nil(t, err)
+				err = store.ResumeCompaction(expirableCtx)
+				require.Nil(t, err)
+
+				assert.True(t, store.compactionCycle.Running())
+
+				err = store.Shutdown(ctx)
+				require.Nil(t, err)
+			})
+		}
 	})
 }
 
@@ -118,72 +149,113 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("assert that context timeout works for long flushes", func(t *testing.T) {
-		dirName := t.TempDir()
+		for _, buckets := range [][]string{
+			{"test_bucket"},
+			{"test_bucket1", "test_bucket2"},
+			{"test_bucket1", "test_bucket2", "test_bucket3", "test_bucket4", "test_bucket5"},
+		} {
+			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
+				dirName := t.TempDir()
 
-		store, err := New(dirName, dirName, logger, nil)
-		require.Nil(t, err)
+				store, err := New(dirName, dirName, logger, nil)
+				require.Nil(t, err)
 
-		err = store.CreateOrLoadBucket(ctx, "test_bucket")
-		require.Nil(t, err)
+				for _, bucket := range buckets {
+					err = store.CreateOrLoadBucket(ctx, bucket)
+					require.Nil(t, err)
+				}
 
-		canceledCtx, cancel := context.WithTimeout(ctx, time.Nanosecond)
-		defer cancel()
+				expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
+				defer cancel()
 
-		err = store.FlushMemtables(canceledCtx)
-		require.NotNil(t, err)
-		assert.Equal(t, "long-running memtable flush in progress: context deadline exceeded", err.Error())
+				err = store.FlushMemtables(expiredCtx)
+				require.NotNil(t, err)
+				assert.Equal(t, "long-running memtable flush in progress: context deadline exceeded", err.Error())
 
-		err = store.Shutdown(ctx)
-		require.Nil(t, err)
+				err = store.Shutdown(ctx)
+				require.Nil(t, err)
+			})
+		}
 	})
 
 	t.Run("assert that flushes run successfully", func(t *testing.T) {
-		dirName := t.TempDir()
+		for _, buckets := range [][]string{
+			{"test_bucket"},
+			{"test_bucket1", "test_bucket2"},
+			{"test_bucket1", "test_bucket2", "test_bucket3", "test_bucket4", "test_bucket5"},
+		} {
+			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
+				dirName := t.TempDir()
 
-		store, err := New(dirName, dirName, logger, nil)
-		require.Nil(t, err)
-
-		err = store.CreateOrLoadBucket(ctx, "test_bucket")
-		require.Nil(t, err)
-
-		t.Run("insert contents into bucket", func(t *testing.T) {
-			bucket := store.Bucket("test_bucket")
-			for i := 0; i < 10; i++ {
-				err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+				store, err := New(dirName, dirName, logger, nil)
 				require.Nil(t, err)
-			}
-		})
 
-		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
+				err = store.CreateOrLoadBucket(ctx, "test_bucket")
+				require.Nil(t, err)
 
-		err = store.FlushMemtables(cancelableCtx)
-		assert.Nil(t, err)
+				for _, bucket := range buckets {
+					err = store.CreateOrLoadBucket(ctx, bucket)
+					require.Nil(t, err)
 
-		err = store.Shutdown(ctx)
-		require.Nil(t, err)
+					t.Run("insert contents into bucket", func(t *testing.T) {
+						bucket := store.Bucket(bucket)
+						for i := 0; i < 10; i++ {
+							err := bucket.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+							require.Nil(t, err)
+						}
+					})
+				}
+
+				expirableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+
+				err = store.FlushMemtables(expirableCtx)
+				assert.Nil(t, err)
+
+				err = store.Shutdown(ctx)
+				require.Nil(t, err)
+			})
+		}
 	})
 
 	t.Run("assert that readonly bucket fails to flush", func(t *testing.T) {
-		dirName := t.TempDir()
+		singleErr := errors.Wrap(storagestate.ErrStatusReadOnly, "flush memtable")
+		expectedErr := func(bucketsCount int) error {
+			ec := &errorcompounder.ErrorCompounder{}
+			for i := 0; i < bucketsCount; i++ {
+				ec.Add(singleErr)
+			}
+			return ec.ToError()
+		}
 
-		store, err := New(dirName, dirName, logger, nil)
-		require.Nil(t, err)
+		for _, buckets := range [][]string{
+			{"test_bucket"},
+			{"test_bucket1", "test_bucket2"},
+			{"test_bucket1", "test_bucket2", "test_bucket3", "test_bucket4", "test_bucket5"},
+		} {
+			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
+				dirName := t.TempDir()
 
-		err = store.CreateOrLoadBucket(ctx, "test_bucket")
-		require.Nil(t, err)
+				store, err := New(dirName, dirName, logger, nil)
+				require.Nil(t, err)
 
-		store.UpdateBucketsStatus(storagestate.StatusReadOnly)
+				for _, bucket := range buckets {
+					err = store.CreateOrLoadBucket(ctx, bucket)
+					require.Nil(t, err)
+				}
 
-		cancelableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
+				store.UpdateBucketsStatus(storagestate.StatusReadOnly)
 
-		err = store.FlushMemtables(cancelableCtx)
-		require.NotNil(t, err)
-		expectedErr := errors.Wrap(storagestate.ErrStatusReadOnly, "flush memtable")
-		assert.EqualError(t, expectedErr, err.Error())
+				expirableCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
 
-		err = store.Shutdown(ctx)
-		require.Nil(t, err)
+				err = store.FlushMemtables(expirableCtx)
+				require.NotNil(t, err)
+				assert.EqualError(t, expectedErr(len(buckets)), err.Error())
+
+				err = store.Shutdown(ctx)
+				require.Nil(t, err)
+			})
+		}
 	})
 }

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -32,7 +32,8 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -122,7 +123,8 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -216,7 +218,8 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -313,7 +316,8 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -375,7 +379,8 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
 			row1Updated := []MapPair{
@@ -418,7 +423,8 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -512,7 +518,8 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -614,7 +621,8 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with memtable only, then an orderly shutdown and restart", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -680,7 +688,8 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
 			row1Updated := []MapPair{
@@ -721,7 +730,8 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -908,7 +918,8 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
@@ -31,7 +32,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -121,7 +122,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -215,7 +216,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -312,7 +313,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -374,7 +375,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				WithStrategy(StrategyMapCollection))
+				cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
 			row1Updated := []MapPair{
@@ -417,7 +418,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -511,7 +512,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -613,7 +614,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with memtable only, then an orderly shutdown and restart", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -679,7 +680,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				WithStrategy(StrategyMapCollection))
+				cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
 			row1Updated := []MapPair{
@@ -720,7 +721,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -907,7 +908,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyMapCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -32,7 +32,8 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -95,7 +96,8 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -165,7 +167,8 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("with a flush after the initial write and after the update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -235,7 +238,8 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -287,7 +291,8 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
 			key1 := []byte("key-1")
@@ -319,7 +324,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1),
 		)
 		require.Nil(t, err)
@@ -412,7 +417,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -472,7 +477,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("with a flush after initial write and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -543,7 +548,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("update in memtable then do an orderly shutdown and reinit", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(),
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -589,7 +594,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 		t.Run("init a new one and verify", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewNoop(),
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 				WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 			require.Nil(t, err)
 
@@ -620,7 +625,8 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -671,7 +677,8 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -726,7 +733,8 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes after initial write and delete", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -789,7 +797,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1023,7 +1032,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1116,7 +1126,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1409,7 +1420,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
@@ -31,7 +32,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -93,7 +94,8 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 	})
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
-		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil, WithStrategy(StrategyReplace))
+		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -163,7 +165,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("with a flush after the initial write and after the update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -233,7 +235,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -285,7 +287,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				WithStrategy(StrategyReplace))
+				cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
 			key1 := []byte("key-1")
@@ -317,8 +319,8 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace),
-			WithSecondaryIndices(1),
+			cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace), WithSecondaryIndices(1),
 		)
 		require.Nil(t, err)
 
@@ -410,8 +412,8 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace),
-			WithSecondaryIndices(1))
+			cyclemanager.NewNoop(),
+			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -470,6 +472,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("with a flush after initial write and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -540,6 +543,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("update in memtable then do an orderly shutdown and reinit", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -585,6 +589,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 		t.Run("init a new one and verify", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+				cyclemanager.NewNoop(),
 				WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 			require.Nil(t, err)
 
@@ -615,7 +620,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -666,7 +671,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -721,7 +726,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes after initial write and delete", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -784,7 +789,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1017,7 +1022,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
 		dirName := t.TempDir()
 
-		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil, WithStrategy(StrategyReplace))
+		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1110,7 +1116,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1403,7 +1409,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyReplace))
+			cyclemanager.NewNoop(), WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
@@ -29,7 +30,7 @@ func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyRoaringSet))
+			cyclemanager.NewNoop(), WithStrategy(StrategyRoaringSet))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -104,7 +105,7 @@ func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with a single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategyRoaringSet))
+			cyclemanager.NewNoop(), WithStrategy(StrategyRoaringSet))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
@@ -30,7 +30,8 @@ func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyRoaringSet))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyRoaringSet))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -105,7 +106,8 @@ func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with a single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategyRoaringSet))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategyRoaringSet))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
@@ -31,7 +32,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -90,7 +91,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -153,7 +154,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -218,7 +219,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -280,7 +281,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				WithStrategy(StrategySetCollection))
+				cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
 			orig1 := [][]byte{[]byte("value 1.1"), []byte("value 1.2")}
@@ -308,7 +309,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -404,7 +405,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -504,7 +505,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes in between and after the update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -613,7 +614,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 	t.Run("update in memtable, make orderly shutdown, then create a new bucket from disk",
 		func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				WithStrategy(StrategySetCollection))
+				cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -661,7 +662,8 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 			})
 
 			t.Run("init another bucket on the same files", func(t *testing.T) {
-				b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil, WithStrategy(StrategySetCollection))
+				b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
+					cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 				require.Nil(t, err)
 
 				expected1 := [][]byte{[]byte("value 1.1"), []byte("value 1.2")} // unchanged
@@ -687,7 +689,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -815,7 +817,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -32,7 +32,8 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -91,7 +92,8 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -154,7 +156,8 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -219,7 +222,8 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -281,7 +285,8 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
 			orig1 := [][]byte{[]byte("value 1.1"), []byte("value 1.2")}
@@ -309,7 +314,8 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -405,7 +411,8 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -505,7 +512,8 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes in between and after the update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -614,7 +622,8 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 	t.Run("update in memtable, make orderly shutdown, then create a new bucket from disk",
 		func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+				cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test
@@ -663,7 +672,8 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			t.Run("init another bucket on the same files", func(t *testing.T) {
 				b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+					cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+					WithStrategy(StrategySetCollection))
 				require.Nil(t, err)
 
 				expected1 := [][]byte{[]byte("value 1.1"), []byte("value 1.2")} // unchanged
@@ -689,7 +699,8 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -817,7 +828,8 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewNoop(), WithStrategy(StrategySetCollection))
+			cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -152,11 +152,8 @@ func (s *Shard) initVectorIndex(
 		ShardName:         s.name,
 		ClassName:         s.index.Config.ClassName.String(),
 		PrometheusMetrics: s.promMetrics,
-		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
-			return hnsw.NewCommitLogger(s.index.Config.RootPath, s.ID(), s.index.logger)
-		},
-		VectorForIDThunk: s.vectorByIndexID,
-		DistanceProvider: distProv,
+		VectorForIDThunk:  s.vectorByIndexID,
+		DistanceProvider:  distProv,
 	}, hnswUserConfig)
 	if err != nil {
 		return errors.Wrapf(err, "init shard %q: hnsw index", s.ID())

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -38,7 +38,7 @@ func (s *Shard) beginBackup(ctx context.Context) (err error) {
 	if err = s.store.FlushMemtables(ctx); err != nil {
 		return errors.Wrap(err, "flush memtables")
 	}
-	if err = s.vectorIndex.PauseMaintenance(ctx); err != nil {
+	if err = s.vectorCycles.PauseMaintenance(ctx); err != nil {
 		return errors.Wrap(err, "pause maintenance")
 	}
 	if err = s.vectorIndex.SwitchCommitLogs(ctx); err != nil {
@@ -70,9 +70,8 @@ func (s *Shard) resumeMaintenanceCycles(ctx context.Context) error {
 	g.Go(func() error {
 		return s.store.ResumeCompaction(ctx)
 	})
-
 	g.Go(func() error {
-		return s.vectorIndex.ResumeMaintenance(ctx)
+		return s.vectorCycles.ResumeMaintenance(ctx)
 	})
 
 	if err := g.Wait(); err != nil {

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -25,13 +25,17 @@ import (
 )
 
 func (s *Shard) initGeoProp(prop *models.Property) error {
+	// safe to call Start() even if cycle is already running
+	// started only if at least one geo prop is indexed
+	s.geoCommitlogMaintenanceCycle.Start()
+
 	idx, err := geo.NewIndex(geo.Config{
 		ID:                 geoPropID(s.ID(), prop.Name),
 		RootPath:           s.index.Config.RootPath,
 		CoordinatesForID:   s.makeCoordinatesForID(prop.Name),
 		DisablePersistence: false,
 		Logger:             s.index.logger,
-	})
+	}, s.geoCommitlogMaintenanceCycle)
 	if err != nil {
 		return errors.Wrapf(err, "create geo index for prop %q", prop.Name)
 	}

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -57,19 +57,20 @@ type Config struct {
 	Logger             logrus.FieldLogger
 }
 
-func NewIndex(config Config, commitlogMaintenanceCycle cyclemanager.CycleManager,
+func NewIndex(config Config, tombstoneCleanupCycle cyclemanager.CycleManager,
+	commitLogMaintenanceCycle cyclemanager.CycleManager,
 ) (*Index, error) {
 	vi, err := hnsw.New(hnsw.Config{
 		VectorForIDThunk:      config.CoordinatesForID.VectorForID,
 		ID:                    config.ID,
 		RootPath:              config.RootPath,
-		MakeCommitLoggerThunk: makeCommitLoggerFromConfig(config, commitlogMaintenanceCycle),
+		MakeCommitLoggerThunk: makeCommitLoggerFromConfig(config, commitLogMaintenanceCycle),
 		DistanceProvider:      distancer.NewGeoProvider(),
 	}, hnswent.UserConfig{
 		MaxConnections:         64,
 		EFConstruction:         128,
 		CleanupIntervalSeconds: hnswent.DefaultCleanupIntervalSeconds,
-	})
+	}, tombstoneCleanupCycle)
 	if err != nil {
 		return nil, errors.Wrap(err, "underlying hnsw index")
 	}

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -98,8 +98,11 @@ func makeCommitLoggerFromConfig(config Config) hnsw.MakeCommitLogger {
 	makeCL := hnsw.MakeNoopCommitLogger
 	if !config.DisablePersistence {
 		makeCL = func() (hnsw.CommitLogger, error) {
-			return hnsw.NewCommitLogger(config.RootPath, config.ID, config.Logger,
-				hnsw.WithCommitlogCycleTicker(cyclemanager.GeoCommitLoggerCycleTicker))
+			// TODO common_cycle_manager make common
+			maintenanceCycle := cyclemanager.NewMulti(cyclemanager.GeoCommitLoggerCycleTicker())
+			maintenanceCycle.Start()
+
+			return hnsw.NewCommitLogger(config.RootPath, config.ID, config.Logger, maintenanceCycle)
 		}
 	}
 	return makeCL

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -42,7 +43,7 @@ func TestGeoJourney(t *testing.T) {
 		CoordinatesForID:   getCoordinates,
 		DisablePersistence: true,
 		RootPath:           "doesnt-matter-persistence-is-off",
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	t.Run("importing all", func(t *testing.T) {

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -43,7 +43,7 @@ func TestGeoJourney(t *testing.T) {
 		CoordinatesForID:   getCoordinates,
 		DisablePersistence: true,
 		RootPath:           "doesnt-matter-persistence-is-off",
-	}, cyclemanager.NewNoop())
+	}, cyclemanager.NewNoop(), cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	t.Run("importing all", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/backup.go
+++ b/adapters/repos/db/vector/hnsw/backup.go
@@ -21,56 +21,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PauseMaintenance makes sure that no new background processes can be started.
-// If a Combining or Condensing operation is already ongoing, the method blocks
-// until the operation has either finished or the context expired
-//
-// If a Delete-Cleanup Cycle is running (TombstoneCleanupCycle), it is aborted,
-// as it's not feasible to wait for such a cycle to complete, as it can take hours.
-func (h *hnsw) PauseMaintenance(ctx context.Context) error {
-	maintenanceCycleStop := make(chan error)
-	cleanupCycleStop := make(chan error)
-
-	go func() {
-		if err := h.commitLogMaintenanceCycle.StopAndWait(ctx); err != nil {
-			maintenanceCycleStop <- errors.Wrap(ctx.Err(), "long-running commitlog maintenance in progress")
-			return
-		}
-		maintenanceCycleStop <- nil
-	}()
-
-	go func() {
-		if err := h.tombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-			cleanupCycleStop <- errors.Wrap(err, "long-running tombstone cleanup in progress")
-			return
-		}
-		cleanupCycleStop <- nil
-	}()
-
-	maintenanceCycleStopErr := <-maintenanceCycleStop
-	cleanupCycleStopErr := <-cleanupCycleStop
-
-	if maintenanceCycleStopErr != nil && cleanupCycleStopErr != nil {
-		return errors.Errorf("%s, %s", maintenanceCycleStopErr, cleanupCycleStopErr)
-	}
-
-	if maintenanceCycleStopErr != nil {
-		// restart tombstone cleanup since it was successfully stopped.
-		// both of these cycles must be either stopped or running.
-		h.tombstoneCleanupCycle.Start()
-		return maintenanceCycleStopErr
-	}
-
-	if cleanupCycleStopErr != nil {
-		// restart commitlog cycle since it was successfully stopped.
-		// both of these cycles must be either stopped or running.
-		h.commitLogMaintenanceCycle.Start()
-		return cleanupCycleStopErr
-	}
-
-	return nil
-}
-
 // SwitchCommitLogs makes sure that the previously writeable commitlog is
 // switched to a new one, thus making the existing file read-only.
 func (h *hnsw) SwitchCommitLogs(ctx context.Context) error {
@@ -139,12 +89,4 @@ func (h *hnsw) ListFiles(ctx context.Context) ([]string, error) {
 	}
 
 	return files, nil
-}
-
-// ResumeMaintenance starts all async cycles. It errors if the operations
-// had not been paused prior.
-func (h *hnsw) ResumeMaintenance(ctx context.Context) error {
-	h.tombstoneCleanupCycle.Start()
-	h.commitLogMaintenanceCycle.Start()
-	return nil
 }

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -34,18 +34,17 @@ func TestBackup_Integration(t *testing.T) {
 
 	indexID := "backup-integration-test"
 
-	dirName := makeTestDir(t)
+	dirName := t.TempDir()
 
 	idx, err := New(Config{
-		RootPath: dirName,
-		ID:       indexID,
-		MakeCommitLoggerThunk: func() (CommitLogger, error) {
-			return NewCommitLogger(dirName, indexID, logrus.New())
-		},
+		RootPath:         dirName,
+		ID:               indexID,
+		Logger:           logrus.New(),
 		DistanceProvider: distancer.NewCosineDistanceProvider(),
 		VectorForIDThunk: testVectorForID,
 	}, enthnsw.NewDefaultUserConfig())
 	require.Nil(t, err)
+	idx.PostStartup()
 
 	t.Run("insert vector into index", func(t *testing.T) {
 		for i := 0; i < 10; i++ {

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -26,15 +26,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 func TestBackup_Integration(t *testing.T) {
 	ctx := context.Background()
 
+	dirName := t.TempDir()
 	indexID := "backup-integration-test"
 
-	dirName := t.TempDir()
+	cycles := &MaintenanceCycles{}
+	cycles.Init(
+		cyclemanager.HnswCommitLoggerCycleTicker(),
+		cyclemanager.NewFixedIntervalTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second))
 
 	idx, err := New(Config{
 		RootPath:         dirName,
@@ -42,7 +47,10 @@ func TestBackup_Integration(t *testing.T) {
 		Logger:           logrus.New(),
 		DistanceProvider: distancer.NewCosineDistanceProvider(),
 		VectorForIDThunk: testVectorForID,
-	}, enthnsw.NewDefaultUserConfig())
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return NewCommitLogger(dirName, indexID, logrus.New(), cycles.CommitLogMaintenance())
+		},
+	}, enthnsw.NewDefaultUserConfig(), cycles.TombstoneCleanup())
 	require.Nil(t, err)
 	idx.PostStartup()
 
@@ -60,7 +68,7 @@ func TestBackup_Integration(t *testing.T) {
 	time.Sleep(time.Second)
 
 	t.Run("pause maintenance", func(t *testing.T) {
-		err = idx.PauseMaintenance(ctx)
+		err = cycles.PauseMaintenance(ctx)
 		require.Nil(t, err)
 	})
 
@@ -106,10 +114,13 @@ func TestBackup_Integration(t *testing.T) {
 	})
 
 	t.Run("resume maintenance", func(t *testing.T) {
-		err = idx.ResumeMaintenance(ctx)
+		err = cycles.ResumeMaintenance(ctx)
 		require.Nil(t, err)
 	})
 
 	err = idx.Shutdown(ctx)
+	require.Nil(t, err)
+
+	err = cycles.Shutdown(ctx)
 	require.Nil(t, err)
 }

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -271,8 +271,8 @@ type hnswCommitLogger struct {
 	maxSizeCombining  int64
 	commitLogger      *commitlog.Logger
 
-	switchLogCycle *cyclemanager.CycleManager
-	condenseCycle  *cyclemanager.CycleManager
+	switchLogCycle cyclemanager.CycleManager
+	condenseCycle  cyclemanager.CycleManager
 	cycleTicker    cyclemanager.TickerProvider
 }
 

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -41,7 +41,7 @@ func commitLogDirectory(rootPath, name string) string {
 }
 
 func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
-	opts ...CommitlogOption,
+	maintenanceCycle cyclemanager.CycleManager, opts ...CommitlogOption,
 ) (*hnswCommitLogger, error) {
 	l := &hnswCommitLogger{
 		rootPath:  rootPath,
@@ -52,24 +52,6 @@ func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
 		// both can be overwritten using functional options
 		maxSizeIndividual: defaultCommitLogSize / 5,
 		maxSizeCombining:  defaultCommitLogSize,
-
-		// Previously we had an interval of 10s in here, which was changed to
-		// 0.5s as part of gh-1867. There's really no way to wait so long in
-		// between checks: If you are running on a low-powered machine, the
-		// interval will simply find that there is no work and do nothing in
-		// each iteration. However, if you are running on a very powerful
-		// machine within 10s you could have potentially created two units of
-		// work, but we'll only be handling one every 10s. This means
-		// uncombined/uncondensed hnsw commit logs will keep piling up can only
-		// be processes long after the initial insert is complete. This also
-		// means that if there is a crash during importing a lot of work needs
-		// to be done at startup, since the commit logs still contain too many
-		// redundancies. So as of now it seems there are only advantages to
-		// running the cleanup checks and work much more often.
-		//
-		// update: switched to dynamic intervals with values between 500ms and 10s
-		// introduced to address https://github.com/weaviate/weaviate/issues/2783
-		cycleTicker: cyclemanager.HnswCommitLoggerCycleTicker,
 	}
 
 	for _, o := range opts {
@@ -83,13 +65,11 @@ func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
 		return nil, err
 	}
 
-	l.switchLogCycle = cyclemanager.NewMulti(l.cycleTicker())
-	l.switchLogCycle.Register(l.startSwitchLogs)
-	l.condenseCycle = cyclemanager.NewMulti(l.cycleTicker())
-	l.condenseCycle.Register(l.startCombineAndCondenseLogs)
+	l.unregisterSwitchLogs = maintenanceCycle.Register(l.startSwitchLogs)
+	l.unregisterCondenseLogs = maintenanceCycle.Register(l.startCombineAndCondenseLogs)
 
 	l.commitLogger = commitlog.NewLoggerWithFile(fd)
-	l.Start()
+
 	return l, nil
 }
 
@@ -271,9 +251,8 @@ type hnswCommitLogger struct {
 	maxSizeCombining  int64
 	commitLogger      *commitlog.Logger
 
-	switchLogCycle cyclemanager.CycleManager
-	condenseCycle  cyclemanager.CycleManager
-	cycleTicker    cyclemanager.TickerProvider
+	unregisterSwitchLogs   cyclemanager.UnregisterFunc
+	unregisterCondenseLogs cyclemanager.UnregisterFunc
 }
 
 type HnswCommitType uint8 // 256 options, plenty of room for future extensions
@@ -407,55 +386,16 @@ func (l *hnswCommitLogger) Reset() error {
 	return l.commitLogger.Reset()
 }
 
-func (l *hnswCommitLogger) Start() {
-	l.switchLogCycle.Start()
-	l.condenseCycle.Start()
-}
-
 // Shutdown waits for ongoing maintenance processes to stop, then cancels their
 // scheduling. The caller can be sure that state on disk is immutable after
 // calling Shutdown().
 func (l *hnswCommitLogger) Shutdown(ctx context.Context) error {
-	switchLogCycleStop := make(chan error)
-	condenseCycleStop := make(chan error)
-
-	go func() {
-		if err := l.switchLogCycle.StopAndWait(ctx); err != nil {
-			switchLogCycleStop <- errors.Wrap(err, "failed to stop commitlog switch cycle")
-			return
-		}
-		switchLogCycleStop <- nil
-	}()
-
-	go func() {
-		if err := l.condenseCycle.StopAndWait(ctx); err != nil {
-			condenseCycleStop <- errors.Wrap(err, "failed to stop commitlog condense cycle")
-			return
-		}
-		condenseCycleStop <- nil
-	}()
-
-	switchLogCycleStopErr := <-switchLogCycleStop
-	condenseCycleStopErr := <-condenseCycleStop
-
-	if switchLogCycleStopErr != nil && condenseCycleStopErr != nil {
-		return errors.Errorf("%s, %s", switchLogCycleStopErr, condenseCycleStopErr)
+	if err := l.unregisterSwitchLogs(ctx); err != nil {
+		return errors.Wrap(err, "failed to unregister commitlog switch from maintenance cycle")
 	}
-
-	if switchLogCycleStopErr != nil {
-		// restart condense cycle since it was successfully stopped.
-		// both of these cycles work together, and need to work in sync
-		l.condenseCycle.Start()
-		return switchLogCycleStopErr
+	if err := l.unregisterCondenseLogs(ctx); err != nil {
+		return errors.Wrap(err, "failed to unregister commitlog condense from maintenance cycle")
 	}
-
-	if condenseCycleStopErr != nil {
-		// restart switch log cycle since it was successfully stopped.
-		// both of these cycles work together, and need to work in sync
-		l.switchLogCycle.Start()
-		return condenseCycleStopErr
-	}
-
 	return nil
 }
 
@@ -610,8 +550,4 @@ func (l *hnswCommitLogger) Flush() error {
 	defer l.Unlock()
 
 	return l.commitLogger.Flush()
-}
-
-func (l *hnswCommitLogger) MaintenanceInProgress() bool {
-	return l.condenseCycle.Running() && l.switchLogCycle.Running()
 }

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -83,8 +83,10 @@ func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
 		return nil, err
 	}
 
-	l.switchLogCycle = cyclemanager.New(l.cycleTicker(), l.startSwitchLogs)
-	l.condenseCycle = cyclemanager.New(l.cycleTicker(), l.startCombineAndCondenseLogs)
+	l.switchLogCycle = cyclemanager.NewMulti(l.cycleTicker())
+	l.switchLogCycle.Register(l.startSwitchLogs)
+	l.condenseCycle = cyclemanager.NewMulti(l.cycleTicker())
+	l.condenseCycle.Register(l.startCombineAndCondenseLogs)
 
 	l.commitLogger = commitlog.NewLoggerWithFile(fd)
 	l.Start()

--- a/adapters/repos/db/vector/hnsw/commit_logger_functional_options.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_functional_options.go
@@ -11,8 +11,6 @@
 
 package hnsw
 
-import "github.com/weaviate/weaviate/entities/cyclemanager"
-
 type CommitlogOption func(l *hnswCommitLogger) error
 
 func WithCommitlogThreshold(size int64) CommitlogOption {
@@ -25,13 +23,6 @@ func WithCommitlogThreshold(size int64) CommitlogOption {
 func WithCommitlogThresholdForCombining(size int64) CommitlogOption {
 	return func(l *hnswCommitLogger) error {
 		l.maxSizeCombining = size
-		return nil
-	}
-}
-
-func WithCommitlogCycleTicker(cycleTicker cyclemanager.TickerProvider) CommitlogOption {
-	return func(l *hnswCommitLogger) error {
-		l.cycleTicker = cycleTicker
 		return nil
 	}
 }

--- a/adapters/repos/db/vector/hnsw/commit_logger_noop.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_noop.go
@@ -29,8 +29,6 @@ func (n *NoopCommitLogger) AddPQ(data ssdhelpers.PQData) error {
 	return nil
 }
 
-func (n *NoopCommitLogger) Start() {}
-
 func (n *NoopCommitLogger) AddNode(node *vertex) error {
 	return nil
 }
@@ -105,8 +103,4 @@ func (n *NoopCommitLogger) RootPath() string {
 
 func (n *NoopCommitLogger) SwitchCommitLogs(force bool) error {
 	return nil
-}
-
-func (n *NoopCommitLogger) MaintenanceInProgress() bool {
-	return false
 }

--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
@@ -59,7 +60,7 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				return vectors[int(id)], nil
 			},
-		}, uc,
+		}, uc, cyclemanager.NewNoop(),
 	)
 	ssdhelpers.Concurrently(uint64(len(vectors)), func(id uint64) {
 		index.Add(uint64(id), vectors[id])

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -36,12 +36,12 @@ func TestCondensor(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 
 	perfect, err := NewCommitLogger(rootPath, "perfect", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer perfect.Shutdown(ctx)
 
@@ -152,17 +152,17 @@ func TestCondensorAppendNodeLinks(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed1.Shutdown(ctx)
 
 	uncondensed2, err := NewCommitLogger(rootPath, "uncondensed2", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed2.Shutdown(ctx)
 
 	control, err := NewCommitLogger(rootPath, "control", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer control.Shutdown(ctx)
 
@@ -247,17 +247,17 @@ func TestCondensorReplaceNodeLinks(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed1.Shutdown(ctx)
 
 	uncondensed2, err := NewCommitLogger(rootPath, "uncondensed2", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed2.Shutdown(ctx)
 
 	control, err := NewCommitLogger(rootPath, "control", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer control.Shutdown(ctx)
 
@@ -347,17 +347,17 @@ func TestCondensorClearLinksAtLevel(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed1.Shutdown(ctx)
 
 	uncondensed2, err := NewCommitLogger(rootPath, "uncondensed2", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed2.Shutdown(ctx)
 
 	control, err := NewCommitLogger(rootPath, "control", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer control.Shutdown(ctx)
 
@@ -443,7 +443,7 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 

--- a/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
@@ -32,11 +32,11 @@ func TestMmapCondensor(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	perfect, err := NewCommitLogger(rootPath, "perfect", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	t.Run("add redundant data to the original log", func(t *testing.T) {
@@ -145,7 +145,7 @@ func TestMmapCondensor(t *testing.T) {
 
 // 	logger, _ := test.NewNullLogger()
 // 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-// 		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+// 		cyclemanager.NewNoop())
 // 	require.Nil(t, err)
 
 // 	t.Run("add data, but do not set an entrypoint", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -47,9 +47,9 @@ func (c Config) Validate() error {
 		ec.Addf("rootPath cannot be empty")
 	}
 
-	// if c.MakeCommitLoggerThunk == nil {
-	// 	ec.Addf("makeCommitLoggerThunk cannot be nil")
-	// }
+	if c.MakeCommitLoggerThunk == nil {
+		ec.Addf("makeCommitLoggerThunk cannot be nil")
+	}
 
 	if c.VectorForIDThunk == nil {
 		ec.Addf("vectorForIDThunk cannot be nil")

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -47,9 +47,9 @@ func (c Config) Validate() error {
 		ec.Addf("rootPath cannot be empty")
 	}
 
-	if c.MakeCommitLoggerThunk == nil {
-		ec.Addf("makeCommitLoggerThunk cannot be nil")
-	}
+	// if c.MakeCommitLoggerThunk == nil {
+	// 	ec.Addf("makeCommitLoggerThunk cannot be nil")
+	// }
 
 	if c.VectorForIDThunk == nil {
 		ec.Addf("vectorForIDThunk cannot be nil")

--- a/adapters/repos/db/vector/hnsw/config_test.go
+++ b/adapters/repos/db/vector/hnsw/config_test.go
@@ -48,14 +48,14 @@ func Test_InValidConfig(t *testing.T) {
 			},
 			expectedErr: errors.Errorf("rootPath cannot be empty"),
 		},
-		// {
-		// 	config: func() Config {
-		// 		v := validConfig()
-		// 		v.MakeCommitLoggerThunk = nil
-		// 		return v
-		// 	},
-		// 	expectedErr: errors.Errorf("makeCommitLoggerThunk cannot be nil"),
-		// },
+		{
+			config: func() Config {
+				v := validConfig()
+				v.MakeCommitLoggerThunk = nil
+				return v
+			},
+			expectedErr: errors.Errorf("makeCommitLoggerThunk cannot be nil"),
+		},
 		{
 			config: func() Config {
 				v := validConfig()

--- a/adapters/repos/db/vector/hnsw/config_test.go
+++ b/adapters/repos/db/vector/hnsw/config_test.go
@@ -48,14 +48,14 @@ func Test_InValidConfig(t *testing.T) {
 			},
 			expectedErr: errors.Errorf("rootPath cannot be empty"),
 		},
-		{
-			config: func() Config {
-				v := validConfig()
-				v.MakeCommitLoggerThunk = nil
-				return v
-			},
-			expectedErr: errors.Errorf("makeCommitLoggerThunk cannot be nil"),
-		},
+		// {
+		// 	config: func() Config {
+		// 		v := validConfig()
+		// 		v.MakeCommitLoggerThunk = nil
+		// 		return v
+		// 	},
+		// 	expectedErr: errors.Errorf("makeCommitLoggerThunk cannot be nil"),
+		// },
 		{
 			config: func() Config {
 				v := validConfig()

--- a/adapters/repos/db/vector/hnsw/debug.go
+++ b/adapters/repos/db/vector/hnsw/debug.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -121,7 +122,7 @@ func NewFromJSONDump(dumpBytes []byte, vecForID VectorForID) (*hnsw, error) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 128,
-	})
+	}, cyclemanager.NewNoop())
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func NewFromJSONDumpMap(dumpBytes []byte, vecForID VectorForID) (*hnsw, error) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 128,
-	})
+	}, cyclemanager.NewNoop())
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/storobj"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
@@ -49,7 +50,7 @@ func TestDelete_WithoutCleaningUpTombstones(t *testing.T) {
 			// zero it will constantly think it's full and needs to be deleted - even
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -142,7 +143,7 @@ func TestDelete_WithCleaningUpTombstonesOnce(t *testing.T) {
 			// zero it will constantly think it's full and needs to be deleted - even
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -255,7 +256,7 @@ func TestDelete_WithCleaningUpTombstonesInBetween(t *testing.T) {
 			// zero it will constantly think it's full and needs to be deleted - even
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
-		})
+		}, cyclemanager.NewNoop())
 		// makes sure index is build only with level 0. To be removed after fixing WEAVIATE-179
 		index.randFunc = func() float64 { return 0.1 }
 
@@ -373,7 +374,7 @@ func createIndexImportAllVectorsAndDeleteEven(t *testing.T, vectors [][]float32)
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	// makes sure index is build only with level 0. To be removed after fixing WEAVIATE-179
@@ -532,9 +533,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				return vectors[int(id)], nil
 			},
-		},
-			userConfig,
-		)
+		}, userConfig, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -659,9 +658,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				return vectors[int(id%uint64(len(vectors)))], nil
 			},
-		},
-			userConfig,
-		)
+		}, userConfig, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -848,7 +845,7 @@ func TestDelete_EntrypointIssues(t *testing.T) {
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	// manually build the index
@@ -991,7 +988,7 @@ func TestDelete_MoreEntrypointIssues(t *testing.T) {
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	// manually build the index
@@ -1066,7 +1063,7 @@ func TestDelete_TombstonedEntrypoint(t *testing.T) {
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	objVec := []float32{0.1, 0.2}
@@ -1237,7 +1234,7 @@ func Test_DeleteEPVecInUnderlyingObjectStore(t *testing.T) {
 			// zero it will constantly think it's full and needs to be deleted - even
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 

--- a/adapters/repos/db/vector/hnsw/dynamic_ef_test.go
+++ b/adapters/repos/db/vector/hnsw/dynamic_ef_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -90,7 +91,7 @@ func Test_DynamicEF(t *testing.T) {
 				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 					return nil, errors.Errorf("not implemented")
 				},
-			}, test.config)
+			}, test.config, cyclemanager.NewNoop())
 			require.Nil(t, err)
 
 			actualEF := index.searchTimeEF(test.limit)

--- a/adapters/repos/db/vector/hnsw/graph_integrity_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/graph_integrity_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -49,14 +50,10 @@ func TestGraphIntegrity(t *testing.T) {
 
 	t.Run("importing into hnsw", func(t *testing.T) {
 		fmt.Printf("importing into hnsw\n")
-		cl := &NoopCommitLogger{}
-		makeCL := func() (CommitLogger, error) {
-			return cl, nil
-		}
 		index, err := New(Config{
 			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
 			ID:                    "graphintegrity",
-			MakeCommitLoggerThunk: makeCL,
+			MakeCommitLoggerThunk: MakeNoopCommitLogger,
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				return vectors[int(id)], nil
 			},
@@ -64,7 +61,7 @@ func TestGraphIntegrity(t *testing.T) {
 		}, ent.UserConfig{
 			MaxConnections: maxNeighbors,
 			EFConstruction: efConstruction,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -620,17 +620,8 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 
 func (h *hnsw) Drop(ctx context.Context) error {
 	// cancel tombstone cleanup goroutine
-
-	// if the interval is 0 we never started a cleanup cycle, therefore there is
-	// no loop running that could receive our cancel and we would be stuck. Thus,
-	// only cancel if we know it's been started.
-	if h.cleanupInterval != 0 {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-
-		if err := h.tombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-			return errors.Wrap(err, "hnsw drop")
-		}
+	if err := h.tombstoneCleanupCycle.StopAndWait(ctx); err != nil {
+		return errors.Wrap(err, "hnsw drop")
 	}
 
 	if h.compressed.Load() {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -261,9 +261,8 @@ func New(cfg Config, uc ent.UserConfig) (*hnsw, error) {
 		className:          cfg.ClassName,
 	}
 
-	index.tombstoneCleanupCycle = cyclemanager.New(
-		cyclemanager.NewFixedIntervalTicker(index.cleanupInterval),
-		index.tombstoneCleanup)
+	index.tombstoneCleanupCycle = cyclemanager.NewMulti(cyclemanager.NewFixedIntervalTicker(index.cleanupInterval))
+	index.tombstoneCleanupCycle.Register(index.tombstoneCleanup)
 	index.insertMetrics = newInsertMetrics(index.metrics)
 
 	if err := index.init(cfg); err != nil {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -105,7 +105,7 @@ type hnsw struct {
 
 	// used for cancellation of the tombstone cleanup goroutine
 	cleanupInterval       time.Duration
-	tombstoneCleanupCycle *cyclemanager.CycleManager
+	tombstoneCleanupCycle cyclemanager.CycleManager
 
 	// // for distributed spike, can be used to call a insertExternal on a different graph
 	// insertHook func(node, targetLevel int, neighborsAtLevel map[int][]uint32)

--- a/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
@@ -69,7 +69,7 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 			MaxConnections:         100,
 			EFConstruction:         100,
 			CleanupIntervalSeconds: 0,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		index = idx
 	})
@@ -120,7 +120,7 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 			MaxConnections:         100,
 			EFConstruction:         100,
 			CleanupIntervalSeconds: 0,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		index = idx
 	})

--- a/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
@@ -37,7 +37,7 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	original, err := NewCommitLogger(rootPath, "corrupt_test", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	data := [][]float32{

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -128,17 +129,16 @@ func createEmptyHnswIndexForTests(t *testing.T, vecForIDFn VectorForID) *hnsw {
 	// footprint. Commit logging and deserializing from a (condensed) commit log
 	// is tested in a separate integration test that takes care of providing and
 	// cleaning up the correct place on disk to write test files
-	makeCL := MakeNoopCommitLogger
 	index, err := New(Config{
 		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
 		ID:                    "unittest",
-		MakeCommitLoggerThunk: makeCL,
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
 		DistanceProvider:      distancer.NewCosineDistanceProvider(),
 		VectorForIDThunk:      vecForIDFn,
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 	return index
 }

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -47,10 +47,12 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
-	original, err := NewCommitLogger(rootPath, "too_many_links_test", logger,
+	maintenanceCycle := cyclemanager.NewMulti(cyclemanager.NewFixedIntervalTicker(1))
+	maintenanceCycle.Start()
+
+	original, err := NewCommitLogger(rootPath, "too_many_links_test", logger, maintenanceCycle,
 		WithCommitlogThreshold(1e5),
-		WithCommitlogThresholdForCombining(5e5),
-		WithCommitlogCycleTicker(cyclemanager.FixedIntervalTickerProvider(1)))
+		WithCommitlogThresholdForCombining(5e5))
 	require.Nil(t, err)
 
 	data := make([][]float32, n)
@@ -194,5 +196,6 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 
 	t.Run("destroy the index", func(t *testing.T) {
 		require.Nil(t, index.Drop(context.Background()))
+		require.Nil(t, maintenanceCycle.StopAndWait(context.Background()))
 	})
 }

--- a/adapters/repos/db/vector/hnsw/maintenance_cycles.go
+++ b/adapters/repos/db/vector/hnsw/maintenance_cycles.go
@@ -1,0 +1,146 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"golang.org/x/sync/errgroup"
+)
+
+type MaintenanceCycles struct {
+	commitLogMaintenance cyclemanager.CycleManager
+	tombstoneCleanup     cyclemanager.CycleManager
+
+	lock sync.Mutex
+}
+
+func (c *MaintenanceCycles) Init(
+	commitlogMaintenanceTicker cyclemanager.CycleTicker,
+	tombstoneCleanupTicker cyclemanager.CycleTicker,
+) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.commitLogMaintenance == nil &&
+		c.tombstoneCleanup == nil {
+		c.commitLogMaintenance = cyclemanager.NewMulti(commitlogMaintenanceTicker)
+		c.tombstoneCleanup = cyclemanager.NewMulti(tombstoneCleanupTicker)
+
+		c.commitLogMaintenance.Start()
+		c.tombstoneCleanup.Start()
+	}
+}
+
+func (c *MaintenanceCycles) CommitLogMaintenance() cyclemanager.CycleManager {
+	return c.commitLogMaintenance
+}
+
+func (c *MaintenanceCycles) TombstoneCleanup() cyclemanager.CycleManager {
+	return c.tombstoneCleanup
+}
+
+// PauseMaintenance makes sure that no new background processes can be started.
+// If a Combining or Condensing operation is already ongoing, the method blocks
+// until the operation has either finished or the context expired
+//
+// If a Delete-Cleanup Cycle is running (TombstoneCleanupCycle), it is aborted,
+// as it's not feasible to wait for such a cycle to complete, as it can take hours.
+func (c *MaintenanceCycles) PauseMaintenance(ctx context.Context) error {
+	c.lock.Lock()
+	if c.commitLogMaintenance == nil &&
+		c.tombstoneCleanup == nil {
+		c.lock.Unlock()
+		return nil
+	}
+	c.lock.Unlock()
+
+	commitlogMaintenanceStop := make(chan error)
+	tombstoneCleanupStop := make(chan error)
+	go func() {
+		if err := c.commitLogMaintenance.StopAndWait(ctx); err != nil {
+			commitlogMaintenanceStop <- errors.Wrap(err, "long-running commitlog maintenance in progress")
+			return
+		}
+		commitlogMaintenanceStop <- nil
+	}()
+	go func() {
+		if err := c.tombstoneCleanup.StopAndWait(ctx); err != nil {
+			tombstoneCleanupStop <- errors.Wrap(err, "long-running tombstone cleanup in progress")
+			return
+		}
+		tombstoneCleanupStop <- nil
+	}()
+
+	commitlogMaintenanceStopErr := <-commitlogMaintenanceStop
+	tombstoneCleanupStopErr := <-tombstoneCleanupStop
+	if commitlogMaintenanceStopErr != nil && tombstoneCleanupStopErr != nil {
+		return errors.Errorf("%s, %s", commitlogMaintenanceStopErr, tombstoneCleanupStopErr)
+	}
+	if commitlogMaintenanceStopErr != nil {
+		// restart tombstone cleanup since it was successfully stopped.
+		// both of these cycles must be either stopped or running.
+		c.tombstoneCleanup.Start()
+		return commitlogMaintenanceStopErr
+	}
+	if tombstoneCleanupStopErr != nil {
+		// restart commitlog cycle since it was successfully stopped.
+		// both of these cycles must be either stopped or running.
+		c.commitLogMaintenance.Start()
+		return tombstoneCleanupStopErr
+	}
+
+	return nil
+}
+
+// ResumeMaintenance starts all async cycles.
+func (c *MaintenanceCycles) ResumeMaintenance(ctx context.Context) error {
+	c.lock.Lock()
+	if c.commitLogMaintenance == nil &&
+		c.tombstoneCleanup == nil {
+		c.lock.Unlock()
+		return nil
+	}
+	c.lock.Unlock()
+
+	c.commitLogMaintenance.Start()
+	c.tombstoneCleanup.Start()
+	return nil
+}
+
+func (c *MaintenanceCycles) Shutdown(ctx context.Context) error {
+	c.lock.Lock()
+	if c.commitLogMaintenance == nil &&
+		c.tombstoneCleanup == nil {
+		c.lock.Unlock()
+		return nil
+	}
+	c.lock.Unlock()
+
+	eg := errgroup.Group{}
+	eg.Go(func() error {
+		if err := c.commitLogMaintenance.StopAndWait(ctx); err != nil {
+			return errors.Wrap(err, "long-running commitlog maintenance in progress")
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		if err := c.tombstoneCleanup.StopAndWait(ctx); err != nil {
+			return errors.Wrap(err, "long-running tombstone cleanup in progress")
+		}
+		return nil
+	})
+	return eg.Wait()
+}

--- a/adapters/repos/db/vector/hnsw/maintenance_cycles_test.go
+++ b/adapters/repos/db/vector/hnsw/maintenance_cycles_test.go
@@ -1,0 +1,93 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestCycles_PauseMaintenance(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("assert that context timeout works for long maintenance cycle", func(t *testing.T) {
+		cycles := &MaintenanceCycles{}
+		cycles.Init(
+			cyclemanager.HnswCommitLoggerCycleTicker(),
+			cyclemanager.NewFixedIntervalTicker(time.Second))
+
+		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
+		defer cancel()
+
+		err := cycles.PauseMaintenance(expiredCtx)
+		require.NotNil(t, err)
+		assert.EqualError(t, err,
+			"long-running commitlog maintenance in progress: context deadline exceeded, "+
+				"long-running tombstone cleanup in progress: context deadline exceeded")
+
+		assert.True(t, cycles.CommitLogMaintenance().Running())
+		assert.True(t, cycles.TombstoneCleanup().Running())
+
+		err = cycles.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+
+	t.Run("assert maintenance is successfully paused", func(t *testing.T) {
+		cycles := &MaintenanceCycles{}
+		cycles.Init(
+			cyclemanager.HnswCommitLoggerCycleTicker(),
+			cyclemanager.NewFixedIntervalTicker(time.Second))
+
+		expireableCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		err := cycles.PauseMaintenance(expireableCtx)
+		require.Nil(t, err)
+
+		assert.False(t, cycles.CommitLogMaintenance().Running())
+		assert.False(t, cycles.TombstoneCleanup().Running())
+
+		err = cycles.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+}
+
+func TestBackup_ResumeMaintenance(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("assert cleanup restarts after pausing", func(t *testing.T) {
+		cycles := &MaintenanceCycles{}
+		cycles.Init(
+			cyclemanager.HnswCommitLoggerCycleTicker(),
+			cyclemanager.NewFixedIntervalTicker(time.Second))
+
+		expireableCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		err := cycles.PauseMaintenance(expireableCtx)
+		require.Nil(t, err)
+
+		err = cycles.ResumeMaintenance(expireableCtx)
+		require.Nil(t, err)
+
+		assert.True(t, cycles.CommitLogMaintenance().Running())
+		assert.True(t, cycles.TombstoneCleanup().Running())
+
+		err = cycles.Shutdown(ctx)
+		require.Nil(t, err)
+	})
+}

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -38,7 +38,7 @@ func TestHnswPersistence(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	makeCL := func() (CommitLogger, error) {
 		return cl, clErr
 	}
@@ -107,7 +107,7 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	makeCL := func() (CommitLogger, error) {
 		return cl, clErr
 	}
@@ -212,7 +212,7 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 	indexID := "integrationtest_deletion"
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	makeCL := func() (CommitLogger, error) {
 		return cl, clErr
 	}
@@ -292,7 +292,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	makeCL := func() (CommitLogger, error) {
 		return NewCommitLogger(dirName, indexID, logger,
-			WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+			cyclemanager.NewNoop())
 	}
 	index, err := New(Config{
 		RootPath:              dirName,

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -51,7 +51,7 @@ func TestHnswPersistence(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -88,7 +88,7 @@ func TestHnswPersistence(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	t.Run("verify that the results match after rebuiling from disk",
@@ -120,7 +120,7 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -191,7 +191,7 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	// the minor corruption (just one missing link) will most likely not render
@@ -225,7 +225,7 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -271,7 +271,7 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	dumpIndex(secondIndex, "without_cleanup_after_rebuild")
@@ -303,7 +303,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -355,7 +355,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 	dumpIndex(secondIndex, "with cleanup second index")
 
@@ -397,7 +397,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	dumpIndex(thirdIndex)
@@ -435,7 +435,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	}, ent.UserConfig{
 		MaxConnections: 30,
 		EFConstruction: 60,
-	})
+	}, cyclemanager.NewNoop())
 	require.Nil(t, err)
 
 	t.Run("load from disk and try to insert again", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/recall_geo_spatial_test.go
+++ b/adapters/repos/db/vector/hnsw/recall_geo_spatial_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -69,7 +70,7 @@ func TestRecallGeo(t *testing.T) {
 		}, ent.UserConfig{
 			MaxConnections: maxNeighbors,
 			EFConstruction: efConstruction,
-		})
+		}, cyclemanager.NewNoop())
 
 		require.Nil(t, err)
 		vectorIndex = index

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -49,7 +50,7 @@ func TestNilCheckOnPartiallyCleanedNode(t *testing.T) {
 			// zero it will constantly think it's full and needs to be deleted - even
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
-		})
+		}, cyclemanager.NewNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 	})

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -167,8 +167,8 @@ func (h *hnsw) tombstoneCleanup(shouldBreak cyclemanager.ShouldBreakFunc) bool {
 // vector cache, however, depend on the shard being ready as they will call
 // getVectorForID.
 func (h *hnsw) PostStartup() {
-	h.tombstoneCleanupCycle.Start()
-	h.commitLogMaintenanceCycle.Start()
+	// h.tombstoneCleanupCycle.Start()
+	// h.commitLogMaintenanceCycle.Start()
 	h.prefillCache()
 }
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -167,8 +167,6 @@ func (h *hnsw) tombstoneCleanup(shouldBreak cyclemanager.ShouldBreakFunc) bool {
 // vector cache, however, depend on the shard being ready as they will call
 // getVectorForID.
 func (h *hnsw) PostStartup() {
-	// h.tombstoneCleanupCycle.Start()
-	// h.commitLogMaintenanceCycle.Start()
 	h.prefillCache()
 }
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -168,6 +168,7 @@ func (h *hnsw) tombstoneCleanup(shouldBreak cyclemanager.ShouldBreakFunc) bool {
 // getVectorForID.
 func (h *hnsw) PostStartup() {
 	h.tombstoneCleanupCycle.Start()
+	h.commitLogMaintenanceCycle.Start()
 	h.prefillCache()
 }
 

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -76,20 +76,12 @@ func (i *Index) Shutdown(context.Context) error {
 	return nil
 }
 
-func (i *Index) PauseMaintenance(context.Context) error {
-	return nil
-}
-
 func (i *Index) SwitchCommitLogs(context.Context) error {
 	return nil
 }
 
 func (i *Index) ListFiles(context.Context) ([]string, error) {
 	return nil, nil
-}
-
-func (i *Index) ResumeMaintenance(context.Context) error {
-	return nil
 }
 
 func (i *Index) ValidateBeforeInsert(vector []float32) error {

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -31,10 +31,8 @@ type VectorIndex interface {
 	Drop(ctx context.Context) error
 	Shutdown(ctx context.Context) error
 	Flush() error
-	PauseMaintenance(ctx context.Context) error
 	SwitchCommitLogs(ctx context.Context) error
 	ListFiles(ctx context.Context) ([]string, error)
-	ResumeMaintenance(ctx context.Context) error
 	PostStartup()
 	ValidateBeforeInsert(vector []float32) error
 }

--- a/entities/cyclemanager/callbacks.go
+++ b/entities/cyclemanager/callbacks.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cyclemanager
+
+import (
+	"context"
+	"sync"
+)
+
+type UnregisterFunc func(ctx context.Context) error
+
+type callbacks interface {
+	register(cycleFunc CycleFunc) UnregisterFunc
+	execute(shouldBreak ShouldBreakFunc) bool
+}
+
+type callbackState struct {
+	cycleFunc  CycleFunc
+	runningCtx context.Context
+}
+
+type multiCallbacks struct {
+	lock    *sync.Mutex
+	counter uint32
+	states  map[uint32]*callbackState
+	keys    []uint32
+
+	canceledCtx context.Context
+}
+
+func newMultiCallbacks() callbacks {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	return &multiCallbacks{
+		lock:        new(sync.Mutex),
+		counter:     0,
+		states:      map[uint32]*callbackState{},
+		keys:        []uint32{},
+		canceledCtx: canceledCtx,
+	}
+}
+
+func (c *multiCallbacks) register(cycleFunc CycleFunc) UnregisterFunc {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	key := c.counter
+	c.keys = append(c.keys, key)
+	c.states[key] = &callbackState{
+		cycleFunc:  cycleFunc,
+		runningCtx: c.canceledCtx,
+	}
+	c.counter++
+
+	return func(ctx context.Context) error {
+		return c.unregister(ctx, key)
+	}
+}
+
+func (c *multiCallbacks) unregister(ctx context.Context, key uint32) error {
+	for {
+		// remove from collection only if not running. wait if already running
+		c.lock.Lock()
+		state, ok := c.states[key]
+		if !ok {
+			c.lock.Unlock()
+			return nil
+		}
+		runningCtx := state.runningCtx
+		if runningCtx.Err() != nil {
+			delete(c.states, key)
+			c.lock.Unlock()
+			return nil
+		}
+		c.lock.Unlock()
+
+		// wait until exec finished
+		select {
+		case <-runningCtx.Done():
+			// get back to the beginning of the loop
+			continue
+		case <-ctx.Done():
+			// in case both context are ready, but incoming ctx was selected
+			// check again running ctx as priority one
+			select {
+			case <-runningCtx.Done():
+				// get back to the beginning of the loop
+				continue
+			default:
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+func (c *multiCallbacks) execute(shouldBreak ShouldBreakFunc) bool {
+	executed := false
+	i := 0
+	for {
+		if shouldBreak() {
+			break
+		}
+
+		c.lock.Lock()
+		if i >= len(c.keys) {
+			c.lock.Unlock()
+			break
+		}
+
+		key := c.keys[i]
+		state, ok := c.states[key]
+		if !ok { // key deleted in the meantime, adjust keys
+			c.keys = append(c.keys[:i], c.keys[i+1:]...)
+			c.lock.Unlock()
+			continue
+		}
+
+		cancelableCtx, cancel := context.WithCancel(context.Background())
+		state.runningCtx = cancelableCtx
+		i++
+		c.lock.Unlock()
+
+		executed = state.cycleFunc(shouldBreak) || executed
+		cancel()
+	}
+
+	return executed
+}

--- a/entities/cyclemanager/callbacks_test.go
+++ b/entities/cyclemanager/callbacks_test.go
@@ -390,7 +390,7 @@ func TestCallbacks_Multi(t *testing.T) {
 		assert.GreaterOrEqual(t, du, 50*time.Millisecond)
 	})
 
-	t.Run("unregister failes due to context timeout", func(t *testing.T) {
+	t.Run("unregister fails due to context timeout", func(t *testing.T) {
 		executedCounter := 0
 		callback := func(shouldBreak ShouldBreakFunc) bool {
 			time.Sleep(50 * time.Millisecond)

--- a/entities/cyclemanager/callbacks_test.go
+++ b/entities/cyclemanager/callbacks_test.go
@@ -1,0 +1,530 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cyclemanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallbacks_Multi(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no callbacks", func(t *testing.T) {
+		ch := make(chan struct{}, 1)
+		var executed bool
+
+		callbacks := newMultiCallbacks()
+
+		go func() {
+			executed = callbacks.execute(func() bool { return false })
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.False(t, executed)
+	})
+
+	t.Run("2 executable callbacks", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		ch := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		callbacks.register(callback1)
+		callbacks.register(callback2)
+
+		go func() {
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 75*time.Millisecond)
+	})
+
+	t.Run("2 non-executable callbacks", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(10 * time.Millisecond)
+			executedCounter1++
+			return false
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(10 * time.Millisecond)
+			executedCounter2++
+			return false
+		}
+		ch := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		callbacks.register(callback1)
+		callbacks.register(callback2)
+
+		go func() {
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.False(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 20*time.Millisecond)
+	})
+
+	t.Run("1 executable callback, 1 unregistered", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		ch := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		unregister := callbacks.register(callback1)
+		require.Nil(t, unregister(ctx))
+
+		go func() {
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.False(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, 2 unregistered", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		ch := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		unregister1 := callbacks.register(callback1)
+		unregister2 := callbacks.register(callback2)
+		require.Nil(t, unregister1(ctx))
+		require.Nil(t, unregister2(ctx))
+
+		go func() {
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.False(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, 1 unregistered", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		ch := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		unregister1 := callbacks.register(callback1)
+		callbacks.register(callback2)
+		require.Nil(t, unregister1(ctx))
+
+		go func() {
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.True(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
+	})
+
+	t.Run("4 executable callbacks, all unregistered at different time", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		executedCounter3 := 0
+		callback3 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter3++
+			return true
+		}
+		executedCounter4 := 0
+		callback4 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter4++
+			return true
+		}
+		ch := make(chan struct{}, 1)
+		var executed1 bool
+		var executed2 bool
+		var executed3 bool
+		var executed4 bool
+		var d1 time.Duration
+		var d2 time.Duration
+		var d3 time.Duration
+		var d4 time.Duration
+
+		callbacks := newMultiCallbacks()
+		unregister1 := callbacks.register(callback1)
+		unregister2 := callbacks.register(callback2)
+		unregister3 := callbacks.register(callback3)
+		unregister4 := callbacks.register(callback4)
+		require.Nil(t, unregister3(ctx))
+
+		go func() {
+			start := time.Now()
+			executed1 = callbacks.execute(func() bool { return false })
+			d1 = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		require.Nil(t, unregister1(ctx))
+
+		go func() {
+			start := time.Now()
+			executed2 = callbacks.execute(func() bool { return false })
+			d2 = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		require.Nil(t, unregister4(ctx))
+
+		go func() {
+			start := time.Now()
+			executed3 = callbacks.execute(func() bool { return false })
+			d3 = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		require.Nil(t, unregister2(ctx))
+
+		go func() {
+			start := time.Now()
+			executed4 = callbacks.execute(func() bool { return false })
+			d4 = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.True(t, executed1)
+		assert.True(t, executed2)
+		assert.True(t, executed3)
+		assert.False(t, executed4)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 3, executedCounter2)
+		assert.Equal(t, 0, executedCounter3)
+		assert.Equal(t, 2, executedCounter4)
+		assert.GreaterOrEqual(t, d1, 75*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
+		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, not executed due to should break", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		shouldBreakCounter := 0
+		shouldBreak := func() bool {
+			shouldBreakCounter++
+			return shouldBreakCounter > 1
+		}
+
+		ch := make(chan struct{}, 1)
+		var executed1 bool
+		var executed2 bool
+		var d1 time.Duration
+		var d2 time.Duration
+
+		callbacks := newMultiCallbacks()
+		callbacks.register(callback1)
+		callbacks.register(callback2)
+
+		go func() {
+			start := time.Now()
+			executed1 = callbacks.execute(shouldBreak)
+			d1 = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+		go func() {
+			start := time.Now()
+			executed2 = callbacks.execute(shouldBreak)
+			d2 = time.Since(start)
+			ch <- struct{}{}
+		}()
+		<-ch
+
+		assert.True(t, executed1)
+		assert.False(t, executed2)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.GreaterOrEqual(t, d1, 25*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 0*time.Millisecond)
+	})
+
+	t.Run("unregister is waiting till the end of execution", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		unregister := callbacks.register(callback)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		start := time.Now()
+		time.Sleep(25 * time.Millisecond)
+		require.Nil(t, unregister(ctx))
+		du := time.Since(start)
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 50*time.Millisecond)
+	})
+
+	t.Run("unregister failes due to context timeout", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed1 bool
+		var executed2 bool
+		var d1 time.Duration
+		var d2 time.Duration
+
+		callbacks := newMultiCallbacks()
+		unregister := callbacks.register(callback)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed1 = callbacks.execute(func() bool { return false })
+			d1 = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		start := time.Now()
+		time.Sleep(25 * time.Millisecond)
+		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+		require.NotNil(t, unregister(ctxTimeout))
+		du := time.Since(start)
+		<-chFinished
+
+		go func() {
+			start := time.Now()
+			executed2 = callbacks.execute(func() bool { return false })
+			d2 = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chFinished
+
+		assert.True(t, executed1)
+		assert.True(t, executed2)
+		assert.Equal(t, 2, executedCounter)
+		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
+
+		cancel()
+	})
+
+	t.Run("register new while executing", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		callbacks.register(callback1)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		time.Sleep(25 * time.Millisecond)
+		callbacks.register(callback2)
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+	})
+
+	t.Run("unregister 2nd and 3rd while executing", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		executedCounter3 := 0
+		callback3 := func(shouldBreak ShouldBreakFunc) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter3++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := newMultiCallbacks()
+		callbacks.register(callback1)
+		unregister2 := callbacks.register(callback2)
+		unregister3 := callbacks.register(callback3)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.execute(func() bool { return false })
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		time.Sleep(25 * time.Millisecond)
+		require.Nil(t, unregister2(ctx))
+		require.Nil(t, unregister3(ctx))
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.Equal(t, 0, executedCounter3)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+	})
+}

--- a/entities/cyclemanager/cyclemanager.go
+++ b/entities/cyclemanager/cyclemanager.go
@@ -139,15 +139,11 @@ func (c *cycleManager) StopAndWait(ctx context.Context) error {
 			return ctx.Err()
 		}
 	case stopped := <-stop:
-		select {
-		case <-done:
-			if !stopped {
+		if !stopped {
+			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-		default:
-			if !stopped {
-				return fmt.Errorf("failed to stop cycle")
-			}
+			return fmt.Errorf("failed to stop cycle")
 		}
 	}
 	return nil

--- a/entities/cyclemanager/cyclemanager.go
+++ b/entities/cyclemanager/cyclemanager.go
@@ -25,7 +25,15 @@ type (
 	CycleFunc func(shouldBreak ShouldBreakFunc) bool
 )
 
-type CycleManager struct {
+type CycleManager interface {
+	Register(cycleFunc CycleFunc) UnregisterFunc
+	Start()
+	Stop(ctx context.Context) chan bool
+	StopAndWait(ctx context.Context) error
+	Running() bool
+}
+
+type cycleManager struct {
 	sync.RWMutex
 
 	callbacks   callbacks
@@ -37,8 +45,8 @@ type CycleManager struct {
 	stopResults  []chan bool
 }
 
-func NewMulti(cycleTicker CycleTicker) *CycleManager {
-	return &CycleManager{
+func NewMulti(cycleTicker CycleTicker) CycleManager {
+	return &cycleManager{
 		callbacks:   newMultiCallbacks(),
 		cycleTicker: cycleTicker,
 		running:     false,
@@ -46,13 +54,13 @@ func NewMulti(cycleTicker CycleTicker) *CycleManager {
 	}
 }
 
-func (c *CycleManager) Register(cycleFunc CycleFunc) UnregisterFunc {
+func (c *cycleManager) Register(cycleFunc CycleFunc) UnregisterFunc {
 	return c.callbacks.register(cycleFunc)
 }
 
 // Starts instance, does not block
 // Does nothing if instance is already started
-func (c *CycleManager) Start() {
+func (c *cycleManager) Start() {
 	c.Lock()
 	defer c.Unlock()
 
@@ -90,7 +98,7 @@ func (c *CycleManager) Start() {
 // If called multiple times, all contexts have to be cancelled to cancel stop
 // (any valid will result in stopping instance)
 // stopResult is the same (consistent) for multiple calls
-func (c *CycleManager) Stop(ctx context.Context) (stopResult chan bool) {
+func (c *cycleManager) Stop(ctx context.Context) (stopResult chan bool) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -114,7 +122,7 @@ func (c *CycleManager) Stop(ctx context.Context) (stopResult chan bool) {
 
 // Stops running instance, waits for stop to occur or context to expire (which comes first)
 // Returns error if instance was not stopped
-func (c *CycleManager) StopAndWait(ctx context.Context) error {
+func (c *cycleManager) StopAndWait(ctx context.Context) error {
 	// if both channels are ready, chan is selected randomly, therefore regardless of
 	// channel selected first, second one is also checked
 	stop := c.Stop(ctx)
@@ -145,14 +153,14 @@ func (c *CycleManager) StopAndWait(ctx context.Context) error {
 	return nil
 }
 
-func (c *CycleManager) Running() bool {
+func (c *cycleManager) Running() bool {
 	c.RLock()
 	defer c.RUnlock()
 
 	return c.running
 }
 
-func (c *CycleManager) shouldStop() bool {
+func (c *cycleManager) shouldStop() bool {
 	for _, ctx := range c.stopContexts {
 		if ctx.Err() == nil {
 			return true
@@ -161,14 +169,14 @@ func (c *CycleManager) shouldStop() bool {
 	return false
 }
 
-func (c *CycleManager) shouldBreakCycleCallback() bool {
+func (c *cycleManager) shouldBreakCycleCallback() bool {
 	c.RLock()
 	defer c.RUnlock()
 
 	return c.shouldStop()
 }
 
-func (c *CycleManager) isStopRequested() bool {
+func (c *cycleManager) isStopRequested() bool {
 	select {
 	case <-c.stopSignal:
 	case <-c.cycleTicker.C():
@@ -183,7 +191,7 @@ func (c *CycleManager) isStopRequested() bool {
 	return true
 }
 
-func (c *CycleManager) handleStopRequest(stopped bool) {
+func (c *cycleManager) handleStopRequest(stopped bool) {
 	for _, stopResult := range c.stopResults {
 		stopResult <- stopped
 		close(stopResult)
@@ -191,4 +199,52 @@ func (c *CycleManager) handleStopRequest(stopped bool) {
 	c.running = !stopped
 	c.stopContexts = nil
 	c.stopResults = nil
+}
+
+func NewNoop() CycleManager {
+	return &noopCycleManager{running: false}
+}
+
+type noopCycleManager struct {
+	running bool
+}
+
+func (c *noopCycleManager) Register(cycleFunc CycleFunc) UnregisterFunc {
+	return func(ctx context.Context) error {
+		return nil
+	}
+}
+
+func (c *noopCycleManager) Start() {
+	c.running = true
+}
+
+func (c *noopCycleManager) Stop(ctx context.Context) chan bool {
+	if !c.running {
+		return c.closedChan(true)
+	}
+	if ctx.Err() != nil {
+		return c.closedChan(false)
+	}
+
+	c.running = false
+	return c.closedChan(true)
+}
+
+func (c *noopCycleManager) StopAndWait(ctx context.Context) error {
+	if <-c.Stop(ctx) {
+		return nil
+	}
+	return ctx.Err()
+}
+
+func (c *noopCycleManager) Running() bool {
+	return c.running
+}
+
+func (c *noopCycleManager) closedChan(val bool) chan bool {
+	ch := make(chan bool, 1)
+	ch <- val
+	close(ch)
+	return ch
 }

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -70,10 +70,10 @@ func TestCycleManager_beforeTimeout(t *testing.T) {
 	var cm *CycleManager
 
 	t.Run("create new", func(t *testing.T) {
-		cm = New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+		cm = NewMulti(NewFixedIntervalTicker(cycleInterval))
+		cm.Register(p.cycleFunc)
 
 		assert.False(t, cm.Running())
-		assert.NotNil(t, cm.cycleFunc)
 		assert.NotNil(t, cm.stopSignal)
 	})
 
@@ -110,10 +110,10 @@ func TestCycleManager_beforeTimeoutWithWait(t *testing.T) {
 	var cm *CycleManager
 
 	t.Run("create new", func(t *testing.T) {
-		cm = New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+		cm = NewMulti(NewFixedIntervalTicker(cycleInterval))
+		cm.Register(p.cycleFunc)
 
 		assert.False(t, cm.Running())
-		assert.NotNil(t, cm.cycleFunc)
 		assert.NotNil(t, cm.stopSignal)
 	})
 
@@ -142,7 +142,8 @@ func TestCycleManager_timeout(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("timeout is reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -179,7 +180,8 @@ func TestCycleManager_timeoutWithWait(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("timeout is reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -210,7 +212,8 @@ func TestCycleManager_doesNotStartMultipleTimes(t *testing.T) {
 	startCount := 5
 
 	p := newProvider(cycleDuration, uint(startCount))
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("multiple starts", func(t *testing.T) {
 		for i := 0; i < startCount; i++ {
@@ -234,7 +237,8 @@ func TestCycleManager_doesNotStartMultipleTimesWithWait(t *testing.T) {
 	startCount := 5
 
 	p := newProvider(cycleDuration, uint(startCount))
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("multiple starts", func(t *testing.T) {
 		for i := 0; i < startCount; i++ {
@@ -258,7 +262,8 @@ func TestCycleManager_handlesMultipleStops(t *testing.T) {
 	stopCount := 5
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("multiple stops", func(t *testing.T) {
 		cm.Start()
@@ -283,7 +288,8 @@ func TestCycleManager_stopsIfNotAllContextsAreCancelled(t *testing.T) {
 	stopTimeout := 5 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("multiple stops, few cancelled", func(t *testing.T) {
 		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
@@ -314,7 +320,8 @@ func TestCycleManager_doesNotStopIfAllContextsAreCancelled(t *testing.T) {
 	stopTimeout := 50 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("multiple stops, few cancelled", func(t *testing.T) {
 		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
@@ -354,7 +361,8 @@ func TestCycleManager_cycleFuncStoppedDueToFrequentStopChecks(t *testing.T) {
 
 	// despite cycleDuration is 30ms, cycle function checks every 20ms (300/15) if it needs to be stopped
 	p := newProviderBreakable(cycleDuration, 1, 15)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("cycle funcion stopped before timeout reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -384,7 +392,8 @@ func TestCycleManager_cycleFuncNotStoppedDueToRareStopChecks(t *testing.T) {
 
 	// despite cycleDuration is 30ms, cycle function checks every 150ms (300/2) if it needs to be stopped
 	p := newProviderBreakable(cycleDuration, 1, 2)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleFunc)
+	cm := NewMulti(NewFixedIntervalTicker(cycleInterval))
+	cm.Register(p.cycleFunc)
 
 	t.Run("timeout reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -67,14 +67,13 @@ func TestCycleManager_beforeTimeout(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	var cm *CycleManager
+	var cm CycleManager
 
 	t.Run("create new", func(t *testing.T) {
 		cm = NewMulti(NewFixedIntervalTicker(cycleInterval))
 		cm.Register(p.cycleFunc)
 
 		assert.False(t, cm.Running())
-		assert.NotNil(t, cm.stopSignal)
 	})
 
 	t.Run("start", func(t *testing.T) {
@@ -107,14 +106,13 @@ func TestCycleManager_beforeTimeoutWithWait(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	var cm *CycleManager
+	var cm CycleManager
 
 	t.Run("create new", func(t *testing.T) {
 		cm = NewMulti(NewFixedIntervalTicker(cycleInterval))
 		cm.Register(p.cycleFunc)
 
 		assert.False(t, cm.Running())
-		assert.NotNil(t, cm.stopSignal)
 	})
 
 	t.Run("start", func(t *testing.T) {

--- a/entities/cyclemanager/interval.go
+++ b/entities/cyclemanager/interval.go
@@ -64,29 +64,3 @@ func HnswCommitLoggerCycleTicker() CycleTicker {
 	return NewExpTicker(hnswCommitLoggerMinInterval, hnswCommitLoggerMaxInterval,
 		hnswCommitLoggerBase, hnswCommitLoggerSteps)
 }
-
-type TickerProvider func() CycleTicker
-
-func FixedIntervalTickerProvider(interval time.Duration) TickerProvider {
-	return func() CycleTicker {
-		return NewFixedIntervalTicker(interval)
-	}
-}
-
-func SeriesTickerProvider(intervals []time.Duration) TickerProvider {
-	return func() CycleTicker {
-		return NewSeriesTicker(intervals)
-	}
-}
-
-func LinearTickerProvider(minInterval, maxInterval time.Duration, steps uint) TickerProvider {
-	return func() CycleTicker {
-		return NewLinearTicker(minInterval, maxInterval, steps)
-	}
-}
-
-func ExpTickerProvider(minInterval, maxInterval time.Duration, base, steps uint) TickerProvider {
-	return func() CycleTicker {
-		return NewExpTicker(minInterval, maxInterval, base, steps)
-	}
-}


### PR DESCRIPTION
### What's being changed:
Addresses https://github.com/weaviate/weaviate/issues/2983
Instead creating multiple cycle managers, separate for each bucket, geo prop etc, common cycle managers are created for different usecases:
- memtable flush (one per store)
- compaction (one per store)
- tombstone cleanup (one per vector index, if created)
- commit log maintenance (one per vector index, if created)
- tombstone cleanup for geo props (one per shard, if any geo prop is indexed)
- commit log maintenance for geo props (one per shard, if any geo prop is indexed)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/75
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
