### PR TITLE
Fill vector cache with cursor

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -179,6 +179,7 @@ func (s *Shard) initVectorIndex(
 		ClassName:         s.index.Config.ClassName.String(),
 		PrometheusMetrics: s.promMetrics,
 		VectorForIDThunk:  s.vectorByIndexID,
+		VectorIterator:    s.newVectorIterator,
 		DistanceProvider:  distProv,
 		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
 			return hnsw.NewCommitLogger(s.index.Config.RootPath, s.ID(), s.index.logger, s.vectorCycles.CommitLogMaintenance())

--- a/adapters/repos/db/shard_read_vector_iterator.go
+++ b/adapters/repos/db/shard_read_vector_iterator.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (

--- a/adapters/repos/db/shard_read_vector_iterator.go
+++ b/adapters/repos/db/shard_read_vector_iterator.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+func (s *Shard) newVectorIterator() hnsw.VectorIterator[float32] {
+	c := s.store.Bucket(helpers.ObjectsBucketLSM).Cursor()
+	return &vectorIterator{c: c}
+}
+
+type vectorIterator struct {
+	c           *lsmkv.CursorReplace
+	initialized bool
+}
+
+func (vi *vectorIterator) Close() {
+	vi.c.Close()
+}
+
+func (vi *vectorIterator) Next() ([]float32, uint64, error) {
+	var k, v []byte
+	if vi.initialized {
+		k, v = vi.c.Next()
+	} else {
+		k, v = vi.c.First()
+		vi.initialized = true
+	}
+
+	if k == nil {
+		return nil, 0, nil
+	}
+
+	id, vec, err := storobj.DocIDAndVectorFromBinary(v)
+	return vec, id, err
+}

--- a/adapters/repos/db/vector/hnsw/compressed_vector_cache.go
+++ b/adapters/repos/db/vector/hnsw/compressed_vector_cache.go
@@ -137,6 +137,11 @@ func (c *compressedShardedLockCache) preload(id uint64, vec []byte) {
 }
 
 //nolint:unused
+func (c *compressedShardedLockCache) load(id uint64, vec []byte) {
+	panic("not implemented")
+}
+
+//nolint:unused
 func (c *compressedShardedLockCache) grow(node uint64) {
 	if node < uint64(len(c.cache)) {
 		return

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ID                    string
 	MakeCommitLoggerThunk MakeCommitLogger
 	VectorForIDThunk      VectorForID
+	VectorIterator        VectorIteratorProvider[float32]
 	Logger                logrus.FieldLogger
 	DistanceProvider      distancer.Provider
 	PrometheusMetrics     *monitoring.PrometheusMetrics

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -201,8 +201,11 @@ func (h *hnsw) prefillCache() {
 			}
 			cursor.Close()
 		} else {
-			it := h.vectorIterator()
-			defer it.Close()
+			var it VectorIterator[float32]
+			if h.vectorIterator != nil {
+				it = h.vectorIterator()
+				defer it.Close()
+			}
 			err = newVectorCachePrefiller(h.cache, h, h.logger, it).Prefill(ctx, limit)
 		}
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -205,6 +205,8 @@ func (h *hnsw) prefillCache() {
 			if h.vectorIterator != nil {
 				it = h.vectorIterator()
 				defer it.Close()
+			} else {
+				it = noopVectorIterator{}
 			}
 			err = newVectorCachePrefiller(h.cache, h, h.logger, it).Prefill(ctx, limit)
 		}
@@ -213,4 +215,11 @@ func (h *hnsw) prefillCache() {
 			h.logger.WithError(err).Error("prefill vector cache")
 		}
 	}()
+}
+
+type noopVectorIterator struct{}
+
+func (nvit noopVectorIterator) Close() {}
+func (nvit noopVectorIterator) Next() ([]float32, uint64, error) {
+	return nil, 0, nil
 }

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -201,7 +201,9 @@ func (h *hnsw) prefillCache() {
 			}
 			cursor.Close()
 		} else {
-			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(ctx, limit)
+			it := h.vectorIterator()
+			defer it.Close()
+			err = newVectorCachePrefiller(h.cache, h, h.logger, it).Prefill(ctx, limit)
 		}
 
 		if err != nil {

--- a/adapters/repos/db/vector/hnsw/vector_cache.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache.go
@@ -168,10 +168,16 @@ func (s *shardedLockCache) preload(id uint64, vec []float32) {
 }
 
 // load is like preload, but obtains an actual write lock, so it's always safe
-// to use
+// to use. In addition, it assumes that the vector has not been normalized yet.
+// Therefore it checks if normalization is required and then normalizes the
+// vector before storing it. Similar to how handleCacheMiss would do this.
 //
 //nolint:unused
 func (s *shardedLockCache) load(id uint64, vec []float32) {
+	if s.normalizeOnRead {
+		vec = distancer.Normalize(vec)
+	}
+
 	s.shardedLocks[id%shardFactor].Lock()
 	defer s.shardedLocks[id%shardFactor].Unlock()
 

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -53,84 +53,23 @@ func newVectorCachePrefiller[T any](cache cache[T], index *hnsw,
 
 func (pf *vectorCachePrefiller[T]) Prefill(ctx context.Context, limit int) error {
 	before := time.Now()
-	if pf.iterator != nil {
-		for v, id, err := pf.iterator.Next(); v != nil; v, id, err = pf.iterator.Next() {
-			if err != nil {
-				return err
-			}
 
-			pf.cache.load(id, v)
-
+	i := 0
+	for v, id, err := pf.iterator.Next(); v != nil; v, id, err = pf.iterator.Next() {
+		if err != nil {
+			return err
 		}
-	} else {
-		for level := pf.maxLevel(); level >= 0; level-- {
-			ok, err := pf.prefillLevel(ctx, level, limit)
-			if err != nil {
-				return err
-			}
 
-			if !ok {
-				break
-			}
+		if i >= limit {
+			break
 		}
+
+		pf.cache.load(id, v)
+		i++
 	}
 
 	pf.logTotal(int(pf.cache.len()), limit, before)
 	return nil
-}
-
-// returns false if the max has been reached, true otherwise
-func (pf *vectorCachePrefiller[T]) prefillLevel(ctx context.Context,
-	level, limit int,
-) (bool, error) {
-	before := time.Now()
-	layerCount := 0
-
-	pf.index.Lock()
-	nodesLen := len(pf.index.nodes)
-	pf.index.Unlock()
-
-	for i := 0; i < nodesLen; i++ {
-		if int(pf.cache.len()) >= limit {
-			break
-		}
-
-		if err := ctx.Err(); err != nil {
-			return false, err
-		}
-
-		pf.index.Lock()
-		node := pf.index.nodes[i]
-		pf.index.Unlock()
-
-		if node == nil {
-			continue
-		}
-
-		if levelOfNode(node) != level {
-			continue
-		}
-
-		// we are not really interested in the result, we just want to populate the
-		// cache
-		pf.index.Lock()
-		pf.cache.get(ctx, uint64(i))
-		layerCount++
-		pf.index.Unlock()
-	}
-
-	pf.logLevel(level, layerCount, before)
-	return true, nil
-}
-
-func (pf *vectorCachePrefiller[T]) logLevel(level, count int, before time.Time) {
-	pf.logger.WithFields(logrus.Fields{
-		"action":     "hnsw_vector_cache_prefill_level",
-		"hnsw_level": level,
-		"count":      count,
-		"took":       time.Since(before),
-		"index_id":   pf.index.id,
-	}).Debug("prefilled level in vector cache")
 }
 
 func (pf *vectorCachePrefiller[T]) logTotal(count, limit int, before time.Time) {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -31,6 +31,7 @@ type cache[T any] interface {
 	countVectors() int64
 	delete(ctx context.Context, id uint64)
 	preload(id uint64, vec []T)
+	load(id uint64, vec []T)
 	prefetch(id uint64)
 	grow(size uint64)
 	drop()
@@ -58,7 +59,7 @@ func (pf *vectorCachePrefiller[T]) Prefill(ctx context.Context, limit int) error
 				return err
 			}
 
-			pf.cache.preload(id, v)
+			pf.cache.load(id, v)
 
 		}
 	} else {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -28,7 +28,7 @@ func TestVectorCachePrefilling(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	pf := newVectorCachePrefiller[float32](cache, index, logger)
+	pf := newVectorCachePrefiller[float32](cache, index, logger, nil)
 
 	t.Run("prefill with limit >= graph size", func(t *testing.T) {
 		cache.reset()
@@ -99,6 +99,11 @@ func (f *fakeCache) delete(ctx context.Context, id uint64) {
 
 //nolint:unused
 func (f *fakeCache) preload(id uint64, vec []float32) {
+	panic("not implemented")
+}
+
+//nolint:unused
+func (f *fakeCache) load(id uint64, vec []float32) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
### What's being changed:

The old vector-cache prefiller was built back when we thought we'd never have larger datasets than 1-2M. With the billion-scale datasets of today, the old prefiller can't prefill vectors fast enough. In addition, we notice that any user that has a performance-critical workload runs with an effectively unlimited vector cache.

The old prefiller tried to prefill layer by layer. Back then, this was a good idea because it would mean that we would always have the highest layers in cache even if there was a limit to prefilling. However, we have since seen that it's far more common to prefill the entire cache (unlimited). In this scenario going layer-by-layer is extremely expensive because it means we need to do an object-by-id lookup for each vector.

This new implementation ignores layers. Instead it uses a cursor to read all vectors sequentially. This makes prefilling the vector cache much faster. The downside is that if the cache is limited, we have no control over which layers are loaded and which aren't. However, IMHO that downside is worth it because performance-critical setups typically run with an unlimited cache anyway.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
