### PR TITLE
Reuse sums memory for combined vector result.

### DIFF
--- a/usecases/vectorizer/combine.go
+++ b/usecases/vectorizer/combine.go
@@ -36,10 +36,9 @@ func CombineVectorsWithWeights(vectors [][]float32, weights []float32) []float32
 			dividers[i]++
 		}
 	}
-	combinedVector := make([]float32, len(sums))
 	for i := 0; i < len(sums); i++ {
-		combinedVector[i] = sums[i] / dividers[i]
+		sums[i] /= dividers[i]
 	}
 
-	return combinedVector
+	return sums
 }


### PR DESCRIPTION
### What's being changed:

Memory allocations are very expensive, so reusing it is the easiest way to speed up processing.

Even for short vectors of size 8
```
func BenchmarkCombine(b *testing.B) {
	for i := 0; i < b.N; i++ {
		CombineVectors([][]float32{
			{-0.214571, -0.605529, -0.335769, -0.185277, -0.212256, 0.478032, -0.536662, 0.298211},
			{-0.14713769, -0.06872862, 0.09911085, -0.06342313, 0.10092197, -0.06624051, -0.06812558, 0.07360107},
			{-0.18123996, -0.2089612, 0.03738429, -0.26224917, 0.18499854, -0.2620146, -0.12802331, -0.07601682},
			{-0.06659584, -0.17120242, 0.07603133, -0.07171547, 0.12537181, -0.19367254, -0.18376349, -0.05517439},
		})
	}
}
```
locally I'm getting
```
% go test ./usecases/vectorizer/ -bench=.
goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/usecases/vectorizer
BenchmarkCombine-8   	15384250	        78.32 ns/op
PASS
ok  	github.com/weaviate/weaviate/usecases/vectorizer	2.356s
```
instead of original
```
% go test ./usecases/vectorizer/ -bench=.
goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/usecases/vectorizer
BenchmarkCombine-8   	13317235	        89.44 ns/op
PASS
ok  	github.com/weaviate/weaviate/usecases/vectorizer	1.411s
```
which is ~12.5% improvement in terms of time, but it's also good for GC, especially for larger inputs.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
