### PR TITLE
Fix potential panic on corrupt .bloom file

### DIFF
--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -299,6 +299,12 @@ func loadWithChecksum(path string, lengthCheck int) ([]byte, error) {
 	if lengthCheck > 0 && len(data) != lengthCheck {
 		return nil, ErrInvalidChecksum
 	}
+
+	if len(data) < 4 {
+		// the file does not even contain the full checksum, we must consider it corrupt
+		return nil, ErrInvalidChecksum
+	}
+
 	chcksm := binary.LittleEndian.Uint32(data[:4])
 	actual := crc32.ChecksumIEEE(data[4:])
 	if chcksm != actual {

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -150,6 +150,42 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	assert.Equal(t, []byte("world"), value)
 }
 
+func TestRepairTooShortBloomOnInit(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+	defer b.Shutdown(ctx)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
+	require.Nil(t, b.FlushMemtable())
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, ".bloom")
+	require.True(t, ok)
+
+	// now corrupt the bloom filter by randomly overriding data
+	require.Nil(t, corruptBloomFileByTruncatingIt(path.Join(dirName, fname)))
+
+	// now create a new bucket and assert that the file is ignored, re-created on
+	// init, and the count matches
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
+
+	value, err := b2.Get([]byte("hello"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("world"), value)
+}
+
 func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
@@ -173,6 +209,43 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 
 	// now corrupt the file by replacing the count value without adapting the checksum
 	require.Nil(t, corruptBloomFile(path.Join(dirName, fname)))
+
+	// now create a new bucket and assert that the file is ignored, re-created on
+	// init, and the count matches
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
+
+	value, err := b2.GetBySecondary(0, []byte("bonjour"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("world"), value)
+}
+
+func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.Nil(t, err)
+	defer b.Shutdown(ctx)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
+		WithSecondaryKey(0, []byte("bonjour"))))
+	require.Nil(t, b.FlushMemtable())
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, "secondary.0.bloom")
+	require.True(t, ok)
+
+	// now corrupt the file by replacing the count value without adapting the checksum
+	require.Nil(t, corruptBloomFileByTruncatingIt(path.Join(dirName, fname)))
 
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
@@ -229,6 +302,36 @@ func corruptBloomFile(fname string) error {
 	for i := 5; i < len(data); i++ {
 		data[i] = 0x01
 	}
+
+	f, err = os.Create(fname)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}
+
+func corruptBloomFileByTruncatingIt(fname string) error {
+	f, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	data = data[:2]
 
 	f, err = os.Create(fname)
 	if err != nil {


### PR DESCRIPTION
### What's being changed:
* treat a too short .bloom file identical to one with an invalid chksum
* fixes #3067 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
