### PR TITLE
Fix reading sharding config and  prevent MT toggling during class updates

### DIFF
--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -454,19 +454,18 @@ func (m *Manager) parseVectorIndexConfig(ctx context.Context,
 	return nil
 }
 
-func (m *Manager) parseShardingConfig(ctx context.Context,
-	class *models.Class,
-) error {
+func (m *Manager) parseShardingConfig(ctx context.Context, class *models.Class) (err error) {
 	// multiTenancyConfig and shardingConfig are mutually exclusive
+	cfg := sharding.Config{} // cfg is empty in case of MT
 	if !schema.MultiTenancyEnabled(class) {
-		parsed, err := sharding.ParseConfig(class.ShardingConfig,
+		cfg, err = sharding.ParseConfig(class.ShardingConfig,
 			m.clusterState.NodeCount())
 		if err != nil {
 			return fmt.Errorf("parse sharding config: %w", err)
 		}
 
-		class.ShardingConfig = parsed
 	}
+	class.ShardingConfig = cfg
 	return nil
 }
 

--- a/usecases/schema/update_test.go
+++ b/usecases/schema/update_test.go
@@ -372,9 +372,9 @@ func TestClassUpdates(t *testing.T) {
 							"desiredCount": json.Number("7"),
 						},
 					})
-				expectedErrMsg := "sharding config: re-sharding not supported yet: shard count is immutable: attempted change from \"1\" to \"7\""
+				expectedErrMsg := "re-sharding not supported yet: shard count is immutable: attempted change from \"1\" to \"7\""
 				require.NotNil(t, err)
-				assert.Equal(t, expectedErrMsg, err.Error())
+				assert.Contains(t, err.Error(), expectedErrMsg)
 			})
 		})
 	})


### PR DESCRIPTION

### What's being changed:

1. Fixed the parsing of the sharding configuration for multi-tenancy (MT) classes. A bug that caused panics has been resolved.
3. Implemented validation for toggling multi-tenancy on existing classes, resulting in the following error handling:
-      disabling multi-tenancy for an existing class is not supported for an existing class with MT enabled.
-      enabling multi-tenancy for an existing class is not supported for an existing non-MT class."

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
