### PR TITLE
Add autocut and relative score ranking algo to hybrid search

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -86,6 +86,16 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 		args.Query = query.(string)
 	}
 
+	autocut, ok := source["autocut"]
+	if ok {
+		args.AutoCut = autocut.(int)
+	}
+
+	// there is a default value in graphql, this value should always be present
+	fusionType, ok := source["fusion_type"]
+	if ok {
+		args.FusionAlgorithm = fusionType.(int)
+	}
 	if _, ok := source["vector"]; ok {
 		vector := source["vector"].([]interface{})
 		args.Vector = make([]float32, len(vector))

--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -92,7 +92,7 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 	}
 
 	// there is a default value in graphql, this value should always be present
-	fusionType, ok := source["fusion_type"]
+	fusionType, ok := source["fusionType"]
 	if ok {
 		args.FusionAlgorithm = fusionType.(int)
 	}

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -65,10 +65,21 @@ func (b *classBuilder) objects() (*graphql.Object, error) {
 }
 
 func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error) {
+	// needs to be defined outside the individual class as there can only be one definition of an enum
+	fusionAlgoEnum := graphql.NewEnum(graphql.EnumConfig{
+		Name: "FusionEnum",
+		Values: graphql.EnumValueConfigMap{
+			"ranked_fusion": &graphql.EnumValueConfig{
+				Value: 0,
+			},
+			"relative_score_fusion": &graphql.EnumValueConfig{
+				Value: 1,
+			},
+		},
+	})
 	classFields := graphql.Fields{}
-
 	for _, class := range kindSchema.Classes {
-		classField, err := b.classField(class)
+		classField, err := b.classField(class, fusionAlgoEnum)
 		if err != nil {
 			return nil, fmt.Errorf("Could not build class for %s", class.Class)
 		}
@@ -84,10 +95,10 @@ func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error)
 	return classes, nil
 }
 
