### PR TITLE
Fix: PQ recall not identical after restart; in condensor replay PQ information into new log if present

### DIFF
--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -499,13 +499,35 @@ func TestCondensorWithPQInformation(t *testing.T) {
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 
+	encoders := []ssdhelpers.PQEncoder{
+		ssdhelpers.NewKMeansWithCenters(
+			4,
+			2,
+			0,
+			[][]float32{{1, 2}, {3, 4}, {5, 6}, {7, 8}},
+		),
+		ssdhelpers.NewKMeansWithCenters(
+			4,
+			2,
+			1,
+			[][]float32{{8, 7}, {6, 5}, {4, 3}, {2, 1}},
+		),
+		ssdhelpers.NewKMeansWithCenters(
+			4,
+			2,
+			2,
+			[][]float32{{1, 2}, {3, 4}, {5, 6}, {7, 8}},
+		),
+	}
+
 	t.Run("add pq info", func(t *testing.T) {
 		uncondensed.AddPQ(ssdhelpers.PQData{
-			Ks:                  3,
-			M:                   0,
-			Dimensions:          5,
+			Ks:                  4,
+			M:                   3,
+			Dimensions:          6,
 			EncoderType:         ssdhelpers.UseKMeansEncoder,
 			EncoderDistribution: uint8(0),
+			Encoders:            encoders,
 			UseBitsEncoding:     false,
 		})
 
@@ -538,11 +560,12 @@ func TestCondensorWithPQInformation(t *testing.T) {
 
 		assert.True(t, res.Compressed)
 		expected := ssdhelpers.PQData{
-			Ks:                  3,
-			M:                   0,
-			Dimensions:          5,
+			Ks:                  4,
+			M:                   3,
+			Dimensions:          6,
 			EncoderType:         ssdhelpers.UseKMeansEncoder,
 			EncoderDistribution: uint8(0),
+			Encoders:            encoders,
 			UseBitsEncoding:     false,
 		}
 


### PR DESCRIPTION
### What's being changed:
* The condensor takes individual HNSW commit logs and removes redundancies
* Before this fix if the original commit log contained PQ information, that information was lost in the condensed output
* This fix takes the information that was written in the original and rewrites it into the new log
* A new test was added to prove that this works. Note: For simplicity's sake, `M` was set to `0`, which means the test only contains metadata, no actual encoder data. This means the test might only tests part of the information we want to retain. The test could probably be improved by writing meaningful data, but for this I need help from @abdelr or @trengrj 
* Note that there is a possibly related bug #3049 which is not fixed in this PR. Note that #3049 also occurs if the condenser is turned off completely, so I believe it has another cause
* fixes #3048 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
