### PR TITLE
Refactor disk usage retrieval during node gossip to async operation

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -49,7 +49,7 @@ func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *Sta
 			log:      logger,
 		},
 	}
-	if err := state.delegate.init(); err != nil {
+	if err := state.delegate.init(diskSpace); err != nil {
 		logger.WithField("action", "init_state.delete_init").Error(err)
 	}
 	cfg.Delegate = &state.delegate


### PR DESCRIPTION
 This prevents blocking the gossip protocol due potentially time-consumming operation 

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
