### PR TITLE
Pq fix cosine with rescoring

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -561,7 +561,6 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 	eps := priorityqueue.NewMin(10)
 	eps.Insert(entryPointID, entryPointDistance)
 	res, err := h.searchLayerByVector(searchVec, eps, ef, 0, allowList)
-
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 	}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -437,8 +437,11 @@ func (h *hnsw) distanceToByteNode(distancer *ssdhelpers.PQDistancer,
 	return distancer.Distance(vec)
 }
 
-func (h *hnsw) distanceFromBytesToFloatNode(distancer *ssdhelpers.PQDistancer, nodeID uint64) (float32, bool, error) {
+func (h *hnsw) distanceFromBytesToFloatNode(concreteDistancer *ssdhelpers.PQDistancer, nodeID uint64) (float32, bool, error) {
 	vec, err := h.VectorForIDThunk(context.Background(), nodeID)
+	if h.distancerProvider.Type() == "cosine-dot" {
+		vec = distancer.Normalize(vec)
+	}
 	if err != nil {
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
@@ -449,7 +452,7 @@ func (h *hnsw) distanceFromBytesToFloatNode(distancer *ssdhelpers.PQDistancer, n
 			return 0, false, errors.Wrapf(err, "get vector of docID %d", nodeID)
 		}
 	}
-	return distancer.DistanceToFloat(vec)
+	return concreteDistancer.DistanceToFloat(vec)
 }
 
 func (h *hnsw) distanceToFloatNode(distancer distancer.Distancer,


### PR DESCRIPTION
### What's being changed:
Fixes a bug when using cosine with rescoring under PQ settings. The bug was introduced since the vectors are stored before normalisation occurred. They were not renormalised when brought back from disk again.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
