### PR TITLE
Pq optimized distance between compressed vectors

### DIFF
--- a/adapters/repos/db/vector/hnsw/priorityqueue/queue.go
+++ b/adapters/repos/db/vector/hnsw/priorityqueue/queue.go
@@ -87,12 +87,6 @@ func (l *Queue) Insert(id uint64, distance float32) int {
 	return i
 }
 
-func (l *Queue) InsertAndRemoveTop(id uint64, distance float32) {
-	l.items[0].Dist = distance
-	l.items[0].ID = id
-	l.heapify(0)
-}
-
 func (l *Queue) Pop() Item {
 	out := l.items[0]
 	l.items[0] = l.items[len(l.items)-1]

--- a/adapters/repos/db/vector/hnsw/priorityqueue/queue.go
+++ b/adapters/repos/db/vector/hnsw/priorityqueue/queue.go
@@ -120,3 +120,7 @@ func (l *Queue) Reset() {
 func (l *Queue) ResetCap(capacity int) {
 	l.items = make([]Item, 0, capacity)
 }
+
+func (l *Queue) Items() []Item {
+	return l.items
+}

--- a/adapters/repos/db/vector/hnsw/priorityqueue/queue.go
+++ b/adapters/repos/db/vector/hnsw/priorityqueue/queue.go
@@ -87,6 +87,12 @@ func (l *Queue) Insert(id uint64, distance float32) int {
 	return i
 }
 
+func (l *Queue) InsertAndRemoveTop(id uint64, distance float32) {
+	l.items[0].Dist = distance
+	l.items[0].ID = id
+	l.heapify(0)
+}
+
 func (l *Queue) Pop() Item {
 	out := l.items[0]
 	l.items[0] = l.items[len(l.items)-1]

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -557,9 +557,9 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 	}
 
 	if h.shouldRescore() {
-		ids := make([]uint64, 0, res.Len())
-		for _, item := range res.Items() {
-			ids = append(ids, item.ID)
+		ids := make([]uint64, res.Len())
+		for i, item := range res.Items() {
+			ids[i] = item.ID
 		}
 		res.Reset()
 		for _, id := range ids {

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -229,13 +229,17 @@ func NewProductQuantizerWithEncoders(cfg ent.PQConfig, distance distancer.Provid
 }
 
 func (pq *ProductQuantizer) buildGlobalDistances() {
+	//This hosts the partial distances between the centroids. This way we do not need
+	//to recalculate all the time when calculating full distances between compressed vecs
 	pq.globalDistances = make([]float32, pq.ks*pq.ks)
 	for segment := 0; segment < pq.m; segment++ {
 		for i := 0; i < pq.ks; i++ {
-			for j := 0; j < pq.ks; j++ {
-				cX := pq.kms[segment].Centroid(byte(i))
+			cX := pq.kms[segment].Centroid(byte(i))
+			for j := 0; j <= pq.ks; j++ {
 				cY := pq.kms[segment].Centroid(byte(j))
 				pq.globalDistances[i*pq.ks+j] = pq.distance.Step(cX, cY)
+				//Just copy from already calculated cell since step should be symmetric.
+				pq.globalDistances[j*pq.ks+i] = pq.globalDistances[i*pq.ks+j]
 			}
 		}
 	}

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -235,7 +235,7 @@ func (pq *ProductQuantizer) buildGlobalDistances() {
 	for segment := 0; segment < pq.m; segment++ {
 		for i := 0; i < pq.ks; i++ {
 			cX := pq.kms[segment].Centroid(byte(i))
-			for j := 0; j <= pq.ks; j++ {
+			for j := 0; j <= i; j++ {
 				cY := pq.kms[segment].Centroid(byte(j))
 				pq.globalDistances[i*pq.ks+j] = pq.distance.Step(cX, cY)
 				// Just copy from already calculated cell since step should be symmetric.

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -12,7 +12,6 @@
 package ssdhelpers
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -358,15 +357,6 @@ func (pq *ProductQuantizer) Fit(data [][]float32) {
 			}
 		})
 	}
-	/*for i := 0; i < 1; i++ {
-		fmt.Println("********")
-		centers := make([]float64, 0)
-		for c := 0; c < pq.ks; c++ {
-			centers = append(centers, float64(pq.kms[i].Centroid(byte(c))[0]))
-		}
-		hist := histogram.Hist(60, centers)
-		histogram.Fprint(os.Stdout, hist, histogram.Linear(5))
-	}*/
 	pq.globalDistances = make([]float32, pq.ks*pq.ks)
 	for segment := 0; segment < pq.m; segment++ {
 		for i := 0; i < pq.ks; i++ {
@@ -380,22 +370,11 @@ func (pq *ProductQuantizer) Fit(data [][]float32) {
 }
 
 func (pq *ProductQuantizer) Encode(vec []float32) []byte {
-	codes := make([]byte, pq.m+4)
+	codes := make([]byte, pq.m)
 	for i := 0; i < pq.m; i++ {
 		PutCode8(pq.kms[i].Encode(vec), codes, i)
 	}
-	dist := pq.DistanceBetweenCompressedAndUncompressedVectors(vec, codes)
-	dist = float32(math.Abs(float64(dist)))
-	binary.LittleEndian.PutUint32(codes[pq.m:], math.Float32bits(dist))
 	return codes
-}
-
-func (pq *ProductQuantizer) Distortion(codes []byte) float32 {
-	dist := math.Float32frombits(binary.LittleEndian.Uint32(codes[pq.m:]))
-	if dist < 0 {
-		return -dist
-	}
-	return dist
 }
 
 func (pq *ProductQuantizer) Decode(code []byte) []float32 {

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -224,6 +224,11 @@ func NewProductQuantizerWithEncoders(cfg ent.PQConfig, distance distancer.Provid
 	}
 
 	pq.kms = encoders
+	pq.buildGlobalDistances()
+	return pq, nil
+}
+
+func (pq *ProductQuantizer) buildGlobalDistances() {
 	pq.globalDistances = make([]float32, pq.ks*pq.ks)
 	for segment := 0; segment < pq.m; segment++ {
 		for i := 0; i < pq.ks; i++ {
@@ -234,7 +239,6 @@ func NewProductQuantizerWithEncoders(cfg ent.PQConfig, distance distancer.Provid
 			}
 		}
 	}
-	return pq, nil
 }
 
 // Only made public for testing purposes... Not sure we need it outside
@@ -357,16 +361,7 @@ func (pq *ProductQuantizer) Fit(data [][]float32) {
 			}
 		})
 	}
-	pq.globalDistances = make([]float32, pq.ks*pq.ks)
-	for segment := 0; segment < pq.m; segment++ {
-		for i := 0; i < pq.ks; i++ {
-			for j := 0; j < pq.ks; j++ {
-				cX := pq.kms[segment].Centroid(byte(i))
-				cY := pq.kms[segment].Centroid(byte(j))
-				pq.globalDistances[i*pq.ks+j] = pq.distance.Step(cX, cY)
-			}
-		}
-	}
+	pq.buildGlobalDistances()
 }
 
 func (pq *ProductQuantizer) Encode(vec []float32) []byte {

--- a/adapters/repos/db/vector/ssdhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/ssdhelpers/product_quantization.go
@@ -229,8 +229,8 @@ func NewProductQuantizerWithEncoders(cfg ent.PQConfig, distance distancer.Provid
 }
 
 func (pq *ProductQuantizer) buildGlobalDistances() {
-	//This hosts the partial distances between the centroids. This way we do not need
-	//to recalculate all the time when calculating full distances between compressed vecs
+	// This hosts the partial distances between the centroids. This way we do not need
+	// to recalculate all the time when calculating full distances between compressed vecs
 	pq.globalDistances = make([]float32, pq.ks*pq.ks)
 	for segment := 0; segment < pq.m; segment++ {
 		for i := 0; i < pq.ks; i++ {
@@ -238,7 +238,7 @@ func (pq *ProductQuantizer) buildGlobalDistances() {
 			for j := 0; j <= pq.ks; j++ {
 				cY := pq.kms[segment].Centroid(byte(j))
 				pq.globalDistances[i*pq.ks+j] = pq.distance.Step(cX, cY)
-				//Just copy from already calculated cell since step should be symmetric.
+				// Just copy from already calculated cell since step should be symmetric.
 				pq.globalDistances[j*pq.ks+i] = pq.globalDistances[i*pq.ks+j]
 			}
 		}


### PR DESCRIPTION
### What's being changed:

This PR introduces some performance optimisations related to:

- Optimised distance calculation between compressed vectors by using a global distance table
- Memory allocation 
- Size of the final rescored result set
- Prevent insertion of element in the final rescored result set that are not good enough so they would be popped anyways

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [X] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.
