### PR TITLE
[Performance] Improve PQ DistanceLookUpTable

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -171,6 +171,7 @@ func (h *hnsw) searchLayerByVector(queryVector []float32,
 	var byteDistancer *ssdhelpers.PQDistancer
 	if h.compressed.Load() {
 		byteDistancer = h.pq.NewDistancer(queryVector)
+		defer h.pq.ReturnDistancer(byteDistancer)
 	} else {
 		floatDistancer = h.distancerProvider.New(queryVector)
 	}

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"math"
+	"sync"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
@@ -51,6 +52,28 @@ func NewDistanceLookUpTable(segments int, centroids int, center []float32) *Dist
 		centroids:  centroids,
 	}
 	return dlt
+}
+
+func (lut *DistanceLookUpTable) Reset(segments int, centroids int, center []float32) {
+	elems := segments * centroids
+	lut.segments = segments
+	lut.centroids = centroids
+	if len(lut.distances) != elems ||
+		len(lut.calculated) != elems ||
+		len(lut.center) != segments {
+		lut.distances = make([]float32, segments*centroids)
+		lut.calculated = make([]bool, segments*centroids)
+		lut.center = make([][]float32, segments)
+	} else {
+		for i := range lut.calculated {
+			lut.calculated[i] = false
+		}
+	}
+
+	ds := len(center) / segments
+	for c := 0; c < segments; c++ {
+		lut.center[c] = center[c*ds : (c+1)*ds]
+	}
 }
 
 func (lut *DistanceLookUpTable) LookUp(
@@ -99,6 +122,30 @@ func (lut *DistanceLookUpTable) setCodeDist(segment int, code uint64, dist float
 	lut.distances[lut.posForSegmentAndCode(segment, code)] = dist
 }
 
+type DLUTPool struct {
+	pool sync.Pool
+}
+
+func NewDLUTPool() *DLUTPool {
+	return &DLUTPool{
+		pool: sync.Pool{
+			New: func() any {
+				return &DistanceLookUpTable{}
+			},
+		},
+	}
+}
+
+func (p *DLUTPool) Get(segments, centroids int, centers []float32) *DistanceLookUpTable {
+	dlt := p.pool.Get().(*DistanceLookUpTable)
+	dlt.Reset(segments, centroids, centers)
+	return dlt
+}
+
+func (p *DLUTPool) Return(dlt *DistanceLookUpTable) {
+	p.pool.Put(dlt)
+}
+
 type ProductQuantizer struct {
 	ks                  int // centroids
 	bits                int // bits amount
@@ -117,6 +164,7 @@ type ProductQuantizer struct {
 	useBitsEncoding     bool
 	ExtractCode         func(encoded []byte, index int) uint64
 	PutCode             func(code uint64, encoded []byte, index int)
+	dlutPool            *DLUTPool
 }
 
 type PQData struct {
@@ -156,6 +204,7 @@ func NewProductQuantizer(segments int, centroids int, useBitsEncoding bool, dist
 		encoderType:         encoderType,
 		encoderDistribution: encoderDistribution,
 		useBitsEncoding:     useBitsEncoding,
+		dlutPool:            NewDLUTPool(),
 	}
 	pq.sharpCodes = pq.bits%8 == 0
 	if pq.bits > 32 {
@@ -330,6 +379,10 @@ func (pq *ProductQuantizer) NewDistancer(a []float32) *PQDistancer {
 	}
 }
 
+func (pq *ProductQuantizer) ReturnDistancer(d *PQDistancer) {
+	pq.dlutPool.Return(d.lut)
+}
+
 func (d *PQDistancer) Distance(x []byte) (float32, bool, error) {
 	return d.pq.Distance(x, d.lut), true, nil
 }
@@ -387,7 +440,7 @@ func (pq *ProductQuantizer) Decode(code []byte) []float32 {
 }
 
 func (pq *ProductQuantizer) CenterAt(vec []float32) *DistanceLookUpTable {
-	return NewDistanceLookUpTable(int(pq.m), int(pq.ks), vec)
+	return pq.dlutPool.Get(int(pq.m), int(pq.ks), vec)
 }
 
 func (pq *ProductQuantizer) Distance(encoded []byte, lut *DistanceLookUpTable) float32 {


### PR DESCRIPTION
Please review and merge #3050  and #3052 first, as this PR builds on top of those.

### What's being changed:
* Improved performance of the PQ DistanceLookupTable in two steps (see improvement per step below)
  * Step 1: Restructured arrays for better cache locality and easier allocations (see commit message for details)
  * Step 2: added a pool to reuse lookup lists between requests
* The new chaos pipeline was used to make sure this change does not alter recall

### Improvements

![image](https://github.com/weaviate/weaviate/assets/8974479/d1667a29-01a5-488d-89d8-ced33589e4d6)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/5037759071/jobs/9034798226
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
