### PR TITLE
Feature/2481 add support for wildcards for include exclude backups

### DIFF
--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -13,6 +13,7 @@ package backup
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -91,18 +92,52 @@ func (d *DistributedBackupDescriptor) Filter(pred func(s string) bool) {
 	}
 }
 
+// Check any inclusion/exclusion class names for wildcards
+func hasWildcards(classes []string) bool {
+	for _, cls := range classes {
+		if strings.ContainsAny(cls, "*?") {
+			return true
+		}
+	}
+	return false
+}
+
 // Include only these classes and remove everything else
 func (d *DistributedBackupDescriptor) Include(classes []string) {
 	if len(classes) == 0 {
 		return
 	}
-	set := make(map[string]struct{}, len(classes))
-	for _, cls := range classes {
-		set[cls] = struct{}{}
-	}
-	pred := func(s string) bool {
-		_, ok := set[s]
-		return ok
+	// if the inclusion list is using wildcards, we need to filter the classes using string comparison
+	// otherwise we can use the faster method of using a map to check if the class is in the set
+	var pred func(s string) bool
+	if hasWildcards(classes) {
+		pred = func(s string) bool {
+			for _, cls := range classes {
+				if cls == s {
+					return true
+				} else if strings.HasPrefix(cls, "*") {
+					// Check ends with
+					if strings.HasSuffix(s, cls[1:]) {
+						return true
+					}
+				} else if strings.HasSuffix(cls, "*") {
+					// Check starts with
+					if strings.HasPrefix(s, cls[:len(cls)-1]) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+	} else {
+		set := make(map[string]struct{}, len(classes))
+		for _, cls := range classes {
+			set[cls] = struct{}{}
+		}
+		pred = func(s string) bool {
+			_, ok := set[s]
+			return ok
+		}
 	}
 	d.Filter(pred)
 }
@@ -112,13 +147,37 @@ func (d *DistributedBackupDescriptor) Exclude(classes []string) {
 	if len(classes) == 0 {
 		return
 	}
-	set := make(map[string]struct{}, len(classes))
-	for _, cls := range classes {
-		set[cls] = struct{}{}
-	}
-	pred := func(s string) bool {
-		_, ok := set[s]
-		return !ok
+	// if the exclusion list is using wildcards, we need to filter the classes using string comparison
+	// otherwise we can use the faster method of using a map to check if the class is in the set
+	var pred func(s string) bool
+	if hasWildcards(classes) {
+		pred = func(s string) bool {
+			for _, cls := range classes {
+				if cls == s {
+					return false
+				} else if strings.HasPrefix(cls, "*") {
+					// Check ends with
+					if strings.HasSuffix(s, cls[1:]) {
+						return false
+					}
+				} else if strings.HasSuffix(cls, "*") {
+					// Check starts with
+					if strings.HasPrefix(s, cls[:len(cls)-1]) {
+						return false
+					}
+				}
+			}
+			return true
+		}
+	} else {
+		set := make(map[string]struct{}, len(classes))
+		for _, cls := range classes {
+			set[cls] = struct{}{}
+		}
+		pred = func(s string) bool {
+			_, ok := set[s]
+			return !ok
+		}
 	}
 	d.Filter(pred)
 }
@@ -244,13 +303,37 @@ func (d *BackupDescriptor) Include(classes []string) {
 	if len(classes) == 0 {
 		return
 	}
-	set := make(map[string]struct{}, len(classes))
-	for _, cls := range classes {
-		set[cls] = struct{}{}
-	}
-	pred := func(s string) bool {
-		_, ok := set[s]
-		return ok
+	// if the inclusion list is using wildcards, we need to filter the classes using string comparison
+	// otherwise we can use the faster method of using a map to check if the class is in the set
+	var pred func(s string) bool
+	if hasWildcards(classes) {
+		pred = func(s string) bool {
+			for _, cls := range classes {
+				if cls == s {
+					return true
+				} else if strings.HasPrefix(cls, "*") {
+					// Check ends with
+					if strings.HasSuffix(s, cls[1:]) {
+						return true
+					}
+				} else if strings.HasSuffix(cls, "*") {
+					// Check starts with
+					if strings.HasPrefix(s, cls[:len(cls)-1]) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+	} else {
+		set := make(map[string]struct{}, len(classes))
+		for _, cls := range classes {
+			set[cls] = struct{}{}
+		}
+		pred = func(s string) bool {
+			_, ok := set[s]
+			return ok
+		}
 	}
 	d.Filter(pred)
 }
@@ -260,13 +343,37 @@ func (d *BackupDescriptor) Exclude(classes []string) {
 	if len(classes) == 0 {
 		return
 	}
-	set := make(map[string]struct{}, len(classes))
-	for _, cls := range classes {
-		set[cls] = struct{}{}
-	}
-	pred := func(s string) bool {
-		_, ok := set[s]
-		return !ok
+	// if the exclusion list is using wildcards, we need to filter the classes using string comparison
+	// otherwise we can use the faster method of using a map to check if the class is in the set
+	var pred func(s string) bool
+	if hasWildcards(classes) {
+		pred = func(s string) bool {
+			for _, cls := range classes {
+				if cls == s {
+					return false
+				} else if strings.HasPrefix(cls, "*") {
+					// Check ends with
+					if strings.HasSuffix(s, cls[1:]) {
+						return false
+					}
+				} else if strings.HasSuffix(cls, "*") {
+					// Check starts with
+					if strings.HasPrefix(s, cls[:len(cls)-1]) {
+						return false
+					}
+				}
+			}
+			return true
+		}
+	} else {
+		set := make(map[string]struct{}, len(classes))
+		for _, cls := range classes {
+			set[cls] = struct{}{}
+		}
+		pred = func(s string) bool {
+			_, ok := set[s]
+			return !ok
+		}
 	}
 	d.Filter(pred)
 }

--- a/entities/backup/descriptor_test.go
+++ b/entities/backup/descriptor_test.go
@@ -28,6 +28,8 @@ func TestExcludeClasses(t *testing.T) {
 		{in: BackupDescriptor{}, xs: []string{}, out: []string{}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "a"}}}, xs: []string{}, out: []string{"a"}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "a"}}}, xs: []string{"a"}, out: []string{}},
+		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "sam"}, {Name: "sally"}}}, xs: []string{"sa*"}, out: []string{}},
+		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "mad"}, {Name: "glad"}}}, xs: []string{"*ad"}, out: []string{}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "1"}, {Name: "2"}, {Name: "3"}, {Name: "4"}}}, xs: []string{"2", "3"}, out: []string{"1", "4"}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "1"}, {Name: "2"}, {Name: "3"}}}, xs: []string{"1", "3"}, out: []string{"2"}},
 
