### PR TITLE
Add GRPC port to meta endpoint

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3886,6 +3886,10 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
+        "grpcPort": {
+          "description": "Port of the GRPC endpoint",
+          "type": "integer"
+        },
         "hostname": {
           "description": "The url of the host.",
           "type": "string",
@@ -8970,6 +8974,10 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
+        "grpcPort": {
+          "description": "Port of the GRPC endpoint",
+          "type": "integer"
+        },
         "hostname": {
           "description": "The url of the host.",
           "type": "string",

--- a/adapters/handlers/rest/handlers_misc.go
+++ b/adapters/handlers/rest/handlers_misc.go
@@ -53,6 +53,7 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 			Hostname: serverConfig.GetHostAddress(),
 			Version:  config.ServerVersion,
 			Modules:  metaInfos,
+			GrpcPort: int64(serverConfig.Config.GRPC.Port),
 		}
 		metricRequestsTotal.logOk("")
 		return meta.NewMetaGetOK().WithPayload(res)

--- a/entities/models/meta.go
+++ b/entities/models/meta.go
@@ -28,6 +28,9 @@ import (
 // swagger:model Meta
 type Meta struct {
 
+	// Port of the GRPC endpoint
+	GrpcPort int64 `json:"grpcPort,omitempty"`
+
 	// The url of the host.
 	Hostname string `json:"hostname,omitempty"`
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -440,6 +440,10 @@
         "modules": {
           "description": "Module-specific meta information",
           "type": "object"
+        },
+        "grpcPort": {
+          "description": "Port of the GRPC endpoint",
+          "type": "integer"
         }
       },
       "type": "object"


### PR DESCRIPTION
### What's being changed:

Adds the GRPC port to the meta endpoint, allowing clients to query it. This improves the UX when instantiating a new client
