### PR TITLE
Introduce reranker-cohere module

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -53,6 +53,7 @@ import (
 	modqnaopenai "github.com/weaviate/weaviate/modules/qna-openai"
 	modqna "github.com/weaviate/weaviate/modules/qna-transformers"
 	modcentroid "github.com/weaviate/weaviate/modules/ref2vec-centroid"
+	modrerankercohere "github.com/weaviate/weaviate/modules/reranker-cohere"
 	modrerankertransformers "github.com/weaviate/weaviate/modules/reranker-transformers"
 	modsum "github.com/weaviate/weaviate/modules/sum-transformers"
 	modspellcheck "github.com/weaviate/weaviate/modules/text-spellcheck"
@@ -517,6 +518,14 @@ func registerModules(appState *state.State) error {
 		appState.Logger.
 			WithField("action", "startup").
 			WithField("module", modrerankertransformers.Name).
+			Debug("enabled module")
+	}
+
+	if _, ok := enabledModules[modrerankercohere.Name]; ok {
+		appState.Modules.Register(modrerankercohere.New())
+		appState.Logger.
+			WithField("action", "startup").
+			WithField("module", modrerankercohere.Name).
 			Debug("enabled module")
 	}
 

--- a/modules/reranker-cohere/additional/models/models.go
+++ b/modules/reranker-cohere/additional/models/models.go
@@ -1,0 +1,18 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package models
+
+// Answer used in qna module to represent
+// the answer to a given question
+type RankResult struct {
+	Score *float64 `json:"score,omitempty"`
+}

--- a/modules/reranker-cohere/additional/provider.go
+++ b/modules/reranker-cohere/additional/provider.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package additional
+
+import (
+	"context"
+
+	"github.com/tailor-inc/graphql"
+	"github.com/tailor-inc/graphql/language/ast"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+type AdditionalProperty interface {
+	AdditionalPropertyFn(ctx context.Context,
+		in []search.Result, params interface{}, limit *int,
+		argumentModuleParams map[string]interface{}, cfg moduletools.ClassConfig) ([]search.Result, error)
+	ExtractAdditionalFn(param []*ast.Argument) interface{}
+	AdditionalPropertyDefaultValue() interface{}
+	AdditionalFieldFn(classname string) *graphql.Field
+}
+
+type GraphQLAdditionalArgumentsProvider struct {
+	CrossRankerProvider AdditionalProperty
+}
+
+func New(CrossRankerProvider AdditionalProperty) *GraphQLAdditionalArgumentsProvider {
+	return &GraphQLAdditionalArgumentsProvider{CrossRankerProvider}
+}
+
+func (p *GraphQLAdditionalArgumentsProvider) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {
+	additionalProperties := map[string]modulecapabilities.AdditionalProperty{}
+	additionalProperties["rerank"] = p.getCrossRanker()
+	return additionalProperties
+}
+
+func (p *GraphQLAdditionalArgumentsProvider) getCrossRanker() modulecapabilities.AdditionalProperty {
+	return modulecapabilities.AdditionalProperty{
+		GraphQLNames:           []string{"rerank"},
+		GraphQLFieldFunction:   p.CrossRankerProvider.AdditionalFieldFn,
+		GraphQLExtractFunction: p.CrossRankerProvider.ExtractAdditionalFn,
+		SearchFunctions: modulecapabilities.AdditionalSearch{
+			ExploreGet:  p.CrossRankerProvider.AdditionalPropertyFn,
+			ExploreList: p.CrossRankerProvider.AdditionalPropertyFn,
+		},
+	}
+}

--- a/modules/reranker-cohere/additional/rank/rank.go
+++ b/modules/reranker-cohere/additional/rank/rank.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tailor-inc/graphql"
+	"github.com/tailor-inc/graphql/language/ast"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/modules/reranker-cohere/ent"
+)
+
+type ReRankerCohereClient interface {
+	Rank(ctx context.Context, cfg moduletools.ClassConfig, rankpropertyValue string, query string) (*ent.RankResult, error)
+}
+
+type ReRankerCohereProvider struct {
+	client ReRankerCohereClient
+}
+
+func New(reranker ReRankerCohereClient) *ReRankerCohereProvider {
+	return &ReRankerCohereProvider{reranker}
+}
+
+func (p *ReRankerCohereProvider) AdditionalPropertyDefaultValue() interface{} {
+	return &Params{}
+}
+
+func (p *ReRankerCohereProvider) ExtractAdditionalFn(param []*ast.Argument) interface{} {
+	return p.parseReRankerCohereArguments(param)
+}
+
+func (p *ReRankerCohereProvider) AdditionalFieldFn(classname string) *graphql.Field {
+	return p.additionalReRankerCohereField(classname)
+}
+
+func (p *ReRankerCohereProvider) AdditionalPropertyFn(ctx context.Context,
+	in []search.Result, params interface{}, limit *int,
+	argumentModuleParams map[string]interface{}, cfg moduletools.ClassConfig,
+) ([]search.Result, error) {
+	if parameters, ok := params.(*Params); ok {
+		return p.getScore(ctx, cfg, in, parameters)
+	}
+	return nil, errors.New("wrong parameters")
+}

--- a/modules/reranker-cohere/additional/rank/rank_graphql_field.go
+++ b/modules/reranker-cohere/additional/rank/rank_graphql_field.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"fmt"
+
+	"github.com/tailor-inc/graphql"
+)
+
+func (p *ReRankerCohereProvider) additionalReRankerCohereField(classname string) *graphql.Field {
+	return &graphql.Field{
+		Args: graphql.FieldConfigArgument{
+			"query": &graphql.ArgumentConfig{
+				Description:  "Properties which contains text",
+				Type:         graphql.String,
+				DefaultValue: nil,
+			},
+			"property": &graphql.ArgumentConfig{
+				Description:  "Property to rank from",
+				Type:         graphql.String,
+				DefaultValue: nil,
+			},
+		},
+		Type: graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+			Name: fmt.Sprintf("%sAdditionalReranker", classname),
+			Fields: graphql.Fields{
+				"score": &graphql.Field{Type: graphql.Float},
+			},
+		})),
+	}
+}

