### PR TITLE
Disable Vulnerability-Scanning step for forked PR's

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -32,6 +32,7 @@ jobs:
           fi
   Vulnerability-Scanning:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork
     steps:
       - uses: actions/checkout@v3
       - name: Scan for Vulnerabilities in Code


### PR DESCRIPTION
### What's being changed:

This PR disables `Vulnerability-Scanning` github action for forked PR's. This step uploads `Sarif Report` to our repo which can only be done from PR's that originate from Weaviate repository.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
