### PR TITLE
DO_NOT_MERGE: increase startup timeout to 3h

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -104,7 +104,7 @@ type vectorRepo interface {
 
 func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 180*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 124*time.Hour)
 	defer cancel()
 
 	config.ServerVersion = parseVersionFromSwaggerSpec()

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -104,7 +104,7 @@ type vectorRepo interface {
 
 func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 180*time.Minute)
 	defer cancel()
 
 	config.ServerVersion = parseVersionFromSwaggerSpec()


### PR DESCRIPTION
I need it for a user that has Weaviate stuck in a crash loop because it does not startup within 1h. The problem is disk setup and they need to create a backup before migrating to better disks.