### PR TITLE
 Improve remote node repair by retrieving complete objects during search

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -139,6 +139,7 @@ func (i *replicatedIndices) Indices() http.Handler {
 		case regxObjects.MatchString(path):
 			if r.Method == http.MethodGet {
 				i.getObjectsMulti().ServeHTTP(w, r)
+				return
 			}
 
 			if r.Method == http.MethodPost {

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -256,12 +256,12 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 		}
 		// set consistency flag
 		for i, n := range sum {
-			if n == maxCount { // if consistent
+			if x := res[i]; x != nil && n == maxCount { // if consistent
 				prev := batch.Data[batch.Index[i]]
-				res[i].BelongsToShard = prev.BelongsToShard
-				res[i].BelongsToNode = prev.BelongsToNode
-				batch.Data[batch.Index[i]] = res[i]
-				res[i].IsConsistent = true
+				x.BelongsToShard = prev.BelongsToShard
+				x.BelongsToNode = prev.BelongsToNode
+				batch.Data[batch.Index[i]] = x
+				x.IsConsistent = true
 			}
 		}
 


### PR DESCRIPTION
### What's being changed:
Modify object retrieval mechanism for remote node repair
Address previous filtering issues that led to partial object retrieval during repairs
Update to fetch complete objects instead of partial objects obtained from the result set of search queries
This PR provides the solution for the previously mentioned [issue](https://github.com/weaviate/weaviate/issues/3267#issuecomment-1652399606)
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
