### PR TITLE
Enable references without ToClass in object creation

### DIFF
--- a/test/acceptance/actions/add_test.go
+++ b/test/acceptance/actions/add_test.go
@@ -17,9 +17,10 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/entities/models"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -125,6 +126,6 @@ func addingObjects(t *testing.T) {
 		secondObject := helper.AssertGetObjectEventually(t, "TestObjectTwo", secondID)
 
 		singleRef := secondObject.Properties.(map[string]interface{})["testReference"].([]interface{})[0].(map[string]interface{})
-		assert.Equal(t, singleRef["beacon"].(string), fmt.Sprintf("weaviate://localhost/%s", firstID))
+		assert.Equal(t, singleRef["beacon"].(string), fmt.Sprintf("weaviate://localhost/TestObject/%s", firstID))
 	})
 }

--- a/test/acceptance/actions/object_test.go
+++ b/test/acceptance/actions/object_test.go
@@ -61,8 +61,8 @@ func TestFindObject(t *testing.T) {
 	// tear down
 	defer helper.DeleteClassObject(t, cls)
 	link1 := map[string]interface{}{
-		"beacon": crossref.NewLocalhost("", first_uuid).String(),
-		"href":   fmt.Sprintf("/v1/objects/%s", first_uuid),
+		"beacon": crossref.NewLocalhost(first_friend, first_uuid).String(),
+		"href":   fmt.Sprintf("/v1/objects/%s/%s", first_friend, first_uuid),
 	}
 	link2 := map[string]interface{}{
 		"beacon": crossref.NewLocalhost(second_friend, second_uuid).String(),
@@ -175,8 +175,8 @@ func TestPutObject(t *testing.T) {
 	})
 
 	link1 := map[string]interface{}{
-		"beacon": crossref.NewLocalhost("", friend_uuid).String(),
-		"href":   fmt.Sprintf("/v1/objects/%s", friend_uuid),
+		"beacon": crossref.NewLocalhost(friend_cls, friend_uuid).String(),
+		"href":   fmt.Sprintf("/v1/objects/%s/%s", friend_cls, friend_uuid),
 	}
 	link2 := map[string]interface{}{
 		"beacon": crossref.NewLocalhost(friend_cls, friend_uuid).String(),
@@ -253,8 +253,8 @@ func TestPatchObject(t *testing.T) {
 	})
 	friendID := helper.AssertCreateObject(t, friend_cls, nil)
 	link1 := map[string]interface{}{
-		"beacon": fmt.Sprintf("weaviate://localhost/%s", friendID),
-		"href":   fmt.Sprintf("/v1/objects/%s", friendID),
+		"beacon": fmt.Sprintf("weaviate://localhost/%s/%s", friend_cls, friendID),
+		"href":   fmt.Sprintf("/v1/objects/%s/%s", friend_cls, friendID),
 	}
 	link2 := map[string]interface{}{
 		"beacon": fmt.Sprintf("weaviate://localhost/%s/%s", friend_cls, friendID),

--- a/test/acceptance/actions/update_test.go
+++ b/test/acceptance/actions/update_test.go
@@ -160,6 +160,6 @@ func updateObjectsDeprecated(t *testing.T) {
 			return refMap["beacon"]
 		}
 
-		helper.AssertEventuallyEqual(t, fmt.Sprintf("weaviate://localhost/%s", thingToRefID), actualThunk)
+		helper.AssertEventuallyEqual(t, fmt.Sprintf("weaviate://localhost/ObjectTestThing/%s", thingToRefID), actualThunk)
 	})
 }

