### PR TITLE
schema: fix log message

### DIFF
--- a/adapters/repos/schema/store.go
+++ b/adapters/repos/schema/store.go
@@ -152,7 +152,7 @@ func (r *store) Close() {
 // migrate from old to new schema
 // It will back up the old schema file if it exists
 func (r *store) migrate(filePath string, from, to int) (err error) {
-	r.log.Infoln("schema migration from v%d to v%d process has started", to, from)
+	r.log.Infof("schema migration from v%d to v%d process has started", from, to)
 	defer func() {
 		if err == nil {
 			r.log.Infof("successfully completed schema migration from v%d to v%d", from, to)


### PR DESCRIPTION
### What's being changed:
Currently, it logs: `schema migration from v%d to v%d process has started 2 0`, which triggers my OCD, which leads to me doing this instead of something actually useful.
