### PR TITLE
Enhancing read repair and query efficiency through randomised querying of replica nodes

### DIFF
--- a/usecases/schema/cache.go
+++ b/usecases/schema/cache.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"fmt"
+	"math/rand"
 	"sync"
 
 	"github.com/weaviate/weaviate/entities/models"
@@ -53,10 +54,20 @@ func (s *schemaCache) ShardOwner(class, shard string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("shard not found")
 	}
-	if len(x.BelongsToNodes) < 1 || x.BelongsToNodes[0] == "" {
-		return "", fmt.Errorf("owner node not found")
+	n := len(x.BelongsToNodes)
+	if n == 0 {
+		return "", fmt.Errorf("found empty node list")
 	}
-	return x.BelongsToNodes[0], nil
+
+	idx := 0
+	if n > 1 {
+		idx = rand.Intn(n)
+	}
+	if owner := x.BelongsToNodes[idx]; owner == "" {
+		return "", fmt.Errorf("found empty node at position %d", idx)
+	} else {
+		return owner, nil
+	}
 }
 
 // ShardOwner returns the node owner of the specified shard

--- a/usecases/schema/cache_test.go
+++ b/usecases/schema/cache_test.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestShardOwner(t *testing.T) {
+	cache := schemaCache{
+		State: State{
+			ShardingState: map[string]*sharding.State{},
+		},
+	}
+
+	// class not found
+	_, err := cache.ShardOwner("C", "S")
+	assert.ErrorContains(t, err, "class not found")
+
+	// shard not found
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+	cache.State.ShardingState["C"] = ss
+	_, err = cache.ShardOwner("C", "S")
+	assert.ErrorContains(t, err, "shard not found")
+
+	// empty node list
+	ss.Physical["S"] = sharding.Physical{}
+	_, err = cache.ShardOwner("C", "S")
+	assert.ErrorContains(t, err, "empty node list")
+
+	// node with an empty name
+	nodes := []string{""}
+	ss.Physical["S"] = sharding.Physical{BelongsToNodes: nodes}
+	_, err = cache.ShardOwner("C", "S")
+	assert.ErrorContains(t, err, "empty node")
+
+	// one owner
+	nodes[0] = "A"
+	owner, err := cache.ShardOwner("C", "S")
+	assert.Nil(t, err)
+	assert.Equal(t, "A", owner)
+
+	// many owner
+	nodes = append(nodes, "B")
+	ss.Physical["S"] = sharding.Physical{BelongsToNodes: nodes}
+	got := map[string]struct{}{}
+	for i := 0; i < 11; i++ {
+		node, _ := cache.ShardOwner("C", "S")
+		got[node] = struct{}{}
+	}
+	want := map[string]struct{}{"A": {}, "B": {}}
+	assert.Equal(t, want, got)
+}
+
+func TestShardReplicas(t *testing.T) {
+	cache := schemaCache{
+		State: State{
+			ShardingState: map[string]*sharding.State{},
+		},
+	}
+
+	// class not found
+	_, err := cache.ShardReplicas("C", "S")
+	assert.ErrorContains(t, err, "class not found")
+
+	// shard not found
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+	cache.State.ShardingState["C"] = ss
+	_, err = cache.ShardReplicas("C", "S")
+	assert.ErrorContains(t, err, "shard not found")
+
+	// node with an empty name
+	nodes := []string{"A", "B"}
+	ss.Physical["S"] = sharding.Physical{BelongsToNodes: nodes}
+	res, err := cache.ShardReplicas("C", "S")
+	assert.Nil(t, err)
+	assert.Equal(t, nodes, res)
+}
+
+func TestTenantShard(t *testing.T) {
+	cache := schemaCache{
+		State: State{
+			ShardingState: map[string]*sharding.State{},
+		},
+	}
+
+	// class not found
+	shard, status := cache.TenantShard("C", "S")
+	assert.Empty(t, shard)
+	assert.Empty(t, status)
+
+	// partitioning is disabled
+	ss := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"S": {},
+		},
+		PartitioningEnabled: false,
+	}
+	cache.State.ShardingState["C"] = ss
+	shard, status = cache.TenantShard("C", "S")
+	assert.Empty(t, shard)
+	assert.Empty(t, status)
+
+	// shard not found
+	ss.PartitioningEnabled = true
+	shard, status = cache.TenantShard("C", "U")
+	assert.Empty(t, shard)
+	assert.Empty(t, status)
+
+	// success
+	shard, status = cache.TenantShard("C", "S")
+	assert.Equal(t, "S", shard)
+	assert.NotEmpty(t, status)
+}


### PR DESCRIPTION
### What's being changed:
This strategy aims to evenly distribute the load across different replicas and enhance the likelihood of read repairs being served by the appropriate node, especially in the context of vector search.

In the current implementation, the serving node always queries the first replica if the shard is not local to the serving node. This modification will introduce randomness to this process, contributing to a more balanced distribution of requests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
