### PR TITLE
Fix build max os build script

### DIFF
--- a/tools/dev/goreleaser_and_sign.sh
+++ b/tools/dev/goreleaser_and_sign.sh
@@ -8,12 +8,12 @@ set -eou pipefail
 export GIT_HASH=$(git rev-parse --short HEAD)
 VERSION="v$(jq -r '.info.version' openapi-specs/schema.json)"
 
-goreleaser build --clean --snapshot # add --snapshot to this commandline to build from non-tagged commit or with unclean directory
+goreleaser build --clean # add --snapshot to this commandline to build from non-tagged commit or with unclean directory
 
 codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" dist/weaviate_darwin_all/weaviate
 
 DARWIN_DIST="dist/weaviate-${VERSION}-darwin-all.zip"
-zip "$DARWIN_DIST" dist/weaviate_darwin_all/weaviate LICENSE README.md
+zip -j "$DARWIN_DIST" dist/weaviate_darwin_all/weaviate LICENSE README.md
 
 codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" "$DARWIN_DIST"
 

--- a/tools/dev/goreleaser_and_sign.sh
+++ b/tools/dev/goreleaser_and_sign.sh
@@ -6,9 +6,14 @@ set -eou pipefail
 # This script calls goreleaser and signs + notarize the binaries for macos
 
 export GIT_HASH=$(git rev-parse --short HEAD)
-VERSION="v$(jq -r '.info.version' openapi-specs/schema.json)"
 
-goreleaser build --clean # add --snapshot to this commandline to build from non-tagged commit or with unclean directory
+# detect if commit is tagged or not (format is "vA.B.Z" with tag and "vA.B.Z-commit" without tag)
+VERSION="$(git describe --tag)"
+if [[ "$VERSION" == *"-"* ]]; then
+  goreleaser build --clean --snapshot
+else
+  goreleaser build --clean
+fi
 
 codesign -f -o runtime --timestamp -s "Developer ID Application: Weaviate B.V. (QUZ8SKLS6R)" dist/weaviate_darwin_all/weaviate
 


### PR DESCRIPTION
### What's being changed:

- don't include folder structure in .zip
- Build with --snapshot on untagged commits. Without --snapshot additional tests are run
- use git describe to get a "better version:
1. v1.19.7 - for tagged commits
2. v1.19.8-1-gff0b484d8 - for untagged commits