@@ -50,6 +52,8 @@ func TestIncludeClasses(t *testing.T) {
 		{in: BackupDescriptor{}, xs: []string{}, out: []string{}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "a"}}}, xs: []string{}, out: []string{"a"}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "a"}}}, xs: []string{"a"}, out: []string{"a"}},
+		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "sam"}, {Name: "sally"}}}, xs: []string{"sa*"}, out: []string{"sam", "sally"}},
+		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "mad"}, {Name: "glad"}}}, xs: []string{"*ad"}, out: []string{"mad", "glad"}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "1"}, {Name: "2"}, {Name: "3"}, {Name: "4"}}}, xs: []string{"2", "3"}, out: []string{"2", "3"}},
 		{in: BackupDescriptor{Classes: []ClassDescriptor{{Name: "1"}, {Name: "2"}, {Name: "3"}}}, xs: []string{"1", "3"}, out: []string{"1", "3"}},
 	}
@@ -281,6 +285,26 @@ func TestDistributedBackupExcludeClasses(t *testing.T) {
 		{
 			in: DistributedBackupDescriptor{
 				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"sam"}},
+					"N2": {Classes: []string{"sally"}},
+				},
+			},
+			xs:  []string{"sa*"},
+			out: []string{},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"mad"}},
+					"N2": {Classes: []string{"glad"}},
+				},
+			},
+			xs:  []string{"*ad"},
+			out: []string{},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
 					"N1": {Classes: []string{"1", "2"}},
 					"N2": {Classes: []string{"3", "4"}},
 				},
@@ -328,6 +352,26 @@ func TestDistributedBackupIncludeClasses(t *testing.T) {
 			},
 			xs:  []string{},
 			out: []string{"a"},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"sam"}},
+					"N2": {Classes: []string{"sally"}},
+				},
+			},
+			xs:  []string{"sa*"},
+			out: []string{"sally", "sam"},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"mad"}},
+					"N2": {Classes: []string{"glad"}},
+				},
+			},
+			xs:  []string{"*ad"},
+			out: []string{"glad", "mad"},
 		},
 		{
 			in: DistributedBackupDescriptor{


### PR DESCRIPTION
### What's being changed:

Closes [#2481 :: add support for wildcards in class lists](https://github.com/weaviate/weaviate/issues/2481)

* Add a helper function to detect if the class list contains wildcards.
* Use that helper in each Include / Exclude function to branch into generating predicate functions that do string comparison (prefix/suffix) instead of set membership.
* Add new test cases to Include / Exclude tests that cover the use of wildcard in the inclusion / exclusion lists.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: https://github.com/weaviate/weaviate-io/pull/821
- [ ] Chaos pipeline run or not necessary. Link to pipeline: noob can haz Chaos Pipeline?
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
