### PR TITLE
Gracefully stop gRPC server

### DIFF
--- a/adapters/handlers/rest/grpc.go
+++ b/adapters/handlers/rest/grpc.go
@@ -16,9 +16,13 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 )
 
-func setupGrpc(state *state.State) {
+func createGrpcServer(state *state.State) *grpc.GRPCServer {
+	return grpc.CreateGRPCServer(state)
+}
+
+func startGrpcServer(server *grpc.GRPCServer, state *state.State) {
 	go func() {
-		if err := grpc.StartAndListen(state); err != nil {
+		if err := grpc.StartAndListen(server, state); err != nil {
 			state.Logger.WithField("action", "grpc_startup").WithError(err).
 				Fatal("failed to start grpc server")
 		}


### PR DESCRIPTION
### What's being changed:

gRPC standard exposes `GracefulStop()` method which gracefully stops the `gRPC` server, among all other things it closes the listening gRPC socket which unblocks gRPC TCP port.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
