### PR TITLE
Cycle manager per class p2

### DIFF
--- a/adapters/repos/db/index_cyclecallbacks.go
+++ b/adapters/repos/db/index_cyclecallbacks.go
@@ -85,7 +85,7 @@ func (index *Index) initCycleCallbacks() {
 
 	vectorTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(id("vector", "tombstone_cleanup"), index.logger, _NUMCPU*2)
 	vectorTombstoneCleanupCycle := cyclemanager.New(
-		cyclemanager.NewFixedIntervalTicker(time.Duration(vectorTombstoneCleanupIntervalSeconds)*time.Second),
+		cyclemanager.NewFixedTicker(time.Duration(vectorTombstoneCleanupIntervalSeconds)*time.Second),
 		vectorTombstoneCleanupCallbacks.CycleCallback)
 
 	geoPropsCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(id("geo_props", "commit_logger"), index.logger, _NUMCPU*2)
@@ -95,7 +95,7 @@ func (index *Index) initCycleCallbacks() {
 
 	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(id("geo_props", "tombstone_cleanup"), index.logger, _NUMCPU*2)
 	geoPropsTombstoneCleanupCycle := cyclemanager.New(
-		cyclemanager.NewFixedIntervalTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
+		cyclemanager.NewFixedTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
 		geoPropsTombstoneCleanupCallbacks.CycleCallback)
 
 	index.cycleCallbacks = &indexCycleCallbacks{

--- a/adapters/repos/db/index_cyclecallbacks.go
+++ b/adapters/repos/db/index_cyclecallbacks.go
@@ -21,23 +21,20 @@ import (
 )
 
 type indexCycleCallbacks struct {
-	// collects collections of compaction callbacks of stores (shards)
-	compactionCallbacks cyclemanager.CycleCallbacks
+	compactionCallbacks cyclemanager.CycleCallbackGroup
 	compactionCycle     cyclemanager.CycleManager
-	// collects collections of flush callbacks of stores (shards)
-	flushCallbacks cyclemanager.CycleCallbacks
+
+	flushCallbacks cyclemanager.CycleCallbackGroup
 	flushCycle     cyclemanager.CycleManager
-	// collects collections of vector maintenance callbacks of shards
-	vectorCommitLoggerCallbacks cyclemanager.CycleCallbacks
-	vectorCommitLoggerCycle     cyclemanager.CycleManager
-	// collects collections of vector cleanup callbacks of shards
-	vectorTombstoneCleanupCallbacks cyclemanager.CycleCallbacks
+
+	vectorCommitLoggerCallbacks     cyclemanager.CycleCallbackGroup
+	vectorCommitLoggerCycle         cyclemanager.CycleManager
+	vectorTombstoneCleanupCallbacks cyclemanager.CycleCallbackGroup
 	vectorTombstoneCleanupCycle     cyclemanager.CycleManager
-	// collects collections of geo properties maintenance callbacks of shards
-	geoPropsCommitLoggerCallbacks cyclemanager.CycleCallbacks
-	geoPropsCommitLoggerCycle     cyclemanager.CycleManager
-	// collects collections of geo properties cleanup callbacks of shards
-	geoPropsTombstoneCleanupCallbacks cyclemanager.CycleCallbacks
+
+	geoPropsCommitLoggerCallbacks     cyclemanager.CycleCallbackGroup
+	geoPropsCommitLoggerCycle         cyclemanager.CycleManager
+	geoPropsTombstoneCleanupCallbacks cyclemanager.CycleCallbackGroup
 	geoPropsTombstoneCleanupCycle     cyclemanager.CycleManager
 }
 
@@ -52,17 +49,17 @@ func (index *Index) initCycleCallbacks() {
 		return strings.Join(elems, "/")
 	}
 
-	compactionCallbacks := cyclemanager.NewCycleCallbacks(id("compaction"), index.logger, _NUMCPU*2)
-	compactionCycle := cyclemanager.New(
+	compactionCallbacks := cyclemanager.NewCallbackGroup(id("compaction"), index.logger, _NUMCPU*2)
+	compactionCycle := cyclemanager.NewManager(
 		cyclemanager.CompactionCycleTicker(),
 		compactionCallbacks.CycleCallback)
 
-	flushCallbacks := cyclemanager.NewCycleCallbacks(id("flush"), index.logger, _NUMCPU*2)
-	flushCycle := cyclemanager.New(
+	flushCallbacks := cyclemanager.NewCallbackGroup(id("flush"), index.logger, _NUMCPU*2)
+	flushCycle := cyclemanager.NewManager(
 		cyclemanager.MemtableFlushCycleTicker(),
 		flushCallbacks.CycleCallback)
 
-	vectorCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(id("vector", "commit_logger"), index.logger, _NUMCPU*2)
+	vectorCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(id("vector", "commit_logger"), index.logger, _NUMCPU*2)
 	// Previously we had an interval of 10s in here, which was changed to
 	// 0.5s as part of gh-1867. There's really no way to wait so long in
 	// between checks: If you are running on a low-powered machine, the
@@ -79,22 +76,22 @@ func (index *Index) initCycleCallbacks() {
 	//
 	// update: switched to dynamic intervals with values between 500ms and 10s
 	// introduced to address https://github.com/weaviate/weaviate/issues/2783
-	vectorCommitLoggerCycle := cyclemanager.New(
+	vectorCommitLoggerCycle := cyclemanager.NewManager(
 		cyclemanager.HnswCommitLoggerCycleTicker(),
 		vectorCommitLoggerCallbacks.CycleCallback)
 
-	vectorTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(id("vector", "tombstone_cleanup"), index.logger, _NUMCPU*2)
-	vectorTombstoneCleanupCycle := cyclemanager.New(
+	vectorTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(id("vector", "tombstone_cleanup"), index.logger, _NUMCPU*2)
+	vectorTombstoneCleanupCycle := cyclemanager.NewManager(
 		cyclemanager.NewFixedTicker(time.Duration(vectorTombstoneCleanupIntervalSeconds)*time.Second),
 		vectorTombstoneCleanupCallbacks.CycleCallback)
 
-	geoPropsCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(id("geo_props", "commit_logger"), index.logger, _NUMCPU*2)
-	geoPropsCommitLoggerCycle := cyclemanager.New(
+	geoPropsCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(id("geo_props", "commit_logger"), index.logger, _NUMCPU*2)
+	geoPropsCommitLoggerCycle := cyclemanager.NewManager(
 		cyclemanager.GeoCommitLoggerCycleTicker(),
 		geoPropsCommitLoggerCallbacks.CycleCallback)
 
-	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(id("geo_props", "tombstone_cleanup"), index.logger, _NUMCPU*2)
-	geoPropsTombstoneCleanupCycle := cyclemanager.New(
+	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(id("geo_props", "tombstone_cleanup"), index.logger, _NUMCPU*2)
+	geoPropsTombstoneCleanupCycle := cyclemanager.NewManager(
 		cyclemanager.NewFixedTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
 		geoPropsTombstoneCleanupCallbacks.CycleCallback)
 
@@ -118,19 +115,19 @@ func (index *Index) initCycleCallbacks() {
 
 func (index *Index) initCycleCallbacksNoop() {
 	index.cycleCallbacks = &indexCycleCallbacks{
-		compactionCallbacks: cyclemanager.NewCycleCallbacksNoop(),
-		compactionCycle:     cyclemanager.NewNoop(),
-		flushCallbacks:      cyclemanager.NewCycleCallbacksNoop(),
-		flushCycle:          cyclemanager.NewNoop(),
+		compactionCallbacks: cyclemanager.NewCallbackGroupNoop(),
+		compactionCycle:     cyclemanager.NewManagerNoop(),
+		flushCallbacks:      cyclemanager.NewCallbackGroupNoop(),
+		flushCycle:          cyclemanager.NewManagerNoop(),
 
-		vectorCommitLoggerCallbacks:     cyclemanager.NewCycleCallbacksNoop(),
-		vectorCommitLoggerCycle:         cyclemanager.NewNoop(),
-		vectorTombstoneCleanupCallbacks: cyclemanager.NewCycleCallbacksNoop(),
-		vectorTombstoneCleanupCycle:     cyclemanager.NewNoop(),
+		vectorCommitLoggerCallbacks:     cyclemanager.NewCallbackGroupNoop(),
+		vectorCommitLoggerCycle:         cyclemanager.NewManagerNoop(),
+		vectorTombstoneCleanupCallbacks: cyclemanager.NewCallbackGroupNoop(),
+		vectorTombstoneCleanupCycle:     cyclemanager.NewManagerNoop(),
 
-		geoPropsCommitLoggerCallbacks:     cyclemanager.NewCycleCallbacksNoop(),
-		geoPropsCommitLoggerCycle:         cyclemanager.NewNoop(),
-		geoPropsTombstoneCleanupCallbacks: cyclemanager.NewCycleCallbacksNoop(),
-		geoPropsTombstoneCleanupCycle:     cyclemanager.NewNoop(),
+		geoPropsCommitLoggerCallbacks:     cyclemanager.NewCallbackGroupNoop(),
+		geoPropsCommitLoggerCycle:         cyclemanager.NewManagerNoop(),
+		geoPropsTombstoneCleanupCallbacks: cyclemanager.NewCallbackGroupNoop(),
+		geoPropsTombstoneCleanupCycle:     cyclemanager.NewManagerNoop(),
 	}
 }

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -40,7 +40,7 @@ func Test_Filters_String(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	propName := "inverted-with-frequency"
@@ -305,7 +305,7 @@ func Test_Filters_Int(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	propName := "inverted-without-frequency"
@@ -501,7 +501,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	propName := "inverted-with-frequency"

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -82,7 +82,7 @@ type Bucket struct {
 // [Store]. In this case the [Store] can manage buckets for you, using methods
 // such as CreateOrLoadBucket().
 func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
-	metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbacks,
+	metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
 	opts ...BucketOption,
 ) (*Bucket, error) {
 	beforeAll := time.Now()

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -158,7 +158,7 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 	}
 
 	id := "bucket/flush/" + b.dir
-	b.flushCallbackCtrl = flushCallbacks.Register(id, true, b.flushAndSwitchIfThresholdsMet)
+	b.flushCallbackCtrl = flushCallbacks.Register(id, b.flushAndSwitchIfThresholdsMet)
 
 	b.metrics.TrackStartupBucket(beforeAll)
 

--- a/adapters/repos/db/lsmkv/bucket_backup_test.go
+++ b/adapters/repos/db/lsmkv/bucket_backup_test.go
@@ -31,7 +31,7 @@ func TestBucketBackup_FlushMemtable(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(ctx, dirName, dirName, logrus.New(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -52,7 +52,7 @@ func TestBucketBackup_ListFiles(t *testing.T) {
 	dirName := t.TempDir()
 
 	b, err := NewBucket(ctx, dirName, dirName, logrus.New(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -26,7 +26,7 @@ func TestBucket_WasDeleted(t *testing.T) {
 	tmpDir := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	b, err := NewBucket(context.Background(), tmpDir, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	t.Cleanup(func() {
 		require.Nil(t, b.Shutdown(context.Background()))
@@ -133,7 +133,7 @@ func TestBucketReadsIntoMemory(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -152,7 +152,7 @@ func TestBucketReadsIntoMemory(t *testing.T) {
 	assert.True(t, ok)
 
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -40,12 +40,12 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 	walThreshold := uint64(4096)
 	tolerance := 4.
 
-	flushCallbacks := cyclemanager.NewCycleCallbacks("flush", nullLogger(), 1)
-	flushCycle := cyclemanager.New(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
+	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
+	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
 	flushCycle.Start()
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), flushCallbacks,
+		cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(1024*1024*1024),
 		WithWalThreshold(walThreshold))
@@ -142,12 +142,12 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	memtableThreshold := uint64(4096)
 	tolerance := 4.
 
-	flushCallbacks := cyclemanager.NewCycleCallbacks("flush", nullLogger(), 1)
-	flushCycle := cyclemanager.New(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
+	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
+	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
 	flushCycle.Start()
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), flushCallbacks,
+		cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(memtableThreshold))
 	require.Nil(t, err)
@@ -235,12 +235,12 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 	t.Run("an empty memtable is not flushed", func(t *testing.T) {
 		dirName := t.TempDir()
 
-		flushCallbacks := cyclemanager.NewCycleCallbacks("flush", nullLogger(), 1)
-		flushCycle := cyclemanager.New(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
+		flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
+		flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
 		flushCycle.Start()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), flushCallbacks,
+			cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -279,12 +279,12 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 	t.Run("a dirty memtable is flushed once the idle period is over", func(t *testing.T) {
 		dirName := t.TempDir()
 
-		flushCallbacks := cyclemanager.NewCycleCallbacks("flush", nullLogger(), 1)
-		flushCycle := cyclemanager.New(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
+		flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
+		flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
 		flushCycle.Start()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), flushCallbacks,
+			cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -327,12 +327,12 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 	t.Run("a dirty memtable is not flushed as long as the next write occurs before the idle threshold", func(t *testing.T) {
 		dirName := t.TempDir()
 
-		flushCallbacks := cyclemanager.NewCycleCallbacks("flush", nullLogger(), 1)
-		flushCycle := cyclemanager.New(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
+		flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
+		flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback)
 		flushCycle.Start()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), flushCallbacks,
+			cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -135,7 +135,7 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -347,7 +347,7 @@ func Test_CompactionReplaceStrategy_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -463,7 +463,7 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryDeletes(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -557,7 +557,7 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryUpdates(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -821,7 +821,7 @@ func Test_CompactionSetStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -941,7 +941,7 @@ func Test_CompactionSetStrategy_RemoveUnnecessary(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -1288,7 +1288,7 @@ func Test_CompactionMapStrategy(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -1414,7 +1414,7 @@ func Test_CompactionMapStrategy_RemoveUnnecessary(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -1532,7 +1532,7 @@ func Test_CompactionReplaceStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -1601,7 +1601,7 @@ func Test_Compaction_FrequentPutDeleteOperations_WithSecondaryKeys(t *testing.T)
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 					WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 				require.Nil(t, err)
 
@@ -1677,7 +1677,7 @@ func Test_CompactionSetStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 					WithStrategy(StrategySetCollection))
 				require.Nil(t, err)
 
@@ -1765,7 +1765,7 @@ func Test_CompactionMapStrategy_FrequentPutDeleteOperations(t *testing.T) {
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 					WithStrategy(StrategyMapCollection))
 				require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -39,7 +39,7 @@ func Test_CompactionRoaringSet(t *testing.T) {
 	control := controlFromInstructions(instr, maxID)
 
 	b, err := NewBucket(testCtx(), t.TempDir(), "", nullLogger(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyRoaringSet))
 	require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
@@ -63,7 +63,7 @@ func prepareBucket(b *testing.B) (bucket *Bucket, cleanup func()) {
 	}()
 
 	bucket, err := NewBucket(testCtxB(), dirName, "", nullLoggerB(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(b, err)

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -43,7 +43,7 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 	values := make([][]byte, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -135,7 +135,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 	values := make([][][]byte, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategySetCollection),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -225,7 +225,7 @@ func TestConcurrentWriting_Map(t *testing.T) {
 	values := make([][]MapPair, amount)
 
 	bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -35,7 +35,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -70,7 +70,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 			// then recreate bucket
 			var err error
 			b, err = NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 		})
@@ -156,7 +156,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
@@ -191,7 +191,7 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 	t.Run("without previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -299,7 +299,7 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
@@ -339,7 +339,7 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -439,7 +439,7 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
@@ -481,7 +481,7 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -619,7 +619,7 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -31,7 +31,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -51,7 +51,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -74,7 +74,7 @@ func TestCreateBloomInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -102,7 +102,7 @@ func TestCreateBloomInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is re-created on init
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -122,7 +122,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 
@@ -142,7 +142,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -159,7 +159,7 @@ func TestRepairTooShortBloomOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -178,7 +178,7 @@ func TestRepairTooShortBloomOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -195,7 +195,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -216,7 +216,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -234,7 +234,7 @@ func TestRepairCorruptedBloomSecondaryOnInitIntoMemory(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -254,7 +254,7 @@ func TestRepairCorruptedBloomSecondaryOnInitIntoMemory(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -271,7 +271,7 @@ func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -291,7 +291,7 @@ func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -58,7 +58,7 @@ type SegmentGroup struct {
 
 func newSegmentGroup(dir string, logger logrus.FieldLogger,
 	mapRequiresSorting bool, metrics *Metrics, strategy string,
-	monitorCount bool, compactionCallbacks cyclemanager.CycleCallbacks,
+	monitorCount bool, compactionCallbacks cyclemanager.CycleCallbackGroup,
 ) (*SegmentGroup, error) {
 	list, err := os.ReadDir(dir)
 	if err != nil {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -132,7 +132,7 @@ func newSegmentGroup(dir string, logger logrus.FieldLogger,
 	}
 
 	id := "segmentgroup/compaction/" + out.dir
-	out.compactionCallbackCtrl = compactionCallbacks.Register(id, true, out.compactIfLevelsMatch)
+	out.compactionCallbackCtrl = compactionCallbacks.Register(id, out.compactIfLevelsMatch)
 
 	return out, nil
 }

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -33,7 +33,7 @@ func TestCreateCNAOnFlush(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -57,7 +57,7 @@ func TestCreateCNAInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -83,7 +83,7 @@ func TestCreateCNAInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is re-created on init
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -103,7 +103,7 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -124,7 +124,7 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -36,7 +36,7 @@ func TestPrecomputeSegmentMeta_Replace(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -99,7 +99,7 @@ func TestPrecomputeSegmentMeta_Set(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategySetCollection))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -46,7 +46,7 @@ type Store struct {
 // disk, it is loaded, if the folder is empty a new store is initialized in
 // there.
 func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
-	classCompactionCallbacks, classFlushCallbacks cyclemanager.CycleCallbacks,
+	shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbacks,
 ) (*Store, error) {
 	s := &Store{
 		dir:           dir,
@@ -55,7 +55,7 @@ func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
 		logger:        logger,
 		metrics:       metrics,
 	}
-	s.initCycleCallbacks(classCompactionCallbacks, classFlushCallbacks)
+	s.initCycleCallbacks(shardCompactionCallbacks, shardFlushCallbacks)
 
 	return s, s.init()
 }

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -46,7 +46,7 @@ type Store struct {
 // disk, it is loaded, if the folder is empty a new store is initialized in
 // there.
 func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
-	shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbacks,
+	shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbackGroup,
 ) (*Store, error) {
 	s := &Store{
 		dir:           dir,

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -39,8 +39,8 @@ func TestStoreBackup_PauseCompaction(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				shardCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
-				shardFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardCompactionCallbacks := cyclemanager.NewCallbackGroup("classCompaction", logger, 1)
+				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
 				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
@@ -74,8 +74,8 @@ func TestStoreBackup_PauseCompaction(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				shardCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
-				shardFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardCompactionCallbacks := cyclemanager.NewCallbackGroup("classCompaction", logger, 1)
+				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
 				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
@@ -119,8 +119,8 @@ func TestStoreBackup_ResumeCompaction(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				shardCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
-				shardFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardCompactionCallbacks := cyclemanager.NewCallbackGroup("classCompaction", logger, 1)
+				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
 				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
@@ -169,8 +169,8 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				shardCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
-				shardFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
+				shardCompactionCallbacks := cyclemanager.NewCallbackGroupNoop()
+				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
 				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
@@ -204,8 +204,8 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				shardCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
-				shardFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
+				shardCompactionCallbacks := cyclemanager.NewCallbackGroupNoop()
+				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
 				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
@@ -256,8 +256,8 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				shardCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
-				shardFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
+				shardCompactionCallbacks := cyclemanager.NewCallbackGroupNoop()
+				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
 				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -39,10 +39,10 @@ func TestStoreBackup_PauseCompaction(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				classCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
-				classFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
+				shardFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
 
-				store, err := New(dirName, dirName, logger, nil, classCompactionCallbacks, classFlushCallbacks)
+				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -74,10 +74,10 @@ func TestStoreBackup_PauseCompaction(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				classCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
-				classFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
+				shardFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
 
-				store, err := New(dirName, dirName, logger, nil, classCompactionCallbacks, classFlushCallbacks)
+				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -119,10 +119,10 @@ func TestStoreBackup_ResumeCompaction(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				classCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
-				classFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardCompactionCallbacks := cyclemanager.NewCycleCallbacks("classCompaction", logger, 1)
+				shardFlushCallbacks := cyclemanager.NewCycleCallbacksNoop()
 
-				store, err := New(dirName, dirName, logger, nil, classCompactionCallbacks, classFlushCallbacks)
+				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -169,10 +169,10 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				classCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
-				classFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
+				shardCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
 
-				store, err := New(dirName, dirName, logger, nil, classCompactionCallbacks, classFlushCallbacks)
+				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -204,10 +204,10 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				classCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
-				classFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
+				shardCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
 
-				store, err := New(dirName, dirName, logger, nil, classCompactionCallbacks, classFlushCallbacks)
+				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
 				err = store.CreateOrLoadBucket(ctx, "test_bucket")
@@ -256,10 +256,10 @@ func TestStoreBackup_FlushMemtable(t *testing.T) {
 			t.Run(fmt.Sprintf("with %d buckets", len(buckets)), func(t *testing.T) {
 				dirName := t.TempDir()
 
-				classCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
-				classFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
+				shardCompactionCallbacks := cyclemanager.NewCycleCallbacksNoop()
+				shardFlushCallbacks := cyclemanager.NewCycleCallbacks("classFlush", logger, 1)
 
-				store, err := New(dirName, dirName, logger, nil, classCompactionCallbacks, classFlushCallbacks)
+				store, err := New(dirName, dirName, logger, nil, shardCompactionCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {

--- a/adapters/repos/db/lsmkv/store_cyclecallbacks.go
+++ b/adapters/repos/db/lsmkv/store_cyclecallbacks.go
@@ -40,12 +40,12 @@ func (s *Store) initCycleCallbacks(classCompactionCallbacks, classFlushCallbacks
 	compactionId := id("compaction")
 	compactionCallbacks := cyclemanager.NewCycleCallbacks(compactionId, s.logger, 1)
 	compactionCallbacksCtrl := classCompactionCallbacks.Register(
-		compactionId, true, compactionCallbacks.CycleCallback)
+		compactionId, compactionCallbacks.CycleCallback)
 
 	flushId := id("flush")
 	flushCallbacks := cyclemanager.NewCycleCallbacks(flushId, s.logger, 1)
 	flushCallbacksCtrl := classFlushCallbacks.Register(
-		flushId, true, flushCallbacks.CycleCallback)
+		flushId, flushCallbacks.CycleCallback)
 
 	s.cycleCallbacks = &storeCycleCallbacks{
 		compactionCallbacks:     compactionCallbacks,

--- a/adapters/repos/db/lsmkv/store_cyclecallbacks.go
+++ b/adapters/repos/db/lsmkv/store_cyclecallbacks.go
@@ -26,7 +26,7 @@ type storeCycleCallbacks struct {
 	flushCallbacksCtrl cyclemanager.CycleCallbackCtrl
 }
 
-func (s *Store) initCycleCallbacks(classCompactionCallbacks, classFlushCallbacks cyclemanager.CycleCallbacks) {
+func (s *Store) initCycleCallbacks(shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbacks) {
 	id := func(elems ...string) string {
 		path, err := filepath.Rel(s.dir, s.rootDir)
 		if err != nil {
@@ -39,12 +39,12 @@ func (s *Store) initCycleCallbacks(classCompactionCallbacks, classFlushCallbacks
 
 	compactionId := id("compaction")
 	compactionCallbacks := cyclemanager.NewCycleCallbacks(compactionId, s.logger, 1)
-	compactionCallbacksCtrl := classCompactionCallbacks.Register(
+	compactionCallbacksCtrl := shardCompactionCallbacks.Register(
 		compactionId, compactionCallbacks.CycleCallback)
 
 	flushId := id("flush")
 	flushCallbacks := cyclemanager.NewCycleCallbacks(flushId, s.logger, 1)
-	flushCallbacksCtrl := classFlushCallbacks.Register(
+	flushCallbacksCtrl := shardFlushCallbacks.Register(
 		flushId, flushCallbacks.CycleCallback)
 
 	s.cycleCallbacks = &storeCycleCallbacks{

--- a/adapters/repos/db/lsmkv/store_cyclecallbacks.go
+++ b/adapters/repos/db/lsmkv/store_cyclecallbacks.go
@@ -19,14 +19,14 @@ import (
 )
 
 type storeCycleCallbacks struct {
-	compactionCallbacks     cyclemanager.CycleCallbacks
+	compactionCallbacks     cyclemanager.CycleCallbackGroup
 	compactionCallbacksCtrl cyclemanager.CycleCallbackCtrl
 
-	flushCallbacks     cyclemanager.CycleCallbacks
+	flushCallbacks     cyclemanager.CycleCallbackGroup
 	flushCallbacksCtrl cyclemanager.CycleCallbackCtrl
 }
 
-func (s *Store) initCycleCallbacks(shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbacks) {
+func (s *Store) initCycleCallbacks(shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbackGroup) {
 	id := func(elems ...string) string {
 		path, err := filepath.Rel(s.dir, s.rootDir)
 		if err != nil {
@@ -38,12 +38,12 @@ func (s *Store) initCycleCallbacks(shardCompactionCallbacks, shardFlushCallbacks
 	}
 
 	compactionId := id("compaction")
-	compactionCallbacks := cyclemanager.NewCycleCallbacks(compactionId, s.logger, 1)
+	compactionCallbacks := cyclemanager.NewCallbackGroup(compactionId, s.logger, 1)
 	compactionCallbacksCtrl := shardCompactionCallbacks.Register(
 		compactionId, compactionCallbacks.CycleCallback)
 
 	flushId := id("flush")
-	flushCallbacks := cyclemanager.NewCycleCallbacks(flushId, s.logger, 1)
+	flushCallbacks := cyclemanager.NewCallbackGroup(flushId, s.logger, 1)
 	flushCallbacksCtrl := shardFlushCallbacks.Register(
 		flushId, flushCallbacks.CycleCallback)
 

--- a/adapters/repos/db/lsmkv/store_integration_test.go
+++ b/adapters/repos/db/lsmkv/store_integration_test.go
@@ -29,7 +29,7 @@ func TestStoreLifecycle(t *testing.T) {
 
 	t.Run("cycle 1", func(t *testing.T) {
 		store, err := New(dirName, dirName, logger, nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(testCtx(), "bucket1", WithStrategy(StrategyReplace))
@@ -56,7 +56,7 @@ func TestStoreLifecycle(t *testing.T) {
 
 	t.Run("cycle 2", func(t *testing.T) {
 		store, err := New(dirName, dirName, logger, nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(testCtx(), "bucket1", WithStrategy(StrategyReplace))

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -29,7 +29,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -120,7 +120,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -215,7 +215,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -313,7 +313,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -376,7 +376,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
@@ -419,7 +419,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -514,7 +514,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -617,7 +617,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with memtable only, then an orderly shutdown and restart", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -684,7 +684,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 
@@ -726,7 +726,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -913,7 +913,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -29,7 +29,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -93,7 +93,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -164,7 +164,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("with a flush after the initial write and after the update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -235,7 +235,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -288,7 +288,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
@@ -320,7 +320,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1),
 		)
 		require.Nil(t, err)
@@ -413,7 +413,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -473,7 +473,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("with a flush after initial write and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -544,7 +544,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 	t.Run("update in memtable then do an orderly shutdown and reinit", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 		require.Nil(t, err)
 
@@ -590,7 +590,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 		t.Run("init a new one and verify", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 			require.Nil(t, err)
 
@@ -620,7 +620,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -672,7 +672,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -728,7 +728,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes after initial write and delete", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -792,7 +792,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -1026,7 +1026,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -1119,7 +1119,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -1409,7 +1409,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
@@ -27,7 +27,7 @@ func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyRoaringSet))
 		require.Nil(t, err)
 
@@ -103,7 +103,7 @@ func TestRoaringSetStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with a single flush in between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategyRoaringSet))
 		require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -29,7 +29,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -89,7 +89,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -153,7 +153,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -219,7 +219,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -282,7 +282,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
@@ -310,7 +310,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -407,7 +407,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -508,7 +508,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 	t.Run("with flushes in between and after the update", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -618,7 +618,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 	t.Run("update in memtable, make orderly shutdown, then create a new bucket from disk",
 		func(t *testing.T) {
 			b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
@@ -668,7 +668,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			t.Run("init another bucket on the same files", func(t *testing.T) {
 				b2, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-					cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 					WithStrategy(StrategySetCollection))
 				require.Nil(t, err)
 
@@ -695,7 +695,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -823,7 +823,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 

--- a/adapters/repos/db/shard_cyclecallbacks.go
+++ b/adapters/repos/db/shard_cyclecallbacks.go
@@ -42,20 +42,24 @@ func (s *Shard) initCycleCallbacks() {
 	compactionId := id("compaction")
 	compactionCallbacks := cyclemanager.NewCycleCallbacks(compactionId, s.index.logger, 1)
 	compactionCallbacksCtrl := s.index.cycleCallbacks.compactionCallbacks.Register(
-		compactionId, compactionCallbacks.CycleCallback)
+		compactionId, compactionCallbacks.CycleCallback,
+		cyclemanager.WithIntervals(cyclemanager.CompactionCycleIntervals()))
 
 	flushId := id("flush")
 	flushCallbacks := cyclemanager.NewCycleCallbacks(flushId, s.index.logger, 1)
 	flushCallbacksCtrl := s.index.cycleCallbacks.flushCallbacks.Register(
-		flushId, flushCallbacks.CycleCallback)
+		flushId, flushCallbacks.CycleCallback,
+		cyclemanager.WithIntervals(cyclemanager.MemtableFlushCycleIntervals()))
 
 	vectorCommitLoggerId := id("vector", "commit_logger")
 	vectorCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(vectorCommitLoggerId, s.index.logger, 1)
 	vectorCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.vectorCommitLoggerCallbacks.Register(
-		vectorCommitLoggerId, vectorCommitLoggerCallbacks.CycleCallback)
+		vectorCommitLoggerId, vectorCommitLoggerCallbacks.CycleCallback,
+		cyclemanager.WithIntervals(cyclemanager.HnswCommitLoggerCycleIntervals()))
 
 	vectorTombstoneCleanupId := id("vector", "tombstone_cleanup")
 	vectorTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(vectorTombstoneCleanupId, s.index.logger, 1)
+	// fixed interval on class level, no need to specify separate on shard level
 	vectorTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.vectorTombstoneCleanupCallbacks.Register(
 		vectorTombstoneCleanupId, vectorTombstoneCleanupCallbacks.CycleCallback)
 
@@ -65,10 +69,12 @@ func (s *Shard) initCycleCallbacks() {
 	geoPropsCommitLoggerId := id("geo_props", "commit_logger")
 	geoPropsCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(geoPropsCommitLoggerId, s.index.logger, 1)
 	geoPropsCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.geoPropsCommitLoggerCallbacks.Register(
-		geoPropsCommitLoggerId, geoPropsCommitLoggerCallbacks.CycleCallback)
+		geoPropsCommitLoggerId, geoPropsCommitLoggerCallbacks.CycleCallback,
+		cyclemanager.WithIntervals(cyclemanager.GeoCommitLoggerCycleIntervals()))
 
 	geoPropsTombstoneCleanupId := id("geoProps", "tombstone_cleanup")
 	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(geoPropsTombstoneCleanupId, s.index.logger, 1)
+	// fixed interval on class level, no need to specify separate on shard level
 	geoPropsTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.geoPropsTombstoneCleanupCallbacks.Register(
 		geoPropsTombstoneCleanupId, geoPropsTombstoneCleanupCallbacks.CycleCallback)
 

--- a/adapters/repos/db/shard_cyclecallbacks.go
+++ b/adapters/repos/db/shard_cyclecallbacks.go
@@ -18,18 +18,18 @@ import (
 )
 
 type shardCycleCallbacks struct {
-	compactionCallbacks     cyclemanager.CycleCallbacks
+	compactionCallbacks     cyclemanager.CycleCallbackGroup
 	compactionCallbacksCtrl cyclemanager.CycleCallbackCtrl
 
-	flushCallbacks     cyclemanager.CycleCallbacks
+	flushCallbacks     cyclemanager.CycleCallbackGroup
 	flushCallbacksCtrl cyclemanager.CycleCallbackCtrl
 
-	vectorCommitLoggerCallbacks     cyclemanager.CycleCallbacks
-	vectorTombstoneCleanupCallbacks cyclemanager.CycleCallbacks
+	vectorCommitLoggerCallbacks     cyclemanager.CycleCallbackGroup
+	vectorTombstoneCleanupCallbacks cyclemanager.CycleCallbackGroup
 	vectorCombinedCallbacksCtrl     cyclemanager.CycleCallbackCtrl
 
-	geoPropsCommitLoggerCallbacks     cyclemanager.CycleCallbacks
-	geoPropsTombstoneCleanupCallbacks cyclemanager.CycleCallbacks
+	geoPropsCommitLoggerCallbacks     cyclemanager.CycleCallbackGroup
+	geoPropsTombstoneCleanupCallbacks cyclemanager.CycleCallbackGroup
 	geoPropsCombinedCallbacksCtrl     cyclemanager.CycleCallbackCtrl
 }
 
@@ -40,25 +40,25 @@ func (s *Shard) initCycleCallbacks() {
 	}
 
 	compactionId := id("compaction")
-	compactionCallbacks := cyclemanager.NewCycleCallbacks(compactionId, s.index.logger, 1)
+	compactionCallbacks := cyclemanager.NewCallbackGroup(compactionId, s.index.logger, 1)
 	compactionCallbacksCtrl := s.index.cycleCallbacks.compactionCallbacks.Register(
 		compactionId, compactionCallbacks.CycleCallback,
 		cyclemanager.WithIntervals(cyclemanager.CompactionCycleIntervals()))
 
 	flushId := id("flush")
-	flushCallbacks := cyclemanager.NewCycleCallbacks(flushId, s.index.logger, 1)
+	flushCallbacks := cyclemanager.NewCallbackGroup(flushId, s.index.logger, 1)
 	flushCallbacksCtrl := s.index.cycleCallbacks.flushCallbacks.Register(
 		flushId, flushCallbacks.CycleCallback,
 		cyclemanager.WithIntervals(cyclemanager.MemtableFlushCycleIntervals()))
 
 	vectorCommitLoggerId := id("vector", "commit_logger")
-	vectorCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(vectorCommitLoggerId, s.index.logger, 1)
+	vectorCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(vectorCommitLoggerId, s.index.logger, 1)
 	vectorCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.vectorCommitLoggerCallbacks.Register(
 		vectorCommitLoggerId, vectorCommitLoggerCallbacks.CycleCallback,
 		cyclemanager.WithIntervals(cyclemanager.HnswCommitLoggerCycleIntervals()))
 
 	vectorTombstoneCleanupId := id("vector", "tombstone_cleanup")
-	vectorTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(vectorTombstoneCleanupId, s.index.logger, 1)
+	vectorTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(vectorTombstoneCleanupId, s.index.logger, 1)
 	// fixed interval on class level, no need to specify separate on shard level
 	vectorTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.vectorTombstoneCleanupCallbacks.Register(
 		vectorTombstoneCleanupId, vectorTombstoneCleanupCallbacks.CycleCallback)
@@ -67,13 +67,13 @@ func (s *Shard) initCycleCallbacks() {
 		vectorCommitLoggerCallbacksCtrl, vectorTombstoneCleanupCallbacksCtrl)
 
 	geoPropsCommitLoggerId := id("geo_props", "commit_logger")
-	geoPropsCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(geoPropsCommitLoggerId, s.index.logger, 1)
+	geoPropsCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(geoPropsCommitLoggerId, s.index.logger, 1)
 	geoPropsCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.geoPropsCommitLoggerCallbacks.Register(
 		geoPropsCommitLoggerId, geoPropsCommitLoggerCallbacks.CycleCallback,
 		cyclemanager.WithIntervals(cyclemanager.GeoCommitLoggerCycleIntervals()))
 
 	geoPropsTombstoneCleanupId := id("geoProps", "tombstone_cleanup")
-	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(geoPropsTombstoneCleanupId, s.index.logger, 1)
+	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(geoPropsTombstoneCleanupId, s.index.logger, 1)
 	// fixed interval on class level, no need to specify separate on shard level
 	geoPropsTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.geoPropsTombstoneCleanupCallbacks.Register(
 		geoPropsTombstoneCleanupId, geoPropsTombstoneCleanupCallbacks.CycleCallback)

--- a/adapters/repos/db/shard_cyclecallbacks.go
+++ b/adapters/repos/db/shard_cyclecallbacks.go
@@ -42,22 +42,22 @@ func (s *Shard) initCycleCallbacks() {
 	compactionId := id("compaction")
 	compactionCallbacks := cyclemanager.NewCycleCallbacks(compactionId, s.index.logger, 1)
 	compactionCallbacksCtrl := s.index.cycleCallbacks.compactionCallbacks.Register(
-		compactionId, true, compactionCallbacks.CycleCallback)
+		compactionId, compactionCallbacks.CycleCallback)
 
 	flushId := id("flush")
 	flushCallbacks := cyclemanager.NewCycleCallbacks(flushId, s.index.logger, 1)
 	flushCallbacksCtrl := s.index.cycleCallbacks.flushCallbacks.Register(
-		flushId, true, flushCallbacks.CycleCallback)
+		flushId, flushCallbacks.CycleCallback)
 
 	vectorCommitLoggerId := id("vector", "commit_logger")
 	vectorCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(vectorCommitLoggerId, s.index.logger, 1)
 	vectorCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.vectorCommitLoggerCallbacks.Register(
-		vectorCommitLoggerId, true, vectorCommitLoggerCallbacks.CycleCallback)
+		vectorCommitLoggerId, vectorCommitLoggerCallbacks.CycleCallback)
 
 	vectorTombstoneCleanupId := id("vector", "tombstone_cleanup")
 	vectorTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(vectorTombstoneCleanupId, s.index.logger, 1)
 	vectorTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.vectorTombstoneCleanupCallbacks.Register(
-		vectorTombstoneCleanupId, true, vectorTombstoneCleanupCallbacks.CycleCallback)
+		vectorTombstoneCleanupId, vectorTombstoneCleanupCallbacks.CycleCallback)
 
 	vectorCombinedCallbacksCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2,
 		vectorCommitLoggerCallbacksCtrl, vectorTombstoneCleanupCallbacksCtrl)
@@ -65,12 +65,12 @@ func (s *Shard) initCycleCallbacks() {
 	geoPropsCommitLoggerId := id("geo_props", "commit_logger")
 	geoPropsCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks(geoPropsCommitLoggerId, s.index.logger, 1)
 	geoPropsCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.geoPropsCommitLoggerCallbacks.Register(
-		geoPropsCommitLoggerId, true, geoPropsCommitLoggerCallbacks.CycleCallback)
+		geoPropsCommitLoggerId, geoPropsCommitLoggerCallbacks.CycleCallback)
 
 	geoPropsTombstoneCleanupId := id("geoProps", "tombstone_cleanup")
 	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks(geoPropsTombstoneCleanupId, s.index.logger, 1)
 	geoPropsTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.geoPropsTombstoneCleanupCallbacks.Register(
-		geoPropsTombstoneCleanupId, true, geoPropsTombstoneCleanupCallbacks.CycleCallback)
+		geoPropsTombstoneCleanupId, geoPropsTombstoneCleanupCallbacks.CycleCallback)
 
 	geoPropsCombinedCallbacksCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2,
 		geoPropsCommitLoggerCallbacksCtrl, geoPropsTombstoneCleanupCallbacksCtrl)

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -59,7 +59,7 @@ type Config struct {
 
 func NewIndex(config Config,
 	commitLogMaintenanceCallbacks, tombstoneCleanupCallbacks,
-	compactionCallbacks, flushCallbacks cyclemanager.CycleCallbacks,
+	compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
 ) (*Index, error) {
 	vi, err := hnsw.New(hnsw.Config{
 		VectorForIDThunk:      config.CoordinatesForID.VectorForID,
@@ -98,7 +98,7 @@ func (i *Index) PostStartup() {
 	i.vectorIndex.PostStartup()
 }
 
-func makeCommitLoggerFromConfig(config Config, maintenanceCallbacks cyclemanager.CycleCallbacks,
+func makeCommitLoggerFromConfig(config Config, maintenanceCallbacks cyclemanager.CycleCallbackGroup,
 ) hnsw.MakeCommitLogger {
 	makeCL := hnsw.MakeNoopCommitLogger
 	if !config.DisablePersistence {

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -44,8 +44,8 @@ func TestGeoJourney(t *testing.T) {
 		DisablePersistence: true,
 		RootPath:           "doesnt-matter-persistence-is-off",
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(),
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	t.Run("importing all", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -44,7 +44,7 @@ func TestBackup_Integration(t *testing.T) {
 	parentCommitLoggerCycle.Start()
 	defer parentCommitLoggerCycle.StopAndWait(ctx)
 	commitLoggerCallbacks := cyclemanager.NewCycleCallbacks("childCommitLogger", logger, 1)
-	commitLoggerCallbacksCtrl := parentCommitLoggerCallbacks.Register("commitLogger", true, commitLoggerCallbacks.CycleCallback)
+	commitLoggerCallbacksCtrl := parentCommitLoggerCallbacks.Register("commitLogger", commitLoggerCallbacks.CycleCallback)
 
 	parentTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("parentTombstoneCleanup", logger, 1)
 	parentTombstoneCleanupCycle := cyclemanager.New(
@@ -53,7 +53,7 @@ func TestBackup_Integration(t *testing.T) {
 	parentTombstoneCleanupCycle.Start()
 	defer parentTombstoneCleanupCycle.StopAndWait(ctx)
 	tombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("childTombstoneCleanup", logger, 1)
-	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", true, tombstoneCleanupCallbacks.CycleCallback)
+	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", tombstoneCleanupCallbacks.CycleCallback)
 
 	combinedCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2, commitLoggerCallbacksCtrl, tombstoneCleanupCallbacksCtrl)
 

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -48,7 +48,7 @@ func TestBackup_Integration(t *testing.T) {
 
 	parentTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("parentTombstoneCleanup", logger, 1)
 	parentTombstoneCleanupCycle := cyclemanager.New(
-		cyclemanager.NewFixedIntervalTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
+		cyclemanager.NewFixedTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
 		parentTombstoneCleanupCallbacks.CycleCallback)
 	parentTombstoneCleanupCycle.Start()
 	defer parentTombstoneCleanupCycle.StopAndWait(ctx)

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -37,22 +37,22 @@ func TestBackup_Integration(t *testing.T) {
 	dirName := t.TempDir()
 	indexID := "backup-integration-test"
 
-	parentCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks("parentCommitLogger", logger, 1)
-	parentCommitLoggerCycle := cyclemanager.New(
+	parentCommitLoggerCallbacks := cyclemanager.NewCallbackGroup("parentCommitLogger", logger, 1)
+	parentCommitLoggerCycle := cyclemanager.NewManager(
 		cyclemanager.HnswCommitLoggerCycleTicker(),
 		parentCommitLoggerCallbacks.CycleCallback)
 	parentCommitLoggerCycle.Start()
 	defer parentCommitLoggerCycle.StopAndWait(ctx)
-	commitLoggerCallbacks := cyclemanager.NewCycleCallbacks("childCommitLogger", logger, 1)
+	commitLoggerCallbacks := cyclemanager.NewCallbackGroup("childCommitLogger", logger, 1)
 	commitLoggerCallbacksCtrl := parentCommitLoggerCallbacks.Register("commitLogger", commitLoggerCallbacks.CycleCallback)
 
-	parentTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("parentTombstoneCleanup", logger, 1)
-	parentTombstoneCleanupCycle := cyclemanager.New(
+	parentTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("parentTombstoneCleanup", logger, 1)
+	parentTombstoneCleanupCycle := cyclemanager.NewManager(
 		cyclemanager.NewFixedTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
 		parentTombstoneCleanupCallbacks.CycleCallback)
 	parentTombstoneCleanupCycle.Start()
 	defer parentTombstoneCleanupCycle.StopAndWait(ctx)
-	tombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("childTombstoneCleanup", logger, 1)
+	tombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("childTombstoneCleanup", logger, 1)
 	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", tombstoneCleanupCallbacks.CycleCallback)
 
 	combinedCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2, commitLoggerCallbacksCtrl, tombstoneCleanupCallbacksCtrl)
@@ -67,7 +67,7 @@ func TestBackup_Integration(t *testing.T) {
 			return NewCommitLogger(dirName, indexID, logger, commitLoggerCallbacks)
 		},
 	}, enthnsw.NewDefaultUserConfig(),
-		tombstoneCleanupCallbacks, cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		tombstoneCleanupCallbacks, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	idx.PostStartup()
 

--- a/adapters/repos/db/vector/hnsw/backup_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_test.go
@@ -41,10 +41,10 @@ func TestBackup_SwitchCommitLogs(t *testing.T) {
 		DistanceProvider: distancer.NewCosineDistanceProvider(),
 		VectorForIDThunk: testVectorForID,
 		MakeCommitLoggerThunk: func() (CommitLogger, error) {
-			return NewCommitLogger(dirName, indexID, logrus.New(), cyclemanager.NewCycleCallbacksNoop())
+			return NewCommitLogger(dirName, indexID, logrus.New(), cyclemanager.NewCallbackGroupNoop())
 		},
 	}, enthnsw.NewDefaultUserConfig(),
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	idx.PostStartup()
 
@@ -71,10 +71,10 @@ func TestBackup_ListFiles(t *testing.T) {
 		DistanceProvider: distancer.NewCosineDistanceProvider(),
 		VectorForIDThunk: testVectorForID,
 		MakeCommitLoggerThunk: func() (CommitLogger, error) {
-			return NewCommitLogger(dirName, indexID, logrus.New(), cyclemanager.NewCycleCallbacksNoop())
+			return NewCommitLogger(dirName, indexID, logrus.New(), cyclemanager.NewCallbackGroupNoop())
 		},
 	}, enthnsw.NewDefaultUserConfig(),
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	idx.PostStartup()
 

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -71,8 +71,8 @@ func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
 		return strings.Join(elems, "/")
 	}
 	l.commitLogger = commitlog.NewLoggerWithFile(fd)
-	l.switchLogsCallbackCtrl = maintenanceCallbacks.Register(id("switch_logs"), true, l.startSwitchLogs)
-	l.condenseLogsCallbackCtrl = maintenanceCallbacks.Register(id("condense_logs"), true, l.startCombineAndCondenseLogs)
+	l.switchLogsCallbackCtrl = maintenanceCallbacks.Register(id("switch_logs"), l.startSwitchLogs)
+	l.condenseLogsCallbackCtrl = maintenanceCallbacks.Register(id("condense_logs"), l.startCombineAndCondenseLogs)
 
 	return l, nil
 }

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -41,7 +41,7 @@ func commitLogDirectory(rootPath, name string) string {
 }
 
 func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
-	maintenanceCallbacks cyclemanager.CycleCallbacks, opts ...CommitlogOption,
+	maintenanceCallbacks cyclemanager.CycleCallbackGroup, opts ...CommitlogOption,
 ) (*hnswCommitLogger, error) {
 	l := &hnswCommitLogger{
 		rootPath:  rootPath,

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -26,7 +26,7 @@ import (
 
 func (h *hnsw) initCompressedStore() error {
 	store, err := lsmkv.New(fmt.Sprintf("%s/%s/%s", h.rootPath, h.className, h.shardName), "", h.logger, nil,
-		h.classCompactionCallbacks, h.classFlushCallbacks)
+		h.shardCompactionCallbacks, h.shardFlushCallbacks)
 	if err != nil {
 		return errors.Wrap(err, "Init lsmkv (compressed vectors store)")
 	}

--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -65,7 +65,7 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 				return container.Slice, nil
 			},
 		}, uc,
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	defer index.Shutdown(context.Background())
 	ssdhelpers.Concurrently(uint64(len(vectors)), func(id uint64) {
 		index.Add(uint64(id), vectors[id])

--- a/adapters/repos/db/vector/hnsw/compress_recall_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_recall_test.go
@@ -89,7 +89,7 @@ func Test_NoRaceCompressionRecall(t *testing.T) {
 					return container.Slice, nil
 				},
 			}, uc,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		init := time.Now()
 		ssdhelpers.Concurrently(uint64(vectors_size), func(id uint64) {
 			index.Add(id, vectors[id])

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -34,12 +34,12 @@ func TestCondensor(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 
 	perfect, err := NewCommitLogger(rootPath, "perfect", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer perfect.Shutdown(ctx)
 
@@ -149,17 +149,17 @@ func TestCondensorAppendNodeLinks(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed1.Shutdown(ctx)
 
 	uncondensed2, err := NewCommitLogger(rootPath, "uncondensed2", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed2.Shutdown(ctx)
 
 	control, err := NewCommitLogger(rootPath, "control", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer control.Shutdown(ctx)
 
@@ -243,17 +243,17 @@ func TestCondensorReplaceNodeLinks(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed1.Shutdown(ctx)
 
 	uncondensed2, err := NewCommitLogger(rootPath, "uncondensed2", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed2.Shutdown(ctx)
 
 	control, err := NewCommitLogger(rootPath, "control", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer control.Shutdown(ctx)
 
@@ -342,17 +342,17 @@ func TestCondensorClearLinksAtLevel(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed1.Shutdown(ctx)
 
 	uncondensed2, err := NewCommitLogger(rootPath, "uncondensed2", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed2.Shutdown(ctx)
 
 	control, err := NewCommitLogger(rootPath, "control", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer control.Shutdown(ctx)
 
@@ -437,7 +437,7 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 
@@ -487,7 +487,7 @@ func TestCondensorWithPQInformation(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	defer uncondensed.Shutdown(ctx)
 

--- a/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
@@ -29,11 +29,11 @@ func TestMmapCondensor(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	perfect, err := NewCommitLogger(rootPath, "perfect", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	t.Run("add redundant data to the original log", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestMmapCondensor(t *testing.T) {
 
 // 	logger, _ := test.NewNullLogger()
 // 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", logger,
-// 		cyclemanager.NewCycleCallbacksNoop())
+// 		cyclemanager.NewCallbackGroupNoop())
 // 	require.Nil(t, err)
 
 // 	t.Run("add data, but do not set an entrypoint", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/debug.go
+++ b/adapters/repos/db/vector/hnsw/debug.go
@@ -123,7 +123,7 @@ func NewFromJSONDump(dumpBytes []byte, vecForID VectorForID) (*hnsw, error) {
 		MaxConnections: 30,
 		EFConstruction: 128,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func NewFromJSONDumpMap(dumpBytes []byte, vecForID VectorForID) (*hnsw, error) {
 		MaxConnections: 30,
 		EFConstruction: 128,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -58,7 +58,7 @@ func TestDelete_WithoutCleaningUpTombstones(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -153,7 +153,7 @@ func TestDelete_WithCleaningUpTombstonesOnce(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -268,7 +268,7 @@ func TestDelete_WithCleaningUpTombstonesInBetween(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		// makes sure index is build only with level 0. To be removed after fixing WEAVIATE-179
 		index.randFunc = func() float64 { return 0.1 }
 
@@ -388,7 +388,7 @@ func createIndexImportAllVectorsAndDeleteEven(t *testing.T, vectors [][]float32)
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	// makes sure index is build only with level 0. To be removed after fixing WEAVIATE-179
@@ -555,7 +555,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 			},
 			TempVectorForIDThunk: TempVectorForIDThunk(vectors),
 		}, userConfig,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -693,7 +693,7 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 			},
 			TempVectorForIDThunk: TempVectorForIDThunk(vectors),
 		}, userConfig,
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 
@@ -891,7 +891,7 @@ func TestDelete_EntrypointIssues(t *testing.T) {
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	// manually build the index
@@ -1036,7 +1036,7 @@ func TestDelete_MoreEntrypointIssues(t *testing.T) {
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	// manually build the index
@@ -1113,7 +1113,7 @@ func TestDelete_TombstonedEntrypoint(t *testing.T) {
 		// after just being deleted, so make sure to use a positive number here.
 		VectorCacheMaxObjects: 100000,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	objVec := []float32{0.1, 0.2}
@@ -1286,7 +1286,7 @@ func Test_DeleteEPVecInUnderlyingObjectStore(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 

--- a/adapters/repos/db/vector/hnsw/dynamic_ef_test.go
+++ b/adapters/repos/db/vector/hnsw/dynamic_ef_test.go
@@ -92,7 +92,7 @@ func Test_DynamicEF(t *testing.T) {
 					return nil, errors.Errorf("not implemented")
 				},
 			}, test.config,
-				cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 			require.Nil(t, err)
 
 			actualEF := index.searchTimeEF(test.limit)

--- a/adapters/repos/db/vector/hnsw/graph_integrity_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/graph_integrity_integration_test.go
@@ -62,7 +62,7 @@ func TestGraphIntegrity(t *testing.T) {
 			MaxConnections: maxNeighbors,
 			EFConstruction: efConstruction,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -278,7 +278,7 @@ func New(cfg Config, uc ent.UserConfig,
 		"hnsw", "tombstone_cleanup",
 		index.className, index.shardName, index.id,
 	}, "/")
-	index.tombstoneCleanupCallbackCtrl = tombstoneCallbacks.Register(id, true, index.tombstoneCleanup)
+	index.tombstoneCleanupCallbackCtrl = tombstoneCallbacks.Register(id, index.tombstoneCleanup)
 	index.insertMetrics = newInsertMetrics(index.metrics)
 
 	if err := index.init(cfg); err != nil {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -107,8 +107,8 @@ type hnsw struct {
 	tombstones map[uint64]struct{}
 
 	tombstoneCleanupCallbackCtrl cyclemanager.CycleCallbackCtrl
-	shardCompactionCallbacks     cyclemanager.CycleCallbacks
-	shardFlushCallbacks          cyclemanager.CycleCallbacks
+	shardCompactionCallbacks     cyclemanager.CycleCallbackGroup
+	shardFlushCallbacks          cyclemanager.CycleCallbackGroup
 
 	// // for distributed spike, can be used to call a insertExternal on a different graph
 	// insertHook func(node, targetLevel int, neighborsAtLevel map[int][]uint32)
@@ -201,7 +201,7 @@ type (
 // truly new index. So instead the index is initialized, with un-biased disk
 // checks first and only then is the commit logger created
 func New(cfg Config, uc ent.UserConfig,
-	tombstoneCallbacks, shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbacks,
+	tombstoneCallbacks, shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbackGroup,
 ) (*hnsw, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config")

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -107,8 +107,8 @@ type hnsw struct {
 	tombstones map[uint64]struct{}
 
 	tombstoneCleanupCallbackCtrl cyclemanager.CycleCallbackCtrl
-	classCompactionCallbacks     cyclemanager.CycleCallbacks
-	classFlushCallbacks          cyclemanager.CycleCallbacks
+	shardCompactionCallbacks     cyclemanager.CycleCallbacks
+	shardFlushCallbacks          cyclemanager.CycleCallbacks
 
 	// // for distributed spike, can be used to call a insertExternal on a different graph
 	// insertHook func(node, targetLevel int, neighborsAtLevel map[int][]uint32)
@@ -201,7 +201,7 @@ type (
 // truly new index. So instead the index is initialized, with un-biased disk
 // checks first and only then is the commit logger created
 func New(cfg Config, uc ent.UserConfig,
-	tombstoneCallbacks, classCompactionCallbacks, classFlushCallbacks cyclemanager.CycleCallbacks,
+	tombstoneCallbacks, shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbacks,
 ) (*hnsw, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config")
@@ -269,8 +269,8 @@ func New(cfg Config, uc ent.UserConfig,
 		TempVectorForIDThunk: cfg.TempVectorForIDThunk,
 		pqConfig:             uc.PQ,
 
-		classCompactionCallbacks: classCompactionCallbacks,
-		classFlushCallbacks:      classFlushCallbacks,
+		shardCompactionCallbacks: shardCompactionCallbacks,
+		shardFlushCallbacks:      shardFlushCallbacks,
 	}
 
 	// TODO common_cycle_manager move to poststartup?

--- a/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
@@ -34,7 +34,7 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	original, err := NewCommitLogger(rootPath, "corrupt_test", logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	data := [][]float32{
@@ -67,7 +67,7 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 			EFConstruction:         100,
 			CleanupIntervalSeconds: 0,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		index = idx
 	})
@@ -119,7 +119,7 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 			EFConstruction:         100,
 			CleanupIntervalSeconds: 0,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		index = idx
 	})

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -139,7 +139,7 @@ func createEmptyHnswIndexForTests(t *testing.T, vecForIDFn VectorForID) *hnsw {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	return index
 }

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -58,7 +58,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 
 	parentTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("parentTombstoneCleanup", logger, 1)
 	parentTombstoneCleanupCycle := cyclemanager.New(
-		cyclemanager.NewFixedIntervalTicker(1),
+		cyclemanager.NewFixedTicker(1),
 		parentTombstoneCleanupCallbacks.CycleCallback)
 	parentTombstoneCleanupCycle.Start()
 	defer parentTombstoneCleanupCycle.StopAndWait(ctx)

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -54,7 +54,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	parentCommitLoggerCycle.Start()
 	defer parentCommitLoggerCycle.StopAndWait(ctx)
 	commitLoggerCallbacks := cyclemanager.NewCycleCallbacks("childCommitLogger", logger, 1)
-	commitLoggerCallbacksCtrl := parentCommitLoggerCallbacks.Register("commitLogger", true, commitLoggerCallbacks.CycleCallback)
+	commitLoggerCallbacksCtrl := parentCommitLoggerCallbacks.Register("commitLogger", commitLoggerCallbacks.CycleCallback)
 
 	parentTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("parentTombstoneCleanup", logger, 1)
 	parentTombstoneCleanupCycle := cyclemanager.New(
@@ -63,7 +63,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	parentTombstoneCleanupCycle.Start()
 	defer parentTombstoneCleanupCycle.StopAndWait(ctx)
 	tombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("childTombstoneCleanup", logger, 1)
-	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", true, tombstoneCleanupCallbacks.CycleCallback)
+	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", tombstoneCleanupCallbacks.CycleCallback)
 
 	original, err := NewCommitLogger(rootPath, "too_many_links_test", logger, commitLoggerCallbacks,
 		WithCommitlogThreshold(1e5),

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -47,22 +47,22 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
-	parentCommitLoggerCallbacks := cyclemanager.NewCycleCallbacks("parentCommitLogger", logger, 1)
-	parentCommitLoggerCycle := cyclemanager.New(
+	parentCommitLoggerCallbacks := cyclemanager.NewCallbackGroup("parentCommitLogger", logger, 1)
+	parentCommitLoggerCycle := cyclemanager.NewManager(
 		cyclemanager.HnswCommitLoggerCycleTicker(),
 		parentCommitLoggerCallbacks.CycleCallback)
 	parentCommitLoggerCycle.Start()
 	defer parentCommitLoggerCycle.StopAndWait(ctx)
-	commitLoggerCallbacks := cyclemanager.NewCycleCallbacks("childCommitLogger", logger, 1)
+	commitLoggerCallbacks := cyclemanager.NewCallbackGroup("childCommitLogger", logger, 1)
 	commitLoggerCallbacksCtrl := parentCommitLoggerCallbacks.Register("commitLogger", commitLoggerCallbacks.CycleCallback)
 
-	parentTombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("parentTombstoneCleanup", logger, 1)
-	parentTombstoneCleanupCycle := cyclemanager.New(
+	parentTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("parentTombstoneCleanup", logger, 1)
+	parentTombstoneCleanupCycle := cyclemanager.NewManager(
 		cyclemanager.NewFixedTicker(1),
 		parentTombstoneCleanupCallbacks.CycleCallback)
 	parentTombstoneCleanupCycle.Start()
 	defer parentTombstoneCleanupCycle.StopAndWait(ctx)
-	tombstoneCleanupCallbacks := cyclemanager.NewCycleCallbacks("childTombstoneCleanup", logger, 1)
+	tombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("childTombstoneCleanup", logger, 1)
 	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", tombstoneCleanupCallbacks.CycleCallback)
 
 	original, err := NewCommitLogger(rootPath, "too_many_links_test", logger, commitLoggerCallbacks,
@@ -103,7 +103,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 2 * n,
 		},
-			tombstoneCleanupCallbacks, cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			tombstoneCleanupCallbacks, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		idx.PostStartup()
 		index = idx
@@ -238,7 +238,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 2 * n,
 		},
-			tombstoneCleanupCallbacks, cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			tombstoneCleanupCallbacks, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		idx.PostStartup()
 		index = idx

--- a/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
+++ b/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
@@ -28,8 +28,8 @@ import (
 func TestPeriodicTombstoneRemoval(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	cleanupIntervalSeconds := 1
-	tombstoneCallbacks := cyclemanager.NewCycleCallbacks("tombstone", logger, 1)
-	tombstoneCleanupCycle := cyclemanager.New(
+	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstone", logger, 1)
+	tombstoneCleanupCycle := cyclemanager.NewManager(
 		cyclemanager.NewFixedTicker(time.Duration(cleanupIntervalSeconds)*time.Second),
 		tombstoneCallbacks.CycleCallback)
 	tombstoneCleanupCycle.Start()
@@ -45,7 +45,7 @@ func TestPeriodicTombstoneRemoval(t *testing.T) {
 		MaxConnections:         30,
 		EFConstruction:         128,
 	},
-		tombstoneCallbacks, cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		tombstoneCallbacks, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	index.PostStartup()
 
 	require.Nil(t, err)

--- a/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
+++ b/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
@@ -30,7 +30,7 @@ func TestPeriodicTombstoneRemoval(t *testing.T) {
 	cleanupIntervalSeconds := 1
 	tombstoneCallbacks := cyclemanager.NewCycleCallbacks("tombstone", logger, 1)
 	tombstoneCleanupCycle := cyclemanager.New(
-		cyclemanager.NewFixedIntervalTicker(time.Duration(cleanupIntervalSeconds)*time.Second),
+		cyclemanager.NewFixedTicker(time.Duration(cleanupIntervalSeconds)*time.Second),
 		tombstoneCallbacks.CycleCallback)
 	tombstoneCleanupCycle.Start()
 

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -36,7 +36,7 @@ func TestHnswPersistence(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	makeCL := func() (CommitLogger, error) {
 		return cl, clErr
 	}
@@ -50,7 +50,7 @@ func TestHnswPersistence(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -88,7 +88,7 @@ func TestHnswPersistence(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	t.Run("verify that the results match after rebuiling from disk",
@@ -106,7 +106,7 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	makeCL := func() (CommitLogger, error) {
 		return cl, clErr
 	}
@@ -120,7 +120,7 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -192,7 +192,7 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	// the minor corruption (just one missing link) will most likely not render
@@ -212,7 +212,7 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 	indexID := "integrationtest_deletion"
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, logger,
-		cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop())
 	makeCL := func() (CommitLogger, error) {
 		return cl, clErr
 	}
@@ -226,7 +226,7 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -273,7 +273,7 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	dumpIndex(secondIndex, "without_cleanup_after_rebuild")
@@ -293,7 +293,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	makeCL := func() (CommitLogger, error) {
 		return NewCommitLogger(dirName, indexID, logger,
-			cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop())
 	}
 	index, err := New(Config{
 		RootPath:              dirName,
@@ -305,7 +305,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {
@@ -358,7 +358,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	dumpIndex(secondIndex, "with cleanup second index")
 
@@ -401,7 +401,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	dumpIndex(thirdIndex)
@@ -440,7 +440,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		MaxConnections: 30,
 		EFConstruction: 60,
 	},
-		cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
 	t.Run("load from disk and try to insert again", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/recall_geo_spatial_test.go
+++ b/adapters/repos/db/vector/hnsw/recall_geo_spatial_test.go
@@ -71,7 +71,7 @@ func TestRecallGeo(t *testing.T) {
 			MaxConnections: maxNeighbors,
 			EFConstruction: efConstruction,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 
 		require.Nil(t, err)
 		vectorIndex = index

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -51,7 +51,7 @@ func TestNilCheckOnPartiallyCleanedNode(t *testing.T) {
 			// after just being deleted, so make sure to use a positive number here.
 			VectorCacheMaxObjects: 100000,
 		},
-			cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop(), cyclemanager.NewCycleCallbacksNoop())
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 		require.Nil(t, err)
 		vectorIndex = index
 	})

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -36,8 +36,8 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", true, callback1)
-		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl1 := callbacks.Register("c1", callback1)
+		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
@@ -66,8 +66,8 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", true, callback1)
-		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl1 := callbacks.Register("c1", callback1)
+		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
@@ -95,8 +95,8 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrlShort := callbacks.Register("short", true, callbackShort)
-		ctrlLong := callbacks.Register("long", true, callbackLong)
+		ctrlShort := callbacks.Register("short", callbackShort)
+		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
@@ -134,8 +134,8 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", true, callback1)
-		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl1 := callbacks.Register("c1", callback1)
+		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
@@ -164,8 +164,8 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", true, callback1)
-		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl1 := callbacks.Register("c1", callback1)
+		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
@@ -193,8 +193,8 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrlShort := callbacks.Register("short", true, callbackShort)
-		ctrlLong := callbacks.Register("long", true, callbackLong)
+		ctrlShort := callbacks.Register("short", callbackShort)
+		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
@@ -232,8 +232,8 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 		}
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", false, callback1)
-		ctrl2 := callbacks.Register("c2", false, callback2)
+		ctrl1 := callbacks.Register("c1", callback1, AsInactive())
+		ctrl2 := callbacks.Register("c2", callback2, AsInactive())
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -35,12 +35,12 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -65,12 +65,12 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -94,12 +94,12 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrlShort := callbacks.Register("short", callbackShort)
 		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -133,12 +133,12 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -163,12 +163,12 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -192,12 +192,12 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrlShort := callbacks.Register("short", callbackShort)
 		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -231,12 +231,12 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 			return true
 		}
 
-		callbacks := NewCycleCallbacks("id", logger, 2)
+		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1, AsInactive())
 		ctrl2 := callbacks.Register("c2", callback2, AsInactive())
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -40,7 +40,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -70,7 +70,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -99,7 +99,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -138,7 +138,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -168,7 +168,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -197,7 +197,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -236,7 +236,7 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2, AsInactive())
 		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
-		cycle := New(NewFixedIntervalTicker(100*time.Millisecond), callbacks.CycleCallback)
+		cycle := New(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 

--- a/entities/cyclemanager/cyclecallbacks.go
+++ b/entities/cyclemanager/cyclecallbacks.go
@@ -350,7 +350,7 @@ type cycleCallbackMeta struct {
 	// or not running (not yet started) - context nil
 	runningCtx context.Context
 	started    time.Time
-	intervals  Intervals
+	intervals  CycleIntervals
 }
 
 type cycleCallbacksNoop struct{}
@@ -375,7 +375,7 @@ func AsInactive() RegisterOption {
 	}
 }
 
-func WithIntervals(intervals Intervals) RegisterOption {
+func WithIntervals(intervals CycleIntervals) RegisterOption {
 	if intervals == nil {
 		return nil
 	}

--- a/entities/cyclemanager/cyclecallbacks_test.go
+++ b/entities/cyclemanager/cyclecallbacks_test.go
@@ -13,7 +13,6 @@ package cyclemanager
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCycleCallback(t *testing.T) {
+func TestCycleCallback_Parallel(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
@@ -109,12 +108,10 @@ func TestCycleCallback(t *testing.T) {
 			executedCounter2++
 			return true
 		}
-		shouldAbortCounter := int32(0)
-		// in total shouldAbort will be called 5x
-		// (3x inside for loop, before routines start, 2x inside routines (once per routine))
-		// let one routine fail, therefore 4 calls should return false
+		shouldAbortCounter := 0
 		shouldAbort := func() bool {
-			return atomic.AddInt32(&shouldAbortCounter, 1) > 4
+			shouldAbortCounter++
+			return shouldAbortCounter > 1
 		}
 		var executed bool
 		var d time.Duration
@@ -194,23 +191,23 @@ func TestCycleCallback(t *testing.T) {
 	})
 }
 
-func TestCycleCallback_Unregister(t *testing.T) {
+func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
 	t.Run("1 executable callback, 1 unregistered", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
 			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
+			executedCounter++
 			return true
 		}
 		var executed bool
 		var d time.Duration
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl := callbacks.Register("c1", true, callback1)
+		ctrl := callbacks.Register("c1", true, callback)
 		require.Nil(t, ctrl.Unregister(ctx))
 
 		start := time.Now()
@@ -218,7 +215,7 @@ func TestCycleCallback_Unregister(t *testing.T) {
 		d = time.Since(start)
 
 		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 0, executedCounter)
 		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
 	})
 
@@ -394,7 +391,7 @@ func TestCycleCallback_Unregister(t *testing.T) {
 		assert.True(t, executed)
 		assert.Equal(t, 1, executedCounter)
 		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 45*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
 	})
 
 	t.Run("unregister fails due to context timeout", func(t *testing.T) {
@@ -425,6 +422,7 @@ func TestCycleCallback_Unregister(t *testing.T) {
 		start := time.Now()
 		time.Sleep(25 * time.Millisecond)
 		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+		defer cancel()
 		require.NotNil(t, ctrl.Unregister(ctxTimeout))
 		du := time.Since(start)
 		<-chFinished
@@ -443,8 +441,6 @@ func TestCycleCallback_Unregister(t *testing.T) {
 		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
 		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
 		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
-
-		cancel()
 	})
 
 	t.Run("unregister 3rd and 4th while executing", func(t *testing.T) {
@@ -505,23 +501,23 @@ func TestCycleCallback_Unregister(t *testing.T) {
 	})
 }
 
-func TestCycleCallback_Deactivate(t *testing.T) {
+func TestCycleCallback_Parallel_Deactivate(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
 	t.Run("1 executable callback, 1 deactivated", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
 			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
+			executedCounter++
 			return true
 		}
 		var executed bool
 		var d time.Duration
 
 		callbacks := NewCycleCallbacks("id", logger, 2)
-		ctrl := callbacks.Register("c1", true, callback1)
+		ctrl := callbacks.Register("c1", true, callback)
 		require.Nil(t, ctrl.Deactivate(ctx))
 
 		start := time.Now()
@@ -529,7 +525,7 @@ func TestCycleCallback_Deactivate(t *testing.T) {
 		d = time.Since(start)
 
 		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 0, executedCounter)
 		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
 	})
 
@@ -705,7 +701,7 @@ func TestCycleCallback_Deactivate(t *testing.T) {
 		assert.True(t, executed)
 		assert.Equal(t, 1, executedCounter)
 		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 45*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
 	})
 
 	t.Run("deactivate fails due to context timeout", func(t *testing.T) {
@@ -736,6 +732,7 @@ func TestCycleCallback_Deactivate(t *testing.T) {
 		start := time.Now()
 		time.Sleep(25 * time.Millisecond)
 		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+		defer cancel()
 		require.NotNil(t, ctrl.Deactivate(ctxTimeout))
 		du := time.Since(start)
 		<-chFinished
@@ -754,8 +751,6 @@ func TestCycleCallback_Deactivate(t *testing.T) {
 		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
 		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
 		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
-
-		cancel()
 	})
 
 	t.Run("deactivate 3rd and 4th while executing", func(t *testing.T) {
@@ -811,6 +806,760 @@ func TestCycleCallback_Deactivate(t *testing.T) {
 		assert.Equal(t, 1, executedCounter1)
 		assert.Equal(t, 1, executedCounter2)
 		assert.Equal(t, 0, executedCounter3)
+		assert.Equal(t, 0, executedCounter3)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+	})
+}
+
+func TestCycleCallback_Sequential(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	t.Run("no callbacks", func(t *testing.T) {
+		var executed bool
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+
+		executed = callbacks.CycleCallback(shouldNotAbort)
+
+		assert.False(t, executed)
+	})
+
+	t.Run("2 executable callbacks", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		callbacks.Register("c1", true, callback1)
+		callbacks.Register("c2", true, callback2)
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 75*time.Millisecond)
+	})
+
+	t.Run("2 non-executable callbacks", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(10 * time.Millisecond)
+			executedCounter1++
+			return false
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(10 * time.Millisecond)
+			executedCounter2++
+			return false
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		callbacks.Register("c1", true, callback1)
+		callbacks.Register("c2", true, callback2)
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.False(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 10*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, not executed due to should abort", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		shouldAbortCounter := 0
+		shouldAbort := func() bool {
+			shouldAbortCounter++
+			return shouldAbortCounter > 1
+		}
+
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		callbacks.Register("c1", true, callback1)
+		callbacks.Register("c2", true, callback2)
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldAbort)
+		d = time.Since(start)
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
+	})
+
+	t.Run("register new while executing", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		callbacks.Register("c1", true, callback1)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.CycleCallback(shouldNotAbort)
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		time.Sleep(25 * time.Millisecond)
+		callbacks.Register("c2", true, callback2)
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+	})
+}
+
+func TestCycleCallback_Sequential_Unregister(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	t.Run("1 executable callback, 1 unregistered", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl := callbacks.Register("c1", true, callback)
+		require.Nil(t, ctrl.Unregister(ctx))
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.False(t, executed)
+		assert.Equal(t, 0, executedCounter)
+		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, 2 unregistered", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", true, callback1)
+		ctrl2 := callbacks.Register("c2", true, callback2)
+		require.Nil(t, ctrl1.Unregister(ctx))
+		require.Nil(t, ctrl2.Unregister(ctx))
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.False(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, 1 unregistered", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", true, callback1)
+		callbacks.Register("c2", true, callback2)
+		require.Nil(t, ctrl1.Unregister(ctx))
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.True(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
+	})
+
+	t.Run("4 executable callbacks, all unregistered at different time", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		executedCounter3 := 0
+		callback3 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter3++
+			return true
+		}
+		executedCounter4 := 0
+		callback4 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter4++
+			return true
+		}
+		var executed1 bool
+		var executed2 bool
+		var executed3 bool
+		var executed4 bool
+		var d1 time.Duration
+		var d2 time.Duration
+		var d3 time.Duration
+		var d4 time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", true, callback1)
+		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl3 := callbacks.Register("c3", true, callback3)
+		ctrl4 := callbacks.Register("c4", true, callback4)
+		require.Nil(t, ctrl3.Unregister(ctx))
+
+		start := time.Now()
+		executed1 = callbacks.CycleCallback(shouldNotAbort)
+		d1 = time.Since(start)
+
+		require.Nil(t, ctrl1.Unregister(ctx))
+
+		start = time.Now()
+		executed2 = callbacks.CycleCallback(shouldNotAbort)
+		d2 = time.Since(start)
+
+		require.Nil(t, ctrl4.Unregister(ctx))
+
+		start = time.Now()
+		executed3 = callbacks.CycleCallback(shouldNotAbort)
+		d3 = time.Since(start)
+
+		require.Nil(t, ctrl2.Unregister(ctx))
+
+		start = time.Now()
+		executed4 = callbacks.CycleCallback(shouldNotAbort)
+		d4 = time.Since(start)
+
+		assert.True(t, executed1)
+		assert.True(t, executed2)
+		assert.True(t, executed3)
+		assert.False(t, executed4)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 3, executedCounter2)
+		assert.Equal(t, 0, executedCounter3)
+		assert.Equal(t, 2, executedCounter4)
+		assert.GreaterOrEqual(t, d1, 75*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
+		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
+	})
+
+	t.Run("unregister is waiting till the end of execution", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl := callbacks.Register("c", true, callback)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.CycleCallback(shouldNotAbort)
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		start := time.Now()
+		time.Sleep(25 * time.Millisecond)
+		require.Nil(t, ctrl.Unregister(ctx))
+		du := time.Since(start)
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
+	})
+
+	t.Run("unregister fails due to context timeout", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed1 bool
+		var executed2 bool
+		var d1 time.Duration
+		var d2 time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl := callbacks.Register("c", true, callback)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed1 = callbacks.CycleCallback(shouldNotAbort)
+			d1 = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		start := time.Now()
+		time.Sleep(25 * time.Millisecond)
+		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+		defer cancel()
+		require.NotNil(t, ctrl.Unregister(ctxTimeout))
+		du := time.Since(start)
+		<-chFinished
+
+		go func() {
+			start := time.Now()
+			executed2 = callbacks.CycleCallback(shouldNotAbort)
+			d2 = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chFinished
+
+		assert.True(t, executed1)
+		assert.True(t, executed2)
+		assert.Equal(t, 2, executedCounter)
+		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
+	})
+
+	t.Run("unregister 2nd and 3rd while executing", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		executedCounter3 := 0
+		callback3 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter3++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		callbacks.Register("c1", true, callback1)
+		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl3 := callbacks.Register("c3", true, callback3)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.CycleCallback(shouldNotAbort)
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		time.Sleep(25 * time.Millisecond)
+		require.Nil(t, ctrl2.Unregister(ctx))
+		require.Nil(t, ctrl3.Unregister(ctx))
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.Equal(t, 0, executedCounter3)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+	})
+}
+
+func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	t.Run("1 executable callback, 1 deactivated", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl := callbacks.Register("c1", true, callback)
+		require.Nil(t, ctrl.Deactivate(ctx))
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.False(t, executed)
+		assert.Equal(t, 0, executedCounter)
+		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, 2 deactivated", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", true, callback1)
+		ctrl2 := callbacks.Register("c2", true, callback2)
+		require.Nil(t, ctrl1.Deactivate(ctx))
+		require.Nil(t, ctrl2.Deactivate(ctx))
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.False(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+	})
+
+	t.Run("2 executable callbacks, 1 deactivated", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", true, callback1)
+		callbacks.Register("c2", true, callback2)
+		require.Nil(t, ctrl1.Deactivate(ctx))
+
+		start := time.Now()
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		d = time.Since(start)
+
+		assert.True(t, executed)
+		assert.Equal(t, 0, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
+	})
+
+	t.Run("4 executable callbacks, all deactivated at different time", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		executedCounter3 := 0
+		callback3 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter3++
+			return true
+		}
+		executedCounter4 := 0
+		callback4 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			executedCounter4++
+			return true
+		}
+		var executed1 bool
+		var executed2 bool
+		var executed3 bool
+		var executed4 bool
+		var d1 time.Duration
+		var d2 time.Duration
+		var d3 time.Duration
+		var d4 time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", true, callback1)
+		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl3 := callbacks.Register("c3", true, callback3)
+		ctrl4 := callbacks.Register("c4", true, callback4)
+		require.Nil(t, ctrl3.Deactivate(ctx))
+
+		start := time.Now()
+		executed1 = callbacks.CycleCallback(shouldNotAbort)
+		d1 = time.Since(start)
+
+		require.Nil(t, ctrl1.Deactivate(ctx))
+
+		start = time.Now()
+		executed2 = callbacks.CycleCallback(shouldNotAbort)
+		d2 = time.Since(start)
+
+		require.Nil(t, ctrl4.Deactivate(ctx))
+
+		start = time.Now()
+		executed3 = callbacks.CycleCallback(shouldNotAbort)
+		d3 = time.Since(start)
+
+		require.Nil(t, ctrl2.Deactivate(ctx))
+
+		start = time.Now()
+		executed4 = callbacks.CycleCallback(shouldNotAbort)
+		d4 = time.Since(start)
+
+		assert.True(t, executed1)
+		assert.True(t, executed2)
+		assert.True(t, executed3)
+		assert.False(t, executed4)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 3, executedCounter2)
+		assert.Equal(t, 0, executedCounter3)
+		assert.Equal(t, 2, executedCounter4)
+		assert.GreaterOrEqual(t, d1, 75*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
+		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
+	})
+
+	t.Run("deactivate is waiting till the end of execution", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl := callbacks.Register("c", true, callback)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.CycleCallback(shouldNotAbort)
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		start := time.Now()
+		time.Sleep(25 * time.Millisecond)
+		require.Nil(t, ctrl.Deactivate(ctx))
+		du := time.Since(start)
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
+	})
+
+	t.Run("deactivate fails due to context timeout", func(t *testing.T) {
+		executedCounter := 0
+		callback := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed1 bool
+		var executed2 bool
+		var d1 time.Duration
+		var d2 time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		ctrl := callbacks.Register("c", true, callback)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed1 = callbacks.CycleCallback(shouldNotAbort)
+			d1 = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		start := time.Now()
+		time.Sleep(25 * time.Millisecond)
+		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+		defer cancel()
+		require.NotNil(t, ctrl.Deactivate(ctxTimeout))
+		du := time.Since(start)
+		<-chFinished
+
+		go func() {
+			start := time.Now()
+			executed2 = callbacks.CycleCallback(shouldNotAbort)
+			d2 = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chFinished
+
+		assert.True(t, executed1)
+		assert.True(t, executed2)
+		assert.Equal(t, 2, executedCounter)
+		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
+		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
+	})
+
+	t.Run("deactivate 2nd and 3rd while executing", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter2++
+			return true
+		}
+		executedCounter3 := 0
+		callback3 := func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			executedCounter3++
+			return true
+		}
+		chStarted := make(chan struct{}, 1)
+		chFinished := make(chan struct{}, 1)
+		var executed bool
+		var d time.Duration
+
+		callbacks := NewCycleCallbacks("id", logger, 1)
+		callbacks.Register("c1", true, callback1)
+		ctrl2 := callbacks.Register("c2", true, callback2)
+		ctrl3 := callbacks.Register("c3", true, callback3)
+
+		go func() {
+			chStarted <- struct{}{}
+			start := time.Now()
+			executed = callbacks.CycleCallback(shouldNotAbort)
+			d = time.Since(start)
+			chFinished <- struct{}{}
+		}()
+		<-chStarted
+		time.Sleep(25 * time.Millisecond)
+		require.Nil(t, ctrl2.Deactivate(ctx))
+		require.Nil(t, ctrl3.Deactivate(ctx))
+		<-chFinished
+
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
 		assert.Equal(t, 0, executedCounter3)
 		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
 	})

--- a/entities/cyclemanager/cyclemanager.go
+++ b/entities/cyclemanager/cyclemanager.go
@@ -47,7 +47,7 @@ type cycleManager struct {
 	stopResults  []chan bool
 }
 
-func New(cycleTicker CycleTicker, cycleCallback CycleCallback) CycleManager {
+func NewManager(cycleTicker CycleTicker, cycleCallback CycleCallback) CycleManager {
 	return &cycleManager{
 		cycleCallback: cycleCallback,
 		cycleTicker:   cycleTicker,
@@ -195,19 +195,19 @@ func (c *cycleManager) handleStopRequest(stopped bool) {
 	c.stopResults = nil
 }
 
-func NewNoop() CycleManager {
-	return &noopCycleManager{running: false}
+func NewManagerNoop() CycleManager {
+	return &cycleManagerNoop{running: false}
 }
 
-type noopCycleManager struct {
+type cycleManagerNoop struct {
 	running bool
 }
 
-func (c *noopCycleManager) Start() {
+func (c *cycleManagerNoop) Start() {
 	c.running = true
 }
 
-func (c *noopCycleManager) Stop(ctx context.Context) chan bool {
+func (c *cycleManagerNoop) Stop(ctx context.Context) chan bool {
 	if !c.running {
 		return c.closedChan(true)
 	}
@@ -219,18 +219,18 @@ func (c *noopCycleManager) Stop(ctx context.Context) chan bool {
 	return c.closedChan(true)
 }
 
-func (c *noopCycleManager) StopAndWait(ctx context.Context) error {
+func (c *cycleManagerNoop) StopAndWait(ctx context.Context) error {
 	if <-c.Stop(ctx) {
 		return nil
 	}
 	return ctx.Err()
 }
 
-func (c *noopCycleManager) Running() bool {
+func (c *cycleManagerNoop) Running() bool {
 	return c.running
 }
 
-func (c *noopCycleManager) closedChan(val bool) chan bool {
+func (c *cycleManagerNoop) closedChan(val bool) chan bool {
 	ch := make(chan bool, 1)
 	ch <- val
 	close(ch)

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -70,7 +70,7 @@ func TestCycleManager_beforeTimeout(t *testing.T) {
 	var cm CycleManager
 
 	t.Run("create new", func(t *testing.T) {
-		cm = New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+		cm = New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 		assert.False(t, cm.Running())
 	})
@@ -108,7 +108,7 @@ func TestCycleManager_beforeTimeoutWithWait(t *testing.T) {
 	var cm CycleManager
 
 	t.Run("create new", func(t *testing.T) {
-		cm = New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+		cm = New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 		assert.False(t, cm.Running())
 	})
@@ -138,7 +138,7 @@ func TestCycleManager_timeout(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("timeout is reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -175,7 +175,7 @@ func TestCycleManager_timeoutWithWait(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("timeout is reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -206,7 +206,7 @@ func TestCycleManager_doesNotStartMultipleTimes(t *testing.T) {
 	startCount := 5
 
 	p := newProvider(cycleDuration, uint(startCount))
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("multiple starts", func(t *testing.T) {
 		for i := 0; i < startCount; i++ {
@@ -230,7 +230,7 @@ func TestCycleManager_doesNotStartMultipleTimesWithWait(t *testing.T) {
 	startCount := 5
 
 	p := newProvider(cycleDuration, uint(startCount))
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("multiple starts", func(t *testing.T) {
 		for i := 0; i < startCount; i++ {
@@ -254,7 +254,7 @@ func TestCycleManager_handlesMultipleStops(t *testing.T) {
 	stopCount := 5
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("multiple stops", func(t *testing.T) {
 		cm.Start()
@@ -279,7 +279,7 @@ func TestCycleManager_stopsIfNotAllContextsAreCancelled(t *testing.T) {
 	stopTimeout := 5 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("multiple stops, few cancelled", func(t *testing.T) {
 		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
@@ -310,7 +310,7 @@ func TestCycleManager_doesNotStopIfAllContextsAreCancelled(t *testing.T) {
 	stopTimeout := 50 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("multiple stops, few cancelled", func(t *testing.T) {
 		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
@@ -350,7 +350,7 @@ func TestCycleManager_cycleCallbackStoppedDueToFrequentStopChecks(t *testing.T) 
 
 	// despite cycleDuration is 30ms, cycle callback checks every 20ms (300/15) if it needs to be stopped
 	p := newProviderBreakable(cycleDuration, 1, 15)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("cycle funcion stopped before timeout reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -380,7 +380,7 @@ func TestCycleManager_cycleCallbackNotStoppedDueToRareStopChecks(t *testing.T) {
 
 	// despite cycleDuration is 30ms, cycle callback checks every 150ms (300/2) if it needs to be stopped
 	p := newProviderBreakable(cycleDuration, 1, 2)
-	cm := New(NewFixedIntervalTicker(cycleInterval), p.cycleCallback)
+	cm := New(NewFixedTicker(cycleInterval), p.cycleCallback)
 
 	t.Run("timeout reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)

--- a/entities/cyclemanager/interval.go
+++ b/entities/cyclemanager/interval.go
@@ -21,9 +21,15 @@ const (
 )
 
 // 3s . 6.8s .. 14.4s .... 29.6s ........ 60s
-func CompactionCycleTicker() CycleTicker {
-	return NewExpTicker(compactionMinInterval, compactionMaxInterval,
+func CompactionCycleIntervals() CycleIntervals {
+	return NewExpIntervals(compactionMinInterval, compactionMaxInterval,
 		compactionBase, compactionSteps)
+}
+
+// run cycle ticker with fixed minimal interval and let each shard
+// take care of its intervals
+func CompactionCycleTicker() CycleTicker {
+	return NewFixedTicker(compactionMinInterval)
 }
 
 const (
@@ -34,9 +40,15 @@ const (
 )
 
 // 100ms . 258ms .. 574ms .... 1.206s ........ 2.471s ................ 5s
-func MemtableFlushCycleTicker() CycleTicker {
-	return NewExpTicker(memtableFlushMinInterval, memtableFlushMaxInterval,
+func MemtableFlushCycleIntervals() CycleIntervals {
+	return NewExpIntervals(memtableFlushMinInterval, memtableFlushMaxInterval,
 		memtableFlushBase, memtableFlushSteps)
+}
+
+// run cycle ticker with fixed minimal interval and let each shard
+// take care of its intervals
+func MemtableFlushCycleTicker() CycleTicker {
+	return NewFixedTicker(memtableFlushMinInterval)
 }
 
 const (
@@ -47,9 +59,15 @@ const (
 )
 
 // 10s . 13.3s .. 20s .... 33.3s ........ 60s
-func GeoCommitLoggerCycleTicker() CycleTicker {
-	return NewExpTicker(geoCommitLoggerMinInterval, geoCommitLoggerMaxInterval,
+func GeoCommitLoggerCycleIntervals() CycleIntervals {
+	return NewExpIntervals(geoCommitLoggerMinInterval, geoCommitLoggerMaxInterval,
 		geoCommitLoggerBase, geoCommitLoggerSteps)
+}
+
+// run cycle ticker with fixed minimal interval and let each shard
+// take care of its intervals
+func GeoCommitLoggerCycleTicker() CycleTicker {
+	return NewFixedTicker(geoCommitLoggerMinInterval)
 }
 
 const (
@@ -60,7 +78,13 @@ const (
 )
 
 // 500ms . 806ms .. 1.42s .... 2.65s ........ 5.1s ................10s
-func HnswCommitLoggerCycleTicker() CycleTicker {
-	return NewExpTicker(hnswCommitLoggerMinInterval, hnswCommitLoggerMaxInterval,
+func HnswCommitLoggerCycleIntervals() CycleIntervals {
+	return NewExpIntervals(hnswCommitLoggerMinInterval, hnswCommitLoggerMaxInterval,
 		hnswCommitLoggerBase, hnswCommitLoggerSteps)
+}
+
+// run cycle ticker with fixed minimal interval and let each shard
+// take care of its intervals
+func HnswCommitLoggerCycleTicker() CycleTicker {
+	return NewFixedTicker(hnswCommitLoggerMinInterval)
 }

--- a/entities/cyclemanager/ticker.go
+++ b/entities/cyclemanager/ticker.go
@@ -28,11 +28,11 @@ type CycleTicker interface {
 }
 
 type cycleTicker struct {
-	intervals Intervals
+	intervals CycleIntervals
 	ticker    *time.Ticker
 }
 
-func newCycleTicker(intervals Intervals) CycleTicker {
+func newCycleTicker(intervals CycleIntervals) CycleTicker {
 	if intervals == nil {
 		return NewNoopTicker()
 	}
@@ -66,7 +66,7 @@ func (t *cycleTicker) CycleExecuted(executed bool) {
 // of execution results reported by cycle function
 //
 // If interval <= 0 given, ticker will not fire
-func NewFixedIntervalTicker(interval time.Duration) CycleTicker {
+func NewFixedTicker(interval time.Duration) CycleTicker {
 	return newCycleTicker(NewFixedIntervals(interval))
 }
 
@@ -131,7 +131,7 @@ func (t *noopTicker) CycleExecuted(executed bool) {
 
 // ===== Intervals =====
 
-type Intervals interface {
+type CycleIntervals interface {
 	Get() time.Duration
 	Reset()
 	Advance()
@@ -170,14 +170,14 @@ func (i *seriesIntervals) Advance() {
 	}
 }
 
-func NewFixedIntervals(interval time.Duration) Intervals {
+func NewFixedIntervals(interval time.Duration) CycleIntervals {
 	if interval <= 0 {
 		return nil
 	}
 	return &fixedIntervals{interval: interval}
 }
 
-func NewSeriesIntervals(intervals []time.Duration) Intervals {
+func NewSeriesIntervals(intervals []time.Duration) CycleIntervals {
 	if len(intervals) == 0 {
 		return nil
 	}
@@ -196,7 +196,7 @@ func NewSeriesIntervals(intervals []time.Duration) Intervals {
 	return &seriesIntervals{intervals: intervals, pos: 0}
 }
 
-func NewLinearIntervals(minInterval, maxInterval time.Duration, steps uint) Intervals {
+func NewLinearIntervals(minInterval, maxInterval time.Duration, steps uint) CycleIntervals {
 	if minInterval <= 0 || maxInterval <= 0 || steps == 0 || minInterval > maxInterval {
 		return nil
 	}
@@ -206,7 +206,7 @@ func NewLinearIntervals(minInterval, maxInterval time.Duration, steps uint) Inte
 	return &seriesIntervals{intervals: linearToIntervals(minInterval, maxInterval, steps), pos: 0}
 }
 
-func NewExpIntervals(minInterval, maxInterval time.Duration, base, steps uint) Intervals {
+func NewExpIntervals(minInterval, maxInterval time.Duration, base, steps uint) CycleIntervals {
 	if minInterval <= 0 || maxInterval <= 0 || base == 0 || steps == 0 || minInterval > maxInterval {
 		return nil
 	}

--- a/entities/cyclemanager/ticker_test.go
+++ b/entities/cyclemanager/ticker_test.go
@@ -455,7 +455,7 @@ func Test_LinearTicker(t *testing.T) {
 		minInterval := 50 * time.Millisecond
 		maxInterval := 100 * time.Millisecond
 		steps := uint(2)
-		tolerance := 3 * time.Millisecond
+		tolerance := 10 * time.Millisecond
 
 		ticker := NewLinearTicker(minInterval, maxInterval, steps)
 		ticker.Start()

--- a/entities/cyclemanager/ticker_test.go
+++ b/entities/cyclemanager/ticker_test.go
@@ -22,7 +22,7 @@ import (
 func Test_FixedIntervalTicker(t *testing.T) {
 	t.Run("channel is empty before started", func(t *testing.T) {
 		interval := 10 * time.Millisecond
-		ticker := NewFixedIntervalTicker(10 * time.Millisecond)
+		ticker := NewFixedTicker(10 * time.Millisecond)
 
 		assert.Len(t, ticker.C(), 0)
 
@@ -36,7 +36,7 @@ func Test_FixedIntervalTicker(t *testing.T) {
 		interval := 50 * time.Millisecond
 		tolerance := 25 * time.Millisecond
 
-		ticker := NewFixedIntervalTicker(interval)
+		ticker := NewFixedTicker(interval)
 		ticker.Start()
 
 		t0 := time.Now()
@@ -64,7 +64,7 @@ func Test_FixedIntervalTicker(t *testing.T) {
 		interval := 50 * time.Millisecond
 		tolerance := 25 * time.Millisecond
 
-		ticker := NewFixedIntervalTicker(interval)
+		ticker := NewFixedTicker(interval)
 		ticker.Start()
 
 		t0 := time.Now()
@@ -106,7 +106,7 @@ func Test_FixedIntervalTicker(t *testing.T) {
 		interval := 50 * time.Millisecond
 		tolerance := 25 * time.Millisecond
 
-		ticker := NewFixedIntervalTicker(interval)
+		ticker := NewFixedTicker(interval)
 		ticker.Start()
 
 		t0 := time.Now()
@@ -139,7 +139,7 @@ func Test_FixedIntervalTicker(t *testing.T) {
 		interval := 50 * time.Millisecond
 		tolerance := 25 * time.Millisecond
 
-		ticker := NewFixedIntervalTicker(interval)
+		ticker := NewFixedTicker(interval)
 		ticker.Start()
 
 		t01 := time.Now()
@@ -170,7 +170,7 @@ func Test_FixedIntervalTicker(t *testing.T) {
 	t.Run("ticker does not run with <= 0 interval", func(t *testing.T) {
 		interval := time.Duration(0)
 
-		ticker := NewFixedIntervalTicker(interval)
+		ticker := NewFixedTicker(interval)
 		ticker.Start()
 
 		tickOccurred := false


### PR DESCRIPTION
### What's being changed:
errgroup inside CycleCallbacks were replaced to waitgroup and channels to reuse created goroutines.
Whenever CycleCallbacks is configured to use 1 goroutine, computation are made within callbacks instead of spawning single goroutine.
CycleCallbacks can accept CycleIntervals to call its callbacks with intervals independently of CycleTicker's intervals

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/98
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
