### PR TITLE
Improve Resilience and Crash Safety for "Add tenants" transaction

### DIFF
--- a/adapters/handlers/rest/clusterapi/schema_component_test.go
+++ b/adapters/handlers/rest/clusterapi/schema_component_test.go
@@ -130,6 +130,10 @@ func setupManagers(t *testing.T) (*schemauc.Manager, *schemauc.Manager) {
 	state := &fakeClusterState{hosts: []string{parsedURL.Host}}
 	localManager := newSchemaManagerWithClusterStateAndClient(state, client)
 
+	// this will also mark the tx managers as ready
+	localManager.StartServing(context.Background())
+	remoteManager.StartServing(context.Background())
+
 	return localManager, remoteManager
 }
 
@@ -165,7 +169,8 @@ func newSchemaManagerWithClusterStateAndClient(clusterState *fakeClusterState,
 		config.Config{DefaultVectorizerModule: config.VectorizerModuleNone},
 		dummyParseVectorConfig, // only option for now
 		vectorizerValidator, dummyValidateInvertedConfig,
-		&fakeModuleConfig{}, clusterState, client, &fakeScaleOutManager{},
+		&fakeModuleConfig{}, clusterState, client, &fakeTxPersistence{},
+		&fakeScaleOutManager{},
 	)
 	if err != nil {
 		panic(err.Error())
@@ -183,4 +188,25 @@ func (f *fakeScaleOutManager) Scale(ctx context.Context,
 }
 
 func (f *fakeScaleOutManager) SetSchemaManager(sm scaler.SchemaManager) {
+}
+
+// does nothing as this component test does not involve crashes
+type fakeTxPersistence struct{}
+
+func (f *fakeTxPersistence) StoreTx(ctx context.Context,
+	tx *cluster.Transaction,
+) error {
+	return nil
+}
+
+func (f *fakeTxPersistence) DeleteTx(ctx context.Context,
+	txID string,
+) error {
+	return nil
+}
+
+func (f *fakeTxPersistence) IterateAll(ctx context.Context,
+	cb func(tx *cluster.Transaction),
+) error {
+	return nil
 }

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -284,6 +284,15 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		os.Exit(1)
 	}
 
+	if err := schemaManager.ResumeDanglingTxs(ctx); err != nil {
+		appState.Logger.
+			WithError(err).
+			WithField("action", "startup").
+			Fatal("schema manager: resume dangling txs")
+		os.Exit(1)
+
+	}
+
 	objectsManager := objects.NewManager(appState.Locks,
 		schemaManager, appState.ServerConfig, appState.Logger,
 		appState.Authorizer, vectorRepo, appState.Modules,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -284,7 +284,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		os.Exit(1)
 	}
 
