### PR TITLE
Fix query vectorizer in text2vec-openai module

### DIFF
--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -39,8 +39,8 @@ func TestClient(t *testing.T) {
 		}
 
 		expected := &ent.VectorizationResult{
-			Text:       "This is my text",
-			Vector:     []float32{0.1, 0.2, 0.3},
+			Text:       []string{"This is my text"},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(context.Background(), "This is my text",
@@ -100,8 +100,8 @@ func TestClient(t *testing.T) {
 			"X-Openai-Api-Key", []string{"some-key"})
 
 		expected := &ent.VectorizationResult{
-			Text:       "This is my text",
-			Vector:     []float32{0.1, 0.2, 0.3},
+			Text:       []string{"This is my text"},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(ctxWithValue, "This is my text",
@@ -188,11 +188,12 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var b map[string]interface{}
 	require.Nil(f.t, json.Unmarshal(bodyBytes, &b))
 
-	textInput := b["input"].(string)
+	textInputArray := b["input"].([]interface{})
+	textInput := textInputArray[0].(string)
 	assert.Greater(f.t, len(textInput), 0)
 
 	embeddingData := map[string]interface{}{
-		"object":    "embedding",
+		"object":    textInput,
 		"index":     0,
 		"embedding": []float32{0.1, 0.2, 0.3},
 	}

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -12,7 +12,7 @@
 package ent
 
 type VectorizationResult struct {
-	Text       string
+	Text       []string
 	Dimensions int
-	Vector     []float32
+	Vector     [][]float32
 }

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -18,29 +18,29 @@ import (
 )
 
 type fakeClient struct {
-	lastInput  string
+	lastInput  []string
 	lastConfig ent.VectorizationConfig
 }
 
 func (c *fakeClient) Vectorize(ctx context.Context,
 	text string, cfg ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
-	c.lastInput = text
+	c.lastInput = []string{text}
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     []float32{0, 1, 2, 3},
+		Vector:     [][]float32{{0, 1, 2, 3}},
 		Dimensions: 4,
-		Text:       text,
+		Text:       []string{text},
 	}, nil
 }
 
 func (c *fakeClient) VectorizeQuery(ctx context.Context,
-	text string, cfg ent.VectorizationConfig,
+	text []string, cfg ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     []float32{0.1, 1.1, 2.1, 3.1},
+		Vector:     [][]float32{{0.1, 1.1, 2.1, 3.1}},
 		Dimensions: 4,
 		Text:       text,
 	}, nil

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -36,7 +36,7 @@ func New(client Client) *Vectorizer {
 type Client interface {
 	Vectorize(ctx context.Context, input string,
 		config ent.VectorizationConfig) (*ent.VectorizationResult, error)
-	VectorizeQuery(ctx context.Context, input string,
+	VectorizeQuery(ctx context.Context, input []string,
 		config ent.VectorizationConfig) (*ent.VectorizationResult, error)
 }
 
@@ -148,7 +148,10 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 		return nil, err
 	}
 
-	return res.Vector, nil
+	if len(res.Vector) > 1 {
+		return v.CombineVectors(res.Vector), nil
+	}
+	return res.Vector[0], nil
 }
 
 func camelCaseToLower(in string) string {

--- a/modules/text2vec-openai/vectorizer/objects_test.go
+++ b/modules/text2vec-openai/vectorizer/objects_test.go
@@ -14,7 +14,6 @@ package vectorizer
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,9 +194,7 @@ func TestVectorizingObjects(t *testing.T) {
 
 			require.Nil(t, err)
 			assert.Equal(t, models.C11yVector{0, 1, 2, 3}, test.input.Vector)
-			expected := strings.Split(test.expectedClientCall, " ")
-			actual := strings.Split(client.lastInput, " ")
-			assert.Equal(t, expected, actual)
+			assert.Equal(t, []string{test.expectedClientCall}, client.lastInput)
 			assert.Equal(t, client.lastConfig.Type, test.expectedOpenAIType)
 			assert.Equal(t, client.lastConfig.Model, test.expectedOpenAIModel)
 		})

--- a/modules/text2vec-openai/vectorizer/texts.go
+++ b/modules/text2vec-openai/vectorizer/texts.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/modules/text2vec-openai/ent"
@@ -22,7 +21,7 @@ import (
 func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	settings ClassSettings,
 ) ([]float32, error) {
-	res, err := v.client.VectorizeQuery(ctx, v.joinSentences(inputs), ent.VectorizationConfig{
+	res, err := v.client.VectorizeQuery(ctx, inputs, ent.VectorizationConfig{
 		Type:         settings.Type(),
 		Model:        settings.Model(),
 		ModelVersion: settings.ModelVersion(),
@@ -34,42 +33,8 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 		return nil, errors.Wrap(err, "remote client vectorize")
 	}
 
-	return res.Vector, nil
-}
-
-func (v *Vectorizer) joinSentences(input []string) string {
-	if len(input) == 1 {
-		return input[0]
+	if len(res.Vector) > 1 {
+		return v.CombineVectors(res.Vector), nil
 	}
-
-	b := &strings.Builder{}
-	for i, sent := range input {
-		if i > 0 {
-			if v.endsWithPunctuation(input[i-1]) {
-				b.WriteString(" ")
-			} else {
-				b.WriteString(". ")
-			}
-		}
-		b.WriteString(sent)
-	}
-
-	return b.String()
-}
-
-func (v *Vectorizer) endsWithPunctuation(sent string) bool {
-	if len(sent) == 0 {
-		// treat an empty string as if it ended with punctuation so we don't add
-		// additional punctuation
-		return true
-	}
-
-	lastChar := sent[len(sent)-1]
-	switch lastChar {
-	case '.', ',', '?', '!':
-		return true
-
-	default:
-		return false
-	}
+	return res.Vector[0], nil
 }

--- a/modules/text2vec-openai/vectorizer/texts_test.go
+++ b/modules/text2vec-openai/vectorizer/texts_test.go
@@ -24,7 +24,6 @@ func TestVectorizingTexts(t *testing.T) {
 	type testCase struct {
 		name                 string
 		input                []string
-		expectedClientCall   string
 		expectedOpenAIType   string
 		openAIType           string
 		expectedOpenAIModel  string
@@ -41,7 +40,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "hello",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -56,7 +54,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "hello world, this is me!",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -71,7 +68,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "this is sentence 1. and here's number 2",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -86,7 +82,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "this is sentence 1. and here's number 2",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -101,7 +96,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "this is sentence 1? and here's number 2",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -116,7 +110,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "this is sentence 1! and here's number 2",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -131,7 +124,6 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedOpenAIType:  "text",
 			openAIModel:         "ada",
 			expectedOpenAIModel: "ada",
-			expectedClientCall:  "this is sentence 1, and here's number 2",
 
 			// use something that doesn't exist on purpose to rule out that this was
 			// set by a default, but validate that the version was set explicitly
@@ -156,7 +148,7 @@ func TestVectorizingTexts(t *testing.T) {
 
 			require.Nil(t, err)
 			assert.Equal(t, []float32{0.1, 1.1, 2.1, 3.1}, vec)
-			assert.Equal(t, test.expectedClientCall, client.lastInput)
+			assert.Equal(t, test.input, client.lastInput)
 			assert.Equal(t, client.lastConfig.Type, test.expectedOpenAIType)
 			assert.Equal(t, client.lastConfig.Model, test.expectedOpenAIModel)
 			assert.Equal(t, client.lastConfig.ModelVersion, test.expectedModelVersion)

--- a/modules/text2vec-openai/vectorizer/todo_move_out_of_here_movements.go
+++ b/modules/text2vec-openai/vectorizer/todo_move_out_of_here_movements.go
@@ -11,30 +11,15 @@
 
 package vectorizer
 
-import "fmt"
+import (
+	"fmt"
+
+	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
+)
 
 // CombineVectors combines all of the vector into sum of their parts
 func (v *Vectorizer) CombineVectors(vectors [][]float32) []float32 {
-	maxVectorLength := 0
-	for i := range vectors {
-		if len(vectors[i]) > maxVectorLength {
-			maxVectorLength = len(vectors[i])
-		}
-	}
-	sums := make([]float32, maxVectorLength)
-	dividers := make([]float32, maxVectorLength)
-	for _, vector := range vectors {
-		for i := 0; i < len(vector); i++ {
-			sums[i] += vector[i]
-			dividers[i]++
-		}
-	}
-	combinedVector := make([]float32, len(sums))
-	for i := 0; i < len(sums); i++ {
-		combinedVector[i] = sums[i] / dividers[i]
-	}
-
-	return combinedVector
+	return libvectorizer.CombineVectors(vectors)
 }
 
 // MoveTo moves one vector toward another


### PR DESCRIPTION
### What's being changed:

Fixes `nearText` query vector calculation in `text2vec-openai` module so that the order of concepts doesn't change the result vector, meaning that the result of this query will always yield the same vector:

```
nearText{ concepts:["A", "B"]} == nearText{ concepts:["B", "A"]}
```

There has been created a follow up [issue](https://github.com/weaviate/weaviate/issues/3187) to apply this fix to all other `text2vec` modules.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
