### PR TITLE
Add combined Query Dimensions Metric

### DIFF
--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -43,6 +43,7 @@ type PrometheusMetrics struct {
 	QueriesDurations                   *prometheus.HistogramVec
 	QueriesFilteredVectorDurations     *prometheus.SummaryVec
 	QueryDimensions                    *prometheus.CounterVec
+	QueryDimensionsCombined            prometheus.Counter
 	GoroutinesCount                    *prometheus.GaugeVec
 	BackupRestoreDurations             *prometheus.SummaryVec
 	BackupStoreDurations               *prometheus.SummaryVec
@@ -203,7 +204,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "query_dimensions_total",
 			Help: "The vector dimensions used by any read-query that involves vectors",
 		}, []string{"query_type", "operation", "class_name"}),
-
+		QueryDimensionsCombined: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "query_dimensions_combined_total",
+			Help: "The vector dimensions used by any read-query that involves vectors, aggregated across all classes and shards. The sum of all labels for query_dimensions_total should always match this labelless metric",
+		}),
 		BackupRestoreDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "backup_restore_ms",
 			Help: "Duration of a backup restore",

--- a/usecases/objects/metrics.go
+++ b/usecases/objects/metrics.go
@@ -19,10 +19,11 @@ import (
 )
 
 type Metrics struct {
-	queriesCount *prometheus.GaugeVec
-	batchTime    *prometheus.HistogramVec
-	dimensions   *prometheus.CounterVec
-	groupClasses bool
+	queriesCount       *prometheus.GaugeVec
+	batchTime          *prometheus.HistogramVec
+	dimensions         *prometheus.CounterVec
+	dimensionsCombined prometheus.Counter
+	groupClasses       bool
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -31,10 +32,11 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 	}
 
 	return &Metrics{
-		queriesCount: prom.QueriesCount,
-		batchTime:    prom.BatchTime,
-		dimensions:   prom.QueryDimensions,
-		groupClasses: prom.GroupClasses,
+		queriesCount:       prom.QueriesCount,
+		batchTime:          prom.BatchTime,
+		dimensions:         prom.QueryDimensions,
+		dimensionsCombined: prom.QueryDimensionsCombined,
+		groupClasses:       prom.GroupClasses,
 	}
 }
 
@@ -184,4 +186,5 @@ func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dim
 		"operation":  operation,
 		"query_type": queryType,
 	}).Add(float64(dims))
+	m.dimensionsCombined.Add(float64(dims))
 }

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -19,10 +19,11 @@ import (
 )
 
 type Metrics struct {
-	queriesCount     *prometheus.GaugeVec
-	queriesDurations *prometheus.HistogramVec
-	dimensions       *prometheus.CounterVec
-	groupClasses     bool
+	queriesCount       *prometheus.GaugeVec
+	queriesDurations   *prometheus.HistogramVec
+	dimensions         *prometheus.CounterVec
+	dimensionsCombined prometheus.Counter
+	groupClasses       bool
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -31,10 +32,11 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 	}
 
 	return &Metrics{
-		queriesCount:     prom.QueriesCount,
-		queriesDurations: prom.QueriesDurations,
-		dimensions:       prom.QueryDimensions,
-		groupClasses:     prom.GroupClasses,
+		queriesCount:       prom.QueriesCount,
+		queriesDurations:   prom.QueriesDurations,
+		dimensions:         prom.QueryDimensions,
+		dimensionsCombined: prom.QueryDimensionsCombined,
+		groupClasses:       prom.GroupClasses,
 	}
 }
 
@@ -129,4 +131,5 @@ func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dim
 		"operation":  operation,
 		"query_type": queryType,
 	}).Add(float64(dims))
+	m.dimensionsCombined.Add(float64(dims))
 }


### PR DESCRIPTION
### What's being changed:
* Query dimensions are currently tracked per class, shard, and operation
* This new metric tracks the sum of all of the above in a single metric. This makes it easier to scrape this in situations where no full Prometheus instance is present, such as on marketplaces.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
