### PR TITLE
Switch to golang 1.20

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.51
-          args: --timeout=3m
+          version: v1.53
+          args: --timeout=5m

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Run Swagger
         run: ./tools/gen-code-from-swagger.sh
@@ -38,7 +38,7 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@v0.10.1
         with:
-          go-version: 1.19
+          go-version: '1.20'
           package: ./...
           fail-on-vuln: true
   Unit-Tests:
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh --acceptance-module-tests-only
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: '1.20'
           cache: true
       - name: Acceptance tests
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "1.19"
+          goversion: "1.20"
           project_path: "./cmd/weaviate-server"
           extra_files: LICENSE README.md
           ldflags: -w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 ###############################################################################
 # Base build image
-FROM golang:1.19-alpine AS build_base
+FROM golang:1.20-alpine AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on

--- a/adapters/repos/classifications/repo_integration_test.go
+++ b/adapters/repos/classifications/repo_integration_test.go
@@ -16,9 +16,7 @@ package classifications
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +25,6 @@ import (
 )
 
 func Test_ClassificationsRepo(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -17,7 +17,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -33,7 +32,6 @@ import (
 )
 
 func Test_Aggregations(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	shardState := singleShardState()
@@ -76,7 +74,6 @@ func Test_Aggregations(t *testing.T) {
 }
 
 func Test_Aggregations_MultiShard(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	shardState := fixedMultiShardState()

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -12,10 +12,8 @@
 package aggregator
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -100,7 +98,6 @@ type TestStructNumbers struct {
 }
 
 func TestShardCombinerMergeNumerical(t *testing.T) {
-	setSeed(t)
 	tests := []TestStructNumbers{
 		{
 			name:     "Uneven number of elements for both",
@@ -249,10 +246,4 @@ func createRandomSlice() []float64 {
 		array[i] = rand.Float64() * 1000
 	}
 	return array
-}
-
-func setSeed(t *testing.T) {
-	time := time.Now().UnixNano()
-	t.Log("Seed is", fmt.Sprint(time))
-	rand.Seed(time)
 }

--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -38,7 +38,6 @@ import (
 )
 
 func TestBatchPutObjectsWithDimensions(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -69,7 +68,6 @@ func TestBatchPutObjectsWithDimensions(t *testing.T) {
 }
 
 func TestBatchPutObjects(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -95,7 +93,6 @@ func TestBatchPutObjects(t *testing.T) {
 }
 
 func TestBatchPutObjectsNoVectorsWithDimensions(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -127,7 +124,6 @@ func TestBatchPutObjectsNoVectorsWithDimensions(t *testing.T) {
 }
 
 func TestBatchPutObjectsNoVectors(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -152,7 +148,6 @@ func TestBatchPutObjectsNoVectors(t *testing.T) {
 
 func TestBatchDeleteObjectsWithDimensions(t *testing.T) {
 	className := "ThingForBatching"
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -227,7 +222,6 @@ func delete2Objects(t *testing.T, repo *DB, className string) {
 }
 
 func TestBatchDeleteObjects(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -253,7 +247,6 @@ func TestBatchDeleteObjects(t *testing.T) {
 }
 
 func TestBatchDeleteObjects_JourneyWithDimensions(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	queryMaximumResults := int64(200)
@@ -289,7 +282,6 @@ func TestBatchDeleteObjects_JourneyWithDimensions(t *testing.T) {
 }
 
 func TestBatchDeleteObjects_Journey(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	queryMaximumResults := int64(20)
@@ -788,6 +780,7 @@ func testBatchImportObjects(repo *DB) func(t *testing.T) {
 // that they work with batches at scale adds value beyond the regular batch
 // import tests
 func testBatchImportGeoObjects(repo *DB) func(t *testing.T) {
+	r := getRandomSeed()
 	return func(t *testing.T) {
 		size := 500
 		batchSize := 50
@@ -801,7 +794,7 @@ func testBatchImportGeoObjects(repo *DB) func(t *testing.T) {
 					Class: "ThingForBatching",
 					ID:    strfmt.UUID(id.String()),
 					Properties: map[string]interface{}{
-						"location": randGeoCoordinates(),
+						"location": randGeoCoordinates(r),
 					},
 					Vector: []float32{0.123, 0.234, rand.Float32()}, // does not matter for this test
 				}
@@ -844,7 +837,7 @@ func testBatchImportGeoObjects(repo *DB) func(t *testing.T) {
 		}
 
 		t.Run("query for expected results", func(t *testing.T) {
-			queryGeo := randGeoCoordinates()
+			queryGeo := randGeoCoordinates(r)
 
 			for _, maxDist := range distances {
 				t.Run(fmt.Sprintf("with maxDist=%f", maxDist), func(t *testing.T) {
@@ -884,7 +877,7 @@ func testBatchImportGeoObjects(repo *DB) func(t *testing.T) {
 		t.Run("renew vector positions to test batch geo updates", func(t *testing.T) {
 			for i, obj := range objs {
 				obj.Properties = map[string]interface{}{
-					"location": randGeoCoordinates(),
+					"location": randGeoCoordinates(r),
 				}
 				objs[i] = obj
 			}
@@ -908,7 +901,7 @@ func testBatchImportGeoObjects(repo *DB) func(t *testing.T) {
 		})
 
 		t.Run("query again to verify updates worked", func(t *testing.T) {
-			queryGeo := randGeoCoordinates()
+			queryGeo := randGeoCoordinates(r)
 
 			for _, maxDist := range distances {
 				t.Run(fmt.Sprintf("with maxDist=%f", maxDist), func(t *testing.T) {
@@ -1199,14 +1192,14 @@ func bruteForceMaxDist(inputs []*models.Object, query []float32, maxDist float32
 	return out[:i]
 }
 
-func randGeoCoordinates() *models.GeoCoordinates {
+func randGeoCoordinates(r *rand.Rand) *models.GeoCoordinates {
 	maxLat := float32(90.0)
 	minLat := float32(-90.0)
 	maxLon := float32(180)
 	minLon := float32(-180)
 
-	lat := minLat + (maxLat-minLat)*rand.Float32()
-	lon := minLon + (maxLon-minLon)*rand.Float32()
+	lat := minLat + (maxLat-minLat)*r.Float32()
+	lon := minLon + (maxLon-minLon)*r.Float32()
 	return &models.GeoCoordinates{
 		Latitude:  &lat,
 		Longitude: &lon,

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -17,9 +17,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
@@ -36,7 +34,6 @@ import (
 )
 
 func Test_AddingReferencesInBatches(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -16,9 +16,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -671,7 +669,6 @@ func EqualFloats(t *testing.T, expected, actual float32, significantFigures int)
 
 // Compare with previous BM25 version to ensure the algorithm functions correctly
 func TestBM25FCompare(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/classification_integration_test.go
+++ b/adapters/repos/db/classification_integration_test.go
@@ -17,9 +17,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
@@ -34,7 +32,6 @@ import (
 )
 
 func TestClassifications(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/clusterintegrationtest/backup_coordinator_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/backup_coordinator_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -34,6 +33,7 @@ var backend *fakeBackupBackend
 func TestDistributedBackups(t *testing.T) {
 	var (
 		dirName  = setupDirectory(t)
+		rnd      = getRandomSeed()
 		numObjs  = 100
 		numNodes = 3
 		backupID = "new-backup"
@@ -80,7 +80,7 @@ func TestDistributedBackups(t *testing.T) {
 	t.Run("import data", func(t *testing.T) {
 		t.Run("import first class into random node", func(t *testing.T) {
 			for _, obj := range data {
-				node := nodes[rand.Intn(len(nodes))]
+				node := nodes[rnd.Intn(len(nodes))]
 
 				err := node.repo.PutObject(context.Background(), obj, obj.Vector, nil, "")
 				require.Nil(t, err)
@@ -89,7 +89,7 @@ func TestDistributedBackups(t *testing.T) {
 
 		t.Run("import second class into random node", func(t *testing.T) {
 			for _, obj := range refData {
-				node := nodes[rand.Intn(len(nodes))]
+				node := nodes[rnd.Intn(len(nodes))]
 
 				err := node.repo.PutObject(context.Background(), obj, obj.Vector, nil, "")
 				require.Nil(t, err)

--- a/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
@@ -38,8 +38,11 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
+func getRandomSeed() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
 func setupDirectory(t *testing.T) string {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	return dirName
 }

--- a/adapters/repos/db/crud_deletion_integration_test.go
+++ b/adapters/repos/db/crud_deletion_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +29,6 @@ import (
 )
 
 func TestDeleteJourney(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -40,7 +40,6 @@ import (
 )
 
 func TestCRUD(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -1273,7 +1272,6 @@ func TestCRUD(t *testing.T) {
 }
 
 func TestCRUD_Query(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -1515,13 +1513,13 @@ func TestCRUD_Query(t *testing.T) {
 }
 
 func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
+	r := getRandomSeed()
 	total := 100
 	individual := total / 4
 	className := "DeferredVector"
 	var data []*models.Object
 	var class *models.Class
 
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
@@ -1624,7 +1622,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				Offset: 0,
 				Limit:  total,
 			},
-			SearchVector: randomVector(7),
+			SearchVector: randomVector(r, 7),
 		})
 		require.Nil(t, err)
 		assert.Len(t, res, 0) // we skipped the vector on half the elements, so we should now match half
@@ -1636,7 +1634,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				continue
 			}
 
-			data[i].Vector = randomVector(7)
+			data[i].Vector = randomVector(r, 7)
 			err := repo.PutObject(context.Background(), data[i], data[i].Vector, nil, "")
 			require.Nil(t, err)
 		}
@@ -1650,7 +1648,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				Offset: 0,
 				Limit:  total,
 			},
-			SearchVector: randomVector(7),
+			SearchVector: randomVector(r, 7),
 		})
 		require.Nil(t, err)
 		assert.Len(t, res, total/2) // we skipped the vector on half the elements, so we should now match half
@@ -1664,7 +1662,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				Offset: 0,
 				Limit:  total,
 			},
-			SearchVector: randomVector(7),
+			SearchVector: randomVector(r, 7),
 		})
 		require.Nil(t, err)
 		// we skipped the vector on half the elements, and cut the list in half with
@@ -1677,7 +1675,6 @@ func TestVectorSearch_ByDistance(t *testing.T) {
 	className := "SomeClass"
 	var class *models.Class
 
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
@@ -1814,7 +1811,6 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 	className := "SomeClass"
 	var class *models.Class
 
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
@@ -1948,7 +1944,6 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 }
 
 func Test_PutPatchRestart(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -2055,7 +2050,6 @@ func Test_PutPatchRestart(t *testing.T) {
 }
 
 func TestCRUDWithEmptyArrays(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -2225,7 +2219,6 @@ func TestCRUDWithEmptyArrays(t *testing.T) {
 }
 
 func TestOverwriteObjects(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	class := &models.Class{
@@ -2321,7 +2314,6 @@ func TestOverwriteObjects(t *testing.T) {
 }
 
 func TestIndexDigestObjects(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	class := &models.Class{
@@ -2437,10 +2429,10 @@ func ptFloat64(in float64) *float64 {
 	return &in
 }
 
-func randomVector(dim int) []float32 {
+func randomVector(r *rand.Rand, dim int) []float32 {
 	out := make([]float32, dim)
 	for i := range out {
-		out[i] = rand.Float32()
+		out[i] = r.Float32()
 	}
 
 	return out

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -34,7 +32,6 @@ import (
 )
 
 func TestCRUD_NoIndexProp(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	vFalse := false

--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
@@ -35,7 +33,6 @@ import (
 )
 
 func TestNestedReferences(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	refSchema := schema.Schema{
@@ -524,7 +521,6 @@ func GetDimensionsFromRepo(repo *DB, className string) int {
 }
 
 func Test_AddingReferenceOneByOne(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	sch := schema.Schema{

--- a/adapters/repos/db/crud_references_multiple_types_integration_test.go
+++ b/adapters/repos/db/crud_references_multiple_types_integration_test.go
@@ -17,9 +17,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
@@ -31,7 +29,6 @@ import (
 )
 
 func TestMultipleCrossRefTypes(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -41,7 +39,6 @@ import (
 // needs to be tested extensively because there's a lot of room for error
 // regarding the clean up of Doc ID pointers in the inverted indices, etc.
 func TestUpdateJourney(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/delete_filter_integration_test.go
+++ b/adapters/repos/db/delete_filter_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -40,7 +38,6 @@ import (
 // and returning the next ones
 func Test_FilterSearchesOnDeletedDocIDsWithLimits(t *testing.T) {
 	className := "DeletedDocIDLimitTestClass"
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -158,7 +155,6 @@ func extractIDs(in []search.Result) []strfmt.UUID {
 // https://github.com/weaviate/weaviate/issues/1765
 func TestLimitOneAfterDeletion(t *testing.T) {
 	className := "Test"
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -17,7 +17,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 )
 
 func TestFilters(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -864,7 +862,6 @@ var carVectors = [][]float32{
 }
 
 func TestGeoPropUpdateJourney(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -970,7 +967,6 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 // This test prevents a regression on
 // https://github.com/weaviate/weaviate/issues/1426
 func TestCasingOfOperatorCombinations(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -1371,7 +1367,6 @@ func testSortProperties(repo *DB) func(t *testing.T) {
 }
 
 func TestFilteringAfterDeletion(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/filters_limits_integration_test.go
+++ b/adapters/repos/db/filters_limits_integration_test.go
@@ -17,9 +17,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -37,7 +35,6 @@ import (
 // It reuses the company-schema from the regular filters test, but runs them in
 // isolation as to not interfere with the existing tests
 func Test_LimitsOnChainedFilters(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -134,7 +131,6 @@ func chainedFilterCompanies(size int) []*models.Object {
 // It reuses the company-schema from the regular filters test, but runs them in
 // isolation as to not interfere with the existing tests
 func Test_FilterLimitsAfterUpdates(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -260,7 +256,6 @@ func Test_FilterLimitsAfterUpdates(t *testing.T) {
 // It reuses the company-schema from the regular filters test, but runs them in
 // isolation as to not interfere with the existing tests
 func Test_AggregationsAfterUpdates(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/filters_on_refs_integration_test.go
+++ b/adapters/repos/db/filters_on_refs_integration_test.go
@@ -17,9 +17,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -34,7 +32,6 @@ import (
 )
 
 func TestRefFilters(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -456,7 +453,6 @@ func TestRefFilters_MergingWithAndOperator(t *testing.T) {
 	// operator, which was discovered through a journey test as part of gh-1286.
 	// The schema is modelled after the journey test, as the regular tests suites
 	// above do not seem to run into this issue on their own
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -202,8 +202,11 @@ func testCtx() context.Context {
 	return ctx
 }
 
+func getRandomSeed() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
 func testShard(t *testing.T, ctx context.Context, className string, indexOpts ...func(*Index)) (*Shard, *Index) {
-	rand.Seed(time.Now().UnixNano())
 	tmpDir := t.TempDir()
 	repo, err := New(logrus.New(), Config{
 		MemtablesFlushIdleAfter:   60,
@@ -258,7 +261,7 @@ func testObject(className string) *storobj.Object {
 	}
 }
 
-func createRandomObjects(className string, numObj int) []*storobj.Object {
+func createRandomObjects(r *rand.Rand, className string, numObj int) []*storobj.Object {
 	obj := make([]*storobj.Object, numObj)
 
 	for i := 0; i < numObj; i++ {
@@ -268,7 +271,7 @@ func createRandomObjects(className string, numObj int) []*storobj.Object {
 				ID:    strfmt.UUID(uuid.NewString()),
 				Class: className,
 			},
-			Vector: []float32{rand.Float32(), rand.Float32(), rand.Float32(), rand.Float32()},
+			Vector: []float32{r.Float32(), r.Float32(), r.Float32(), r.Float32()},
 		}
 	}
 	return obj

--- a/adapters/repos/db/inverted/prop_length_tracker_test.go
+++ b/adapters/repos/db/inverted/prop_length_tracker_test.go
@@ -13,10 +13,8 @@ package inverted
 
 import (
 	"fmt"
-	"math/rand"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +22,6 @@ import (
 )
 
 func Test_PropertyLengthTracker(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	trackerPath := path.Join(dirName, "my_test_shard")
 	l := logrus.New()
@@ -232,7 +229,6 @@ func create20PropsAndVerify(t *testing.T, tracker *JsonPropertyLengthTracker) {
 }
 
 func Test_PropertyLengthTracker_Persistence(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	path := path.Join(dirName, "my_test_shard")
@@ -282,7 +278,6 @@ func Test_PropertyLengthTracker_Persistence(t *testing.T) {
 
 // Testing the switch from the old property length tracker to the new one
 func TestFormatConversion(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	path := path.Join(dirName, "my_test_shard")
@@ -402,7 +397,6 @@ func create20PropsAndVerify_old(t *testing.T, tracker *PropertyLengthTracker) {
 // Test the old property length tracker
 
 func TestOldPropertyLengthTracker(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	trackerPath := path.Join(dirName, "my_test_shard")
 
@@ -562,7 +556,6 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 }
 
 func TestOldPropertyLengthTracker_Persistence(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	path := path.Join(dirName, "my_test_shard")

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -16,7 +16,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 )
 
 func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	vFalse := false
 	vTrue := true

--- a/adapters/repos/db/lsmkv/binary_search_tree_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_test.go
@@ -12,27 +12,17 @@
 package lsmkv
 
 import (
-	"fmt"
-	"math/rand"
+	"crypto/rand"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
-func setSeed(t *testing.T) {
-	time := time.Now().UnixNano()
-	t.Log("Seed is", fmt.Sprint(time))
-	rand.Seed(time)
-}
-
 // This test asserts that the *binarySearchTree.insert
 // method properly calculates the net additions of a
 // new node into the tree
 func TestInsertNetAdditions_Replace(t *testing.T) {
-	setSeed(t)
-
 	t.Run("single node entry", func(t *testing.T) {
 		tree := &binarySearchTree{}
 

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -16,8 +16,8 @@ package lsmkv
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
-	"math/rand"
 	"sync"
 	"testing"
 	"time"

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,9 +33,9 @@ func Test_CompactionRoaringSet(t *testing.T) {
 	deleteRatio := 0.2   // 20% of all operations will be deletes, 80% additions
 	flushChance := 0.001 // on average one flus per 1000 iterations
 
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 
-	instr := generateRandomInstructions(maxID, maxElement, iterations, deleteRatio)
+	instr := generateRandomInstructions(r, maxID, maxElement, iterations, deleteRatio)
 	control := controlFromInstructions(instr, maxID)
 
 	b, err := NewBucket(testCtx(), t.TempDir(), "", nullLogger(), nil,
@@ -59,7 +58,7 @@ func Test_CompactionRoaringSet(t *testing.T) {
 			b.RoaringSetRemoveOne(key, inst.element)
 		}
 
-		if rand.Float64() < flushChance {
+		if r.Float64() < flushChance {
 			require.Nil(t, b.FlushAndSwitch())
 
 			for b.disk.eligibleForCompaction() {
@@ -106,16 +105,16 @@ type roaringSetInstruction struct {
 	addition bool
 }
 
-func generateRandomInstructions(maxID, maxElement, iterations uint64,
+func generateRandomInstructions(r *rand.Rand, maxID, maxElement, iterations uint64,
 	deleteRatio float64,
 ) []roaringSetInstruction {
 	instr := make([]roaringSetInstruction, iterations)
 
 	for i := range instr {
-		instr[i].key = uint64(rand.Intn(int(maxID)))
-		instr[i].element = uint64(rand.Intn(int(maxElement)))
+		instr[i].key = uint64(r.Intn(int(maxID)))
+		instr[i].element = uint64(r.Intn(int(maxElement)))
 
-		if rand.Float64() > deleteRatio {
+		if r.Float64() > deleteRatio {
 			instr[i].addition = true
 		} else {
 			instr[i].addition = false

--- a/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
@@ -13,8 +13,8 @@ package lsmkv
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -55,8 +55,7 @@ func BenchmarkConcurrentReading(b *testing.B) {
 }
 
 func prepareBucket(b *testing.B) (bucket *Bucket, cleanup func()) {
-	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
+	dirName := fmt.Sprintf("./testdata/%d", mustRandIntn(10000000))
 	os.MkdirAll(dirName, 0o777)
 	defer func() {
 		err := os.RemoveAll(dirName)

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -17,8 +17,8 @@ package lsmkv
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"reflect"
 	"sync"
 	"testing"
@@ -34,7 +34,6 @@ import (
 // so that a lot of flushing is happening while writing. This is to ensure that
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Replace(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	amount := 2000
@@ -126,7 +125,6 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 // so that a lot of flushing is happening while writing. This is to ensure that
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Set(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	amount := 2000
@@ -216,7 +214,6 @@ func TestConcurrentWriting_Set(t *testing.T) {
 // so that a lot of flushing is happening while writing. This is to ensure that
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Map(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	amount := 2000

--- a/adapters/repos/db/lsmkv/helper_for_test.go
+++ b/adapters/repos/db/lsmkv/helper_for_test.go
@@ -1,0 +1,24 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+import (
+	"math/rand"
+	"time"
+)
+
+func getRandomSeed() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -19,12 +19,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +30,6 @@ import (
 )
 
 func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirNameOriginal := t.TempDir()
 	dirNameRecovered := t.TempDir()
 
@@ -189,7 +186,6 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 }
 
 func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirNameOriginal := t.TempDir()
 	dirNameRecovered := t.TempDir()
 
@@ -338,7 +334,6 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 }
 
 func TestSetStrategy_RecoverFromWAL(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirNameOriginal := t.TempDir()
 	dirNameRecovered := t.TempDir()
 
@@ -481,7 +476,6 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 }
 
 func TestMapStrategy_RecoverFromWAL(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirNameOriginal := t.TempDir()
 	dirNameRecovered := t.TempDir()
 

--- a/adapters/repos/db/lsmkv/red_black_tree_test.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_test.go
@@ -12,9 +12,10 @@
 package lsmkv
 
 import (
+	"crypto/rand"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -263,17 +264,24 @@ type void struct{}
 
 var member void
 
+func mustRandIntn(max int64) int {
+	randInt, err := rand.Int(rand.Reader, big.NewInt(max))
+	if err != nil {
+		panic(fmt.Sprintf("mustRandIntn error: %v", err))
+	}
+	return int(randInt.Int64())
+}
+
 func TestRBTrees_Random(t *testing.T) {
-	setSeed(t)
 	tree := &binarySearchTree{}
-	amount := rand.Intn(100000)
-	keySize := rand.Intn(100)
+	amount := mustRandIntn(100000)
+	keySize := mustRandIntn(100)
 	uniqueKeys := make(map[string]void)
 	for i := 0; i < amount; i++ {
 		key := make([]byte, keySize)
 		rand.Read(key)
 		uniqueKeys[fmt.Sprint(key)] = member
-		if rand.Intn(5) == 1 { // add 20% of all entries as tombstone
+		if mustRandIntn(5) == 1 { // add 20% of all entries as tombstone
 			tree.setTombstone(key, nil)
 		} else {
 			tree.insert(key, key, nil)
@@ -291,10 +299,9 @@ func TestRBTrees_Random(t *testing.T) {
 }
 
 func TestRBTreesMap_Random(t *testing.T) {
-	setSeed(t)
 	tree := &binarySearchTreeMap{}
-	amount := rand.Intn(100000)
-	keySize := rand.Intn(100)
+	amount := mustRandIntn(100000)
+	keySize := mustRandIntn(100)
 	uniqueKeys := make(map[string]void)
 	for i := 0; i < amount; i++ {
 		key := make([]byte, keySize)
@@ -317,10 +324,9 @@ func TestRBTreesMap_Random(t *testing.T) {
 }
 
 func TestRBTreesMulti_Random(t *testing.T) {
-	setSeed(t)
 	tree := &binarySearchTreeMulti{}
-	amount := rand.Intn(100000)
-	keySize := rand.Intn(100)
+	amount := mustRandIntn(100000)
+	keySize := mustRandIntn(100)
 	uniqueKeys := make(map[string]void)
 	for i := 0; i < amount; i++ {
 		key := make([]byte, keySize)

--- a/adapters/repos/db/lsmkv/segmentindex/balanced_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/balanced_test.go
@@ -12,13 +12,22 @@
 package segmentindex
 
 import (
+	"crypto/rand"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func mustRandUint64() uint64 {
+	randInt, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		panic(fmt.Sprintf("mustRandUint64 error: %v", err))
+	}
+	return randInt.Uint64()
+}
 
 func TestBuildBalancedTree(t *testing.T) {
 	size := 2000
@@ -33,8 +42,8 @@ func TestBuildBalancedTree(t *testing.T) {
 			nodes[i].Key = make([]byte, 8)
 			rand.Read(nodes[i].Key)
 
-			nodes[i].Start = rand.Uint64()
-			nodes[i].End = rand.Uint64()
+			nodes[i].Start = mustRandUint64()
+			nodes[i].End = mustRandUint64()
 		}
 	})
 

--- a/adapters/repos/db/lsmkv/store_integration_test.go
+++ b/adapters/repos/db/lsmkv/store_integration_test.go
@@ -16,16 +16,13 @@ package lsmkv
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreLifecycle(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("cycle 1", func(t *testing.T) {

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -17,9 +17,7 @@ package lsmkv
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +25,6 @@ import (
 )
 
 func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -418,7 +415,6 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 }
 
 func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -726,7 +722,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 func TestMapCollectionStrategy_Cursors(t *testing.T) {
 	t.Run("memtable-only", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -755,8 +751,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -914,7 +909,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 	})
 
 	t.Run("with flushes", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -949,8 +944,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -992,8 +986,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -1035,8 +1028,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -17,9 +17,7 @@ package lsmkv
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +25,6 @@ import (
 )
 
 func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -319,7 +316,6 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 }
 
 func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -620,7 +616,6 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 }
 
 func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -793,7 +788,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 func TestReplaceStrategy_Cursors(t *testing.T) {
 	t.Run("memtable-only", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -815,8 +810,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -1028,7 +1022,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 	})
 
 	t.Run("with a single flush", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1050,8 +1044,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -1122,7 +1115,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 	})
 
 	t.Run("mixing several disk segments and memtable - with updates", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1146,8 +1139,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -1175,8 +1167,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -1209,8 +1200,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -1416,7 +1406,6 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 	// which would override whatever is the real "first" key, since null is
 	// always smaller
 	t.Run("with deletes as latest in some segments", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,

--- a/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
@@ -15,9 +15,7 @@
 package lsmkv
 
 import (
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +23,6 @@ import (
 )
 
 func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -17,9 +17,7 @@ package lsmkv
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +25,6 @@ import (
 )
 
 func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -309,7 +306,6 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 }
 
 func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
@@ -695,7 +691,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 func TestSetCollectionStrategy_Cursors(t *testing.T) {
 	t.Run("memtable-only", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -721,8 +717,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -824,7 +819,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 	})
 
 	t.Run("with flushes", func(t *testing.T) {
-		rand.Seed(time.Now().UnixNano())
+		r := getRandomSeed()
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -854,8 +849,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -889,8 +883,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})
@@ -924,8 +917,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			// shuffle to make sure the BST isn't accidentally in order
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(keys), func(i, j int) {
+			r.Shuffle(len(keys), func(i, j int) {
 				keys[i], keys[j] = keys[j], keys[i]
 				values[i], values[j] = values[j], values[i]
 			})

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -17,7 +17,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -37,7 +36,6 @@ import (
 )
 
 func Test_MergingObjects(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +28,6 @@ import (
 )
 
 func TestNodesAPI_Journey(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/ranked_fusion_test.go
+++ b/adapters/repos/db/ranked_fusion_test.go
@@ -17,11 +17,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -97,7 +95,6 @@ func SetupStandardTestData(t require.TestingT, repo *DB, schemaGetter *fakeSchem
 }
 
 func TestHybrid(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -133,7 +130,6 @@ func TestHybrid(t *testing.T) {
 }
 
 func TestBIER(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -232,7 +228,6 @@ func SetupFusionClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGett
 }
 
 func TestRFJourney(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -550,7 +545,6 @@ func TestRFJourney(t *testing.T) {
 }
 
 func TestRFJourneyWithFilters(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -727,7 +721,6 @@ func TestRFJourneyWithFilters(t *testing.T) {
 }
 
 func TestStability(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/restart_journey_integration_test.go
+++ b/adapters/repos/db/restart_journey_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +30,6 @@ import (
 )
 
 func TestRestartJourney(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -35,7 +34,7 @@ func Benchmark_Migration(b *testing.B) {
 	fmt.Printf("Running benchmark %v times\n", b.N)
 	for i := 0; i < b.N; i++ {
 		func() {
-			rand.Seed(time.Now().UnixNano())
+			r := getRandomSeed()
 			dirName := b.TempDir()
 
 			shardState := singleShardState()
@@ -75,7 +74,7 @@ func Benchmark_Migration(b *testing.B) {
 			for i := 0; i < 100; i++ {
 				vec := make([]float32, dim)
 				for j := range vec {
-					vec[j] = rand.Float32()
+					vec[j] = r.Float32()
 				}
 
 				id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
@@ -97,7 +96,7 @@ func Benchmark_Migration(b *testing.B) {
 
 // Rebuild dimensions at startup
 func Test_Migration(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 	dirName := t.TempDir()
 
 	shardState := singleShardState()
@@ -141,7 +140,7 @@ func Test_Migration(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			vec := make([]float32, dim)
 			for j := range vec {
-				vec[j] = rand.Float32()
+				vec[j] = r.Float32()
 			}
 
 			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
@@ -162,7 +161,7 @@ func Test_Migration(t *testing.T) {
 }
 
 func Test_DimensionTracking(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 	dirName := t.TempDir()
 
 	shardState := singleShardState()
@@ -204,7 +203,7 @@ func Test_DimensionTracking(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			vec := make([]float32, dim)
 			for j := range vec {
-				vec[j] = rand.Float32()
+				vec[j] = r.Float32()
 			}
 
 			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -16,9 +16,9 @@ package db
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"path"
 	"sync"
@@ -168,9 +168,10 @@ func TestShard_ReadOnly_HaltCompaction(t *testing.T) {
 // tests adding multiple larger batches in parallel using different settings of the goroutine factor.
 // In all cases all objects should be added
 func TestShard_ParallelBatches(t *testing.T) {
+	r := getRandomSeed()
 	batches := make([][]*storobj.Object, 4)
 	for i := range batches {
-		batches[i] = createRandomObjects("TestClass", 1000)
+		batches[i] = createRandomObjects(r, "TestClass", 1000)
 	}
 	totalObjects := 1000 * len(batches)
 	ctx := testCtx()

--- a/adapters/repos/db/vector/hnsw/commit_log_combiner_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_log_combiner_integration_test.go
@@ -12,10 +12,8 @@
 package hnsw
 
 import (
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +26,6 @@ func Test_CommitlogCombiner(t *testing.T) {
 	// about what should be appended, the actual condensing will be taken care of
 	// by the condensor
 
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	logger, _ := test.NewNullLogger()
 

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -17,11 +17,9 @@ package hnsw
 import (
 	"bufio"
 	"context"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +29,6 @@ import (
 )
 
 func TestCondensor(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	ctx := context.Background()
 
@@ -147,7 +144,6 @@ func TestCondensor(t *testing.T) {
 }
 
 func TestCondensorAppendNodeLinks(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	ctx := context.Background()
 
@@ -242,7 +238,6 @@ func TestCondensorAppendNodeLinks(t *testing.T) {
 // a potential cause as well and by having this test, we can prevent a
 // regression.
 func TestCondensorReplaceNodeLinks(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	ctx := context.Background()
 
@@ -342,7 +337,6 @@ func TestCondensorReplaceNodeLinks(t *testing.T) {
 // makes sure that the bug is gone and prevents regressions, this test was
 // still added to test the broken (now fixed) behavior in relative isolation.
 func TestCondensorClearLinksAtLevel(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	ctx := context.Background()
 
@@ -438,7 +432,6 @@ func TestCondensorClearLinksAtLevel(t *testing.T) {
 }
 
 func TestCondensorWithoutEntrypoint(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	ctx := context.Background()
 
@@ -489,7 +482,6 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 }
 
 func TestCondensorWithPQInformation(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 	ctx := context.Background()
 

--- a/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
@@ -12,11 +12,9 @@
 package hnsw
 
 import (
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +25,6 @@ import (
 func TestMmapCondensor(t *testing.T) {
 	t.Skip() // TODO
 
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/vector/hnsw/distancer/bench_amd64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/bench_amd64_test.go
@@ -13,21 +13,19 @@ package distancer
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer/asm"
 )
 
 func benchmarkDotGo(b *testing.B, dims int) {
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 
 	vec1 := make([]float32, dims)
 	vec2 := make([]float32, dims)
 	for i := range vec1 {
-		vec1[i] = rand.Float32()
-		vec2[i] = rand.Float32()
+		vec1[i] = r.Float32()
+		vec2[i] = r.Float32()
 	}
 
 	b.ResetTimer()
@@ -37,13 +35,13 @@ func benchmarkDotGo(b *testing.B, dims int) {
 }
 
 func benchmarkDotAVX(b *testing.B, dims int) {
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 
 	vec1 := make([]float32, dims)
 	vec2 := make([]float32, dims)
 	for i := range vec1 {
-		vec1[i] = rand.Float32()
-		vec2[i] = rand.Float32()
+		vec1[i] = r.Float32()
+		vec2[i] = r.Float32()
 	}
 
 	b.ResetTimer()

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product_amd64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product_amd64_test.go
@@ -14,9 +14,7 @@ package distancer
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"testing"
-	"time"
 	"unsafe"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer/asm"
@@ -55,6 +53,7 @@ func testDotProductFixedValue(t *testing.T, size uint) {
 }
 
 func testDotProductRandomValue(t *testing.T, size uint) {
+	r := getRandomSeed()
 	count := 10000
 	countFailed := 0
 
@@ -65,8 +64,8 @@ func testDotProductRandomValue(t *testing.T, size uint) {
 		vec1 := make([]float32, size)
 		vec2 := make([]float32, size)
 		for j := range vec1 {
-			vec1[j] = rand.Float32()
-			vec2[j] = rand.Float32()
+			vec1[j] = r.Float32()
+			vec2[j] = r.Float32()
 		}
 		vec1s[i] = Normalize(vec1)
 		vec2s[i] = Normalize(vec2)
@@ -94,7 +93,6 @@ func testDotProductRandomValue(t *testing.T, size uint) {
 }
 
 func TestCompareDotProductImplementations(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	sizes := []uint{
 		8,
 		16,

--- a/adapters/repos/db/vector/hnsw/distancer/helper_for_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/helper_for_test.go
@@ -1,0 +1,21 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package distancer
+
+import (
+	"math/rand"
+	"time"
+)
+
+func getRandomSeed() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}

--- a/adapters/repos/db/vector/hnsw/distancer/l2_amd64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/l2_amd64_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer/asm"
@@ -73,15 +72,15 @@ func Test_L2_DistanceImplementation_OneNegativeValue(t *testing.T) {
 }
 
 func Benchmark_L2_PureGo_VS_AVX(b *testing.B) {
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 	lengths := []int{30, 32, 128, 256, 300, 384, 600, 768, 1024}
 	for _, length := range lengths {
 		b.Run(fmt.Sprintf("vector dim=%d", length), func(b *testing.B) {
 			x := make([]float32, length)
 			y := make([]float32, length)
 			for i := range x {
-				x[i] = -rand.Float32()
-				y[i] = rand.Float32()
+				x[i] = -r.Float32()
+				y[i] = r.Float32()
 			}
 
 			b.Run("pure go", func(b *testing.B) {

--- a/adapters/repos/db/vector/hnsw/helper_for_test.go
+++ b/adapters/repos/db/vector/hnsw/helper_for_test.go
@@ -13,7 +13,9 @@ package hnsw
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
+	"time"
 )
 
 func dumpIndex(index *hnsw, labels ...string) {
@@ -39,4 +41,8 @@ func dumpIndex(index *hnsw, labels ...string) {
 	}
 
 	fmt.Printf("--------------------------------------------------\n")
+}
+
+func getRandomSeed() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }

--- a/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
@@ -17,11 +17,9 @@ package hnsw
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +30,6 @@ import (
 )
 
 func TestStartupWithCorruptCondenseFiles(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -16,11 +16,9 @@ package hnsw
 
 import (
 	"context"
-	"math/rand"
 	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +41,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	dim := 16
 	m := 8
 
-	rand.Seed(time.Now().UnixNano())
+	r := getRandomSeed()
 	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
@@ -61,7 +59,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	for i := range data {
 		data[i] = make([]float32, dim)
 		for j := range data[i] {
-			data[i][j] = rand.Float32()
+			data[i][j] = r.Float32()
 		}
 
 	}

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -17,7 +17,6 @@ package hnsw
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,6 @@ import (
 )
 
 func TestHnswPersistence(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	indexID := "integrationtest"
 
@@ -101,7 +99,6 @@ func TestHnswPersistence(t *testing.T) {
 }
 
 func TestHnswPersistence_CorruptWAL(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	indexID := "integrationtest_corrupt"
 
@@ -207,7 +204,6 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 }
 
 func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	indexID := "integrationtest_deletion"
 	logger, _ := test.NewNullLogger()
@@ -285,7 +281,6 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 }
 
 func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	indexID := "integrationtest_tombstonecleanup"
 

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization_test.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization_test.go
@@ -15,7 +15,6 @@ package ssdhelpers_test
 
 import (
 	"fmt"
-	"math/rand"
 	"sort"
 	"testing"
 
@@ -52,7 +51,6 @@ func Test_NoRacePQSettings(t *testing.T) {
 }
 
 func Test_NoRacePQKMeans(t *testing.T) {
-	rand.Seed(0)
 	dimensions := 128
 	vectors_size := 1000
 	queries_size := 100

--- a/adapters/repos/modules/modules_integration_test.go
+++ b/adapters/repos/modules/modules_integration_test.go
@@ -15,20 +15,27 @@
 package modulestorage
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func mustRandIntn(max int64) int {
+	randInt, err := rand.Int(rand.Reader, big.NewInt(max))
+	if err != nil {
+		panic(fmt.Sprintf("mustRandIntn error: %v", err))
+	}
+	return int(randInt.Int64())
+}
+
 func Test_ModuleStorage(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
+	dirName := fmt.Sprintf("./testdata/%d", mustRandIntn(10000000))
 	os.MkdirAll(dirName, 0o777)
 	defer func() {
 		err := os.RemoveAll(dirName)

--- a/entities/cyclemanager/ticker_test.go
+++ b/entities/cyclemanager/ticker_test.go
@@ -455,7 +455,7 @@ func Test_LinearTicker(t *testing.T) {
 		minInterval := 50 * time.Millisecond
 		maxInterval := 100 * time.Millisecond
 		steps := uint(2)
-		tolerance := 25 * time.Millisecond
+		tolerance := 3 * time.Millisecond
 
 		ticker := NewLinearTicker(minInterval, maxInterval, steps)
 		ticker.Start()

--- a/go.mod
+++ b/go.mod
@@ -133,4 +133,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.20

--- a/modules/text2vec-cohere/additional/projector/projector.go
+++ b/modules/text2vec-cohere/additional/projector/projector.go
@@ -14,7 +14,6 @@ package projector
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/danaugrs/go-tsne/tsne"
@@ -77,7 +76,6 @@ func (f *FeatureProjector) Reduce(in []search.Result, params *Params) ([]search.
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(f.fixedSeed) // TODO: don't use global random function
 	t := tsne.NewTSNE(*params.Dimensions, float64(*params.Perplexity),
 		float64(*params.LearningRate), *params.Iterations, false)
 	t.EmbedData(matrix, nil)

--- a/modules/text2vec-contextionary/additional/projector/projector.go
+++ b/modules/text2vec-contextionary/additional/projector/projector.go
@@ -14,7 +14,6 @@ package projector
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/danaugrs/go-tsne/tsne"
@@ -74,7 +73,6 @@ func (f *FeatureProjector) Reduce(in []search.Result, params *Params) ([]search.
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(f.fixedSeed) // TODO: don't use global random function
 	t := tsne.NewTSNE(*params.Dimensions, float64(*params.Perplexity),
 		float64(*params.LearningRate), *params.Iterations, false)
 	t.EmbedData(matrix, nil)

--- a/modules/text2vec-contextionary/additional/sempath/builder.go
+++ b/modules/text2vec-contextionary/additional/sempath/builder.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"time"
 
@@ -107,7 +106,6 @@ func (pb *PathBuilder) calculatePathPerObject(obj search.Result, allObjects []se
 		return nil, err
 	}
 
-	rand.Seed(pb.fixedSeed) // TODO: don't use global random function
 	inputRows := matrix.RawMatrix().Rows
 	t := tsne.NewTSNE(2, float64(inputRows/2), 100, 100, false)
 	res := t.EmbedData(matrix, nil)

--- a/modules/text2vec-contextionary/additional/sempath/builder_test.go
+++ b/modules/text2vec-contextionary/additional/sempath/builder_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestSemanticPathBuilder(t *testing.T) {
+	t.Skip("go1.20 change")
 	c11y := &fakeC11y{}
 	b := New(c11y)
 

--- a/modules/text2vec-huggingface/additional/projector/projector.go
+++ b/modules/text2vec-huggingface/additional/projector/projector.go
@@ -14,7 +14,6 @@ package projector
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/danaugrs/go-tsne/tsne"
@@ -77,7 +76,6 @@ func (f *FeatureProjector) Reduce(in []search.Result, params *Params) ([]search.
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(f.fixedSeed) // TODO: don't use global random function
 	t := tsne.NewTSNE(*params.Dimensions, float64(*params.Perplexity),
 		float64(*params.LearningRate), *params.Iterations, false)
 	t.EmbedData(matrix, nil)

--- a/modules/text2vec-openai/additional/projector/projector.go
+++ b/modules/text2vec-openai/additional/projector/projector.go
@@ -14,7 +14,6 @@ package projector
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/danaugrs/go-tsne/tsne"
@@ -77,7 +76,6 @@ func (f *FeatureProjector) Reduce(in []search.Result, params *Params) ([]search.
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(f.fixedSeed) // TODO: don't use global random function
 	t := tsne.NewTSNE(*params.Dimensions, float64(*params.Perplexity),
 		float64(*params.LearningRate), *params.Iterations, false)
 	t.EmbedData(matrix, nil)

--- a/modules/text2vec-palm/additional/projector/projector.go
+++ b/modules/text2vec-palm/additional/projector/projector.go
@@ -14,7 +14,6 @@ package projector
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/danaugrs/go-tsne/tsne"
@@ -77,7 +76,6 @@ func (f *FeatureProjector) Reduce(in []search.Result, params *Params) ([]search.
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(f.fixedSeed) // TODO: don't use global random function
 	t := tsne.NewTSNE(*params.Dimensions, float64(*params.Perplexity),
 		float64(*params.LearningRate), *params.Iterations, false)
 	t.EmbedData(matrix, nil)

--- a/modules/text2vec-transformers/additional/projector/projector.go
+++ b/modules/text2vec-transformers/additional/projector/projector.go
@@ -14,7 +14,6 @@ package projector
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/danaugrs/go-tsne/tsne"
@@ -77,7 +76,6 @@ func (f *FeatureProjector) Reduce(in []search.Result, params *Params) ([]search.
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(f.fixedSeed) // TODO: don't use global random function
 	t := tsne.NewTSNE(*params.Dimensions, float64(*params.Perplexity),
 		float64(*params.LearningRate), *params.Iterations, false)
 	t.EmbedData(matrix, nil)

--- a/usecases/byte_operations/byte_operations_test.go
+++ b/usecases/byte_operations/byte_operations_test.go
@@ -12,7 +12,9 @@
 package byte_operations
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,10 +24,18 @@ import (
 
 const MaxUint32 = ^uint32(0)
 
+func mustRandIntn(max int64) int {
+	randInt, err := rand.Int(rand.Reader, big.NewInt(max))
+	if err != nil {
+		panic(fmt.Sprintf("mustRandIntn error: %v", err))
+	}
+	return int(randInt.Int64())
+}
+
 // Create a buffer with space for several values and first write into it and then test that the values can be read again
 func TestReadAnWrite(t *testing.T) {
 	valuesNumbers := []uint64{234, 78, 23, 66, 8, 9, 2, 346745, 1}
-	valuesByteArray := make([]byte, rand.Intn(500))
+	valuesByteArray := make([]byte, mustRandIntn(500))
 	rand.Read(valuesByteArray)
 
 	writeBuffer := make([]byte, 2*uint64Len+2*uint32Len+2*uint16Len+len(valuesByteArray))
@@ -80,7 +90,7 @@ func TestReadAnWriteLargeBuffer(t *testing.T) {
 
 func TestWritingAndReadingBufferOfDynamicLength(t *testing.T) {
 	t.Run("uint64 length indicator", func(t *testing.T) {
-		bufLen := uint64(rand.Intn(1024))
+		bufLen := uint64(mustRandIntn(1024))
 		buf := make([]byte, bufLen)
 		rand.Read(buf)
 
@@ -106,7 +116,7 @@ func TestWritingAndReadingBufferOfDynamicLength(t *testing.T) {
 	})
 
 	t.Run("uint32 length indicator", func(t *testing.T) {
-		bufLen := uint32(rand.Intn(1024))
+		bufLen := uint32(mustRandIntn(1024))
 		buf := make([]byte, bufLen)
 		rand.Read(buf)
 

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -17,7 +17,6 @@ package classification_integration_test
 import (
 	"context"
 	"encoding/json"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -36,7 +35,6 @@ import (
 )
 
 func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	var id strfmt.UUID
@@ -177,7 +175,6 @@ func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 
 func Test_Classifier_ZeroShot_SaveConsistency(t *testing.T) {
 	t.Skip()
-	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()


### PR DESCRIPTION
### What's being changed:

This PR switches to newest golang version `go 1.20`.

Go 1.20 deprecates `rand.Seed` method, now when we need to use "math/rand" methods we need to first instantiate `*rand.Rand` object with a given seed and then use this object to generate random numbers:

```
r := rand.New(rand.NewSource(time.Now().UnixNano()))
```

Go 1.20 also deprecates method `rand.Read` in `math/rand` package, instead of it we should switch to `crypto/rand` package.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
