### PR TITLE
Change hybrid default fusion algorithm to ranked fusion

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -90,6 +90,8 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 	fusionType, ok := source["fusionType"]
 	if ok {
 		args.FusionAlgorithm = fusionType.(int)
+	} else {
+		args.FusionAlgorithm = config.HybridRankedFusion
 	}
 	if _, ok := source["vector"]; ok {
 		vector := source["vector"].([]interface{})

--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -86,7 +86,6 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 		args.Query = query.(string)
 	}
 
-	// there is a default value in graphql, this value should always be present
 	fusionType, ok := source["fusionType"]
 	if ok {
 		args.FusionAlgorithm = fusionType.(int)

--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -15,7 +15,12 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate/entities/searchparams"
-	"github.com/weaviate/weaviate/usecases/config"
+)
+
+const DefaultAlpha = float64(0.75)
+const (
+	HybridRankedFusion = iota
+	HybridRelativeScoreFusion
 )
 
 func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*searchparams.HybridSearch, error) {
@@ -74,7 +79,7 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 	if ok {
 		args.Alpha = alpha.(float64)
 	} else {
-		args.Alpha = config.DefaultAlpha
+		args.Alpha = DefaultAlpha
 	}
 
 	if args.Alpha < 0 || args.Alpha > 1 {
@@ -90,7 +95,7 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 	if ok {
 		args.FusionAlgorithm = fusionType.(int)
 	} else {
-		args.FusionAlgorithm = config.HybridRankedFusion
+		args.FusionAlgorithm = HybridRankedFusion
 	}
 	if _, ok := source["vector"]; ok {
 		vector := source["vector"].([]interface{})

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -14,7 +14,7 @@ package get
 import (
 	"fmt"
 
-	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -72,10 +72,10 @@ func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error)
 		Name: "FusionEnum",
 		Values: graphql.EnumValueConfigMap{
 			"rankedFusion": &graphql.EnumValueConfig{
-				Value: config.HybridRankedFusion,
+				Value: common_filters.HybridRankedFusion,
 			},
 			"relativeScoreFusion": &graphql.EnumValueConfig{
-				Value: config.HybridRelativeScoreFusion,
+				Value: common_filters.HybridRelativeScoreFusion,
 			},
 		},
 	})

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -14,6 +14,8 @@ package get
 import (
 	"fmt"
 
+	"github.com/weaviate/weaviate/usecases/config"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tailor-inc/graphql"
@@ -70,10 +72,10 @@ func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error)
 		Name: "FusionEnum",
 		Values: graphql.EnumValueConfigMap{
 			"rankedFusion": &graphql.EnumValueConfig{
-				Value: HybridRankedFusion,
+				Value: config.HybridRankedFusion,
 			},
 			"relativeScoreFusion": &graphql.EnumValueConfig{
-				Value: HybridRelativeScoreFusion,
+				Value: config.HybridRelativeScoreFusion,
 			},
 		},
 	})

