### PR TITLE
Add support for properties field in generate groupedResult argument

### DIFF
--- a/modules/generative-cohere/additional/generate/generate.go
+++ b/modules/generative-cohere/additional/generate/generate.go
@@ -39,7 +39,7 @@ func New(cohere cohereClient) *GenerateProvider {
 	return &GenerateProvider{cohere, maximumNumberOfGoroutines}
 }
 
-func (p *GenerateProvider) AdditonalPropertyDefaultValue() interface{} {
+func (p *GenerateProvider) AdditionalPropertyDefaultValue() interface{} {
 	return &Params{}
 }
 

--- a/modules/generative-cohere/additional/generate/generate_graphql_field.go
+++ b/modules/generative-cohere/additional/generate/generate_graphql_field.go
@@ -42,6 +42,11 @@ func (p *GenerateProvider) additionalGenerateField(classname string) *graphql.Fi
 							Description: "task",
 							Type:        graphql.String,
 						},
+						"properties": &graphql.InputObjectFieldConfig{
+							Description:  "Properties used for the generation",
+							Type:         graphql.NewList(graphql.String),
+							DefaultValue: nil,
+						},
 					},
 				}),
 				DefaultValue: nil,

--- a/modules/generative-cohere/additional/generate/generate_params.go
+++ b/modules/generative-cohere/additional/generate/generate_params.go
@@ -12,8 +12,9 @@
 package generate
 
 type Params struct {
-	Prompt *string
-	Task   *string
+	Prompt     *string
+	Task       *string
+	Properties []string
 }
 
 func (n Params) GetPrompt() string {
@@ -22,4 +23,8 @@ func (n Params) GetPrompt() string {
 
 func (n Params) GetTask() string {
 	return *n.Task
+}
+
+func (n Params) GetProperties() []string {
+	return n.Properties
 }

--- a/modules/generative-cohere/additional/generate/generate_params_extractor.go
+++ b/modules/generative-cohere/additional/generate/generate_params_extractor.go
@@ -27,7 +27,19 @@ func (p *GenerateProvider) parseGenerateArguments(args []*ast.Argument) *Params 
 			out.Prompt = &obj[0].Value.(*ast.StringValue).Value
 		case "groupedResult":
 			obj := arg.Value.(*ast.ObjectValue).Fields
-			out.Task = &obj[0].Value.(*ast.StringValue).Value
+			for _, field := range obj {
+				switch field.Name.Value {
+				case "task":
+					out.Task = &field.Value.(*ast.StringValue).Value
+				case "properties":
+					inp := field.Value.GetValue().([]ast.Value)
+					out.Properties = make([]string, len(inp))
+
+					for i, value := range inp {
+						out.Properties[i] = value.(*ast.StringValue).Value
+					}
+				}
+			}
 
 		default:
 			// ignore what we don't recognize

--- a/modules/generative-cohere/additional/provider.go
+++ b/modules/generative-cohere/additional/provider.go
@@ -26,7 +26,7 @@ type AdditionalProperty interface {
 		in []search.Result, params interface{}, limit *int,
 		argumentModuleParams map[string]interface{}, cfg moduletools.ClassConfig) ([]search.Result, error)
 	ExtractAdditionalFn(param []*ast.Argument) interface{}
-	AdditonalPropertyDefaultValue() interface{}
+	AdditionalPropertyDefaultValue() interface{}
 	AdditionalFieldFn(classname string) *graphql.Field
 }
 

--- a/modules/generative-cohere/module.go
+++ b/modules/generative-cohere/module.go
@@ -94,4 +94,5 @@ func (m *GenerativeCohereModule) AdditionalProperties() map[string]modulecapabil
 var (
 	_ = modulecapabilities.Module(New())
 	_ = modulecapabilities.AdditionalProperties(New())
+	_ = modulecapabilities.MetaProvider(New())
 )


### PR DESCRIPTION
### What's being changed:

This PR adds missing `properties` field in `groupedResult` in `generative-cohere` module.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
