### PR TITLE
generative-palm: Support new Google PaLM modules

### DIFF
--- a/modules/text2vec-palm/config/class_settings.go
+++ b/modules/text2vec-palm/config/class_settings.go
@@ -35,10 +35,14 @@ const (
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	DefaultApiEndpoint           = "us-central1-aiplatform.googleapis.com"
-	DefaultModelID               = "textembedding-gecko"
+	DefaultModelID               = "textembedding-gecko@001"
 )
 
-var availablePalmModels = []string{DefaultModelID}
+var availablePalmModels = []string{
+	DefaultModelID,
+	"textembedding-gecko@latest",
+	"textembedding-gecko-multilingual@latest",
+}
 
 type classSettings struct {
 	cfg moduletools.ClassConfig

--- a/modules/text2vec-palm/config/class_settings_test.go
+++ b/modules/text2vec-palm/config/class_settings_test.go
@@ -37,7 +37,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 			wantApiEndpoint: "us-central1-aiplatform.googleapis.com",
 			wantProjectID:   "projectId",
-			wantModelID:     "textembedding-gecko",
+			wantModelID:     "textembedding-gecko@001",
 			wantErr:         nil,
 		},
 		{
@@ -50,7 +50,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 			wantApiEndpoint: "google.com",
 			wantProjectID:   "projectId",
-			wantModelID:     "textembedding-gecko",
+			wantModelID:     "textembedding-gecko@001",
 			wantErr:         nil,
 		},
 		{
@@ -70,7 +70,7 @@ func Test_classSettings_Validate(t *testing.T) {
 					"modelId":   "wrong-model",
 				},
 			},
-			wantErr: errors.Errorf("wrong modelId available model names are: [textembedding-gecko]"),
+			wantErr: errors.Errorf("wrong modelId available model names are: [textembedding-gecko@001 textembedding-gecko@latest textembedding-gecko-multilingual@latest]"),
 		},
 		{
 			name: "all wrong",
@@ -81,7 +81,8 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantErr: errors.Errorf("projectId cannot be empty, " +
-				"wrong modelId available model names are: [textembedding-gecko]"),
+				"wrong modelId available model names are: " +
+				"[textembedding-gecko@001 textembedding-gecko@latest textembedding-gecko-multilingual@latest]"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What's being changed:

Google announced new PaLM models this week at Google Next, this PR adds support for those:

Supported models

You can get text embeddings by using the following models:

textembedding-gecko@001 (stable)
textembedding-gecko@latest(public preview: an embeddings model with enhanced AI quality)
textembedding-gecko-multilingual@latest (public preview: an embeddings model designed to use a wide range of non-English languages.)

The default changed from textembedding-gecko to textembedding-gecko@001

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
