### PR TITLE
Fixes internal timestamps filtering by valueDate

### DIFF
--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -459,10 +459,11 @@ func (s *Searcher) extractTimestampProp(propName string, propType schema.DataTyp
 		if err != nil {
 			return nil, errors.Wrap(err, "trying parse time as RFC3339 string")
 		}
+
 		// if propType is a `valueDate`, we need to convert
 		// it to ms before fetching. this is the format by
 		// which our timestamps are indexed
-		byteValue = []byte(strconv.FormatInt(t.UnixNano()/int64(time.Millisecond), 10))
+		byteValue = []byte(strconv.FormatInt(t.UnixMilli(), 10))
 	default:
 		return nil, fmt.Errorf(
 			"failed to extract timestamp prop, unsupported type '%T' for prop '%s'", propType, propName)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -14,8 +14,8 @@ package inverted
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -445,20 +445,24 @@ func (s *Searcher) extractTimestampProp(propName string, propType schema.DataTyp
 		if !ok {
 			return nil, fmt.Errorf("expected value to be string, got '%T'", value)
 		}
+		_, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected value to be timestamp, got '%s'", v)
+		}
 		byteValue = []byte(v)
 	case schema.DataTypeDate:
+		v, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected value to be string, got '%T'", value)
+		}
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return nil, errors.Wrap(err, "trying parse time as RFC3339 string")
+		}
 		// if propType is a `valueDate`, we need to convert
 		// it to ms before fetching. this is the format by
 		// which our timestamps are indexed
-		v, ok := value.(time.Time)
-		if !ok {
-			return nil, fmt.Errorf("expected value to be time.Time, got '%T'", value)
-		}
-		b, err := json.Marshal(v.UnixNano() / int64(time.Millisecond))
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to extract timestamp prop '%s", propName)
-		}
-		byteValue = b
+		byteValue = []byte(strconv.FormatInt(t.UnixNano()/int64(time.Millisecond), 10))
 	default:
 		return nil, fmt.Errorf(
 			"failed to extract timestamp prop, unsupported type '%T' for prop '%s'", propType, propName)

--- a/adapters/repos/db/inverted/searcher_value_extractors.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors.go
@@ -73,7 +73,7 @@ func (s *Searcher) extractDateValue(in interface{}) ([]byte, error) {
 	case string:
 		parsed, err := time.Parse(time.RFC3339, t)
 		if err != nil {
-			return nil, errors.Wrap(err, "try parsing time as RFC3339 string")
+			return nil, errors.Wrap(err, "trying parse time as RFC3339 string")
 		}
 
 		asInt64 = parsed.UnixNano()

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -354,7 +354,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 	})
 
 	now := time.Now()
-	timestamp := now.UnixNano() / int64(time.Millisecond)
+	timestamp := now.UnixMilli()
 	testID := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a62")
 
 	t.Run("insert test object", func(t *testing.T) {

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -16,7 +16,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -354,15 +353,16 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 		require.Nil(t, err)
 	})
 
-	now := time.Now().UnixNano() / int64(time.Millisecond)
+	now := time.Now()
+	timestamp := now.UnixNano() / int64(time.Millisecond)
 	testID := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a62")
 
 	t.Run("insert test object", func(t *testing.T) {
 		obj := &models.Object{
 			ID:                 testID,
 			Class:              "TestClass",
-			CreationTimeUnix:   now,
-			LastUpdateTimeUnix: now,
+			CreationTimeUnix:   timestamp,
+			LastUpdateTimeUnix: timestamp,
 			Properties:         map[string]interface{}{"name": "objectarooni"},
 		}
 		vec := []float32{1, 2, 3}
@@ -379,7 +379,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 					Property: "_creationTimeUnix",
 				},
 				Value: &filters.Value{
-					Value: fmt.Sprint(now),
+					Value: fmt.Sprint(timestamp),
 					Type:  schema.DataTypeText,
 				},
 			},
@@ -393,7 +393,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 					Property: "_lastUpdateTimeUnix",
 				},
 				Value: &filters.Value{
-					Value: fmt.Sprint(now),
+					Value: fmt.Sprint(timestamp),
 					Type:  schema.DataTypeText,
 				},
 			},
@@ -401,28 +401,32 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 
 		createTimeDateFilter := &filters.LocalFilter{
 			Root: &filters.Clause{
-				Operator: filters.OperatorEqual,
+				// since RFC3339 is limited to seconds,
+				// >= operator is used to match object with timestamp containing milliseconds
+				Operator: filters.OperatorGreaterThanEqual,
 				On: &filters.Path{
 					Class:    "TestClass",
 					Property: "_creationTimeUnix",
 				},
 				Value: &filters.Value{
-					Value: msToRFC3339(now),
-					Type:  dtDate,
+					Value: now.Format(time.RFC3339),
+					Type:  schema.DataTypeDate,
 				},
 			},
 		}
 
 		updateTimeDateFilter := &filters.LocalFilter{
 			Root: &filters.Clause{
-				Operator: filters.OperatorEqual,
+				// since RFC3339 is limited to seconds,
+				// >= operator is used to match object with timestamp containing milliseconds
+				Operator: filters.OperatorGreaterThanEqual,
 				On: &filters.Path{
 					Class:    "TestClass",
 					Property: "_lastUpdateTimeUnix",
 				},
 				Value: &filters.Value{
-					Value: msToRFC3339(now),
-					Type:  dtDate,
+					Value: now.Format(time.RFC3339),
+					Type:  schema.DataTypeDate,
 				},
 			},
 		}
@@ -501,35 +505,4 @@ func TestFilterPropertyLengthError(t *testing.T) {
 	}
 	_, err = repo.ClassSearch(context.Background(), params)
 	require.NotNil(t, err)
-}
-
-func msToRFC3339(ms int64) time.Time {
-	sec, ns := splitMilliTimestamp(ms)
-	return time.Unix(sec, ns)
-}
-
-// splitMilliTimestamp allows us to take a timestamp
-// in unix epoch milliseconds, and split it into the
-// needed seconds/nanoseconds required by `time.Unix`.
-// once weaviate supports go version >= 1.17, we can
-// remove this func and just pass `ms` to `time.UnixMilli`
-func splitMilliTimestamp(ms int64) (sec int64, ns int64) {
-	// remove 3 least significant digits of `ms`
-	// so we end up with the seconds/nanoseconds
-	// needed to convert to RFC3339 formatted
-	// timestamp.
-	for i := int64(0); i < 3; i++ {
-		ns += int64(math.Pow(float64(10), float64(i))) * (ms % 10)
-		ms /= 10
-	}
-
-	// after removing 3 least significant digits,
-	// ms now represents the timestamp in seconds
-	sec = ms
-
-	// the least 3 significant digits only represent
-	// milliseconds, and need to be converted to nano
-	ns *= 1e6
-
-	return
 }


### PR DESCRIPTION
### What's being changed:
fixes filtering by internal timestamps (`_creationTimeUnix` and `_lastUpdateTimeUnix`) provided as `valueDate` in RFC3339 format.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
