### PR TITLE
Enforce minimum replication factor according to system-wide config

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -39,6 +39,7 @@ import (
 	modulestorage "github.com/weaviate/weaviate/adapters/repos/modules"
 	schemarepo "github.com/weaviate/weaviate/adapters/repos/schema"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/replication"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	modstgazure "github.com/weaviate/weaviate/modules/backup-azure"
 	modstgfs "github.com/weaviate/weaviate/modules/backup-filesystem"
@@ -174,6 +175,13 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		MaxImportGoroutinesFactor: appState.ServerConfig.Config.MaxImportGoroutinesFactor,
 		TrackVectorDimensions:     appState.ServerConfig.Config.TrackVectorDimensions,
 		ResourceUsage:             appState.ServerConfig.Config.ResourceUsage,
+		// Pass dummy replication config with minimum factor 1. Otherwise the
+		// setting is not backward-compatible. The user may have created a class
+		// with factor=1 before the change was introduced. Now their setup would no
+		// longer start up if the required minimum is now higher than 1. We want
+		// the required minimum to only apply to newly created classes - not block
+		// loading existing ones.
+		Replication: replication.GlobalConfig{MinimumFactor: 1},
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics) // TODO client
 	if err != nil {
 		appState.Logger.

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -50,7 +50,7 @@ func (db *DB) init(ctx context.Context) error {
 					},
 				}
 			}
