### PR TITLE
Add goreleaser config and build script

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,23 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    main: ./cmd/weaviate-server
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -w
+      - -extldflags "-static"
+      - -X github.com/weaviate/weaviate/usecases/config.GitHash={{ .Env.GIT_HASH }}
+
+# create a "fat" binary for MacOS
+universal_binaries:
+  - replace: true
+

--- a/tools/dev/build.sh
+++ b/tools/dev/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# run from weaviate Root
+
+export GIT_HASH=$(git rev-parse --short HEAD)
+goreleaser build  --clean --snapshot
+
+codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" dist/weaviate_darwin_all/weaviate
+
+zip dist/weaviate_darwin_all.zip dist/weaviate_darwin_all/weaviate
+
+codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" dist/weaviate_darwin_all.zip
+
+xcrun notarytool submit dist/weaviate_darwin_all.zip --keychain-profile "AC_PASSWORD_PRIVAT" --wait

--- a/tools/dev/build.sh
+++ b/tools/dev/build.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-#
-# run from weaviate Root
+# run from Weaviate Root
 
 export GIT_HASH=$(git rev-parse --short HEAD)
-goreleaser build  --clean --snapshot
+goreleaser build --clean
 
 codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" dist/weaviate_darwin_all/weaviate
 

--- a/tools/dev/build.sh
+++ b/tools/dev/build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+set -eou pipefail
+
 # run from Weaviate Root
 
 export GIT_HASH=$(git rev-parse --short HEAD)
-goreleaser build --clean
+goreleaser build --clean # add --snapshot to this commandline to build from non-tagged commit or with unclean directory
 
 codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" dist/weaviate_darwin_all/weaviate
 


### PR DESCRIPTION
### What's being changed:

For this to work you need to have:
- a valid apple certificate
- an app specific password

Adds configuration for goreleaser to build weaviate for linux + macos.
I tested that weaviate executable:
- starts
- githash and version are set correctly
- ran some basic tests
The binaries produced by gorelaser are unsigned and not notarized

This PR also adds a build script, that
- starts goreleaser
- initiates the signing and notarization process



