### PR TITLE
Acceptance tests for read-repaired object vectors

### DIFF
--- a/test/acceptance/replication/crud_ops.go
+++ b/test/acceptance/replication/crud_ops.go
@@ -64,9 +64,13 @@ func createTenantObjects(t *testing.T, host string, batch []*models.Object) {
 	helper.CreateObjectsBatch(t, batch)
 }
 
-func getObject(t *testing.T, host, class string, id strfmt.UUID) (*models.Object, error) {
+func getObject(t *testing.T, host, class string, id strfmt.UUID, withVec bool) (*models.Object, error) {
 	helper.SetupClient(host)
-	return helper.GetObject(t, class, id)
+	var include string
+	if withVec {
+		include = "vector"
+	}
+	return helper.GetObject(t, class, id, include)
 }
 
 func getTenantObject(t *testing.T, host, class string, id strfmt.UUID, tenant string) (*models.Object, error) {

--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -198,7 +198,7 @@ func immediateReplicaCRUD(t *testing.T) {
 	})
 
 	t.Run("patch an object", func(t *testing.T) {
-		before, err := getObject(t, compose.GetWeaviate().URI(), "Article", articleIDs[0])
+		before, err := getObject(t, compose.GetWeaviate().URI(), "Article", articleIDs[0], false)
 		require.Nil(t, err)
 		newTitle := "Article#9000"
 
@@ -350,7 +350,7 @@ func eventualReplicaCRUD(t *testing.T) {
 
 	t.Run("assert any future writes are replicated", func(t *testing.T) {
 		t.Run("patch an object", func(t *testing.T) {
-			before, err := getObject(t, compose.GetWeaviate().URI(), "Article", articleIDs[0])
+			before, err := getObject(t, compose.GetWeaviate().URI(), "Article", articleIDs[0], false)
 			require.Nil(t, err)
 			newTitle := "Article#9000"
 

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -49,6 +49,7 @@ func readRepair(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor: 2,
 		}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor: 2,
@@ -89,7 +90,6 @@ func readRepair(t *testing.T) {
 		Properties: map[string]interface{}{
 			"contents": "a new paragraph",
 		},
-		Vector: []float32{1, 2, 3, 4, 5},
 	}
 
 	t.Run("add new object to node one", func(t *testing.T) {
@@ -102,7 +102,7 @@ func readRepair(t *testing.T) {
 	})
 
 	t.Run("run fetch to trigger read repair", func(t *testing.T) {
-		_, err := getObject(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID)
+		_, err := getObject(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, true)
 		require.Nil(t, err)
 	})
 
@@ -116,6 +116,7 @@ func readRepair(t *testing.T) {
 		assert.Equal(t, repairObj.ID, resp.ID)
 		assert.Equal(t, repairObj.Class, resp.Class)
 		assert.EqualValues(t, repairObj.Properties, resp.Properties)
+		assert.EqualValues(t, repairObj.Vector, resp.Vector)
 	})
 
 	replaceObj := repairObj
@@ -153,5 +154,6 @@ func readRepair(t *testing.T) {
 		assert.Equal(t, replaceObj.ID, resp.ID)
 		assert.Equal(t, replaceObj.Class, resp.Class)
 		assert.EqualValues(t, replaceObj.Properties, resp.Properties)
+		assert.EqualValues(t, replaceObj.Vector, resp.Vector)
 	})
 }


### PR DESCRIPTION
### What's being changed:

Refactor replication read repair tests to assert repaired object vectors are propagated to the coordinator

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
