### PR TITLE
pq: ensure compressed cache is at the right size after restart

### DIFF
--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -138,6 +138,9 @@ func (h *hnsw) restoreFromDisk() error {
 		if err != nil {
 			return errors.Wrap(err, "Restoring PQ data.")
 		}
+
+		// make sure the compressed cache fits the current size
+		h.compressedVectorsCache.grow(uint64(len(h.nodes)))
 	} else {
 		// make sure the cache fits the current size
 		h.cache.grow(uint64(len(h.nodes)))


### PR DESCRIPTION
### What's being changed:

After a restart, we now grow the compressed cache to the same size as the index.
This prevents an out-of-band crash during insertions where, after a restart, the size of the compressed cache smaller than the size of the index.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
