### PR TITLE
Enable unused, nolintlint; fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ linters:
     - gofumpt
     - exhaustive
     - govet
+    - unused
+    - nolintlint
 linters-settings:
   exhaustive:
     # Presence of "default" case in switch statements satisfies exhaustiveness,

--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -226,7 +226,7 @@ func (t *JsonPropertyLengthTracker) bucketFromValue(value float32) int {
 
 // Returns the value that the given bucket represents
 //
-//nolint:all
+//nolint:unused
 func (t *JsonPropertyLengthTracker) valueFromBucket(bucket int) float32 {
 	if t.UnlimitedBuckets {
 		return float32(bucket)

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -24,7 +24,6 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-//nolint:all
 func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID) error {
 	if s.isReadOnly() {
 		return storagestate.ErrStatusReadOnly

--- a/adapters/repos/db/vector/hnsw/compressed_vector_cache.go
+++ b/adapters/repos/db/vector/hnsw/compressed_vector_cache.go
@@ -22,16 +22,14 @@ import (
 )
 
 type compressedShardedLockCache struct {
-	shardedLocks []sync.RWMutex
-	cache        [][]byte
-	maxSize      int64
-	count        int64
-	cancel       chan bool
-	vectorForID  CompressedVectorForID
-	logger       logrus.FieldLogger
-	//nolint:unused
-	dims int32
-	//nolint:unused
+	shardedLocks        []sync.RWMutex
+	cache               [][]byte
+	maxSize             int64
+	count               int64
+	cancel              chan bool
+	vectorForID         CompressedVectorForID
+	logger              logrus.FieldLogger
+	dims                int32
 	trackDimensionsOnce sync.Once
 
 	// The maintenanceLock makes sure that only one maintenance operation, such
@@ -58,7 +56,6 @@ func newCompressedShardedLockCache(vecForID CompressedVectorForID, maxSize int, 
 	return vc
 }
 
-//nolint:unused
 func (c *compressedShardedLockCache) get(ctx context.Context, id uint64) ([]byte, error) {
 	c.shardedLocks[id%shardFactor].RLock()
 	vec := c.cache[id]
@@ -89,7 +86,6 @@ func (c *compressedShardedLockCache) delete(ctx context.Context, id uint64) {
 	atomic.AddInt64(&c.count, -1)
 }
 
-//nolint:unused
 func (c *compressedShardedLockCache) handleCacheMiss(ctx context.Context, id uint64) ([]byte, error) {
 	vec, err := c.vectorForID(ctx, id)
 	if err != nil {
@@ -151,7 +147,6 @@ func (c *compressedShardedLockCache) preload(id uint64, vec []byte) {
 	c.cache[id] = vec
 }
 
-//nolint:unused
 func (c *compressedShardedLockCache) grow(node uint64) {
 	if node < uint64(len(c.cache)) {
 		return

--- a/adapters/repos/db/vector/hnsw/heuristic.go
+++ b/adapters/repos/db/vector/hnsw/heuristic.go
@@ -128,7 +128,7 @@ func (h *hnsw) selectNeighborsHeuristic(input *priorityqueue.Queue,
 	// rewind and return to pool
 	returnList = returnList[:0]
 
-	// nolint:staticcheck
+	//nolint:staticcheck
 	h.pools.pqItemSlice.Put(returnList)
 
 	return nil

--- a/adapters/repos/db/vector/hnsw/vector_cache.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache.go
@@ -154,7 +154,6 @@ func (s *shardedLockCache) prefetch(id uint64) {
 	prefetchFunc(uintptr(unsafe.Pointer(&s.cache[id])))
 }
 
-//nolint:unused
 func (s *shardedLockCache) preload(id uint64, vec []float32) {
 	s.shardedLocks[id%shardFactor].Lock()
 	defer s.shardedLocks[id%shardFactor].Unlock()
@@ -167,7 +166,6 @@ func (s *shardedLockCache) preload(id uint64, vec []float32) {
 	s.cache[id] = vec
 }
 
-//nolint:unused
 func (s *shardedLockCache) grow(node uint64) {
 	if node < uint64(len(s.cache)) {
 		return
@@ -190,18 +188,15 @@ func (s *shardedLockCache) len() int32 {
 	return int32(len(s.cache))
 }
 
-//nolint:unused
 func (s *shardedLockCache) countVectors() int64 {
 	return atomic.LoadInt64(&s.count)
 }
 
-//nolint:unused
 func (s *shardedLockCache) drop() {
 	s.deleteAllVectors()
 	s.cancel <- true
 }
 
-//nolint:unused
 func (s *shardedLockCache) deleteAllVectors() {
 	s.obtainAllLocks()
 	defer s.releaseAllLocks()


### PR DESCRIPTION
### What's being changed:

This PR modifies golangci-lint config by enabling `unused` and `nolintlint` linters. Also, removes redundant `//nolint:` directives.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
