### PR TITLE
Fixes resolving refs for MT classes on search

### DIFF
--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -44,6 +44,7 @@ type Aggregator struct {
 	shardVersion           uint16
 	propLengths            *inverted.JsonPropertyLengthTracker
 	isFallbackToSearchable inverted.IsFallbackToSearchable
+	tenant                 string
 }
 
 func New(store *lsmkv.Store, params aggregation.Params,
@@ -51,6 +52,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 	deletedDocIDs inverted.DeletedDocIDChecker, stopwords stopwords.StopwordDetector,
 	shardVersion uint16, vectorIndex vectorIndex, logger logrus.FieldLogger,
 	propLengths *inverted.JsonPropertyLengthTracker, isFallbackToSearchable inverted.IsFallbackToSearchable,
+	tenant string,
 ) *Aggregator {
 	return &Aggregator{
 		logger:                 logger,
@@ -64,6 +66,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 		vectorIndex:            vectorIndex,
 		propLengths:            propLengths,
 		isFallbackToSearchable: isFallbackToSearchable,
+		tenant:                 tenant,
 	}
 }
 

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -92,7 +92,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 		s := a.getSchema.GetSchemaSkipAuth()
 		allow, err = inverted.NewSearcher(a.logger, a.store, s, nil,
 			a.classSearcher, a.deletedDocIDs, a.stopwords, a.shardVersion,
-			a.isFallbackToSearchable).
+			a.isFallbackToSearchable, a.tenant).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},
 				a.params.ClassName)
 		if err != nil {

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -79,7 +79,7 @@ func Test_Filters_String(t *testing.T) {
 	})
 
 	searcher := NewSearcher(logger, store, createSchema(),
-		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false })
+		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false }, "")
 
 	type test struct {
 		name                     string
@@ -343,7 +343,7 @@ func Test_Filters_Int(t *testing.T) {
 	})
 
 	searcher := NewSearcher(logger, store, createSchema(),
-		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false })
+		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false }, "")
 
 	type test struct {
 		name                     string
@@ -524,7 +524,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 	})
 
 	searcher := NewSearcher(logger, store, createSchema(),
-		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false })
+		nil, nil, nil, fakeStopwordDetector{}, 2, func() bool { return false }, "")
 
 	type test struct {
 		name                     string

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -46,6 +46,7 @@ type Searcher struct {
 	stopwords              stopwords.StopwordDetector
 	shardVersion           uint16
 	isFallbackToSearchable IsFallbackToSearchable
+	tenant                 string
 }
 
 type DeletedDocIDChecker interface {
@@ -57,6 +58,7 @@ func NewSearcher(logger logrus.FieldLogger, store *lsmkv.Store,
 	propIndices propertyspecific.Indices, classSearcher ClassSearcher,
 	deletedDocIDs DeletedDocIDChecker, stopwords stopwords.StopwordDetector,
 	shardVersion uint16, isFallbackToSearchable IsFallbackToSearchable,
+	tenant string,
 ) *Searcher {
 	return &Searcher{
 		logger:                 logger,
@@ -68,6 +70,7 @@ func NewSearcher(logger logrus.FieldLogger, store *lsmkv.Store,
 		stopwords:              stopwords,
 		shardVersion:           shardVersion,
 		isFallbackToSearchable: isFallbackToSearchable,
+		tenant:                 tenant,
 	}
 }
 
@@ -272,7 +275,7 @@ func (s *Searcher) extractReferenceFilter(prop *models.Property,
 	filter *filters.Clause,
 ) (*propValuePair, error) {
 	ctx := context.TODO()
-	return newRefFilterExtractor(s.logger, s.classSearcher, filter, prop).
+	return newRefFilterExtractor(s.logger, s.classSearcher, filter, prop, s.tenant).
 		Do(ctx)
 }
 

--- a/adapters/repos/db/inverted/searcher_ref_filter.go
+++ b/adapters/repos/db/inverted/searcher_ref_filter.go
@@ -33,6 +33,7 @@ type refFilterExtractor struct {
 	classSearcher ClassSearcher
 	filter        *filters.Clause
 	property      *models.Property
+	tenant        string
 }
 
 // ClassSearcher is anything that allows a root-level ClassSearch
@@ -43,13 +44,14 @@ type ClassSearcher interface {
 }
 
 func newRefFilterExtractor(logger logrus.FieldLogger, classSearcher ClassSearcher,
-	filter *filters.Clause, property *models.Property,
+	filter *filters.Clause, property *models.Property, tenant string,
 ) *refFilterExtractor {
 	return &refFilterExtractor{
 		logger:        logger,
 		classSearcher: classSearcher,
 		filter:        filter,
 		property:      property,
+		tenant:        tenant,
 	}
 }
 
@@ -94,6 +96,7 @@ func (r *refFilterExtractor) paramsForNestedRequest() (dto.GetParams, error) {
 		// to perform the same search limits cutoff check that we do with
 		// the root query
 		AdditionalProperties: additional.Properties{ReferenceQuery: true},
+		Tenant:               r.tenant,
 	}, nil
 }
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -596,3 +596,11 @@ func (s *Shard) objectCount() int {
 func (s *Shard) isFallbackToSearchable() bool {
 	return s.fallbackToSearchable
 }
+
+func (s *Shard) tenant() string {
+	// TODO provide better impl
+	if s.index.partitioningEnabled {
+		return s.name
+	}
+	return ""
+}

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -23,6 +23,6 @@ func (s *Shard) aggregate(ctx context.Context,
 ) (*aggregation.Result, error) {
 	return aggregator.New(s.store, params, s.index.getSchema,
 		s.index.classSearcher, s.deletedDocIDs, s.index.stopwords, s.versioner.Version(),
-		s.vectorIndex, s.index.logger, s.propLengths, s.isFallbackToSearchable).
+		s.vectorIndex, s.index.logger, s.propLengths, s.isFallbackToSearchable, s.tenant()).
 		Do(ctx)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -184,7 +184,8 @@ func (s *Shard) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 			objs, err = inverted.NewSearcher(s.index.logger, s.store,
 				s.index.getSchema.GetSchemaSkipAuth(),
 				s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
-				s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable).
+				s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable,
+				s.tenant()).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
 			if err != nil {
 				return nil, nil, err
@@ -212,7 +213,8 @@ func (s *Shard) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 	objs, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(),
 		s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
-		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable).
+		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable,
+		s.tenant()).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName)
 	return objs, nil, err
 }
