### PR TITLE
Missing callback unregister

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -277,7 +277,7 @@ func (s *Shard) drop() error {
 	defer cancel()
 
 	// unregister all callbacks at once, in parallel
-	if err := cyclemanager.NewCycleCombinedCallbackCtrl(0,
+	if err := cyclemanager.NewCombinedCallbackCtrl(0,
 		s.cycleCallbacks.compactionCallbacksCtrl,
 		s.cycleCallbacks.flushCallbacksCtrl,
 		s.cycleCallbacks.vectorCombinedCallbacksCtrl,
@@ -552,7 +552,7 @@ func (s *Shard) shutdown(ctx context.Context) error {
 	}
 
 	// unregister all callbacks at once, in parallel
-	if err := cyclemanager.NewCycleCombinedCallbackCtrl(0,
+	if err := cyclemanager.NewCombinedCallbackCtrl(0,
 		s.cycleCallbacks.compactionCallbacksCtrl,
 		s.cycleCallbacks.flushCallbacksCtrl,
 		s.cycleCallbacks.vectorCombinedCallbacksCtrl,

--- a/adapters/repos/db/shard_cyclecallbacks.go
+++ b/adapters/repos/db/shard_cyclecallbacks.go
@@ -63,7 +63,7 @@ func (s *Shard) initCycleCallbacks() {
 	vectorTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.vectorTombstoneCleanupCallbacks.Register(
 		vectorTombstoneCleanupId, vectorTombstoneCleanupCallbacks.CycleCallback)
 
-	vectorCombinedCallbacksCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2,
+	vectorCombinedCallbacksCtrl := cyclemanager.NewCombinedCallbackCtrl(2,
 		vectorCommitLoggerCallbacksCtrl, vectorTombstoneCleanupCallbacksCtrl)
 
 	geoPropsCommitLoggerId := id("geo_props", "commit_logger")
@@ -78,7 +78,7 @@ func (s *Shard) initCycleCallbacks() {
 	geoPropsTombstoneCleanupCallbacksCtrl := s.index.cycleCallbacks.geoPropsTombstoneCleanupCallbacks.Register(
 		geoPropsTombstoneCleanupId, geoPropsTombstoneCleanupCallbacks.CycleCallback)
 
-	geoPropsCombinedCallbacksCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2,
+	geoPropsCombinedCallbacksCtrl := cyclemanager.NewCombinedCallbackCtrl(2,
 		geoPropsCommitLoggerCallbacksCtrl, geoPropsTombstoneCleanupCallbacksCtrl)
 
 	s.cycleCallbacks = &shardCycleCallbacks{

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -55,7 +55,7 @@ func TestBackup_Integration(t *testing.T) {
 	tombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("childTombstoneCleanup", logger, 1)
 	tombstoneCleanupCallbacksCtrl := parentTombstoneCleanupCallbacks.Register("tombstoneCleanup", tombstoneCleanupCallbacks.CycleCallback)
 
-	combinedCtrl := cyclemanager.NewCycleCombinedCallbackCtrl(2, commitLoggerCallbacksCtrl, tombstoneCleanupCallbacksCtrl)
+	combinedCtrl := cyclemanager.NewCombinedCallbackCtrl(2, commitLoggerCallbacksCtrl, tombstoneCleanupCallbacksCtrl)
 
 	idx, err := New(Config{
 		RootPath:         dirName,

--- a/entities/cyclemanager/cyclecallbackctrl.go
+++ b/entities/cyclemanager/cyclecallbackctrl.go
@@ -62,7 +62,7 @@ type cycleCombinedCallbackCtrl struct {
 // Creates combined controller to manage all provided controllers at once as it was single instance.
 // Methods (activate, deactivate, unregister) calls nested controllers' methods in parallel by number of
 // goroutines given as argument. If < 1 value given, NumCPU is used.
-func NewCycleCombinedCallbackCtrl(routinesLimit int, ctrls ...CycleCallbackCtrl) CycleCallbackCtrl {
+func NewCombinedCallbackCtrl(routinesLimit int, ctrls ...CycleCallbackCtrl) CycleCallbackCtrl {
 	if routinesLimit <= 0 {
 		routinesLimit = _NUMCPU
 	}
@@ -189,7 +189,7 @@ func (c *cycleCombinedCallbackCtrl) combineErrors(errors ...error) error {
 
 type cycleCallbackCtrlNoop struct{}
 
-func NewCycleCallbackCtrlNoop() CycleCallbackCtrl {
+func NewCallbackCtrlNoop() CycleCallbackCtrl {
 	return &cycleCallbackCtrlNoop{}
 }
 

--- a/entities/cyclemanager/cyclecallbackctrl.go
+++ b/entities/cyclemanager/cyclecallbackctrl.go
@@ -59,6 +59,9 @@ type cycleCombinedCallbackCtrl struct {
 	ctrls         []CycleCallbackCtrl
 }
 
+// Creates combined controller to manage all provided controllers at once as it was single instance.
+// Methods (activate, deactivate, unregister) calls nested controllers' methods in parallel by number of
+// goroutines given as argument. If < 1 value given, NumCPU is used.
 func NewCycleCombinedCallbackCtrl(routinesLimit int, ctrls ...CycleCallbackCtrl) CycleCallbackCtrl {
 	if routinesLimit <= 0 {
 		routinesLimit = _NUMCPU

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -38,7 +38,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
@@ -68,7 +68,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
@@ -97,7 +97,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrlShort := callbacks.Register("short", callbackShort)
 		ctrlLong := callbacks.Register("long", callbackLong)
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
@@ -136,7 +136,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
@@ -166,7 +166,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1)
 		ctrl2 := callbacks.Register("c2", callback2)
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
@@ -195,7 +195,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrlShort := callbacks.Register("short", callbackShort)
 		ctrlLong := callbacks.Register("long", callbackLong)
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrlShort, ctrlLong)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()
@@ -234,7 +234,7 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 2)
 		ctrl1 := callbacks.Register("c1", callback1, AsInactive())
 		ctrl2 := callbacks.Register("c2", callback2, AsInactive())
-		combinedCtrl := NewCycleCombinedCallbackCtrl(2, ctrl1, ctrl2)
+		combinedCtrl := NewCombinedCallbackCtrl(2, ctrl1, ctrl2)
 
 		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback)
 		cycle.Start()

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -365,7 +365,7 @@ func NewCallbackGroupNoop() CycleCallbackGroup {
 }
 
 func (c *cycleCallbackGroupNoop) Register(id string, cycleCallback CycleCallback, options ...RegisterOption) CycleCallbackCtrl {
-	return NewCycleCallbackCtrlNoop()
+	return NewCallbackCtrlNoop()
 }
 
 func (c *cycleCallbackGroupNoop) CycleCallback(shouldAbort ShouldAbortCallback) bool {


### PR DESCRIPTION
### What's being changed:
Adds missing cycle callbacks unregistration at shard's drop call.
Unregisters all callbacks in parallel (instead sequentially as before).
Renames cycle callbacks ctrl's constructors.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
