### PR TITLE
Add support for compilation on windows

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -125,9 +125,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          # we cannot use 1.20.6 version of go bc of a bug in go 1.20.6 that affects testcontainers
-          # should be changed back '1.20' once this is fixed
-          go-version: '1.20.5'
+          go-version: '1.20'
           cache: true
       - name: goreleaser
         run: |
@@ -178,9 +176,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          # we cannot use 1.20.6 version of go bc of a bug in go 1.20.6 that affects testcontainers
-          # should be changed back '1.20' once this is fixed
-          go-version: '1.20.5'
+          go-version: '1.20'
           cache: true
       - name: start weaviate
         shell: bash

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -184,10 +184,13 @@ jobs:
           cache: true
       - name: start weaviate
         shell: bash
+        # Weaviate is started without a Vectorizer as running text2vec-contextionary on GH actions is difficult:
+        # - docker on GHA only supports windows container - which we currently are not build
+        # - building those containers without a windows machine is difficult to figure out
         run: ./weaviate.exe --scheme http --port 8080 &
       - name: run acceptance tests
         shell: bash
-        run: go test -count 1 -race test/acceptance/actions/*.go
+        run: go test -count 1 -race test/acceptance/actions/*.go  # tests that don't need a Vectorizer
 
   Push-Docker:
     needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -118,6 +118,76 @@ jobs:
           fail_ci_if_error: true
           files: ./coverage-integration.txt, ./coverage-unit.txt
           verbose: true
+  Compile-and-upload-binaries:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          # we cannot use 1.20.6 version of go bc of a bug in go 1.20.6 that affects testcontainers
+          # should be changed back '1.20' once this is fixed
+          go-version: '1.20.5'
+          cache: true
+      - name: goreleaser
+        run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install goreleaser
+          GIT_HASH=$(git rev-parse --short HEAD) goreleaser build  --clean --snapshot
+      - name: Upload macos
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-macos-unsigned
+          path: dist/weaviate_darwin_all
+      - name: Upload windows
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-windows-amd64
+          path: dist/weaviate_windows_amd64_v1
+      - name: Upload windows
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-windows-arm64
+          path: dist/weaviate_windows_arm64
+      - name: Upload linux amd64
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-linux-amd64
+          path: dist/weaviate_linux_amd64_v1
+      - name: Upload linux arm64
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-linux-arm64
+          path: dist/weaviate_linux_arm64
+
+
+  Acceptance-Tests-windows:
+    needs: Compile-and-upload-binaries
+    runs-on: windows-latest
+    env:
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: true
+      PERSISTENCE_DATA_PATH: /tmp
+      QUERY_DEFAULTS_LIMIT: 20
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: binaries-windows-amd64
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          # we cannot use 1.20.6 version of go bc of a bug in go 1.20.6 that affects testcontainers
+          # should be changed back '1.20' once this is fixed
+          go-version: '1.20.5'
+          cache: true
+      - name: start weaviate
+        shell: bash
+        run: ./weaviate.exe --scheme http --port 8080 &
+      - name: run acceptance tests
+        shell: bash
+        run: go test -count 1 -race test/acceptance/actions/*.go
 
   Push-Docker:
     needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     main: ./cmd/weaviate-server
     goarch:
       - amd64

--- a/adapters/clients/cluster_schema_test.go
+++ b/adapters/clients/cluster_schema_test.go
@@ -187,7 +187,7 @@ func TestOpenTransactionUnhappyPaths(t *testing.T) {
 			shutdownPrematurely: true,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 			},
-			expectedErrContains: "connection refused",
+			expectedErrContains: "refused",
 		},
 		{
 			name: "tx id mismatch",
@@ -301,7 +301,7 @@ func TestAbortTransactionUnhappyPaths(t *testing.T) {
 			shutdownPrematurely: true,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 			},
-			expectedErrContains: "connection refused",
+			expectedErrContains: "refused",
 		},
 	}
 
@@ -399,7 +399,7 @@ func TestCommitTransactionUnhappyPaths(t *testing.T) {
 			shutdownPrematurely: true,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 			},
-			expectedErrContains: "connection refused",
+			expectedErrContains: "refused",
 		},
 	}
 

--- a/adapters/repos/db/disk_use_unix.go
+++ b/adapters/repos/db/disk_use_unix.go
@@ -1,0 +1,33 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build !windows
+
+package db
+
+import (
+	"syscall"
+)
+
+func (d *DB) getDiskUse(diskPath string) diskUse {
+	fs := syscall.Statfs_t{}
+
+	err := syscall.Statfs(diskPath, &fs)
+	if err != nil {
+		d.logger.WithField("action", "read_disk_use").
+			WithField("path", diskPath).
+			Errorf("failed to read disk usage: %s", err)
+	}
+
+	return diskUse{
+		total: fs.Blocks * uint64(fs.Bsize),
+		free:  fs.Bfree * uint64(fs.Bsize),
+		avail: fs.Bfree * uint64(fs.Bsize),
+	}
+}

--- a/adapters/repos/db/disk_use_unix.go
+++ b/adapters/repos/db/disk_use_unix.go
@@ -7,6 +7,8 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
+//
+
 //go:build !windows
 
 package db

--- a/adapters/repos/db/disk_use_windows.go
+++ b/adapters/repos/db/disk_use_windows.go
@@ -1,0 +1,42 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build windows
+
+package db
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func (d *DB) getDiskUse(diskPath string) diskUse {
+	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes uint64
+
+	_, _ = syscall.UTF16PtrFromString(diskPath)
+
+	err := windows.GetDiskFreeSpaceEx(
+		syscall.StringToUTF16Ptr(diskPath),
+		&freeBytesAvailable,
+		&totalNumberOfBytes,
+		&totalNumberOfFreeBytes,
+	)
+	if err != nil {
+		d.logger.WithField("action", "read_disk_use").
+			WithField("path", diskPath).
+			Errorf("failed to read disk usage: %s", err)
+	}
+
+	return diskUse{
+		total: totalNumberOfBytes,
+		free:  totalNumberOfFreeBytes,
+		avail: freeBytesAvailable,
+	}
+}

--- a/adapters/repos/db/disk_use_windows.go
+++ b/adapters/repos/db/disk_use_windows.go
@@ -7,6 +7,8 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
+//
+
 //go:build windows
 
 package db

--- a/adapters/repos/db/inverted/prop_length_tracker_test.go
+++ b/adapters/repos/db/inverted/prop_length_tracker_test.go
@@ -41,29 +41,33 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		tests := []test{
 			{
 				values:       []float32{2, 2, 3, 100, 100, 500, 7},
-				name:         "mixed values",
+				name:         "mixed_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values: []float32{
 					1000, 1200, 1000, 1300, 800, 2000, 2050,
 					2070, 900,
 				},
-				name:         "high values",
+				name:         "high_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values: []float32{
 					60000, 50000, 65000,
 				},
-				name:         "very high values",
+				name:         "very_high_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values: []float32{
 					1, 2, 4, 3, 4, 2, 1, 5, 6, 7, 8, 2, 7, 2, 3, 5,
 					6, 3, 5, 9, 3, 4, 8,
 				},
-				name:         "very low values",
+				name:         "very_low_values",
 				floatCompare: true,
-			}, {
+			},
+			{
 				values:       []float32{0, 0},
 				name:         "zeros",
 				floatCompare: false,
@@ -72,7 +76,7 @@ func Test_PropertyLengthTracker(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				tracker, err := NewJsonPropertyLengthTracker(trackerPath, l)
+				tracker, err := NewJsonPropertyLengthTracker(trackerPath+test.name, l)
 				require.Nil(t, err)
 
 				actualMean := float32(0)
@@ -90,6 +94,7 @@ func Test_PropertyLengthTracker(t *testing.T) {
 				} else {
 					assert.Equal(t, actualMean, res)
 				}
+				require.Nil(t, tracker.Close())
 			})
 		}
 	})
@@ -122,6 +127,8 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		assert.Equal(t, 3, sum)
 		assert.Equal(t, 1, count)
 		assert.InEpsilon(t, 3, mean, 0.1)
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("multiple properties (can all fit on one page)", func(t *testing.T) {
@@ -170,6 +177,8 @@ func Test_PropertyLengthTracker(t *testing.T) {
 
 			assert.InEpsilon(t, actualMean, res, 0.1)
 		}
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("with more properties that can fit on one page", func(t *testing.T) {
@@ -178,6 +187,8 @@ func Test_PropertyLengthTracker(t *testing.T) {
 		require.Nil(t, err)
 
 		create20PropsAndVerify(t, tracker)
+
+		require.Nil(t, tracker.Close())
 	})
 }
 
@@ -415,27 +426,27 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 		tests := []test{
 			{
 				values:       []float32{2, 2, 3, 100, 100, 500, 7},
-				name:         "mixed values",
+				name:         "mixed_values",
 				floatCompare: true,
 			}, {
 				values: []float32{
 					1000, 1200, 1000, 1300, 800, 2000, 2050,
 					2070, 900,
 				},
-				name:         "high values",
+				name:         "high_values",
 				floatCompare: true,
 			}, {
 				values: []float32{
 					60000, 50000, 65000,
 				},
-				name:         "very high values",
+				name:         "very_high_values",
 				floatCompare: true,
 			}, {
 				values: []float32{
 					1, 2, 4, 3, 4, 2, 1, 5, 6, 7, 8, 2, 7, 2, 3, 5,
 					6, 3, 5, 9, 3, 4, 8,
 				},
-				name:         "very low values",
+				name:         "very_low_values",
 				floatCompare: true,
 			}, {
 				values:       []float32{0, 0},
@@ -446,7 +457,7 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				tracker, err := NewPropertyLengthTracker(trackerPath)
+				tracker, err := NewPropertyLengthTracker(trackerPath + test.name)
 				require.Nil(t, err)
 
 				actualMean := float32(0)
@@ -464,6 +475,7 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 				} else {
 					assert.Equal(t, actualMean, res)
 				}
+				require.Nil(t, tracker.Close())
 			})
 		}
 	})
@@ -496,6 +508,8 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 		assert.Equal(t, 3, sum)
 		assert.Equal(t, 1, count)
 		assert.InEpsilon(t, 3, mean, 0.1)
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("multiple properties (can all fit on one page)", func(t *testing.T) {
@@ -544,6 +558,8 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 
 			assert.InEpsilon(t, actualMean, res, 0.1)
 		}
+
+		require.Nil(t, tracker.Close())
 	})
 
 	t.Run("with more properties that can fit on one page", func(t *testing.T) {
@@ -552,6 +568,8 @@ func TestOldPropertyLengthTracker(t *testing.T) {
 		require.Nil(t, err)
 
 		create20PropsAndVerify_old(t, tracker)
+
+		require.Nil(t, tracker.Close())
 	})
 }
 
@@ -600,6 +618,10 @@ func TestOldPropertyLengthTracker_Persistence(t *testing.T) {
 		require.Nil(t, err)
 		assert.InEpsilon(t, actualMeanForProp20, res, 0.1)
 	})
+
+	t.Run("shut down the second tracker", func(t *testing.T) {
+		require.Nil(t, secondTracker.Close())
+	})
 }
 
 func Test_PropertyLengthTracker_Overflow(t *testing.T) {
@@ -617,4 +639,6 @@ func Test_PropertyLengthTracker_Overflow(t *testing.T) {
 	// Check that property that would cause the internal counter to overflow is not added
 	err = tracker.TrackProperty("OVERFLOW", float32(123))
 	require.NotNil(t, err)
+
+	require.Nil(t, tracker.Close())
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -28,6 +28,9 @@ func TestBucket_WasDeleted(t *testing.T) {
 	b, err := NewBucket(context.Background(), tmpDir, "", logger, nil,
 		cyclemanager.NewNoop(), cyclemanager.NewNoop())
 	require.Nil(t, err)
+	t.Cleanup(func() {
+		require.Nil(t, b.Shutdown(context.Background()))
+	})
 
 	var (
 		key = []byte("key")

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
@@ -50,6 +50,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.False(t, setKey2.Additions.Contains(2))
 		assert.True(t, setKey2.Additions.Contains(3))
 		assert.True(t, setKey2.Additions.Contains(4))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("inserting lists", func(t *testing.T) {
@@ -75,6 +77,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.False(t, setKey2.Additions.Contains(2))
 		assert.True(t, setKey2.Additions.Contains(3))
 		assert.True(t, setKey2.Additions.Contains(4))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("inserting bitmaps", func(t *testing.T) {
@@ -102,6 +106,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.False(t, setKey2.Additions.Contains(2))
 		assert.True(t, setKey2.Additions.Contains(3))
 		assert.True(t, setKey2.Additions.Contains(4))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("removing individual entries", func(t *testing.T) {
@@ -123,6 +129,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		require.Nil(t, err)
 		assert.False(t, setKey2.Additions.Contains(8))
 		assert.True(t, setKey2.Deletions.Contains(8))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("removing lists", func(t *testing.T) {
@@ -148,6 +156,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.Equal(t, 2, setKey2.Deletions.GetCardinality())
 		assert.True(t, setKey2.Deletions.Contains(9))
 		assert.True(t, setKey2.Deletions.Contains(10))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("removing bitmaps", func(t *testing.T) {
@@ -173,6 +183,8 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.Equal(t, 2, setKey2.Deletions.GetCardinality())
 		assert.True(t, setKey2.Deletions.Contains(9))
 		assert.True(t, setKey2.Deletions.Contains(10))
+
+		require.Nil(t, m.commitlog.close())
 	})
 
 	t.Run("adding/removing bitmaps", func(t *testing.T) {
@@ -204,5 +216,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		assert.Equal(t, 2, setKey2.Deletions.GetCardinality())
 		assert.True(t, setKey2.Deletions.Contains(9))
 		assert.True(t, setKey2.Deletions.Contains(10))
+
+		require.Nil(t, m.commitlog.close())
 	})
 }

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -26,6 +26,9 @@ func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	dir := t.TempDir()
 	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, nil)
 	require.Nil(t, err)
+	t.Cleanup(func() {
+		require.Nil(t, m.commitlog.close())
+	})
 
 	t.Run("add initial value", func(t *testing.T) {
 		err = m.put([]byte("my-key"), []byte("my-value"),

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -7,7 +7,6 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
-//
 
 package lsmkv
 
@@ -15,8 +14,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"syscall"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
@@ -76,7 +75,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		return nil, errors.Wrap(err, "stat file")
 	}
 
-	content, err := syscall.Mmap(int(file.Fd()), 0, int(fileInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	content, err := mmap.MapRegion(file, int(fileInfo.Size()), mmap.RDONLY, 0, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "mmap file")
 	}
@@ -145,7 +144,8 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 }
 
 func (s *segment) close() error {
-	return syscall.Munmap(s.contents)
+	mmmap := mmap.MMap(s.contents)
+	return mmmap.Unmap()
 }
 
 func (s *segment) drop() error {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -7,6 +7,7 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
+//
 
 package lsmkv
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -34,7 +34,6 @@ func TestCreateBloomOnFlush(t *testing.T) {
 		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -48,6 +47,8 @@ func TestCreateBloomOnFlush(t *testing.T) {
 
 	_, ok = findFileWithExt(files, "secondary.0.bloom")
 	assert.True(t, ok)
+	// on Windows we have to shutdown the bucket before opening it again
+	require.Nil(t, b.Shutdown(ctx))
 
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
 		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
@@ -124,7 +125,6 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
 	require.Nil(t, b.FlushMemtable())
@@ -136,6 +136,8 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 
 	// now corrupt the bloom filter by randomly overriding data
 	require.Nil(t, corruptBloomFile(path.Join(dirName, fname)))
+	// on Windows we have to shutdown the bucket before opening it again
+	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
@@ -196,7 +198,6 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 		cyclemanager.NewNoop(), cyclemanager.NewNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -209,6 +210,8 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 
 	// now corrupt the file by replacing the count value without adapting the checksum
 	require.Nil(t, corruptBloomFile(path.Join(dirName, fname)))
+	// on Windows we have to shutdown the bucket before opening it again
+	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -78,6 +78,7 @@ func TestCreateCNAInit(t *testing.T) {
 	_, ok = findFileWithExt(files, ".cna")
 	require.False(t, ok, "verify the file is really gone")
 
+	// on Windows we have to shutdown the bucket before opening it again
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
@@ -118,6 +119,8 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	// now corrupt the file by replacing the count value without adapting the checksum
 	require.Nil(t, corruptCNAFile(path.Join(dirName, fname), 12345))
 
+	// on Windows we have to shutdown the bucket before opening it again
+	require.Nil(t, b.Shutdown(ctx))
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -7,6 +7,7 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
+//
 
 package lsmkv
 

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -156,7 +156,9 @@ func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger)
 		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		unixErr := "no such file or directory"
+		windowsErr := "The system cannot find the file specified."
+		assert.True(t, strings.Contains(err.Error(), unixErr) || strings.Contains(err.Error(), windowsErr))
 	})
 
 	t.Run("segment header can't be parsed", func(t *testing.T) {

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/debug"
-	"syscall"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/storagestate"
@@ -63,23 +62,6 @@ func (d *DB) scanResourceUsage() {
 			}
 		}
 	}()
-}
-
-func (d *DB) getDiskUse(diskPath string) diskUse {
-	fs := syscall.Statfs_t{}
-
-	err := syscall.Statfs(diskPath, &fs)
-	if err != nil {
-		d.logger.WithField("action", "read_disk_use").
-			WithField("path", diskPath).
-			Errorf("failed to read disk usage: %s", err)
-	}
-
-	return diskUse{
-		total: fs.Blocks * uint64(fs.Bsize),
-		free:  fs.Bfree * uint64(fs.Bsize),
-		avail: fs.Bfree * uint64(fs.Bsize),
-	}
 }
 
 type resourceScanState struct {

--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -66,6 +66,7 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 			},
 		}, uc, cyclemanager.NewNoop(),
 	)
+	defer index.Shutdown(context.Background())
 	ssdhelpers.Concurrently(uint64(len(vectors)), func(id uint64) {
 		index.Add(uint64(id), vectors[id])
 	})

--- a/adapters/repos/db/vector/hnsw/condensor_mmap_reader.go
+++ b/adapters/repos/db/vector/hnsw/condensor_mmap_reader.go
@@ -14,8 +14,8 @@ package hnsw
 import (
 	"bufio"
 	"os"
-	"syscall"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/pkg/errors"
 )
 
@@ -28,9 +28,7 @@ func newMmapCondensorReader() *MmapCondensorReader {
 	return &MmapCondensorReader{}
 }
 
-func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex,
-	targetName string,
-) error {
+func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex, targetName string) error {
 	r.reader = bufio.NewReaderSize(source, 1024*1024)
 
 	scratchFile, err := os.Create(targetName)
@@ -43,8 +41,7 @@ func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex,
 		return errors.Wrap(err, "truncate scratch file to size")
 	}
 
-	mmapSpace, err := syscall.Mmap(int(scratchFile.Fd()), 0, size,
-		syscall.PROT_WRITE, syscall.MAP_PRIVATE)
+	mmapSpace, err := mmap.MapRegion(scratchFile, size, mmap.COPY, 0, 0)
 	if err != nil {
 		return errors.Wrap(err, "mmap scratch file")
 	}
@@ -55,7 +52,7 @@ func (r *MmapCondensorReader) Do(source *os.File, index mmapIndex,
 		return err
 	}
 
-	if err := syscall.Munmap(r.target); err != nil {
+	if err := mmapSpace.Unmap(); err != nil {
 		return errors.Wrap(err, "munmap scratch file")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/coreos/go-oidc/v3 v3.4.0
+	github.com/edsrzf/mmap-go v1.1.0
 	github.com/googleapis/gax-go/v2 v2.11.0
 	github.com/pkoukk/tiktoken-go v0.1.1
 	github.com/tailor-inc/graphql v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -162,6 +162,8 @@ func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, err
 func logConnectionRefused(logger logrus.FieldLogger, err error) {
 	if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
 		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+	} else if strings.Contains(err.Error(), "connectex: No connection could be made because the target machine actively refused it.") {
+		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 	}
 }
 
@@ -253,6 +255,8 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 	res, err := c.grpcClient.VectorForCorpi(ctx, &pb.Corpi{Corpi: corpi, Overrides: overrides})
 	if err != nil {
 		if strings.Contains(err.Error(), "connect: connection refused") {
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		} else if strings.Contains(err.Error(), "connectex: No connection could be made because the target machine actively refused it.") {
 			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
 		}
 		st, ok := status.FromError(err)

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const ModelUncontactable = "module uncontactable"
+
 // Client establishes a gRPC connection to a remote contextionary service
 type Client struct {
 	grpcClient pb.ContextionaryClient
@@ -161,9 +163,9 @@ func (c *Client) VectorForWord(ctx context.Context, word string) ([]float32, err
 
 func logConnectionRefused(logger logrus.FieldLogger, err error) {
 	if strings.Contains(fmt.Sprintf("%v", err), "connect: connection refused") {
-		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		logger.WithError(err).WithField("module", "contextionary").Warnf(ModelUncontactable)
 	} else if strings.Contains(err.Error(), "connectex: No connection could be made because the target machine actively refused it.") {
-		logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+		logger.WithError(err).WithField("module", "contextionary").Warnf(ModelUncontactable)
 	}
 }
 
@@ -255,9 +257,9 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 	res, err := c.grpcClient.VectorForCorpi(ctx, &pb.Corpi{Corpi: corpi, Overrides: overrides})
 	if err != nil {
 		if strings.Contains(err.Error(), "connect: connection refused") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf(ModelUncontactable)
 		} else if strings.Contains(err.Error(), "connectex: No connection could be made because the target machine actively refused it.") {
-			c.logger.WithError(err).WithField("module", "contextionary").Warnf("module uncontactable")
+			c.logger.WithError(err).WithField("module", "contextionary").Warnf(ModelUncontactable)
 		}
 		st, ok := status.FromError(err)
 		if !ok || st.Code() != codes.InvalidArgument {

--- a/test/acceptance/run.sh
+++ b/test/acceptance/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eou pipefail
+
+function main() {
+  # needed for test/docker package during replication tests
+  export TEST_WEAVIATE_IMAGE=weaviate/test-server
+  # for now we need to run the tests sequentially, there seems to be some sort of issues with running them in parallel
+    for pkg in $(go list ./... | grep 'test/acceptance' | grep -v 'test/acceptance/stress_tests' ); do
+      if ! go test -count 1 -race "$pkg"; then
+        echo "Test for $pkg failed" >&2
+        return 1
+      fi
+    done
+    for pkg in $(go list ./... | grep 'test/acceptance/stress_tests' ); do
+      if ! go test -count 1 "$pkg"; then
+        echo "Test for $pkg failed" >&2
+        return 1
+      fi
+    done
+    # tests with go client are in a separate package with its own dependencies to isolate them
+    cd 'test/acceptance_with_go_client'
+    for pkg in $(go list ./... ); do
+      if ! go test -count 1 -race "$pkg"; then
+        echo "Test for $pkg failed" >&2
+        return 1
+      fi
+    done
+}
+
+main "$@"

--- a/test/run.sh
+++ b/test/run.sh
@@ -118,29 +118,7 @@ function run_integration_tests() {
 }
 
 function run_acceptance_tests() {
-  # needed for test/docker package during replication tests
-  export TEST_WEAVIATE_IMAGE=weaviate/test-server
-  # for now we need to run the tests sequentially, there seems to be some sort of issues with running them in parallel
-    for pkg in $(go list ./... | grep 'test/acceptance' | grep -v 'test/acceptance/stress_tests' ); do
-      if ! go test -count 1 -race "$pkg"; then
-        echo "Test for $pkg failed" >&2
-        return 1
-      fi
-    done
-    for pkg in $(go list ./... | grep 'test/acceptance/stress_tests' ); do
-      if ! go test -count 1 "$pkg"; then
-        echo "Test for $pkg failed" >&2
-        return 1
-      fi
-    done
-    # tests with go client are in a separate package with its own dependencies to isolate them
-    cd 'test/acceptance_with_go_client'
-    for pkg in $(go list ./... ); do
-      if ! go test -count 1 -race "$pkg"; then
-        echo "Test for $pkg failed" >&2
-        return 1
-      fi
-    done
+  ./test/acceptance/run.sh --include-slow
 }
 
 function run_module_tests() {

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/hashicorp/memberlist"
@@ -291,16 +290,3 @@ func (e events) NotifyLeave(node *memberlist.Node) {
 // updated, usually involving the meta data. The Node argument
 // must not be modified.
 func (e events) NotifyUpdate(*memberlist.Node) {}
-
-// diskSpace return the disk space usage
-func diskSpace(path string) (DiskUsage, error) {
-	fs := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &fs)
-	if err != nil {
-		return DiskUsage{}, err
-	}
-	return DiskUsage{
-		Total:     fs.Blocks * uint64(fs.Bsize),
-		Available: fs.Bavail * uint64(fs.Bsize),
-	}, nil
-}

--- a/usecases/cluster/disk_use_unix.go
+++ b/usecases/cluster/disk_use_unix.go
@@ -1,0 +1,29 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build !windows
+
+package cluster
+
+import (
+	"syscall"
+)
+
+// diskSpace return the disk space usage
+func diskSpace(path string) (DiskUsage, error) {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return DiskUsage{}, err
+	}
+	return DiskUsage{
+		Total:     fs.Blocks * uint64(fs.Bsize),
+		Available: fs.Bavail * uint64(fs.Bsize),
+	}, nil
+}

--- a/usecases/cluster/disk_use_unix.go
+++ b/usecases/cluster/disk_use_unix.go
@@ -7,6 +7,8 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
+//
+
 //go:build !windows
 
 package cluster

--- a/usecases/cluster/disk_use_windows.go
+++ b/usecases/cluster/disk_use_windows.go
@@ -1,0 +1,36 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//go:build windows
+
+package cluster
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// diskSpace return the disk space usage
+func diskSpace(path string) (DiskUsage, error) {
+	var freeBytesAvailableToCaller, totalBytes, totalFreeBytes uint64
+
+	err := windows.GetDiskFreeSpaceEx(
+		windows.StringToUTF16Ptr(path),
+		&freeBytesAvailableToCaller,
+		&totalBytes,
+		&totalFreeBytes,
+	)
+	if err != nil {
+		return DiskUsage{}, err
+	}
+
+	return DiskUsage{
+		Total:     totalBytes,
+		Available: freeBytesAvailableToCaller,
+	}, nil
+}

--- a/usecases/cluster/disk_use_windows.go
+++ b/usecases/cluster/disk_use_windows.go
@@ -7,6 +7,8 @@
 //  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
+//
+
 //go:build windows
 
 package cluster


### PR DESCRIPTION
### What's being changed:

Closes https://github.com/weaviate/weaviate/issues/2955

- Adds support for windows, original PR: https://github.com/weaviate/weaviate/pull/3069
- Compiles binaries for linux, windows and macos (unsigned) and uploads them
- Runs some acceptance tests on windows to verify that everything is working. Note that building contextionary is non-trivial and docker on GHA cannot run linux containers and therefore only some acceptance tests work.


