### PR TITLE
pq: implement cache miss logic

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -101,3 +101,11 @@ func (h *hnsw) storeCompressedVector(index uint64, vector []byte) {
 	binary.LittleEndian.PutUint64(Id, index)
 	h.compressedStore.Bucket(helpers.CompressedObjectsBucketLSM).Put(Id, vector)
 }
+
+func (h *hnsw) getCompressedVectorForID(ctx context.Context, id uint64) ([]byte, error) {
+	vec, err := h.vectorForID(ctx, id)
+	if err != nil {
+		return nil, errors.Wrap(err, "Getting vector for id")
+	}
+	return h.pq.Encode(vec), nil
+}

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	ssdhelpers "github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
@@ -107,5 +108,11 @@ func (h *hnsw) getCompressedVectorForID(ctx context.Context, id uint64) ([]byte,
 	if err != nil {
 		return nil, errors.Wrap(err, "Getting vector for id")
 	}
+	if h.distancerProvider.Type() == "cosine-dot" {
+		// cosine-dot requires normalized vectors, as the dot product and cosine
+		// similarity are only identical if the vector is normalized
+		vec = distancer.Normalize(vec)
+	}
+
 	return h.pq.Encode(vec), nil
 }

--- a/adapters/repos/db/vector/hnsw/compressed_vector_cache_test.go
+++ b/adapters/repos/db/vector/hnsw/compressed_vector_cache_test.go
@@ -12,15 +12,20 @@
 package hnsw
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
+func dummyCompressedVectorForID(context.Context, uint64) ([]byte, error) {
+	return nil, nil
+}
+
 func TestCompressedVectorCacheGrowth(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	vectorCache := newCompressedShardedLockCache(1000000, logger)
+	vectorCache := newCompressedShardedLockCache(dummyCompressedVectorForID, 1000000, logger)
 	id := 100000
 	assert.True(t, len(vectorCache.cache) < id)
 	vectorCache.grow(uint64(id))
@@ -28,4 +33,28 @@ func TestCompressedVectorCacheGrowth(t *testing.T) {
 	last := vectorCache.count
 	vectorCache.grow(uint64(id))
 	assert.True(t, len(vectorCache.cache) == int(last))
+}
+
+func TestCompressedVectorCacheCacheMiss(t *testing.T) {
+	ctx := context.Background()
+
+	logger, _ := test.NewNullLogger()
+	called := 0
+	m := map[uint64][]byte{
+		10: {0, 1, 2, 3},
+		11: {4, 5, 6, 7},
+	}
+
+	vectorCache := newCompressedShardedLockCache(func(ctx context.Context, id uint64) ([]byte, error) {
+		called++
+		return m[id], nil
+	}, 1000000, logger)
+
+	got, err := vectorCache.get(ctx, 10)
+	assert.Nil(t, err)
+	assert.Equal(t, m[10], got)
+
+	got, err = vectorCache.get(ctx, 11)
+	assert.Nil(t, err)
+	assert.Equal(t, m[11], got)
 }

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -98,7 +98,7 @@ func (h *hnsw) UpdateUserConfig(updated schema.VectorIndexConfig, callback func(
 
 	// compression got enabled in this update
 	if h.compressedVectorsCache == (*compressedShardedLockCache)(nil) {
-		h.compressedVectorsCache = newCompressedShardedLockCache(parsed.VectorCacheMaxObjects, h.logger)
+		h.compressedVectorsCache = newCompressedShardedLockCache(h.getCompressedVectorForID, parsed.VectorCacheMaxObjects, h.logger)
 	} else {
 		if h.compressed.Load() {
 			h.compressedVectorsCache.updateMaxSize(int64(parsed.VectorCacheMaxObjects))


### PR DESCRIPTION
### What's being changed:

This is an attempt to handle loading compressed vectors during a cache miss.
We now load the vector from the vectorFromID thunk and compress it on the fly when needed.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/5862434118
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
