### PR TITLE
Fix Weaviate's panic on a wrong properties type defined in object sent using Batch API

### DIFF
--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -158,8 +158,11 @@ func (b *BatchManager) validateObject(ctx context.Context, principal *models.Pri
 		err = validation.New(b.vectorRepo.Exists, b.config, repl).Object(ctx, object, class)
 		ec.Add(err)
 
-		err = b.modulesProvider.UpdateVector(ctx, object, class, nil, b.findObject, b.logger)
-		ec.Add(err)
+		if err == nil {
+			// update vector only if we passed validation
+			err = b.modulesProvider.UpdateVector(ctx, object, class, nil, b.findObject, b.logger)
+			ec.Add(err)
+		}
 	}
 
 	*resultsC <- BatchObject{

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -59,7 +59,10 @@ func (v *Validator) properties(ctx context.Context, object interface{}, class *m
 		return nil
 	}
 
-	inputSchema := isp.(map[string]interface{})
+	inputSchema, ok := isp.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("could not recognize object's properties: %v", isp)
+	}
 	returnSchema := map[string]interface{}{}
 
 	for propertyKey, propertyValue := range inputSchema {


### PR DESCRIPTION
### What's being changed:

This PR fixes Weaviate panic went an object with wrong properties is being sent through Batch API:

```
panic: interface conversion: models.PropertySchema is []interface {}, not map[string]interface {}

goroutine 10152 [running]:
github.com/weaviate/weaviate/usecases/objects/validation.(*Validator).properties(0xc0027d4000?, {0x1b6d598, 0xc007812480}, {0x169af20?, 0xc0066d84d0}, 0x18?)
	/go/src/github.com/weaviate/weaviate/usecases/objects/validation/properties_validation.go:61 +0x43f
github.com/weaviate/weaviate/usecases/objects/validation.(*Validator).Object(0xc000100c00?, {0x1b6d598?, 0xc007812480?}, 0x12?, 0xc007dfe000?)
	/go/src/github.com/weaviate/weaviate/usecases/objects/validation/model_validation.go:85 +0xab
github.com/weaviate/weaviate/usecases/objects.(*BatchManager).validateObject(0xc003184680, {0x1b6d598, 0xc007812480}, 0x443825?, 0xc005e629f0?, 0xc007e7c0e0, 0x1f, 0xc000128210, 0x0?, 0xc006d0e0c0)
	/go/src/github.com/weaviate/weaviate/usecases/objects/batch_add.go:158 +0x7c7
created by github.com/weaviate/weaviate/usecases/objects.(*BatchManager).validateObjectsConcurrently
	/go/src/github.com/weaviate/weaviate/usecases/objects/batch_add.go:95 +0xe7
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
