### PR TITLE
feat: use mmap-go for windows support

### DIFF
--- a/adapters/clients/cluster_schema_test.go
+++ b/adapters/clients/cluster_schema_test.go
@@ -187,7 +187,7 @@ func TestOpenTransactionUnhappyPaths(t *testing.T) {
 			shutdownPrematurely: true,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 			},
-			expectedErrContains: "connection refused",
+			expectedErrContains: "refused",
 		},
 		{
 			name: "tx id mismatch",
@@ -301,7 +301,7 @@ func TestAbortTransactionUnhappyPaths(t *testing.T) {
 			shutdownPrematurely: true,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 			},
-			expectedErrContains: "connection refused",
+			expectedErrContains: "refused",
 		},
 	}
 
@@ -399,7 +399,7 @@ func TestCommitTransactionUnhappyPaths(t *testing.T) {
 			shutdownPrematurely: true,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 			},
-			expectedErrContains: "connection refused",
+			expectedErrContains: "refused",
 		},
 	}
 

--- a/adapters/repos/db/disk_use_unix.go
+++ b/adapters/repos/db/disk_use_unix.go
@@ -1,0 +1,33 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build !windows
+
+package db
+
+import (
+	"syscall"
+)
+
+func (d *DB) getDiskUse(diskPath string) diskUse {
+	fs := syscall.Statfs_t{}
+
+	err := syscall.Statfs(diskPath, &fs)
+	if err != nil {
+		d.logger.WithField("action", "read_disk_use").
+			WithField("path", diskPath).
+			Errorf("failed to read disk usage: %s", err)
+	}
+
+	return diskUse{
+		total: fs.Blocks * uint64(fs.Bsize),
+		free:  fs.Bfree * uint64(fs.Bsize),
+		avail: fs.Bfree * uint64(fs.Bsize),
+	}
+}

--- a/adapters/repos/db/disk_use_windows.go
+++ b/adapters/repos/db/disk_use_windows.go
@@ -1,0 +1,42 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build windows
+
+package db
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func (d *DB) getDiskUse(diskPath string) diskUse {
+	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes uint64
+
+	_, _ = syscall.UTF16PtrFromString(diskPath)
+
+	err := windows.GetDiskFreeSpaceEx(
+		syscall.StringToUTF16Ptr(diskPath),
+		&freeBytesAvailable,
+		&totalNumberOfBytes,
+		&totalNumberOfFreeBytes,
+	)
+	if err != nil {
+		d.logger.WithField("action", "read_disk_use").
+			WithField("path", diskPath).
+			Errorf("failed to read disk usage: %s", err)
+	}
+
+	return diskUse{
+		total: totalNumberOfBytes,
+		free:  totalNumberOfFreeBytes,
+		avail: freeBytesAvailable,
+	}
+}

--- a/adapters/repos/db/inverted/prop_length_tracker_test.go
+++ b/adapters/repos/db/inverted/prop_length_tracker_test.go
@@ -42,29 +42,33 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		tests := []test{
 			{
 				values:       []float32{2, 2, 3, 100, 100, 500, 7},
-				name:         "mixed values",
+				name:         "mixed_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values: []float32{
 					1000, 1200, 1000, 1300, 800, 2000, 2050,
 					2070, 900,
 				},
-				name:         "high values",
+				name:         "high_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values: []float32{
 					60000, 50000, 65000,
 				},
-				name:         "very high values",
+				name:         "very_high_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values: []float32{
 					1, 2, 4, 3, 4, 2, 1, 5, 6, 7, 8, 2, 7, 2, 3, 5,
 					6, 3, 5, 9, 3, 4, 8,
 				},
-				name:         "very low values",
+				name:         "very_low_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values:       []float32{0, 0},
 				name:         "zeros",
 				floatCompare: false,
@@ -73,7 +77,7 @@ func Test_PropertyLengthTracker(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				tracker, err := NewJsonPropertyLengthTracker(trackerPath)
+				tracker, err := NewJsonPropertyLengthTracker(trackerPath + test.name)
 				require.Nil(t, err)
 
 				actualMean := float32(0)
@@ -91,6 +95,7 @@ func Test_PropertyLengthTracker(t *testing.T) {
 				} else {
 					assert.Equal(t, actualMean, res)
 				}
+				require.Nil(t, tracker.Close())
 			})
 		}
 	})
