### PR TITLE
pq: handle cache miss error during deletion

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -289,7 +289,8 @@ func (h *hnsw) reassignNeighbor(neighbor uint64, deleteList helpers.AllowList, b
 
 	var neighborVec []float32
 	if h.compressed.Load() {
-		vec, err := h.compressedVectorsCache.get(context.Background(), neighbor)
+		var vec []byte
+		vec, err = h.compressedVectorsCache.get(context.Background(), neighbor)
 		if err == nil {
 			neighborVec = h.pq.Decode(vec)
 		}


### PR DESCRIPTION
### What's being changed:

This fix a panic in production related to deletion when PQ is enabled.
It appears the err variable is shadowed by the one in the if statement, which makes the error not being caught by the outer scope. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
