### PR TITLE
Enhance class delete operation for idempotency and improved robustness

### DIFF
--- a/adapters/handlers/rest/clusterapi/schema_component_test.go
+++ b/adapters/handlers/rest/clusterapi/schema_component_test.go
@@ -80,7 +80,7 @@ func TestComponentCluster(t *testing.T) {
 		err := localManager.AddClass(ctx, nil, testClass())
 		require.Nil(t, err)
 
-		err = localManager.DeleteClass(ctx, nil, testClass().Class, false)
+		err = localManager.DeleteClass(ctx, nil, testClass().Class)
 		require.Nil(t, err)
 
 		localSchema, err := localManager.GetSchema(nil)

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2500,11 +2500,6 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "boolean",
-            "name": "force",
-            "in": "query"
           }
         ],
         "responses": {
@@ -7247,11 +7242,6 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "boolean",
-            "name": "force",
-            "in": "query"
           }
         ],
         "responses": {

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -98,11 +98,7 @@ func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
 }
 
 func (s *schemaHandlers) deleteClass(params schema.SchemaObjectsDeleteParams, principal *models.Principal) middleware.Responder {
-	force := false
-	if params.Force != nil {
-		force = *params.Force
-	}
-	err := s.manager.DeleteClass(params.HTTPRequest.Context(), principal, params.ClassName, force)
+	err := s.manager.DeleteClass(params.HTTPRequest.Context(), principal, params.ClassName)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch err.(type) {

--- a/adapters/handlers/rest/operations/schema/schema_objects_delete_parameters.go
+++ b/adapters/handlers/rest/operations/schema/schema_objects_delete_parameters.go
@@ -20,10 +20,8 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
-	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 )
 
 // NewSchemaObjectsDeleteParams creates a new SchemaObjectsDeleteParams object
@@ -48,10 +46,6 @@ type SchemaObjectsDeleteParams struct {
 	  In: path
 	*/
 	ClassName string
-	/*
-	  In: query
-	*/
-	Force *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -63,15 +57,8 @@ func (o *SchemaObjectsDeleteParams) BindRequest(r *http.Request, route *middlewa
 
 	o.HTTPRequest = r
 
-	qs := runtime.Values(r.URL.Query())
-
 	rClassName, rhkClassName, _ := route.Params.GetOK("className")
 	if err := o.bindClassName(rClassName, rhkClassName, route.Formats); err != nil {
-		res = append(res, err)
-	}
-
-	qForce, qhkForce, _ := qs.GetOK("force")
-	if err := o.bindForce(qForce, qhkForce, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -90,29 +77,6 @@ func (o *SchemaObjectsDeleteParams) bindClassName(rawData []string, hasKey bool,
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.ClassName = raw
-
-	return nil
-}
-
-// bindForce binds and validates parameter Force from query.
-func (o *SchemaObjectsDeleteParams) bindForce(rawData []string, hasKey bool, formats strfmt.Registry) error {
-	var raw string
-	if len(rawData) > 0 {
-		raw = rawData[len(rawData)-1]
-	}
-
-	// Required: false
-	// AllowEmptyValue: false
-
-	if raw == "" { // empty values pass all other validations
-		return nil
-	}
-
-	value, err := swag.ConvertBool(raw)
-	if err != nil {
-		return errors.InvalidType("force", "query", "bool", raw)
-	}
-	o.Force = &value
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/schema/schema_objects_delete_urlbuilder.go
+++ b/adapters/handlers/rest/operations/schema/schema_objects_delete_urlbuilder.go
@@ -21,15 +21,11 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
-
-	"github.com/go-openapi/swag"
 )
 
 // SchemaObjectsDeleteURL generates an URL for the schema objects delete operation
 type SchemaObjectsDeleteURL struct {
 	ClassName string
-
-	Force *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -69,18 +65,6 @@ func (o *SchemaObjectsDeleteURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
-
-	qs := make(url.Values)
-
-	var forceQ string
-	if o.Force != nil {
-		forceQ = swag.FormatBool(*o.Force)
-	}
-	if forceQ != "" {
-		qs.Set("force", forceQ)
-	}
-
-	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -93,12 +93,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 }
 
 func (m *Migrator) DropClass(ctx context.Context, className string) error {
-	err := m.db.DeleteIndex(schema.ClassName(className))
-	if err != nil {
-		return errors.Wrapf(err, "delete idx for class '%s'", className)
-	}
-
-	return nil
+	return m.db.DeleteIndex(schema.ClassName(className))
 }
 
 func (m *Migrator) UpdateClass(ctx context.Context, className string, newClassName *string) error {

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -180,16 +180,18 @@ func (db *DB) DeleteIndex(className schema.ClassName) error {
 	db.indexLock.Lock()
 	defer db.indexLock.Unlock()
 
+	// Get index
 	id := indexID(className)
-	index, ok := db.indices[id]
-	if !ok {
-		return errors.Errorf("exist index %s", id)
+	index := db.indices[id]
+	if index == nil {
+		return nil
 	}
+
+	// Drop index
 	index.dropIndex.Lock()
 	defer index.dropIndex.Unlock()
-	err := index.drop()
-	if err != nil {
-		return errors.Wrapf(err, "drop index %s", id)
+	if err := index.drop(); err != nil {
+		db.logger.WithField("action", "delete_index").WithField("class", className).Error(err)
 	}
 	delete(db.indices, id)
 	return nil

--- a/client/schema/schema_objects_delete_parameters.go
+++ b/client/schema/schema_objects_delete_parameters.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 )
 
 // NewSchemaObjectsDeleteParams creates a new SchemaObjectsDeleteParams object,
@@ -75,9 +74,6 @@ type SchemaObjectsDeleteParams struct {
 
 	// ClassName.
 	ClassName string
-
-	// Force.
-	Force *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -143,17 +139,6 @@ func (o *SchemaObjectsDeleteParams) SetClassName(className string) {
 	o.ClassName = className
 }
 
-// WithForce adds the force to the schema objects delete params
-func (o *SchemaObjectsDeleteParams) WithForce(force *bool) *SchemaObjectsDeleteParams {
-	o.SetForce(force)
-	return o
-}
-
-// SetForce adds the force to the schema objects delete params
-func (o *SchemaObjectsDeleteParams) SetForce(force *bool) {
-	o.Force = force
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *SchemaObjectsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -165,23 +150,6 @@ func (o *SchemaObjectsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg 
 	// path param className
 	if err := r.SetPathParam("className", o.ClassName); err != nil {
 		return err
-	}
-
-	if o.Force != nil {
-
-		// query param force
-		var qrForce bool
-
-		if o.Force != nil {
-			qrForce = *o.Force
-		}
-		qForce := swag.FormatBool(qrForce)
-		if qForce != "" {
-
-			if err := r.SetQueryParam("force", qForce); err != nil {
-				return err
-			}
-		}
 	}
 
 	if len(res) > 0 {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1136,7 +1136,7 @@
           "format": "uri",
           "type": "string"
         },
-        "tenant" : {
+        "tenant": {
           "type": "string",
           "description": "Name of the reference tenant."
         }
@@ -3713,12 +3713,6 @@
             "in": "path",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "force",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
           }
         ],
         "responses": {

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -52,9 +52,9 @@ func TestAutoschemaCasingClass(t *testing.T) {
 			_, err = creator.WithClassName(tt.className2).Do(ctx)
 			require.Nil(t, err)
 
-			// class exists only once in Uppercase, so lowercase delete has to fail
+			// Regardless of whether a class exists or not, the delete operation will always return a success
 			require.Nil(t, c.Schema().ClassDeleter().WithClassName(upperClassName).Do(ctx))
-			require.NotNil(t, c.Schema().ClassDeleter().WithClassName(lowerClassName).Do(ctx))
+			require.Nil(t, c.Schema().ClassDeleter().WithClassName(lowerClassName).Do(ctx))
 		})
 	}
 }

--- a/test/acceptance_with_go_client/schema_test.go
+++ b/test/acceptance_with_go_client/schema_test.go
@@ -83,9 +83,9 @@ func TestSchemaCasingClass(t *testing.T) {
 				require.Equal(t, data, 1.)
 			}
 
-			// class exists only once in Uppercase, so lowercase delete has to fail
+			// Regardless of whether a class exists or not, the delete operation will always return a success
 			require.Nil(t, c.Schema().ClassDeleter().WithClassName(tt.className1).Do(ctx))
-			require.NotNil(t, c.Schema().ClassDeleter().WithClassName(tt.className2).Do(ctx))
+			require.Nil(t, c.Schema().ClassDeleter().WithClassName(tt.className2).Do(ctx))
 		})
 	}
 }

--- a/test/helper/assertions.go
+++ b/test/helper/assertions.go
@@ -20,6 +20,7 @@ import (
 // Asserts that the request did not return an error.
 // Optionally perform some checks only if the request did not fail
 func AssertRequestOk(t *testing.T, response interface{}, err error, checkFn func()) {
+	t.Helper()
 	if err != nil {
 		responseJson, _ := json.MarshalIndent(response, "", "  ")
 		errorPayload, _ := json.MarshalIndent(err, "", " ")

--- a/test/helper/objects_assertions.go
+++ b/test/helper/objects_assertions.go
@@ -23,6 +23,7 @@ import (
 )
 
 func AssertCreateObject(t *testing.T, className string, schema map[string]interface{}) strfmt.UUID {
+	t.Helper()
 	params := objects.NewObjectsCreateParams().WithBody(
 		&models.Object{
 			Class:      className,
@@ -42,6 +43,7 @@ func AssertCreateObject(t *testing.T, className string, schema map[string]interf
 }
 
 func AssertGetObject(t *testing.T, class string, uuid strfmt.UUID, include ...string) *models.Object {
+	t.Helper()
 	obj, err := GetObject(t, class, uuid, include...)
 	AssertRequestOk(t, obj, err, nil)
 	return obj

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -68,7 +68,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:       "DeleteClass",
-			additionalArgs:   []interface{}{"somename", false},
+			additionalArgs:   []interface{}{"somename"},
 			expectedVerb:     "delete",
 			expectedResource: "schema/objects",
 		},

--- a/usecases/schema/cache.go
+++ b/usecases/schema/cache.go
@@ -133,3 +133,29 @@ func (s *schemaCache) setState(st State) {
 	defer s.Unlock()
 	s.State = st
 }
+
+func (s *schemaCache) detachClass(name string) bool {
+	s.Lock()
+	defer s.Unlock()
+	schema, ci := s.ObjectSchema, -1
+	for i, cls := range schema.Classes {
+		if cls.Class == name {
+			ci = i
+			break
+		}
+	}
+	if ci == -1 {
+		return false
+	}
+	nc := len(schema.Classes)
+	schema.Classes[ci] = schema.Classes[nc-1]
+	schema.Classes[nc-1] = nil // to prevent leaking this pointer.
+	schema.Classes = schema.Classes[:nc-1]
+	return true
+}
+
+func (s *schemaCache) deleteClassState(name string) {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.ShardingState, name)
+}

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -70,7 +70,7 @@ func TestFailedCommits(t *testing.T) {
 				})
 			},
 			action: func(t *testing.T, sm *Manager) {
-				assert.Nil(t, sm.DeleteClass(ctx, nil, "MyClass", false))
+				assert.Nil(t, sm.DeleteClass(ctx, nil, "MyClass"))
 			},
 			expSchema: []*models.Class{
 				classWithDefaultsWithProps(t, "OtherClass", nil),

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -13,28 +13,27 @@ package schema
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
 // DeleteClass from the schema
-func (m *Manager) DeleteClass(ctx context.Context, principal *models.Principal, class string, force bool) error {
+func (m *Manager) DeleteClass(ctx context.Context, principal *models.Principal, class string) error {
 	err := m.Authorizer.Authorize(principal, "delete", "schema/objects")
 	if err != nil {
 		return err
 	}
 
-	return m.deleteClass(ctx, class, force)
+	return m.deleteClass(ctx, class)
 }
 
-func (m *Manager) deleteClass(ctx context.Context, className string, force bool) error {
+func (m *Manager) deleteClass(ctx context.Context, className string) error {
 	m.Lock()
 	defer m.Unlock()
 
 	tx, err := m.cluster.BeginTransaction(ctx, DeleteClass,
-		DeleteClassPayload{className, force}, DefaultTxTTL)
+		DeleteClassPayload{className}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
 		// be up for a schema transaction) or concurrent transactions from other
@@ -59,56 +58,28 @@ func (m *Manager) deleteClass(ctx context.Context, className string, force bool)
 		m.logger.WithError(err).Errorf("not every node was able to commit")
 	}
 
-	return m.deleteClassApplyChanges(ctx, className, force)
+	return m.deleteClassApplyChanges(ctx, className)
 }
 
-func (m *Manager) deleteClassApplyChanges(ctx context.Context,
-	className string, force bool,
-) error {
-	classIdx := -1
-	var sch *models.Schema
-	m.schemaCache.RLockGuard(func() error {
-		sch = m.schemaCache.ObjectSchema
-		for idx, class := range sch.Classes {
-			if class.Class == className {
-				classIdx = idx
-				break
-			}
-		}
-		return nil
-	})
-
-	if classIdx == -1 && !force {
-		return fmt.Errorf("could not find class '%s'", className)
-	}
-
-	if classIdx > -1 {
-		// make sure not to delete another class if the force flag is set, but the class does not exist
-		m.schemaCache.LockGuard(func() {
-			sch.Classes[classIdx] = sch.Classes[len(sch.Classes)-1]
-			sch.Classes[len(sch.Classes)-1] = nil // to prevent leaking this pointer.
-			sch.Classes = sch.Classes[:len(sch.Classes)-1]
-		})
-	}
-
-	err := m.migrator.DropClass(ctx, className)
-	if err != nil {
-		if !force {
-			return err
-		}
-
-		m.logger.WithError(err).
-			Errorf("ignoring class delete error because force is set")
-	}
-
-	m.schemaCache.LockGuard(func() { delete(m.schemaCache.ShardingState, className) })
+func (m *Manager) deleteClassApplyChanges(ctx context.Context, className string) error {
 	if err := m.repo.DeleteClass(ctx, className); err != nil {
+		m.logger.WithField("action", "delete_class").
+			WithField("class", className).Errorf("schema: %v", err)
 		return err
 	}
-	m.logger.
-		WithField("action", "schema_delete_class").
-		Debugf("delete class %q from schema", className)
 
+	if ok := m.schemaCache.detachClass(className); !ok {
+		return nil
+	}
+
+	if err := m.migrator.DropClass(ctx, className); err != nil {
+		m.logger.WithField("action", "delete_class").
+			WithField("class", className).Errorf("migrator: %v", err)
+	}
+
+	m.schemaCache.deleteClassState(className)
+
+	m.logger.WithField("action", "delete_class").WithField("class", className).Debug("")
 	m.triggerSchemaUpdateCallbacks()
 
 	return nil

--- a/usecases/schema/delete_test.go
+++ b/usecases/schema/delete_test.go
@@ -26,7 +26,6 @@ func TestForceDelete(t *testing.T) {
 		name           string
 		existingSchema []*models.Class
 		classToDelete  string
-		force          bool
 		expErr         bool
 		expErrMsg      string
 		expSchema      []*models.Class
@@ -34,8 +33,7 @@ func TestForceDelete(t *testing.T) {
 
 	tests := []test{
 		{
-			name:  "class exists, regular delete",
-			force: false,
+			name: "class exists",
 			existingSchema: []*models.Class{
 				{Class: "MyClass", VectorIndexType: "hnsw"},
 				{Class: "OtherClass", VectorIndexType: "hnsw"},
@@ -47,34 +45,7 @@ func TestForceDelete(t *testing.T) {
 			expErr: false,
 		},
 		{
-			name:  "class does not exist, regular delete",
-			force: false,
-			existingSchema: []*models.Class{
-				{Class: "OtherClass", VectorIndexType: "hnsw"},
-			},
-			classToDelete: "MyClass",
-			expSchema: []*models.Class{
-				classWithDefaultsSet(t, "OtherClass"),
-			},
-			expErr:    true,
-			expErrMsg: "could not find class",
-		},
-		{
-			name:  "class exists, force delete",
-			force: true,
-			existingSchema: []*models.Class{
-				{Class: "MyClass", VectorIndexType: "hnsw"},
-				{Class: "OtherClass", VectorIndexType: "hnsw"},
-			},
-			classToDelete: "MyClass",
-			expSchema: []*models.Class{
-				classWithDefaultsSet(t, "OtherClass"),
-			},
-			expErr: false,
-		},
-		{
-			name:  "class does not exist, force delete",
-			force: true,
+			name: "class does not exist",
 			existingSchema: []*models.Class{
 				{Class: "OtherClass", VectorIndexType: "hnsw"},
 			},
@@ -102,10 +73,10 @@ func TestForceDelete(t *testing.T) {
 
 			sm, err := newManagerWithClusterAndTx(t, clusterState, txClient, initialSchema)
 			require.Nil(t, err)
-			err = sm.DeleteClass(context.Background(), nil, test.classToDelete, test.force)
+			err = sm.DeleteClass(context.Background(), nil, test.classToDelete)
 
 			if test.expErr {
-				require.NotNil(t, err, "opeartion should have errord")
+				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), test.expErrMsg)
 			} else {
 				require.Nil(t, err)

--- a/usecases/schema/incoming_commit.go
+++ b/usecases/schema/incoming_commit.go
@@ -119,7 +119,7 @@ func (m *Manager) handleDeleteClassCommit(ctx context.Context,
 			tx.Payload)
 	}
 
-	return m.deleteClassApplyChanges(ctx, pl.ClassName, pl.Force)
+	return m.deleteClassApplyChanges(ctx, pl.ClassName)
 }
 
 func (m *Manager) handleUpdateClassCommit(ctx context.Context,

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -277,7 +277,7 @@ func testRemoveObjectClass(t *testing.T, lsm *Manager) {
 	assert.Contains(t, objectClasses, "Car")
 
 	// Now delete the class
-	err = lsm.DeleteClass(context.Background(), nil, "Car", false)
+	err = lsm.DeleteClass(context.Background(), nil, "Car")
 	assert.Nil(t, err)
 
 	objectClasses = testGetClassNames(lsm)

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -255,16 +255,17 @@ func (m *Manager) GetTenants(ctx context.Context, principal *models.Principal, c
 	}
 
 	var tenants []*models.Tenant
-	m.schemaCache.RLock()
-	if ss := m.schemaCache.ShardingState[cls.Class]; ss != nil {
-		tenants = make([]*models.Tenant, len(ss.Physical))
-		i := 0
-		for tenant := range ss.Physical {
-			tenants[i] = &models.Tenant{Name: tenant}
-			i++
+	m.schemaCache.RLockGuard(func() error {
+		if ss := m.schemaCache.ShardingState[cls.Class]; ss != nil {
+			tenants = make([]*models.Tenant, len(ss.Physical))
+			i := 0
+			for tenant := range ss.Physical {
+				tenants[i] = &models.Tenant{Name: tenant}
+				i++
+			}
 		}
-	}
-	m.schemaCache.RUnlock()
+		return nil
+	})
 
 	return tenants, nil
 }

--- a/usecases/schema/transactions.go
+++ b/usecases/schema/transactions.go
@@ -69,7 +69,6 @@ type DeleteTenantsPayload struct {
 
 type DeleteClassPayload struct {
 	ClassName string `json:"className"`
-	Force     bool   `json:"force"`
 }
 
 type UpdateClassPayload struct {


### PR DESCRIPTION
### What's being changed:
Deletion is idempotent
Now, when deleting a non-existing class, the operation will return a success instead of raising an error
Improved robustness it starts by deleting the class from the schema first
Improved index deletion to minimize side-effects
Improved Index::Drop to attempt deleting all shards even if individual shard deletion fails
The `force` flag has been removed because of idempotency

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/weaviate/weaviate-chaos-engineering/pull/94
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
