### PR TITLE
Ensure thread-safety when reading the schema

### DIFF
--- a/usecases/schema/cache.go
+++ b/usecases/schema/cache.go
@@ -121,3 +121,15 @@ func (s *schemaCache) RLockGuard(reader func() error) error {
 	defer s.RUnlock()
 	return reader()
 }
+
+func (s *schemaCache) isEmpty() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.State.ObjectSchema == nil || len(s.State.ObjectSchema.Classes) == 0
+}
+
+func (s *schemaCache) setState(st State) {
+	s.Lock()
+	defer s.Unlock()
+	s.State = st
+}

--- a/usecases/schema/incoming_commit.go
+++ b/usecases/schema/incoming_commit.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -40,18 +41,20 @@ func (m *Manager) handleCommit(ctx context.Context, tx *cluster.Transaction) err
 
 func (m *Manager) handleTxResponse(ctx context.Context,
 	tx *cluster.Transaction,
-) error {
-	switch tx.Type {
-	case ReadSchema:
+) (data []byte, err error) {
+	if tx.Type != ReadSchema {
+		return nil, nil
+	}
+	m.schemaCache.RLockGuard(func() error {
 		tx.Payload = ReadSchemaPayload{
 			Schema: &m.schemaCache.State,
 		}
-		return nil
-	// TODO
-	default:
-		// silently ignore. Not all types support responses
-		return nil
-	}
+
+		data, err = json.Marshal(tx)
+		tx.Payload = ReadSchemaPayload{}
+		return err
+	})
+	return
 }
 
 func (m *Manager) handleAddClassCommit(ctx context.Context,

--- a/usecases/schema/remove_duplicate_props.go
+++ b/usecases/schema/remove_duplicate_props.go
@@ -18,12 +18,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-func (m *Manager) removeDuplicatePropsIfPresent() {
-	for _, c := range m.schemaCache.ObjectSchema.Classes {
-		c.Properties = m.deduplicateProps(c.Properties, c.Class)
-	}
-}
-
 func (m *Manager) deduplicateProps(props []*models.Property,
 	className string,
 ) []*models.Property {


### PR DESCRIPTION
### What's being changed:
The race condition occurs when writing and reading the schema concurrently. 
Reading the schema was not mutually exclusive, leading to a potential inconsistent view of the schema.
It's important to note that this issue existed in v1.19 and previous versions

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
