### PR TITLE
Fix AutoSchema determine type logic to prevent returing an empty data type

### DIFF
--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -231,6 +231,9 @@ func (m *autoSchemaManager) determineType(value interface{}) []schema.DataType {
 					return []schema.DataType{schema.DataTypeBooleanArray}
 				}
 			}
+			if len(dataType) == 0 {
+				return fallbackDataType
+			}
 			return dataType
 		}
 		return fallbackDataType

--- a/usecases/objects/auto_schema_test.go
+++ b/usecases/objects/auto_schema_test.go
@@ -281,6 +281,19 @@ func Test_autoSchemaManager_determineType(t *testing.T) {
 			},
 			want: []schema.DataType{schema.DataTypeStringArray},
 		},
+		{
+			name: "determine error type that is not recognized",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled:       true,
+					DefaultString: schema.DataTypeText.String(),
+				},
+			},
+			args: args{
+				value: []interface{}{[]interface{}{"panic"}},
+			},
+			want: []schema.DataType{schema.DataTypeText},
+		},
 	}
 	for _, tt := range tests {
 		vectorRepo := &fakeVectorRepo{}


### PR DESCRIPTION
### What's being changed:

This PR fixes a panic when AutoSchema is not able to determine an array type.

```
panic: runtime error: index out of range [0] with length 0

goroutine 10424 [running]:
github.com/weaviate/weaviate/usecases/modules.(*Provider).setSinglePropertyConfigDefaults(0x157de20?, 0x1bbe828?, 0xc003724700?, {0x7f04b2b391b8?, 0xc003724700?})
	/go/src/github.com/weaviate/weaviate/usecases/modules/module_config_init_and_validate.go:96 +0x6b8
github.com/weaviate/weaviate/usecases/modules.(*Provider).SetSinglePropertyDefaults(0xc0003a0e10, 0xc0001d7360, 0xc003df6b90?)
	/go/src/github.com/weaviate/weaviate/usecases/modules/module_config_init_and_validate.go:61 +0xf0
github.com/weaviate/weaviate/usecases/schema.(*Manager).setNewPropDefaults(0xc0001fb400, 0xc003df6b48?, 0xc00291e410?)
	/go/src/github.com/weaviate/weaviate/usecases/schema/add_property.go:97 +0x6c
github.com/weaviate/weaviate/usecases/schema.(*Manager).addClassProperty(0xc0001fb400, {0x1bbd8d8, 0xc002a859e0}, {0xc0029fe6a0, 0x4}, 0xc003176930)
	/go/src/github.com/weaviate/weaviate/usecases/schema/add_property.go:54 +0x25a
github.com/weaviate/weaviate/usecases/schema.(*Manager).AddClassProperty(0xc0001fb400, {0x1bbd8d8, 0xc002a859e0}, 0x14fe500?, {0xc0029fe6a0, 0x4}, 0xc00318e740?)
	/go/src/github.com/weaviate/weaviate/usecases/schema/add_property.go:34 +0x95
github.com/weaviate/weaviate/usecases/objects.(*autoSchemaManager).updateClass(0xc0003c0000, {0x1bbd8d8, 0xc002a859e0}, 0x0?, {0xc0029fe6a0, 0x4}, {0xc00318e740, 0x5, 0x0?}, {0xc00335c480, ...})
	/go/src/github.com/weaviate/weaviate/usecases/objects/auto_schema.go:132 +0x37b
github.com/weaviate/weaviate/usecases/objects.(*autoSchemaManager).performAutoSchema(0xc0003c0000, {0x1bbd8d8, 0xc002a859e0}, 0x80?, 0xc0003ba310)
	/go/src/github.com/weaviate/weaviate/usecases/objects/auto_schema.go:83 +0x18e
github.com/weaviate/weaviate/usecases/objects.(*autoSchemaManager).autoSchema(...)
	/go/src/github.com/weaviate/weaviate/usecases/objects/auto_schema.go:54
github.com/weaviate/weaviate/usecases/objects.(*BatchManager).validateObject(0xc0003c0080, {0x1bbd8d8, 0xc002a859e0}, 0x443905?, 0xc00291e360?, 0xc0003ba310, 0x2f, 0xc00040e450, 0x0?, 0x0)
	/go/src/github.com/weaviate/weaviate/usecases/objects/batch_add.go:114 +0xf7
created by github.com/weaviate/weaviate/usecases/objects.(*BatchManager).validateObjectsConcurrently
	/go/src/github.com/weaviate/weaviate/usecases/objects/batch_add.go:95 +0xe7
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
