### PR TITLE
Tenant object batch operations support

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -570,6 +570,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantKeyParameterQuery"
           }
         ],
         "responses": {
@@ -5000,6 +5003,12 @@ func init() {
             "type": "string",
             "description": "Determines how many replicas must acknowledge a request before it is considered successful",
             "name": "consistency_level",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant_key",
             "in": "query"
           }
         ],

--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -83,7 +83,10 @@ func (h *batchObjectHandlers) addReferences(params batch.BatchReferencesCreatePa
 			WithPayload(errPayloadFromSingleErr(err))
 	}
 
-	references, err := h.manager.AddReferences(params.HTTPRequest.Context(), principal, params.Body, repl)
+	tenantKey := getTenantKey(params.TenantKey)
+
+	references, err := h.manager.AddReferences(
+		params.HTTPRequest.Context(), principal, params.Body, repl, tenantKey)
 	if err != nil {
 		switch err.(type) {
 		case errors.Forbidden:

--- a/adapters/handlers/rest/operations/batch/batch_references_create_parameters.go
+++ b/adapters/handlers/rest/operations/batch/batch_references_create_parameters.go
@@ -54,6 +54,10 @@ type BatchReferencesCreateParams struct {
 	  In: query
 	*/
 	ConsistencyLevel *string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	TenantKey *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -101,6 +105,11 @@ func (o *BatchReferencesCreateParams) BindRequest(r *http.Request, route *middle
 	if err := o.bindConsistencyLevel(qConsistencyLevel, qhkConsistencyLevel, route.Formats); err != nil {
 		res = append(res, err)
 	}
+
+	qTenantKey, qhkTenantKey, _ := qs.GetOK("tenant_key")
+	if err := o.bindTenantKey(qTenantKey, qhkTenantKey, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -121,6 +130,24 @@ func (o *BatchReferencesCreateParams) bindConsistencyLevel(rawData []string, has
 		return nil
 	}
 	o.ConsistencyLevel = &raw
+
+	return nil
+}
+
+// bindTenantKey binds and validates parameter TenantKey from query.
+func (o *BatchReferencesCreateParams) bindTenantKey(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.TenantKey = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/batch/batch_references_create_urlbuilder.go
+++ b/adapters/handlers/rest/operations/batch/batch_references_create_urlbuilder.go
@@ -25,6 +25,7 @@ import (
 // BatchReferencesCreateURL generates an URL for the batch references create operation
 type BatchReferencesCreateURL struct {
 	ConsistencyLevel *string
+	TenantKey        *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -66,6 +67,14 @@ func (o *BatchReferencesCreateURL) Build() (*url.URL, error) {
 	}
 	if consistencyLevelQ != "" {
 		qs.Set("consistency_level", consistencyLevelQ)
+	}
+
+	var tenantKeyQ string
+	if o.TenantKey != nil {
+		tenantKeyQ = *o.TenantKey
+	}
+	if tenantKeyQ != "" {
+		qs.Set("tenant_key", tenantKeyQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -76,7 +76,7 @@ func (db *DB) BatchPutObjects(ctx context.Context, objs objects.BatchObjects,
 }
 
 func (db *DB) AddBatchReferences(ctx context.Context, references objects.BatchReferences,
-	repl *additional.ReplicationProperties,
+	repl *additional.ReplicationProperties, tenantKey string,
 ) (objects.BatchReferences, error) {
 	refByClass := make(map[schema.ClassName]objects.BatchReferences)
 	indexByClass := make(map[schema.ClassName]*Index)
@@ -108,7 +108,7 @@ func (db *DB) AddBatchReferences(ctx context.Context, references objects.BatchRe
 		if !ok {
 			continue
 		}
-		errs := index.addReferencesBatch(ctx, queue, repl)
+		errs := index.addReferencesBatch(ctx, queue, repl, tenantKey)
 		index.dropIndex.RUnlock()
 		for i, err := range errs {
 			if err != nil {

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -179,7 +179,7 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 				OriginalIndex: i,
 			}
 		}
-		_, err = repo.AddBatchReferences(context.Background(), refs, nil)
+		_, err = repo.AddBatchReferences(context.Background(), refs, nil, "")
 		assert.Nil(t, err)
 	})
 
@@ -232,7 +232,7 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 				OriginalIndex: i,
 			}
 		}
-		_, err = repo.AddBatchReferences(context.Background(), refs, nil)
+		_, err = repo.AddBatchReferences(context.Background(), refs, nil, "")
 		assert.Nil(t, err)
 	})
 

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -125,7 +125,7 @@ func testDistributed(t *testing.T, dirName string, batch bool) {
 			node := nodes[rand.Intn(len(nodes))]
 
 			batch := refsAsBatch(refData, "toFirst")
-			res, err := node.repo.AddBatchReferences(context.Background(), batch, nil)
+			res, err := node.repo.AddBatchReferences(context.Background(), batch, nil, "")
 			require.Nil(t, err)
 			for _, ind := range res {
 				require.Nil(t, ind.Err)

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -1152,7 +1152,7 @@ func TestCRUD(t *testing.T) {
 				}
 				refBatch[i] = ref
 			}
-			batchRefResp, err := repo.AddBatchReferences(context.Background(), refBatch, nil)
+			batchRefResp, err := repo.AddBatchReferences(context.Background(), refBatch, nil, "")
 			require.Nil(t, err)
 			require.Len(t, batchRefResp, numThings)
 			for _, r := range batchRefResp {

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -142,7 +142,7 @@ func Test_MultiShardJourneys_BatchedImports(t *testing.T) {
 			}
 		}
 
-		_, err := repo.AddBatchReferences(context.Background(), refBatch, nil)
+		_, err := repo.AddBatchReferences(context.Background(), refBatch, nil, "")
 		require.Nil(t, err)
 	})
 

--- a/client/batch/batch_references_create_parameters.go
+++ b/client/batch/batch_references_create_parameters.go
@@ -86,6 +86,12 @@ type BatchReferencesCreateParams struct {
 	*/
 	ConsistencyLevel *string
 
+	/* TenantKey.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	TenantKey *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -161,6 +167,17 @@ func (o *BatchReferencesCreateParams) SetConsistencyLevel(consistencyLevel *stri
 	o.ConsistencyLevel = consistencyLevel
 }
 
+// WithTenantKey adds the tenantKey to the batch references create params
+func (o *BatchReferencesCreateParams) WithTenantKey(tenantKey *string) *BatchReferencesCreateParams {
+	o.SetTenantKey(tenantKey)
+	return o
+}
+
+// SetTenantKey adds the tenantKey to the batch references create params
+func (o *BatchReferencesCreateParams) SetTenantKey(tenantKey *string) {
+	o.TenantKey = tenantKey
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *BatchReferencesCreateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -186,6 +203,23 @@ func (o *BatchReferencesCreateParams) WriteToRequest(r runtime.ClientRequest, re
 		if qConsistencyLevel != "" {
 
 			if err := r.SetQueryParam("consistency_level", qConsistencyLevel); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.TenantKey != nil {
+
+		// query param tenant_key
+		var qrTenantKey string
+
+		if o.TenantKey != nil {
+			qrTenantKey = *o.TenantKey
+		}
+		qTenantKey := qrTenantKey
+		if qTenantKey != "" {
+
+			if err := r.SetQueryParam("tenant_key", qTenantKey); err != nil {
 				return err
 			}
 		}

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3309,6 +3309,9 @@
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantKeyParameterQuery"
           }
         ],
         "responses": {

--- a/test/acceptance/multi_tenancy/add_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/add_tenant_objects_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 func TestAddTenantObjects(t *testing.T) {
+	className := "MultiTenantClass"
 	tenantKey := "tenantName"
 	testClass := models.Class{
-		Class: "MultiTenantClass",
+		Class: className,
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:   true,
 			TenantKey: tenantKey,
@@ -41,21 +42,21 @@ func TestAddTenantObjects(t *testing.T) {
 	tenantObjects := []*models.Object{
 		{
 			ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
-			Class: testClass.Class,
+			Class: className,
 			Properties: map[string]interface{}{
 				tenantKey: tenantNames[0],
 			},
 		},
 		{
 			ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
-			Class: testClass.Class,
+			Class: className,
 			Properties: map[string]interface{}{
 				tenantKey: tenantNames[1],
 			},
 		},
 		{
 			ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
-			Class: testClass.Class,
+			Class: className,
 			Properties: map[string]interface{}{
 				tenantKey: tenantNames[2],
 			},
@@ -63,7 +64,7 @@ func TestAddTenantObjects(t *testing.T) {
 	}
 
 	defer func() {
-		helper.DeleteClass(t, testClass.Class)
+		helper.DeleteClass(t, className)
 	}()
 
 	t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
@@ -75,7 +76,7 @@ func TestAddTenantObjects(t *testing.T) {
 		for i := range tenants {
 			tenants[i] = &models.Tenant{tenantNames[i]}
 		}
-		helper.CreateTenants(t, testClass.Class, tenants)
+		helper.CreateTenants(t, className, tenants)
 	})
 
 	t.Run("add tenant objects", func(t *testing.T) {

--- a/test/acceptance/multi_tenancy/batch_add_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/batch_add_tenant_objects_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-func TestAddTenantObjects(t *testing.T) {
+func TestBatchAddTenantObjects(t *testing.T) {
 	tenantKey := "tenantName"
 	testClass := models.Class{
 		Class: "MultiTenantClass",
@@ -79,15 +79,14 @@ func TestAddTenantObjects(t *testing.T) {
 	})
 
 	t.Run("add tenant objects", func(t *testing.T) {
-		for i, obj := range tenantObjects {
-			helper.CreateTenantObject(t, obj, tenantNames[i])
-		}
+		helper.CreateObjectsBatch(t, tenantObjects)
 	})
 
-	t.Run("verify object creation", func(t *testing.T) {
+	t.Run("get tenant objects", func(t *testing.T) {
 		for i, obj := range tenantObjects {
 			resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[i])
 			require.Nil(t, err)
+			assert.Equal(t, obj.ID, resp.ID)
 			assert.Equal(t, obj.Class, resp.Class)
 			assert.Equal(t, obj.Properties, resp.Properties)
 		}

--- a/test/acceptance/multi_tenancy/batch_add_tenant_references_test.go
+++ b/test/acceptance/multi_tenancy/batch_add_tenant_references_test.go
@@ -1,0 +1,133 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestBatchAddTenantReferences(t *testing.T) {
+	className := "MultiTenantClass"
+	tenantKey := "tenantName"
+	tenantName := "Tenant1"
+	refProp := "relatedTo"
+	testClass := models.Class{
+		Class: className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled:   true,
+			TenantKey: tenantKey,
+		},
+		Properties: []*models.Property{
+			{
+				Name:     tenantKey,
+				DataType: []string{"string"},
+			},
+			{
+				Name:     refProp,
+				DataType: []string{className},
+			},
+		},
+	}
+	tenantObjects := []*models.Object{
+		{
+			ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
+			Class: className,
+			Properties: map[string]interface{}{
+				tenantKey: tenantName,
+			},
+		},
+		{
+			ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
+			Class: className,
+			Properties: map[string]interface{}{
+				tenantKey: tenantName,
+			},
+		},
+		{
+			ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
+			Class: className,
+			Properties: map[string]interface{}{
+				tenantKey: tenantName,
+			},
+		},
+	}
+
+	defer func() {
+		helper.DeleteClass(t, className)
+	}()
+
+	t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+		helper.CreateClass(t, &testClass)
+	})
+
+	t.Run("create tenants", func(t *testing.T) {
+		tenants := []*models.Tenant{{Name: tenantName}}
+		helper.CreateTenants(t, className, tenants)
+	})
+
+	t.Run("add tenant objects", func(t *testing.T) {
+		for _, obj := range tenantObjects {
+			helper.CreateTenantObject(t, obj, tenantName)
+		}
+
+		t.Run("verify object creation", func(t *testing.T) {
+			for _, obj := range tenantObjects {
+				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantName)
+				require.Nil(t, err)
+				require.Equal(t, obj.Class, resp.Class)
+				require.Equal(t, obj.Properties, resp.Properties)
+			}
+		})
+	})
+
+	t.Run("add tenant references", func(t *testing.T) {
+		refs := []*models.BatchReference{
+			{
+				From: strfmt.URI(crossref.NewSource(schema.ClassName(className),
+					schema.PropertyName(refProp), tenantObjects[0].ID).String()),
+				To: strfmt.URI(crossref.NewLocalhost(className, tenantObjects[0].ID).String()),
+			},
+			{
+				From: strfmt.URI(crossref.NewSource(schema.ClassName(className),
+					schema.PropertyName(refProp), tenantObjects[0].ID).String()),
+				To: strfmt.URI(crossref.NewLocalhost(className, tenantObjects[1].ID).String()),
+			},
+			{
+				From: strfmt.URI(crossref.NewSource(schema.ClassName(className),
+					schema.PropertyName(refProp), tenantObjects[0].ID).String()),
+				To: strfmt.URI(crossref.NewLocalhost(className, tenantObjects[2].ID).String()),
+			},
+		}
+		helper.AddTenantReferences(t, refs, tenantName)
+	})
+
+	t.Run("verify object references", func(t *testing.T) {
+		resp, err := helper.TenantObject(t, tenantObjects[0].Class, tenantObjects[0].ID, tenantName)
+		require.Nil(t, err)
+		require.Equal(t, tenantObjects[0].Class, resp.Class)
+		require.Equal(t, tenantObjects[0].ID, resp.ID)
+		relatedTo := resp.Properties.(map[string]interface{})[refProp].([]interface{})
+		require.Len(t, relatedTo, 3)
+		for i, rel := range relatedTo {
+			beacon := rel.(map[string]interface{})["beacon"].(string)
+			assert.Equal(t, helper.NewBeacon(className, tenantObjects[i].ID), strfmt.URI(beacon))
+		}
+	})
+}

--- a/test/acceptance/multi_tenancy/batch_delete_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/batch_delete_tenant_objects_test.go
@@ -1,0 +1,121 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/objects"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestBatchDeleteTenantObjects(t *testing.T) {
+	className := "MultiTenantClass"
+	tenantKey := "tenantName"
+	testClass := models.Class{
+		Class: className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled:   true,
+			TenantKey: tenantKey,
+		},
+		Properties: []*models.Property{
+			{
+				Name:     tenantKey,
+				DataType: []string{"string"},
+			},
+		},
+	}
+	tenantNames := []string{
+		"Tenant1", "Tenant2", "Tenant3",
+	}
+	tenantObjects := []*models.Object{
+		{
+			ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
+			Class: className,
+			Properties: map[string]interface{}{
+				tenantKey: tenantNames[0],
+			},
+		},
+		{
+			ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
+			Class: className,
+			Properties: map[string]interface{}{
+				tenantKey: tenantNames[1],
+			},
+		},
+		{
+			ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
+			Class: className,
+			Properties: map[string]interface{}{
+				tenantKey: tenantNames[2],
+			},
+		},
+	}
+
+	defer func() {
+		helper.DeleteClass(t, className)
+	}()
+
+	t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+		helper.CreateClass(t, &testClass)
+	})
+
+	t.Run("create tenants", func(t *testing.T) {
+		tenants := make([]*models.Tenant, len(tenantNames))
+		for i := range tenants {
+			tenants[i] = &models.Tenant{tenantNames[i]}
+		}
+		helper.CreateTenants(t, className, tenants)
+	})
+
+	t.Run("add tenant objects", func(t *testing.T) {
+		helper.CreateObjectsBatch(t, tenantObjects)
+
+		t.Run("verify tenant objects", func(t *testing.T) {
+			for i, obj := range tenantObjects {
+				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[i])
+				require.Nil(t, err)
+				require.Equal(t, obj.ID, resp.ID)
+				require.Equal(t, obj.Class, resp.Class)
+				require.Equal(t, obj.Properties, resp.Properties)
+			}
+		})
+	})
+
+	t.Run("batch delete tenant objects", func(t *testing.T) {
+		glob := "*"
+		where := models.WhereFilter{
+			Operator:    filters.OperatorLike.Name(),
+			Path:        []string{"id"},
+			ValueString: &glob,
+		}
+		match := models.BatchDeleteMatch{
+			Class: className,
+			Where: &where,
+		}
+		batch := models.BatchDelete{Match: &match}
+		helper.DeleteObjectsBatch(t, &batch)
+
+		t.Run("verify tenant object deletion", func(t *testing.T) {
+			for i, obj := range tenantObjects {
+				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[i])
+				assert.Nil(t, resp)
+				assert.NotNil(t, err)
+				assert.EqualError(t, objects.NewObjectsClassGetNotFound(), err.Error())
+			}
+		})
+	})
+}

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -82,7 +82,10 @@ func CreateObjectsBatch(t *testing.T, objects []*models.Object) {
 	resp, err := Client(t).Batch.BatchObjectsCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
 	for _, elem := range resp.Payload {
-		assert.Nil(t, elem.Result.Errors)
+		if !assert.Nil(t, elem.Result.Errors) {
+			t.Logf("expected nil, got: %v",
+				elem.Result.Errors.Error[0].Message)
+		}
 	}
 }
 
@@ -143,6 +146,25 @@ func AddReferences(t *testing.T, refs []*models.BatchReference) {
 	params := batch.NewBatchReferencesCreateParams().WithBody(refs)
 	resp, err := Client(t).Batch.BatchReferencesCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
+	for _, elem := range resp.Payload {
+		if !assert.Nil(t, elem.Result.Errors) {
+			t.Logf("expected nil, got: %v",
+				elem.Result.Errors.Error[0].Message)
+		}
+	}
+}
+
+func AddTenantReferences(t *testing.T, refs []*models.BatchReference, tenantKey string) {
+	params := batch.NewBatchReferencesCreateParams().
+		WithBody(refs).WithTenantKey(&tenantKey)
+	resp, err := Client(t).Batch.BatchReferencesCreate(params, nil)
+	AssertRequestOk(t, resp, err, nil)
+	for _, elem := range resp.Payload {
+		if !assert.Nil(t, elem.Result.Errors) {
+			t.Logf("expected nil, got: %v",
+				elem.Result.Errors.Error[0].Message)
+		}
+	}
 }
 
 func AddReference(t *testing.T, object *models.Object, ref *models.SingleRef, prop string) {

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -111,7 +111,7 @@ type VectorRepo interface {
 
 type vectorRepo interface {
 	VectorRepo
-	BatchPutObjects(ctx context.Context, things objects.BatchObjects,
+	BatchPutObjects(ctx context.Context, objects objects.BatchObjects,
 		repl *additional.ReplicationProperties) (objects.BatchObjects, error)
 }
 

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -223,6 +223,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 			additionalArgs: []interface{}{
 				[]*models.BatchReference{},
 				&additional.ReplicationProperties{},
+				"",
 			},
 			expectedVerb:     "update",
 			expectedResource: "batch/*",

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -42,7 +42,8 @@ type BatchVectorRepo interface {
 type batchRepoNew interface {
 	BatchPutObjects(ctx context.Context, objects BatchObjects,
 		repl *additional.ReplicationProperties) (BatchObjects, error)
-	BatchDeleteObjects(ctx context.Context, params BatchDeleteParams, repl *additional.ReplicationProperties) (BatchDeleteResult, error)
+	BatchDeleteObjects(ctx context.Context, params BatchDeleteParams,
+		repl *additional.ReplicationProperties) (BatchDeleteResult, error)
 	AddBatchReferences(ctx context.Context, references BatchReferences,
 		repl *additional.ReplicationProperties) (BatchReferences, error)
 }

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -45,7 +45,7 @@ type batchRepoNew interface {
 	BatchDeleteObjects(ctx context.Context, params BatchDeleteParams,
 		repl *additional.ReplicationProperties) (BatchDeleteResult, error)
 	AddBatchReferences(ctx context.Context, references BatchReferences,
-		repl *additional.ReplicationProperties) (BatchReferences, error)
+		repl *additional.ReplicationProperties, tenantKey string) (BatchReferences, error)
 }
 
 // NewBatchManager creates a new manager

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -24,7 +24,7 @@ import (
 
 // AddReferences Class Instances in batch to the connected DB
 func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Principal,
-	refs []*models.BatchReference, repl *additional.ReplicationProperties,
+	refs []*models.BatchReference, repl *additional.ReplicationProperties, tenantKey string,
 ) (BatchReferences, error) {
 	err := b.authorizer.Authorize(principal, "update", "batch/*")
 	if err != nil {
@@ -40,18 +40,18 @@ func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Prin
 	b.metrics.BatchRefInc()
 	defer b.metrics.BatchRefDec()
 
-	return b.addReferences(ctx, refs, repl)
+	return b.addReferences(ctx, refs, repl, tenantKey)
 }
 
 func (b *BatchManager) addReferences(ctx context.Context, refs []*models.BatchReference,
-	repl *additional.ReplicationProperties,
+	repl *additional.ReplicationProperties, tenantKey string,
 ) (BatchReferences, error) {
 	if err := b.validateReferenceForm(refs); err != nil {
 		return nil, NewErrInvalidUserInput("invalid params: %v", err)
 	}
 
 	batchReferences := b.validateReferencesConcurrently(refs)
-	if res, err := b.vectorRepo.AddBatchReferences(ctx, batchReferences, repl); err != nil {
+	if res, err := b.vectorRepo.AddBatchReferences(ctx, batchReferences, repl, tenantKey); err != nil {
 		return nil, NewErrInternal("could not add batch request to connector: %v", err)
 	} else {
 		return res, nil

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -193,7 +193,7 @@ func (f *fakeVectorRepo) BatchPutObjects(ctx context.Context, batch BatchObjects
 }
 
 func (f *fakeVectorRepo) AddBatchReferences(ctx context.Context, batch BatchReferences,
-	repl *additional.ReplicationProperties,
+	repl *additional.ReplicationProperties, tenantKey string,
 ) (BatchReferences, error) {
 	args := f.Called(batch)
 	return batch, args.Error(0)

--- a/usecases/objects/multi_tenancy.go
+++ b/usecases/objects/multi_tenancy.go
@@ -1,0 +1,26 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package objects
+
+import "github.com/weaviate/weaviate/entities/models"
+
+// ParseTenantKeyFromObject extract the value of the tenant key if it exists
+func ParseTenantKeyFromObject(tenantKeyName string, o *models.Object) string {
+	if props, _ := o.Properties.(map[string]interface{}); props != nil {
+		if rawVal := props[tenantKeyName]; rawVal != nil {
+			if key, _ := rawVal.(string); key != "" {
+				return key
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
### What's being changed:

Support for the following batch operations:
- `POST /batch/objects`
- `DELETE /batch/objects`
- `POST /batch/references`

### Tenant key query param

The only endpoint of the 3 introduced above which requires a `tenant_key` query parameter is `POST /batch/references`. The reason for this is that adding batch references should be isolated to a single tenant.

Adding a batch of objects can safely be done across multiple tenants, since object creation itself does not violate the tenant boundary.

Deleting a batch of objects already requires a class name in the request body, and requires a where filter to match objects, so there is already client control to only delete objects for a specific tenant, or otherwise.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
