### PR TITLE
Fix vectorization of concepts in nearText argument

### DIFF
--- a/modules/text2vec-cohere/clients/vectorizer.go
+++ b/modules/text2vec-cohere/clients/vectorizer.go
@@ -121,7 +121,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	return &ent.VectorizationResult{
 		Text:       input,
 		Dimensions: len(resBody.Embeddings[0]),
-		Vector:     resBody.Embeddings,
+		Vectors:    resBody.Embeddings,
 	}, nil
 }
 

--- a/modules/text2vec-cohere/clients/vectorizer.go
+++ b/modules/text2vec-cohere/clients/vectorizer.go
@@ -121,7 +121,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	return &ent.VectorizationResult{
 		Text:       input,
 		Dimensions: len(resBody.Embeddings[0]),
-		Vector:     resBody.Embeddings[0],
+		Vector:     resBody.Embeddings,
 	}, nil
 }
 

--- a/modules/text2vec-cohere/clients/vectorizer_test.go
+++ b/modules/text2vec-cohere/clients/vectorizer_test.go
@@ -43,7 +43,7 @@ func TestClient(t *testing.T) {
 		}
 		expected := &ent.VectorizationResult{
 			Text:       []string{"This is my text"},
-			Vector:     [][]float32{{0.1, 0.2, 0.3}},
+			Vectors:    [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(context.Background(), []string{"This is my text"},
@@ -115,7 +115,7 @@ func TestClient(t *testing.T) {
 
 		expected := &ent.VectorizationResult{
 			Text:       []string{"This is my text"},
-			Vector:     [][]float32{{0.1, 0.2, 0.3}},
+			Vectors:    [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(ctxWithValue, []string{"This is my text"},

--- a/modules/text2vec-cohere/clients/vectorizer_test.go
+++ b/modules/text2vec-cohere/clients/vectorizer_test.go
@@ -43,7 +43,7 @@ func TestClient(t *testing.T) {
 		}
 		expected := &ent.VectorizationResult{
 			Text:       []string{"This is my text"},
-			Vector:     []float32{0.1, 0.2, 0.3},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(context.Background(), []string{"This is my text"},
@@ -115,7 +115,7 @@ func TestClient(t *testing.T) {
 
 		expected := &ent.VectorizationResult{
 			Text:       []string{"This is my text"},
-			Vector:     []float32{0.1, 0.2, 0.3},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(ctxWithValue, []string{"This is my text"},

--- a/modules/text2vec-cohere/ent/vectorization_result.go
+++ b/modules/text2vec-cohere/ent/vectorization_result.go
@@ -14,5 +14,5 @@ package ent
 type VectorizationResult struct {
 	Text       []string
 	Dimensions int
-	Vector     [][]float32
+	Vectors    [][]float32
 }

--- a/modules/text2vec-cohere/ent/vectorization_result.go
+++ b/modules/text2vec-cohere/ent/vectorization_result.go
@@ -14,5 +14,5 @@ package ent
 type VectorizationResult struct {
 	Text       []string
 	Dimensions int
-	Vector     []float32
+	Vector     [][]float32
 }

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -28,7 +28,7 @@ func (c *fakeClient) Vectorize(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     []float32{0, 1, 2, 3},
+		Vector:     [][]float32{{0, 1, 2, 3}},
 		Dimensions: 4,
 		Text:       text,
 	}, nil
@@ -40,7 +40,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     []float32{0.1, 1.1, 2.1, 3.1},
+		Vector:     [][]float32{{0.1, 1.1, 2.1, 3.1}},
 		Dimensions: 4,
 		Text:       text,
 	}, nil

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -28,7 +28,7 @@ func (c *fakeClient) Vectorize(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     [][]float32{{0, 1, 2, 3}},
+		Vectors:    [][]float32{{0, 1, 2, 3}},
 		Dimensions: 4,
 		Text:       text,
 	}, nil
@@ -40,7 +40,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     [][]float32{{0.1, 1.1, 2.1, 3.1}},
+		Vectors:    [][]float32{{0.1, 1.1, 2.1, 3.1}},
 		Dimensions: 4,
 		Text:       text,
 	}, nil

--- a/modules/text2vec-cohere/vectorizer/objects.go
+++ b/modules/text2vec-cohere/vectorizer/objects.go
@@ -138,7 +138,11 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 		return nil, err
 	}
 
-	return res.Vector, nil
+	if len(res.Vector) > 1 {
+		return v.CombineVectors(res.Vector), nil
+	}
+
+	return res.Vector[0], nil
 }
 
 func camelCaseToLower(in string) string {

--- a/modules/text2vec-cohere/vectorizer/objects.go
+++ b/modules/text2vec-cohere/vectorizer/objects.go
@@ -137,12 +137,14 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 	if err != nil {
 		return nil, err
 	}
-
-	if len(res.Vector) > 1 {
-		return v.CombineVectors(res.Vector), nil
+	if len(res.Vectors) == 0 {
+		return nil, fmt.Errorf("no vectors generated")
 	}
 
-	return res.Vector[0], nil
+	if len(res.Vectors) > 1 {
+		return v.CombineVectors(res.Vectors), nil
+	}
+	return res.Vectors[0], nil
 }
 
 func camelCaseToLower(in string) string {

--- a/modules/text2vec-cohere/vectorizer/texts.go
+++ b/modules/text2vec-cohere/vectorizer/texts.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/modules/text2vec-cohere/ent"
@@ -22,50 +21,12 @@ import (
 func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	settings ClassSettings,
 ) ([]float32, error) {
-	res, err := v.client.VectorizeQuery(ctx, []string{v.joinSentences(inputs)}, ent.VectorizationConfig{
+	res, err := v.client.VectorizeQuery(ctx, inputs, ent.VectorizationConfig{
 		Model:    settings.Model(),
 		Truncate: settings.Truncate(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "remote client vectorize")
 	}
-
-	return res.Vector, nil
-}
-
-func (v *Vectorizer) joinSentences(input []string) string {
-	if len(input) == 1 {
-		return input[0]
-	}
-
-	b := &strings.Builder{}
-	for i, sent := range input {
-		if i > 0 {
-			if v.endsWithPunctuation(input[i-1]) {
-				b.WriteString(" ")
-			} else {
-				b.WriteString(". ")
-			}
-		}
-		b.WriteString(sent)
-	}
-
-	return b.String()
-}
-
-func (v *Vectorizer) endsWithPunctuation(sent string) bool {
-	if len(sent) == 0 {
-		// treat an empty string as if it ended with punctuation so we don't add
-		// additional punctuation
-		return true
-	}
-
-	lastChar := sent[len(sent)-1]
-	switch lastChar {
-	case '.', ',', '?', '!':
-		return true
-
-	default:
-		return false
-	}
+	return v.CombineVectors(res.Vector), nil
 }

--- a/modules/text2vec-cohere/vectorizer/texts.go
+++ b/modules/text2vec-cohere/vectorizer/texts.go
@@ -28,5 +28,5 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	if err != nil {
 		return nil, errors.Wrap(err, "remote client vectorize")
 	}
-	return v.CombineVectors(res.Vector), nil
+	return v.CombineVectors(res.Vectors), nil
 }

--- a/modules/text2vec-cohere/vectorizer/texts_test.go
+++ b/modules/text2vec-cohere/vectorizer/texts_test.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,6 @@ func TestVectorizingTexts(t *testing.T) {
 	type testCase struct {
 		name                string
 		input               []string
-		expectedClientCall  string
 		expectedCohereModel string
 		cohereModel         string
 	}
@@ -36,49 +34,42 @@ func TestVectorizingTexts(t *testing.T) {
 			input:               []string{"hello"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "hello",
 		},
 		{
 			name:                "multiple words",
 			input:               []string{"hello world, this is me!"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "hello world, this is me!",
 		},
 		{
 			name:                "multiple sentences (joined with a dot)",
 			input:               []string{"this is sentence 1", "and here's number 2"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "this is sentence 1. and here's number 2",
 		},
 		{
 			name:                "multiple sentences already containing a dot",
 			input:               []string{"this is sentence 1.", "and here's number 2"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "this is sentence 1. and here's number 2",
 		},
 		{
 			name:                "multiple sentences already containing a question mark",
 			input:               []string{"this is sentence 1?", "and here's number 2"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "this is sentence 1? and here's number 2",
 		},
 		{
 			name:                "multiple sentences already containing an exclamation mark",
 			input:               []string{"this is sentence 1!", "and here's number 2"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "this is sentence 1! and here's number 2",
 		},
 		{
 			name:                "multiple sentences already containing comma",
 			input:               []string{"this is sentence 1,", "and here's number 2"},
 			cohereModel:         "large",
 			expectedCohereModel: "large",
-			expectedClientCall:  "this is sentence 1, and here's number 2",
 		},
 	}
 
@@ -95,7 +86,7 @@ func TestVectorizingTexts(t *testing.T) {
 
 			require.Nil(t, err)
 			assert.Equal(t, []float32{0.1, 1.1, 2.1, 3.1}, vec)
-			assert.Equal(t, test.expectedClientCall, strings.Join(client.lastInput, ","))
+			assert.Equal(t, test.input, client.lastInput)
 			assert.Equal(t, test.expectedCohereModel, client.lastConfig.Model)
 		})
 	}

--- a/modules/text2vec-cohere/vectorizer/todo_move_out_of_here_movements.go
+++ b/modules/text2vec-cohere/vectorizer/todo_move_out_of_here_movements.go
@@ -11,30 +11,15 @@
 
 package vectorizer
 
-import "fmt"
+import (
+	"fmt"
+
+	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
+)
 
 // CombineVectors combines all of the vector into sum of their parts
 func (v *Vectorizer) CombineVectors(vectors [][]float32) []float32 {
-	maxVectorLength := 0
-	for i := range vectors {
-		if len(vectors[i]) > maxVectorLength {
-			maxVectorLength = len(vectors[i])
-		}
-	}
-	sums := make([]float32, maxVectorLength)
-	dividers := make([]float32, maxVectorLength)
-	for _, vector := range vectors {
-		for i := 0; i < len(vector); i++ {
-			sums[i] += vector[i]
-			dividers[i]++
-		}
-	}
-	combinedVector := make([]float32, len(sums))
-	for i := 0; i < len(sums); i++ {
-		combinedVector[i] = sums[i] / dividers[i]
-	}
-
-	return combinedVector
+	return libvectorizer.CombineVectors(vectors)
 }
 
 // MoveTo moves one vector toward another

--- a/modules/text2vec-huggingface/vectorizer/texts.go
+++ b/modules/text2vec-huggingface/vectorizer/texts.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/modules/text2vec-contextionary/vectorizer"
@@ -23,63 +22,30 @@ import (
 func (v *Vectorizer) VectorizeInput(ctx context.Context, input string,
 	icheck vectorizer.ClassIndexCheck,
 ) ([]float32, error) {
-	vectorS, err := v.client.VectorizeQuery(ctx, input, ent.VectorizationConfig{}) // FIXME config?
+	res, err := v.client.VectorizeQuery(ctx, input, ent.VectorizationConfig{})
 	if err != nil {
 		return nil, err
 	}
-	return vectorS.Vector, nil
+	return res.Vector, nil
 }
 
 func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	settings ClassSettings,
 ) ([]float32, error) {
-	res, err := v.client.VectorizeQuery(ctx, v.joinSentences(inputs), ent.VectorizationConfig{
-		EndpointURL:  settings.EndpointURL(),
-		Model:        settings.QueryModel(),
-		WaitForModel: settings.OptionWaitForModel(),
-		UseGPU:       settings.OptionUseGPU(),
-		UseCache:     settings.OptionUseCache(),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "remote client vectorize")
-	}
-
-	return res.Vector, nil
-}
-
-func (v *Vectorizer) joinSentences(input []string) string {
-	if len(input) == 1 {
-		return input[0]
-	}
-
-	b := &strings.Builder{}
-	for i, sent := range input {
-		if i > 0 {
-			if v.endsWithPunctuation(input[i-1]) {
-				b.WriteString(" ")
-			} else {
-				b.WriteString(". ")
-			}
+	vectors := make([][]float32, len(inputs))
+	for i := range inputs {
+		res, err := v.client.VectorizeQuery(ctx, inputs[i], ent.VectorizationConfig{
+			EndpointURL:  settings.EndpointURL(),
+			Model:        settings.QueryModel(),
+			WaitForModel: settings.OptionWaitForModel(),
+			UseGPU:       settings.OptionUseGPU(),
+			UseCache:     settings.OptionUseCache(),
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "remote client vectorize")
 		}
-		b.WriteString(sent)
+		vectors[i] = res.Vector
 	}
 
-	return b.String()
-}
-
-func (v *Vectorizer) endsWithPunctuation(sent string) bool {
-	if len(sent) == 0 {
-		// treat an empty string as if it ended with punctuation so we don't add
-		// additional punctuation
-		return true
-	}
-
-	lastChar := sent[len(sent)-1]
-	switch lastChar {
-	case '.', ',', '?', '!':
-		return true
-
-	default:
-		return false
-	}
+	return v.CombineVectors(vectors), nil
 }

--- a/modules/text2vec-huggingface/vectorizer/texts_test.go
+++ b/modules/text2vec-huggingface/vectorizer/texts_test.go
@@ -24,7 +24,6 @@ func TestVectorizingTexts(t *testing.T) {
 	type testCase struct {
 		name                     string
 		input                    []string
-		expectedClientCall       string
 		expectedHuggingFaceModel string
 		huggingFaceModel         string
 		huggingFaceEndpointURL   string
@@ -36,56 +35,48 @@ func TestVectorizingTexts(t *testing.T) {
 			input:                    []string{"hello"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "hello",
 		},
 		{
 			name:                     "multiple words",
 			input:                    []string{"hello world, this is me!"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "hello world, this is me!",
 		},
 		{
 			name:                     "multiple sentences (joined with a dot)",
 			input:                    []string{"this is sentence 1", "and here's number 2"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "this is sentence 1. and here's number 2",
 		},
 		{
 			name:                     "multiple sentences already containing a dot",
 			input:                    []string{"this is sentence 1.", "and here's number 2"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "this is sentence 1. and here's number 2",
 		},
 		{
 			name:                     "multiple sentences already containing a question mark",
 			input:                    []string{"this is sentence 1?", "and here's number 2"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "this is sentence 1? and here's number 2",
 		},
 		{
 			name:                     "multiple sentences already containing an exclamation mark",
 			input:                    []string{"this is sentence 1!", "and here's number 2"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "this is sentence 1! and here's number 2",
 		},
 		{
 			name:                     "multiple sentences already containing comma",
 			input:                    []string{"this is sentence 1,", "and here's number 2"},
 			huggingFaceModel:         "sentence-transformers/gtr-t5-xl",
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
-			expectedClientCall:       "this is sentence 1, and here's number 2",
 		},
 		{
 			name:                     "single word with inference url",
 			input:                    []string{"hello"},
 			huggingFaceEndpointURL:   "http://url.cloud",
 			expectedHuggingFaceModel: "",
-			expectedClientCall:       "hello",
 		},
 	}
 
@@ -103,7 +94,6 @@ func TestVectorizingTexts(t *testing.T) {
 
 			require.Nil(t, err)
 			assert.Equal(t, []float32{0.1, 1.1, 2.1, 3.1}, vec)
-			assert.Equal(t, test.expectedClientCall, client.lastInput)
 			assert.Equal(t, test.expectedHuggingFaceModel, client.lastConfig.Model)
 		})
 	}

--- a/modules/text2vec-huggingface/vectorizer/todo_move_out_of_here_movements.go
+++ b/modules/text2vec-huggingface/vectorizer/todo_move_out_of_here_movements.go
@@ -11,30 +11,15 @@
 
 package vectorizer
 
-import "fmt"
+import (
+	"fmt"
+
+	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
+)
 
 // CombineVectors combines all of the vector into sum of their parts
 func (v *Vectorizer) CombineVectors(vectors [][]float32) []float32 {
-	maxVectorLength := 0
-	for i := range vectors {
-		if len(vectors[i]) > maxVectorLength {
-			maxVectorLength = len(vectors[i])
-		}
-	}
-	sums := make([]float32, maxVectorLength)
-	dividers := make([]float32, maxVectorLength)
-	for _, vector := range vectors {
-		for i := 0; i < len(vector); i++ {
-			sums[i] += vector[i]
-			dividers[i]++
-		}
-	}
-	combinedVector := make([]float32, len(sums))
-	for i := 0; i < len(sums); i++ {
-		combinedVector[i] = sums[i] / dividers[i]
-	}
-
-	return combinedVector
+	return libvectorizer.CombineVectors(vectors)
 }
 
 // MoveTo moves one vector toward another

--- a/modules/text2vec-palm/clients/palm.go
+++ b/modules/text2vec-palm/clients/palm.go
@@ -122,9 +122,9 @@ func (v *palm) vectorize(ctx context.Context, input []string, config ent.Vectori
 	}
 
 	return &ent.VectorizationResult{
-		Text:       input,
+		Texts:      input,
 		Dimensions: len(resBody.Predictions[0].Embeddings.Values),
-		Vector:     vectors,
+		Vectors:    vectors,
 	}, nil
 }
 

--- a/modules/text2vec-palm/clients/palm_test.go
+++ b/modules/text2vec-palm/clients/palm_test.go
@@ -44,8 +44,8 @@ func TestClient(t *testing.T) {
 			logger: nullLogger(),
 		}
 		expected := &ent.VectorizationResult{
-			Text:       []string{"This is my text"},
-			Vector:     [][]float32{{0.1, 0.2, 0.3}},
+			Texts:      []string{"This is my text"},
+			Vectors:    [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(context.Background(), []string{"This is my text"},
@@ -115,8 +115,8 @@ func TestClient(t *testing.T) {
 			"X-Palm-Api-Key", []string{"some-key"})
 
 		expected := &ent.VectorizationResult{
-			Text:       []string{"This is my text"},
-			Vector:     [][]float32{{0.1, 0.2, 0.3}},
+			Texts:      []string{"This is my text"},
+			Vectors:    [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(ctxWithValue, []string{"This is my text"}, ent.VectorizationConfig{})

--- a/modules/text2vec-palm/clients/palm_test.go
+++ b/modules/text2vec-palm/clients/palm_test.go
@@ -44,8 +44,8 @@ func TestClient(t *testing.T) {
 			logger: nullLogger(),
 		}
 		expected := &ent.VectorizationResult{
-			Text:       "This is my text",
-			Vector:     []float32{0.1, 0.2, 0.3},
+			Text:       []string{"This is my text"},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(context.Background(), []string{"This is my text"},
@@ -115,8 +115,8 @@ func TestClient(t *testing.T) {
 			"X-Palm-Api-Key", []string{"some-key"})
 
 		expected := &ent.VectorizationResult{
-			Text:       "This is my text",
-			Vector:     []float32{0.1, 0.2, 0.3},
+			Text:       []string{"This is my text"},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
 		res, err := c.Vectorize(ctxWithValue, []string{"This is my text"}, ent.VectorizationConfig{})

--- a/modules/text2vec-palm/ent/vectorization_result.go
+++ b/modules/text2vec-palm/ent/vectorization_result.go
@@ -12,7 +12,7 @@
 package ent
 
 type VectorizationResult struct {
-	Text       string
+	Text       []string
 	Dimensions int
-	Vector     []float32
+	Vector     [][]float32
 }

--- a/modules/text2vec-palm/ent/vectorization_result.go
+++ b/modules/text2vec-palm/ent/vectorization_result.go
@@ -12,7 +12,7 @@
 package ent
 
 type VectorizationResult struct {
-	Text       []string
+	Texts      []string
 	Dimensions int
-	Vector     [][]float32
+	Vectors    [][]float32
 }

--- a/modules/text2vec-palm/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-palm/vectorizer/fakes_for_test.go
@@ -28,9 +28,9 @@ func (c *fakeClient) Vectorize(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     []float32{0, 1, 2, 3},
+		Vector:     [][]float32{{0, 1, 2, 3}},
 		Dimensions: 4,
-		Text:       text[0],
+		Text:       text,
 	}, nil
 }
 
@@ -40,9 +40,9 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     []float32{0.1, 1.1, 2.1, 3.1},
+		Vector:     [][]float32{{0.1, 1.1, 2.1, 3.1}},
 		Dimensions: 4,
-		Text:       text[0],
+		Text:       text,
 	}, nil
 }
 

--- a/modules/text2vec-palm/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-palm/vectorizer/fakes_for_test.go
@@ -28,9 +28,9 @@ func (c *fakeClient) Vectorize(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     [][]float32{{0, 1, 2, 3}},
+		Vectors:    [][]float32{{0, 1, 2, 3}},
 		Dimensions: 4,
-		Text:       text,
+		Texts:      text,
 	}, nil
 }
 
@@ -40,9 +40,9 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	c.lastInput = text
 	c.lastConfig = cfg
 	return &ent.VectorizationResult{
-		Vector:     [][]float32{{0.1, 1.1, 2.1, 3.1}},
+		Vectors:    [][]float32{{0.1, 1.1, 2.1, 3.1}},
 		Dimensions: 4,
-		Text:       text,
+		Texts:      text,
 	}, nil
 }
 

--- a/modules/text2vec-palm/vectorizer/objects.go
+++ b/modules/text2vec-palm/vectorizer/objects.go
@@ -141,7 +141,11 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 		return nil, err
 	}
 
-	return res.Vector, nil
+	if len(res.Vector) > 1 {
+		return v.CombineVectors(res.Vector), nil
+	}
+
+	return res.Vector[0], nil
 }
 
 func camelCaseToLower(in string) string {

--- a/modules/text2vec-palm/vectorizer/objects.go
+++ b/modules/text2vec-palm/vectorizer/objects.go
@@ -140,12 +140,14 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 	if err != nil {
 		return nil, err
 	}
-
-	if len(res.Vector) > 1 {
-		return v.CombineVectors(res.Vector), nil
+	if len(res.Vectors) == 0 {
+		return nil, fmt.Errorf("no vectors generated")
 	}
 
-	return res.Vector[0], nil
+	if len(res.Vectors) > 1 {
+		return v.CombineVectors(res.Vectors), nil
+	}
+	return res.Vectors[0], nil
 }
 
 func camelCaseToLower(in string) string {

--- a/modules/text2vec-palm/vectorizer/texts.go
+++ b/modules/text2vec-palm/vectorizer/texts.go
@@ -30,5 +30,5 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 		return nil, errors.Wrap(err, "remote client vectorize")
 	}
 
-	return v.CombineVectors(res.Vector), nil
+	return v.CombineVectors(res.Vectors), nil
 }

--- a/modules/text2vec-palm/vectorizer/texts.go
+++ b/modules/text2vec-palm/vectorizer/texts.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/modules/text2vec-palm/ent"
@@ -22,7 +21,7 @@ import (
 func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	settings ClassSettings,
 ) ([]float32, error) {
-	res, err := v.client.VectorizeQuery(ctx, []string{v.joinSentences(inputs)}, ent.VectorizationConfig{
+	res, err := v.client.VectorizeQuery(ctx, inputs, ent.VectorizationConfig{
 		ApiEndpoint: settings.ApiEndpoint(),
 		ProjectID:   settings.ProjectID(),
 		Model:       settings.ModelID(),
@@ -31,42 +30,5 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 		return nil, errors.Wrap(err, "remote client vectorize")
 	}
 
-	return res.Vector, nil
-}
-
-func (v *Vectorizer) joinSentences(input []string) string {
-	if len(input) == 1 {
-		return input[0]
-	}
-
-	b := &strings.Builder{}
-	for i, sent := range input {
-		if i > 0 {
-			if v.endsWithPunctuation(input[i-1]) {
-				b.WriteString(" ")
-			} else {
-				b.WriteString(". ")
-			}
-		}
-		b.WriteString(sent)
-	}
-
-	return b.String()
-}
-
-func (v *Vectorizer) endsWithPunctuation(sent string) bool {
-	if len(sent) == 0 {
-		// treat an empty string as if it ended with punctuation so we don't add
-		// additional punctuation
-		return true
-	}
-
-	lastChar := sent[len(sent)-1]
-	switch lastChar {
-	case '.', ',', '?', '!':
-		return true
-
-	default:
-		return false
-	}
+	return v.CombineVectors(res.Vector), nil
 }

--- a/modules/text2vec-palm/vectorizer/texts_test.go
+++ b/modules/text2vec-palm/vectorizer/texts_test.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,6 @@ func TestVectorizingTexts(t *testing.T) {
 	type testCase struct {
 		name                string
 		input               []string
-		expectedClientCall  string
 		expectedApiEndpoint string
 		expectedProjectID   string
 		expectedEndpointID  string
@@ -35,53 +33,46 @@ func TestVectorizingTexts(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:               "single word",
-			input:              []string{"hello"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "hello",
+			name:              "single word",
+			input:             []string{"hello"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 		{
-			name:               "multiple words",
-			input:              []string{"hello world, this is me!"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "hello world, this is me!",
+			name:              "multiple words",
+			input:             []string{"hello world, this is me!"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 		{
-			name:               "multiple sentences (joined with a dot)",
-			input:              []string{"this is sentence 1", "and here's number 2"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "this is sentence 1. and here's number 2",
+			name:              "multiple sentences (joined with a dot)",
+			input:             []string{"this is sentence 1", "and here's number 2"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 		{
-			name:               "multiple sentences already containing a dot",
-			input:              []string{"this is sentence 1.", "and here's number 2"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "this is sentence 1. and here's number 2",
+			name:              "multiple sentences already containing a dot",
+			input:             []string{"this is sentence 1.", "and here's number 2"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 		{
-			name:               "multiple sentences already containing a question mark",
-			input:              []string{"this is sentence 1?", "and here's number 2"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "this is sentence 1? and here's number 2",
+			name:              "multiple sentences already containing a question mark",
+			input:             []string{"this is sentence 1?", "and here's number 2"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 		{
-			name:               "multiple sentences already containing an exclamation mark",
-			input:              []string{"this is sentence 1!", "and here's number 2"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "this is sentence 1! and here's number 2",
+			name:              "multiple sentences already containing an exclamation mark",
+			input:             []string{"this is sentence 1!", "and here's number 2"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 		{
-			name:               "multiple sentences already containing comma",
-			input:              []string{"this is sentence 1,", "and here's number 2"},
-			palmModel:          "large",
-			expectedPalmModel:  "large",
-			expectedClientCall: "this is sentence 1, and here's number 2",
+			name:              "multiple sentences already containing comma",
+			input:             []string{"this is sentence 1,", "and here's number 2"},
+			palmModel:         "large",
+			expectedPalmModel: "large",
 		},
 	}
 
@@ -100,7 +91,7 @@ func TestVectorizingTexts(t *testing.T) {
 
 			require.Nil(t, err)
 			assert.Equal(t, []float32{0.1, 1.1, 2.1, 3.1}, vec)
-			assert.Equal(t, test.expectedClientCall, strings.Join(client.lastInput, ","))
+			assert.Equal(t, test.input, client.lastInput)
 			assert.Equal(t, test.expectedApiEndpoint, client.lastConfig.ApiEndpoint)
 			assert.Equal(t, test.expectedProjectID, client.lastConfig.ProjectID)
 			assert.Equal(t, test.expectedEndpointID, client.lastConfig.Model)

--- a/modules/text2vec-palm/vectorizer/todo_move_out_of_here_movements.go
+++ b/modules/text2vec-palm/vectorizer/todo_move_out_of_here_movements.go
@@ -11,30 +11,15 @@
 
 package vectorizer
 
-import "fmt"
+import (
+	"fmt"
+
+	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
+)
 
 // CombineVectors combines all of the vector into sum of their parts
 func (v *Vectorizer) CombineVectors(vectors [][]float32) []float32 {
-	maxVectorLength := 0
-	for i := range vectors {
-		if len(vectors[i]) > maxVectorLength {
-			maxVectorLength = len(vectors[i])
-		}
-	}
-	sums := make([]float32, maxVectorLength)
-	dividers := make([]float32, maxVectorLength)
-	for _, vector := range vectors {
-		for i := 0; i < len(vector); i++ {
-			sums[i] += vector[i]
-			dividers[i]++
-		}
-	}
-	combinedVector := make([]float32, len(sums))
-	for i := 0; i < len(sums); i++ {
-		combinedVector[i] = sums[i] / dividers[i]
-	}
-
-	return combinedVector
+	return libvectorizer.CombineVectors(vectors)
 }
 
 // MoveTo moves one vector toward another

--- a/modules/text2vec-transformers/vectorizer/texts.go
+++ b/modules/text2vec-transformers/vectorizer/texts.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/modules/text2vec-transformers/ent"
@@ -22,49 +21,16 @@ import (
 func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	settings ClassSettings,
 ) ([]float32, error) {
-	res, err := v.client.VectorizeQuery(ctx, v.joinSentences(inputs), ent.VectorizationConfig{
-		PoolingStrategy: settings.PoolingStrategy(),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "remote client vectorize")
-	}
-
-	return res.Vector, nil
-}
-
-func (v *Vectorizer) joinSentences(input []string) string {
-	if len(input) == 1 {
-		return input[0]
-	}
-
-	b := &strings.Builder{}
-	for i, sent := range input {
-		if i > 0 {
-			if v.endsWithPunctuation(input[i-1]) {
-				b.WriteString(" ")
-			} else {
-				b.WriteString(". ")
-			}
+	vectors := make([][]float32, len(inputs))
+	for i := range inputs {
+		res, err := v.client.VectorizeQuery(ctx, inputs[i], ent.VectorizationConfig{
+			PoolingStrategy: settings.PoolingStrategy(),
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "remote client vectorize")
 		}
-		b.WriteString(sent)
+		vectors[i] = res.Vector
 	}
 
-	return b.String()
-}
-
-func (v *Vectorizer) endsWithPunctuation(sent string) bool {
-	if len(sent) == 0 {
-		// treat an empty string as if it ended with punctuation so we don't add
-		// additional punctuation
-		return true
-	}
-
-	lastChar := sent[len(sent)-1]
-	switch lastChar {
-	case '.', ',', '?', '!':
-		return true
-
-	default:
-		return false
-	}
+	return v.CombineVectors(vectors), nil
 }

--- a/modules/text2vec-transformers/vectorizer/texts_test.go
+++ b/modules/text2vec-transformers/vectorizer/texts_test.go
@@ -24,7 +24,6 @@ func TestVectorizingTexts(t *testing.T) {
 	type testCase struct {
 		name                    string
 		input                   []string
-		expectedClientCall      string
 		expectedPoolingStrategy string
 		poolingStrategy         string
 	}
@@ -35,14 +34,12 @@ func TestVectorizingTexts(t *testing.T) {
 			input:                   []string{"hello"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "hello",
 		},
 		{
 			name:                    "multiple words",
 			input:                   []string{"hello world, this is me!"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "hello world, this is me!",
 		},
 
 		{
@@ -50,7 +47,6 @@ func TestVectorizingTexts(t *testing.T) {
 			input:                   []string{"this is sentence 1", "and here's number 2"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "this is sentence 1. and here's number 2",
 		},
 
 		{
@@ -58,28 +54,24 @@ func TestVectorizingTexts(t *testing.T) {
 			input:                   []string{"this is sentence 1.", "and here's number 2"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "this is sentence 1. and here's number 2",
 		},
 		{
 			name:                    "multiple sentences already containing a question mark",
 			input:                   []string{"this is sentence 1?", "and here's number 2"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "this is sentence 1? and here's number 2",
 		},
 		{
 			name:                    "multiple sentences already containing an exclamation mark",
 			input:                   []string{"this is sentence 1!", "and here's number 2"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "this is sentence 1! and here's number 2",
 		},
 		{
 			name:                    "multiple sentences already containing comma",
 			input:                   []string{"this is sentence 1,", "and here's number 2"},
 			poolingStrategy:         "cls",
 			expectedPoolingStrategy: "cls",
-			expectedClientCall:      "this is sentence 1, and here's number 2",
 		},
 	}
 
@@ -96,7 +88,6 @@ func TestVectorizingTexts(t *testing.T) {
 
 			require.Nil(t, err)
 			assert.Equal(t, []float32{0, 1, 2, 3}, vec)
-			assert.Equal(t, test.expectedClientCall, client.lastInput)
 			assert.Equal(t, client.lastConfig.PoolingStrategy, test.expectedPoolingStrategy)
 		})
 	}

--- a/modules/text2vec-transformers/vectorizer/todo_move_out_of_here_movements.go
+++ b/modules/text2vec-transformers/vectorizer/todo_move_out_of_here_movements.go
@@ -11,30 +11,15 @@
 
 package vectorizer
 
-import "fmt"
+import (
+	"fmt"
+
+	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
+)
 
 // CombineVectors combines all of the vector into sum of their parts
 func (v *Vectorizer) CombineVectors(vectors [][]float32) []float32 {
-	maxVectorLength := 0
-	for i := range vectors {
-		if len(vectors[i]) > maxVectorLength {
-			maxVectorLength = len(vectors[i])
-		}
-	}
-	sums := make([]float32, maxVectorLength)
-	dividers := make([]float32, maxVectorLength)
-	for _, vector := range vectors {
-		for i := 0; i < len(vector); i++ {
-			sums[i] += vector[i]
-			dividers[i]++
-		}
-	}
-	combinedVector := make([]float32, len(sums))
-	for i := 0; i < len(sums); i++ {
-		combinedVector[i] = sums[i] / dividers[i]
-	}
-
-	return combinedVector
+	return libvectorizer.CombineVectors(vectors)
 }
 
 // MoveTo moves one vector toward another

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -26,7 +26,9 @@ import (
 	modgenerativeopenai "github.com/weaviate/weaviate/modules/generative-openai"
 	modgenerativepalm "github.com/weaviate/weaviate/modules/generative-palm"
 	modqnaopenai "github.com/weaviate/weaviate/modules/qna-openai"
+	modrerankercohere "github.com/weaviate/weaviate/modules/reranker-cohere"
 	modcohere "github.com/weaviate/weaviate/modules/text2vec-cohere"
+	modhuggingface "github.com/weaviate/weaviate/modules/text2vec-huggingface"
 	modopenai "github.com/weaviate/weaviate/modules/text2vec-openai"
 	modpalm "github.com/weaviate/weaviate/modules/text2vec-palm"
 )
@@ -194,6 +196,11 @@ func (d *Compose) WithText2VecPaLM() *Compose {
 	return d
 }
 
+func (d *Compose) WithText2VecHuggingFace() *Compose {
+	d.enableModules = append(d.enableModules, modhuggingface.Name)
+	return d
+}
+
 func (d *Compose) WithGenerativeOpenAI() *Compose {
 	d.enableModules = append(d.enableModules, modgenerativeopenai.Name)
 	return d
@@ -211,6 +218,11 @@ func (d *Compose) WithGenerativePaLM() *Compose {
 
 func (d *Compose) WithQnAOpenAI() *Compose {
 	d.enableModules = append(d.enableModules, modqnaopenai.Name)
+	return d
+}
+
+func (d *Compose) WithRerankerCohere() *Compose {
+	d.enableModules = append(d.enableModules, modrerankercohere.Name)
 	return d
 }
 

--- a/test/modules/many-modules/many_modules_test.go
+++ b/test/modules/many-modules/many_modules_test.go
@@ -35,8 +35,9 @@ func Test_ManyModules(t *testing.T) {
 
 		expectedModuleNames := []string{
 			"generative-cohere", "generative-palm", "generative-openai",
-			"text2vec-cohere", "text2vec-contextionary", "text2vec-openai",
+			"text2vec-cohere", "text2vec-contextionary", "text2vec-openai", "text2vec-huggingface",
 			"text2vec-palm", "text2vec-transformers", "sum-transformers", "qna-openai",
+			"reranker-cohere",
 		}
 
 		modules, ok := meta.Modules.(map[string]interface{})

--- a/test/modules/many-modules/setup_test.go
+++ b/test/modules/many-modules/setup_test.go
@@ -31,11 +31,13 @@ func TestMain(m *testing.M) {
 		WithText2VecOpenAI().
 		WithText2VecCohere().
 		WithText2VecPaLM().
+		WithText2VecHuggingFace().
 		WithGenerativeOpenAI().
 		WithGenerativeCohere().
 		WithGenerativePaLM().
 		WithSUMTransformers().
 		WithQnAOpenAI().
+		WithRerankerCohere().
 		Start(ctx)
 	if err != nil {
 		panic(errors.Wrapf(err, "cannot start"))


### PR DESCRIPTION
### What's being changed:

This fixes how we create vector using `nearText` argument when there are passed multiple `concepts`.
This PR closes #3187 issue.
 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