@@ -123,6 +128,8 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		assert.Equal(t, 3, sum)
 		assert.Equal(t, 1, count)
 		assert.InEpsilon(t, 3, mean, 0.1)
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("multiple properties (can all fit on one page)", func(t *testing.T) {
@@ -171,6 +178,8 @@ func Test_PropertyLengthTracker(t *testing.T) {
 
 			assert.InEpsilon(t, actualMean, res, 0.1)
 		}
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("with more properties that can fit on one page", func(t *testing.T) {
@@ -179,6 +188,8 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		require.Nil(t, err)
 
 		create20PropsAndVerify(t, tracker)
+
+		require.Nil(t, tracker.Close())
 	})
 }
 
@@ -416,27 +427,27 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 		tests := []test{
 			{
 				values:       []float32{2, 2, 3, 100, 100, 500, 7},
-				name:         "mixed values",
+				name:         "mixed_values",
 				floatCompare: true,
 			}, {
 				values: []float32{
 					1000, 1200, 1000, 1300, 800, 2000, 2050,
 					2070, 900,
 				},
-				name:         "high values",
+				name:         "high_values",
 				floatCompare: true,
 			}, {
 				values: []float32{
 					60000, 50000, 65000,
 				},
-				name:         "very high values",
+				name:         "very_high_values",
 				floatCompare: true,
 			}, {
 				values: []float32{
 					1, 2, 4, 3, 4, 2, 1, 5, 6, 7, 8, 2, 7, 2, 3, 5,
 					6, 3, 5, 9, 3, 4, 8,
 				},
-				name:         "very low values",
+				name:         "very_low_values",
 				floatCompare: true,
 			}, {
 				values:       []float32{0, 0},
@@ -447,7 +458,7 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				tracker, err := NewPropertyLengthTracker(trackerPath)
+				tracker, err := NewPropertyLengthTracker(trackerPath + test.name)
 				require.Nil(t, err)
 
 				actualMean := float32(0)
@@ -465,6 +476,7 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 				} else {
 					assert.Equal(t, actualMean, res)
 				}
+				require.Nil(t, tracker.Close())
 			})
 		}
 	})
@@ -497,6 +509,8 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 		assert.Equal(t, 3, sum)
 		assert.Equal(t, 1, count)
 		assert.InEpsilon(t, 3, mean, 0.1)
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("multiple properties (can all fit on one page)", func(t *testing.T) {
@@ -545,6 +559,8 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 
 			assert.InEpsilon(t, actualMean, res, 0.1)
 		}
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("with more properties that can fit on one page", func(t *testing.T) {
@@ -553,6 +569,8 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 		require.Nil(t, err)
 
 		create20PropsAndVerify_old(t, tracker)
+
+		require.Nil(t, tracker.Close())
 	})
 }
 
@@ -602,6 +620,10 @@ func TestOldPropertyLengthTracker_Persistence(t *testing.T) {
 		require.Nil(t, err)
 		assert.InEpsilon(t, actualMeanForProp20, res, 0.1)
 	})