-func (b *classBuilder) classField(class *models.Class) (*graphql.Field, error) {
+func (b *classBuilder) classField(class *models.Class, fusionEnum *graphql.Enum) (*graphql.Field, error) {
 	classObject := b.classObject(class)
 	b.knownClasses[class.Class] = classObject
-	classField := buildGetClassField(classObject, class, b.modulesProvider)
+	classField := buildGetClassField(classObject, class, b.modulesProvider, fusionEnum)
 	return &classField, nil
 }
 

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -70,10 +70,10 @@ func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error)
 		Name: "FusionEnum",
 		Values: graphql.EnumValueConfigMap{
 			"ranked_fusion": &graphql.EnumValueConfig{
-				Value: 0,
+				Value: HybridRankedFusion,
 			},
 			"relative_score_fusion": &graphql.EnumValueConfig{
-				Value: 1,
+				Value: HybridRelativeScoreFusion,
 			},
 		},
 	})

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -69,10 +69,10 @@ func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error)
 	fusionAlgoEnum := graphql.NewEnum(graphql.EnumConfig{
 		Name: "FusionEnum",
 		Values: graphql.EnumValueConfigMap{
-			"ranked_fusion": &graphql.EnumValueConfig{
+			"rankedFusion": &graphql.EnumValueConfig{
 				Value: HybridRankedFusion,
 			},
-			"relative_score_fusion": &graphql.EnumValueConfig{
+			"relativeScoreFusion": &graphql.EnumValueConfig{
 				Value: HybridRelativeScoreFusion,
 			},
 		},

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -201,7 +201,7 @@ func newPhoneNumberObject(className string, propertyName string) *graphql.Object
 }
 
 func buildGetClassField(classObject *graphql.Object,
-	class *models.Class, modulesProvider ModulesProvider,
+	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) graphql.Field {
 	field := graphql.Field{
 		Type:        graphql.NewList(classObject),
@@ -231,7 +231,7 @@ func buildGetClassField(classObject *graphql.Object,
 	}
 
 	field.Args["bm25"] = bm25Argument(class.Class)
-	field.Args["hybrid"] = hybridArgument(classObject, class, modulesProvider)
+	field.Args["hybrid"] = hybridArgument(classObject, class, modulesProvider, fusionEnum)
 
 	if modulesProvider != nil {
 		for name, argument := range modulesProvider.GetArguments(class) {

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -69,7 +69,7 @@ func hybridOperands(classObject *graphql.Object,
 			Description: "Which properties should be included in the sparse search",
 			Type:        graphql.NewList(graphql.String),
 		},
-		"fusion_type": &graphql.InputObjectFieldConfig{
+		"fusionType": &graphql.InputObjectFieldConfig{
 			Description:  "Algorithm used for fusing results from vector and keyword search",
 			DefaultValue: fusionEnum.Values()[HybridRankedFusion].Value,
 			Type:         fusionEnum,

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -20,6 +20,11 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
+const (
+	HybridRankedFusion = iota
+	HybridRelativeScoreFusion
+)
+
 func hybridArgument(classObject *graphql.Object,
 	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) *graphql.ArgumentConfig {
@@ -66,7 +71,7 @@ func hybridOperands(classObject *graphql.Object,
 		},
 		"fusion_type": &graphql.InputObjectFieldConfig{
 			Description:  "Algorithm used for fusing results from vector and keyword search",
-			DefaultValue: fusionEnum.Values()[0].Value,
+			DefaultValue: fusionEnum.Values()[HybridRankedFusion].Value,
 			Type:         fusionEnum,
 		},
 	}

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -21,14 +21,14 @@ import (
 )
 
 func hybridArgument(classObject *graphql.Object,
-	class *models.Class, modulesProvider ModulesProvider,
+	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) *graphql.ArgumentConfig {
 	prefix := fmt.Sprintf("GetObjects%s", class.Class)
 	return &graphql.ArgumentConfig{
 		Type: graphql.NewInputObject(
 			graphql.InputObjectConfig{
 				Name:        fmt.Sprintf("%sHybridInpObj", prefix),
-				Fields:      hybridOperands(classObject, class, modulesProvider),
+				Fields:      hybridOperands(classObject, class, modulesProvider, fusionEnum),
 				Description: "Hybrid search",
 			},
 		),
@@ -36,12 +36,13 @@ func hybridArgument(classObject *graphql.Object,
 }
 
 func hybridOperands(classObject *graphql.Object,
-	class *models.Class, modulesProvider ModulesProvider,
+	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) graphql.InputObjectConfigFieldMap {
 	ss := graphql.NewInputObject(graphql.InputObjectConfig{
 		Name:   class.Class + "SubSearch",
 		Fields: hybridSubSearch(classObject, class, modulesProvider),
 	})
+
 	fieldMap := graphql.InputObjectConfigFieldMap{
 		"query": &graphql.InputObjectFieldConfig{
 			Description: "Query string",
@@ -55,9 +56,18 @@ func hybridOperands(classObject *graphql.Object,
 			Description: "Vector search",
 			Type:        graphql.NewList(graphql.Float),
 		},
+		"autocut": &graphql.InputObjectFieldConfig{
+			Description: "Cut off number of results after the Nth extrema. Off by default, negative numbers mean off",
+			Type:        graphql.Int,
+		},
 		"properties": &graphql.InputObjectFieldConfig{
 			Description: "Which properties should be included in the sparse search",
 			Type:        graphql.NewList(graphql.String),
+		},
+		"fusion_type": &graphql.InputObjectFieldConfig{
+			Description:  "Algorithm used for fusing results from vector and keyword search",
+			DefaultValue: "ranked_fusion",
+			Type:         fusionEnum,
 		},
 	}
 

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -66,7 +66,7 @@ func hybridOperands(classObject *graphql.Object,
 		},
 		"fusion_type": &graphql.InputObjectFieldConfig{
 			Description:  "Algorithm used for fusing results from vector and keyword search",
-			DefaultValue: "ranked_fusion",
+			DefaultValue: fusionEnum.Values()[0].Value,
 			Type:         fusionEnum,
 		},
 	}

--- a/adapters/repos/db/ranked_fusion_test.go
+++ b/adapters/repos/db/ranked_fusion_test.go
@@ -10,7 +10,6 @@
 //
 
 //go:build integrationTest
-// +build integrationTest
 
 package db
 
@@ -43,30 +42,11 @@ import (
 	"github.com/weaviate/weaviate/usecases/traverser/hybrid"
 )
 
-/*
-  {
-        "document": "BACKGROUND: Common warts (verruca vulgaris) are benign epithelial proliferations associated with human papillomavirus (HPV) infection. Salicylic acid and cryotherapy are the most frequent treatments for common warts, but can be painful and cause scarring, and have high failure and recrudescence rates. Topical vitamin A has been shown to be a successful treatment of common warts in prior informal studies. CASE: The subject is a healthy, physically-active 30 old female with a 9 year history of common warts on the back of the right hand. The warts resisted treatment with salicylic acid, apple cider vinegar and an over-the-counter blend of essential oils marketed for the treatment of warts. Daily topical application of natural vitamin A derived from fish liver oil (25,000 IU) led to replacement of all the warts with normal skin. Most of the smaller warts had been replaced by 70 days. A large wart on the middle knuckle required 6 months of vitamin A treatment to resolve completely. CONCLUSION: Retinoids should be further investigated in controlled studies to determine their effectiveness in treating common warts and the broad range of other benign and cancerous lesions induced by HPVs.",
-        "DocID": "MED-941"
-    },
-
-*/
-
 type TestDoc struct {
 	DocID    string
 	Document string
 }
 
-/*
-	{
-	    "queryID": "PLAIN-4",
-	    "query": "Using Diet to Treat Asthma and Eczema",
-	    "matchingDocIDs": [
-	        "MED-2441",
-	        "MED-2472",
-	        "MED-2444"
-	    ]
-	},
-*/
 type TestQuery struct {
 	QueryID        string
 	Query          string
@@ -201,21 +181,6 @@ func TestBIER(t *testing.T) {
 	}
 }
 
-func FusionConfig(k1, b float32) *models.InvertedIndexConfig {
-	return &models.InvertedIndexConfig{
-		Bm25: &models.BM25Config{
-			K1: k1,
-			B:  b,
-		},
-		CleanupIntervalSeconds: 60,
-		Stopwords: &models.StopwordConfig{
-			Preset: "none",
-		},
-		IndexNullState:      true,
-		IndexPropertyLength: true,
-	}
-}
-
 func addObj(repo *DB, i int, props map[string]interface{}, vec []float32) error {
 	id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
 
@@ -324,7 +289,7 @@ func TestRFJourney(t *testing.T) {
 	resultSet2 := []*hybrid.Result{doc2, doc1, doc3}
 
 	t.Run("Fusion Reciprocal", func(t *testing.T) {
-		results := hybrid.FusionReciprocal([]float64{0.4, 0.6},
+		results := hybrid.FusionRanked([]float64{0.4, 0.6},
 			[][]*hybrid.Result{resultSet1, resultSet2})
 		fmt.Println("--- Start results for Fusion Reciprocal ---")
 		for _, result := range results {
@@ -340,7 +305,7 @@ func TestRFJourney(t *testing.T) {
 	})
 
 	t.Run("Fusion Reciprocal 2", func(t *testing.T) {
-		results := hybrid.FusionReciprocal([]float64{0.8, 0.2},
+		results := hybrid.FusionRanked([]float64{0.8, 0.2},
 			[][]*hybrid.Result{resultSet1, resultSet2})
 		fmt.Println("--- Start results for Fusion Reciprocal ---")
 		for _, result := range results {
@@ -356,7 +321,7 @@ func TestRFJourney(t *testing.T) {
 	})
 
 	t.Run("Vector Only", func(t *testing.T) {
-		results := hybrid.FusionReciprocal([]float64{0.0, 1.0},
+		results := hybrid.FusionRanked([]float64{0.0, 1.0},
 			[][]*hybrid.Result{resultSet1, resultSet2})
 		fmt.Println("--- Start results for Fusion Reciprocal ---")
 		for _, result := range results {
@@ -372,7 +337,7 @@ func TestRFJourney(t *testing.T) {
 	})
 
 	t.Run("BM25 only", func(t *testing.T) {
-		results := hybrid.FusionReciprocal([]float64{1.0, 0.0},
+		results := hybrid.FusionRanked([]float64{1.0, 0.0},
 			[][]*hybrid.Result{resultSet1, resultSet2})
 		fmt.Println("--- Start results for Fusion Reciprocal ---")
 		for _, result := range results {
@@ -437,7 +402,7 @@ func TestRFJourney(t *testing.T) {
 		})
 	}
 
-	res := hybrid.FusionReciprocal([]float64{0.2, 0.8}, [][]*hybrid.Result{results_set_1_hybrid, results_set_2_hybrid})
+	res := hybrid.FusionRanked([]float64{0.2, 0.8}, [][]*hybrid.Result{results_set_1_hybrid, results_set_2_hybrid})
 	fmt.Println("--- Start results for Fusion Reciprocal (", len(res), ")---")
 	for _, r := range res {
 
@@ -819,7 +784,7 @@ func TestStability(t *testing.T) {
 	resultSet2 := []*hybrid.Result{doc2, doc1, doc3}
 
 	t.Run("Fusion Reciprocal", func(t *testing.T) {
-		results := hybrid.FusionReciprocal([]float64{0.4, 0.6},
+		results := hybrid.FusionRanked([]float64{0.4, 0.6},
 			[][]*hybrid.Result{resultSet1, resultSet2})
 		fmt.Println("--- Start results for Fusion Reciprocal ---")
 		for _, result := range results {

--- a/entities/searchparams/retrieval.go
+++ b/entities/searchparams/retrieval.go
@@ -33,13 +33,14 @@ type WeightedSearchResult struct {
 }
 
 type HybridSearch struct {
-	SubSearches interface{} `json:"subSearches"`
-	Type        string      `json:"type"`
-	Alpha       float64     `json:"alpha"`
-	Query       string      `json:"query"`
-	Vector      []float32   `json:"vector"`
-	AutoCut     int         `json:"autocut"`
-	Properties  []string    `json:"properties"`
+	SubSearches     interface{} `json:"subSearches"`
+	Type            string      `json:"type"`
+	Alpha           float64     `json:"alpha"`
+	Query           string      `json:"query"`
+	Vector          []float32   `json:"vector"`
+	AutoCut         int         `json:"autocut"`
+	Properties      []string    `json:"properties"`
+	FusionAlgorithm int         `json:"fusionalgorithm"`
 }
 
 type NearObject struct {

--- a/test/acceptance_with_go_client/search_test.go
+++ b/test/acceptance_with_go_client/search_test.go
@@ -210,7 +210,7 @@ func TestAutocut(t *testing.T) {
 	AddClassAndObjects(t, className, string(schema.DataTypeTextArray), c)
 	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 
-	searchQuery := []string{"hybrid:{query:\"rain nice\", alpha: 0, fusion_type: relative_score_fusion", "bm25:{query:\"rain nice\""}
+	searchQuery := []string{"hybrid:{query:\"rain nice\", alpha: 0, fusionType: relativeScoreFusion", "bm25:{query:\"rain nice\""}
 	cases := []struct {
 		autocut    int
 		numResults int

--- a/test/benchmark_bm25/cmd/import.go
+++ b/test/benchmark_bm25/cmd/import.go
@@ -27,6 +27,7 @@ func init() {
 	rootCmd.AddCommand(importCmd)
 	importCmd.PersistentFlags().IntVarP(&BatchSize, "batch-size", "b", DefaultBatchSize, "number of objects in a single import batch")
 	importCmd.PersistentFlags().IntVarP(&MultiplyProperties, "multiply-properties", "m", DefaultMultiplyProperties, "create artifical copies of real properties by setting a value larger than 1. The properties have identical contents, so it won't alter results, but leads to many more calculations.")
+	importCmd.PersistentFlags().BoolVarP(&Vectorizer, "vectorizer", "v", DefaultVectorizer, "Vectorize import data with default vectorizer")
 }
 
 var importCmd = &cobra.Command{
@@ -62,7 +63,7 @@ var importCmd = &cobra.Command{
 		}
 
 		if err := client.Schema().ClassCreator().
-			WithClass(lib.SchemaFromDataset(datasets.Datasets[0])).
+			WithClass(lib.SchemaFromDataset(datasets.Datasets[0], Vectorizer)).
 			Do(context.Background()); err != nil {
 			return fmt.Errorf("create schema for %s: %w", datasets.Datasets[0], err)
 		}

--- a/test/benchmark_bm25/cmd/query.go
+++ b/test/benchmark_bm25/cmd/query.go
@@ -18,6 +18,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/weaviate/weaviate/entities/models"
+
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/filters"
 
 	"github.com/spf13/cobra"
@@ -30,6 +32,8 @@ func init() {
 	queryCmd.PersistentFlags().IntVarP(&BatchSize, "batch-size", "b", DefaultBatchSize, "number of objects in a single import batch")
 	queryCmd.PersistentFlags().IntVarP(&QueriesCount, "count", "c", DefaultQueriesCount, "run only the specified amount of queries, negative numbers mean unlimited")
 	queryCmd.PersistentFlags().IntVarP(&FilterObjectPercentage, "filter", "f", DefaultFilterObjectPercentage, "The given percentage of objects are filtered out. Off by default, use <=0 to disable")
+	queryCmd.PersistentFlags().Float32VarP(&Alpha, "alpha", "a", DefaultAlpha, "Weighting for keyword vs vector search. Alpha = 0 (Default) is pure BM25 search.")
+	queryCmd.PersistentFlags().StringVarP(&Ranking, "ranking´", "r", DefaultRanking, "Which ranking algorithm should be used for hybrid search, rankedFusion (default) and  relativeScoreFusion.")
 }
 
 var queryCmd = &cobra.Command{
@@ -74,21 +78,30 @@ var queryCmd = &cobra.Command{
 		className := lib.ClassNameFromDatasetID(ds.ID)
 		for i, query := range q {
 			before := time.Now()
-			bm25 := &graphql.BM25ArgumentBuilder{}
-			bm25.WithQuery(query.Query)
+			var err error
+			var result *models.GraphQLResponse
 
-			bm25Query := client.GraphQL().Get().WithClassName(className).
-				WithLimit(100).WithBM25(bm25).WithFields(graphql.Field{Name: "_additional { id }"}, graphql.Field{Name: propNameWithId})
+			if Alpha == 0 {
+				bm25 := &graphql.BM25ArgumentBuilder{}
+				bm25.WithQuery(query.Query)
 
-			if FilterObjectPercentage > 0 {
-				filter := filters.Where()
-				filter.WithPath([]string{"modulo_100"})
-				filter.WithOperator(filters.GreaterThan)
-				filter.WithValueInt(int64(FilterObjectPercentage))
-				bm25Query = bm25Query.WithWhere(filter)
+				queryBuilder := client.GraphQL().Get().WithClassName(className).
+					WithLimit(100).WithBM25(bm25).WithFields(graphql.Field{Name: "_additional { id }"}, graphql.Field{Name: propNameWithId})
+
+				if FilterObjectPercentage > 0 {
+					filter := filters.Where()
+					filter.WithPath([]string{"modulo_100"})
+					filter.WithOperator(filters.GreaterThan)
+					filter.WithValueInt(int64(FilterObjectPercentage))
+					queryBuilder = queryBuilder.WithWhere(filter)
+				}
+				result, err = queryBuilder.Do(context.Background())
+			} else {
+				// use raw as go client does not support ranking for hybrid
+				rawQuery := fmt.Sprintf("{Get{%s(hybrid:{query: %q, alpha: %v, fusionType: %s}){%s _additional { id }}}}", className, query.Query, Alpha, Ranking, propNameWithId)
+				result, err = client.GraphQL().Raw().WithQuery(rawQuery).Do(context.Background())
 			}
 
-			result, err := bm25Query.Do(context.Background())
 			if err != nil {
 				return err
 			}

--- a/test/benchmark_bm25/cmd/root.go
+++ b/test/benchmark_bm25/cmd/root.go
@@ -25,6 +25,9 @@ var (
 	QueriesCount           int
 	MultiplyProperties     int
 	FilterObjectPercentage int
+	Alpha                  float32
+	Ranking                string
+	Vectorizer             bool
 )
 
 const (
@@ -34,6 +37,9 @@ const (
 	DefaultQueriesCount           = -1
 	DefaultMultiplyProperties     = 1
 	DefaultFilterObjectPercentage = 0
+	DefaultAlpha                  = 0
+	DefaultRanking                = "ranked_fusion"
+	DefaultVectorizer             = false
 )
 
 var rootCmd = &cobra.Command{

--- a/test/benchmark_bm25/lib/schema.go
+++ b/test/benchmark_bm25/lib/schema.go
@@ -18,13 +18,15 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-func SchemaFromDataset(ds Dataset) *models.Class {
+func SchemaFromDataset(ds Dataset, includeVectorizer bool) *models.Class {
 	out := &models.Class{}
 	out.Class = ClassNameFromDatasetID(ds.ID)
-	out.VectorIndexConfig = map[string]interface{}{
-		"skip": true,
+	if !includeVectorizer {
+		out.VectorIndexConfig = map[string]interface{}{
+			"skip": true,
+		}
+		out.Vectorizer = "none"
 	}
-	out.Vectorizer = "none"
 	out.InvertedIndexConfig = &models.InvertedIndexConfig{
 		Stopwords: &models.StopwordConfig{
 			Preset: "none",

--- a/usecases/traverser/hybrid/fusion_test.go
+++ b/usecases/traverser/hybrid/fusion_test.go
@@ -31,6 +31,8 @@ func TestFusionRelativeScore(t *testing.T) {
 		{weights: []float64{0.5, 0.5}, inputScores: [][]float32{{0, 2, 0.1}, {0, 0.2, 2}}, expectedScores: []float32{0.55, 0.525, 0}, expectedOrder: []uint64{1, 2, 0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{0.5, 0.5, 0}, {0, 0.01, 0.001}}, expectedScores: []float32{1, 0.75, 0.025}, expectedOrder: []uint64{1, 0, 2}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {}}, expectedScores: []float32{}, expectedOrder: []uint64{}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1}, {}}, expectedScores: []float32{0}, expectedOrder: []uint64{0}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {1}}, expectedScores: []float32{0}, expectedOrder: []uint64{0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 2}, {}}, expectedScores: []float32{0.75, 0}, expectedOrder: []uint64{1, 0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {1, 2}}, expectedScores: []float32{0.25, 0}, expectedOrder: []uint64{1, 0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 1}, {1, 2}}, expectedScores: []float32{0.25, 0}, expectedOrder: []uint64{1, 0}},

--- a/usecases/traverser/hybrid/fusion_test.go
+++ b/usecases/traverser/hybrid/fusion_test.go
@@ -30,6 +30,8 @@ func TestFusionRelativeScore(t *testing.T) {
 		{weights: []float64{0.5, 0.5}, inputScores: [][]float32{{1, 2, 3}, {0, 1, 2}}, expectedScores: []float32{1, 0.5, 0}, expectedOrder: []uint64{2, 1, 0}},
 		{weights: []float64{0.5, 0.5}, inputScores: [][]float32{{0, 2, 0.1}, {0, 0.2, 2}}, expectedScores: []float32{0.55, 0.525, 0}, expectedOrder: []uint64{1, 2, 0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{0.5, 0.5, 0}, {0, 0.01, 0.001}}, expectedScores: []float32{1, 0.75, 0.025}, expectedOrder: []uint64{1, 0, 2}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {}}, expectedScores: []float32{}, expectedOrder: []uint64{}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 1}, {1, 2}}, expectedScores: []float32{0.25, 0}, expectedOrder: []uint64{1, 0}},
 	}
 	for _, tt := range cases {
 		t.Run("hybrid fusion", func(t *testing.T) {
@@ -42,8 +44,8 @@ func TestFusionRelativeScore(t *testing.T) {
 				results = append(results, result)
 			}
 			fused := FusionRelativeScore(tt.weights, results)
-			var fusedScores []float32
-			var fusedOrder []uint64
+			fusedScores := []float32{} // don't use nil slice declaration, should be explicitly empty
+			fusedOrder := []uint64{}
 
 			for _, score := range fused {
 				fusedScores = append(fusedScores, score.Score)

--- a/usecases/traverser/hybrid/fusion_test.go
+++ b/usecases/traverser/hybrid/fusion_test.go
@@ -31,8 +31,11 @@ func TestFusionRelativeScore(t *testing.T) {
 		{weights: []float64{0.5, 0.5}, inputScores: [][]float32{{0, 2, 0.1}, {0, 0.2, 2}}, expectedScores: []float32{0.55, 0.525, 0}, expectedOrder: []uint64{1, 2, 0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{0.5, 0.5, 0}, {0, 0.01, 0.001}}, expectedScores: []float32{1, 0.75, 0.025}, expectedOrder: []uint64{1, 0, 2}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {}}, expectedScores: []float32{}, expectedOrder: []uint64{}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 2}, {}}, expectedScores: []float32{0.75, 0}, expectedOrder: []uint64{1, 0}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {1, 2}}, expectedScores: []float32{0.25, 0}, expectedOrder: []uint64{1, 0}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 1}, {1, 2}}, expectedScores: []float32{0.25, 0}, expectedOrder: []uint64{1, 0}},
 		{weights: []float64{1}, inputScores: [][]float32{{1, 2, 3}}, expectedScores: []float32{1, 0.5, 0}, expectedOrder: []uint64{2, 1, 0}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 2, 3, 4}, {1, 2, 3}}, expectedScores: []float32{0.75, 0.75, 0.375, 0}, expectedOrder: []uint64{3, 2, 1, 0}},
 	}
 	for _, tt := range cases {
 		t.Run("hybrid fusion", func(t *testing.T) {

--- a/usecases/traverser/hybrid/fusion_test.go
+++ b/usecases/traverser/hybrid/fusion_test.go
@@ -32,6 +32,7 @@ func TestFusionRelativeScore(t *testing.T) {
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{0.5, 0.5, 0}, {0, 0.01, 0.001}}, expectedScores: []float32{1, 0.75, 0.025}, expectedOrder: []uint64{1, 0, 2}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{}, {}}, expectedScores: []float32{}, expectedOrder: []uint64{}},
 		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{1, 1}, {1, 2}}, expectedScores: []float32{0.25, 0}, expectedOrder: []uint64{1, 0}},
+		{weights: []float64{1}, inputScores: [][]float32{{1, 2, 3}}, expectedScores: []float32{1, 0.5, 0}, expectedOrder: []uint64{2, 1, 0}},
 	}
 	for _, tt := range cases {
 		t.Run("hybrid fusion", func(t *testing.T) {

--- a/usecases/traverser/hybrid/fusion_test.go
+++ b/usecases/traverser/hybrid/fusion_test.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hybrid
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+func TestFusionRelativeScore(t *testing.T) {
+	cases := []struct {
+		weights        []float64
+		inputScores    [][]float32
+		expectedScores []float32
+		expectedOrder  []uint64
+	}{
+		{weights: []float64{0.5, 0.5}, inputScores: [][]float32{{1, 2, 3}, {0, 1, 2}}, expectedScores: []float32{1, 0.5, 0}, expectedOrder: []uint64{2, 1, 0}},
+		{weights: []float64{0.5, 0.5}, inputScores: [][]float32{{0, 2, 0.1}, {0, 0.2, 2}}, expectedScores: []float32{0.55, 0.525, 0}, expectedOrder: []uint64{1, 2, 0}},
+		{weights: []float64{0.75, 0.25}, inputScores: [][]float32{{0.5, 0.5, 0}, {0, 0.01, 0.001}}, expectedScores: []float32{1, 0.75, 0.025}, expectedOrder: []uint64{1, 0, 2}},
+	}
+	for _, tt := range cases {
+		t.Run("hybrid fusion", func(t *testing.T) {
+			var results [][]*Result
+			for i := range tt.inputScores {
+				var result []*Result
+				for j, score := range tt.inputScores[i] {
+					result = append(result, &Result{uint64(j), &search.Result{SecondarySortValue: score, ID: strfmt.UUID(fmt.Sprint(j))}})
+				}
+				results = append(results, result)
+			}
+			fused := FusionRelativeScore(tt.weights, results)
+			var fusedScores []float32
+			var fusedOrder []uint64
+
+			for _, score := range fused {
+				fusedScores = append(fusedScores, score.Score)
+				fusedOrder = append(fusedOrder, score.DocID)
+			}
+
+			assert.InDeltaSlice(t, tt.expectedScores, fusedScores, 0.0001)
+			assert.Equal(t, tt.expectedOrder, fusedOrder)
+		})
+	}
+}

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -85,8 +85,13 @@ func FusionRelativeScore(weights []float64, results [][]*Result) []*Result {
 		return []*Result{}
 	}
 
-	maximum := []float32{results[0][0].SecondarySortValue, results[1][0].SecondarySortValue}
-	minimum := []float32{results[0][0].SecondarySortValue, results[1][0].SecondarySortValue}
+	maximum := []float32{results[0][0].SecondarySortValue}
+	minimum := []float32{results[0][0].SecondarySortValue}
+
+	if len(results) > 1 {
+		maximum = append(maximum, results[1][0].SecondarySortValue)
+		minimum = append(minimum, results[1][0].SecondarySortValue)
+	}
 
 	for i := range results {
 		for _, res := range results[i] {

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -81,7 +81,7 @@ func FusionRanked(weights []float64, results [][]*Result) []*Result {
 //
 // The normalized scores are then combined using their respective weight and the combined scores are sorted
 func FusionRelativeScore(weights []float64, results [][]*Result) []*Result {
-	if len(results[0]) == 0 && len(results[1]) == 0 {
+	if len(results[0]) == 0 && (len(results) == 1 || len(results[1]) == 0) {
 		return []*Result{}
 	}
 
@@ -107,8 +107,14 @@ func FusionRelativeScore(weights []float64, results [][]*Result) []*Result {
 		}
 	}
 
-	// normalize scores between 0 and 1
-	mapResults := make(map[strfmt.UUID]*Result)
+	// normalize scores between 0 and 1 and sum uo the normalized scores from different sources
+	// pre-allocate map, at this stage we do not know how many total, combined results there are, but it is at least the
+	// length of the longer input list
+	numResults := len(results[0])
+	if len(results) > 1 && len(results[1]) > numResults {
+		numResults = len(results[1])
+	}
+	mapResults := make(map[strfmt.UUID]*Result, numResults)
 	for i := range results {
 		weight := float32(weights[i])
 		for _, res := range results[i] {

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -74,7 +74,7 @@ func FusionRanked(weights []float64, results [][]*Result) []*Result {
 // results. This method retains more information than ranked fusion and should result in better results.
 //
 // The scores from each result are normalized between 0 and 1, e.g. the maximum score becomes 1 and the minimum 0 and the
-// other scores are inbetween, keeping their relative distance to the other scores.
+// other scores are in between, keeping their relative distance to the other scores.
 // Example:
 //
 //	Input score = [1, 8, 6, 11] => [0, 0.7, 0.5, 1]

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -81,19 +81,21 @@ func FusionRanked(weights []float64, results [][]*Result) []*Result {
 //
 // The normalized scores are then combined using their respective weight and the combined scores are sorted
 func FusionRelativeScore(weights []float64, results [][]*Result) []*Result {
-	if len(results[0]) == 0 {
+	if len(results[0]) == 0 && len(results[1]) == 0 {
 		return []*Result{}
 	}
 
-	maximum := []float32{results[0][0].SecondarySortValue}
-	minimum := []float32{results[0][0].SecondarySortValue}
-
-	if len(results) > 1 {
-		maximum = append(maximum, results[1][0].SecondarySortValue)
-		minimum = append(minimum, results[1][0].SecondarySortValue)
-	}
+	var maximum []float32
+	var minimum []float32
 
 	for i := range results {
+		if len(results[i]) > 0 {
+			maximum = append(maximum, results[i][0].SecondarySortValue)
+			minimum = append(minimum, results[i][0].SecondarySortValue)
+		} else { // dummy values so the indices match
+			maximum = append(maximum, 0)
+			minimum = append(minimum, 0)
+		}
 		for _, res := range results[i] {
 			if res.SecondarySortValue > maximum[i] {
 				maximum[i] = res.SecondarySortValue

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -118,11 +118,10 @@ func FusionRelativeScore(weights []float64, results [][]*Result) []*Result {
 	for i := range results {
 		weight := float32(weights[i])
 		for _, res := range results[i] {
-			var score float32
+			score := float32(0)
+			// if min an max are the same, score stays at 0. If all scores are identical
 			if maximum[i] != minimum[i] {
 				score = weight * (res.SecondarySortValue - minimum[i]) / (maximum[i] - minimum[i])
-			} else {
-				score = 0
 			}
 
 			previousResult, ok := mapResults[res.ID]

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/get"
+
 	"github.com/weaviate/weaviate/entities/autocut"
 
 	"github.com/sirupsen/logrus"
@@ -150,10 +152,12 @@ func (s *Searcher) Search(ctx context.Context) (Results, error) {
 		}
 	}
 	var fused []*Result
-	if s.params.FusionAlgorithm == 0 {
+	if s.params.FusionAlgorithm == get.HybridRankedFusion {
 		fused = FusionRanked(weights, found)
-	} else {
+	} else if s.params.FusionAlgorithm != get.HybridRelativeScoreFusion {
 		fused = FusionRelativeScore(weights, found)
+	} else {
+		return nil, fmt.Errorf("unknown ranking alogrithm %v for hybrid search", s.params.FusionAlgorithm)
 	}
 
 	if s.postProcFunc != nil {

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -151,6 +151,10 @@ func (s *Searcher) Search(ctx context.Context) (Results, error) {
 			weights = append(weights, weight)
 		}
 	}
+	if len(weights) != len(found) {
+		return nil, fmt.Errorf("length of weights and results do not match for hybrid search %v vs. %v", len(weights), len(found))
+	}
+
 	var fused []*Result
 	if s.params.FusionAlgorithm == get.HybridRankedFusion {
 		fused = FusionRanked(weights, found)

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -154,7 +154,7 @@ func (s *Searcher) Search(ctx context.Context) (Results, error) {
 	var fused []*Result
 	if s.params.FusionAlgorithm == get.HybridRankedFusion {
 		fused = FusionRanked(weights, found)
-	} else if s.params.FusionAlgorithm != get.HybridRelativeScoreFusion {
+	} else if s.params.FusionAlgorithm == get.HybridRelativeScoreFusion {
 		fused = FusionRelativeScore(weights, found)
 	} else {
 		return nil, fmt.Errorf("unknown ranking algorithm %v for hybrid search", s.params.FusionAlgorithm)

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -157,7 +157,7 @@ func (s *Searcher) Search(ctx context.Context) (Results, error) {
 	} else if s.params.FusionAlgorithm != get.HybridRelativeScoreFusion {
 		fused = FusionRelativeScore(weights, found)
 	} else {
-		return nil, fmt.Errorf("unknown ranking alogrithm %v for hybrid search", s.params.FusionAlgorithm)
+		return nil, fmt.Errorf("unknown ranking algorithm %v for hybrid search", s.params.FusionAlgorithm)
 	}
 
 	if s.postProcFunc != nil {


### PR DESCRIPTION
### What's being changed:

// FusionRelativeScore uses the relative differences in the scores from keyword and vector search to combine the
// results. This method retains more information than ranked fusion and should result in better results.
//
// The scores from each result are normalized between 0 and 1, e.g. the maximum score becomes 1 and the minimum 0 and the
// other scores are in between, keeping their relative distance to the other scores.
// Example:
//
//	Input score = [1, 8, 6, 11] => [0, 0.7, 0.5, 1]
//
// The normalized scores are then combined using their respective weight and the combined scores are sorted

These scores can then be used for autocut.

Usage:
```
{
  Get {
    CLASS(
      hybrid: {autocut: 2, query: "nice day", alpha: 0.5, vector: [4, 5, 4], fusion_type: relative_score_fusion}
    ) {
      prop
      _additional {
        score
        vector
      }
    }
  }
}

```
- autocut to enabled autocut
- fusion_type: relative_score_fusion to enable new fusion algo, default is ranked_fusion
Can be used independently from each other

### Review checklist
- [x] All new code is covered by tests where it is reasonable.

