### PR TITLE
[distance][perf] Use fewer math.Sqrt calls.

### DIFF
--- a/usecases/vectorizer/distance.go
+++ b/usecases/vectorizer/distance.go
@@ -44,5 +44,5 @@ func cosineSim(a, b []float32) (float32, error) {
 		sumBSquare += float64(b[i] * b[i])
 	}
 
-	return float32(sumProduct / (math.Sqrt(sumASquare) * math.Sqrt(sumBSquare))), nil
+	return float32(sumProduct / (math.Sqrt(sumASquare * sumBSquare))), nil
 }

--- a/usecases/vectorizer/distance_test.go
+++ b/usecases/vectorizer/distance_test.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package vectorizer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCosineSimilarity(t *testing.T) {
+	type args struct {
+		a, b []float32
+	}
+	tests := []struct {
+		name string
+		args args
+		want float32
+	}{
+		{
+			"Distance between identical vectors",
+			args{
+				a: []float32{1, 2, 3},
+				b: []float32{1, 2, 3},
+			},
+			1.0,
+		},
+		{
+			"Distance between similar vectors",
+			args{
+				a: []float32{1, 2, 3},
+				b: []float32{2, 3, 4},
+			},
+			0.99258333,
+		},
+		{
+			"Distance between opposite vectors",
+			args{
+				a: []float32{0, 1},
+				b: []float32{0, -1},
+			},
+			-1.0,
+		},
+		{
+			"Distance between perpendicular vectors",
+			args{
+				a: []float32{0, 1},
+				b: []float32{1, 0},
+			},
+			0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := cosineSim(tt.args.a, tt.args.b); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CombineVectors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCosineSim_DifferentDimensions(t *testing.T) {
+	a := []float32{1, 2, 3}
+	b := []float32{4, 5}
+	_, err := cosineSim(a, b)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}
+
+func BenchmarkCosineSimilarity(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cosineSim([]float32{-0.214571, -0.605529, -0.335769, -0.185277, -0.212256, 0.478032, -0.536662, 0.298211},
+			[]float32{-0.14713769, -0.06872862, 0.09911085, -0.06342313, 0.10092197, -0.06624051, -0.06812558, 0.07360107},
+		)
+	}
+}


### PR DESCRIPTION
### What's being changed:
Use mathematical property of square root $\sqrt{x} \times \sqrt{y}$ is equal to $\sqrt{x \times y}$. In addition to one fewer expensive operation, this change improves precision, since every float64 operation increases error.

Unlike in math, in practice due to limited float64 precision this change may result in overflows for vectors that previously would work, but given that the max float64 is 1.7976931348623157e+308, this should hopefully not be a problem.

Benchmark results:
before
```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkCosineSimilarity$ github.com/weaviate/weaviate/usecases/vectorizer

goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/usecases/vectorizer
BenchmarkCosineSimilarity-8     78623644            15.27 ns/op        0 B/op          0 allocs/op
PASS
ok      github.com/weaviate/weaviate/usecases/vectorizer    1.359s
```
after:
```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkCosineSimilarity$ github.com/weaviate/weaviate/usecases/vectorizer

goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/usecases/vectorizer
BenchmarkCosineSimilarity-8     67631196            15.13 ns/op        0 B/op          0 allocs/op
PASS
ok      github.com/weaviate/weaviate/usecases/vectorizer    1.185s
```

It's just a marginal perf improvement, but since it's also good for precision, this may be a good change.