### PR TITLE
Change reranker-cohere's module default model to multilingual one (rerank-multilingual-v2.0)

### DIFF
--- a/modules/reranker-cohere/config/class_settings.go
+++ b/modules/reranker-cohere/config/class_settings.go
@@ -29,7 +29,7 @@ var availableCohereModels = []string{
 
 // note it might not like this -- might want int values for e.g. MaxTokens
 var (
-	DefaultCohereModel     = "rerank-english-v2.0"
+	DefaultCohereModel     = "rerank-multilingual-v2.0"
 	DefaultReturnDocuments = false
 )
 

--- a/modules/reranker-cohere/config/class_settings_test.go
+++ b/modules/reranker-cohere/config/class_settings_test.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/moduletools"
+)
+
+func Test_classSettings_Validate(t *testing.T) {
+	tests := []struct {
+		name                string
+		cfg                 moduletools.ClassConfig
+		wantModel           string
+		wantReturnDocuments bool
+		wantErr             error
+	}{
+		{
+			name: "default settings",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{},
+			},
+			wantModel:           "rerank-multilingual-v2.0",
+			wantReturnDocuments: false,
+		},
+		{
+			name: "custom settings",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":           "rerank-english-v2.0",
+					"returnDocuments": true,
+				},
+			},
+			wantModel:           "rerank-english-v2.0",
+			wantReturnDocuments: true,
+		},
+		{
+			name: "unsupported model error",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model": "rerank-french-v2.0",
+				},
+			},
+			wantErr: fmt.Errorf("wrong Cohere model name, available model names are: [rerank-english-v2.0 rerank-multilingual-v2.0]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ic := NewClassSettings(tt.cfg)
+			if tt.wantErr != nil {
+				assert.EqualError(t, ic.Validate(nil), tt.wantErr.Error())
+			} else {
+				assert.Equal(t, tt.wantModel, ic.Model())
+				assert.Equal(t, tt.wantReturnDocuments, ic.ReturnDocuments())
+			}
+		})
+	}
+}
+
+type fakeClassConfig struct {
+	classConfig map[string]interface{}
+}
+
+func (f fakeClassConfig) Class() map[string]interface{} {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) Tenant() string {
+	return ""
+}
+
+func (f fakeClassConfig) ClassByModuleName(moduleName string) map[string]interface{} {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) Property(propName string) map[string]interface{} {
+	return nil
+}


### PR DESCRIPTION
### What's being changed:

This PR changes the default Cohere Rerank model to a multilingual one.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
