### PR TITLE
Update docker compose doc link

### DIFF
--- a/docker-compose/Readme.md
+++ b/docker-compose/Readme.md
@@ -5,4 +5,4 @@ languages. Instead you can now configure your own docker-compose file - on the
 fly - using Weaviate's documentation.
 
 Click here to [generate a `docker-compose.yml` file with your desired
-configuration](https://www.semi.technology/documentation/weaviate/current/getting-started/installation.html#docker-compose).
+configuration](https://weaviate.io/developers/weaviate/installation/docker-compose).

--- a/tools/release_template/main.go
+++ b/tools/release_template/main.go
@@ -48,7 +48,7 @@ func printRelaeseNotes(languages []language, version string) {
 	fmt.Printf("See also: example docker-compose files in %s. ", makeLinks(languages, version))
 	fmt.Printf("If you need to configure additional settings, you can also generate " +
 		"a custom `docker-compose.yml` file [using the documentation]" +
-		"(https://www.semi.technology/documentation/weaviate/current/getting-started/installation.html#docker-compose).")
+		"(https://weaviate.io/developers/weaviate/installation/docker-compose).")
 	fmt.Printf("\n## Breaking Changes\n*none*\n")
 	fmt.Printf("\n## New Features\n*none*\n")
 	fmt.Printf("\n## Fixes\n*none*\n")


### PR DESCRIPTION
### What's being changed:
docker compose document link `https://www.semi.technology/documentation/weaviate/current/getting-started/installation.html#docker-compose` can't redirect to docker compose document page, I think this link  `https://www.semi.technology/documentation/weaviate/current/getting-started/installation.html#docker-compose`  is the right one?

So I want update this link. If there have any concern or question please let me know.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
