### PR TITLE
Fix data race in binary search tree

### DIFF
--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -332,6 +332,8 @@ func (m *Memtable) IdleDuration() time.Duration {
 }
 
 func (m *Memtable) countStats() *countStats {
+	m.RLock()
+	defer m.RUnlock()
 	return m.key.countStats()
 }
 


### PR DESCRIPTION
### What's being changed:

When using the nodes API concurrently with adding objects there are data races. Performance tests (./test/benchmark/run_performance_tracker.sh) show no differences

### Review checklist

- [x] Performance tests have been run or not necessary.
