### PR TITLE
Ensure proper vector sync to target nodes during read repair

### DIFF
--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -2293,7 +2293,11 @@ func TestOverwriteObjects(t *testing.T) {
 
 	t.Run("overwrite with fresh object", func(t *testing.T) {
 		input := []*objects.VObject{
-			{LatestObject: fresh, StaleUpdateTime: stale.LastUpdateTimeUnix},
+			{
+				LatestObject:    fresh,
+				Vector:          []float32{4, 5, 6},
+				StaleUpdateTime: stale.LastUpdateTimeUnix,
+			},
 		}
 
 		idx := repo.GetIndex(schema.ClassName(class.Class))

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -350,7 +350,7 @@ func (i *Index) overwriteObjects(ctx context.Context,
 		case curUpdateTime == u.StaleUpdateTime:
 			// the stored object is not the most recent version. in
 			// this case, we overwrite it with the more recent one.
-			err := s.putObject(ctx, storobj.FromObject(data, data.Vector))
+			err := s.putObject(ctx, storobj.FromObject(data, u.Vector))
 			if err != nil {
 				r.Err = fmt.Sprintf("overwrite stale object: %v", err)
 			}

--- a/usecases/objects/replication.go
+++ b/usecases/objects/replication.go
@@ -25,6 +25,8 @@ type VObject struct {
 	// LatestObject is to most up-to-date version of an object
 	LatestObject *models.Object `json:"object,omitempty"`
 
+	Vector []float32 `json:"vector"`
+
 	// StaleUpdateTime is the LastUpdateTimeUnix of the stale object sent to the coordinator
 	StaleUpdateTime int64 `json:"updateTime,omitempty"`
 
@@ -40,11 +42,16 @@ type VObject struct {
 type vobjectMarshaler struct {
 	StaleUpdateTime int64
 	Version         uint64
+	Vector          []float32
 	LatestObject    []byte
 }
 
 func (vo *VObject) MarshalBinary() ([]byte, error) {
-	b := vobjectMarshaler{StaleUpdateTime: vo.StaleUpdateTime, Version: vo.Version}
+	b := vobjectMarshaler{
+		StaleUpdateTime: vo.StaleUpdateTime,
+		Vector:          vo.Vector,
+		Version:         vo.Version,
+	}
 	if vo.LatestObject != nil {
 		obj, err := vo.LatestObject.MarshalBinary()
 		if err != nil {
@@ -64,6 +71,7 @@ func (vo *VObject) UnmarshalBinary(data []byte) error {
 		return err
 	}
 	vo.StaleUpdateTime = b.StaleUpdateTime
+	vo.Vector = b.Vector
 	vo.Version = b.Version
 
 	if b.LatestObject != nil {

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -87,6 +87,7 @@ func (r *repairer) repairOne(ctx context.Context,
 		gr.Go(func() error {
 			ups := []*objects.VObject{{
 				LatestObject:    &updates.Object.Object,
+				Vector:          updates.Object.Vector,
 				StaleUpdateTime: vote.UTime,
 			}}
 			resp, err := cl.Overwrite(ctx, vote.sender, r.class, shard, ups)
@@ -150,6 +151,7 @@ func (r *repairer) repairExist(ctx context.Context,
 		gr.Go(func() error {
 			ups := []*objects.VObject{{
 				LatestObject:    &resp.Object.Object,
+				Vector:          resp.Object.Vector,
 				StaleUpdateTime: vote.UTime,
 			}}
 			resp, err := cl.Overwrite(ctx, vote.sender, r.class, shard, ups)
@@ -263,7 +265,12 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 		for j, x := range lastTimes {
 			cTime := vote.UpdateTimeAt(j)
 			if x.T != cTime && !x.Deleted && result[j] != nil && vote.Count[j] == nVotes {
-				query = append(query, &objects.VObject{LatestObject: &result[j].Object, StaleUpdateTime: cTime})
+				obj := objects.VObject{
+					LatestObject:    &result[j].Object,
+					Vector:          result[j].Vector,
+					StaleUpdateTime: cTime,
+				}
+				query = append(query, &obj)
 				m[string(result[j].ID())] = j
 			}
 		}


### PR DESCRIPTION

### What's being changed:
Prior to this pull request, only object attributes were repaired in the vector. This PR fixes the identified https://github.com/weaviate/weaviate/issues/3267 by ensuring vector repair is performed correctly.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
