### PR TITLE
improves GQL query resiliency

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -155,6 +155,15 @@ func (f *fakeSchemaManager) ShardOwner(class, shard string) (string, error) {
 	return ss.Physical[shard].BelongsToNodes[0], nil
 }
 
+func (f *fakeSchemaManager) ShardReplicas(class, shard string) ([]string, error) {
+	ss := f.shardState
+	x, ok := ss.Physical[shard]
+	if !ok {
+		return nil, fmt.Errorf("shard not found")
+	}
+	return x.BelongsToNodes, nil
+}
+
 func (f *fakeSchemaManager) TenantShard(class, tenant string) (string, string) {
 	return tenant, models.TenantActivityStatusHOT
 }

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -56,7 +56,16 @@ func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error) {
 	if len(x.BelongsToNodes) < 1 || x.BelongsToNodes[0] == "" {
 		return "", fmt.Errorf("owner node not found")
 	}
-	return ss.Physical[shard].BelongsToNodes[0], nil
+	return x.BelongsToNodes[0], nil
+}
+
+func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) {
+	ss := f.shardState
+	x, ok := ss.Physical[shard]
+	if !ok {
+		return nil, fmt.Errorf("shard not found")
+	}
+	return x.BelongsToNodes, nil
 }
 
 func (f *fakeSchemaGetter) TenantShard(class, tenant string) (string, string) {

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -43,7 +43,9 @@ func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	panic("not implemented")
 }
 
-func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error) { return "", nil }
+func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error)      { return "", nil }
+func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) { return nil, nil }
+
 func (f *fakeSchemaGetter) TenantShard(class, tenant string) (string, string) {
 	return tenant, models.TenantActivityStatusHOT
 }

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -48,6 +48,10 @@ func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error) {
 	return shard, nil
 }
 
+func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) {
+	return []string{shard}, nil
+}
+
 func (f *fakeSchemaGetter) TenantShard(class, tenant string) (string, string) {
 	return tenant, models.TenantActivityStatusHOT
 }

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -62,6 +62,15 @@ func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error) {
 	return ss.Physical[shard].BelongsToNodes[0], nil
 }
 
+func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) {
+	ss := f.shardState
+	x, ok := ss.Physical[shard]
+	if !ok {
+		return nil, fmt.Errorf("shard not found")
+	}
+	return x.BelongsToNodes, nil
+}
+
 func (f *fakeSchemaGetter) TenantShard(class, tenant string) (string, string) {
 	return tenant, models.TenantActivityStatusHOT
 }

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -67,6 +67,7 @@ type SchemaGetter interface {
 	ShardOwner(class, shard string) (string, error)
 	TenantShard(class, tenant string) (string, string)
 	ShardFromUUID(class string, uuid []byte) string
+	ShardReplicas(class, shard string) ([]string, error)
 }
 
 type VectorizerValidator interface {

--- a/usecases/sharding/remote_index_test.go
+++ b/usecases/sharding/remote_index_test.go
@@ -1,0 +1,118 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package sharding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+var errAny = errors.New("anyErr")
+
+func TestQueryReplica(t *testing.T) {
+	var (
+		ctx                      = context.Background()
+		canceledCtx, cancledFunc = context.WithCancel(ctx)
+	)
+	cancledFunc()
+	doIf := func(targetNode string) func(node, host string) (interface{}, error) {
+		return func(node, host string) (interface{}, error) {
+			if node != targetNode {
+				return nil, errAny
+			}
+			return node, nil
+		}
+	}
+	tests := []struct {
+		ctx        context.Context
+		resolver   fakeNodeResolver
+		schema     fakeSchema
+		targetNode string
+		success    bool
+		name       string
+	}{
+		{
+			ctx, newFakeResolver(0, 0), newFakeSchema(0, 0), "N0", false, "empty schema",
+		},
+		{
+			ctx, newFakeResolver(0, 1), newFakeSchema(1, 2), "N2", false, "unresolved name",
+		},
+		{
+			ctx, newFakeResolver(0, 1), newFakeSchema(0, 1), "N0", true, "one replica",
+		},
+		{
+			ctx, newFakeResolver(0, 9), newFakeSchema(0, 9), "N2", true, "random selection",
+		},
+		{
+			canceledCtx, newFakeResolver(0, 9), newFakeSchema(0, 9), "N2", false, "canceled",
+		},
+	}
+
+	for _, test := range tests {
+		rindex := RemoteIndex{"C", &test.schema, nil, &test.resolver}
+		got, err := rindex.queryReplicas(test.ctx, "S", doIf(test.targetNode))
+		if !test.success {
+			if got != nil {
+				t.Errorf("%s: want: nil, got: %v", test.name, got)
+			} else if err == nil {
+				t.Errorf("%s: must return an error", test.name)
+			}
+			continue
+		}
+		lastNode, ok := got.(string)
+		if !ok {
+			t.Errorf("%s: result type want: string, got: %t", test.name, got)
+		}
+		if lastNode != test.targetNode {
+			t.Errorf("%s: last responding node want:%s got:%s", test.name, test.targetNode, lastNode)
+		}
+	}
+}
+
+func newFakeResolver(fromNode, toNode int) fakeNodeResolver {
+	m := make(map[string]string, toNode-fromNode)
+	for i := fromNode; i < toNode; i++ {
+		m[fmt.Sprintf("N%d", i)] = fmt.Sprintf("H%d", i)
+	}
+	return fakeNodeResolver{m}
+}
+
+func newFakeSchema(fromNode, toNode int) fakeSchema {
+	nodes := make([]string, 0, toNode-fromNode)
+	for i := fromNode; i < toNode; i++ {
+		nodes = append(nodes, fmt.Sprintf("N%d", i))
+	}
+	return fakeSchema{nodes}
+}
+
+type fakeNodeResolver struct {
+	rTable map[string]string
+}
+
+func (f *fakeNodeResolver) NodeHostname(name string) (string, bool) {
+	host, ok := f.rTable[name]
+	return host, ok
+}
+
+type fakeSchema struct {
+	nodes []string
+}
+
+func (f *fakeSchema) ShardOwner(class, shard string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeSchema) ShardReplicas(class, shard string) ([]string, error) {
+	return f.nodes, nil
+}

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -231,7 +231,14 @@ func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	panic("not implemented")
 }
 
-func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error) { return shard, nil }
+func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error) {
+	return shard, nil
+}
+
+func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) {
+	return []string{shard}, nil
+}
+
 func (f *fakeSchemaGetter) TenantShard(class, tenant string) (string, string) {
 	return tenant, models.TenantActivityStatusHOT
 }


### PR DESCRIPTION
### What's being changed:
This enhancement introduces the functionality to retry GQL queries on both the same replica and different replica nodes. This enhancement aims to enhance query resiliency by addressing both temporary and permanent errors related to single replicas.

Replica selection has been enhanced to randomize the selection process. This ensures a more balanced distribution of the query load across all available replicas.

Fixes #3453

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