--- a/test/acceptance/classifications/knn_classification_test.go
+++ b/test/acceptance/classifications/knn_classification_test.go
@@ -81,7 +81,7 @@ func knnClassification(t *testing.T) {
 		schema, ok := res.Payload.Properties.(map[string]interface{})
 		require.True(t, ok)
 
-		expectedRefTarget := fmt.Sprintf("weaviate://localhost/%s",
+		expectedRefTarget := fmt.Sprintf("weaviate://localhost/RecipeType/%s",
 			recipeTypeSavory)
 		ref := schema["ofType"].([]interface{})[0].(map[string]interface{})
 		assert.Equal(t, ref["beacon"].(string), expectedRefTarget)
@@ -99,7 +99,7 @@ func knnClassification(t *testing.T) {
 		schema, ok := res.Payload.Properties.(map[string]interface{})
 		require.True(t, ok)
 
-		expectedRefTarget := fmt.Sprintf("weaviate://localhost/%s",
+		expectedRefTarget := fmt.Sprintf("weaviate://localhost/RecipeType/%s",
 			recipeTypeSweet)
 		ref := schema["ofType"].([]interface{})[0].(map[string]interface{})
 		assert.Equal(t, ref["beacon"].(string), expectedRefTarget)

--- a/test/acceptance/graphql_resolvers/multi_reftype_bug_test.go
+++ b/test/acceptance/graphql_resolvers/multi_reftype_bug_test.go
@@ -29,6 +29,9 @@ func TestMultipleRefTypeIssues(t *testing.T) {
 	className := func(suffix string) string {
 		return "MultiRefTypeBug" + suffix
 	}
+	defer deleteObjectClass(t, className("TargetOne"))
+	defer deleteObjectClass(t, className("TargetTwo"))
+	defer deleteObjectClass(t, className("Source"))
 
 	const (
 		targetOneID strfmt.UUID = "155c5914-6594-4cde-b3ab-f8570b561965"

--- a/test/acceptance/objects/crefs_test.go
+++ b/test/acceptance/objects/crefs_test.go
@@ -131,6 +131,117 @@ func TestRefsWithoutToClass(t *testing.T) {
 	}, objWithoutRef)
 }
 
+func TestBatchRefsMultiTarget(t *testing.T) {
+	refToClassName := "ReferenceTo"
+	refFromClassName := "ReferenceFrom"
+	defer deleteObjectClass(t, refToClassName)
+	defer deleteObjectClass(t, refFromClassName)
+
+	params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: refToClassName})
+	resp, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+	helper.AssertRequestOk(t, resp, err, nil)
+
+	refFromClass := &models.Class{
+		Class: refFromClassName,
+		Properties: []*models.Property{
+			{
+				DataType: []string{refToClassName, refFromClassName},
+				Name:     "ref",
+			},
+		},
+	}
+	params2 := clschema.NewSchemaObjectsCreateParams().WithObjectClass(refFromClass)
+	resp2, err := helper.Client(t).Schema.SchemaObjectsCreate(params2, nil)
+	helper.AssertRequestOk(t, resp2, err, nil)
+
+	uuidsTo := make([]strfmt.UUID, 10)
+	uuidsFrom := make([]strfmt.UUID, 10)
+	for i := 0; i < 10; i++ {
+		uuidsTo[i] = assertCreateObject(t, refToClassName, map[string]interface{}{})
+		assertGetObjectEventually(t, uuidsTo[i])
+		uuidsFrom[i] = assertCreateObject(t, refFromClassName, map[string]interface{}{})
+		assertGetObjectEventually(t, uuidsFrom[i])
+	}
+
+	// add refs without toClass
+	var batchRefs []*models.BatchReference
+	for i := range uuidsFrom[:2] {
+		from := beaconStart + "ReferenceFrom/" + uuidsFrom[i] + "/ref"
+		to := beaconStart + uuidsTo[i]
+		batchRefs = append(batchRefs, &models.BatchReference{From: strfmt.URI(from), To: strfmt.URI(to)})
+	}
+
+	// add refs with toClass target 1
+	for i := range uuidsFrom[2:5] {
+		j := i + 2
+		from := beaconStart + "ReferenceFrom/" + uuidsFrom[j] + "/ref"
+		to := beaconStart + "ReferenceTo/" + uuidsTo[j]
+		batchRefs = append(batchRefs, &models.BatchReference{From: strfmt.URI(from), To: strfmt.URI(to)})
+	}
+
+	// add refs with toClass target 2
+	for i := range uuidsFrom[5:] {
+		j := i + 5
+		from := beaconStart + "ReferenceFrom/" + uuidsFrom[j] + "/ref"
+		to := beaconStart + "ReferenceFrom/" + uuidsTo[j]
+		batchRefs = append(batchRefs, &models.BatchReference{From: strfmt.URI(from), To: strfmt.URI(to)})
+	}
+
+	postRefParams := batch.NewBatchReferencesCreateParams().WithBody(batchRefs)
+	postRefResponse, err := helper.Client(t).Batch.BatchReferencesCreate(postRefParams, nil)
+	helper.AssertRequestOk(t, postRefResponse, err, nil)
+
+	// no autodetect for multi-target
+	for i := range uuidsFrom[:2] {
+		objWithRef := func() interface{} {
+			obj := assertGetObjectWithClass(t, uuidsFrom[i], refFromClassName)
+			return obj.Properties
+		}
+		testhelper.AssertEventuallyEqual(t, map[string]interface{}{
+			"ref": []interface{}{
+				map[string]interface{}{
+					"beacon": fmt.Sprintf(beaconStart+"%s", uuidsTo[i].String()),
+					"href":   fmt.Sprintf(pathStart+"%s", uuidsTo[i].String()),
+				},
+			},
+		}, objWithRef)
+	}
+
+	// refs for target 1
+	for i := range uuidsFrom[2:5] {
+		j := i + 2
+		objWithRef := func() interface{} {
+			obj := assertGetObjectWithClass(t, uuidsFrom[j], refFromClassName)
+			return obj.Properties
+		}
+		testhelper.AssertEventuallyEqual(t, map[string]interface{}{
+			"ref": []interface{}{
+				map[string]interface{}{
+					"beacon": fmt.Sprintf(beaconStart+"%s/%s", refToClassName, uuidsTo[j].String()),
+					"href":   fmt.Sprintf(pathStart+"%s/%s", refToClassName, uuidsTo[j].String()),
+				},
+			},
+		}, objWithRef)
+	}
+
+	// refs for target 2
+	for i := range uuidsFrom[5:] {
+		j := i + 5
+		objWithRef := func() interface{} {
+			obj := assertGetObjectWithClass(t, uuidsFrom[j], refFromClassName)
+			return obj.Properties
+		}
+		testhelper.AssertEventuallyEqual(t, map[string]interface{}{
+			"ref": []interface{}{
+				map[string]interface{}{
+					"beacon": fmt.Sprintf(beaconStart+"%s/%s", refFromClassName, uuidsTo[j].String()),
+					"href":   fmt.Sprintf(pathStart+"%s/%s", refFromClassName, uuidsTo[j].String()),
+				},
+			},
+		}, objWithRef)
+	}
+}
+
 func TestBatchRefsWithoutToClass(t *testing.T) {
 	refToClassName := "ReferenceTo"
 	refFromClassName := "ReferenceFrom"
@@ -164,8 +275,7 @@ func TestBatchRefsWithoutToClass(t *testing.T) {
 		assertGetObjectEventually(t, uuidsFrom[i])
 	}
 
-	batchRefs := []*models.BatchReference{}
-
+	var batchRefs []*models.BatchReference
 	for i := range uuidsFrom {
 		from := beaconStart + "ReferenceFrom/" + uuidsFrom[i] + "/ref"
 		to := beaconStart + uuidsTo[i]

--- a/test/acceptance/objects/crefs_without_waiting_for_refresh_test.go
+++ b/test/acceptance/objects/crefs_without_waiting_for_refresh_test.go
@@ -96,8 +96,8 @@ func Test_AddingReferenceWithoutWaiting_UsingPostObjects(t *testing.T) {
 		"name": "My City",
 		"hasPlace": []interface{}{
 			map[string]interface{}{
-				"beacon": fmt.Sprintf("weaviate://localhost/%s", placeID.String()),
-				"href":   fmt.Sprintf("/v1/objects/%s", placeID.String()),
+				"beacon": fmt.Sprintf("weaviate://localhost/%s/%s", "ReferenceWaitingTestPlace", placeID.String()),
+				"href":   fmt.Sprintf("/v1/objects/%s/%s", "ReferenceWaitingTestPlace", placeID.String()),
 			},
 		},
 	}, actualThunk)

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -118,6 +118,9 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 			if err != nil {
 				return NewErrInvalidUserInput("get prop: %v", err)
 			}
+			if len(prop.DataType) > 1 {
+				continue // can't auto-detect for multi-target
+			}
 			target = prop.DataType[0] // datatype is the name of the class that is referenced
 			classPropTarget[className+propName] = target
 		}

--- a/usecases/objects/merge_test.go
+++ b/usecases/objects/merge_test.go
@@ -338,7 +338,7 @@ func Test_MergeObject(t *testing.T) {
 					"name": "My little pony zoo with extra sparkles",
 					"hasAnimals": []interface{}{
 						map[string]interface{}{
-							"beacon": "weaviate://localhost/a8ffc82c-9845-4014-876c-11369353c33c",
+							"beacon": "weaviate://localhost/AnimalAction/a8ffc82c-9845-4014-876c-11369353c33c",
 						},
 					},
 				},
@@ -360,7 +360,7 @@ func Test_MergeObject(t *testing.T) {
 				References: BatchReferences{
 					BatchReference{
 						From: crossrefMustParseSource("weaviate://localhost/ZooAction/dd59815b-142b-4c54-9b12-482434bd54ca/hasAnimals"),
-						To:   crossrefMustParse("weaviate://localhost/a8ffc82c-9845-4014-876c-11369353c33c"),
+						To:   crossrefMustParse("weaviate://localhost/AnimalAction/a8ffc82c-9845-4014-876c-11369353c33c"),
 					},
 				},
 			},

--- a/usecases/objects/references.go
+++ b/usecases/objects/references.go
@@ -20,19 +20,23 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-func (m *Manager) autodetectToClass(ctx context.Context, principal *models.Principal, fromClass, fromProperty string, beaconRef strfmt.URI) (strfmt.URI, strfmt.URI, *Error) {
+func (m *Manager) autodetectToClass(ctx context.Context, principal *models.Principal, fromClass, fromProperty string, beaconRef strfmt.URI) (strfmt.URI, strfmt.URI, bool, *Error) {
 	// autodetect to class from schema if not part of reference
 	class, err := m.schemaManager.GetClass(ctx, principal, fromClass)
 	if err != nil {
-		return "", "", &Error{"cannot get class", StatusInternalServerError, err}
+		return "", "", false, &Error{"cannot get class", StatusInternalServerError, err}
 	}
 	prop, err := schema.GetPropertyByName(class, schema.LowercaseFirstLetter(fromProperty))
 	if err != nil {
-		return "", "", &Error{"cannot get property", StatusInternalServerError, err}
+		return "", "", false, &Error{"cannot get property", StatusInternalServerError, err}
 	}
+	if len(prop.DataType) > 1 {
+		return "", "", false, nil // can't autodetect for multi target
+	}
+
 	toClass := prop.DataType[0] // datatype is the name of the class that is referenced
 	beaconElements := strings.Split(string(beaconRef), "/")
 	toUUID := beaconElements[len(beaconElements)-1]
 	toBeacon := "weaviate://localhost/" + string(toClass) + "/" + toUUID // datatype is the name of the class that is referenced
-	return strfmt.URI(toClass), strfmt.URI(toBeacon), nil
+	return strfmt.URI(toClass), strfmt.URI(toBeacon), true, nil
 }

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -70,12 +70,14 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 
 	if !deprecatedEndpoint {
 		if input.Class != "" && strings.Count(string(input.Ref.Beacon), "/") == 3 {
-			toClass, toBeacon, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Ref.Beacon)
+			toClass, toBeacon, replace, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Ref.Beacon)
 			if err != nil {
 				return err
 			}
-			input.Ref.Class = toClass
-			input.Ref.Beacon = toBeacon
+			if replace {
+				input.Ref.Class = toClass
+				input.Ref.Beacon = toBeacon
+			}
 		}
 		ok, err := m.vectorRepo.Exists(ctx, input.Class, input.ID, repl, tenant)
 		if err != nil {

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -42,12 +42,14 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 
 	deprecatedEndpoint := input.Class == ""
 	if input.Class != "" && strings.Count(string(input.Reference.Beacon), "/") == 3 {
-		toClass, toBeacon, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Reference.Beacon)
+		toClass, toBeacon, replace, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Reference.Beacon)
 		if err != nil {
 			return err
 		}
-		input.Reference.Class = toClass
-		input.Reference.Beacon = toBeacon
+		if replace {
+			input.Reference.Class = toClass
+			input.Reference.Beacon = toBeacon
+		}
 	}
 
 	res, err := m.getObjectFromRepo(ctx, input.Class, input.ID,

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -81,12 +81,15 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 
 	for i, ref := range input.Refs {
 		if strings.Count(string(ref.Beacon), "/") == 3 {
-			toClass, toBeacon, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, ref.Beacon)
+			toClass, toBeacon, replace, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, ref.Beacon)
 			if err != nil {
 				return err
 			}
-			input.Refs[i].Class = toClass
-			input.Refs[i].Beacon = toBeacon
+
+			if replace {
+				input.Refs[i].Class = toClass
+				input.Refs[i].Beacon = toBeacon
+			}
 		}
 	}
 

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -99,6 +99,9 @@ func (v *Validator) properties(ctx context.Context, class *models.Class,
 					if err != nil {
 						return err
 					}
+					if len(prop.DataType) > 1 {
+						continue
+					}
 					toClass := prop.DataType[0] // datatype is the name of the class that is referenced
 					beaconElements := strings.Split(beacon, "/")
 					toUUID := beaconElements[len(beaconElements)-1]

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -82,6 +82,33 @@ func (v *Validator) properties(ctx context.Context, class *models.Class,
 			return err
 		}
 
+		// autodetect to_class in references
+		if dataType.String() == schema.DataTypeCRef.String() {
+			propertyValueSlice, ok := propertyValue.([]interface{})
+			if !ok {
+				return fmt.Errorf("reference property is not a slice %v", propertyValue)
+			}
+			for i := range propertyValueSlice {
+				propertyValueMap, ok := propertyValueSlice[i].(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("reference property is not a map %v", propertyValueMap)
+				}
+				beacon := propertyValueMap["beacon"].(string)
+				if strings.Count(beacon, "/") == 3 {
+					prop, err := schema.GetPropertyByName(class, schema.LowercaseFirstLetter(propertyKey))
+					if err != nil {
+						return err
+					}
+					toClass := prop.DataType[0] // datatype is the name of the class that is referenced
+					beaconElements := strings.Split(beacon, "/")
+					toUUID := beaconElements[len(beaconElements)-1]
+					toBeacon := "weaviate://localhost/" + string(toClass) + "/" + toUUID
+
+					propertyValue.([]interface{})[i].(map[string]interface{})["beacon"] = toBeacon
+				}
+			}
+		}
+
 		data, err := v.extractAndValidateProperty(ctx, propertyKeyLowerCase, propertyValue, className, dataType)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What's being changed:

Enables to send references in the format `"weaviate://localhost/UUID"` instead of  `"weaviate://localhost/TOCLASS/UUID"`. This allows for one parameter less on object creation and needed for the new client.

autodetection is skipped for multi-target references

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

