### PR TITLE
pq: handle nil vectors during compression

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -75,9 +75,13 @@ func (h *hnsw) Compress(cfg ent.PQConfig) error {
 
 	h.compressActionLock.Lock()
 	defer h.compressActionLock.Unlock()
-	ssdhelpers.Concurrently(uint64(len(cleanData)),
+	ssdhelpers.Concurrently(uint64(len(data)),
 		func(index uint64) {
-			encoded := h.pq.Encode(cleanData[index])
+			if data[index] == nil {
+				return
+			}
+
+			encoded := h.pq.Encode(data[index])
 			h.storeCompressedVector(index, encoded)
 			h.compressedVectorsCache.preload(index, encoded)
 		})

--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -15,9 +15,12 @@ package hnsw_test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -85,4 +88,88 @@ func Test_NoRaceCompressDoesNotCrash(t *testing.T) {
 		_, _, err := index.SearchByVector(v, k, nil)
 		assert.Nil(t, err)
 	}
+}
+
+func TestHnswPqNilVectors(t *testing.T) {
+	dimensions := 20
+	vectors_size := 10_000
+	queries_size := 10
+
+	vectors, _ := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
+
+	// set some vectors to nil
+	for i := range vectors {
+		if i == 500 {
+			vectors[i] = nil
+		}
+	}
+
+	userConfig := ent.UserConfig{
+		MaxConnections: 30,
+		EFConstruction: 64,
+		EF:             32,
+
+		// The actual size does not matter for this test, but if it defaults to
+		// zero it will constantly think it's full and needs to be deleted - even
+		// after just being deleted, so make sure to use a positive number here.
+		VectorCacheMaxObjects: 1000000,
+	}
+
+	rootPath := "doesnt-matter-as-committlogger-is-mocked-out"
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(rootPath)
+
+	index, err := hnsw.New(hnsw.Config{
+		RootPath:              rootPath,
+		ID:                    "nil-vector-test",
+		MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[int(id)], nil
+		},
+		TempVectorForIDThunk: hnsw.TempVectorForIDThunk(vectors),
+	}, userConfig, cyclemanager.NewNoop())
+
+	require.NoError(t, err)
+
+	ssdhelpers.Concurrently(uint64(len(vectors)/2), func(id uint64) {
+		if vectors[id] == nil {
+			return
+		}
+
+		err := index.Add(uint64(id), vectors[id])
+		require.Nil(t, err)
+	})
+
+	userConfig.PQ = ent.PQConfig{
+		Enabled: true,
+		Encoder: ent.PQEncoder{
+			Type:         ent.PQEncoderTypeTile,
+			Distribution: ent.PQEncoderDistributionLogNormal,
+		},
+		BitCompression: false,
+		Segments:       0,
+		Centroids:      256,
+	}
+
+	ch := make(chan error)
+	err = index.UpdateUserConfig(userConfig, func() {
+		close(ch)
+	})
+	require.NoError(t, err)
+
+	<-ch
+	start := uint64(len(vectors) / 2)
+	ssdhelpers.Concurrently(uint64(len(vectors)/2), func(id uint64) {
+		if vectors[id+start] == nil {
+			return
+		}
+
+		err = index.Add(uint64(id)+start, vectors[id+start])
+		require.Nil(t, err)
+	})
 }


### PR DESCRIPTION
### What's being changed:

This fixes a bug where the cache would get unaligned when there is a gap (nil vectors) in the indexed data.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
