### PR TITLE
Add support for gpt-3.5-turbo-16k model in generative-openai module

### DIFF
--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -36,6 +36,7 @@ var availableOpenAILegacyModels = []string{
 
 var availableOpenAIModels = []string{
 	"gpt-3.5-turbo",
+	"gpt-3.5-turbo-16k",
 	"gpt-4",
 	"gpt-4-32k",
 }

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -112,6 +112,26 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantErr:              nil,
 		},
 		{
+			name: "With gpt-3.5-turbo-16k model",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":            "gpt-3.5-turbo-16k",
+					"maxTokens":        4097,
+					"temperature":      0.5,
+					"topP":             3,
+					"frequencyPenalty": 0.1,
+					"presencePenalty":  0.9,
+				},
+			},
+			wantModel:            "gpt-3.5-turbo-16k",
+			wantMaxTokens:        4097,
+			wantTemperature:      0.5,
+			wantTopP:             3,
+			wantFrequencyPenalty: 0.1,
+			wantPresencePenalty:  0.9,
+			wantErr:              nil,
+		},
+		{
 			name: "Wrong maxTokens configured",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{


### PR DESCRIPTION
### What's being changed:

Added support for `gpt-3.5-turbo-16k` OpenAI model.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
