### PR TITLE
hnsw: fix tombstone related race conditions

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -579,7 +579,9 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 
 		h.resetLock.Lock()
 		if !breakCleanUpTombstonedNodes() {
+			h.Lock()
 			h.nodes[id] = nil
+			h.Unlock()
 			if h.compressed.Load() {
 				h.compressedVectorsCache.delete(context.TODO(), id)
 			} else {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -116,10 +116,17 @@ func (h *hnsw) restoreFromDisk() error {
 		h.metrics.TrackStartupIndividual(beforeIndividual)
 	}
 
+	h.Lock()
 	h.nodes = state.Nodes
+	h.Unlock()
+
 	h.currentMaximumLayer = int(state.Level)
 	h.entryPointID = state.Entrypoint
+
+	h.tombstoneLock.Lock()
 	h.tombstones = state.Tombstones
+	h.tombstoneLock.Unlock()
+
 	h.compressed.Store(state.Compressed)
 
 	if state.Compressed {


### PR DESCRIPTION
### What's being changed:

This contains cherry-picked commits from the https://github.com/weaviate/weaviate/pull/3186 branch where we detected a few race conditions related to tombstones, thanks to the HNSW stress tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