+
+	t.Run("shut down the second tracker", func(t *testing.T) {
+		require.Nil(t, secondTracker.Close())
+	})
 }
 
 func Test_PropertyLengthTracker_Overflow(t *testing.T) {
@@ -619,4 +641,6 @@ func Test_PropertyLengthTracker_Overflow(t *testing.T) {
 	// Check that property that would cause the internal counter to overflow is not added
 	err = tracker.TrackProperty("OVERFLOW", float32(123))
 	require.NotNil(t, err)
+
+	require.Nil(t, tracker.Close())
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -27,6 +27,9 @@ func TestBucket_WasDeleted(t *testing.T) {
 	b, err := NewBucket(context.Background(), tmpDir, "", logger, nil,
 		cyclemanager.NewNoop(), cyclemanager.NewNoop())
 	require.Nil(t, err)
+	t.Cleanup(func() {
+		require.Nil(t, b.Shutdown(context.Background()))
+	})
 
 	var (
 		key = []byte("key")

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
@@ -50,6 +50,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.False(t, setKey2.Additions.Contains(2))
 		assert.True(t, setKey2.Additions.Contains(3))
 		assert.True(t, setKey2.Additions.Contains(4))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("inserting lists", func(t *testing.T) {
@@ -75,6 +77,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.False(t, setKey2.Additions.Contains(2))
 		assert.True(t, setKey2.Additions.Contains(3))
 		assert.True(t, setKey2.Additions.Contains(4))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("inserting bitmaps", func(t *testing.T) {
@@ -102,6 +106,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.False(t, setKey2.Additions.Contains(2))
 		assert.True(t, setKey2.Additions.Contains(3))
 		assert.True(t, setKey2.Additions.Contains(4))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("removing individual entries", func(t *testing.T) {
@@ -123,6 +129,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		require.Nil(t, err)
 		assert.False(t, setKey2.Additions.Contains(8))
 		assert.True(t, setKey2.Deletions.Contains(8))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("removing lists", func(t *testing.T) {
@@ -148,6 +156,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.Equal(t, 2, setKey2.Deletions.GetCardinality())
 		assert.True(t, setKey2.Deletions.Contains(9))
 		assert.True(t, setKey2.Deletions.Contains(10))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("removing bitmaps", func(t *testing.T) {
@@ -173,6 +183,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.Equal(t, 2, setKey2.Deletions.GetCardinality())
 		assert.True(t, setKey2.Deletions.Contains(9))
 		assert.True(t, setKey2.Deletions.Contains(10))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("adding/removing bitmaps", func(t *testing.T) {
@@ -204,5 +216,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.Equal(t, 2, setKey2.Deletions.GetCardinality())
 		assert.True(t, setKey2.Deletions.Contains(9))
 		assert.True(t, setKey2.Deletions.Contains(10))
+
+		require.Nil(t, m.commitlog.close())
 	})
 }

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -26,6 +26,9 @@ func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	dir := t.TempDir()
 	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, nil)
 	require.Nil(t, err)
+	t.Cleanup(func() {
+		require.Nil(t, m.commitlog.close())
+	})
 
 	t.Run("add initial value", func(t *testing.T) {
 		err = m.put([]byte("my-key"), []byte("my-value"),

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -7,7 +7,6 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
-//
 
 package lsmkv
 
@@ -15,8 +14,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"syscall"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
@@ -76,7 +75,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		return nil, errors.Wrap(err, "stat file")
 	}
 
-	content, err := syscall.Mmap(int(file.Fd()), 0, int(fileInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	content, err := mmap.MapRegion(file, int(fileInfo.Size()), mmap.RDONLY, 0, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "mmap file")
 	}
@@ -145,7 +144,8 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 }
 
 func (s *segment) close() error {
-	return syscall.Munmap(s.contents)
+	mmmap := mmap.MMap(s.contents)
+	return mmmap.Unmap()
 }
 
 func (s *segment) drop() error {

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -78,6 +78,7 @@ func TestCreateCNAInit(t *testing.T) {
 	_, ok = findFileWithExt(files, ".cna")
 	require.False(t, ok, "verify the file is really gone")
 
+	// on Windows we have to shutdown the bucket before opening it again
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
@@ -118,6 +119,8 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	// now corrupt the file by replacing the count value without adapting the checksum
 	require.Nil(t, corruptCNAFile(path.Join(dirName, fname), 12345))
 
+	// on Windows we have to shutdown the bucket before opening it again
+	require.Nil(t, b.Shutdown(ctx))
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -156,7 +156,9 @@ func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger)
 		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		unixErr := "no such file or directory"
+		windowsErr := "The system cannot find the file specified."
+		assert.True(t, strings.Contains(err.Error(), unixErr) || strings.Contains(err.Error(), windowsErr))
 	})
 
 	t.Run("segment header can't be parsed", func(t *testing.T) {

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/debug"
-	"syscall"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/storagestate"
@@ -63,23 +62,6 @@ func (d *DB) scanResourceUsage() {
 			}
 		}
 	}()
-}
-
-func (d *DB) getDiskUse(diskPath string) diskUse {
-	fs := syscall.Statfs_t{}
-
-	err := syscall.Statfs(diskPath, &fs)
-	if err != nil {
-		d.logger.WithField("action", "read_disk_use").
-			WithField("path", diskPath).
-			Errorf("failed to read disk usage: %s", err)
-	}
-
-	return diskUse{
-		total: fs.Blocks * uint64(fs.Bsize),
-		free:  fs.Bfree * uint64(fs.Bsize),
-		avail: fs.Bfree * uint64(fs.Bsize),
-	}
 }
 
 type resourceScanState struct {

--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -62,6 +62,7 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 			},
 		}, uc, cyclemanager.NewNoop(),
 	)
+	defer index.Shutdown(context.Background())
 	ssdhelpers.Concurrently(uint64(len(vectors)), func(id uint64) {
 		index.Add(uint64(id), vectors[id])
 	})

--- a/adapters/repos/db/vector/hnsw/condensor_mmap_reader.go
+++ b/adapters/repos/db/vector/hnsw/condensor_mmap_reader.go
@@ -14,8 +14,8 @@ package hnsw
 import (
 	"bufio"
 	"os"
-	"syscall"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/pkg/errors"
 )
 
@@ -28,9 +28,7 @@ func newMmapCondensorReader() *MmapCondensorReader {
 	return &MmapCondensorReader{}
 }
 
-func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex,
-	targetName string,
-) error {
+func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex, targetName string) error {
 	r.reader = bufio.NewReaderSize(source, 1024*1024)
 
 	scratchFile, err := os.Create(targetName)
@@ -43,8 +41,7 @@ func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex,
 		return errors.Wrap(err, "truncate scratch file to size")
 	}
 
-	mmapSpace, err := syscall.Mmap(int(scratchFile.Fd()), 0, size,
-		syscall.PROT_WRITE, syscall.MAP_PRIVATE)
+	mmapSpace, err := mmap.MapRegion(scratchFile, size, mmap.COPY, 0, 0)
 	if err != nil {
 		return errors.Wrap(err, "mmap scratch file")
 	}
@@ -55,7 +52,7 @@ func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex,
 		return err
 	}
 
-	if err := syscall.Munmap(r.target); err != nil {
+	if err := mmapSpace.Unmap(); err != nil {
 		return errors.Wrap(err, "munmap scratch file")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0
 	github.com/coreos/go-oidc/v3 v3.4.0
+	github.com/edsrzf/mmap-go v1.1.0
 	github.com/pkoukk/tiktoken-go v0.1.1
 	github.com/tailor-inc/graphql v0.1.0
 	github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -162,6 +162,8 @@ func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, err
 func logConnectionRefused(logger logrus.FieldLogger, err error) {
 	if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+	} else if strings.Contains(err.Error(), "connectex: No connection could be made because the target machine actively refused it.") {
+		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 	}
 }
 
@@ -253,6 +255,8 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 	res, err := c.grpcClient.VectorForCorpi(ctx, &pb.Corpi{Corpi: corpi, Overrides: overrides})
 	if err != nil {
 		if strings.Contains(err.Error(), "connect: connection refused") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		} else if strings.Contains(err.Error(), "connectex: No connection could be made because the target machine actively refused it.") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		st, ok := status.FromError(err)

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/hashicorp/memberlist"
@@ -264,16 +263,3 @@ func (e events) NotifyLeave(node *memberlist.Node) {
 // updated, usually involving the meta data. The Node argument
 // must not be modified.
 func (e events) NotifyUpdate(*memberlist.Node) {}
-
-// diskSpace return the disk space usage
-func diskSpace(path string) (DiskUsage, error) {
-	fs := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &fs)
-	if err != nil {
-		return DiskUsage{}, err
-	}
-	return DiskUsage{
-		Total:     fs.Blocks * uint64(fs.Bsize),
-		Available: fs.Bavail * uint64(fs.Bsize),
-	}, nil
-}

--- a/usecases/cluster/disk_use_unix.go
+++ b/usecases/cluster/disk_use_unix.go
@@ -1,0 +1,29 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build !windows
+
+package cluster
+
+import (
+	"syscall"
+)
+
+// diskSpace return the disk space usage
+func diskSpace(path string) (DiskUsage, error) {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return DiskUsage{}, err
+	}
+	return DiskUsage{
+		Total:     fs.Blocks * uint64(fs.Bsize),
+		Available: fs.Bavail * uint64(fs.Bsize),
+	}, nil
+}

--- a/usecases/cluster/disk_use_windows.go
+++ b/usecases/cluster/disk_use_windows.go
@@ -1,0 +1,36 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build windows
+
+package cluster
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// diskSpace return the disk space usage
+func diskSpace(path string) (DiskUsage, error) {
+	var freeBytesAvailableToCaller, totalBytes, totalFreeBytes uint64
+
+	err := windows.GetDiskFreeSpaceEx(
+		windows.StringToUTF16Ptr(path),
+		&freeBytesAvailableToCaller,
+		&totalBytes,
+		&totalFreeBytes,
+	)
+	if err != nil {
+		return DiskUsage{}, err
+	}
+
+	return DiskUsage{
+		Total:     totalBytes,
+		Available: freeBytesAvailableToCaller,
+	}, nil
+}


### PR DESCRIPTION
### What's being changed:
- Adding support for windows to address https://github.com/weaviate/weaviate/issues/2955
- Added dependency on https://github.com/edsrzf/mmap-go to enable cross-platform mmap
- Updated unit tests so that they can run on windows
  - Mainly ensuring underlying files are closed before Go's `Testing.TempDir()` is cleaned up (which otherwise results in errors/panics in tests).
  - Updated some of the `connection refused` tests to support windows error messages

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