-			if err := replica.ValidateConfig(class); err != nil {
+			if err := replica.ValidateConfig(class, db.config.Replication); err != nil {
 				return fmt.Errorf("replication config: %w", err)
 			}
 

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -37,7 +37,7 @@ type Migrator struct {
 func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 	shardState *sharding.State,
 ) error {
-	if err := replica.ValidateConfig(class); err != nil {
+	if err := replica.ValidateConfig(class, m.db.config.Replication); err != nil {
 		return fmt.Errorf("replication config: %w", err)
 	}
 

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/storobj"
 
 	"github.com/pkg/errors"
@@ -135,6 +136,7 @@ type Config struct {
 	TrackVectorDimensions     bool
 	ServerVersion             string
 	GitHash                   string
+	Replication               replication.GlobalConfig
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package replication
 
 // GlobalConfig represents system-wide config that may restrict settings of an

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -1,0 +1,10 @@
+package replication
+
+// GlobalConfig represents system-wide config that may restrict settings of an
+// individual class
+type GlobalConfig struct {
+	// MinimumFactor can enforce replication. For example, with MinimumFactor set
+	// to 2, users can no longer create classes with a factor of 1, therefore
+	// forcing them to have replicated classes.
+	MinimumFactor int `json:"minimum_factor" yaml:"minimum_factor"`
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/deprecations"
+	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/cluster"
@@ -68,33 +69,34 @@ type Flags struct {
 
 // Config outline of the config file
 type Config struct {
-	Name                                string         `json:"name" yaml:"name"`
-	Debug                               bool           `json:"debug" yaml:"debug"`
-	QueryDefaults                       QueryDefaults  `json:"query_defaults" yaml:"query_defaults"`
-	QueryMaximumResults                 int64          `json:"query_maximum_results" yaml:"query_maximum_results"`
-	Contextionary                       Contextionary  `json:"contextionary" yaml:"contextionary"`
-	Authentication                      Authentication `json:"authentication" yaml:"authentication"`
-	Authorization                       Authorization  `json:"authorization" yaml:"authorization"`
-	Origin                              string         `json:"origin" yaml:"origin"`
-	Persistence                         Persistence    `json:"persistence" yaml:"persistence"`
-	DefaultVectorizerModule             string         `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
-	DefaultVectorDistanceMetric         string         `json:"default_vector_distance_metric" yaml:"default_vector_distance_metric"`
-	EnableModules                       string         `json:"enable_modules" yaml:"enable_modules"`
-	ModulesPath                         string         `json:"modules_path" yaml:"modules_path"`
-	AutoSchema                          AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
-	Cluster                             cluster.Config `json:"cluster" yaml:"cluster"`
-	Monitoring                          Monitoring     `json:"monitoring" yaml:"monitoring"`
-	GRPC                                GRPC           `json:"grpc" yaml:"grpc"`
-	Profiling                           Profiling      `json:"profiling" yaml:"profiling"`
-	ResourceUsage                       ResourceUsage  `json:"resource_usage" yaml:"resource_usage"`
-	MaxImportGoroutinesFactor           float64        `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
-	MaximumConcurrentGetRequests        int            `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
-	TrackVectorDimensions               bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
-	ReindexVectorDimensionsAtStartup    bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
-	RecountPropertiesAtStartup          bool           `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
-	ReindexSetToRoaringsetAtStartup     bool           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
-	IndexMissingTextFilterableAtStartup bool           `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
-	DisableGraphQL                      bool           `json:"disable_graphql" yaml:"disable_graphql"`
+	Name                                string                   `json:"name" yaml:"name"`
+	Debug                               bool                     `json:"debug" yaml:"debug"`
+	QueryDefaults                       QueryDefaults            `json:"query_defaults" yaml:"query_defaults"`
+	QueryMaximumResults                 int64                    `json:"query_maximum_results" yaml:"query_maximum_results"`
+	Contextionary                       Contextionary            `json:"contextionary" yaml:"contextionary"`
+	Authentication                      Authentication           `json:"authentication" yaml:"authentication"`
+	Authorization                       Authorization            `json:"authorization" yaml:"authorization"`
+	Origin                              string                   `json:"origin" yaml:"origin"`
+	Persistence                         Persistence              `json:"persistence" yaml:"persistence"`
+	DefaultVectorizerModule             string                   `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
+	DefaultVectorDistanceMetric         string                   `json:"default_vector_distance_metric" yaml:"default_vector_distance_metric"`
+	EnableModules                       string                   `json:"enable_modules" yaml:"enable_modules"`
+	ModulesPath                         string                   `json:"modules_path" yaml:"modules_path"`
+	AutoSchema                          AutoSchema               `json:"auto_schema" yaml:"auto_schema"`
+	Cluster                             cluster.Config           `json:"cluster" yaml:"cluster"`
+	Replication                         replication.GlobalConfig `json:"replication" yaml:"replication"`
+	Monitoring                          Monitoring               `json:"monitoring" yaml:"monitoring"`
+	GRPC                                GRPC                     `json:"grpc" yaml:"grpc"`
+	Profiling                           Profiling                `json:"profiling" yaml:"profiling"`
+	ResourceUsage                       ResourceUsage            `json:"resource_usage" yaml:"resource_usage"`
+	MaxImportGoroutinesFactor           float64                  `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
+	MaximumConcurrentGetRequests        int                      `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
+	TrackVectorDimensions               bool                     `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
+	ReindexVectorDimensionsAtStartup    bool                     `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
+	RecountPropertiesAtStartup          bool                     `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
+	ReindexSetToRoaringsetAtStartup     bool                     `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
+	IndexMissingTextFilterableAtStartup bool                     `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
+	DisableGraphQL                      bool                     `json:"disable_graphql" yaml:"disable_graphql"`
 }
 
 type moduleProvider interface {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -269,6 +269,14 @@ func FromEnv(config *Config) error {
 	}
 
 	config.DisableGraphQL = enabled(os.Getenv("DISABLE_GRAPHQL"))
+
+	if err := parsePositiveInt(
+		"REPLICATION_MINIMUM_FACTOR",
+		func(val int) { config.Replication.MinimumFactor = val },
+		DefaultMinimumReplicationFactor,
+	); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -344,6 +352,7 @@ const (
 	DefaultPersistenceMemtablesMaxDuration    = 45
 	DefaultMaxConcurrentGetRequests           = 0
 	DefaultGRPCPort                           = 50051
+	DefaultMinimumReplicationFactor           = 1
 )
 
 const VectorizerModuleNone = "none"

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -472,3 +472,33 @@ func TestEnvironmentPrometheusGroupClasses_NewName(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentMinimumReplicationFactor(t *testing.T) {
+	factors := []struct {
+		name        string
+		value       []string
+		expected    int
+		expectedErr bool
+	}{
+		{"Valid", []string{"3"}, 3, false},
+		{"not given", []string{}, DefaultMinimumReplicationFactor, false},
+		{"invalid factor", []string{"-1"}, -1, true},
+		{"zero factor", []string{"0"}, -1, true},
+		{"not parsable", []string{"I'm not a number"}, -1, true},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.value) == 1 {
+				t.Setenv("REPLICATION_MINIMUM_FACTOR", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.Replication.MinimumFactor)
+			}
+		})
+	}
+}

--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -15,20 +15,26 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
 )
 
 type nodeCounter interface {
 	NodeCount() int
 }
 
-func ValidateConfig(class *models.Class) error {
+func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) error {
 	if class.ReplicationConfig == nil {
-		class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+		class.ReplicationConfig = &models.ReplicationConfig{Factor: int64(globalCfg.MinimumFactor)}
 		return nil
 	}
 
+	if class.ReplicationConfig.Factor > 0 && class.ReplicationConfig.Factor < int64(globalCfg.MinimumFactor) {
+		return fmt.Errorf("invalid replication factor: setup requires a minimum replication factor of %d: got %d",
+			globalCfg.MinimumFactor, class.ReplicationConfig.Factor)
+	}
+
 	if class.ReplicationConfig.Factor < 1 {
-		class.ReplicationConfig.Factor = 1
+		class.ReplicationConfig.Factor = int64(globalCfg.MinimumFactor)
 	}
 
 	return nil

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -390,7 +390,7 @@ func (m *Manager) validateCanAddClass(
 		return err
 	}
 
-	if err := replica.ValidateConfig(class); err != nil {
+	if err := replica.ValidateConfig(class, m.config.Replication); err != nil {
 		return err
 	}
 

--- a/usecases/schema/startup_cluster_sync_test.go
+++ b/usecases/schema/startup_cluster_sync_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -413,7 +414,10 @@ func newManagerWithClusterAndTx(t *testing.T, clusterState clusterState,
 	}
 	repo.schema = *initialSchema
 	sm, err := NewManager(&NilMigrator{}, repo, logger, &fakeAuthorizer{},
-		config.Config{DefaultVectorizerModule: config.VectorizerModuleNone},
+		config.Config{
+			DefaultVectorizerModule: config.VectorizerModuleNone,
+			Replication:             replication.GlobalConfig{MinimumFactor: 1},
+		},
 		dummyParseVectorConfig, // only option for now
 		&fakeVectorizerValidator{}, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, clusterState, txClient, &fakeScaleOutManager{},


### PR DESCRIPTION
## Motivation

On the WCS, there is a setting for a "HA cluster" which is created with at least two Weaviate pods in different zones. However, if the user doesn't turn on replication in their schema config, they don't make use of those replicas. This feature introduces an ability to force the user to turn on replication. 

## Backward compatibility

* The setup only applies to creating new classes
* Old classes that do not meet the minimum still start up fine
* Old classes that do not meet the minimum can still be updated. This neither fails validation nor force-upgrades them

## Usage

An environment variable `REPLICATION_MINIMUM_FACTOR=<int>` is introduced. If not set, it default to `1`.

## Behavior + Examples:

All examples assume a `REPLICATION_MINIMUM_FACTOR=2`

## Case 1: User doesn't care

If the user doesn't specify an explicit config, they will use exactly the minimum.

<img width="1515" alt="Screenshot 2023-08-06 at 11 09 25 AM" src="https://github.com/weaviate/weaviate/assets/8974479/e62de00d-0cae-472f-9439-1d689dc8a5e5">

## Case 2: User is a rebel

Users who try to specify an illegal value receive an error. They must assume they will now be on Santa's naughty list. 

<img width="1254" alt="Screenshot 2023-08-06 at 11 06 39 AM" src="https://github.com/weaviate/weaviate/assets/8974479/35eb8342-f99e-4263-9a20-fb5d0bbef88b">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
