### PR TITLE
Fix metrics grouping, add e2e test

### DIFF
--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -48,8 +48,8 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	shardName string,
 ) *Metrics {
 	if promMetrics.GroupClasses {
-		className = "_grouped"
-		shardName = "_grouped"
+		className = "n/a"
+		shardName = "n/a"
 	}
 
 	replace := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
@@ -147,7 +147,7 @@ func (m *Metrics) MemtableOpObserver(path, strategy, op string) NsObserver {
 	}
 
 	if m.groupClasses {
-		path = "_grouped"
+		path = "n/a"
 	}
 
 	curried := m.memtableDurations.With(prometheus.Labels{

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -132,6 +132,10 @@ func (sg *SegmentGroup) compactOnce() error {
 
 	strategy := sg.segmentAtPos(pair[0]).strategy
 
+	pathLabel := "_grouped"
+	if sg.metrics != nil && !sg.metrics.groupClasses {
+		pathLabel = sg.dir
+	}
 	switch strategy {
 
 	// TODO: call metrics just once with variable strategy label
@@ -141,8 +145,8 @@ func (sg *SegmentGroup) compactOnce() error {
 			sg.segmentAtPos(pair[1]).newCursor(), level, secondaryIndices, scratchSpacePath)
 
 		if sg.metrics != nil {
-			sg.metrics.CompactionReplace.With(prometheus.Labels{"path": sg.dir}).Set(1)
-			defer sg.metrics.CompactionReplace.With(prometheus.Labels{"path": sg.dir}).Set(0)
+			sg.metrics.CompactionReplace.With(prometheus.Labels{"path": pathLabel}).Inc()
+			defer sg.metrics.CompactionReplace.With(prometheus.Labels{"path": pathLabel}).Dec()
 		}
 
 		if err := c.do(); err != nil {
@@ -154,8 +158,8 @@ func (sg *SegmentGroup) compactOnce() error {
 			scratchSpacePath)
 
 		if sg.metrics != nil {
-			sg.metrics.CompactionSet.With(prometheus.Labels{"path": sg.dir}).Set(1)
-			defer sg.metrics.CompactionSet.With(prometheus.Labels{"path": sg.dir}).Set(0)
+			sg.metrics.CompactionSet.With(prometheus.Labels{"path": pathLabel}).Inc()
+			defer sg.metrics.CompactionSet.With(prometheus.Labels{"path": pathLabel}).Dec()
 		}
 
 		if err := c.do(); err != nil {
@@ -168,8 +172,8 @@ func (sg *SegmentGroup) compactOnce() error {
 			level, secondaryIndices, scratchSpacePath, sg.mapRequiresSorting)
 
 		if sg.metrics != nil {
-			sg.metrics.CompactionMap.With(prometheus.Labels{"path": sg.dir}).Set(1)
-			defer sg.metrics.CompactionMap.With(prometheus.Labels{"path": sg.dir}).Set(0)
+			sg.metrics.CompactionMap.With(prometheus.Labels{"path": pathLabel}).Inc()
+			defer sg.metrics.CompactionMap.With(prometheus.Labels{"path": pathLabel}).Dec()
 		}
 
 		if err := c.do(); err != nil {

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -132,7 +132,7 @@ func (sg *SegmentGroup) compactOnce() error {
 
 	strategy := sg.segmentAtPos(pair[0]).strategy
 
-	pathLabel := "_grouped"
+	pathLabel := "n/a"
 	if sg.metrics != nil && !sg.metrics.groupClasses {
 		pathLabel = sg.dir
 	}

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -45,8 +45,8 @@ func NewMetrics(
 	}
 
 	if prom.GroupClasses {
-		className = "_grouped"
-		shardName = "_grouped"
+		className = "n/a"
+		shardName = "n/a"
 	}
 
 	m.monitoring = true

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -42,8 +42,8 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 	}
 
 	if prom.GroupClasses {
-		className = "_grouped"
-		shardName = "_grouped"
+		className = "n/a"
+		shardName = "n/a"
 	}
 
 	tombstones := prom.VectorIndexTombstones.With(prometheus.Labels{

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -21,6 +21,12 @@ services:
       ENABLE_MODULES: text2vec-contextionary
       PROMETHEUS_MONITORING_ENABLED: 'true'
       PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'
+
+      # necessary for the metrics tests, some metrics only exist once segments
+      # are flushed. If we wait to long the before run is completely in
+      # memtables, the after run has some flushed which leads to some metrics
+      # diffs in the before and after
+      PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS: 2
   contextionary:
     image: semitechnologies/contextionary:en0.16.0-v1.2.1
     ports:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -10,6 +10,7 @@ services:
     ports:
      - "8080:8080"
      - "6060:6060"
+     - "2112:2112"
     environment:
       LOG_LEVEL: "debug"
       CONTEXTIONARY_URL: contextionary:9999
@@ -18,6 +19,8 @@ services:
       PERSISTENCE_DATA_PATH: "./data"
       DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
       ENABLE_MODULES: text2vec-contextionary
+      PROMETHEUS_MONITORING_ENABLED: 'true'
+      PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'
   contextionary:
     image: semitechnologies/contextionary:en0.16.0-v1.2.1
     ports:

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -14,7 +14,6 @@ package test
 import (
 	"bufio"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math"
 	"math/rand"
@@ -22,8 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-openapi/strfmt"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/objects"
@@ -73,7 +70,7 @@ func queryMetricsClass(t *testing.T, classIndex int) {
 	resp, err := helper.Client(t).Objects.
 		ObjectsClassGet(
 			objects.NewObjectsClassGetParams().
-				WithID(intToUUID(1)).
+				WithID(helper.IntToUUID(1)).
 				WithClassName(metricsClassName(classIndex)),
 			nil)
 
@@ -85,7 +82,7 @@ func queryMetricsClass(t *testing.T, classIndex int) {
 	helper.Client(t).Objects.
 		ObjectsClassGet(
 			objects.NewObjectsClassGetParams().
-				WithID(intToUUID(math.MaxUint64)).
+				WithID(helper.IntToUUID(math.MaxUint64)).
 				WithClassName(metricsClassName(classIndex)),
 			nil)
 
@@ -112,12 +109,6 @@ func queryMetricsClass(t *testing.T, classIndex int) {
 	assert.Len(t, objs, 1)
 }
 
-func intToUUID(in uint64) strfmt.UUID {
-	id := [16]byte{}
-	binary.BigEndian.PutUint64(id[8:16], in)
-	return strfmt.UUID(uuid.UUID(id).String())
-}
-
 // make sure that we use both individual as well as batch imports, as they
 // might produce different metrics
 func importMetricsClass(t *testing.T, classIndex int) {
@@ -127,7 +118,7 @@ func importMetricsClass(t *testing.T, classIndex int) {
 		Properties: map[string]interface{}{
 			"some_text": "this object was created individually",
 		},
-		ID:     intToUUID(1),
+		ID:     helper.IntToUUID(1),
 		Vector: randomVector(4),
 	})
 

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -89,6 +89,8 @@ func Test_GraphQL(t *testing.T) {
 	t.Run("aggregates with hybrid search", aggregationWithHybridSearch)
 	t.Run("expected aggregate failures with invalid conditions", aggregatesWithExpectedFailures)
 
+	t.Run("metrics count is stable when more classes are added", metricsCount)
+
 	// tear down
 	deleteObjectClass(t, "Person")
 	deleteObjectClass(t, "Pizza")

--- a/test/helper/uuid.go
+++ b/test/helper/uuid.go
@@ -1,0 +1,20 @@
+package helper
+
+import (
+	"encoding/binary"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+)
+
+// InToUUID takes an unsigned int64 and places it in BigEndian fashion into the
+// upper 8 bytes of a 16 byte UUID. This makes it easy to produce easy-to-read
+// UUIDs in test scenarios. For example:
+//
+//	IntToUUID(1)
+//	// returns "00000000-0000-0000-0000-000000000001"
+func IntToUUID(in uint64) strfmt.UUID {
+	id := [16]byte{}
+	binary.BigEndian.PutUint64(id[8:16], in)
+	return strfmt.UUID(uuid.UUID(id).String())
+}

--- a/test/helper/uuid.go
+++ b/test/helper/uuid.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package helper
 
 import (

--- a/usecases/objects/metrics.go
+++ b/usecases/objects/metrics.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	queriesCount *prometheus.GaugeVec
 	batchTime    *prometheus.HistogramVec
 	dimensions   *prometheus.CounterVec
+	groupClasses bool
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -33,6 +34,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 		queriesCount: prom.QueriesCount,
 		batchTime:    prom.BatchTime,
 		dimensions:   prom.QueryDimensions,
+		groupClasses: prom.GroupClasses,
 	}
 }
 
@@ -171,6 +173,10 @@ func (m *Metrics) BatchOp(op string, startNs int64) {
 func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dims int) {
 	if m == nil {
 		return
+	}
+
+	if m.groupClasses {
+		className = "_grouped"
 	}
 
 	m.dimensions.With(prometheus.Labels{

--- a/usecases/objects/metrics.go
+++ b/usecases/objects/metrics.go
@@ -176,7 +176,7 @@ func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dim
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	m.dimensions.With(prometheus.Labels{

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -44,7 +44,7 @@ func (m *Metrics) QueriesAggregateInc(className string) {
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	m.queriesCount.With(prometheus.Labels{
@@ -59,7 +59,7 @@ func (m *Metrics) QueriesAggregateDec(className string) {
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	m.queriesCount.With(prometheus.Labels{
@@ -74,7 +74,7 @@ func (m *Metrics) QueriesGetInc(className string) {
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	m.queriesCount.With(prometheus.Labels{
@@ -89,7 +89,7 @@ func (m *Metrics) QueriesObserveDuration(className string, startMs int64) {
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	took := float64(time.Now().UnixMilli() - startMs)
@@ -106,7 +106,7 @@ func (m *Metrics) QueriesGetDec(className string) {
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	m.queriesCount.With(prometheus.Labels{
@@ -121,7 +121,7 @@ func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dim
 	}
 
 	if m.groupClasses {
-		className = "_grouped"
+		className = "n/a"
 	}
 
 	m.dimensions.With(prometheus.Labels{

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	queriesCount     *prometheus.GaugeVec
 	queriesDurations *prometheus.HistogramVec
 	dimensions       *prometheus.CounterVec
+	groupClasses     bool
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -33,12 +34,17 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 		queriesCount:     prom.QueriesCount,
 		queriesDurations: prom.QueriesDurations,
 		dimensions:       prom.QueryDimensions,
+		groupClasses:     prom.GroupClasses,
 	}
 }
 
 func (m *Metrics) QueriesAggregateInc(className string) {
 	if m == nil {
 		return
+	}
+
+	if m.groupClasses {
+		className = "_grouped"
 	}
 
 	m.queriesCount.With(prometheus.Labels{
@@ -52,6 +58,10 @@ func (m *Metrics) QueriesAggregateDec(className string) {
 		return
 	}
 
+	if m.groupClasses {
+		className = "_grouped"
+	}
+
 	m.queriesCount.With(prometheus.Labels{
 		"class_name": className,
 		"query_type": "aggregate",
@@ -63,6 +73,10 @@ func (m *Metrics) QueriesGetInc(className string) {
 		return
 	}
 
+	if m.groupClasses {
+		className = "_grouped"
+	}
+
 	m.queriesCount.With(prometheus.Labels{
 		"class_name": className,
 		"query_type": "get_graphql",
@@ -72,6 +86,10 @@ func (m *Metrics) QueriesGetInc(className string) {
 func (m *Metrics) QueriesObserveDuration(className string, startMs int64) {
 	if m == nil {
 		return
+	}
+
+	if m.groupClasses {
+		className = "_grouped"
 	}
 
 	took := float64(time.Now().UnixMilli() - startMs)
@@ -87,6 +105,10 @@ func (m *Metrics) QueriesGetDec(className string) {
 		return
 	}
 
+	if m.groupClasses {
+		className = "_grouped"
+	}
+
 	m.queriesCount.With(prometheus.Labels{
 		"class_name": className,
 		"query_type": "get_graphql",
@@ -96,6 +118,10 @@ func (m *Metrics) QueriesGetDec(className string) {
 func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dims int) {
 	if m == nil {
 		return
+	}
+
+	if m.groupClasses {
+		className = "_grouped"
 	}
 
 	m.dimensions.With(prometheus.Labels{


### PR DESCRIPTION
### What's being changed:
* Adds e2e test to make sure metrics count does not change when new classes are added, loaded, and queried when grouping is on
* Fix the remaining metrics that correlated with class count when grouping is on
* Fix naming inconsistency in label values. Some had `n/a` (very old), and others had `_grouped` (recently introduced). Now all show `n/a`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
