### PR TITLE
Fix potencial nil pointer in requests_total metric in get object REST endpoint

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -155,14 +155,14 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 	if params.Include != nil {
 		class, err := h.manager.GetObjectsClass(params.HTTPRequest.Context(), principal, params.ID)
 		if err != nil {
-			h.metricRequestsTotal.logUserError(class.Class)
+			h.metricRequestsTotal.logUserError(params.ClassName)
 			return objects.NewObjectsClassGetBadRequest().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 
 		additional, err = parseIncludeParam(params.Include, h.modulesProvider, true, class)
 		if err != nil {
-			h.metricRequestsTotal.logError(class.Class, err)
+			h.metricRequestsTotal.logError(params.ClassName, err)
 			return objects.NewObjectsClassGetBadRequest().
 				WithPayload(errPayloadFromSingleErr(err))
 		}


### PR DESCRIPTION
### What's being changed:

Fixes potencial nil pointer in requests_total metric in get object REST endpoint

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
