### PR TITLE
Limited concurrency for BM25 queries, with pread

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -224,7 +224,8 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 		},
 	}
 	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: sch}
-	queue := make(chan job, 100000)
+	queue := make(chan batchJob, 100000)
+
 	idx := &Index{
 		Config:                IndexConfig{RootPath: tmpDir, ClassName: schema.ClassName(className)},
 		invertedIndexConfig:   schema.InvertedIndexConfig{},
@@ -240,7 +241,7 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 
 	shardName := shardState.AllPhysicalShards()[0]
 
-	shd, err := NewShard(ctx, nil, shardName, idx, &class, repo.jobQueueCh)
+	shd, err := NewShard(ctx, nil, shardName, idx, &class, repo.batchJobQueueCh)
 	if err != nil {
 		panic(err)
 	}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -141,7 +141,7 @@ type Index struct {
 	dropIndex sync.RWMutex
 
 	metrics         *Metrics
-	centralJobQueue chan job
+	centralJobQueue chan batchJob
 
 	partitioningEnabled bool
 }
@@ -162,7 +162,7 @@ func NewIndex(ctx context.Context, config IndexConfig,
 	cs inverted.ClassSearcher, logger logrus.FieldLogger,
 	nodeResolver nodeResolver, remoteClient sharding.RemoteIndexClient,
 	replicaClient replica.Client,
-	promMetrics *monitoring.PrometheusMetrics, class *models.Class, jobQueueCh chan job,
+	promMetrics *monitoring.PrometheusMetrics, class *models.Class, jobQueueCh chan batchJob,
 ) (*Index, error) {
 	sd, err := stopwords.NewDetectorFromConfig(invertedIndexConfig.Stopwords)
 	if err != nil {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -70,7 +70,7 @@ func (db *DB) init(ctx context.Context) error {
 				inverted.ConfigFromModel(invertedConfig),
 				class.VectorIndexConfig.(schema.VectorIndexConfig),
 				db.schemaGetter, db, db.logger, db.nodeResolver, db.remoteIndex,
-				db.replicaClient, db.promMetrics, class, db.jobQueueCh)
+				db.replicaClient, db.promMetrics, class, db.batchJobQueueCh)
 			if err != nil {
 				return errors.Wrap(err, "create index")
 			}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -183,7 +183,7 @@ func (b *BM25Searcher) wand(
 	indices := make([]map[uint64]int, lengthAllResults)
 
 	var eg errgroup.Group
-	eg.SetLimit(_NUMCPU)
+	eg.SetLimit(4)
 	offset := 0
 
 	for _, tokenization := range tokenizationsOrdered {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -33,6 +33,7 @@ type segment struct {
 	dataStartPos          uint64
 	dataEndPos            uint64
 	contents              []byte
+	contentFile           *os.File
 	bloomFilter           *bloom.BloomFilter
 	secondaryBloomFilters []*bloom.BloomFilter
 	strategy              segmentindex.Strategy
@@ -69,7 +70,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	if err != nil {
 		return nil, errors.Wrap(err, "open file")
 	}
-	defer file.Close()
+	//defer file.Close()
 
 	fileInfo, err := file.Stat()
 	if err != nil {
@@ -104,6 +105,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		level:               header.Level,
 		path:                path,
 		contents:            content,
+		contentFile:         file,
 		version:             header.Version,
 		secondaryIndexCount: header.SecondaryIndices,
 		segmentStartPos:     header.IndexStart,

--- a/adapters/repos/db/lsmkv/segment_replace_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_replace_strategy.go
@@ -57,7 +57,9 @@ func (s *segment) get(key []byte) ([]byte, error) {
 	// Similar approach was used to fix SEGFAULT in collection strategy
 	// https://github.com/weaviate/weaviate/issues/1837
 	contentsCopy := make([]byte, node.End-node.Start)
-	copy(contentsCopy, s.contents[node.Start:node.End])
+	//copy(contentsCopy, s.contents[node.Start:node.End])
+
+	s.contentFile.ReadAt(contentsCopy, int64(node.Start))
 
 	return s.replaceStratParseData(contentsCopy)
 }
@@ -97,7 +99,8 @@ func (s *segment) getBySecondaryIntoMemory(pos int, key []byte, buffer []byte) (
 	} else {
 		contentsCopy = make([]byte, node.End-node.Start)
 	}
-	copy(contentsCopy, s.contents[node.Start:node.End])
+	//copy(contentsCopy, s.contents[node.Start:node.End])
+	s.contentFile.ReadAt(contentsCopy, int64(node.Start))
 	currContent, err := s.replaceStratParseData(contentsCopy)
 	return currContent, err, contentsCopy
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -61,7 +61,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 		inverted.ConfigFromModel(class.InvertedIndexConfig),
 		class.VectorIndexConfig.(schema.VectorIndexConfig),
 		m.db.schemaGetter, m.db, m.logger, m.db.nodeResolver, m.db.remoteIndex,
-		m.db.replicaClient, m.db.promMetrics, class, m.db.jobQueueCh)
+		m.db.replicaClient, m.db.promMetrics, class, m.db.batchJobQueueCh)
 	if err != nil {
 		return errors.Wrap(err, "create index")
 	}

--- a/adapters/repos/db/ranked_fusion_test.go
+++ b/adapters/repos/db/ranked_fusion_test.go
@@ -962,6 +962,5 @@ func TestHybridOverSearch(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, 1, len(hybridResults))
 		require.Equal(t, strfmt.UUID("9889a225-3b28-477d-b8fc-5f6071bb4731"), hybridResults[0].ID)
-		// require.Equal(t, "79a636c2-3314-442e-a4d1-e94d7c0afc3a", hybridResults[1].ID)
 	})
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -109,7 +109,7 @@ func New(logger logrus.FieldLogger, config Config,
 		promMetrics:         promMetrics,
 		shutdown:            make(chan struct{}),
 		batchJobQueueCh:     make(chan batchJob, 100000),
-		bm25fJobQueueCh:     make(chan bM25fJob, _NUMCPU),
+		bm25fJobQueueCh:     make(chan bM25fJob, _NUMCPU/2),
 		maxNumberGoroutines: int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
 		resourceScanState:   newResourceScanState(),
 	}
@@ -121,7 +121,7 @@ func New(logger logrus.FieldLogger, config Config,
 		go db.batchWorker()
 	}
 
-	for i := 0; i < _NUMCPU; i++ {
+	for i := 0; i < _NUMCPU/2; i++ {
 		go db.bm25Worker()
 	}
 

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -17,13 +17,13 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-
-	"github.com/weaviate/weaviate/entities/storobj"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -121,6 +121,10 @@ func New(logger logrus.FieldLogger, config Config,
 		go db.batchWorker()
 	}
 
+	for i := 0; i < _NUMCPU; i++ {
+		go db.bm25Worker()
+	}
+
 	return db, nil
 }
 
@@ -242,7 +246,37 @@ type batchJob struct {
 	batcher *objectsBatcher
 }
 
+func (db *DB) bm25Worker() {
+	t := time.NewTicker(time.Millisecond)
+	for {
+		select {
+		case <-db.shutdown:
+			return
+		case <-t.C:
+			job := <-db.bm25fJobQueueCh
+
+			db.logger.WithField("bm25_queue_count", "sub").
+				Debugf("items in queue: %d", len(db.bm25fJobQueueCh))
+			metric, err := monitoring.GetMetrics().BM25fQueueCount.GetMetricWithLabelValues("class")
+			if err == nil {
+				metric.Sub(1)
+			}
+
+			objs, dists, err := db.search(job.ctx, job.params)
+			if err != nil {
+				job.response <- bM25fJobResponse{err: err}
+			} else {
+				job.response <- bM25fJobResponse{
+					objects: objs,
+					dists:   dists,
+				}
+			}
+		}
+	}
+}
+
 type bM25fJob struct {
+	ctx      context.Context
 	params   dto.GetParams
 	response chan bM25fJobResponse
 }

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -14,6 +14,10 @@ package db
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/refcache"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -27,9 +31,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/traverser"
-	"sort"
-	"strings"
-	"sync"
 )
 
 func (db *DB) Aggregate(ctx context.Context,

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -63,7 +63,7 @@ type Shard struct {
 	propertyIndicesLock sync.RWMutex
 	stopMetrics         chan struct{}
 
-	centralJobQueue chan job // reference to queue used by all shards
+	centralJobQueue chan batchJob // reference to queue used by all shards
 
 	docIdLock []sync.Mutex
 	// replication
@@ -85,7 +85,7 @@ type Shard struct {
 }
 
 func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
-	shardName string, index *Index, class *models.Class, jobQueueCh chan job,
+	shardName string, index *Index, class *models.Class, jobQueueCh chan batchJob,
 ) (*Shard, error) {
 	before := time.Now()
 

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -219,7 +219,7 @@ func (ob *objectsBatcher) storeAdditionalStorageWithWorkers(ctx context.Context)
 
 		ob.wg.Add(1)
 		status := ob.statuses[object.ID()]
-		ob.shard.centralJobQueue <- job{
+		ob.shard.centralJobQueue <- batchJob{
 			object:  object,
 			status:  status,
 			index:   i,

--- a/modules/text2vec-transformers/clients/startup_test.go
+++ b/modules/text2vec-transformers/clients/startup_test.go
@@ -52,7 +52,7 @@ func TestWaitForStartup(t *testing.T) {
 		v := New(url, url, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
-		err := v.WaitForStartup(ctx, 150*time.Millisecond)
+		err := v.WaitForStartup(ctx, 50*time.Millisecond)
 
 		require.NotNil(t, err, nullLogger())
 		assert.Contains(t, err.Error(), "init context expired before remote was ready: send check ready request")

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -45,7 +45,6 @@ case $CONFIG in
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
-      LOG_LEVEL="trace" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -55,6 +55,7 @@ type PrometheusMetrics struct {
 	BackupRestoreDataTransferred       *prometheus.CounterVec
 	BackupStoreDataTransferred         *prometheus.CounterVec
 	VectorDimensionsSum                *prometheus.GaugeVec
+	BM25fQueueCount                    *prometheus.GaugeVec
 
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.SummaryVec
@@ -246,6 +247,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "backup_store_data_transferred",
 			Help: "Total number of bytes transferred during a backup store",
 		}, []string{"backend_name", "class_name"}),
+		BM25fQueueCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "bm25_queued_requests_count",
+			Help: "Total number of BM25f requests waiting to be processed",
+		}, []string{"class_name"}),
 	}
 }
 

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -16,12 +16,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/weaviate/weaviate/entities/autocut"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/autocut"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/inverted"
@@ -304,13 +303,13 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		oldLimit := params.Pagination.Limit
 		params.Pagination.Limit = enforcedMin - params.Pagination.Offset
 
-		res, dists, err := e.searcher.SparseObjectSearch(ctx, params)
+		objs, dists, err := e.searcher.SparseObjectSearch(ctx, params)
 		if err != nil {
 			return nil, nil, err
 		}
 		params.Pagination.Limit = oldLimit
 
-		return res, dists, nil
+		return objs, dists, nil
 	}
 
 	denseSearch := func(vec []float32) ([]*storobj.Object, []float32, error) {


### PR DESCRIPTION
# Do not merge

### What's being changed:

- Queue BM25 requests and limit number of goroutines used to create terms (see #3423)
- Experimental pread for replace strategy (see  #3089)
- Based on tag v1.20.6

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
