### PR TITLE
Move tenant out of singleRef

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -1552,6 +1552,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -1635,6 +1638,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -1718,6 +1724,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2092,6 +2101,9 @@ func init() {
             "schema": {
               "$ref": "#/definitions/MultipleRef"
             }
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2157,6 +2169,9 @@ func init() {
             "schema": {
               "$ref": "#/definitions/SingleRef"
             }
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2222,6 +2237,9 @@ func init() {
             "schema": {
               "$ref": "#/definitions/SingleRef"
             }
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -4343,10 +4361,6 @@ func init() {
         "schema": {
           "description": "If using a concept reference (rather than a direct reference), specify the desired properties here",
           "$ref": "#/definitions/PropertySchema"
-        },
-        "tenant": {
-          "description": "Name of the reference tenant.",
-          "type": "string"
         }
       }
     },
@@ -6204,6 +6218,12 @@ func init() {
             "description": "Determines how many replicas must acknowledge a request before it is considered successful",
             "name": "consistency_level",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6290,6 +6310,12 @@ func init() {
             "description": "Determines how many replicas must acknowledge a request before it is considered successful",
             "name": "consistency_level",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6375,6 +6401,12 @@ func init() {
             "type": "string",
             "description": "Determines how many replicas must acknowledge a request before it is considered successful",
             "name": "consistency_level",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant",
             "in": "query"
           }
         ],
@@ -6765,6 +6797,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/MultipleRef"
             }
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6830,6 +6868,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/SingleRef"
             }
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6895,6 +6939,12 @@ func init() {
             "schema": {
               "$ref": "#/definitions/SingleRef"
             }
+          },
+          {
+            "type": "string",
+            "description": "Specifies the tenant in a request targeting a multi-tenant class",
+            "name": "tenant",
+            "in": "query"
           }
         ],
         "responses": {
@@ -9193,10 +9243,6 @@ func init() {
         "schema": {
           "description": "If using a concept reference (rather than a direct reference), specify the desired properties here",
           "$ref": "#/definitions/PropertySchema"
-        },
-        "tenant": {
-          "description": "Name of the reference tenant.",
-          "type": "string"
         }
       }
     },

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -64,11 +64,11 @@ type objectsManager interface {
 	MergeObject(context.Context, *models.Principal, *models.Object,
 		*additional.ReplicationProperties) *uco.Error
 	AddObjectReference(context.Context, *models.Principal, *uco.AddReferenceInput,
-		*additional.ReplicationProperties) *uco.Error
+		*additional.ReplicationProperties, string) *uco.Error
 	UpdateObjectReferences(context.Context, *models.Principal,
-		*uco.PutReferenceInput, *additional.ReplicationProperties) *uco.Error
+		*uco.PutReferenceInput, *additional.ReplicationProperties, string) *uco.Error
 	DeleteObjectReference(context.Context, *models.Principal, *uco.DeleteReferenceInput,
-		*additional.ReplicationProperties) *uco.Error
+		*additional.ReplicationProperties, string) *uco.Error
 	GetObjectsClass(ctx context.Context, principal *models.Principal, id strfmt.UUID) (*models.Class, error)
 }
 
@@ -414,8 +414,9 @@ func (h *objectHandlers) addObjectReference(
 		return objects.NewObjectsCreateBadRequest().
 			WithPayload(errPayloadFromSingleErr(err))
 	}
+	tenant := getTenant(params.Tenant)
 