-	if err := schemaManager.ResumeDanglingTxs(ctx); err != nil {
+	if err := schemaManager.StartServing(ctx); err != nil {
 		appState.Logger.
 			WithError(err).
 			WithField("action", "startup").

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -346,6 +346,10 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
+		if err := schemaManager.Shutdown(ctx); err != nil {
+			panic(err)
+		}
+
 		if err := repo.Shutdown(ctx); err != nil {
 			panic(err)
 		}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	modulestorage "github.com/weaviate/weaviate/adapters/repos/modules"
 	schemarepo "github.com/weaviate/weaviate/adapters/repos/schema"
+	txstore "github.com/weaviate/weaviate/adapters/repos/transactions"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/entities/replication"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -227,10 +228,22 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	// TODO: configure http transport for efficient intra-cluster comm
 	schemaTxClient := clients.NewClusterSchema(clusterHttpClient)
+	schemaTxPersistence := txstore.NewStore(
+		appState.ServerConfig.Config.Persistence.DataPath, appState.Logger)
+	schemaTxPersistence.SetUmarshalFn(schemaUC.UnmarshalTransaction)
+	if err := schemaTxPersistence.Open(); err != nil {
+		appState.Logger.
+			WithField("action", "startup").WithError(err).
+			Fatal("could not open tx repo")
+		os.Exit(1)
+
+	}
+
 	schemaManager, err := schemaUC.NewManager(migrator, schemaRepo,
 		appState.Logger, appState.Authorizer, appState.ServerConfig.Config,
 		enthnsw.ParseAndValidateConfig, appState.Modules, inverted.ValidateConfig,
-		appState.Modules, appState.Cluster, schemaTxClient, scaler,
+		appState.Modules, appState.Cluster, schemaTxClient,
+		schemaTxPersistence, scaler,
 	)
 	if err != nil {
 		appState.Logger.

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -213,7 +213,7 @@ func (s *schemaHandlers) updateShardStatus(params schema.SchemaObjectsShardsUpda
 func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 	principal *models.Principal,
 ) middleware.Responder {
-	err := s.manager.AddTenants(
+	created, err := s.manager.AddTenants(
 		params.HTTPRequest.Context(), principal, params.ClassName, params.Body)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
@@ -227,10 +227,8 @@ func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 		}
 	}
 
-	payload := params.Body
-
 	s.metricRequestsTotal.logOk(params.ClassName)
-	return schema.NewTenantsCreateOK().WithPayload(payload)
+	return schema.NewTenantsCreateOK().WithPayload(created)
 }
 
 func (s *schemaHandlers) updateTenants(params schema.TenantsUpdateParams,

--- a/adapters/repos/classifications/distributed_repo.go
+++ b/adapters/repos/classifications/distributed_repo.go
@@ -100,7 +100,7 @@ func (r *DistributedRepo) TxManager() *cluster.TxManager {
 	return r.txRemote
 }
 
-// TODO: classifications do not yet make use of the new durability guarantees
+// NOTE: classifications do not yet make use of the new durability guarantees
 // introduced by the txManager as part of v1.21.3. The reasoning behind this is
 // that the classification itself is not crash-safe anyway, so there is no
 // point. We need to decide down the line what to do with this? It is a rarely

--- a/adapters/repos/classifications/distributed_repo.go
+++ b/adapters/repos/classifications/distributed_repo.go
@@ -42,7 +42,10 @@ func NewDistributeRepo(remoteClient cluster.Client,
 	logger logrus.FieldLogger,
 ) *DistributedRepo {
 	broadcaster := cluster.NewTxBroadcaster(memberLister, remoteClient)
-	txRemote := cluster.NewTxManager(broadcaster, logger)
+	// TODO: THIS WILL PANIC! The persistence can't be nil here. Either we
+	// introduce a dummy or we refactor the current one to work for multiple
+	// purposes.
+	txRemote := cluster.NewTxManager(broadcaster, nil, logger)
 	repo := &DistributedRepo{
 		txRemote:  txRemote,
 		localRepo: localRepo,

--- a/adapters/repos/transactions/store.go
+++ b/adapters/repos/transactions/store.go
@@ -1,0 +1,148 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package txstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"go.etcd.io/bbolt"
+)
+
+var txBucket = []byte("transactions")
+
+type Store struct {
+	db           *bbolt.DB
+	log          logrus.FieldLogger
+	homeDir      string
+	unmarshaller unmarshalFn
+}
+
+func NewStore(homeDir string, logger logrus.FieldLogger) *Store {
+	return &Store{
+		homeDir: homeDir,
+		log:     logger,
+	}
+}
+
+func (s *Store) SetUmarshalFn(fn unmarshalFn) {
+	s.unmarshaller = fn
+}
+
+func (s *Store) Open() error {
+	if err := os.MkdirAll(s.homeDir, 0o777); err != nil {
+		return fmt.Errorf("create root directory %q: %w", s.homeDir, err)
+	}
+
+	path := path.Join(s.homeDir, "tx.db")
+	boltDB, err := initBoltDB(path)
+	if err != nil {
+		return fmt.Errorf("init bolt_db: %w", err)
+	}
+
+	s.db = boltDB
+
+	return nil
+}
+
+func (s *Store) StoreTx(ctx context.Context, tx *cluster.Transaction) error {
+	data, err := json.Marshal(txWrapper{
+		ID:      tx.ID,
+		Payload: tx.Payload,
+		Type:    tx.Type,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal tx: %w", err)
+	}
+
+	return s.db.Update(func(boltTx *bbolt.Tx) error {
+		b := boltTx.Bucket(txBucket)
+		return b.Put([]byte(tx.ID), data)
+	})
+}
+
+func (s *Store) DeleteTx(ctx context.Context, txId string) error {
+	return s.db.Update(func(boltTx *bbolt.Tx) error {
+		b := boltTx.Bucket(txBucket)
+		return b.Delete([]byte(txId))
+	})
+}
+
+func (s *Store) IterateAll(ctx context.Context,
+	cb func(tx *cluster.Transaction),
+) error {
+	return s.db.View(func(boltTx *bbolt.Tx) error {
+		b := boltTx.Bucket(txBucket)
+		c := b.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			var txWrap txWrapperRead
+			if err := json.Unmarshal(v, &txWrap); err != nil {
+				return err
+			}
+
+			tx := cluster.Transaction{
+				ID:   txWrap.ID,
+				Type: txWrap.Type,
+			}
+
+			pl, err := s.unmarshaller(tx.Type, txWrap.Payload)
+			if err != nil {
+				return err
+			}
+
+			tx.Payload = pl
+
+			cb(&tx)
+
+		}
+		return nil
+	})
+}
+
+func (s *Store) Close() error {
+	return nil
+}
+
+func initBoltDB(filePath string) (*bbolt.DB, error) {
+	db, err := bbolt.Open(filePath, 0o600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", filePath, err)
+	}
+
+	root := func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(txBucket)
+		return err
+	}
+
+	return db, db.Update(root)
+}
+
+type txWrapper struct {
+	ID      string                  `json:"id"`
+	Payload any                     `json:"payload"`
+	Type    cluster.TransactionType `json:"type"`
+}
+
+// delayed unmarshalling of the payload, so we can inject a specific
+// marshaller
+type txWrapperRead struct {
+	ID      string                  `json:"id"`
+	Payload json.RawMessage         `json:"payload"`
+	Type    cluster.TransactionType `json:"type"`
+}
+
+type unmarshalFn func(txType cluster.TransactionType, payload json.RawMessage) (any, error)

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -134,7 +134,7 @@ func (c *TxManager) HaveDanglingTxs(ctx context.Context,
 	allowedTypes []TransactionType,
 ) (found bool) {
 	c.persistence.IterateAll(context.Background(), func(tx *Transaction) {
-		if slices.Contains(allowedTypes, tx.Type) {
+		if !slices.Contains(allowedTypes, tx.Type) {
 			return
 		}
 		found = true

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -134,13 +134,10 @@ func (c *TxManager) HaveDanglingTxs(ctx context.Context,
 	allowedTypes []TransactionType,
 ) (found bool) {
 	c.persistence.IterateAll(context.Background(), func(tx *Transaction) {
-		if !slices.Contains(allowedTypes, tx.Type) {
-			fmt.Printf("%s not contained\n", tx.Type)
+		if slices.Contains(allowedTypes, tx.Type) {
 			return
 		}
-		fmt.Printf("%s contained\n", tx.Type)
 		found = true
-		return
 	})
 
 	return

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -132,7 +132,7 @@ func Test_Schema_Authorization(t *testing.T) {
 				"Nodes", "NodeName", "ClusterHealthScore", "ClusterStatus", "ResolveParentNodes",
 				"CopyShardingState", "TxManager", "RestoreClass",
 				"ShardOwner", "TenantShard", "ShardFromUUID", "LockGuard", "RLockGuard", "ShardReplicas",
-				"Shutdown":
+				"StartServing", "Shutdown": // internal methods to indicate readiness state
 				// don't require auth on methods which are exported because other
 				// packages need to call them for maintenance and other regular jobs,
 				// but aren't user facing
@@ -153,7 +153,7 @@ func Test_Schema_Authorization(t *testing.T) {
 					dummyParseVectorConfig, &fakeVectorizerValidator{},
 					dummyValidateInvertedConfig, &fakeModuleConfig{},
 					&fakeClusterState{hosts: []string{"node1"}}, &fakeTxClient{},
-					&fakeScaleOutManager{})
+					&fakeTxPersistence{}, &fakeScaleOutManager{})
 				require.Nil(t, err)
 
 				var args []interface{}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -131,7 +131,8 @@ func Test_Schema_Authorization(t *testing.T) {
 				"TryLock", "RLocker", "TryRLock", // introduced by sync.Mutex in go 1.18
 				"Nodes", "NodeName", "ClusterHealthScore", "ClusterStatus", "ResolveParentNodes",
 				"CopyShardingState", "TxManager", "RestoreClass",
-				"ShardOwner", "TenantShard", "ShardFromUUID", "LockGuard", "RLockGuard", "ShardReplicas":
+				"ShardOwner", "TenantShard", "ShardFromUUID", "LockGuard", "RLockGuard", "ShardReplicas",
+				"Shutdown":
 				// don't require auth on methods which are exported because other
 				// packages need to call them for maintenance and other regular jobs,
 				// but aren't user facing

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -131,6 +131,8 @@ func TestFailedCommits(t *testing.T) {
 			sm, err := newManagerWithClusterAndTx(t, clusterState, txClient, initialSchema)
 			require.Nil(t, err)
 
+			sm.StartServing(context.Background())
+
 			if test.prepare != nil {
 				test.prepare(t, sm)
 			}

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -49,7 +49,10 @@ type Manager struct {
 	RestoreError            sync.Map
 	sync.RWMutex
 
-	// TODO: explain
+	// As outlined in [*cluster.TxManager.TryResumeDanglingTxs] the current
+	// implementation isn't perfect. It does not actually know if a tx was meant
+	// to be committed or not. Instead we do a simple workaround. We check if the
+	// schema is out of sync and only then do we try to resume transactions.
 	shouldTryToResumeTx bool
 
 	schemaCache

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -182,6 +182,7 @@ func NewManager(migrator migrate.Migrator, repo SchemaStore,
 
 	m.cluster.SetCommitFn(m.handleCommit)
 	m.cluster.SetResponseFn(m.handleTxResponse)
+	m.cluster.SetAllowUnready(allowUnreadyTxs)
 	txBroadcaster.SetConsensusFunction(newReadConsensus(m.parseConfigs, m.logger))
 
 	err := m.loadOrInitializeSchema(context.Background())

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -310,7 +310,7 @@ func (m *Manager) StartServing(ctx context.Context) error {
 // dangling after a restart and retries to commit them if appropriate.
 //
 // This can only be called when all areas responding to side effects of
-// commiting a transaction are ready. In practice this means, the DB must be
+// committing a transaction are ready. In practice this means, the DB must be
 // ready to try and call this method.
 func (m *Manager) resumeDanglingTransactions(ctx context.Context) error {
 	var shouldResume bool

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -289,6 +289,10 @@ func (m *Manager) loadOrInitializeSchema(ctx context.Context) error {
 // commiting a transaction are ready. In practice this means, the DB must be
 // ready to try and call this method.
 func (m *Manager) ResumeDanglingTxs(ctx context.Context) error {
+	// only start accepting incoming connections after dangling TXs have been
+	// resumed
+	defer m.cluster.StartAcceptIncoming()
+
 	ok, err := m.cluster.TryResumeDanglingTxs(ctx, resumableTxs)
 	if err != nil {
 		return fmt.Errorf("try resuming dangling transactions: %w", err)

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -155,7 +155,8 @@ func NewManager(migrator migrate.Migrator, repo SchemaStore,
 	hnswConfigParser VectorConfigParser, vectorizerValidator VectorizerValidator,
 	invertedConfigValidator InvertedConfigValidator,
 	moduleConfig ModuleConfig, clusterState clusterState,
-	txClient cluster.Client, scaleoutManager scaleOut,
+	txClient cluster.Client, txPersistence cluster.Persistence,
+	scaleoutManager scaleOut,
 ) (*Manager, error) {
 	txBroadcaster := cluster.NewTxBroadcaster(clusterState, txClient)
 	m := &Manager{
@@ -169,7 +170,7 @@ func NewManager(migrator migrate.Migrator, repo SchemaStore,
 		vectorizerValidator:     vectorizerValidator,
 		invertedConfigValidator: invertedConfigValidator,
 		moduleConfig:            moduleConfig,
-		cluster:                 cluster.NewTxManager(txBroadcaster, logger),
+		cluster:                 cluster.NewTxManager(txBroadcaster, txPersistence, logger),
 		clusterState:            clusterState,
 		scaleOut:                scaleoutManager,
 	}

--- a/usecases/schema/startup_cluster_sync.go
+++ b/usecases/schema/startup_cluster_sync.go
@@ -64,6 +64,10 @@ func (m *Manager) startupClusterSync(ctx context.Context) error {
 	if m.cluster.HaveDanglingTxs(ctx, resumableTxs) {
 		m.logger.WithFields(logrusStartupSyncFields()).
 			Infof("schema out of sync, but there are dangling transactions, the check will be repeated after an attempt to resume those transactions")
+
+		m.LockGuard(func() {
+			m.shouldTryToResumeTx = true
+		})
 		return nil
 	}
 

--- a/usecases/schema/startup_cluster_sync_test.go
+++ b/usecases/schema/startup_cluster_sync_test.go
@@ -420,7 +420,7 @@ func newManagerWithClusterAndTx(t *testing.T, clusterState clusterState,
 		},
 		dummyParseVectorConfig, // only option for now
 		&fakeVectorizerValidator{}, dummyValidateInvertedConfig,
-		&fakeModuleConfig{}, clusterState, txClient, &fakeScaleOutManager{},
+		&fakeModuleConfig{}, clusterState, txClient, &fakeTxPersistence{}, &fakeScaleOutManager{},
 	)
 
 	return sm, err

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -79,12 +79,15 @@ func (m *Manager) AddTenants(ctx context.Context,
 		Class:   class,
 		Tenants: make([]TenantCreate, 0, len(partitions)),
 	}
-	for i := range names {
-		request.Tenants = append(request.Tenants, TenantCreate{
-			Name:   names[i],
-			Nodes:  partitions[names[i]],
-			Status: schema.ActivityStatus(validated[i].ActivityStatus),
-		})
+	for i, name := range names {
+		part, ok := partitions[name]
+		if ok {
+			request.Tenants = append(request.Tenants, TenantCreate{
+				Name:   name,
+				Nodes:  part,
+				Status: schema.ActivityStatus(validated[i].ActivityStatus),
+			})
+		}
 	}
 
 	// open cluster-wide transaction

--- a/usecases/schema/tenant_test.go
+++ b/usecases/schema/tenant_test.go
@@ -153,7 +153,7 @@ func TestAddTenants(t *testing.T) {
 		sm := newSchemaManager()
 		err := sm.AddClass(ctx, nil, test.initial)
 		if err == nil {
-			err = sm.AddTenants(ctx, nil, test.Class, test.tenants)
+			_, err = sm.AddTenants(ctx, nil, test.Class, test.tenants)
 		}
 		if len(test.errMsgs) == 0 {
 			assert.Nil(t, err)
@@ -321,7 +321,7 @@ func TestUpdateTenants(t *testing.T) {
 			t.Fatalf("%s: add class: %v", test.name, err)
 		}
 		if !test.skipAdd {
-			if err := sm.AddTenants(ctx, nil, cls, tenants); err != nil {
+			if _, err := sm.AddTenants(ctx, nil, cls, tenants); err != nil {
 				t.Fatalf("%s: add tenants: %v", test.name, err)
 			}
 		}
@@ -351,7 +351,6 @@ func TestUpdateTenants(t *testing.T) {
 func TestDeleteTenants(t *testing.T) {
 	var (
 		ctx     = context.Background()
-		mt      = &models.MultiTenancyConfig{Enabled: true}
 		tenants = []*models.Tenant{
 			{Name: "USER1"},
 			{Name: "USER2"},
@@ -382,7 +381,7 @@ func TestDeleteTenants(t *testing.T) {
 			Class:   "UnknownClass",
 			tenants: tenants,
 			initial: &models.Class{
-				Class: cls, MultiTenancyConfig: mt,
+				Class: cls, MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 				Properties:        properties,
 				ReplicationConfig: repConfig,
 			},
@@ -422,7 +421,7 @@ func TestDeleteTenants(t *testing.T) {
 				Properties:         properties,
 				ReplicationConfig:  repConfig,
 			},
-			errMsg: "tenant",
+			errMsg: "empty tenant name at index 1",
 		},
 		{
 			name:    "Success",
@@ -446,7 +445,7 @@ func TestDeleteTenants(t *testing.T) {
 			t.Fatalf("%s: add class: %v", test.name, err)
 		}
 		if test.addTenants {
-			err = sm.AddTenants(ctx, nil, test.Class, tenants)
+			_, err = sm.AddTenants(ctx, nil, test.Class, tenants)
 			if err != nil {
 				t.Fatalf("%s: add tenants: %v", test.name, err)
 			}

--- a/usecases/schema/transactions.go
+++ b/usecases/schema/transactions.go
@@ -46,6 +46,12 @@ var resumableTxs = []cluster.TransactionType{
 	addTenants,
 }
 
+// any tx that is listed here will bypass the ready-check, i.e. they will
+// execute even if the DB is unready.
+var allowUnreadyTxs = []cluster.TransactionType{
+	ReadSchema, // required at startup, does not write
+}
+
 type AddClassPayload struct {
 	Class *models.Class   `json:"class"`
 	State *sharding.State `json:"state"`

--- a/usecases/schema/transactions.go
+++ b/usecases/schema/transactions.go
@@ -40,6 +40,12 @@ const (
 	DefaultTxTTL = 60 * time.Second
 )
 
+// any tx that is listed here will be tried to commit if it is still open on
+// startup
+var resumableTxs = []cluster.TransactionType{
+	addTenants,
+}
+
 type AddClassPayload struct {
 	Class *models.Class   `json:"class"`
 	State *sharding.State `json:"state"`

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -306,7 +306,7 @@ func (s *State) GetPartitions(nodes nodes, shards []string, replFactor int64) (m
 	partitions := make(map[string][]string, len(shards))
 	for _, name := range shards {
 		if _, alreadyExists := s.Physical[name]; alreadyExists {
-			return nil, fmt.Errorf("tenant %s already exists", name)
+			continue
 		}
 		owners := make([]string, 1, replFactor)
 		node := it.Next()


### PR DESCRIPTION
This PR considerably improves the resilience and crash safety for "add tenants" transactions. It does so in multiple stages:

## Stage 1: Readiness checks
* Adds a “ready” state to the TxManager that
* Blocks shutdown while a tx is committing -> Before this change, even an orderly shutdown at the wrong moment could lead to a corrupt schema
    * Disallows incoming (write) transactions after the server receives a shutdown signal -> otherwise, commits would fail if the index for the class has already shut down
    * Disallows incoming (write) transactions while the DB is still starting up -> otherwise, commits would fail with `index is nil` if the DB is not ready yet

## Stage 2: Crash Safety

* Any time we open a tx, we now write it into a (new) boltdb storage
* Any time we successfully commit a tx, we delete the tx from boltdb storage
    * In other words, if all is fine the store will always be eventually empty 
* However, if a node crashes with an open transaction it can now resume the transaction. There are some limitations:
    * Currently only the “add_tenants” transaction is considered resumable, this is because I verified that it’s indeed idempotent, but I’m not sure yet about other txs. For example, if we replay “create class” will it lead to the class being duplicated or will it just do nothing if the class is already there
    * Currently, we don’t know if a transaction was supposed to be committed or not (for example if the kill occurs in the first phase after writing the data to disk, but before the coordinator ever sent a commit). Applying the tx now would be wrong (the other nodes never did). I took a very simple shortcut for this: I check if the schema is out of sync and only resume txs if it is. If it’s already in sync I assume that the tx was never commited and just discard it. <--- This really is just a shortcut, I think a way better option would be to communicate with other nodes to see which txs were historically considered committed, but I didn’t want to make the scope even larger and the wokaround seems to work.

## Stage 3: Fixing Remaining Bugs
The above two fixed most, but not all issues. Additionally, I could find one other bug. There was a possibility for a "Schrödinger Transaction", a tx that was both committed and aborted at the same time. The flawed logic was that if a commit had failed for some nodes, the error handler would abort the commit for other nodes. However, this lead to an unpredictable race. Depending on the speed of each request, some nodes would see the commit, others would see the abort. An out-of-sync situation was almost guaranteed. Now, the behavior as it should be for a two-phase commit: Once we decided to commit, there is no way back. If a node doesn't receive the commit signal or dies trying to honor it, it is now up to the node itself to recover (Stage 2), but we no longer jeopardize the schema of any of the other nodes.

## Chaos Testing
* I’ve created [a new chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/pull/113) to reproduce the issue. 
    * Here is an example run with `v1.21.2`[ where you can clearly see that it fails](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/6059486965/job/16442660580).
    * Here is an example run [with the latest image](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/6084000245/job/16505021414).
* This test pipeline was used throughout all stages to validate findings and fixes 

## Limitations

The main limitation is that currently, only the `add_tenants` transaction is considered resumable. This is because the transaction handling needs to be idempotent. I did not verify if other types are idempotent. As a result, any other commit type other than `add_tenants` does not benefit from the new improvements.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
