### PR TITLE
Prevent unbounded concurrency in ref-filter queries

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -90,6 +90,9 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
 		pv.docIDs = dbm
 	} else {
 		eg := errgroup.Group{}
+		// prevent unbounded concurrency, see
+		// https://github.com/weaviate/weaviate/issues/3179 for details
+		eg.SetLimit(2 * _NUMCPU)
 		for i, child := range pv.children {
 			i, child := i, child
 			eg.Go(func() error {


### PR DESCRIPTION
### What's being changed:
* Set `MaxConnsPerHost` limit to prevent spawning infinite connections
* Limit concurrency in situations that do heavy disk I/O or could spawn connections

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
