### PR TITLE
Do not assume node is out of bounds in deserializer

### DIFF
--- a/adapters/repos/db/vector/hnsw/deserializer.go
+++ b/adapters/repos/db/vector/hnsw/deserializer.go
@@ -353,9 +353,13 @@ func (d *Deserializer) ReadClearLinks(r io.Reader, res *DeserializationResult,
 		return err
 	}
 
-	if int(id) >= len(res.Nodes) {
-		// node is out of bounds, so it can't exist, nothing to do here
-		return nil
+	newNodes, changed, err := growIndexToAccomodateNode(res.Nodes, id, d.logger)
+	if err != nil {
+		return err
+	}
+
+	if changed {
+		res.Nodes = newNodes
 	}
 
 	if res.Nodes[id] == nil {
@@ -380,9 +384,13 @@ func (d *Deserializer) ReadClearLinksAtLevel(r io.Reader, res *DeserializationRe
 		return err
 	}
 
-	if int(id) >= len(res.Nodes) {
-		// node is out of bounds, so it can't exist, nothing to do here
-		return nil
+	newNodes, changed, err := growIndexToAccomodateNode(res.Nodes, id, d.logger)
+	if err != nil {
+		return err
+	}
+
+	if changed {
+		res.Nodes = newNodes
 	}
 
 	if keepReplaceInfo {
@@ -439,9 +447,13 @@ func (d *Deserializer) ReadDeleteNode(r io.Reader, res *DeserializationResult) e
 		return err
 	}
 
-	if int(id) >= len(res.Nodes) {
-		// node is out of bounds, so it can't exist, nothing to do here
-		return nil
+	newNodes, changed, err := growIndexToAccomodateNode(res.Nodes, id, d.logger)
+	if err != nil {
+		return err
+	}
+
+	if changed {
+		res.Nodes = newNodes
 	}
 
 	res.Nodes[id] = nil

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -142,6 +142,57 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 		}
 	})
 
+	t.Run("delete 10 percent of data", func(t *testing.T) {
+		type tuple struct {
+			vec []float32
+			id  uint64
+		}
+
+		jobs := make(chan tuple, n)
+
+		wg := sync.WaitGroup{}
+		worker := func(jobs chan tuple) {
+			for job := range jobs {
+				index.Delete(job.id)
+			}
+
+			wg.Done()
+		}
+
+		for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+			wg.Add(1)
+			go worker(jobs)
+		}
+
+		for i, vec := range data[:n/10] {
+			jobs <- tuple{id: uint64(i), vec: vec}
+		}
+
+		close(jobs)
+
+		wg.Wait()
+	})
+
+	index.Flush()
+
+	t.Run("verify there are no nodes with too many links - post deletion", func(t *testing.T) {
+		for i, node := range index.nodes {
+			if node == nil {
+				continue
+			}
+
+			for level, conns := range node.connections {
+				m := index.maximumConnections
+				if level == 0 {
+					m = index.maximumConnectionsLayerZero
+				}
+
+				assert.LessOrEqualf(t, len(conns), m, "node %d at level %d with %d conns",
+					i, level, len(conns))
+			}
+		}
+	})
+
 	t.Run("destroy the old index", func(t *testing.T) {
 		// kill the commit loger and index
 		require.Nil(t, original.Shutdown(context.Background()))


### PR DESCRIPTION
### What's being changed:

The HNSW deserializer assumed if `id > len(res.Nodes)` then the node was out of bounds. However `len(res.Nodes)` is just set initially to the `initialSize` of the HNSW index. With the reduction of initialSize in https://github.com/weaviate/weaviate/pull/3005 this triggered `Test_NoRace_ManySmallCommitlogs` to become flaky with too many links. This PR changes the deserializer to run `growIndexToAccomodateNode` in these conditions.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