-	objErr := h.manager.AddObjectReference(params.HTTPRequest.Context(), principal, &input, repl)
+	objErr := h.manager.AddObjectReference(params.HTTPRequest.Context(), principal, &input, repl, tenant)
 	if objErr != nil {
 		switch {
 		case objErr.Forbidden():
@@ -451,7 +452,9 @@ func (h *objectHandlers) putObjectReferences(params objects.ObjectsClassReferenc
 			WithPayload(errPayloadFromSingleErr(err))
 	}
 
-	objErr := h.manager.UpdateObjectReferences(params.HTTPRequest.Context(), principal, &input, repl)
+	tenant := getTenant(params.Tenant)
+
+	objErr := h.manager.UpdateObjectReferences(params.HTTPRequest.Context(), principal, &input, repl, tenant)
 	if objErr != nil {
 		switch {
 		case objErr.Forbidden():
@@ -486,8 +489,9 @@ func (h *objectHandlers) deleteObjectReference(params objects.ObjectsClassRefere
 		return objects.NewObjectsCreateBadRequest().
 			WithPayload(errPayloadFromSingleErr(err))
 	}
+	tenant := getTenant(params.Tenant)
 
-	objErr := h.manager.DeleteObjectReference(params.HTTPRequest.Context(), principal, &input, repl)
+	objErr := h.manager.DeleteObjectReference(params.HTTPRequest.Context(), principal, &input, repl, tenant)
 	if objErr != nil {
 		switch objErr.Code {
 		case uco.StatusForbidden:

--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -1110,19 +1110,19 @@ func (f *fakeManager) DeleteObject(_ context.Context, _ *models.Principal,
 }
 
 func (f *fakeManager) AddObjectReference(context.Context, *models.Principal,
-	*uco.AddReferenceInput, *additional.ReplicationProperties,
+	*uco.AddReferenceInput, *additional.ReplicationProperties, string,
 ) *uco.Error {
 	return f.addRefErr
 }
 
 func (f *fakeManager) UpdateObjectReferences(context.Context, *models.Principal,
-	*uco.PutReferenceInput, *additional.ReplicationProperties,
+	*uco.PutReferenceInput, *additional.ReplicationProperties, string,
 ) *uco.Error {
 	return f.putRefErr
 }
 
 func (f *fakeManager) DeleteObjectReference(context.Context, *models.Principal,
-	*uco.DeleteReferenceInput, *additional.ReplicationProperties,
+	*uco.DeleteReferenceInput, *additional.ReplicationProperties, string,
 ) *uco.Error {
 	return f.deleteRefErr
 }

--- a/adapters/handlers/rest/operations/objects/objects_class_references_create_parameters.go
+++ b/adapters/handlers/rest/operations/objects/objects_class_references_create_parameters.go
@@ -70,6 +70,10 @@ type ObjectsClassReferencesCreateParams struct {
 	  In: path
 	*/
 	PropertyName string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	Tenant *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -128,6 +132,11 @@ func (o *ObjectsClassReferencesCreateParams) BindRequest(r *http.Request, route 
 
 	rPropertyName, rhkPropertyName, _ := route.Params.GetOK("propertyName")
 	if err := o.bindPropertyName(rPropertyName, rhkPropertyName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTenant, qhkTenant, _ := qs.GetOK("tenant")
+	if err := o.bindTenant(qTenant, qhkTenant, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -211,6 +220,24 @@ func (o *ObjectsClassReferencesCreateParams) bindPropertyName(rawData []string, 
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.PropertyName = raw
+
+	return nil
+}
+
+// bindTenant binds and validates parameter Tenant from query.
+func (o *ObjectsClassReferencesCreateParams) bindTenant(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Tenant = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_class_references_create_urlbuilder.go
+++ b/adapters/handlers/rest/operations/objects/objects_class_references_create_urlbuilder.go
@@ -32,6 +32,7 @@ type ObjectsClassReferencesCreateURL struct {
 	PropertyName string
 
 	ConsistencyLevel *string
+	Tenant           *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -94,6 +95,14 @@ func (o *ObjectsClassReferencesCreateURL) Build() (*url.URL, error) {
 	}
 	if consistencyLevelQ != "" {
 		qs.Set("consistency_level", consistencyLevelQ)
+	}
+
+	var tenantQ string
+	if o.Tenant != nil {
+		tenantQ = *o.Tenant
+	}
+	if tenantQ != "" {
+		qs.Set("tenant", tenantQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/adapters/handlers/rest/operations/objects/objects_class_references_delete_parameters.go
+++ b/adapters/handlers/rest/operations/objects/objects_class_references_delete_parameters.go
@@ -70,6 +70,10 @@ type ObjectsClassReferencesDeleteParams struct {
 	  In: path
 	*/
 	PropertyName string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	Tenant *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -128,6 +132,11 @@ func (o *ObjectsClassReferencesDeleteParams) BindRequest(r *http.Request, route 
 
 	rPropertyName, rhkPropertyName, _ := route.Params.GetOK("propertyName")
 	if err := o.bindPropertyName(rPropertyName, rhkPropertyName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTenant, qhkTenant, _ := qs.GetOK("tenant")
+	if err := o.bindTenant(qTenant, qhkTenant, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -211,6 +220,24 @@ func (o *ObjectsClassReferencesDeleteParams) bindPropertyName(rawData []string, 
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.PropertyName = raw
+
+	return nil
+}
+
+// bindTenant binds and validates parameter Tenant from query.
+func (o *ObjectsClassReferencesDeleteParams) bindTenant(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Tenant = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_class_references_delete_urlbuilder.go
+++ b/adapters/handlers/rest/operations/objects/objects_class_references_delete_urlbuilder.go
@@ -32,6 +32,7 @@ type ObjectsClassReferencesDeleteURL struct {
 	PropertyName string
 
 	ConsistencyLevel *string
+	Tenant           *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -94,6 +95,14 @@ func (o *ObjectsClassReferencesDeleteURL) Build() (*url.URL, error) {
 	}
 	if consistencyLevelQ != "" {
 		qs.Set("consistency_level", consistencyLevelQ)
+	}
+
+	var tenantQ string
+	if o.Tenant != nil {
+		tenantQ = *o.Tenant
+	}
+	if tenantQ != "" {
+		qs.Set("tenant", tenantQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/adapters/handlers/rest/operations/objects/objects_class_references_put_parameters.go
+++ b/adapters/handlers/rest/operations/objects/objects_class_references_put_parameters.go
@@ -70,6 +70,10 @@ type ObjectsClassReferencesPutParams struct {
 	  In: path
 	*/
 	PropertyName string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	Tenant *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -128,6 +132,11 @@ func (o *ObjectsClassReferencesPutParams) BindRequest(r *http.Request, route *mi
 
 	rPropertyName, rhkPropertyName, _ := route.Params.GetOK("propertyName")
 	if err := o.bindPropertyName(rPropertyName, rhkPropertyName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTenant, qhkTenant, _ := qs.GetOK("tenant")
+	if err := o.bindTenant(qTenant, qhkTenant, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -211,6 +220,24 @@ func (o *ObjectsClassReferencesPutParams) bindPropertyName(rawData []string, has
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.PropertyName = raw
+
+	return nil
+}
+
+// bindTenant binds and validates parameter Tenant from query.
+func (o *ObjectsClassReferencesPutParams) bindTenant(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Tenant = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_class_references_put_urlbuilder.go
+++ b/adapters/handlers/rest/operations/objects/objects_class_references_put_urlbuilder.go
@@ -32,6 +32,7 @@ type ObjectsClassReferencesPutURL struct {
 	PropertyName string
 
 	ConsistencyLevel *string
+	Tenant           *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -94,6 +95,14 @@ func (o *ObjectsClassReferencesPutURL) Build() (*url.URL, error) {
 	}
 	if consistencyLevelQ != "" {
 		qs.Set("consistency_level", consistencyLevelQ)
+	}
+
+	var tenantQ string
+	if o.Tenant != nil {
+		tenantQ = *o.Tenant
+	}
+	if tenantQ != "" {
+		qs.Set("tenant", tenantQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/adapters/handlers/rest/operations/objects/objects_references_create_parameters.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_create_parameters.go
@@ -61,6 +61,10 @@ type ObjectsReferencesCreateParams struct {
 	  In: path
 	*/
 	PropertyName string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	Tenant *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -71,6 +75,8 @@ func (o *ObjectsReferencesCreateParams) BindRequest(r *http.Request, route *midd
 	var res []error
 
 	o.HTTPRequest = r
+
+	qs := runtime.Values(r.URL.Query())
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
@@ -107,6 +113,11 @@ func (o *ObjectsReferencesCreateParams) BindRequest(r *http.Request, route *midd
 
 	rPropertyName, rhkPropertyName, _ := route.Params.GetOK("propertyName")
 	if err := o.bindPropertyName(rPropertyName, rhkPropertyName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTenant, qhkTenant, _ := qs.GetOK("tenant")
+	if err := o.bindTenant(qTenant, qhkTenant, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -158,6 +169,24 @@ func (o *ObjectsReferencesCreateParams) bindPropertyName(rawData []string, hasKe
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.PropertyName = raw
+
+	return nil
+}
+
+// bindTenant binds and validates parameter Tenant from query.
+func (o *ObjectsReferencesCreateParams) bindTenant(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Tenant = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_references_create_urlbuilder.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_create_urlbuilder.go
@@ -30,6 +30,8 @@ type ObjectsReferencesCreateURL struct {
 	ID           strfmt.UUID
 	PropertyName string
 
+	Tenant *string
+
 	_basePath string
 	// avoid unkeyed usage
 	_ struct{}
@@ -75,6 +77,18 @@ func (o *ObjectsReferencesCreateURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var tenantQ string
+	if o.Tenant != nil {
+		tenantQ = *o.Tenant
+	}
+	if tenantQ != "" {
+		qs.Set("tenant", tenantQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_references_delete_parameters.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_delete_parameters.go
@@ -61,6 +61,10 @@ type ObjectsReferencesDeleteParams struct {
 	  In: path
 	*/
 	PropertyName string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	Tenant *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -71,6 +75,8 @@ func (o *ObjectsReferencesDeleteParams) BindRequest(r *http.Request, route *midd
 	var res []error
 
 	o.HTTPRequest = r
+
+	qs := runtime.Values(r.URL.Query())
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
@@ -107,6 +113,11 @@ func (o *ObjectsReferencesDeleteParams) BindRequest(r *http.Request, route *midd
 
 	rPropertyName, rhkPropertyName, _ := route.Params.GetOK("propertyName")
 	if err := o.bindPropertyName(rPropertyName, rhkPropertyName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTenant, qhkTenant, _ := qs.GetOK("tenant")
+	if err := o.bindTenant(qTenant, qhkTenant, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -158,6 +169,24 @@ func (o *ObjectsReferencesDeleteParams) bindPropertyName(rawData []string, hasKe
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.PropertyName = raw
+
+	return nil
+}
+
+// bindTenant binds and validates parameter Tenant from query.
+func (o *ObjectsReferencesDeleteParams) bindTenant(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Tenant = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_references_delete_urlbuilder.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_delete_urlbuilder.go
@@ -30,6 +30,8 @@ type ObjectsReferencesDeleteURL struct {
 	ID           strfmt.UUID
 	PropertyName string
 
+	Tenant *string
+
 	_basePath string
 	// avoid unkeyed usage
 	_ struct{}
@@ -75,6 +77,18 @@ func (o *ObjectsReferencesDeleteURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var tenantQ string
+	if o.Tenant != nil {
+		tenantQ = *o.Tenant
+	}
+	if tenantQ != "" {
+		qs.Set("tenant", tenantQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_references_update_parameters.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_update_parameters.go
@@ -61,6 +61,10 @@ type ObjectsReferencesUpdateParams struct {
 	  In: path
 	*/
 	PropertyName string
+	/*Specifies the tenant in a request targeting a multi-tenant class
+	  In: query
+	*/
+	Tenant *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -71,6 +75,8 @@ func (o *ObjectsReferencesUpdateParams) BindRequest(r *http.Request, route *midd
 	var res []error
 
 	o.HTTPRequest = r
+
+	qs := runtime.Values(r.URL.Query())
 
 	if runtime.HasBody(r) {
 		defer r.Body.Close()
@@ -107,6 +113,11 @@ func (o *ObjectsReferencesUpdateParams) BindRequest(r *http.Request, route *midd
 
 	rPropertyName, rhkPropertyName, _ := route.Params.GetOK("propertyName")
 	if err := o.bindPropertyName(rPropertyName, rhkPropertyName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTenant, qhkTenant, _ := qs.GetOK("tenant")
+	if err := o.bindTenant(qTenant, qhkTenant, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -158,6 +169,24 @@ func (o *ObjectsReferencesUpdateParams) bindPropertyName(rawData []string, hasKe
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.PropertyName = raw
+
+	return nil
+}
+
+// bindTenant binds and validates parameter Tenant from query.
+func (o *ObjectsReferencesUpdateParams) bindTenant(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Tenant = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/objects/objects_references_update_urlbuilder.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_update_urlbuilder.go
@@ -30,6 +30,8 @@ type ObjectsReferencesUpdateURL struct {
 	ID           strfmt.UUID
 	PropertyName string
 
+	Tenant *string
+
 	_basePath string
 	// avoid unkeyed usage
 	_ struct{}
@@ -75,6 +77,18 @@ func (o *ObjectsReferencesUpdateURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var tenantQ string
+	if o.Tenant != nil {
+		tenantQ = *o.Tenant
+	}
+	if tenantQ != "" {
+		qs.Set("tenant", tenantQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/client/objects/objects_class_references_create_parameters.go
+++ b/client/objects/objects_class_references_create_parameters.go
@@ -103,6 +103,12 @@ type ObjectsClassReferencesCreateParams struct {
 	*/
 	PropertyName string
 
+	/* Tenant.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	Tenant *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -211,6 +217,17 @@ func (o *ObjectsClassReferencesCreateParams) SetPropertyName(propertyName string
 	o.PropertyName = propertyName
 }
 
+// WithTenant adds the tenant to the objects class references create params
+func (o *ObjectsClassReferencesCreateParams) WithTenant(tenant *string) *ObjectsClassReferencesCreateParams {
+	o.SetTenant(tenant)
+	return o
+}
+
+// SetTenant adds the tenant to the objects class references create params
+func (o *ObjectsClassReferencesCreateParams) SetTenant(tenant *string) {
+	o.Tenant = tenant
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ObjectsClassReferencesCreateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -254,6 +271,23 @@ func (o *ObjectsClassReferencesCreateParams) WriteToRequest(r runtime.ClientRequ
 	// path param propertyName
 	if err := r.SetPathParam("propertyName", o.PropertyName); err != nil {
 		return err
+	}
+
+	if o.Tenant != nil {
+
+		// query param tenant
+		var qrTenant string
+
+		if o.Tenant != nil {
+			qrTenant = *o.Tenant
+		}
+		qTenant := qrTenant
+		if qTenant != "" {
+
+			if err := r.SetQueryParam("tenant", qTenant); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/objects/objects_class_references_delete_parameters.go
+++ b/client/objects/objects_class_references_delete_parameters.go
@@ -103,6 +103,12 @@ type ObjectsClassReferencesDeleteParams struct {
 	*/
 	PropertyName string
 
+	/* Tenant.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	Tenant *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -211,6 +217,17 @@ func (o *ObjectsClassReferencesDeleteParams) SetPropertyName(propertyName string
 	o.PropertyName = propertyName
 }
 
+// WithTenant adds the tenant to the objects class references delete params
+func (o *ObjectsClassReferencesDeleteParams) WithTenant(tenant *string) *ObjectsClassReferencesDeleteParams {
+	o.SetTenant(tenant)
+	return o
+}
+
+// SetTenant adds the tenant to the objects class references delete params
+func (o *ObjectsClassReferencesDeleteParams) SetTenant(tenant *string) {
+	o.Tenant = tenant
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ObjectsClassReferencesDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -254,6 +271,23 @@ func (o *ObjectsClassReferencesDeleteParams) WriteToRequest(r runtime.ClientRequ
 	// path param propertyName
 	if err := r.SetPathParam("propertyName", o.PropertyName); err != nil {
 		return err
+	}
+
+	if o.Tenant != nil {
+
+		// query param tenant
+		var qrTenant string
+
+		if o.Tenant != nil {
+			qrTenant = *o.Tenant
+		}
+		qTenant := qrTenant
+		if qTenant != "" {
+
+			if err := r.SetQueryParam("tenant", qTenant); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/objects/objects_class_references_put_parameters.go
+++ b/client/objects/objects_class_references_put_parameters.go
@@ -103,6 +103,12 @@ type ObjectsClassReferencesPutParams struct {
 	*/
 	PropertyName string
 
+	/* Tenant.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	Tenant *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -211,6 +217,17 @@ func (o *ObjectsClassReferencesPutParams) SetPropertyName(propertyName string) {
 	o.PropertyName = propertyName
 }
 
+// WithTenant adds the tenant to the objects class references put params
+func (o *ObjectsClassReferencesPutParams) WithTenant(tenant *string) *ObjectsClassReferencesPutParams {
+	o.SetTenant(tenant)
+	return o
+}
+
+// SetTenant adds the tenant to the objects class references put params
+func (o *ObjectsClassReferencesPutParams) SetTenant(tenant *string) {
+	o.Tenant = tenant
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ObjectsClassReferencesPutParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -254,6 +271,23 @@ func (o *ObjectsClassReferencesPutParams) WriteToRequest(r runtime.ClientRequest
 	// path param propertyName
 	if err := r.SetPathParam("propertyName", o.PropertyName); err != nil {
 		return err
+	}
+
+	if o.Tenant != nil {
+
+		// query param tenant
+		var qrTenant string
+
+		if o.Tenant != nil {
+			qrTenant = *o.Tenant
+		}
+		qTenant := qrTenant
+		if qTenant != "" {
+
+			if err := r.SetQueryParam("tenant", qTenant); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/objects/objects_references_create_parameters.go
+++ b/client/objects/objects_references_create_parameters.go
@@ -91,6 +91,12 @@ type ObjectsReferencesCreateParams struct {
 	*/
 	PropertyName string
 
+	/* Tenant.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	Tenant *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -177,6 +183,17 @@ func (o *ObjectsReferencesCreateParams) SetPropertyName(propertyName string) {
 	o.PropertyName = propertyName
 }
 
+// WithTenant adds the tenant to the objects references create params
+func (o *ObjectsReferencesCreateParams) WithTenant(tenant *string) *ObjectsReferencesCreateParams {
+	o.SetTenant(tenant)
+	return o
+}
+
+// SetTenant adds the tenant to the objects references create params
+func (o *ObjectsReferencesCreateParams) SetTenant(tenant *string) {
+	o.Tenant = tenant
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ObjectsReferencesCreateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -198,6 +215,23 @@ func (o *ObjectsReferencesCreateParams) WriteToRequest(r runtime.ClientRequest, 
 	// path param propertyName
 	if err := r.SetPathParam("propertyName", o.PropertyName); err != nil {
 		return err
+	}
+
+	if o.Tenant != nil {
+
+		// query param tenant
+		var qrTenant string
+
+		if o.Tenant != nil {
+			qrTenant = *o.Tenant
+		}
+		qTenant := qrTenant
+		if qTenant != "" {
+
+			if err := r.SetQueryParam("tenant", qTenant); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/objects/objects_references_delete_parameters.go
+++ b/client/objects/objects_references_delete_parameters.go
@@ -91,6 +91,12 @@ type ObjectsReferencesDeleteParams struct {
 	*/
 	PropertyName string
 
+	/* Tenant.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	Tenant *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -177,6 +183,17 @@ func (o *ObjectsReferencesDeleteParams) SetPropertyName(propertyName string) {
 	o.PropertyName = propertyName
 }
 
+// WithTenant adds the tenant to the objects references delete params
+func (o *ObjectsReferencesDeleteParams) WithTenant(tenant *string) *ObjectsReferencesDeleteParams {
+	o.SetTenant(tenant)
+	return o
+}
+
+// SetTenant adds the tenant to the objects references delete params
+func (o *ObjectsReferencesDeleteParams) SetTenant(tenant *string) {
+	o.Tenant = tenant
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ObjectsReferencesDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -198,6 +215,23 @@ func (o *ObjectsReferencesDeleteParams) WriteToRequest(r runtime.ClientRequest, 
 	// path param propertyName
 	if err := r.SetPathParam("propertyName", o.PropertyName); err != nil {
 		return err
+	}
+
+	if o.Tenant != nil {
+
+		// query param tenant
+		var qrTenant string
+
+		if o.Tenant != nil {
+			qrTenant = *o.Tenant
+		}
+		qTenant := qrTenant
+		if qTenant != "" {
+
+			if err := r.SetQueryParam("tenant", qTenant); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/objects/objects_references_update_parameters.go
+++ b/client/objects/objects_references_update_parameters.go
@@ -91,6 +91,12 @@ type ObjectsReferencesUpdateParams struct {
 	*/
 	PropertyName string
 
+	/* Tenant.
+
+	   Specifies the tenant in a request targeting a multi-tenant class
+	*/
+	Tenant *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -177,6 +183,17 @@ func (o *ObjectsReferencesUpdateParams) SetPropertyName(propertyName string) {
 	o.PropertyName = propertyName
 }
 
+// WithTenant adds the tenant to the objects references update params
+func (o *ObjectsReferencesUpdateParams) WithTenant(tenant *string) *ObjectsReferencesUpdateParams {
+	o.SetTenant(tenant)
+	return o
+}
+
+// SetTenant adds the tenant to the objects references update params
+func (o *ObjectsReferencesUpdateParams) SetTenant(tenant *string) {
+	o.Tenant = tenant
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ObjectsReferencesUpdateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -198,6 +215,23 @@ func (o *ObjectsReferencesUpdateParams) WriteToRequest(r runtime.ClientRequest, 
 	// path param propertyName
 	if err := r.SetPathParam("propertyName", o.PropertyName); err != nil {
 		return err
+	}
+
+	if o.Tenant != nil {
+
+		// query param tenant
+		var qrTenant string
+
+		if o.Tenant != nil {
+			qrTenant = *o.Tenant
+		}
+		qTenant := qrTenant
+		if qTenant != "" {
+
+			if err := r.SetQueryParam("tenant", qTenant); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/entities/models/single_ref.go
+++ b/entities/models/single_ref.go
@@ -47,9 +47,6 @@ type SingleRef struct {
 
 	// If using a concept reference (rather than a direct reference), specify the desired properties here
 	Schema PropertySchema `json:"schema,omitempty"`
-
-	// Name of the reference tenant.
-	Tenant string `json:"tenant,omitempty"`
 }
 
 // Validate validates this single ref

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1053,10 +1053,6 @@
         "classification": {
           "description": "Additional Meta information about classifications if the item was part of one",
           "$ref": "#/definitions/ReferenceMetaClassification"
-        },
-        "tenant": {
-          "type": "string",
-          "description": "Name of the reference tenant."
         }
       }
     },
@@ -2680,6 +2676,9 @@
             "schema": {
               "$ref": "#/definitions/SingleRef"
             }
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2745,6 +2744,9 @@
             "schema": {
               "$ref": "#/definitions/MultipleRef"
             }
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2810,6 +2812,9 @@
             "schema": {
               "$ref": "#/definitions/SingleRef"
             }
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2887,6 +2892,9 @@
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -2970,6 +2978,9 @@
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {
@@ -3053,6 +3064,9 @@
           },
           {
             "$ref": "#/parameters/CommonConsistencyLevelParameterQuery"
+          },
+          {
+            "$ref": "#/parameters/CommonTenantParameterQuery"
           }
         ],
         "responses": {

--- a/test/acceptance/multi_tenancy/tenant_objects_reference_test.go
+++ b/test/acceptance/multi_tenancy/tenant_objects_reference_test.go
@@ -26,7 +26,7 @@ func TestTenantObjectsReference(t *testing.T) {
 	mutableProp := "mutableProp"
 	refProp := "refProp"
 	testClass := models.Class{
-		Class: "MultiTenantClass",
+		Class: className,
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled: true,
 		},
@@ -118,7 +118,7 @@ func TestTenantObjectsReference(t *testing.T) {
 	t.Run("create tenants", func(t *testing.T) {
 		tenants := make([]*models.Tenant, len(tenantNames))
 		for i := range tenants {
-			tenants[i] = &models.Tenant{tenantNames[i]}
+			tenants[i] = &models.Tenant{Name: tenantNames[i]}
 		}
 		helper.CreateTenants(t, className, tenants)
 	})
@@ -142,8 +142,8 @@ func TestTenantObjectsReference(t *testing.T) {
 
 	t.Run("add tenant object references", func(t *testing.T) {
 		for i, obj := range tenantObjects {
-			ref := &models.SingleRef{Beacon: helper.NewBeacon(className, tenantRefs[i].ID), Tenant: tenantNames[i]}
-			helper.AddReference(t, obj, ref, refProp)
+			ref := &models.SingleRef{Beacon: helper.NewBeacon(className, tenantRefs[i].ID)}
+			helper.AddReferenceTenant(t, obj, ref, refProp, tenantNames[i])
 		}
 
 		t.Run("assert tenant object references", func(t *testing.T) {
@@ -162,8 +162,8 @@ func TestTenantObjectsReference(t *testing.T) {
 
 	t.Run("delete tenant object references", func(Z *testing.T) {
 		for i, obj := range tenantObjects {
-			ref := &models.SingleRef{Beacon: helper.NewBeacon(className, tenantRefs[i].ID), Tenant: tenantNames[i]}
-			helper.DeleteReference(t, obj, ref, refProp)
+			ref := &models.SingleRef{Beacon: helper.NewBeacon(className, tenantRefs[i].ID)}
+			helper.DeleteReferenceTenant(t, obj, ref, refProp, tenantNames[i])
 		}
 
 		t.Run("assert tenant object references", func(t *testing.T) {

--- a/test/acceptance/multi_tenancy/update_tenant_references_test.go
+++ b/test/acceptance/multi_tenancy/update_tenant_references_test.go
@@ -1,0 +1,134 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestTenantObjectsReferenceUpdates(t *testing.T) {
+	className := "MultiTenantClass"
+	refProp := "refProp1"
+
+	class := models.Class{
+		Class:              className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		Properties: []*models.Property{
+			{Name: refProp, DataType: []string{className}},
+		},
+	}
+	defer func() {
+		helper.DeleteClass(t, className)
+	}()
+	helper.CreateClass(t, &class)
+
+	tenantNames := []string{"Tenant1", "Tenant2", "Tenant3"}
+	tenants := make([]*models.Tenant, len(tenantNames))
+	for i := range tenants {
+		tenants[i] = &models.Tenant{Name: tenantNames[i]}
+	}
+	helper.CreateTenants(t, className, tenants)
+
+	objs := make([]*models.Object, 0)
+	for i := 0; i < len(tenantNames)*4; i++ {
+		obj := &models.Object{
+			ID:     strfmt.UUID(uuid.New().String()),
+			Class:  className,
+			Tenant: tenantNames[i%len(tenantNames)],
+		}
+		objs = append(objs, obj)
+		helper.CreateObject(t, obj)
+	}
+
+	for _, obj := range objs {
+		ref := &models.SingleRef{Beacon: helper.NewBeacon(className, obj.ID)}
+		helper.AddReferenceTenant(t, obj, ref, refProp, obj.Tenant)
+		helper.AddReferenceTenant(t, obj, ref, refProp, obj.Tenant)
+	}
+
+	for _, obj := range objs {
+		resp, err := helper.TenantObject(t, obj.Class, obj.ID, obj.Tenant)
+		require.Nil(t, err)
+		require.Equal(t, obj.ID, resp.ID)
+		require.Equal(t, obj.Class, resp.Class)
+		refs := resp.Properties.(map[string]interface{})[refProp].([]interface{})
+		require.Len(t, refs, 2)
+		expectedBeacon := helper.NewBeacon(className, obj.ID).String()
+		assert.Equal(t, expectedBeacon, refs[0].(map[string]interface{})["beacon"])
+	}
+
+	t.Run("Update reference - single", func(t *testing.T) {
+		for i, obj := range objs {
+			j := (i + len(tenantNames)) % len(objs) // always reference the next object with the same tenant
+			ref := models.MultipleRef{{Beacon: helper.NewBeacon(className, objs[j].ID)}}
+			helper.UpdateReferenceTenant(t, obj, ref, refProp, obj.Tenant)
+		}
+
+		for i, obj := range objs {
+			resp, err := helper.TenantObject(t, obj.Class, obj.ID, obj.Tenant)
+			require.Nil(t, err)
+			require.Equal(t, obj.ID, resp.ID)
+			require.Equal(t, obj.Class, resp.Class)
+			refs := resp.Properties.(map[string]interface{})[refProp].([]interface{})
+			require.Len(t, refs, 1)
+			j := (i + len(tenantNames)) % len(objs) // always reference the next object with the same tenant
+			expectedBeacon := helper.NewBeacon(className, objs[j].ID).String()
+			assert.Equal(t, expectedBeacon, refs[0].(map[string]interface{})["beacon"])
+		}
+	})
+
+	t.Run("Update reference - multiple", func(t *testing.T) {
+		for i, obj := range objs {
+			ref := models.MultipleRef{}
+			j := (i + 2*len(tenantNames)) % len(objs)
+			ref = append(ref, &models.SingleRef{Beacon: helper.NewBeacon(className, objs[j].ID)})
+			ref = append(ref, &models.SingleRef{Beacon: helper.NewBeacon(className, objs[j].ID)})
+			ref = append(ref, &models.SingleRef{Beacon: helper.NewBeacon(className, objs[j].ID)})
+			helper.UpdateReferenceTenant(t, obj, ref, refProp, obj.Tenant)
+		}
+
+		for i, obj := range objs {
+			resp, err := helper.TenantObject(t, obj.Class, obj.ID, obj.Tenant)
+			require.Nil(t, err)
+			require.Equal(t, obj.ID, resp.ID)
+			require.Equal(t, obj.Class, resp.Class)
+			refs := resp.Properties.(map[string]interface{})[refProp].([]interface{})
+			require.Len(t, refs, 3)
+			j := (i + 2*len(tenantNames)) % len(objs) // always reference the next object with the same tenant
+			expectedBeacon := helper.NewBeacon(className, objs[j].ID).String()
+			assert.Equal(t, expectedBeacon, refs[0].(map[string]interface{})["beacon"])
+		}
+	})
+
+	t.Run("Update reference - empty", func(t *testing.T) {
+		for _, obj := range objs {
+			ref := models.MultipleRef{}
+			helper.UpdateReferenceTenant(t, obj, ref, refProp, obj.Tenant)
+		}
+
+		for _, obj := range objs {
+			resp, err := helper.TenantObject(t, obj.Class, obj.ID, obj.Tenant)
+			require.Nil(t, err)
+			require.Equal(t, obj.ID, resp.ID)
+			require.Equal(t, obj.Class, resp.Class)
+			refs := resp.Properties.(map[string]interface{})[refProp].([]interface{})
+			require.Len(t, refs, 0)
+		}
+	})
+}

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -166,10 +166,31 @@ func AddReference(t *testing.T, object *models.Object, ref *models.SingleRef, pr
 	AssertRequestOk(t, resp, err, nil)
 }
 
+func AddReferenceTenant(t *testing.T, object *models.Object, ref *models.SingleRef, prop string, tenant string) {
+	params := objects.NewObjectsClassReferencesCreateParams().
+		WithClassName(object.Class).WithID(object.ID).WithBody(ref).WithPropertyName(prop).WithTenant(&tenant)
+	resp, err := Client(t).Objects.ObjectsClassReferencesCreate(params, nil)
+	AssertRequestOk(t, resp, err, nil)
+}
+
 func DeleteReference(t *testing.T, object *models.Object, ref *models.SingleRef, prop string) {
 	params := objects.NewObjectsClassReferencesDeleteParams().
 		WithClassName(object.Class).WithID(object.ID).WithBody(ref).WithPropertyName(prop)
 	resp, err := Client(t).Objects.ObjectsClassReferencesDelete(params, nil)
+	AssertRequestOk(t, resp, err, nil)
+}
+
+func DeleteReferenceTenant(t *testing.T, object *models.Object, ref *models.SingleRef, prop string, tenant string) {
+	params := objects.NewObjectsClassReferencesDeleteParams().
+		WithClassName(object.Class).WithID(object.ID).WithBody(ref).WithPropertyName(prop).WithTenant(&tenant)
+	resp, err := Client(t).Objects.ObjectsClassReferencesDelete(params, nil)
+	AssertRequestOk(t, resp, err, nil)
+}
+
+func UpdateReferenceTenant(t *testing.T, object *models.Object, ref models.MultipleRef, prop string, tenant string) {
+	params := objects.NewObjectsClassReferencesPutParams().
+		WithClassName(object.Class).WithID(object.ID).WithBody(ref).WithPropertyName(prop).WithTenant(&tenant)
+	resp, err := Client(t).Objects.ObjectsClassReferencesPut(params, nil)
 	AssertRequestOk(t, resp, err, nil)
 }
 

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -34,14 +34,14 @@ type DeleteReferenceInput struct {
 }
 
 func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.Principal,
-	input *DeleteReferenceInput, repl *additional.ReplicationProperties,
+	input *DeleteReferenceInput, repl *additional.ReplicationProperties, tenant string,
 ) *Error {
 	m.metrics.DeleteReferenceInc()
 	defer m.metrics.DeleteReferenceDec()
 
 	deprecatedEndpoint := input.Class == ""
 	res, err := m.getObjectFromRepo(ctx, input.Class, input.ID,
-		additional.Properties{}, nil, input.Reference.Tenant)
+		additional.Properties{}, nil, tenant)
 	if err != nil {
 		errnf := ErrNotFound{}
 		if errors.As(err, &errnf) {
@@ -70,7 +70,7 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	}
 
 	obj := res.Object()
-	obj.Tenant = input.Reference.Tenant
+	obj.Tenant = tenant
 	ok, errmsg := removeReference(obj, input.Property, &input.Reference)
 	if errmsg != "" {
 		return &Error{errmsg, StatusInternalServerError, nil}


### PR DESCRIPTION
### What's being changed:

- Move tenant out of body of SingleRef and add it as a REST parameter. reference update now work with multi-refs and tenants

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