--- a/modules/reranker-cohere/additional/rank/rank_graphql_field_test.go
+++ b/modules/reranker-cohere/additional/rank/rank_graphql_field_test.go
@@ -1,0 +1,43 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tailor-inc/graphql"
+)
+
+func Test_additionalCrossRankerField(t *testing.T) {
+	// given
+	reRankerProvider := &ReRankerCohereProvider{}
+	classname := "Class"
+
+	// when
+	reRanker := reRankerProvider.additionalReRankerCohereField(classname)
+
+	assert.NotNil(t, reRanker)
+	assert.Equal(t, "ClassAdditionalReranker", reRanker.Type.Name())
+	assert.NotNil(t, reRanker.Type)
+	reRankerObjectList, reRankerObjectListOK := reRanker.Type.(*graphql.List)
+	assert.True(t, reRankerObjectListOK)
+	reRankerObject, reRankerObjectOK := reRankerObjectList.OfType.(*graphql.Object)
+	assert.True(t, reRankerObjectOK)
+	assert.Equal(t, 1, len(reRankerObject.Fields()))
+	assert.NotNil(t, reRankerObject.Fields()["score"])
+
+	assert.NotNil(t, reRanker.Args)
+	assert.Equal(t, 2, len(reRanker.Args))
+	assert.NotNil(t, reRanker.Args["query"])
+	assert.NotNil(t, reRanker.Args["property"])
+}

--- a/modules/reranker-cohere/additional/rank/rank_params.go
+++ b/modules/reranker-cohere/additional/rank/rank_params.go
@@ -1,0 +1,31 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+type Params struct {
+	Property *string
+	Query    *string
+}
+
+func (n Params) GetQuery() string {
+	if n.Query != nil {
+		return *n.Query
+	}
+	return ""
+}
+
+func (n Params) GetProperty() string {
+	if n.Property != nil {
+		return *n.Property
+	}
+	return ""
+}

--- a/modules/reranker-cohere/additional/rank/rank_params_extractor.go
+++ b/modules/reranker-cohere/additional/rank/rank_params_extractor.go
@@ -1,0 +1,31 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"github.com/tailor-inc/graphql/language/ast"
+)
+
+func (p *ReRankerCohereProvider) parseReRankerCohereArguments(args []*ast.Argument) *Params {
+	out := &Params{}
+
+	for _, arg := range args {
+		switch arg.Name.Value {
+		case "query":
+			out.Query = &arg.Value.(*ast.StringValue).Value
+		case "property":
+			out.Property = &arg.Value.(*ast.StringValue).Value
+		}
+	}
+
+	return out
+}

