### PR TITLE
Add defaultMaxToken for gpt3.5-16k, updates response model for Palm

### DIFF
--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -52,11 +52,12 @@ var (
 
 // todo Need to parse the tokenLimits in a smarter way, as the prompt defines the max length
 var defaultMaxTokens = map[string]float64{
-	"text-davinci-002": 4097,
-	"text-davinci-003": 4097,
-	"gpt-3.5-turbo":    4097,
-	"gpt-4":            8192,
-	"gpt-4-32k":        32768,
+	"text-davinci-002":  4097,
+	"text-davinci-003":  4097,
+	"gpt-3.5-turbo":     4097,
+	"gpt-3.5-turbo-16k": 16384,
+	"gpt-4":             8192,
+	"gpt-4-32k":         32768,
 }
 
 type ClassSettings interface {

--- a/modules/generative-palm/clients/palm.go
+++ b/modules/generative-palm/clients/palm.go
@@ -85,7 +85,6 @@ func (v *palm) Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt
 			{
 				Messages: []message{
 					{
-						Author:  "user",
 						Content: prompt,
 					},
 				},
@@ -231,8 +230,8 @@ type generateResponse struct {
 }
 
 type prediction struct {
-	Candidates       []candidate       `json:"candidates,omitempty"`
-	SafetyAttributes *safetyAttributes `json:"safetyAttributes,omitempty"`
+	Candidates       []candidate         `json:"candidates,omitempty"`
+	SafetyAttributes *[]safetyAttributes `json:"safetyAttributes,omitempty"`
 }
 
 type candidate struct {


### PR DESCRIPTION
### What's being changed:

generative-openai: Fixes defaultMaxTokens for gpt3.5-turbo-16k
generative-palm: Fixes response model parsing

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
