### PR TITLE
Fix nil pointer in Explore queries with module near<Media> arguments

### DIFF
--- a/usecases/modules/module_config.go
+++ b/usecases/modules/module_config.go
@@ -32,6 +32,12 @@ func NewClassBasedModuleConfig(class *models.Class,
 	}
 }
 
+func NewCrossClassModuleConfig() *ClassBasedModuleConfig {
+	// explicitly setting tenant to "" in order to flag that a cross class search
+	// is being done without a tenant context
+	return &ClassBasedModuleConfig{tenant: ""}
+}
+
 func (cbmc *ClassBasedModuleConfig) Class() map[string]interface{} {
 	return cbmc.ClassByModuleName(cbmc.moduleName)
 }

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -653,7 +653,8 @@ func (p *Provider) CrossClassVectorFromSearchParam(ctx context.Context,
 		if searcher, ok := mod.(modulecapabilities.Searcher); ok {
 			if vectorSearches := searcher.VectorSearches(); vectorSearches != nil {
 				if searchVectorFn := vectorSearches[param]; searchVectorFn != nil {
-					vector, err := searchVectorFn(ctx, params, "", findVectorFn, nil)
+					cfg := NewCrossClassModuleConfig()
+					vector, err := searchVectorFn(ctx, params, "", findVectorFn, cfg)
 					if err != nil {
 						return nil, errors.Errorf("vectorize params: %v", err)
 					}

--- a/usecases/modules/searchers_test.go
+++ b/usecases/modules/searchers_test.go
@@ -88,9 +88,12 @@ func TestModulesWithSearchers(t *testing.T) {
 				cfg moduletools.ClassConfig,
 			) ([]float32, error) {
 				// this is a cross-class search, such as is used for Explore{}, in this
-				// case we do not have class-based config, so the optional argument is
-				// nil! Modules must be able to deal with this situation!
-				assert.Nil(t, cfg)
+				// case we do not have class-based config, but we need at least pass
+				// a tenant information, that's why we pass an empty config with empty tenant
+				// so that it would be possible to perform cross class searches, without
+				// tenant context. Modules must be able to deal with this situation!
+				assert.NotNil(t, cfg)
+				assert.Equal(t, "", cfg.Tenant())
 
 				// take the findVectorFn and append one dimension. This doesn't make too
 				// much sense, but helps verify that the modules method was used in the


### PR DESCRIPTION
### What's being changed:

This PR fixes `runtime error: invalid memory address or nil pointer dereference` when doing `Explore` queries with module `near<Media>` arguments.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
