### PR TITLE
Remove tenants from response for AddTenant

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2741,13 +2741,7 @@ func init() {
         ],
         "responses": {
           "200": {
-            "description": "Added new tenants to the specified class",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Tenant"
-              }
-            }
+            "description": "Added new tenants to the specified class"
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
@@ -7440,13 +7434,7 @@ func init() {
         ],
         "responses": {
           "200": {
-            "description": "Added new tenants to the specified class",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Tenant"
-              }
-            }
+            "description": "Added new tenants to the specified class"
           },
           "401": {
             "description": "Unauthorized or invalid credentials."

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -207,9 +207,7 @@ func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 		}
 	}
 
-	payload := params.Body
-
-	return schema.NewTenantsCreateOK().WithPayload(payload)
+	return schema.NewTenantsCreateOK()
 }
 
 func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,

--- a/adapters/handlers/rest/operations/schema/tenants_create_responses.go
+++ b/adapters/handlers/rest/operations/schema/tenants_create_responses.go
@@ -33,11 +33,6 @@ TenantsCreateOK Added new tenants to the specified class
 swagger:response tenantsCreateOK
 */
 type TenantsCreateOK struct {
-
-	/*
-	  In: Body
-	*/
-	Payload []*models.Tenant `json:"body,omitempty"`
 }
 
 // NewTenantsCreateOK creates TenantsCreateOK with default headers values
@@ -46,30 +41,12 @@ func NewTenantsCreateOK() *TenantsCreateOK {
 	return &TenantsCreateOK{}
 }
 
-// WithPayload adds the payload to the tenants create o k response
-func (o *TenantsCreateOK) WithPayload(payload []*models.Tenant) *TenantsCreateOK {
-	o.Payload = payload
-	return o
-}
-
-// SetPayload sets the payload to the tenants create o k response
-func (o *TenantsCreateOK) SetPayload(payload []*models.Tenant) {
-	o.Payload = payload
-}
-
 // WriteResponse to the client
 func (o *TenantsCreateOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.WriteHeader(200)
-	payload := o.Payload
-	if payload == nil {
-		// return empty array
-		payload = make([]*models.Tenant, 0, 50)
-	}
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
-	}
+	rw.WriteHeader(200)
 }
 
 // TenantsCreateUnauthorizedCode is the HTTP code returned for type TenantsCreateUnauthorized

--- a/client/schema/tenants_create_responses.go
+++ b/client/schema/tenants_create_responses.go
@@ -80,7 +80,6 @@ TenantsCreateOK describes a response with status code 200, with default header v
 Added new tenants to the specified class
 */
 type TenantsCreateOK struct {
-	Payload []*models.Tenant
 }
 
 // IsSuccess returns true when this tenants create o k response has a 2xx status code
@@ -114,23 +113,14 @@ func (o *TenantsCreateOK) Code() int {
 }
 
 func (o *TenantsCreateOK) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK ", 200)
 }
 
 func (o *TenantsCreateOK) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK  %+v", 200, o.Payload)
-}
-
-func (o *TenantsCreateOK) GetPayload() []*models.Tenant {
-	return o.Payload
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK ", 200)
 }
 
 func (o *TenantsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
-		return err
-	}
 
 	return nil
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -4013,13 +4013,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Added new tenants to the specified class",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Tenant"
-              }
-            }
+            "description": "Added new tenants to the specified class"
           },
           "401": {
             "description": "Unauthorized or invalid credentials."


### PR DESCRIPTION
### What's being changed:

response from AddTenants contained the Tenants simply returning the body. For a successfull request it now only returns a status code 

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

