### PR TITLE
Fixes analyzing bool array

### DIFF
--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -158,7 +158,7 @@ func (a *Analyzer) BoolArray(in []bool) ([]Countable, error) {
 	out := make([]Countable, len(in))
 	for i := range in {
 		b := bytes.NewBuffer(nil)
-		err := binary.Write(b, binary.LittleEndian, &in)
+		err := binary.Write(b, binary.LittleEndian, &in[i])
 		if err != nil {
 			return nil, err
 		}

--- a/adapters/repos/db/inverted/analyzer_test.go
+++ b/adapters/repos/db/inverted/analyzer_test.go
@@ -315,6 +315,85 @@ func TestAnalyzer(t *testing.T) {
 		sort.Slice(afterSort, func(a, b int) bool { return bytes.Compare(afterSort[a], afterSort[b]) == -1 })
 		assert.Equal(t, results, afterSort)
 	})
+
+	byteTrue := []byte{0x1}
+	byteFalse := []byte{0x0}
+
+	t.Run("analyze bool", func(t *testing.T) {
+		t.Run("true", func(t *testing.T) {
+			countable, err := a.Bool(true)
+			require.Nil(t, err)
+			require.Len(t, countable, 1)
+
+			c := countable[0]
+			assert.Equal(t, byteTrue, c.Data)
+			assert.Equal(t, float32(0), c.TermFrequency)
+		})
+
+		t.Run("false", func(t *testing.T) {
+			countable, err := a.Bool(false)
+			require.Nil(t, err)
+			require.Len(t, countable, 1)
+
+			c := countable[0]
+			assert.Equal(t, byteFalse, c.Data)
+			assert.Equal(t, float32(0), c.TermFrequency)
+		})
+	})
+
+	t.Run("analyze bool array", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			values   []bool
+			expected [][]byte
+		}
+
+		testCases := []testCase{
+			{
+				name:     "[true]",
+				values:   []bool{true},
+				expected: [][]byte{byteTrue},
+			},
+			{
+				name:     "[false]",
+				values:   []bool{false},
+				expected: [][]byte{byteFalse},
+			},
+			{
+				name:     "[true, true, true]",
+				values:   []bool{true, true, true},
+				expected: [][]byte{byteTrue, byteTrue, byteTrue},
+			},
+			{
+				name:     "[false, false, false]",
+				values:   []bool{false, false, false},
+				expected: [][]byte{byteFalse, byteFalse, byteFalse},
+			},
+			{
+				name:     "[false, true, false, true]",
+				values:   []bool{false, true, false, true},
+				expected: [][]byte{byteFalse, byteTrue, byteFalse, byteTrue},
+			},
+			{
+				name:     "[]",
+				values:   []bool{},
+				expected: [][]byte{},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				countable, err := a.BoolArray(tc.values)
+				require.Nil(t, err)
+				require.Len(t, countable, len(tc.expected))
+
+				for i := range countable {
+					assert.Equal(t, tc.expected[i], countable[i].Data)
+					assert.Equal(t, float32(0), countable[i].TermFrequency)
+				}
+			})
+		}
+	})
 }
 
 func TestAnalyzer_DefaultEngPreset(t *testing.T) {

--- a/entities/storobj/parse_single_object.go
+++ b/entities/storobj/parse_single_object.go
@@ -56,6 +56,17 @@ func ParseAndExtractNumberArrayProp(data []byte, propName string) ([]float64, bo
 	return vals, true, nil
 }
 
+func ParseAndExtractBoolArrayProp(data []byte, propName string) ([]bool, bool, error) {
+	vals := []bool{}
+	err := parseAndExtractValueProp(data, propName, func(value []byte) {
+		vals = append(vals, mustExtractBool(value))
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return vals, true, nil
+}
+
 func parseAndExtractValueProp(data []byte, propName string, valueFn func(value []byte)) error {
 	propsBytes, err := extractPropsBytes(data)
 	if err != nil {
@@ -88,6 +99,14 @@ func mustExtractNumber(value []byte) float64 {
 		panic("not a float64")
 	}
 	return number
+}
+
+func mustExtractBool(value []byte) bool {
+	boolVal, err := strconv.ParseBool(string(value))
+	if err != nil {
+		panic("not a bool")
+	}
+	return boolVal
 }
 
 func extractID(data []byte) ([]string, bool, error) {

--- a/test/acceptance_with_go_client/filters_tests/where_test.go
+++ b/test/acceptance_with_go_client/filters_tests/where_test.go
@@ -48,59 +48,59 @@ func TestWhereFilter(t *testing.T) {
 			Properties: []*models.Property{
 				{
 					Name:     "color",
-					DataType: []string{schema.DataTypeText.String()},
+					DataType: schema.DataTypeText.PropString(),
 				},
 				{
 					Name:     "colors",
-					DataType: []string{schema.DataTypeTextArray.String()},
+					DataType: schema.DataTypeTextArray.PropString(),
 				},
 				{
 					Name:     "author",
-					DataType: []string{schema.DataTypeString.String()},
+					DataType: schema.DataTypeString.PropString(),
 				},
 				{
 					Name:     "authors",
-					DataType: []string{schema.DataTypeStringArray.String()},
+					DataType: schema.DataTypeStringArray.PropString(),
 				},
 				{
 					Name:     "number",
-					DataType: []string{schema.DataTypeNumber.String()},
+					DataType: schema.DataTypeNumber.PropString(),
 				},
 				{
 					Name:     "numbers",
-					DataType: []string{schema.DataTypeNumberArray.String()},
+					DataType: schema.DataTypeNumberArray.PropString(),
 				},
 				{
 					Name:     "int",
-					DataType: []string{schema.DataTypeInt.String()},
+					DataType: schema.DataTypeInt.PropString(),
 				},
 				{
 					Name:     "ints",
-					DataType: []string{schema.DataTypeIntArray.String()},
+					DataType: schema.DataTypeIntArray.PropString(),
 				},
 				{
 					Name:     "date",
-					DataType: []string{schema.DataTypeDate.String()},
+					DataType: schema.DataTypeDate.PropString(),
 				},
 				{
 					Name:     "dates",
-					DataType: []string{schema.DataTypeDateArray.String()},
+					DataType: schema.DataTypeDateArray.PropString(),
 				},
 				{
 					Name:     "bool",
-					DataType: []string{schema.DataTypeBoolean.String()},
+					DataType: schema.DataTypeBoolean.PropString(),
 				},
 				{
 					Name:     "bools",
-					DataType: []string{schema.DataTypeBooleanArray.String()},
+					DataType: schema.DataTypeBooleanArray.PropString(),
 				},
 				{
 					Name:     "uuid",
-					DataType: []string{schema.DataTypeUUID.String()},
+					DataType: schema.DataTypeUUID.PropString(),
 				},
 				{
 					Name:     "uuids",
-					DataType: []string{schema.DataTypeUUIDArray.String()},
+					DataType: schema.DataTypeUUIDArray.PropString(),
 				},
 			},
 		}
@@ -279,6 +279,24 @@ func TestWhereFilter(t *testing.T) {
 				expectedIds: []string{id1, id2, id3},
 			},
 			{
+				name: "contains all bools with bool array",
+				where: filters.Where().
+					WithPath([]string{"bools"}).
+					WithOperator(filters.ContainsAll).
+					WithValueBoolean(true, false, true),
+				property:    "bools",
+				expectedIds: []string{id1, id2},
+			},
+			{
+				name: "contains any bools with bool array",
+				where: filters.Where().
+					WithPath([]string{"bools"}).
+					WithOperator(filters.ContainsAny).
+					WithValueBoolean(true, false),
+				property:    "bools",
+				expectedIds: []string{id1, id2, id3},
+			},
+			{
 				name: "contains all uuids with uuid array",
 				where: filters.Where().
 					WithPath([]string{"uuids"}).
@@ -387,6 +405,15 @@ func TestWhereFilter(t *testing.T) {
 					WithOperator(filters.ContainsAny).
 					WithValueInt(1, 2, 3),
 				property:    "int",
+				expectedIds: []string{id1, id2, id3},
+			},
+			{
+				name: "contains any bool with bool",
+				where: filters.Where().
+					WithPath([]string{"bool"}).
+					WithOperator(filters.ContainsAny).
+					WithValueBoolean(true, false, true),
+				property:    "bool",
 				expectedIds: []string{id1, id2, id3},
 			},
 			{


### PR DESCRIPTION
### What's being changed:
Fixes analyzing bool values of bool array property, in the result fixing inverted index of bool props.
Switches aggregation of bool values of bool array props from inverted index property bucket to objects bucket to correctly count duplicated values (as it is done for other property types).

Already indexed properties of bool array type will not be fixed. Change will be applied to newly added objects only. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
