### PR TITLE
Use tenant names in delete

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2786,26 +2786,20 @@ func init() {
             "required": true
           },
           {
-            "name": "body",
+            "name": "tenants",
             "in": "body",
             "required": true,
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Tenant"
+                "type": "string"
               }
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Deleted tenants from specified class.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Tenant"
-              }
-            }
+            "description": "Deleted tenants from specified class."
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
@@ -7491,26 +7485,20 @@ func init() {
             "required": true
           },
           {
-            "name": "body",
+            "name": "tenants",
             "in": "body",
             "required": true,
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Tenant"
+                "type": "string"
               }
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Deleted tenants from specified class.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Tenant"
-              }
-            }
+            "description": "Deleted tenants from specified class."
           },
           "401": {
             "description": "Unauthorized or invalid credentials."

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -216,7 +216,7 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	err := s.manager.DeleteTenants(
-		params.HTTPRequest.Context(), principal, params.ClassName, params.Body)
+		params.HTTPRequest.Context(), principal, params.ClassName, params.Tenants)
 	if err != nil {
 		switch err.(type) {
 		case errors.Forbidden:
@@ -228,9 +228,7 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 		}
 	}
 
-	payload := params.Body
-
-	return schema.NewTenantsDeleteOK().WithPayload(payload)
+	return schema.NewTenantsDeleteOK()
 }
 
 func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager) {

--- a/adapters/handlers/rest/operations/schema/tenants_delete_responses.go
+++ b/adapters/handlers/rest/operations/schema/tenants_delete_responses.go
@@ -33,11 +33,6 @@ TenantsDeleteOK Deleted tenants from specified class.
 swagger:response tenantsDeleteOK
 */
 type TenantsDeleteOK struct {
-
-	/*
-	  In: Body
-	*/
-	Payload []*models.Tenant `json:"body,omitempty"`
 }
 
 // NewTenantsDeleteOK creates TenantsDeleteOK with default headers values
@@ -46,30 +41,12 @@ func NewTenantsDeleteOK() *TenantsDeleteOK {
 	return &TenantsDeleteOK{}
 }
 
-// WithPayload adds the payload to the tenants delete o k response
-func (o *TenantsDeleteOK) WithPayload(payload []*models.Tenant) *TenantsDeleteOK {
-	o.Payload = payload
-	return o
-}
-
-// SetPayload sets the payload to the tenants delete o k response
-func (o *TenantsDeleteOK) SetPayload(payload []*models.Tenant) {
-	o.Payload = payload
-}
-
 // WriteResponse to the client
 func (o *TenantsDeleteOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.WriteHeader(200)
-	payload := o.Payload
-	if payload == nil {
-		// return empty array
-		payload = make([]*models.Tenant, 0, 50)
-	}
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
-	}
+	rw.WriteHeader(200)
 }
 
 // TenantsDeleteUnauthorizedCode is the HTTP code returned for type TenantsDeleteUnauthorized

--- a/client/schema/tenants_delete_parameters.go
+++ b/client/schema/tenants_delete_parameters.go
@@ -25,8 +25,6 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-
-	"github.com/weaviate/weaviate/entities/models"
 )
 
 // NewTenantsDeleteParams creates a new TenantsDeleteParams object,
