### PR TITLE
Better error message for unknown replication level

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -782,7 +782,7 @@ func getConsistencyLevel(lvl *string) (string, error) {
 		case replica.One, replica.Quorum, replica.All:
 			return *lvl, nil
 		default:
-			return "", fmt.Errorf("unrecognized consistency level %q, "+
+			return "", fmt.Errorf("unrecognized consistency level '%v', "+
 				"try one of the following: ['ONE', 'QUORUM', 'ALL']", *lvl)
 		}
 	}


### PR DESCRIPTION
### What's being changed:
The error message now reads:
"unrecognized consistency level 'QUOR', try one of the following: ['ONE', 'QUORUM', 'ALL']"
Closes https://github.com/weaviate/weaviate/issues/2704.

### Review checklist
Changes to tests and documentation should not be necessary.