@@ -381,7 +383,8 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 	list, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(),
 		s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
-		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable).
+		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable,
+		s.tenant()).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)
 	if err != nil {
 		return nil, errors.Wrap(err, "build inverted filter allow list")

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -148,7 +148,8 @@ func (s *Shard) findDocIDs(ctx context.Context,
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(), nil,
 		s.index.classSearcher, s.deletedDocIDs, s.index.stopwords,
-		s.versioner.version, s.isFallbackToSearchable).
+		s.versioner.version, s.isFallbackToSearchable,
+		s.tenant()).
 		DocIDs(ctx, filters, additional.Properties{}, s.index.Config.ClassName)
 	if err != nil {
 		return nil, err

--- a/test/acceptance_with_go_client/fixtures/food.go
+++ b/test/acceptance_with_go_client/fixtures/food.go
@@ -274,6 +274,22 @@ func CreateDataPizzaForTenants(t *testing.T, client *weaviate.Client, tenantName
 	})
 }
 
+func CreateDataSoupChickenForTenants(t *testing.T, client *weaviate.Client, tenantNames ...string) {
+	createDataForTenants(t, client, tenantNames, func() []*models.Object {
+		return []*models.Object{
+			objectSoupChicken(),
+		}
+	})
+}
+
+func CreateDataSoupBeautifulForTenants(t *testing.T, client *weaviate.Client, tenantNames ...string) {
+	createDataForTenants(t, client, tenantNames, func() []*models.Object {
+		return []*models.Object{
+			objectSoupBeautiful(),
+		}
+	})
+}
+
 func CreateDataSoupForTenants(t *testing.T, client *weaviate.Client, tenantNames ...string) {
 	createDataForTenants(t, client, tenantNames, func() []*models.Object {
 		return []*models.Object{

--- a/test/acceptance_with_go_client/multi_tenancy_tests/batch_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/batch_test.go
@@ -588,4 +588,121 @@ func TestBatchDelete_MultiTenancy(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("deletes objects from MT class by ref", func(t *testing.T) {
+		defer cleanup()
+
+		tenant1 := "tenantNo1"
+		tenant2 := "tenantNo2"
+		soupIdByTenantAndPizza := map[string]map[string]string{
+			tenant1: {
+				fixtures.PIZZA_QUATTRO_FORMAGGI_ID: fixtures.SOUP_CHICKENSOUP_ID,
+				fixtures.PIZZA_FRUTTI_DI_MARE_ID:   fixtures.SOUP_CHICKENSOUP_ID,
+			},
+			tenant2: {
+				fixtures.PIZZA_HAWAII_ID: fixtures.SOUP_BEAUTIFUL_ID,
+				fixtures.PIZZA_DOENER_ID: fixtures.SOUP_BEAUTIFUL_ID,
+			},
+		}
+
+		t.Run("add data", func(t *testing.T) {
+			fixtures.CreateSchemaPizzaForTenants(t, client)
+			fixtures.CreateTenantsPizza(t, client, tenant1, tenant2)
+			fixtures.CreateDataPizzaQuattroFormaggiForTenants(t, client, tenant1)
+			fixtures.CreateDataPizzaFruttiDiMareForTenants(t, client, tenant1)
+			fixtures.CreateDataPizzaHawaiiForTenants(t, client, tenant2)
+			fixtures.CreateDataPizzaDoenerForTenants(t, client, tenant2)
+
+			fixtures.CreateSchemaSoupForTenants(t, client)
+			fixtures.CreateTenantsSoup(t, client, tenant1, tenant2)
+			fixtures.CreateDataSoupChickenForTenants(t, client, tenant1)
+			fixtures.CreateDataSoupBeautifulForTenants(t, client, tenant2)
+		})
+
+		t.Run("create ref property", func(t *testing.T) {
+			err := client.Schema().PropertyCreator().
+				WithClassName("Soup").
+				WithProperty(&models.Property{
+					Name:     "relatedToPizza",
+					DataType: []string{"Pizza"},
+				}).
+				Do(context.Background())
+
+			require.Nil(t, err)
+		})
+
+		t.Run("create refs", func(t *testing.T) {
+			references := []*models.BatchReference{}
+
+			for tenant, pizzaToSoup := range soupIdByTenantAndPizza {
+				for pizzaId, soupId := range pizzaToSoup {
+					rpb := client.Batch().ReferencePayloadBuilder().
+						WithFromClassName("Soup").
+						WithFromRefProp("relatedToPizza").
+						WithFromID(soupId).
+						WithToClassName("Pizza").
+						WithToID(pizzaId).
+						WithTenant(tenant)
+
+					references = append(references, rpb.Payload())
+				}
+			}
+
+			resp, err := client.Batch().ReferencesBatcher().
+				WithReferences(references...).
+				Do(context.Background())
+
+			require.Nil(t, err)
+			require.NotNil(t, resp)
+			assert.Len(t, resp, len(references))
+			for i := range resp {
+				require.NotNil(t, resp[i].Result)
+				assert.Nil(t, resp[i].Result.Errors)
+			}
+		})
+
+		for tenant, pizzaToSoup := range soupIdByTenantAndPizza {
+			i := 0
+			for pizzaId := range pizzaToSoup {
+				resp, err := client.Batch().ObjectsBatchDeleter().
+					WithClassName("Soup").
+					WithWhere(filters.Where().
+						WithOperator(filters.Like).
+						WithPath([]string{"relatedToPizza", "Pizza", "_id"}).
+						WithValueText(pizzaId)).
+					WithOutput("minimal").
+					WithTenant(tenant).
+					Do(context.Background())
+
+				require.Nil(t, err)
+				require.NotNil(t, resp)
+				require.NotNil(t, resp.Results)
+
+				// single soup references two pizzas, so soup will be deleted only for 1st pizza
+				if i == 0 {
+					assert.Equal(t, int64(1), resp.Results.Matches)
+					assert.Equal(t, int64(1), resp.Results.Successful)
+				} else {
+					assert.Equal(t, int64(0), resp.Results.Matches)
+					assert.Equal(t, int64(0), resp.Results.Successful)
+				}
+				i++
+			}
+		}
+
+		t.Run("verify deleted", func(t *testing.T) {
+			for tenant, pizzaToSoup := range soupIdByTenantAndPizza {
+				for _, soupId := range pizzaToSoup {
+					exists, err := client.Data().Checker().
+						WithID(soupId).
+						WithClassName("Soup").
+						WithTenant(tenant).
+						Do(context.Background())
+
+					require.Nil(t, err)
+					require.False(t, exists)
+				}
+			}
+		})
+	})
 }


### PR DESCRIPTION
### What's being changed:
Passes missing tenant id to internal search executed on search by referenced properties

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
