### PR TITLE
Resolve deadlock between backup and replication processes

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -91,11 +92,13 @@ func (db *DB) ShardsBackup(
 	if err := idx.initBackup(bakID); err != nil {
 		return cd, fmt.Errorf("init backup state for class %q: %w", class, err)
 	}
+
 	defer func() {
 		if err != nil {
 			go idx.ReleaseBackup(ctx, bakID)
 		}
 	}()
+
 	sm := make(map[string]*Shard, len(shards))
 	for _, shardName := range shards {
 		shard := idx.shards.Load(shardName)
@@ -104,6 +107,12 @@ func (db *DB) ShardsBackup(
 		}
 		sm[shardName] = shard
 	}
+
+	// prevent writing into the index during collection of metadata
+	if err := idx.backupMutex.LockWithContext(ctx); err != nil {
+		return cd, err
+	}
+	defer idx.backupMutex.Unlock()
 	for shardName, shard := range sm {
 		if err := shard.beginBackup(ctx); err != nil {
 			return cd, fmt.Errorf("class %q: shard %q: begin backup: %w", class, shardName, err)
@@ -186,11 +195,18 @@ func (i *Index) descriptor(ctx context.Context, backupID string, desc *backup.Cl
 	if err := i.initBackup(backupID); err != nil {
 		return err
 	}
+
 	defer func() {
 		if err != nil {
 			go i.ReleaseBackup(ctx, backupID)
 		}
 	}()
+
+	// prevent writing into the index during collection of metadata
+	if err := i.backupMutex.LockWithContext(ctx); err != nil {
+		return err
+	}
+	defer i.backupMutex.Unlock()
 
 	if err = i.ForEachShard(func(name string, s *Shard) error {
 		if err = s.beginBackup(ctx); err != nil {
@@ -228,28 +244,26 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 }
 
 func (i *Index) initBackup(id string) error {
-	i.backupStateLock.Lock()
-	defer i.backupStateLock.Unlock()
-
-	if i.backupState.InProgress {
+	new := &BackupState{
+		BackupID:   id,
+		InProgress: true,
+	}
+	if !i.lastBackup.CompareAndSwap(nil, new) {
+		bid := ""
+		if x := i.lastBackup.Load(); x != nil {
+			bid = x.BackupID
+		}
 		return errors.Errorf(
 			"cannot create new backup, backup ‘%s’ is not yet released, this "+
 				"means its contents have not yet been fully copied to its destination, "+
-				"try again later", i.backupState.BackupID)
-	}
-
-	i.backupState = BackupState{
-		BackupID:   id,
-		InProgress: true,
+				"try again later", bid)
 	}
 
 	return nil
 }
 
 func (i *Index) resetBackupState() {
-	i.backupStateLock.Lock()
-	defer i.backupStateLock.Unlock()
-	i.backupState = BackupState{InProgress: false}
+	i.lastBackup.Store(nil)
 }
 
 func (i *Index) resumeMaintenanceCycles(ctx context.Context) (lastErr error) {
@@ -282,4 +296,46 @@ func (i *Index) marshalSchema() ([]byte, error) {
 	}
 
 	return b, err
+}
+
+const (
+	mutexRetryDuration  = time.Millisecond * 500
+	mutexNotifyDuration = 20 * time.Second
+)
+
+// backupMutex is an adapter built around rwmutex that facilitates cooperative blocking between write and read locks
+type backupMutex struct {
+	sync.RWMutex
+	log            logrus.FieldLogger
+	retryDuration  time.Duration
+	notifyDuration time.Duration
+}
+
+// LockWithContext attempts to acquire a write lock while respecting the provided context.
+// It reports whether the lock acquisition was successful or if the context has been cancelled.
+func (m *backupMutex) LockWithContext(ctx context.Context) error {
+	return m.lock(ctx, m.TryLock)
+}
+
+func (m *backupMutex) lock(ctx context.Context, tryLock func() bool) error {
+	if tryLock() {
+		return nil
+	}
+	curTime := time.Now()
+	t := time.NewTicker(m.retryDuration)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			if tryLock() {
+				return nil
+			}
+			if time.Since(curTime) > m.notifyDuration {
+				curTime = time.Now()
+				m.log.Info("backup process waiting for ongoing writes to finish")
+			}
+		}
+	}
 }

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	tlog "github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestBackupMutex(t *testing.T) {
+	l, _ := tlog.NewNullLogger()
+	t.Run("success first time", func(t *testing.T) {
+		m := backupMutex{log: l, retryDuration: time.Millisecond, notifyDuration: 5 * time.Millisecond}
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Millisecond)
+		defer cancel()
+		if err := m.LockWithContext(ctx); err != nil {
+			t.Errorf("error want:nil got:%v ", err)
+		}
+	})
+	t.Run("success after retry", func(t *testing.T) {
+		m := backupMutex{log: l, retryDuration: 2 * time.Millisecond, notifyDuration: 5 * time.Millisecond}
+		m.RLock()
+		go func() {
+			defer m.RUnlock()
+			time.Sleep(time.Millisecond * 15)
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := m.LockWithContext(ctx); err != nil {
+			t.Errorf("error want:nil got:%v ", err)
+		}
+	})
+	t.Run("cancelled context", func(t *testing.T) {
+		m := backupMutex{log: l, retryDuration: time.Millisecond, notifyDuration: 5 * time.Millisecond}
+		m.RLock()
+		defer m.RUnlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Millisecond)
+		defer cancel()
+		err := m.LockWithContext(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("error want:%v got:%v", err, context.DeadlineExceeded)
+		}
+	})
+}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -20,6 +20,7 @@ import (
 	golangSort "sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -123,9 +124,6 @@ type Index struct {
 	stopwords             *stopwords.Detector
 	replicator            *replica.Replicator
 
-	backupState     BackupState
-	backupStateLock sync.RWMutex
-
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
 
@@ -149,6 +147,9 @@ type Index struct {
 	partitioningEnabled bool
 
 	cycleCallbacks *indexCycleCallbacks
+
+	backupMutex backupMutex
+	lastBackup  atomic.Pointer[BackupState]
 }
 
 func (i *Index) ID() string {
@@ -195,6 +196,7 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 		metrics:             NewMetrics(logger, promMetrics, cfg.ClassName.String(), "n/a"),
 		centralJobQueue:     jobQueueCh,
 		partitioningEnabled: shardState.PartitioningEnabled,
+		backupMutex:         backupMutex{log: logger, retryDuration: mutexRetryDuration, notifyDuration: mutexNotifyDuration},
 	}
 	index.initCycleCallbacks()
 
@@ -383,8 +385,8 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object,
 			object.Class(), i.Config.ClassName)
 	}
 
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	shardName, err := i.determineObjectShard(object.ID(), object.Object.Tenant)
 	if err != nil {
 		return objects.NewErrInvalidUserInput("determine shard: %v", err)
@@ -414,8 +416,8 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object,
 func (i *Index) IncomingPutObject(ctx context.Context, shardName string,
 	object *storobj.Object,
 ) error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	localShard := i.localShard(shardName)
 	if localShard == nil {
 		return errors.Errorf("shard %q does not exist locally", shardName)
@@ -530,8 +532,8 @@ func parseAsStringToTime(in interface{}) (time.Time, error) {
 func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 	replProps *additional.ReplicationProperties,
 ) []error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	type objsAndPos struct {
 		objects []*storobj.Object
 		pos     []int
@@ -612,8 +614,8 @@ func duplicateErr(in error, count int) []error {
 func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 	objects []*storobj.Object,
 ) []error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	localShard := i.shards.Load(shardName)
 	if localShard == nil {
 		return duplicateErr(errors.Errorf("shard %q does not exist locally",
@@ -641,8 +643,8 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 func (i *Index) addReferencesBatch(ctx context.Context, refs objects.BatchReferences,
 	replProps *additional.ReplicationProperties,
 ) []error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	type refsAndPos struct {
 		refs objects.BatchReferences
 		pos  []int
@@ -693,8 +695,8 @@ func (i *Index) addReferencesBatch(ctx context.Context, refs objects.BatchRefere
 func (i *Index) IncomingBatchAddReferences(ctx context.Context, shardName string,
 	refs objects.BatchReferences,
 ) []error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	localShard := i.shards.Load(shardName)
 	if localShard == nil {
 		return duplicateErr(errors.Errorf("shard %q does not exist locally",
@@ -1323,8 +1325,8 @@ func (i *Index) IncomingSearch(ctx context.Context, shardName string,
 func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 	replProps *additional.ReplicationProperties, tenant string,
 ) error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 
 	if err := i.validateMultiTenancy(tenant); err != nil {
 		return err
@@ -1356,8 +1358,8 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 func (i *Index) IncomingDeleteObject(ctx context.Context, shardName string,
 	id strfmt.UUID,
 ) error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return errors.Errorf("shard %q does not exist locally", shardName)
@@ -1375,8 +1377,8 @@ func (i *Index) localShard(name string) *Shard {
 func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 	replProps *additional.ReplicationProperties, tenant string,
 ) error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 
 	if err := i.validateMultiTenancy(tenant); err != nil {
 		return err
@@ -1415,8 +1417,8 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 func (i *Index) IncomingMergeObject(ctx context.Context, shardName string,
 	mergeDoc objects.MergeDocument,
 ) error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	shard := i.shards.Load(shardName)
 	if shard == nil {
 		return errors.Errorf("shard %q does not exist locally", shardName)
@@ -1494,8 +1496,8 @@ func (i *Index) drop() error {
 		return nil
 	}
 
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 
 	i.shards.Range(dropShard)
 	return eg.Wait()
@@ -1506,8 +1508,8 @@ func (i *Index) drop() error {
 // To roll back the deletion, the user must call Commit(false)
 func (i *Index) dropShards(names []string) (commit func(success bool), err error) {
 	shards := make(map[string]*Shard, len(names))
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 
 	// mark deleted shards
 	for _, name := range names {
@@ -1556,8 +1558,8 @@ func (i *Index) dropShards(names []string) (commit func(success bool), err error
 }
 
 func (i *Index) Shutdown(ctx context.Context) error {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 
 	// TODO run in parallel?
 	// TODO allow every resource cleanup to run, before returning early with error
@@ -1704,8 +1706,8 @@ func (i *Index) IncomingFindDocIDs(ctx context.Context, shardName string,
 func (i *Index) batchDeleteObjects(ctx context.Context, shardDocIDs map[string][]uint64,
 	dryRun bool, replProps *additional.ReplicationProperties,
 ) (objects.BatchSimpleObjects, error) {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	before := time.Now()
 	defer i.metrics.BatchDelete(before, "delete_from_shards_total")
 
@@ -1750,8 +1752,8 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardDocIDs map[string][
 func (i *Index) IncomingDeleteObjectBatch(ctx context.Context, shardName string,
 	docIDs []uint64, dryRun bool,
 ) objects.BatchSimpleObjects {
-	i.backupStateLock.RLock()
-	defer i.backupStateLock.RUnlock()
+	i.backupMutex.RLock()
+	defer i.backupMutex.RUnlock()
 	shard := i.shards.Load(shardName)
 	if shard == nil {
 		return objects.BatchSimpleObjects{

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -287,8 +287,8 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 		return nil
 	}
 	applyCold := func() error {
-		idx.backupStateLock.RLock()
-		defer idx.backupStateLock.RUnlock()
+		idx.backupMutex.RLock()
+		defer idx.backupMutex.RUnlock()
 
 		for _, name := range shardsToCold {
 			shard, ok := idx.shards.Swap(name, nil) // mark as deactivated

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -220,7 +220,7 @@ func (i *Index) CommitReplication(shard, requestID string) interface{} {
 	if localShard == nil {
 		return nil
 	}
-	return localShard.commit(context.Background(), requestID, &i.backupStateLock)
+	return localShard.commit(context.Background(), requestID, &i.backupMutex)
 }
 
 func (i *Index) AbortReplication(shard, requestID string) interface{} {

--- a/adapters/repos/db/shard_replication.go
+++ b/adapters/repos/db/shard_replication.go
@@ -56,7 +56,7 @@ func (p *pendingReplicaTasks) delete(requestID string) {
 	p.Unlock()
 }
 
-func (s *Shard) commit(ctx context.Context, requestID string, backupReadLock *sync.RWMutex) interface{} {
+func (s *Shard) commit(ctx context.Context, requestID string, backupReadLock *backupMutex) interface{} {
 	f, ok := s.replicationMap.get(requestID)
 	if !ok {
 		return nil


### PR DESCRIPTION
### What's being changed:
This commit aims to address a deadlock issue related from concurrent interactions between backup and replication processes.
The issue can be attributed to two factors:

- The initial use use of backup mutex solely for preventing parallel backups, it didn't consider concurrent writes during metadata collections
- The use of RwMutex for synchronisation in the backup processes. Specifically, calling mutex.Lock led to the blocking of new readers, including those from the replication process, even when these readers were capable of processing.

As a result, a deadlock situation arose when at least two nodes were engaged in batch-style updates. In this context, the backup process attempted to acquire a write lock, which subsequently prevented the read mutex from being released.

To resolve this, the commit introduces improved synchronization mechanisms, ensuring that both the backup and replication processes operate harmoniously and without causing deadlocks.

Notably, this solution addresses concurrent backups by adopting a lock-free mechanism instead of relying on the existing mutex implementation. Furthermore, the mutex is now exclusively employed to prevent modifications to the class state during metadata collection. The implementation also introduces a cooperative write lock, which enables new readers to process while awaiting their turn to acquire the lock, in a manner similar to other readers. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/weaviate/weaviate-chaos-engineering/pull/110
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
