### PR TITLE
Autodetect reference class from property type

### DIFF
--- a/test/acceptance/objects/crefs_test.go
+++ b/test/acceptance/objects/crefs_test.go
@@ -72,6 +72,23 @@ func Test_refs_without_to_class(t *testing.T) {
 			},
 		},
 	}, objWithRef)
+
+	// delete reference without class
+	deleteRefParams := objects.NewObjectsClassReferencesDeleteParams().
+		WithID(refFromId).
+		WithPropertyName("ref").WithClassName(refFromClass.Class).
+		WithBody(&models.SingleRef{
+			Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/%s", refToId.String())),
+		})
+	deleteRefResponse, err := helper.Client(t).Objects.ObjectsClassReferencesDelete(deleteRefParams, nil)
+	helper.AssertRequestOk(t, deleteRefResponse, err, nil)
+	objWithoutRef := func() interface{} {
+		obj := assertGetObjectWithClass(t, refFromId, "ReferenceFrom")
+		return obj.Properties
+	}
+	testhelper.AssertEventuallyEqual(t, map[string]interface{}{
+		"ref": []interface{}{},
+	}, objWithoutRef)
 }
 
 // This test suite is meant to prevent a regression on

--- a/test/acceptance/objects/helpers_for_test.go
+++ b/test/acceptance/objects/helpers_for_test.go
@@ -66,6 +66,18 @@ func assertGetObject(t *testing.T, uuid strfmt.UUID) *models.Object {
 	return object
 }
 
