### PR TITLE
Fix: prevent batch add from panicking due to out of bounds indexing 

### DIFF
--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -48,8 +48,16 @@ func (db *DB) BatchPutObjects(ctx context.Context, objs objects.BatchObjects,
 	for class, queue := range objectByClass {
 		index, ok := db.indices[indexID(schema.ClassName(class))]
 		if !ok {
-			for _, ind := range queue.originalIndex {
-				objs[queue.originalIndex[ind]].Err = fmt.Errorf("could not find index for class %v. It might have been deleted in the meantime", class)
+			msg := fmt.Sprintf("could not find index for class %v. It might have been deleted in the meantime", class)
+			db.logger.Warn(msg)
+			for _, origIdx := range queue.originalIndex {
+				if origIdx >= len(objs) {
+					db.logger.Errorf(
+						"batch add queue index out of bounds. len(objs) == %d, queue.originalIndex == %d",
+						len(objs), origIdx)
+					break
+				}
+				objs[origIdx].Err = fmt.Errorf(msg)
 			}
 			continue
 		}


### PR DESCRIPTION
### What's being changed:

- use the correct index value in the queue underpinning batch add operation.
- make a bounds check before accessing nested array
- add more verbose logging to increase visibility in the affected area

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
