### PR TITLE
Pq training limit

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -66,7 +66,17 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 		index.Add(uint64(id), vectors[id])
 	})
 	index.Delete(delete_indices...)
-	index.Compress(dimensions, 256, false, int(ssdhelpers.UseKMeansEncoder), int(ssdhelpers.LogNormalEncoderDistribution))
+
+	cfg := ent.PQConfig{
+		Enabled: true,
+		Encoder: ent.PQEncoder{
+			Type:         ent.PQEncoderTypeKMeans,
+			Distribution: ent.PQEncoderDistributionLogNormal,
+		},
+		Segments:  dimensions,
+		Centroids: 256,
+	}
+	index.Compress(cfg)
 	for _, v := range queries {
 		_, _, err := index.SearchByVector(v, k, nil)
 		assert.Nil(t, err)

--- a/adapters/repos/db/vector/hnsw/compress_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_test.go
@@ -178,8 +178,8 @@ func TestHnswPqGist(t *testing.T) {
 					Enabled:  false,
 					Segments: dimensions / int(math.Pow(2, float64(segmentRate))),
 					Encoder: ent.PQEncoder{
-						Type:         "kmeans",
-						Distribution: "log-normal",
+						Type:         ent.PQEncoderTypeKMeans,
+						Distribution: ent.PQEncoderDistributionLogNormal,
 					},
 				},
 			}
@@ -346,8 +346,8 @@ func TestHnswPqSift(t *testing.T) {
 				Enabled:  false,
 				Segments: dimensions / int(math.Pow(2, float64(segmentRate))),
 				Encoder: ent.PQEncoder{
-					Type:         "tile",
-					Distribution: "log-normal",
+					Type:         ent.PQEncoderTypeTile,
+					Distribution: ent.PQEncoderDistributionLogNormal,
 				},
 			},
 			VectorCacheMaxObjects: 10e12,
@@ -369,7 +369,19 @@ func TestHnswPqSift(t *testing.T) {
 		})
 		before = time.Now()
 		fmt.Println("Start compressing...")
-		index.Compress(dimensions/int(math.Pow(2, float64(segmentRate))), centroids, false, int(ssdhelpers.UseKMeansEncoder), int(ssdhelpers.LogNormalEncoderDistribution)) /*should have configuration.compressed = true*/
+
+		cfg := ent.PQConfig{
+			Enabled:        true,
+			Segments:       dimensions / int(math.Pow(2, float64(segmentRate))),
+			Centroids:      centroids,
+			BitCompression: false,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeKMeans,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+		}
+
+		index.Compress(cfg) /*should have configuration.compressed = true*/
 		fmt.Printf("Time to compress: %s", time.Since(before))
 		fmt.Println()
 		ssdhelpers.Concurrently(uint64(vectors_size-switch_at), func(_, id uint64, _ *sync.Mutex) {
@@ -531,8 +543,8 @@ func TestHnswPqDeepImage(t *testing.T) {
 					Enabled:  false,
 					Segments: dimensions / int(math.Pow(2, float64(segmentRate))),
 					Encoder: ent.PQEncoder{
-						Type:         "kmeans",
-						Distribution: "normal",
+						Type:         ent.PQEncoderTypeKMeans,
+						Distribution: ent.PQEncoderDistributionNormal,
 					},
 				},
 				VectorCacheMaxObjects: 10e12,

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -514,7 +513,13 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 		// zero it will constantly think it's full and needs to be deleted - even
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
-		PQ:                    ent.PQConfig{Enabled: true, Encoder: ent.PQEncoder{Type: "tile", Distribution: "normal"}},
+		PQ: ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeTile,
+				Distribution: ent.PQEncoderDistributionNormal,
+			},
+		},
 	}
 
 	t.Run("import the test vectors", func(t *testing.T) {
@@ -541,7 +546,17 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 			err := vectorIndex.Add(uint64(i), vec)
 			require.Nil(t, err)
 		}
-		index.Compress(0, 256, false, int(ssdhelpers.UseTileEncoder), int(ssdhelpers.LogNormalEncoderDistribution))
+		cfg := ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeTile,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+			BitCompression: false,
+			Segments:       0,
+			Centroids:      256,
+		}
+		index.Compress(cfg)
 	})
 
 	var control []uint64
