### PR TITLE
close the indexCounter file before removal

### DIFF
--- a/adapters/repos/db/indexcounter/counter.go
+++ b/adapters/repos/db/indexcounter/counter.go
@@ -89,7 +89,9 @@ func (c *Counter) Drop() error {
 	if c.f == nil {
 		return nil
 	}
-	err := os.Remove(c.f.Name())
+	filename := c.FileName()
+	c.f.Close()
+	err := os.Remove(filename)
 	if err != nil {
 		return errors.Wrap(err, "drop counter file")
 	}


### PR DESCRIPTION
### What's being changed:
The open indexCounter file is ensured to be closed at the point of removal from the file system. This fixes a bug observed within the Windows binary associated with files held by multiple simultaneous processes when attempting to delete a class schema.

Closes #2955

This bug went undetected due to the current inability to test functionality that requires a vectorizer on Windows as disclosed [here](https://github.com/weaviate/weaviate/blob/master/.github/workflows/pull_requests.yaml#L189). 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

My Windows machine is not capable of running the full testing suite locally. Can it be done in Github actions or by someone with more compute? Perhaps there is an EC2 instance where this can be done?