### PR TITLE
Fix support for 65k vector dimensions

### DIFF
--- a/entities/storobj/parse_single_object.go
+++ b/entities/storobj/parse_single_object.go
@@ -138,11 +138,11 @@ func extractPropsBytes(data []byte) ([]byte, error) {
 
 	vecLen := binary.LittleEndian.Uint16(data[discardBytesPreVector : discardBytesPreVector+2])
 
-	classNameStart := discardBytesPreVector + 2 + vecLen*4
+	classNameStart := int64(discardBytesPreVector) + 2 + int64(vecLen)*4
 
 	classNameLen := binary.LittleEndian.Uint16(data[classNameStart : classNameStart+2])
 
-	propsLenStart := classNameStart + 2 + classNameLen
+	propsLenStart := classNameStart + 2 + int64(classNameLen)
 	propsLen := binary.LittleEndian.Uint32(data[propsLenStart : propsLenStart+4])
 
 	start := int64(propsLenStart + 4)


### PR DESCRIPTION
### What's being changed:

This PR fixes method that partially extracts properties from object when store objects with vectors with >16k dimensionality.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
