### PR TITLE
Fix for checking the RERANKER_INFERENCE_API mandatory setting

### DIFF
--- a/modules/reranker-transformers/module.go
+++ b/modules/reranker-transformers/module.go
@@ -66,7 +66,7 @@ func (m *ReRankerModule) initAdditional(ctx context.Context,
 ) error {
 	uri := os.Getenv("RERANKER_INFERENCE_API")
 	if uri == "" {
-		return nil
+		return errors.Errorf("required variable RERANKER_INFERENCE_API is not set")
 	}
 
 	client := client.New(uri, logger)


### PR DESCRIPTION
### What's being changed:

In case of missing `RERANKER_INFERENCE_API` module needs to return an error, this PR fixes this behaviour.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
