### PR TITLE
Pq optimization after rescoring

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -561,7 +561,6 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 	eps := priorityqueue.NewMin(10)
 	eps.Insert(entryPointID, entryPointDistance)
 	res, err := h.searchLayerByVector(searchVec, eps, ef, 0, allowList)
-
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 	}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -437,8 +437,11 @@ func (h *hnsw) distanceToByteNode(distancer *ssdhelpers.PQDistancer,
 	return distancer.Distance(vec)
 }
 
-func (h *hnsw) distanceFromBytesToFloatNode(distancer *ssdhelpers.PQDistancer, nodeID uint64) (float32, bool, error) {
+func (h *hnsw) distanceFromBytesToFloatNode(concreteDistancer *ssdhelpers.PQDistancer, nodeID uint64) (float32, bool, error) {
 	vec, err := h.VectorForIDThunk(context.Background(), nodeID)
+	if h.distancerProvider.Type() == "cosine-dot" {
+		vec = distancer.Normalize(vec)
+	}
 	if err != nil {
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
@@ -449,7 +452,7 @@ func (h *hnsw) distanceFromBytesToFloatNode(distancer *ssdhelpers.PQDistancer, n
 			return 0, false, errors.Wrapf(err, "get vector of docID %d", nodeID)
 		}
 	}
-	return distancer.DistanceToFloat(vec)
+	return concreteDistancer.DistanceToFloat(vec)
 }
 
 func (h *hnsw) distanceToFloatNode(distancer distancer.Distancer,

--- a/adapters/repos/db/vector/ssdhelpers/kmeans.go
+++ b/adapters/repos/db/vector/ssdhelpers/kmeans.go
@@ -258,6 +258,6 @@ func (m *KMeans) Center(point []float32) []float32 {
 	return m.centers[m.Nearest(point)]
 }
 
-func (m *KMeans) Centroid(i uint64) []float32 {
+func (m *KMeans) Centroid(i byte) []float32 {
 	return m.centers[i]
 }

--- a/adapters/repos/db/vector/ssdhelpers/kmeans_test.go
+++ b/adapters/repos/db/vector/ssdhelpers/kmeans_test.go
@@ -39,9 +39,9 @@ func Test_NoRaceKMeansNNearest(t *testing.T) {
 		0,
 	)
 	kmeans.Fit(vectors)
-	centers := make([]uint64, 6)
+	centers := make([]byte, 6)
 	for i := range centers {
-		centers[i] = kmeans.Nearest(vectors[i])
+		centers[i] = byte(kmeans.Nearest(vectors[i]))
 	}
 	for v := range vectors {
 		min, _, _ := distanceProvider.SingleDist(vectors[v], kmeans.Centroid(centers[v]))

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization_test.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization_test.go
@@ -14,7 +14,6 @@
 package ssdhelpers_test
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -87,247 +86,15 @@ func Test_NoRacePQKMeans(t *testing.T) {
 	assert.True(t, recall > 0.99)
 }
 
-func Test_NoRacePQDecodeBits(t *testing.T) {
-	t.Run("extracts correctly on one code per byte", func(t *testing.T) {
-		amount := 100
-		centroids := 256
-		values := make([]byte, 0, amount)
-		for i := byte(0); i < byte(amount); i++ {
-			values = append(values, i)
-		}
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("extracts correctly on 6 bits", func(t *testing.T) {
-		amount := 8
-		centroids := 64
-		values := []byte{0, 16, 131, 16, 81, 135, 0}
-
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("extracts correctly on 12 bits", func(t *testing.T) {
-		amount := 4
-		centroids := 4096
-		values := []byte{0, 0, 1, 0, 32, 3, 0, 0}
-
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("extracts correctly on one code per two bytes", func(t *testing.T) {
-		amount := 100
-		centroids := 65536
-		values := make([]byte, 2*amount)
-		for i := 0; i < amount; i++ {
-			binary.BigEndian.PutUint16(values[2*i:2*i+2], uint16(i))
-		}
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-}
-
-func Test_NoRacePQEncodeBits(t *testing.T) {
-	t.Run("encodes correctly on one code per byte", func(t *testing.T) {
-		amount := 100
-		centroids := 256
-		values := make([]byte, amount)
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			pq.PutCode(uint64(i), values, i)
-		}
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("encodes correctly on one code per two bytes", func(t *testing.T) {
-		amount := 100
-		centroids := 65536
-		values := make([]byte, 2*amount)
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			pq.PutCode(uint64(i), values, i)
-		}
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("encodes correctly on 10 bits", func(t *testing.T) {
-		amount := 100
-		centroids := 1024
-		values := make([]byte, 2*amount)
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			true,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			pq.PutCode(uint64(i), values, i)
-		}
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-}
-
 func Test_NoRacePQDecodeBytes(t *testing.T) {
 	t.Run("extracts correctly on one code per byte", func(t *testing.T) {
 		amount := 100
-		centroids := 256
 		values := make([]byte, 0, amount)
 		for i := byte(0); i < byte(amount); i++ {
 			values = append(values, i)
 		}
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
 		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("extracts correctly on 6 bits", func(t *testing.T) {
-		amount := 100
-		centroids := 64
-		values := make([]byte, 0, amount)
-		for i := byte(0); i < byte(amount); i++ {
-			values = append(values, i)
-		}
-
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("extracts correctly on 12 bits", func(t *testing.T) {
-		amount := 100
-		centroids := 4096
-		values := make([]byte, 2*amount)
-		for i := byte(0); i < byte(amount); i++ {
-			binary.BigEndian.PutUint16(values[2*i:], uint16(i))
-		}
-
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("extracts correctly on one code per two bytes", func(t *testing.T) {
-		amount := 100
-		centroids := 65536
-		values := make([]byte, 2*amount)
-		for i := 0; i < amount; i++ {
-			binary.BigEndian.PutUint16(values[2*i:], uint16(i))
-		}
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
+			code := ssdhelpers.ExtractCode8(values, i)
 			assert.Equal(t, code, uint64(i))
 		}
 	})
@@ -336,66 +103,12 @@ func Test_NoRacePQDecodeBytes(t *testing.T) {
 func Test_NoRacePQEncodeBytes(t *testing.T) {
 	t.Run("encodes correctly on one code per byte", func(t *testing.T) {
 		amount := 100
-		centroids := 256
 		values := make([]byte, amount)
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
 		for i := 0; i < amount; i++ {
-			pq.PutCode(uint64(i), values, i)
+			ssdhelpers.PutCode8(uint64(i), values, i)
 		}
 		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("encodes correctly on one code per two bytes", func(t *testing.T) {
-		amount := 100
-		centroids := 65536
-		values := make([]byte, 2*amount)
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			pq.PutCode(uint64(i), values, i)
-		}
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
-			assert.Equal(t, code, uint64(i))
-		}
-	})
-
-	t.Run("encodes correctly on 10 bits", func(t *testing.T) {
-		amount := 100
-		centroids := 1024
-		values := make([]byte, 2*amount)
-		pq, _ := ssdhelpers.NewProductQuantizer(
-			amount,
-			centroids,
-			false,
-			nil,
-			amount,
-			ssdhelpers.UseKMeansEncoder,
-			ssdhelpers.LogNormalEncoderDistribution,
-		)
-		for i := 0; i < amount; i++ {
-			pq.PutCode(uint64(i), values, i)
-		}
-		for i := 0; i < amount; i++ {
-			code := pq.ExtractCode(values, i)
+			code := ssdhelpers.ExtractCode8(values, i)
 			assert.Equal(t, code, uint64(i))
 		}
 	})

--- a/adapters/repos/db/vector/ssdhelpers/tile_encoder.go
+++ b/adapters/repos/db/vector/ssdhelpers/tile_encoder.go
@@ -180,11 +180,11 @@ func (te *TileEncoder) Encode(x []float32) uint64 {
 	return uint64(intPart)
 }
 
-func (te *TileEncoder) centroid(b uint64) []float32 {
+func (te *TileEncoder) centroid(b byte) []float32 {
 	res := make([]float32, 0, 1)
 	if b == 0 {
 		res = append(res, float32(te.distribution.Quantile(1/te.bins)))
-	} else if b == uint64(te.bins) {
+	} else if b == byte(te.bins) {
 		res = append(res, float32(te.distribution.Quantile((te.bins-1)/te.bins)))
 	} else {
 		b64 := float64(b)
@@ -194,7 +194,7 @@ func (te *TileEncoder) centroid(b uint64) []float32 {
 	return res
 }
 
-func (te *TileEncoder) Centroid(b uint64) []float32 {
+func (te *TileEncoder) Centroid(b byte) []float32 {
 	if te.centroids[b].Calculated.Load() {
 		return te.centroids[b].Center
 	}


### PR DESCRIPTION
### What's being changed:
With rescoring, we do not really need to support centroids over 256. One byte per code should be enough so we could optimise the encode/decode code to allow the compiler to inline the extract/put code and gain some performance. We also do not need to cast bytes to uint64 anymore since the size is fixed.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