--- a/modules/reranker-cohere/additional/rank/rank_params_extractor_test.go
+++ b/modules/reranker-cohere/additional/rank/rank_params_extractor_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tailor-inc/graphql/language/ast"
+)
+
+func Test_parseCrossRankerArguments(t *testing.T) {
+	type args struct {
+		args []*ast.Argument
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Params
+	}{
+		{
+			name: "Should create with no params",
+			args: args{},
+			want: &Params{},
+		},
+		{
+			name: "Should create with query param",
+			args: args{
+				args: []*ast.Argument{
+					createStringArg("query", "sample query"),
+				},
+			},
+			want: &Params{
+				Query: strPtr("sample query"),
+			},
+		},
+		{
+			name: "Should create with property param",
+			args: args{
+				args: []*ast.Argument{
+					createStringArg("property", "sample property"),
+				},
+			},
+			want: &Params{
+				Property: strPtr("sample property"),
+			},
+		},
+		{
+			name: "Should create with all params",
+			args: args{
+				args: []*ast.Argument{
+					createStringArg("query", "sample query"),
+					createStringArg("property", "sample property"),
+				},
+			},
+			want: &Params{
+				Query:    strPtr("sample query"),
+				Property: strPtr("sample property"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ReRankerCohereProvider{}
+			if got := p.parseReRankerCohereArguments(tt.args.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseReRankerCohereArguments() = %v, want %v", got, tt.want)
+			}
+			actual := p.parseReRankerCohereArguments(tt.args.args)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}
+
+func createStringArg(name, value string) *ast.Argument {
+	n := ast.Name{
+		Value: name,
+	}
+	val := ast.StringValue{
+		Kind:  "Kind",
+		Value: value,
+	}
+	arg := ast.Argument{
+		Name:  ast.NewName(&n),
+		Kind:  "Kind",
+		Value: &val,
+	}
+	a := ast.NewArgument(&arg)
+	return a
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/modules/reranker-cohere/additional/rank/rank_result.go
+++ b/modules/reranker-cohere/additional/rank/rank_result.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/weaviate/weaviate/entities/moduletools"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+	rerankmodels "github.com/weaviate/weaviate/modules/reranker-cohere/additional/models"
+)
+
+func (p *ReRankerCohereProvider) getScore(ctx context.Context, cfg moduletools.ClassConfig,
+	in []search.Result, params *Params,
+) ([]search.Result, error) {
+	if len(in) == 0 {
+		return nil, nil
+	} else {
+		if params == nil {
+			return nil, fmt.Errorf("no params provided")
+		}
+
+		rankProperty := params.GetProperty()
+		query := params.GetQuery()
+
+		// check if user parameter values are valid
+		if len(rankProperty) == 0 {
+			return in, errors.New("no properties provided")
+		}
+
+		for i := range in { // for each result of the general GraphQL Query
+			// get text property
+			rankPropertyValue := ""
+			schema := in[i].Object().Properties.(map[string]interface{})
+			for property, value := range schema {
+				if valueString, ok := value.(string); ok {
+					if property == rankProperty {
+						rankPropertyValue = valueString
+					}
+				}
+			}
+
+			ap := in[i].AdditionalProperties
+			if ap == nil {
+				ap = models.AdditionalProperties{}
+			}
+
+			result, _ := p.client.Rank(ctx, cfg, rankPropertyValue, query) // didn't implement error yet
+			ap["rerank"] = []*rerankmodels.RankResult{
+				{
+					Score: &result.Score,
+				},
+			}
+			in[i].AdditionalProperties = ap
+		}
+	}
+	// sort the list
+	sort.Slice(in, func(i, j int) bool {
+		apI := in[i].AdditionalProperties["rerank"].([]*rerankmodels.RankResult)
+		apJ := in[j].AdditionalProperties["rerank"].([]*rerankmodels.RankResult)
+
+		// Sort in descending order, based on Score values
+		return *apI[0].Score > *apJ[0].Score
+	})
+	return in, nil
+}

--- a/modules/reranker-cohere/additional/rank/rank_test.go
+++ b/modules/reranker-cohere/additional/rank/rank_test.go
@@ -1,0 +1,116 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rank
+
+import (
+	"context"
+	"testing"
+
+	"github.com/weaviate/weaviate/modules/reranker-cohere/ent"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+func TestAdditionalAnswerProvider(t *testing.T) {
+	t.Run("should fail with empty content", func(t *testing.T) {
+		// given
+		rankClient := &fakeRankClient{}
+		rankProvider := New(rankClient)
+		in := []search.Result{
+			{
+				ID: "some-uuid",
+			},
+		}
+		fakeParams := &Params{}
+		limit := 1
+		argumentModuleParams := map[string]interface{}{}
+
+		// when
+		out, err := rankProvider.AdditionalPropertyFn(context.Background(), in, fakeParams, &limit, argumentModuleParams, nil)
+
+		// then
+		require.NotNil(t, err)
+		require.NotEmpty(t, out)
+		assert.Error(t, err, "empty schema content")
+	})
+
+	t.Run("should fail with empty params", func(t *testing.T) {
+		// given
+		rankClient := &fakeRankClient{}
+		rankProvider := New(rankClient)
+		in := []search.Result{
+			{
+				ID: "some-uuid",
+				Schema: map[string]interface{}{
+					"content": "content",
+				},
+			},
+		}
+		fakeParams := &Params{}
+		limit := 1
+		argumentModuleParams := map[string]interface{}{}
+
+		// when
+		out, err := rankProvider.AdditionalPropertyFn(context.Background(), in, fakeParams, &limit, argumentModuleParams, nil)
+
+		// then
+		require.NotNil(t, err)
+		require.NotEmpty(t, out)
+		assert.Error(t, err, "empty params")
+	})
+
+	t.Run("should rank", func(t *testing.T) {
+		rankClient := &fakeRankClient{}
+		rankProvider := New(rankClient)
+		in := []search.Result{
+			{
+				ID: "some-uuid",
+				Schema: map[string]interface{}{
+					"content": "this is the content",
+				},
+			},
+		}
+		property := "content"
+		query := "this is the query"
+		fakeParams := &Params{Property: &property, Query: &query}
+		limit := 1
+		argumentModuleParams := map[string]interface{}{}
+
+		// when
+		out, err := rankProvider.AdditionalPropertyFn(context.Background(), in, fakeParams, &limit, argumentModuleParams, nil)
+		// then
+		require.Nil(t, err)
+		require.NotEmpty(t, out)
+		assert.Equal(t, 1, len(in))
+		answer, answerOK := in[0].AdditionalProperties["rerank"]
+		assert.True(t, answerOK)
+		assert.NotNil(t, answer)
+		answerAdditional, _ := answer.(ent.RankResult)
+		// assert.True(t, answerAdditionalOK)
+		assert.Equal(t, float64(0), answerAdditional.Score)
+	})
+}
+
+type fakeRankClient struct{}
+
+func (c *fakeRankClient) Rank(ctx context.Context, cfg moduletools.ClassConfig, rankpropertyValue string, query string) (result *ent.RankResult, err error) {
+	score := 0.15
+	result = &ent.RankResult{
+		Score:             score,
+		Query:             query,
+		RankPropertyValue: rankpropertyValue,
+	}
+	return result, nil
+}

--- a/modules/reranker-cohere/clients/ranker.go
+++ b/modules/reranker-cohere/clients/ranker.go
@@ -1,0 +1,156 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/reranker-cohere/config"
+	"github.com/weaviate/weaviate/modules/reranker-cohere/ent"
+)
+
+type client struct {
+	apiKey     string
+	host       string
+	path       string
+	httpClient *http.Client
+	logger     logrus.FieldLogger
+}
+
+func New(apiKey string, logger logrus.FieldLogger) *client {
+	return &client{
+		apiKey:     apiKey,
+		httpClient: &http.Client{},
+		host:       "https://api.cohere.ai",
+		path:       "/v1/rerank",
+		logger:     logger,
+	}
+}
+
+func (v *client) Rank(ctx context.Context, cfg moduletools.ClassConfig,
+	rankpropertyValue string, query string,
+) (*ent.RankResult, error) {
+	settings := config.NewClassSettings(cfg)
+	cohereUrl, err := url.JoinPath(v.host, v.path)
+	if err != nil {
+		return nil, errors.Wrap(err, "join Cohere API host and path")
+	}
+
+	cohereDocumentsInput := []string{rankpropertyValue}
+
+	input := RankInput{
+		RankPropertyValue: cohereDocumentsInput,
+		Query:             query,
+		Model:             settings.Model(),
+		ReturnDocuments:   settings.ReturnDocuments(),
+	}
+
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshal body")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", cohereUrl, bytes.NewReader(body))
+	if err != nil {
+		return nil, errors.Wrap(err, "create POST request")
+	}
+
+	apiKey, err := v.getApiKey(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Cohere API Key")
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("BEARER %s", apiKey))
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "send POST request")
+	}
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read response body")
+	}
+
+	var resBody RankResponse
+	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
+		return nil, errors.Wrap(err, "unmarshal response body")
+	}
+
+	if res.StatusCode > 399 {
+		var apiError cohereApiError
+		err = json.Unmarshal(bodyBytes, &apiError)
+		if err != nil {
+			return nil, errors.Wrap(err, "unmarshal error from response body")
+		}
+		return nil, errors.Errorf("fail with status %d: %s", res.StatusCode, apiError.Message)
+	}
+	return &ent.RankResult{
+		RankPropertyValue: rankpropertyValue,
+		Query:             query,
+		Score:             resBody.Results[0].RelevanceScore,
+	}, nil
+}
+
+func (v *client) getApiKey(ctx context.Context) (string, error) {
+	if len(v.apiKey) > 0 {
+		return v.apiKey, nil
+	}
+	apiKey := ctx.Value("X-Cohere-Api-Key")
+	if apiKeyHeader, ok := apiKey.([]string); ok &&
+		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {
+		return apiKeyHeader[0], nil
+	}
+	return "", errors.New("no api key found " +
+		"neither in request header: X-Cohere-Api-Key " +
+		"nor in environment variable under COHERE_APIKEY")
+}
+
+type RankInput struct {
+	RankPropertyValue []string `json:"documents"`
+	Query             string   `json:"query"`
+	Model             string   `json:"model"`
+	ReturnDocuments   bool     `json:"return_documents"`
+}
+
+type Result struct {
+	Index          int     `json:"index"`
+	RelevanceScore float64 `json:"relevance_score"`
+}
+
+type APIVersion struct {
+	Version string `json:"version"`
+}
+
+type Meta struct {
+	APIVersion APIVersion `json:"api_version"`
+}
+
+type RankResponse struct {
+	ID      string   `json:"id"`
+	Results []Result `json:"results"`
+	Meta    Meta     `json:"meta"`
+}
+
+type cohereApiError struct {
+	Message string `json:"error"`
+}

