### PR TITLE
defers releasing dropindex locks on batch adding objects and refs

### DIFF
--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -44,26 +44,38 @@ func (db *DB) BatchPutObjects(ctx context.Context, objs objects.BatchObjects,
 		objectByClass[item.Object.Class] = queue
 	}
 
-	db.indexLock.RLock()
-	for class, queue := range objectByClass {
-		index, ok := db.indices[indexID(schema.ClassName(class))]
-		if !ok {
-			for _, ind := range queue.originalIndex {
-				objs[queue.originalIndex[ind]].Err = fmt.Errorf("could not find index for class %v. It might have been deleted in the meantime", class)
-			}
-			continue
-		}
-		index.dropIndex.RLock()
-		indexByClass[class] = index
-	}
-	db.indexLock.RUnlock()
+	// wrapped by func to acquire and safely release indexLock only for duration of loop
+	func() {
+		db.indexLock.RLock()
+		defer db.indexLock.RUnlock()
 
-	for class, queue := range objectByClass {
-		index, ok := indexByClass[class]
-		if !ok {
-			continue
+		for class, queue := range objectByClass {
+			index, ok := db.indices[indexID(schema.ClassName(class))]
+			if !ok {
+				for _, ind := range queue.originalIndex {
+					objs[queue.originalIndex[ind]].Err = fmt.Errorf("could not find index for class %v. It might have been deleted in the meantime", class)
+				}
+				continue
+			}
+			index.dropIndex.RLock()
+			indexByClass[class] = index
 		}
+	}()
+
+	// safely release remaining locks (in case of panic)
+	defer func() {
+		for _, index := range indexByClass {
+			if index != nil {
+				index.dropIndex.RUnlock()
+			}
+		}
+	}()
+
+	for class, index := range indexByClass {
+		queue := objectByClass[class]
 		errs := index.putObjectBatch(ctx, queue.objects, repl)
+		// remove index from map to skip releasing its lock in defer
+		indexByClass[class] = nil
 		index.dropIndex.RUnlock()
 		for i, err := range errs {
 			if err != nil {
@@ -89,26 +101,38 @@ func (db *DB) AddBatchReferences(ctx context.Context, references objects.BatchRe
 		refByClass[item.From.Class] = append(refByClass[item.From.Class], item)
 	}
 
-	db.indexLock.RLock()
-	for class, queue := range refByClass {
-		index, ok := db.indices[indexID(class)]
-		if !ok {
-			for _, item := range queue {
-				references[item.OriginalIndex].Err = fmt.Errorf("could not find index for class %v. It might have been deleted in the meantime", class)
-			}
-			continue
-		}
-		index.dropIndex.RLock()
-		indexByClass[class] = index
-	}
-	db.indexLock.RUnlock()
+	// wrapped by func to acquire and safely release indexLock only for duration of loop
+	func() {
+		db.indexLock.RLock()
+		defer db.indexLock.RUnlock()
 
-	for class, queue := range refByClass {
-		index, ok := indexByClass[class]
-		if !ok {
-			continue
+		for class, queue := range refByClass {
+			index, ok := db.indices[indexID(class)]
+			if !ok {
+				for _, item := range queue {
+					references[item.OriginalIndex].Err = fmt.Errorf("could not find index for class %v. It might have been deleted in the meantime", class)
+				}
+				continue
+			}
+			index.dropIndex.RLock()
+			indexByClass[class] = index
 		}
+	}()
+
+	// safely release remaining locks (in case of panic)
+	defer func() {
+		for _, index := range indexByClass {
+			if index != nil {
+				index.dropIndex.RUnlock()
+			}
+		}
+	}()
+
+	for class, index := range indexByClass {
+		queue := refByClass[class]
 		errs := index.addReferencesBatch(ctx, queue, repl)
+		// remove index from map to skip releasing its lock in defer
+		indexByClass[class] = nil
 		index.dropIndex.RUnlock()
 		for i, err := range errs {
 			if err != nil {

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -215,25 +215,54 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 		})
 	})
 
-	t.Run("add reference between them - second batch", func(t *testing.T) {
+	t.Run("add reference between them - second batch including errors", func(t *testing.T) {
 		source, err := crossref.ParseSource(fmt.Sprintf(
 			"weaviate://localhost/AddingBatchReferencesTestSource/%s/toTarget",
 			sourceID))
 		require.Nil(t, err)
+		sourceNonExistingClass, err := crossref.ParseSource(fmt.Sprintf(
+			"weaviate://localhost/NonExistingClass/%s/toTarget",
+			sourceID))
+		require.Nil(t, err)
+		sourceNonExistingProp, err := crossref.ParseSource(fmt.Sprintf(
+			"weaviate://localhost/AddingBatchReferencesTestSource/%s/nonExistingProp",
+			sourceID))
+		require.Nil(t, err)
+
 		targets := []strfmt.UUID{target3, target4}
-		refs := make(objects.BatchReferences, len(targets))
+		refs := make(objects.BatchReferences, 3*len(targets))
 		for i, target := range targets {
 			to, err := crossref.Parse(fmt.Sprintf("weaviate://localhost/%s", target))
 			require.Nil(t, err)
-			refs[i] = objects.BatchReference{
+
+			refs[3*i] = objects.BatchReference{
 				Err:           nil,
 				From:          source,
 				To:            to,
-				OriginalIndex: i,
+				OriginalIndex: 3 * i,
+			}
+			refs[3*i+1] = objects.BatchReference{
+				Err:           nil,
+				From:          sourceNonExistingClass,
+				To:            to,
+				OriginalIndex: 3*i + 1,
+			}
+			refs[3*i+2] = objects.BatchReference{
+				Err:           nil,
+				From:          sourceNonExistingProp,
+				To:            to,
+				OriginalIndex: 3*i + 2,
 			}
 		}
-		_, err = repo.AddBatchReferences(context.Background(), refs, nil)
+		batchRefs, err := repo.AddBatchReferences(context.Background(), refs, nil)
 		assert.Nil(t, err)
+		require.Len(t, batchRefs, 6)
+		assert.Nil(t, batchRefs[0].Err)
+		assert.Nil(t, batchRefs[3].Err)
+		assert.Contains(t, batchRefs[1].Err.Error(), "NonExistingClass")
+		assert.Contains(t, batchRefs[4].Err.Error(), "NonExistingClass")
+		assert.Contains(t, batchRefs[2].Err.Error(), "nonExistingProp")
+		assert.Contains(t, batchRefs[5].Err.Error(), "nonExistingProp")
 	})
 
 	t.Run("check all references are now present", func(t *testing.T) {
@@ -359,4 +388,16 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 			require.Len(t, res, 1)
 			assert.Equal(t, sourceID, res[0].ID)
 		})
+
+	t.Run("remove source and target classes", func(t *testing.T) {
+		err := repo.DeleteIndex("AddingBatchReferencesTestSource")
+		assert.Nil(t, err)
+		err = repo.DeleteIndex("AddingBatchReferencesTestTarget")
+		assert.Nil(t, err)
+
+		t.Run("verify classes do not exist", func(t *testing.T) {
+			assert.False(t, repo.IndexExists("AddingBatchReferencesTestSource"))
+			assert.False(t, repo.IndexExists("AddingBatchReferencesTestTarget"))
+		})
+	})
 }


### PR DESCRIPTION
### What's being changed:
moves releasing dropindex locks to defer to avoid deadlocks on panic

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
