### PR TITLE
Fix data race in commit logger

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -65,10 +65,9 @@ func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
 		return nil, err
 	}
 
+	l.commitLogger = commitlog.NewLoggerWithFile(fd)
 	l.unregisterSwitchLogs = maintenanceCycle.Register(l.startSwitchLogs)
 	l.unregisterCondenseLogs = maintenanceCycle.Register(l.startCombineAndCondenseLogs)
-
-	l.commitLogger = commitlog.NewLoggerWithFile(fd)
 
 	return l, nil
 }


### PR DESCRIPTION
### What's being changed:

The cycle manager (calling switchCommitLogs::switchCommitLogs ) and the commit logger New() function had a race.

chaos pipeline succesfull: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/5454016115

race stack trace
```
2023-07-02 21:20:50 Read at 0x00c00292a6f0 by goroutine 2319:
2023-07-02 21:20:50   github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog.(*Logger).FileSize()
2023-07-02 21:20:50       /go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog/logger.go:219 +0x2c
2023-07-02 21:20:50   github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnswCommitLogger).switchCommitLogs()
2023-07-02 21:20:50       /go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commit_logger.go:442 +0x8c
2023-07-02 21:20:50   github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnswCommitLogger).startSwitchLogs()
2023-07-02 21:20:50       /go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commit_logger.go:407 +0x34
2023-07-02 21:20:50   github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnswCommitLogger).startSwitchLogs-fm()
2023-07-02 21:20:50       <autogenerated>:1 +0x3c
2023-07-02 21:20:50   github.com/weaviate/weaviate/entities/cyclemanager.(*multiCallbacks).execute()
2023-07-02 21:20:50       /go/src/github.com/weaviate/weaviate/entities/cyclemanager/callbacks.go:131 +0x1b0
2023-07-02 21:20:50   github.com/weaviate/weaviate/entities/cyclemanager.(*cycleManager).Start.func1()
2023-07-02 21:20:50       /go/src/github.com/weaviate/weaviate/entities/cyclemanager/cyclemanager.go:87 +0x174
2023-07-02 21:20:50 
2023-07-02 21:20:50 Previous write at 0x00c00292a6f0 by goroutine 1878:
2023-07-02 21:20:50   github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog.NewLoggerWithFile()
2023-07-02 21:20:50       /go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog/logger.go:56 +0x564
2023-07-02 21:20:50   github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.NewCommitLogger()
```