--- a/modules/reranker-cohere/clients/ranker_meta.go
+++ b/modules/reranker-cohere/clients/ranker_meta.go
@@ -1,0 +1,19 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+func (s *client) MetaInfo() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"name":              "Reranker - Cohere",
+		"documentationHref": "https://txt.cohere.com/rerank/",
+	}, nil
+}

--- a/modules/reranker-cohere/clients/ranker_test.go
+++ b/modules/reranker-cohere/clients/ranker_test.go
@@ -1,0 +1,110 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/modules/reranker-cohere/ent"
+)
+
+func nullLogger() logrus.FieldLogger {
+	l, _ := test.NewNullLogger()
+	return l
+}
+
+func TestRank(t *testing.T) {
+	t.Run("when the server has a successful response", func(t *testing.T) {
+		handler := &testRankHandler{
+			t: t,
+			response: RankResponse{
+				Results: []Result{
+					{
+						Index:          0,
+						RelevanceScore: 0.9,
+					},
+				},
+			},
+		}
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		c := New("apiKey", nullLogger())
+		c.host = server.URL
+
+		expected := &ent.RankResult{
+			RankPropertyValue: "I work at Apple",
+			Query:             "Where do I work?",
+			Score:             0.9,
+		}
+
+		res, err := c.Rank(context.Background(), nil, "I work at Apple", "Where do I work?")
+
+		assert.Nil(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("when the server has an error", func(t *testing.T) {
+		handler := &testRankHandler{
+			t: t,
+			response: RankResponse{
+				Results: []Result{},
+			},
+			errorMessage: "some error from the server",
+		}
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		c := New("apiKey", nullLogger())
+		c.host = server.URL
+
+		_, err := c.Rank(context.Background(), nil, "I work at Apple", "Where do I work?")
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "some error from the server")
+	})
+}
+
+type testRankHandler struct {
+	t            *testing.T
+	response     RankResponse
+	errorMessage string
+}
+
+func (f *testRankHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if f.errorMessage != "" {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"` + f.errorMessage + `"}`))
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	require.Nil(f.t, err)
+	defer r.Body.Close()
+
+	var b RankInput
+	require.Nil(f.t, json.Unmarshal(bodyBytes, &b))
+
+	outBytes, err := json.Marshal(f.response)
+	require.Nil(f.t, err)
+
+	w.Write(outBytes)
+}

--- a/modules/reranker-cohere/config.go
+++ b/modules/reranker-cohere/config.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modrerankercohere
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func (m *ReRankerCohereModule) ClassConfigDefaults() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *ReRankerCohereModule) PropertyConfigDefaults(
+	dt *schema.DataType,
+) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *ReRankerCohereModule) ValidateClass(ctx context.Context,
+	class *models.Class, cfg moduletools.ClassConfig,
+) error {
+	return nil
+}
+
+var _ = modulecapabilities.ClassConfigurator(New())

--- a/modules/reranker-cohere/config/class_settings.go
+++ b/modules/reranker-cohere/config/class_settings.go
@@ -1,0 +1,112 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package config
+
+import (
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/moduletools"
+)
+
+const (
+	modelProperty   = "model"
+	returnDocuments = "returnDocuments"
+)
+
+var availableCohereModels = []string{
+	"rerank-english-v2.0",
+	"rerank-multilingual-v2.0",
+}
+
+// note it might not like this -- might want int values for e.g. MaxTokens
+var (
+	DefaultCohereModel     = "rerank-english-v2.0"
+	DefaultReturnDocuments = false
+)
+
+type classSettings struct {
+	cfg moduletools.ClassConfig
+}
+
+func NewClassSettings(cfg moduletools.ClassConfig) *classSettings {
+	return &classSettings{cfg: cfg}
+}
+
+func (ic *classSettings) Validate(class *models.Class) error {
+	if ic.cfg == nil {
+		// we would receive a nil-config on cross-class requests, such as Explore{}
+		return errors.New("empty config")
+	}
+	model := ic.getStringProperty(modelProperty, DefaultCohereModel)
+	if model == nil || !ic.validateModel(*model) {
+		return errors.Errorf("wrong Cohere model name, available model names are: %v", availableCohereModels)
+	}
+
+	return nil
+}
+
+func (ic *classSettings) getStringProperty(name string, defaultValue string) *string {
+	if ic.cfg == nil {
+		// we would receive a nil-config on cross-class requests, such as Explore{}
+		return &defaultValue
+	}
+
+	model, ok := ic.cfg.ClassByModuleName("reranker-cohere")[name]
+	if ok {
+		asString, ok := model.(string)
+		if ok {
+			return &asString
+		}
+		var empty string
+		return &empty
+	}
+	return &defaultValue
+}
+
+func (ic *classSettings) getBoolProperty(name string, defaultValue *bool) *bool {
+	if ic.cfg == nil {
+		// we would receive a nil-config on cross-class requests, such as Explore{}
+		return defaultValue
+	}
+
+	val, ok := ic.cfg.ClassByModuleName("reranker-cohere")[name]
+	if ok {
+		asBool, ok := val.(bool)
+		if ok {
+			return &asBool
+		}
+		var empty bool
+		return &empty
+	}
+	return defaultValue
+}
+
+func (ic *classSettings) validateModel(model string) bool {
+	return contains(availableCohereModels, model)
+}
+
+func (ic *classSettings) Model() string {
+	return *ic.getStringProperty(modelProperty, DefaultCohereModel)
+}
+
+func (ic *classSettings) ReturnDocuments() bool {
+	return *ic.getBoolProperty(returnDocuments, &DefaultReturnDocuments)
+}
+
+func contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/reranker-cohere/ent/rank_result.go
+++ b/modules/reranker-cohere/ent/rank_result.go
@@ -1,0 +1,18 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package ent
+
+type RankResult struct {
+	Query             string
+	RankPropertyValue string
+	Score             float64
+}

--- a/modules/reranker-cohere/module.go
+++ b/modules/reranker-cohere/module.go
@@ -1,0 +1,95 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modrerankercohere
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	rerankeradditional "github.com/weaviate/weaviate/modules/reranker-cohere/additional"
+	rerankeradditionalrank "github.com/weaviate/weaviate/modules/reranker-cohere/additional/rank"
+	"github.com/weaviate/weaviate/modules/reranker-cohere/clients"
+	"github.com/weaviate/weaviate/modules/reranker-cohere/ent"
+)
+
+const Name = "reranker-cohere"
+
+func New() *ReRankerCohereModule {
+	return &ReRankerCohereModule{}
+}
+
+type ReRankerCohereModule struct {
+	reranker                     ReRankerCohereClient
+	additionalPropertiesProvider modulecapabilities.AdditionalProperties
+}
+
+type ReRankerCohereClient interface {
+	Rank(ctx context.Context, cfg moduletools.ClassConfig, property string, query string) (*ent.RankResult, error)
+	MetaInfo() (map[string]interface{}, error)
+}
+
+func (m *ReRankerCohereModule) Name() string {
+	return Name
+}
+
+func (m *ReRankerCohereModule) Type() modulecapabilities.ModuleType {
+	return modulecapabilities.Text2TextReranker
+}
+
+func (m *ReRankerCohereModule) Init(ctx context.Context,
+	params moduletools.ModuleInitParams,
+) error {
+	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+		return errors.Wrap(err, "init cross encoder")
+	}
+
+	return nil
+}
+
+func (m *ReRankerCohereModule) initAdditional(ctx context.Context,
+	logger logrus.FieldLogger,
+) error {
+	apiKey := os.Getenv("COHERE_APIKEY")
+
+	client := clients.New(apiKey, logger)
+
+	m.reranker = client
+
+	rerankerProvider := rerankeradditionalrank.New(m.reranker)
+	m.additionalPropertiesProvider = rerankeradditional.New(rerankerProvider)
+	return nil
+}
+
+func (m *ReRankerCohereModule) MetaInfo() (map[string]interface{}, error) {
+	return m.reranker.MetaInfo()
+}
+
+func (m *ReRankerCohereModule) RootHandler() http.Handler {
+	// TODO: remove once this is a capability interface
+	return nil
+}
+
+func (m *ReRankerCohereModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {
+	return m.additionalPropertiesProvider.AdditionalProperties()
+}
+
+// verify we implement the modules.Module interface
+var (
+	_ = modulecapabilities.Module(New())
+	_ = modulecapabilities.AdditionalProperties(New())
+	_ = modulecapabilities.MetaProvider(New())
+)

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -361,7 +361,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       QNA_INFERENCE_API="http://localhost:8001" \
       CLUSTER_HOSTNAME="node1" \
-      ENABLE_MODULES="text2vec-contextionary,generative-palm,text2vec-palm,qna-openai,generative-openai,text2vec-openai,generative-cohere,text2vec-cohere" \
+      ENABLE_MODULES="text2vec-contextionary,generative-palm,text2vec-palm,qna-openai,generative-openai,text2vec-openai,generative-cohere,text2vec-cohere,reranker-cohere" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -466,6 +466,18 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-cohere \
       ENABLE_MODULES="text2vec-cohere" \
+      go_run ./cmd/weaviate-server \
+        --scheme http \
+        --host "127.0.0.1" \
+        --port 8080 \
+        --read-timeout=600s \
+        --write-timeout=600s
+    ;;
+
+  local-all-cohere)
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
+      DEFAULT_VECTORIZER_MODULE=text2vec-cohere \
+      ENABLE_MODULES="text2vec-cohere,reranker-cohere,generative-cohere" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \


### PR DESCRIPTION
### What's being changed:
What's being changed:
Cross Encoder Re-Rankers in Weaviate! (From Cohere API)

To configure:
COHERE_APIKEY: 'cohere api key'
ENABLE_MODULES: 'reranker-cohere'

To query:
```graphql
{
  Get {
    Product(limit:50){
      content
      _additional {
        rerank(
          property: "content"
          query: "what is ref2vec?"
        ) {
        score
        }
      }
  }
}
```

Review checklist
 Documentation has been updated, if necessary. Link to changed documentation:
 Chaos pipeline run or not necessary. Link to pipeline:
 All new code is covered by tests where it is reasonable.
 Performance tests have been run or not necessary.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [X] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.
