### PR TITLE
Fix PQ recall drop after restart

### DIFF
--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -495,7 +495,7 @@ func TestCondensorWithPQInformation(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		WithCommitlogCycleTicker(cyclemanager.NewNoopTicker))
+		cyclemanager.NewNoop())
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -188,7 +188,16 @@ func (h *hnsw) prefillCache() {
 			for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 				id := binary.LittleEndian.Uint64(k)
 				h.compressedVectorsCache.grow(id)
-				h.compressedVectorsCache.preload(id, v)
+
+				// Make sure to copy the vector. The cursor only guarantees that
+				// the underlying memory won't change until we hit .Next(). Since
+				// we want to keep this around in the cache "forever", we need to
+				// alloc some new memory and copy the vector.
+				//
+				// https://github.com/weaviate/weaviate/issues/3049
+				vc := make([]byte, len(v))
+				copy(vc, v)
+				h.compressedVectorsCache.preload(id, vc)
 			}
 			cursor.Close()
 		} else {

--- a/adapters/repos/db/vector/ssdhelpers/kmeans.go
+++ b/adapters/repos/db/vector/ssdhelpers/kmeans.go
@@ -14,6 +14,7 @@ package ssdhelpers
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"math/rand"
 
@@ -32,6 +33,29 @@ type KMeans struct {
 	segment            int         // Segment where it operates
 
 	data KMeansPartitionData // Non persistent data used only during the fitting process
+}
+
+// String prints some minimal information about the encoder. This can be
+// used for viability checks to see if the encoder was initialized
+// correctly – for example after a restart.
+func (k *KMeans) String() string {
+	maxElem := 5
+	var firstCenters []float32
+	i := 0
+	for _, center := range k.centers {
+		for _, centerVal := range center {
+			if i == maxElem {
+				break
+			}
+
+			firstCenters = append(firstCenters, centerVal)
+			i++
+		}
+		if i == maxElem {
+			break
+		}
+	}
+	return fmt.Sprintf("KMeans Encoder: K=%d, dim=%d, segment=%d first_center_truncated=%v", k.K, k.dimensions, k.segment, firstCenters)
 }
 
 type KMeansPartitionData struct {


### PR DESCRIPTION
Please review & merge #3050 first because this PR builds on top of it.

### What's being changed:
* fixes #3049 
* the cursor used to prefill the compressed cache reuses its memory internally. However, we assigned this memory straight to the cache. This means we could end up with all identical vectors in the cache after a restart.
* This fix copies the memory before calling `.Next()` to make sure the memory is unique.
* This was discovered as part of building a new e2e pipeline containing a restart. This new pipeline will act as the test that prevents a regression.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/5037759071/jobs/9034798226
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