+func assertGetObjectWithClass(t *testing.T, uuid strfmt.UUID, class string) *models.Object {
+	getResp, err := helper.Client(t).Objects.ObjectsClassGet(objects.NewObjectsClassGetParams().WithID(uuid).WithClassName(class), nil)
+
+	var object *models.Object
+
+	helper.AssertRequestOk(t, getResp, err, func() {
+		object = getResp.Payload
+	})
+
+	return object
+}
+
 func assertGetObjectEventually(t *testing.T, uuid strfmt.UUID) *models.Object {
 	var (
 		resp *objects.ObjectsGetOK

--- a/test/acceptance_with_go_client/search_test.go
+++ b/test/acceptance_with_go_client/search_test.go
@@ -212,7 +212,7 @@ func TestAutocut(t *testing.T) {
 	AddClassAndObjects(t, className, string(schema.DataTypeTextArray), c, "none")
 	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 
-	searchQuery := []string{"hybrid:{query:\"rain nice\", alpha: 0, fusionType: relativeScoreFusion", "bm25:{query:\"rain nice\""}
+	searchQuery := []string{"hybrid:{query:\"rain nice\", alpha: 0.0, fusionType: relativeScoreFusion", "bm25:{query:\"rain nice\""}
 	cases := []struct {
 		autocut    int
 		numResults int

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -97,7 +97,7 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 	classPropTarget := make(map[string]string)
 	scheme, err := b.schemaManager.GetSchema(principal)
 	if err != nil {
-		return NewErrInvalidUserInput("get schema", err)
+		return NewErrInvalidUserInput("get schema: %v", err)
 	}
 	for i, ref := range batchReferences {
 		// get to class from property datatype
@@ -111,12 +111,12 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 		if !ok {
 			class := scheme.FindClassByName(ref.From.Class)
 			if class == nil {
-				return NewErrInvalidUserInput("class for ref does not exist: "+className, err)
+				return NewErrInvalidUserInput("class for ref does not exist: "+className+": %v", err)
 			}
 
 			prop, err := schema.GetPropertyByName(class, propName)
 			if err != nil {
-				return NewErrInvalidUserInput("get prop", err)
+				return NewErrInvalidUserInput("get prop: %v", err)
 			}
 			target = prop.DataType[0] // datatype is the name of the class that is referenced
 			classPropTarget[className+propName] = target

--- a/usecases/objects/references.go
+++ b/usecases/objects/references.go
@@ -1,0 +1,38 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package objects
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func (m *Manager) autodetectToClass(ctx context.Context, principal *models.Principal, fromClass, fromProperty string, beaconRef strfmt.URI) (strfmt.URI, strfmt.URI, *Error) {
+	// autodetect to class from schema if not part of reference
+	class, err := m.schemaManager.GetClass(ctx, principal, fromClass)
+	if err != nil {
+		return "", "", &Error{"cannot get class", StatusInternalServerError, err}
+	}
+	prop, err := schema.GetPropertyByName(class, schema.LowercaseFirstLetter(fromProperty))
+	if err != nil {
+		return "", "", &Error{"cannot get property", StatusInternalServerError, err}
+	}
+	toClass := prop.DataType[0] // datatype is the name of the class that is referenced
+	beaconElements := strings.Split(string(beaconRef), "/")
+	toUUID := beaconElements[len(beaconElements)-1]
+	toBeacon := "weaviate://localhost/" + string(toClass) + "/" + toUUID // datatype is the name of the class that is referenced
+	return strfmt.URI(toClass), strfmt.URI(toBeacon), nil
+}

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -66,6 +67,23 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		}
 		return &Error{"validate inputs", StatusBadRequest, err}
 	}
+
+	// autodetect to class from schema if not part of reference
+	if !deprecatedEndpoint && input.Ref.Class == "" && strings.Count(string(input.Ref.Beacon), "/") == 3 {
+		class, err := m.schemaManager.GetClass(ctx, principal, input.Class)
+		if err != nil {
+			return &Error{"cannot get class", StatusInternalServerError, err}
+		}
+		prop, err := schema.GetPropertyByName(class, schema.LowercaseFirstLetter(input.Property))
+		if err != nil {
+			return &Error{"cannot get property", StatusInternalServerError, err}
+		}
+		input.Ref.Class = strfmt.URI(prop.DataType[0]) // datatype is the name of the class that is referenced
+		beaconElements := strings.Split(string(input.Ref.Beacon), "/")
+		toUUID := beaconElements[len(beaconElements)-1]
+		input.Ref.Beacon = strfmt.URI("weaviate://localhost/" + string(input.Ref.Class) + "/" + toUUID) // datatype is the name of the class that is referenced
+	}
+
 	if !deprecatedEndpoint {
 		ok, err := m.vectorRepo.Exists(ctx, input.Class, input.ID, repl, tenant)
 		if err != nil {

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -40,6 +41,15 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	defer m.metrics.DeleteReferenceDec()
 
 	deprecatedEndpoint := input.Class == ""
+	if input.Class != "" && strings.Count(string(input.Reference.Beacon), "/") == 3 {
+		toClass, toBeacon, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Reference.Beacon)
+		if err != nil {
+			return err
+		}
+		input.Reference.Class = toClass
+		input.Reference.Beacon = toBeacon
+	}
+
 	res, err := m.getObjectFromRepo(ctx, input.Class, input.ID,
 		additional.Properties{}, nil, tenant)
 	if err != nil {

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -401,7 +401,7 @@ func Test_ReferenceDelete(t *testing.T) {
 		cls    = "Zoo"
 		prop   = "hasAnimals"
 		id     = strfmt.UUID("d18c8e5e-000-0000-0000-56b0cfe33ce7")
-		uri    = strfmt.URI("weaviate://localhost/d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
+		uri    = strfmt.URI("weaviate://localhost/Animal/d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
 		anyErr = errors.New("any")
 		ref    = models.SingleRef{Beacon: uri}
 		ref2   = &models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/d18c8e5e-a339-4c15-8af6-56b0cfe33ce5")}

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -109,7 +109,7 @@ func Test_ReferenceAdd(t *testing.T) {
 			Ref:      ref,
 		}
 		source = crossref.NewSource(schema.ClassName(cls), schema.PropertyName(prop), id)
-		target = crossref.New("localhost", "", refID)
+		target = crossref.New("localhost", "Animal", refID)
 	)
 
 	tests := []struct {

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -247,9 +247,9 @@ func Test_ReferenceUpdate(t *testing.T) {
 		prop   = "hasAnimals"
 		id     = strfmt.UUID("d18c8e5e-000-0000-0000-56b0cfe33ce7")
 		refID  = strfmt.UUID("d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
-		uri    = strfmt.URI("weaviate://localhost/d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
+		uri    = strfmt.URI("weaviate://localhost/Animals/d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
 		anyErr = errors.New("any")
-		refs   = models.MultipleRef{&models.SingleRef{Beacon: uri}}
+		refs   = models.MultipleRef{&models.SingleRef{Beacon: uri, Class: "Animals"}}
 		req    = PutReferenceInput{
 			Class:    cls,
 			ID:       id,
@@ -368,7 +368,7 @@ func Test_ReferenceUpdate(t *testing.T) {
 			}
 
 			if tc.Stage >= 2 {
-				m.repo.On("Exists", "", refID).Return(true, tc.ErrTargetExists).Once()
+				m.repo.On("Exists", "Animals", refID).Return(true, tc.ErrTargetExists).Once()
 			}
 
 			if tc.Stage >= 3 {

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -76,6 +77,17 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 			return &Error{"bad inputs", StatusUnprocessableEntity, err}
 		}
 		return &Error{"bad inputs", StatusBadRequest, err}
+	}
+
+	for i, ref := range input.Refs {
+		if strings.Count(string(ref.Beacon), "/") == 3 {
+			toClass, toBeacon, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, ref.Beacon)
+			if err != nil {
+				return err
+			}
+			input.Refs[i].Class = toClass
+			input.Refs[i].Beacon = toBeacon
+		}
 	}
 
 	obj := res.Object()


### PR DESCRIPTION
### What's being changed:

Allows to send references without the ToClass parameter. It can be deduces from the datatype of the class.

This is added for:
- add/update/delete references
- batch add references

This allows to simplify reference creation in the clients


I meassured the performance and couldn't find a different between autodetecting the class vs providing it
