### PR TITLE
Disallow changes to distance setting after creating a class

### DIFF
--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -73,7 +73,7 @@ func validateImmutableIntField(u immutableParameter,
 	oldField := u.accessor(previous)
 	newField := u.accessor(next)
 	if oldField != newField {
-		return errors.Errorf("%s is immutable: attempted change from \"%d\" to \"%d\"",
+		return errors.Errorf("%s is immutable: attempted change from \"%v\" to \"%v\"",
 			u.name, oldField, newField)
 	}
 

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -30,7 +30,7 @@ func ValidateUserConfigUpdate(initial, updated schema.VectorIndexConfig) error {
 		return errors.Errorf("updated is not UserConfig, but %T", updated)
 	}
 
-	immutableFields := []immutableInt{
+	immutableFields := []immutableParameter{
 		{
 			name:     "efConstruction",
 			accessor: func(c ent.UserConfig) interface{} { return c.EFConstruction },
@@ -62,12 +62,12 @@ func ValidateUserConfigUpdate(initial, updated schema.VectorIndexConfig) error {
 	return nil
 }
 
-type immutableInt struct {
+type immutableParameter struct {
 	accessor func(c ent.UserConfig) interface{}
 	name     string
 }
 
-func validateImmutableIntField(u immutableInt,
+func validateImmutableIntField(u immutableParameter,
 	previous, next ent.UserConfig,
 ) error {
 	oldField := u.accessor(previous)

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -33,11 +33,11 @@ func ValidateUserConfigUpdate(initial, updated schema.VectorIndexConfig) error {
 	immutableFields := []immutableInt{
 		{
 			name:     "efConstruction",
-			accessor: func(c ent.UserConfig) int { return c.EFConstruction },
+			accessor: func(c ent.UserConfig) interface{} { return c.EFConstruction },
 		},
 		{
 			name:     "maxConnections",
-			accessor: func(c ent.UserConfig) int { return c.MaxConnections },
+			accessor: func(c ent.UserConfig) interface{} { return c.MaxConnections },
 		},
 		{
 			// NOTE: There isn't a technical reason for this to be immutable, it
@@ -45,7 +45,11 @@ func ValidateUserConfigUpdate(initial, updated schema.VectorIndexConfig) error {
 			// current timer and start a new one. Certainly possible, but let's see
 			// if anyone actually needs this before implementing it.
 			name:     "cleanupIntervalSeconds",
-			accessor: func(c ent.UserConfig) int { return c.CleanupIntervalSeconds },
+			accessor: func(c ent.UserConfig) interface{} { return c.CleanupIntervalSeconds },
+		},
+		{
+			name:     "distance",
+			accessor: func(c ent.UserConfig) interface{} { return c.Distance },
 		},
 	}
 
@@ -59,7 +63,7 @@ func ValidateUserConfigUpdate(initial, updated schema.VectorIndexConfig) error {
 }
 
 type immutableInt struct {
-	accessor func(c ent.UserConfig) int
+	accessor func(c ent.UserConfig) interface{}
 	name     string
 }
 

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -54,7 +54,7 @@ func ValidateUserConfigUpdate(initial, updated schema.VectorIndexConfig) error {
 	}
 
 	for _, u := range immutableFields {
-		if err := validateImmutableIntField(u, initialParsed, updatedParsed); err != nil {
+		if err := validateImmutableField(u, initialParsed, updatedParsed); err != nil {
 			return err
 		}
 	}
@@ -67,7 +67,7 @@ type immutableParameter struct {
 	name     string
 }
 
-func validateImmutableIntField(u immutableParameter,
+func validateImmutableField(u immutableParameter,
 	previous, next ent.UserConfig,
 ) error {
 	oldField := u.accessor(previous)

--- a/adapters/repos/db/vector/hnsw/config_update_test.go
+++ b/adapters/repos/db/vector/hnsw/config_update_test.go
@@ -56,6 +56,14 @@ func TestUserConfigUpdates(t *testing.T) {
 						"attempted change from \"60\" to \"90\""),
 			},
 			{
+				name:    "attempting to change distance",
+				initial: ent.UserConfig{Distance: "cosine"},
+				update:  ent.UserConfig{Distance: "l2-squared"},
+				expectedError: errors.Errorf(
+					"distance is immutable: " +
+						"attempted change from \"cosine\" to \"l2-squared\""),
+			},
+			{
 				name:          "changing ef",
 				initial:       ent.UserConfig{EF: 100},
 				update:        ent.UserConfig{EF: -1},

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -305,6 +305,7 @@ func TestUpdateClassWithoutVectorIndex(t *testing.T) {
 	})
 }
 
+// This test ensures that distance belongs to the immutable properties, i.e. no changes to it are possible after creating the class.
 func TestUpdateDistanceSettings(t *testing.T) {
 	className := "Cosine_Class"
 

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -305,6 +305,9 @@ func TestUpdateClassWithoutVectorIndex(t *testing.T) {
 	})
 }
 
+// This test prevents a regression of
+// https://github.com/weaviate/weaviate/issues//3177
+//
 // This test ensures that distance belongs to the immutable properties, i.e. no changes to it are possible after creating the class.
 func TestUpdateDistanceSettings(t *testing.T) {
 	className := "Cosine_Class"

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -305,6 +305,63 @@ func TestUpdateClassWithoutVectorIndex(t *testing.T) {
 	})
 }
 
+func TestUpdateDistanceSettings(t *testing.T) {
+	className := "Cosine_Class"
+
+	t.Run("asserting that this class does not exist yet", func(t *testing.T) {
+		assert.NotContains(t, GetObjectClassNames(t), className)
+	})
+
+	defer func(t *testing.T) {
+		params := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		_, err := helper.Client(t).Schema.SchemaObjectsDelete(params, nil)
+		assert.Nil(t, err)
+		if err != nil {
+			if typed, ok := err.(*clschema.SchemaObjectsDeleteBadRequest); ok {
+				fmt.Println(typed.Payload.Error[0].Message)
+			}
+		}
+	}(t)
+
+	t.Run("initially creating the class", func(t *testing.T) {
+		c := &models.Class{
+			Class:      className,
+			Vectorizer: "none",
+			Properties: []*models.Property{
+				{
+					Name:         "name",
+					DataType:     schema.DataTypeText.PropString(),
+					Tokenization: models.PropertyTokenizationWhitespace,
+				},
+			},
+			VectorIndexConfig: map[string]interface{}{
+				"distance": "cosine",
+			},
+		}
+
+		params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Trying to change the distance measurement", func(t *testing.T) {
+		params := clschema.NewSchemaObjectsGetParams().
+			WithClassName(className)
+		res, err := helper.Client(t).Schema.SchemaObjectsGet(params, nil)
+		require.Nil(t, err)
+
+		class := res.Payload
+
+		class.VectorIndexConfig.(map[string]interface{})["distance"] = "l2-squared"
+
+		updateParams := clschema.NewSchemaObjectsUpdateParams().
+			WithClassName(className).
+			WithObjectClass(class)
+		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
+		assert.NotNil(t, err)
+	})
+}
+
 // TODO: https://github.com/weaviate/weaviate/issues/973
 // // This test prevents a regression on the fix for this bug:
 // // https://github.com/weaviate/weaviate/issues/831


### PR DESCRIPTION
### What's being changed:
Disallows changing the distance parameter of a class after it has been created. This should not be possible, because the HNSW graph depends on it. Closes https://github.com/weaviate/weaviate/issues/3177.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: Not necessary
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not necessary
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not necessary