--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -502,7 +502,7 @@ func TestExtractAdditionalFields(t *testing.T) {
 			expectedResult: map[string]interface{}{
 				"_additional": map[string]interface{}{
 					"classification": map[string]interface{}{
-						"id":               strfmt.UUID("12345"),
+						"id":               "12345",
 						"basedOn":          []interface{}{"primitiveProp"},
 						"scope":            []interface{}{"refprop1", "refprop2", "refprop3"},
 						"classifiedFields": []interface{}{"refprop3"},

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -67,7 +67,7 @@ func hybridOperands(classObject *graphql.Object,
 		},
 		"fusionType": &graphql.InputObjectFieldConfig{
 			Description:  "Algorithm used for fusing results from vector and keyword search",
-			DefaultValue: fusionEnum.Values()[HybridRankedFusion].Value,
+			DefaultValue: fusionEnum.Values()[0].Name,
 			Type:         fusionEnum,
 		},
 	}

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -66,9 +66,8 @@ func hybridOperands(classObject *graphql.Object,
 			Type:        graphql.NewList(graphql.String),
 		},
 		"fusionType": &graphql.InputObjectFieldConfig{
-			Description:  "Algorithm used for fusing results from vector and keyword search",
-			DefaultValue: fusionEnum.Values()[0].Name,
-			Type:         fusionEnum,
+			Description: "Algorithm used for fusing results from vector and keyword search",
+			Type:        fusionEnum,
 		},
 	}
 

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -20,11 +20,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-const (
-	HybridRankedFusion = iota
-	HybridRelativeScoreFusion
-)
-
 func hybridArgument(classObject *graphql.Object,
 	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) *graphql.ArgumentConfig {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/pkoukk/tiktoken-go v0.1.1
-	github.com/tailor-inc/graphql v0.4.1
+	github.com/tailor-inc/graphql v0.2.1
 	github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d
 	golang.org/x/text v0.9.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -565,8 +565,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v0.0.0-20180708030551-c4c61651e9e3/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
-github.com/tailor-inc/graphql v0.4.1 h1:pAl/Xwy8aMtDVX0QjNj/S8vAWVM0e3IrK9554w0c2wg=
-github.com/tailor-inc/graphql v0.4.1/go.mod h1:KtXmBAjFV+o3NEaWvtOStTMqE7g7sCWIGazL5sgJU7k=
+github.com/tailor-inc/graphql v0.2.1 h1:l0zILC0GiSH02DjeJVvGPoDCMWhqQa+fSvQDyCg3zYk=
+github.com/tailor-inc/graphql v0.2.1/go.mod h1:Rl0/u8OoidpQkaoKFph1ElyMc3EI6GYdC30rI6fQHak=
 github.com/testcontainers/testcontainers-go v0.19.0 h1:3bmFPuQRgVIQwxZJERyzB8AogmJW3Qzh8iDyfJbPhi8=
 github.com/testcontainers/testcontainers-go v0.19.0/go.mod h1:3YsSoxK0rGEUzbGD4gUVt1Nm3GJpCIq94GX+2LSf3d4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -53,6 +53,11 @@ const (
 )
 
 const (
+	HybridRankedFusion = iota
+	HybridRelativeScoreFusion
+)
+
+const (
 	DefaultMaxImportGoroutinesFactor = float64(1.5)
 
 	DefaultDiskUseWarningPercentage  = uint64(80)

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -47,14 +47,6 @@ const (
 	// These BM25 tuning params can be overwritten on a per-class basis
 	DefaultBM25k1 = float32(1.2)
 	DefaultBM25b  = float32(0.75)
-
-	// These hybrid tuning params can be overwritten on a per-class basis
-	DefaultAlpha = float64(0.75)
-)
-
-const (
-	HybridRankedFusion = iota
-	HybridRelativeScoreFusion
 )
 
 const (

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -15,7 +15,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 
 	"github.com/weaviate/weaviate/entities/autocut"
 
@@ -157,9 +157,9 @@ func (s *Searcher) Search(ctx context.Context) (Results, error) {
 	}
 
 	var fused []*Result
-	if s.params.FusionAlgorithm == config.HybridRankedFusion {
+	if s.params.FusionAlgorithm == common_filters.HybridRankedFusion {
 		fused = FusionRanked(weights, found)
-	} else if s.params.FusionAlgorithm == config.HybridRelativeScoreFusion {
+	} else if s.params.FusionAlgorithm == common_filters.HybridRelativeScoreFusion {
 		fused = FusionRelativeScore(weights, found)
 	} else {
 		return nil, fmt.Errorf("unknown ranking algorithm %v for hybrid search", s.params.FusionAlgorithm)

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -15,9 +15,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/weaviate/weaviate/entities/autocut"
+	"github.com/weaviate/weaviate/usecases/config"
 
-	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/get"
+	"github.com/weaviate/weaviate/entities/autocut"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -157,9 +157,9 @@ func (s *Searcher) Search(ctx context.Context) (Results, error) {
 	}
 
 	var fused []*Result
-	if s.params.FusionAlgorithm == get.HybridRankedFusion {
+	if s.params.FusionAlgorithm == config.HybridRankedFusion {
 		fused = FusionRanked(weights, found)
-	} else if s.params.FusionAlgorithm == get.HybridRelativeScoreFusion {
+	} else if s.params.FusionAlgorithm == config.HybridRelativeScoreFusion {
 		fused = FusionRelativeScore(weights, found)
 	} else {
 		return nil, fmt.Errorf("unknown ranking algorithm %v for hybrid search", s.params.FusionAlgorithm)


### PR DESCRIPTION
### What's being changed:

- remove default value for hybrid fusion as it was not compatible with the enum values
- downgrade graphql library. The newest version changed something on the handling of default values non-included, causing the ruby client to send nil values that then caused crashes (see screenshots)

<img width="263" alt="before" src="https://github.com/weaviate/weaviate/assets/5353192/bcac7ce9-f991-49a2-8039-0511ff3d8299">
<img width="263" alt="after" src="https://github.com/weaviate/weaviate/assets/5353192/2acd2c6f-872a-4313-a4b4-1d875527d28a">

