### PR TITLE
[ratelimiter][perf] Use non-blocking rate limiter.

### DIFF
--- a/usecases/ratelimiter/limiter_test.go
+++ b/usecases/ratelimiter/limiter_test.go
@@ -102,3 +102,11 @@ func TestLimiterCantGoNegative(t *testing.T) {
 	}
 	assert.False(t, l.TryInc())
 }
+
+func BenchmarkLimiter(b *testing.B) {
+	l := New(-1)
+	for i := 0; i < b.N; i++ {
+		l.TryInc()
+		l.Dec()
+	}
+}


### PR DESCRIPTION
### What's being changed:
This change uses lock-free rate limiter implementation, which is much more performant according to added benchmark - ~4.5X faster, in fact.

I wouldn't recommend using either implementation of this "ratelimiter" since technically it doesn't really limit anything - it's a semaphore, so instead of rate it limits the number of concurrent users. Real rate limiters usually use Token Bucket, Leaky Bucket, Fixed Window, Sliding Log, Sliding Window or their combination.

Before:
```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkLimiter$ github.com/weaviate/weaviate/usecases/ratelimiter

goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/usecases/ratelimiter
BenchmarkLimiter-8      348353496            3.071 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/weaviate/weaviate/usecases/ratelimiter   1.567s
```
after:
```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkLimiter$ github.com/weaviate/weaviate/usecases/ratelimiter

goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/usecases/ratelimiter
BenchmarkLimiter-8      1000000000           0.6769 ns/op          0 B/op          0 allocs/op
PASS
ok      github.com/weaviate/weaviate/usecases/ratelimiter   0.912s
```