@@ -74,11 +72,11 @@ TenantsDeleteParams contains all the parameters to send to the API endpoint
 */
 type TenantsDeleteParams struct {
 
-	// Body.
-	Body []*models.Tenant
-
 	// ClassName.
 	ClassName string
+
+	// Tenants.
+	Tenants []string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -133,17 +131,6 @@ func (o *TenantsDeleteParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithBody adds the body to the tenants delete params
-func (o *TenantsDeleteParams) WithBody(body []*models.Tenant) *TenantsDeleteParams {
-	o.SetBody(body)
-	return o
-}
-
-// SetBody adds the body to the tenants delete params
-func (o *TenantsDeleteParams) SetBody(body []*models.Tenant) {
-	o.Body = body
-}
-
 // WithClassName adds the className to the tenants delete params
 func (o *TenantsDeleteParams) WithClassName(className string) *TenantsDeleteParams {
 	o.SetClassName(className)
@@ -155,6 +142,17 @@ func (o *TenantsDeleteParams) SetClassName(className string) {
 	o.ClassName = className
 }
 
+// WithTenants adds the tenants to the tenants delete params
+func (o *TenantsDeleteParams) WithTenants(tenants []string) *TenantsDeleteParams {
+	o.SetTenants(tenants)
+	return o
+}
+
+// SetTenants adds the tenants to the tenants delete params
+func (o *TenantsDeleteParams) SetTenants(tenants []string) {
+	o.Tenants = tenants
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *TenantsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -162,15 +160,15 @@ func (o *TenantsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
-	if o.Body != nil {
-		if err := r.SetBodyParam(o.Body); err != nil {
-			return err
-		}
-	}
 
 	// path param className
 	if err := r.SetPathParam("className", o.ClassName); err != nil {
 		return err
+	}
+	if o.Tenants != nil {
+		if err := r.SetBodyParam(o.Tenants); err != nil {
+			return err
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/schema/tenants_delete_responses.go
+++ b/client/schema/tenants_delete_responses.go
@@ -80,7 +80,6 @@ TenantsDeleteOK describes a response with status code 200, with default header v
 Deleted tenants from specified class.
 */
 type TenantsDeleteOK struct {
-	Payload []*models.Tenant
 }
 
 // IsSuccess returns true when this tenants delete o k response has a 2xx status code
@@ -114,23 +113,14 @@ func (o *TenantsDeleteOK) Code() int {
 }
 
 func (o *TenantsDeleteOK) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK ", 200)
 }
 
 func (o *TenantsDeleteOK) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK  %+v", 200, o.Payload)
-}
-
-func (o *TenantsDeleteOK) GetPayload() []*models.Tenant {
-	return o.Payload
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK ", 200)
 }
 
 func (o *TenantsDeleteOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
-		return err
-	}
 
 	return nil
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -4059,25 +4059,19 @@
           },
           {
             "in": "body",
-            "name": "body",
+            "name": "tenants",
             "required": true,
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Tenant"
+                "type": "string"
               }
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Deleted tenants from specified class.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Tenant"
-              }
-            }
+            "description": "Deleted tenants from specified class."
           },
           "401": {
             "description": "Unauthorized or invalid credentials."

--- a/test/acceptance/multi_tenancy/create_and_delete_tenants_test.go
+++ b/test/acceptance/multi_tenancy/create_and_delete_tenants_test.go
@@ -121,15 +121,15 @@ func TestDeleteTenants(t *testing.T) {
 
 	t.Run("Delete non-existent tenant alongside existing", func(Z *testing.T) {
 		err := helper.DeleteTenants(t, testClass.Class, []string{"tenant1", "tenant5"})
-		require.NotNil(t, err)
+		require.Nil(t, err)
 
-		// nothing deleted
+		// idempotent - deleting multiple times works - tenant1 is removed
 		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
 		require.Nil(t, err)
 		require.NotNil(t, resp.Payload)
 		require.NotNil(t, resp.Payload.Nodes)
 		require.Len(t, resp.Payload.Nodes, 1)
-		require.Len(t, resp.Payload.Nodes[0].Shards, 3)
+		require.Len(t, resp.Payload.Nodes[0].Shards, 2)
 	})
 
 	t.Run("Delete tenants", func(Z *testing.T) {

--- a/test/acceptance/multi_tenancy/create_and_delete_tenants_test.go
+++ b/test/acceptance/multi_tenancy/create_and_delete_tenants_test.go
@@ -87,3 +87,61 @@ func TestCreateTenants(t *testing.T) {
 		require.NotNil(t, err)
 	})
 }
+
+func TestDeleteTenants(t *testing.T) {
+	testClass := models.Class{
+		Class:              "MultiTenantClassDelete",
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	}
+
+	defer func() {
+		helper.DeleteClass(t, testClass.Class)
+	}()
+	helper.CreateClass(t, &testClass)
+
+	tenants := []string{"tenant1", "tenant2", "tenant3"}
+	var tenantsObject []*models.Tenant
+	for _, tenant := range tenants {
+		tenantsObject = append(tenantsObject, &models.Tenant{Name: tenant})
+	}
+	helper.CreateTenants(t, testClass.Class, tenantsObject)
+
+	t.Run("Delete same tenant multiple times", func(Z *testing.T) {
+		err := helper.DeleteTenants(t, testClass.Class, []string{"tenant1", "tenant1"})
+		require.NotNil(t, err)
+
+		// nothing deleted
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		require.Nil(t, err)
+		require.NotNil(t, resp.Payload)
+		require.NotNil(t, resp.Payload.Nodes)
+		require.Len(t, resp.Payload.Nodes, 1)
+		require.Len(t, resp.Payload.Nodes[0].Shards, 3)
+	})
+
+	t.Run("Delete non-existent tenant alongside existing", func(Z *testing.T) {
+		err := helper.DeleteTenants(t, testClass.Class, []string{"tenant1", "tenant5"})
+		require.NotNil(t, err)
+
+		// nothing deleted
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		require.Nil(t, err)
+		require.NotNil(t, resp.Payload)
+		require.NotNil(t, resp.Payload.Nodes)
+		require.Len(t, resp.Payload.Nodes, 1)
+		require.Len(t, resp.Payload.Nodes[0].Shards, 3)
+	})
+
+	t.Run("Delete tenants", func(Z *testing.T) {
+		err := helper.DeleteTenants(t, testClass.Class, []string{"tenant1", "tenant3"})
+		require.Nil(t, err)
+
+		// successfully deleted
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		require.Nil(t, err)
+		require.NotNil(t, resp.Payload)
+		require.NotNil(t, resp.Payload.Nodes)
+		require.Len(t, resp.Payload.Nodes, 1)
+		require.Len(t, resp.Payload.Nodes[0].Shards, 1)
+	})
+}

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -206,6 +206,12 @@ func CreateTenantsReturnError(t *testing.T, class string, tenants []*models.Tena
 	return err
 }
 
+func DeleteTenants(t *testing.T, class string, tenants []string) error {
+	params := schema.NewTenantsDeleteParams().WithClassName(class).WithTenants(tenants)
+	_, err := Client(t).Schema.TenantsDelete(params, nil)
+	return err
+}
+
 func NewBeacon(className string, id strfmt.UUID) strfmt.URI {
 	return crossref.New("localhost", className, id).SingleRef().Beacon
 }

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -98,7 +98,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:       "DeleteTenants",
-			additionalArgs:   []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
+			additionalArgs:   []interface{}{"className", []string{"P1"}},
 			expectedVerb:     "delete",
 			expectedResource: tenantsPath,
 		},

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -38,9 +38,13 @@ func (m *Manager) AddTenants(ctx context.Context,
 	if err := m.Authorizer.Authorize(principal, "update", tenantsPath); err != nil {
 		return err
 	}
+	tenantNames := make([]string, len(tenants))
+	for i, tenant := range tenants {
+		tenantNames[i] = tenant.Name
+	}
 
 	// validation
-	if err := validateTenants(tenants); err != nil {
+	if err := validateTenants(tenantNames); err != nil {
 		return err
 	}
 	cls := m.getClassByName(class)
@@ -52,10 +56,6 @@ func (m *Manager) AddTenants(ctx context.Context,
 	}
 
 	// create transaction payload
-	tenantNames := make([]string, len(tenants))
-	for i, tenant := range tenants {
-		tenantNames[i] = tenant.Name
-	}
 	partitions, err := m.getPartitions(cls, tenantNames)
 	if err != nil {
 		return fmt.Errorf("get partitions from class %q: %w", class, err)
@@ -105,16 +105,16 @@ func (m *Manager) getPartitions(cls *models.Class, shards []string) (map[string]
 	return st.GetPartitions(m.clusterState, shards, rf)
 }
 
-func validateTenants(tenants []*models.Tenant) error {
+func validateTenants(tenants []string) error {
 	names := make(map[string]struct{}, len(tenants)) // check for name uniqueness
 	for i, tenant := range tenants {
-		_, nameExists := names[tenant.Name]
+		_, nameExists := names[tenant]
 		if nameExists {
-			return uco.NewErrInvalidUserInput("duplicate tenant name %s", tenant.Name)
+			return uco.NewErrInvalidUserInput("duplicate tenant name %s", tenant)
 		}
-		names[tenant.Name] = struct{}{}
+		names[tenant] = struct{}{}
 
-		if !regexTenantName.MatchString(tenant.Name) {
+		if !regexTenantName.MatchString(tenant) {
 			return uco.NewErrInvalidUserInput("invalid tenant name at index %d", i)
 		}
 	}
@@ -170,9 +170,10 @@ func (m *Manager) onAddTenants(ctx context.Context, class *models.Class, request
 	return nil
 }
 
-// DeleteTenants is used to delete tenants of a class
+// DeleteTenants is used to delete tenants of a class.
+//
 // Class must exist and has partitioning enabled
-func (m *Manager) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []*models.Tenant) error {
+func (m *Manager) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
 	if err := m.Authorizer.Authorize(principal, "delete", tenantsPath); err != nil {
 		return err
 	}
@@ -188,15 +189,23 @@ func (m *Manager) DeleteTenants(ctx context.Context, principal *models.Principal
 		return fmt.Errorf("multi-tenancy is not enabled for class %q", class)
 	}
 
-	// create transaction payload
-	tenantNames := make([]string, len(tenants))
-	for i, tenant := range tenants {
-		tenantNames[i] = tenant.Name
+	m.shardingStateLock.Lock()
+	ss := m.state.ShardingState[class]
+	var nonExistentTenants []string
+	for _, tenant := range tenants {
+		if !ss.PartitionExists(tenant) {
+			nonExistentTenants = append(nonExistentTenants, tenant)
+		}
 	}
+	if len(nonExistentTenants) > 0 {
+		m.shardingStateLock.Unlock()
+		return fmt.Errorf("tenants do not exist %s", nonExistentTenants)
+	}
+	m.shardingStateLock.Unlock()
 
 	request := DeleteTenantsPayload{
 		Class:   class,
-		Tenants: tenantNames,
+		Tenants: tenants,
 	}
 
 	// open cluster-wide transaction

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -189,20 +189,6 @@ func (m *Manager) DeleteTenants(ctx context.Context, principal *models.Principal
 		return fmt.Errorf("multi-tenancy is not enabled for class %q", class)
 	}
 
-	m.shardingStateLock.Lock()
-	ss := m.state.ShardingState[class]
-	var nonExistentTenants []string
-	for _, tenant := range tenants {
-		if !ss.PartitionExists(tenant) {
-			nonExistentTenants = append(nonExistentTenants, tenant)
-		}
-	}
-	if len(nonExistentTenants) > 0 {
-		m.shardingStateLock.Unlock()
-		return fmt.Errorf("tenants do not exist %s", nonExistentTenants)
-	}
-	m.shardingStateLock.Unlock()
-
 	request := DeleteTenantsPayload{
 		Class:   class,
 		Tenants: tenants,

--- a/usecases/schema/tenant_test.go
+++ b/usecases/schema/tenant_test.go
@@ -228,7 +228,12 @@ func TestDeleteTenants(t *testing.T) {
 				t.Fatalf("%s: add tenants: %v", test.name, err)
 			}
 		}
-		err = sm.DeleteTenants(ctx, nil, test.Class, test.tenants)
+		var tenantNames []string
+		for i := range test.tenants {
+			tenantNames = append(tenantNames, test.tenants[i].Name)
+		}
+
+		err = sm.DeleteTenants(ctx, nil, test.Class, tenantNames)
 		if test.errMsg == "" {
 			if err != nil {
 				t.Fatalf("%s: remove tenants: %v", test.name, err)

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -343,6 +343,12 @@ func (s *State) DeletePartition(name string) {
 	delete(s.Physical, name)
 }
 
+// PartitionExists to physical shards
+func (s *State) PartitionExists(name string) bool {
+	_, ok := s.Physical[name]
+	return ok
+}
+
 func (s *State) initVirtual() {
 	count := s.Config.DesiredVirtualCount
 	s.Virtual = make([]Virtual, count)

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -343,12 +343,6 @@ func (s *State) DeletePartition(name string) {
 	delete(s.Physical, name)
 }
 
-// PartitionExists to physical shards
-func (s *State) PartitionExists(name string) bool {
-	_, ok := s.Physical[name]
-	return ok
-}
-
 func (s *State) initVirtual() {
 	count := s.Config.DesiredVirtualCount
 	s.Virtual = make([]Virtual, count)


### PR DESCRIPTION
### What's being changed:

- change API of tenant delete to use names instead of Tenant-objects
- only return status, not list of tenants

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

