### PR TITLE
Gracefully handle potential panics in batch add

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"runtime/debug"
 	golangSort "sort"
@@ -574,7 +575,7 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 					for pos := range group.pos {
 						out[pos] = fmt.Errorf("an unexpected error occurred: %s", err)
 					}
-					fmt.Printf("panic: %s\n", err)
+					fmt.Fprintf(os.Stderr, "panic: %s\n", err)
 					debug.PrintStack()
 				}
 			}()

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -254,7 +255,7 @@ func (ob *objectsBatcher) storeSingleObjectInAdditionalStorage(ctx context.Conte
 		err := recover()
 		if err != nil {
 			ob.setErrorAtIndex(fmt.Errorf("an unexpected error occurred: %s", err), index)
-			fmt.Printf("panic: %s\n", err)
+			fmt.Fprintf(os.Stderr, "panic: %s\n", err)
 			debug.PrintStack()
 		}
 	}()

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -13,6 +13,8 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -248,6 +250,15 @@ func (ob *objectsBatcher) shouldSkipInAdditionalStorage(i int) bool {
 func (ob *objectsBatcher) storeSingleObjectInAdditionalStorage(ctx context.Context,
 	object *storobj.Object, status objectInsertStatus, index int,
 ) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			ob.setErrorAtIndex(fmt.Errorf("an unexpected error occurred: %s", err), index)
+			fmt.Printf("panic: %s\n", err)
+			debug.PrintStack()
+		}
+	}()
+
 	if err := ctx.Err(); err != nil {
 		ob.setErrorAtIndex(errors.Wrap(err, "insert to vector index"), index)
 		return


### PR DESCRIPTION
### What's being changed:

Fixes #3440.

In the rare case that an unexpected panic occurs when trying to add a batch, it should not crash the whole system. Instead, Weaviate should gracefully recover. This new change does so by:

* putting the panic message into a user-facing error wrapped with a message about an unexpected error having occurred
* still printing the panic message and stack trace to the console as if the panic was uncaught, so that it can still be used for troubleshooting

This required adding the recover in two places because any time we spawn a new goroutine, an existing recovery (such as the global one in the HTTP middleware) no longer catches the panic. The current code spawns goroutines in two places:
- while iterating over indexes/shards there is a waitgroup that each spawns a new routine
- while working on vector indexing from the queue, each worker is a a separate goroutine

Tested manually, as there is no (known) way to invoke a panic through public interfaces. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
