### PR TITLE
Fix get requests with classname and include

### DIFF
--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -1091,6 +1091,16 @@ func (f *fakeManager) GetObjectsClass(ctx context.Context,
 	return class, nil
 }
 
+func (f *fakeManager) GetObjectClassFromName(ctx context.Context, principal *models.Principal,
+	className string,
+) (*models.Class, error) {
+	class := &models.Class{
+		Class:      f.getObjectReturn.Class,
+		Vectorizer: "text2vec-contextionary",
+	}
+	return class, nil
+}
+
 func (f *fakeManager) GetObjects(ctx context.Context, principal *models.Principal, offset *int64, limit *int64, sort *string, order *string, after *string, addl additional.Properties, tenant string) ([]*models.Object, error) {
 	return f.queryResult, nil
 }

--- a/test/acceptance/multi_tenancy/get_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/get_tenant_objects_test.go
@@ -96,6 +96,16 @@ func TestGetTenantObjects(t *testing.T) {
 			assert.Equal(t, obj.Properties, resp.Properties)
 		}
 	})
+
+	t.Run("get tenant objects with include", func(t *testing.T) {
+		for i, obj := range tenantObjects {
+			resp, err := helper.TenantObjectWithInclude(t, obj.Class, obj.ID, tenantNames[i], "vector")
+			require.Nil(t, err)
+			assert.Equal(t, obj.ID, resp.ID)
+			assert.Equal(t, obj.Class, resp.Class)
+			assert.Equal(t, obj.Properties, resp.Properties)
+		}
+	})
 }
 
 func TestListTenantObjects(t *testing.T) {

--- a/test/helper/objects_assertions.go
+++ b/test/helper/objects_assertions.go
@@ -121,6 +121,16 @@ func TenantObject(t *testing.T, class string, id strfmt.UUID, tenant string) (*m
 	return getResp.Payload, nil
 }
 
+func TenantObjectWithInclude(t *testing.T, class string, id strfmt.UUID, tenant string, includes string) (*models.Object, error) {
+	req := objects.NewObjectsClassGetParams().
+		WithClassName(class).WithID(id).WithTenant(&tenant).WithInclude(&includes)
+	getResp, err := Client(t).Objects.ObjectsClassGet(req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return getResp.Payload, nil
+}
+
 func GetObjectCL(t *testing.T, class string, uuid strfmt.UUID,
 	cl replica.ConsistencyLevel, include ...string,
 ) (*models.Object, error) {

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -98,6 +98,12 @@ func Test_Kinds_Authorization(t *testing.T) {
 			expectedResource: "objects/foo",
 		},
 		{
+			methodName:       "GetObjectClassFromName",
+			additionalArgs:   []interface{}{strfmt.UUID("foo")},
+			expectedVerb:     "get",
+			expectedResource: "objects/foo",
+		},
+		{
 			methodName:       "HeadObject",
 			additionalArgs:   []interface{}{"class", strfmt.UUID("foo")},
 			expectedVerb:     "head",

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -110,6 +110,17 @@ func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Princip
 	return s.GetClass(schema.ClassName(res.ClassName)), nil
 }
 
+func (m *Manager) GetObjectClassFromName(ctx context.Context, principal *models.Principal,
+	className string,
+) (*models.Class, error) {
+	s, err := m.schemaManager.GetSchema(principal)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetClass(schema.ClassName(className)), nil
+}
+
 func (m *Manager) getObjectFromRepo(ctx context.Context, class string, id strfmt.UUID,
 	adds additional.Properties, repl *additional.ReplicationProperties, tenant string,
 ) (res *search.Result, err error) {


### PR DESCRIPTION
### What's being changed:

Get REST requests with include would ignore the class parameter and try to fetch the object to determine its class - this could cause problems with MT enabled classes and sometimes wold not find the object

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