@@ -667,7 +682,17 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 			err := vectorIndex.Add(uint64(i), vec)
 			require.Nil(t, err)
 		}
-		index.Compress(0, 256, false, int(ssdhelpers.UseTileEncoder), int(ssdhelpers.LogNormalEncoderDistribution))
+		cfg := ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeTile,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+			BitCompression: false,
+			Segments:       0,
+			Centroids:      256,
+		}
+		index.Compress(cfg)
 		for i := len(vectors); i < 1000; i++ {
 			err := vectorIndex.Add(uint64(i), vectors[i%len(vectors)])
 			require.Nil(t, err)

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -146,6 +146,7 @@ type hnsw struct {
 	compressed             atomic.Bool
 	doNotRescore           atomic.Bool
 	pq                     *ssdhelpers.ProductQuantizer
+	pqConfig               ent.PQConfig
 	compressedVectorsCache cache[byte]
 	compressedStore        *lsmkv.Store
 	compressActionLock     *sync.RWMutex
@@ -259,6 +260,7 @@ func New(cfg Config, uc ent.UserConfig, tombstoneCleanupCycle cyclemanager.Cycle
 		compressActionLock: &sync.RWMutex{},
 		className:          cfg.ClassName,
 		VectorForIDThunk:   cfg.VectorForIDThunk,
+		pqConfig:           uc.PQ,
 	}
 
 	// TODO common_cycle_manager move to poststartup?

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -128,12 +128,11 @@ func (h *hnsw) restoreFromDisk() error {
 			return err
 		}
 		h.cache.drop()
+
 		h.pq, err = ssdhelpers.NewProductQuantizerWithEncoders(
-			int(state.PQData.M),
-			int(state.PQData.Ks),
-			state.PQData.UseBitsEncoding,
+			h.pqConfig,
 			h.distancerProvider,
-			int(state.PQData.Dimensions), state.PQData.EncoderType,
+			int(state.PQData.Dimensions),
 			state.PQData.Encoders,
 		)
 		if err != nil {

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -171,6 +171,7 @@ type PQData struct {
 	EncoderDistribution byte
 	Encoders            []PQEncoder
 	UseBitsEncoding     bool
+	TrainingLimit       int
 }
 
 type PQEncoder interface {
@@ -265,6 +266,7 @@ func (pq *ProductQuantizer) ExposeFields() PQData {
 		M:                   uint16(pq.m),
 		EncoderDistribution: byte(pq.encoderDistribution),
 		Encoders:            pq.kms,
+		TrainingLimit:       pq.trainingLimit,
 	}
 }
 

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -183,22 +183,22 @@ type PQEncoder interface {
 
 func NewProductQuantizer(cfg ent.PQConfig, distance distancer.Provider, dimensions int) (*ProductQuantizer, error) {
 	if cfg.Segments <= 0 {
-		return nil, errors.New("Segments cannot be 0 nor negative")
+		return nil, errors.New("segments cannot be 0 nor negative")
 	}
 	if cfg.Centroids > 256 {
-		return nil, fmt.Errorf("Centroids should not be higher than 256. Attempting to use %d", centroids)
+		return nil, fmt.Errorf("centroids should not be higher than 256. Attempting to use %d", cfg.Centroids)
 	}
 	if dimensions%cfg.Segments != 0 {
-		return nil, errors.New("Segments should be an integer divisor of dimensions")
+		return nil, errors.New("segments should be an integer divisor of dimensions")
 	}
 	encoderType, err := parseEncoder(cfg.Encoder.Type)
 	if err != nil {
-		return nil, errors.New("Invalid encoder type")
+		return nil, errors.New("invalid encoder type")
 	}
 
 	encoderDistribution, err := parseEncoderDistribution(cfg.Encoder.Distribution)
 	if err != nil {
-		return nil, errors.New("Invalid encoder distribution")
+		return nil, errors.New("invalid encoder distribution")
 	}
 	pq := &ProductQuantizer{
 		ks:                  cfg.Centroids,
@@ -319,7 +319,6 @@ func (d *PQDistancer) DistanceToFloat(x []float32) (float32, bool, error) {
 func (pq *ProductQuantizer) Fit(data [][]float32) {
 	if pq.trainingLimit > 0 && len(data) > pq.trainingLimit {
 		data = data[:pq.trainingLimit]
-		fmt.Printf("pq: training limit reached, using %d vectors\n", pq.trainingLimit)
 	}
 	switch pq.encoderType {
 	case UseTileEncoder:

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -89,6 +89,7 @@ func (u *UserConfig) SetDefaults() {
 		BitCompression: DefaultPQBitCompression,
 		Segments:       DefaultPQSegments,
 		Centroids:      DefaultPQCentroids,
+		TrainingLimit:  DefaultPQTrainingLimit,
 		Encoder: PQEncoder{
 			Type:         DefaultPQEncoderType,
 			Distribution: DefaultPQEncoderDistribution,

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -50,6 +50,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
@@ -79,6 +80,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
@@ -119,6 +121,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
@@ -159,6 +162,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
@@ -199,6 +203,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
@@ -237,6 +242,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
@@ -262,6 +268,7 @@ func Test_UserConfig(t *testing.T) {
 					"bitCompression": false,
 					"segments":       float64(64),
 					"centroids":      float64(DefaultPQCentroids),
+					"trainingLimit":  float64(DefaultPQTrainingLimit),
 					"encoder": map[string]interface{}{
 						"type":         "tile",
 						"distribution": "normal",
@@ -280,9 +287,10 @@ func Test_UserConfig(t *testing.T) {
 				DynamicEFFactor:        19,
 				Distance:               DefaultDistanceMetric,
 				PQ: PQConfig{
-					Enabled:   true,
-					Segments:  64,
-					Centroids: DefaultPQCentroids,
+					Enabled:       true,
+					Segments:      64,
+					Centroids:     DefaultPQCentroids,
+					TrainingLimit: DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         "tile",
 						Distribution: "normal",
@@ -308,6 +316,7 @@ func Test_UserConfig(t *testing.T) {
 					"bitCompression": false,
 					"segments":       float64(64),
 					"centroids":      float64(DefaultPQCentroids),
+					"trainingLimit":  float64(DefaultPQTrainingLimit),
 					"encoder": map[string]interface{}{
 						"type": "kmeans",
 					},
@@ -325,11 +334,12 @@ func Test_UserConfig(t *testing.T) {
 				DynamicEFFactor:        19,
 				Distance:               DefaultDistanceMetric,
 				PQ: PQConfig{
-					Enabled:   true,
-					Segments:  64,
-					Centroids: DefaultPQCentroids,
+					Enabled:       true,
+					Segments:      64,
+					Centroids:     DefaultPQCentroids,
+					TrainingLimit: DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
-						Type:         "kmeans",
+						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,
 					},
 				},
@@ -347,7 +357,7 @@ func Test_UserConfig(t *testing.T) {
 				},
 			},
 			expectErr:    true,
-			expectErrMsg: "invalid encoder type: bernoulli",
+			expectErrMsg: "invalid encoder type bernoulli",
 		},
 
 		{
@@ -361,7 +371,7 @@ func Test_UserConfig(t *testing.T) {
 				},
 			},
 			expectErr:    true,
-			expectErrMsg: "invalid encoder distribution: lognormal",
+			expectErrMsg: "invalid encoder distribution lognormal",
 		},
 
 		{
@@ -394,6 +404,7 @@ func Test_UserConfig(t *testing.T) {
 					BitCompression: DefaultPQBitCompression,
 					Segments:       DefaultPQSegments,
 					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
 					Encoder: PQEncoder{
 						Type:         DefaultPQEncoderType,
 						Distribution: DefaultPQEncoderDistribution,

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -57,7 +57,8 @@ func testGetSchemaWithoutClient(t *testing.T) {
 							"distribution": "log-normal",
 							"type":         "kmeans",
 						},
-						"segments": float64(0),
+						"segments":      float64(0),
+						"trainingLimit": float64(100000),
 					},
 				},
 				"shardingConfig": map[string]interface{}{


### PR DESCRIPTION
### What's being changed:

- A new pq parameter `trainingLimit` is added with default of 100,000 to stop product quantization taking too long to fit in the case where a large amount of vectors are loaded before fitting.
- Config parsing for `Compress` and `NewProductQuantizer` is moved into a settings struct

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
