### PR TITLE
Improve index and tenants deletion performance by concurrently deleting shards

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1416,23 +1416,28 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 	return res, nil
 }
 
-func (i *Index) drop() (firstErr error) {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+func (i *Index) drop() error {
+	var eg errgroup.Group
+	eg.SetLimit(_NUMCPU * 2)
 	fields := logrus.Fields{"action": "drop_shard", "class": i.Config.ClassName}
-	i.shards.Range(func(name string, shard *Shard) error {
+	dropShard := func(name string, shard *Shard) error {
 		if shard == nil {
 			return nil
 		}
-		if err := shard.drop(); err != nil {
-			logrus.WithFields(fields).WithField("id", shard.ID()).Error(err)
-			if firstErr == nil {
-				firstErr = err
+		eg.Go(func() error {
+			if err := shard.drop(); err != nil {
+				logrus.WithFields(fields).WithField("id", shard.ID()).Error(err)
 			}
-		}
+			return nil
+		})
 		return nil
-	})
-	return
+	}
+
+	i.backupStateLock.RLock()
+	defer i.backupStateLock.RUnlock()
+
+	i.shards.Range(dropShard)
+	return eg.Wait()
 }
 
 func (i *Index) Shutdown(ctx context.Context) error {


### PR DESCRIPTION
### What's being changed:
Implemented concurrent shard deletions, which significantly improves the performance of deleting MT classes as well as tenants

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/weaviate/weaviate-chaos-engineering/pull/95
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
