### PR TITLE
Fix issues with references and toClass autodetect

### DIFF
--- a/test/acceptance/multi_tenancy/batch_add_tenant_references_test.go
+++ b/test/acceptance/multi_tenancy/batch_add_tenant_references_test.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/weaviate/weaviate/client/batch"
+
 	"github.com/google/uuid"
 
 	"github.com/go-openapi/strfmt"
@@ -236,18 +238,13 @@ func TestBatchAddTenantReferences(t *testing.T) {
 		}
 
 		resp, err := helper.AddReferences(t, refs)
-		require.Nil(t, err)
-		require.NotNil(t, resp)
-		require.Len(t, resp, 1)
-		require.Empty(t, resp[0].To)
-		require.Empty(t, resp[0].From)
-		require.NotNil(t, resp[0].Result)
-		require.NotNil(t, resp[0].Result.Errors)
-		require.Len(t, resp[0].Result.Errors.Error, 1)
-		require.NotNil(t, resp[0].Result.Errors.Error[0])
-		expectedMsg := fmt.Sprintf(`target: object %s/%s not found for tenant %q`,
+		require.NotNil(t, err)
+		require.Nil(t, resp)
+
+		errParsed := err.(*batch.BatchReferencesCreateInternalServerError)
+		expectedMsg := fmt.Sprintf(`batch validation: target: object %s/%s not found for tenant %q`,
 			className2, mtObject2DiffTenant.ID, tenantName1)
-		assert.Equal(t, expectedMsg, resp[0].Result.Errors.Error[0].Message)
+		assert.Equal(t, expectedMsg, errParsed.Payload.Error[0].Message)
 	})
 
 	t.Run("add tenant reference - from MT class to single tenant class", func(t *testing.T) {
@@ -284,17 +281,11 @@ func TestBatchAddTenantReferences(t *testing.T) {
 		}
 
 		resp, err := helper.AddReferences(t, refs)
-		require.Nil(t, err)
-		require.NotNil(t, resp)
-		require.Len(t, resp, 1)
-		require.Empty(t, resp[0].To)
-		require.Empty(t, resp[0].From)
-		require.NotNil(t, resp[0].Result)
-		require.NotNil(t, resp[0].Result.Errors)
-		require.Len(t, resp[0].Result.Errors.Error, 1)
-		require.NotNil(t, resp[0].Result.Errors.Error[0])
-		expectedMsg := "invalid reference: cannot reference a multi-tenant enabled class from a non multi-tenant enabled class"
-		assert.Equal(t, expectedMsg, resp[0].Result.Errors.Error[0].Message)
+		require.NotNil(t, err)
+		require.Nil(t, resp)
+		errParsed := err.(*batch.BatchReferencesCreateInternalServerError)
+		expectedMsg := "batch validation: invalid reference: cannot reference a multi-tenant enabled class from a non multi-tenant enabled class"
+		assert.Equal(t, expectedMsg, errParsed.Payload.Error[0].Message)
 	})
 }
 

--- a/test/acceptance/objects/crefs_test.go
+++ b/test/acceptance/objects/crefs_test.go
@@ -374,8 +374,12 @@ func TestBatchRefsWithoutFromAndToClass(t *testing.T) {
 	}
 
 	postRefParams := batch.NewBatchReferencesCreateParams().WithBody(batchRefs)
-	_, err = helper.Client(t).Batch.BatchReferencesCreate(postRefParams, nil)
-	require.NotNil(t, err) // error triggered
+	resp3, err := helper.Client(t).Batch.BatchReferencesCreate(postRefParams, nil)
+	require.Nil(t, err)
+	require.NotNil(t, resp3)
+	for i := range resp3.Payload {
+		require.NotNil(t, resp3.Payload[i].Result.Errors)
+	}
 }
 
 func TestBatchRefsWithoutToClass(t *testing.T) {

--- a/test/acceptance/objects/crefs_test.go
+++ b/test/acceptance/objects/crefs_test.go
@@ -819,8 +819,8 @@ func Test_CREFWithCardinalityMany_UsingPostReference(t *testing.T) {
 		"name": "My City",
 		"hasPlaces": []interface{}{
 			map[string]interface{}{
-				"beacon": fmt.Sprintf("weaviate://localhost/%s", place1ID.String()),
-				"href":   fmt.Sprintf("/v1/objects/%s", place1ID.String()),
+				"beacon": fmt.Sprintf("weaviate://localhost/%s/%s", placeClass.Class, place1ID.String()),
+				"href":   fmt.Sprintf("/v1/objects/%s/%s", placeClass.Class, place1ID.String()),
 			},
 		},
 	}, actualThunk)
@@ -843,12 +843,12 @@ func Test_CREFWithCardinalityMany_UsingPostReference(t *testing.T) {
 
 	expectedRefs := []interface{}{
 		map[string]interface{}{
-			"beacon": fmt.Sprintf("weaviate://localhost/%s", place1ID.String()),
-			"href":   fmt.Sprintf("/v1/objects/%s", place1ID.String()),
+			"beacon": fmt.Sprintf("weaviate://localhost/%s/%s", placeClass.Class, place1ID.String()),
+			"href":   fmt.Sprintf("/v1/objects/%s/%s", placeClass.Class, place1ID.String()),
 		},
 		map[string]interface{}{
-			"beacon": fmt.Sprintf("weaviate://localhost/%s", place2ID.String()),
-			"href":   fmt.Sprintf("/v1/objects/%s", place2ID.String()),
+			"beacon": fmt.Sprintf("weaviate://localhost/%s/%s", placeClass.Class, place2ID.String()),
+			"href":   fmt.Sprintf("/v1/objects/%s/%s", placeClass.Class, place2ID.String()),
 		},
 	}
 

--- a/test/acceptance/objects/helpers_for_test.go
+++ b/test/acceptance/objects/helpers_for_test.go
@@ -40,12 +40,13 @@ func assertCreateObject(t *testing.T, className string, schema map[string]interf
 	return objectID
 }
 
-func assertCreateObjectWithID(t *testing.T, className string, id strfmt.UUID, schema map[string]interface{}) {
+func assertCreateObjectWithID(t *testing.T, className, tenant string, id strfmt.UUID, schema map[string]interface{}) {
 	params := objects.NewObjectsCreateParams().WithBody(
 		&models.Object{
 			ID:         id,
 			Class:      className,
 			Properties: schema,
+			Tenant:     tenant,
 		})
 
 	resp, err := helper.Client(t).Objects.ObjectsCreate(params, nil)

--- a/test/acceptance/objects/rapid_updates_add_reference_test.go
+++ b/test/acceptance/objects/rapid_updates_add_reference_test.go
@@ -94,14 +94,14 @@ func Test_RapidlyAddingReferences(t *testing.T) {
 
 	t.Run("adding all objects (without referencing)", func(t *testing.T) {
 		t.Run("source object", func(t *testing.T) {
-			assertCreateObjectWithID(t, sourceClass, sourceID, map[string]interface{}{
+			assertCreateObjectWithID(t, sourceClass, "", sourceID, map[string]interface{}{
 				"name": "Source Object",
 			})
 		})
 
 		t.Run("target objects", func(t *testing.T) {
 			for i, id := range targetIDs {
-				assertCreateObjectWithID(t, targetClass, id, map[string]interface{}{
+				assertCreateObjectWithID(t, targetClass, "", id, map[string]interface{}{
 					"name": fmt.Sprintf("target object %d", i),
 				})
 			}

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -109,7 +109,7 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 	}
 	for i, ref := range batchReferences {
 		// get to class from property datatype
-		if ref.To.Class != "" || ref.From.Class == "" {
+		if ref.To.Class != "" {
 			continue
 		}
 		className := string(ref.From.Class)

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
@@ -53,6 +55,12 @@ func (b *BatchManager) addReferences(ctx context.Context, principal *models.Prin
 	}
 
 	batchReferences := b.validateReferencesConcurrently(ctx, principal, refs)
+	for i := range batchReferences {
+		if batchReferences[i].Err != nil {
+			return nil, errors.Wrap(batchReferences[i].Err, "batch validation")
+		}
+	}
+
 	if err := b.autodetectToClass(ctx, principal, batchReferences); err != nil {
 		return nil, err
 	}
@@ -101,7 +109,7 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 	}
 	for i, ref := range batchReferences {
 		// get to class from property datatype
-		if ref.To.Class != "" {
+		if ref.To.Class != "" || ref.From.Class == "" {
 			continue
 		}
 		className := string(ref.From.Class)

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -17,8 +17,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
@@ -55,11 +53,6 @@ func (b *BatchManager) addReferences(ctx context.Context, principal *models.Prin
 	}
 
 	batchReferences := b.validateReferencesConcurrently(ctx, principal, refs)
-	for i := range batchReferences {
-		if batchReferences[i].Err != nil {
-			return nil, errors.Wrap(batchReferences[i].Err, "batch validation")
-		}
-	}
 
 	if err := b.autodetectToClass(ctx, principal, batchReferences); err != nil {
 		return nil, err
@@ -109,7 +102,7 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 	}
 	for i, ref := range batchReferences {
 		// get to class from property datatype
-		if ref.To.Class != "" {
+		if ref.To.Class != "" || ref.Err != nil {
 			continue
 		}
 		className := string(ref.From.Class)

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -112,12 +112,14 @@ func (b *BatchManager) autodetectToClass(ctx context.Context,
 		if !ok {
 			class := scheme.FindClassByName(ref.From.Class)
 			if class == nil {
-				return NewErrInvalidUserInput("class for ref does not exist: "+className+": %v", err)
+				batchReferences[i].Err = fmt.Errorf("class %s does not exist", className)
+				continue
 			}
 
 			prop, err := schema.GetPropertyByName(class, propName)
 			if err != nil {
-				return NewErrInvalidUserInput("get prop: %v", err)
+				batchReferences[i].Err = fmt.Errorf("property %s does not exist for class %s", propName, className)
+				continue
 			}
 			if len(prop.DataType) > 1 {
 				continue // can't auto-detect for multi-target

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -75,6 +75,7 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		if replace {
 			input.Ref.Class = toClass
 			input.Ref.Beacon = toBeacon
+			targetRef.Class = string(toClass)
 		}
 	}
 

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -59,26 +58,31 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		return &Error{"cannot lock", StatusInternalServerError, err}
 	}
 	defer unlock()
-
 	validator := validation.New(m.vectorRepo.Exists, m.config, repl)
-	if err := input.validate(ctx, principal, validator, m.schemaManager, tenant); err != nil {
+	targetRef, err := input.validate(principal, validator, m.schemaManager)
+	if err != nil {
 		if errors.As(err, &ErrMultiTenancy{}) {
 			return &Error{"validate inputs", StatusUnprocessableEntity, err}
 		}
 		return &Error{"validate inputs", StatusBadRequest, err}
 	}
 
-	if !deprecatedEndpoint {
-		if input.Class != "" && strings.Count(string(input.Ref.Beacon), "/") == 3 {
-			toClass, toBeacon, replace, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Ref.Beacon)
-			if err != nil {
-				return err
-			}
-			if replace {
-				input.Ref.Class = toClass
-				input.Ref.Beacon = toBeacon
-			}
+	if input.Class != "" && targetRef.Class == "" {
+		toClass, toBeacon, replace, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, input.Ref.Beacon)
+		if err != nil {
+			return err
 		}
+		if replace {
+			input.Ref.Class = toClass
+			input.Ref.Beacon = toBeacon
+		}
+	}
+
+	if err := input.validateExistence(ctx, validator, tenant, targetRef); err != nil {
+		return &Error{"validate existence", StatusBadRequest, err}
+	}
+
+	if !deprecatedEndpoint {
 		ok, err := m.vectorRepo.Exists(ctx, input.Class, input.ID, repl, tenant)
 		if err != nil {
 			switch err.(type) {
@@ -137,21 +141,28 @@ type AddReferenceInput struct {
 }
 
 func (req *AddReferenceInput) validate(
-	ctx context.Context,
 	principal *models.Principal,
 	v *validation.Validator,
-	sm schemaManager, tenant string,
-) error {
+	sm schemaManager,
+) (*crossref.Ref, error) {
 	if err := validateReferenceName(req.Class, req.Property); err != nil {
-		return err
+		return nil, err
 	}
-	if err := v.ValidateSingleRef(ctx, &req.Ref, "validate reference", tenant); err != nil {
-		return err
+	ref, err := v.ValidateSingleRef(&req.Ref)
+	if err != nil {
+		return nil, err
 	}
 
 	schema, err := sm.GetSchema(principal)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return validateReferenceSchema(req.Class, req.Property, schema)
+	return ref, validateReferenceSchema(req.Class, req.Property, schema)
+}
+
+func (req *AddReferenceInput) validateExistence(
+	ctx context.Context,
+	v *validation.Validator, tenant string, ref *crossref.Ref,
+) error {
+	return v.ValidateExistence(ctx, ref, "validate reference", tenant)
 }

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -50,7 +50,7 @@ func Test_ReferencesAddDeprecated(t *testing.T) {
 		}, nil)
 		expectedRefProperty := "hasAnimals"
 		source := crossref.NewSource(schema.ClassName(cls), schema.PropertyName(expectedRefProperty), id)
-		target := crossref.New("localhost", "", "d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
+		target := crossref.New("localhost", "Animal", "d18c8e5e-a339-4c15-8af6-56b0cfe33ce7")
 		m.repo.On("AddReference", source, target).Return(nil)
 		m.modulesProvider.On("UsingRef2Vec", mock.Anything).Return(false)
 
@@ -142,23 +142,23 @@ func Test_ReferenceAdd(t *testing.T) {
 		},
 		{
 			Name: "get schema",
-			Req:  req, Stage: 2,
+			Req:  req, Stage: 1,
 			ErrSchema: anyErr,
 			WantCode:  StatusBadRequest,
 		},
 		{
 			Name: "empty data type",
-			Req:  AddReferenceInput{Class: cls, ID: id, Property: "emptyType", Ref: ref}, Stage: 2,
+			Req:  AddReferenceInput{Class: cls, ID: id, Property: "emptyType", Ref: ref}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{
 			Name: "primitive data type",
-			Req:  AddReferenceInput{Class: cls, ID: id, Property: "name", Ref: ref}, Stage: 2,
+			Req:  AddReferenceInput{Class: cls, ID: id, Property: "name", Ref: ref}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{
 			Name: "unknown property",
-			Req:  AddReferenceInput{Class: cls, ID: id, Property: "unknown", Ref: ref}, Stage: 2,
+			Req:  AddReferenceInput{Class: cls, ID: id, Property: "unknown", Ref: ref}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{
@@ -303,23 +303,23 @@ func Test_ReferenceUpdate(t *testing.T) {
 		},
 		{
 			Name: "get schema",
-			Req:  req, Stage: 2,
+			Req:  req, Stage: 1,
 			ErrSchema: anyErr,
 			WantCode:  StatusBadRequest,
 		},
 		{
 			Name: "empty data type",
-			Req:  PutReferenceInput{Class: cls, ID: id, Property: "emptyType", Refs: refs}, Stage: 2,
+			Req:  PutReferenceInput{Class: cls, ID: id, Property: "emptyType", Refs: refs}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{
 			Name: "primitive data type",
-			Req:  PutReferenceInput{Class: cls, ID: id, Property: "name", Refs: refs}, Stage: 2,
+			Req:  PutReferenceInput{Class: cls, ID: id, Property: "name", Refs: refs}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{
 			Name: "unknown property",
-			Req:  PutReferenceInput{Class: cls, ID: id, Property: "unknown", Refs: refs}, Stage: 2,
+			Req:  PutReferenceInput{Class: cls, ID: id, Property: "unknown", Refs: refs}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -41,7 +41,7 @@ func Test_ReferencesAddDeprecated(t *testing.T) {
 			},
 		}
 		m := newFakeGetManager(zooAnimalSchemaForTest())
-		m.repo.On("Exists", "", mock.Anything).Return(true, nil)
+		m.repo.On("Exists", "Animal", mock.Anything).Return(true, nil)
 		m.repo.On("ObjectByID", mock.Anything, mock.Anything, mock.Anything).Return(&search.Result{
 			ClassName: cls,
 			Schema: map[string]interface{}{
@@ -211,7 +211,7 @@ func Test_ReferenceAdd(t *testing.T) {
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			m.modulesProvider.On("UsingRef2Vec", mock.Anything).Return(false)
 			if tc.Stage >= 2 {
-				m.repo.On("Exists", "", refID).Return(true, tc.ErrTargetExists).Once()
+				m.repo.On("Exists", "Animal", refID).Return(true, tc.ErrTargetExists).Once()
 			}
 			if tc.Stage >= 3 {
 				m.repo.On("Exists", tc.Req.Class, tc.Req.ID).Return(!tc.SrcNotFound, tc.ErrSrcExists).Once()

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -15,12 +15,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
 
@@ -72,7 +72,8 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	defer unlock()
 
 	validator := validation.New(m.vectorRepo.Exists, m.config, repl)
-	if err := input.validate(ctx, principal, validator, m.schemaManager, tenant); err != nil {
+	parsedTargetRefs, err := input.validate(ctx, principal, validator, m.schemaManager, tenant)
+	if err != nil {
 		if errors.As(err, &ErrMultiTenancy{}) {
 			return &Error{"bad inputs", StatusUnprocessableEntity, err}
 		}
@@ -80,7 +81,7 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	}
 
 	for i, ref := range input.Refs {
-		if strings.Count(string(ref.Beacon), "/") == 3 {
+		if parsedTargetRefs[i].Class == "" {
 			toClass, toBeacon, replace, err := m.autodetectToClass(ctx, principal, input.Class, input.Property, ref.Beacon)
 			if err != nil {
 				return err
@@ -91,6 +92,10 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 				input.Refs[i].Beacon = toBeacon
 			}
 		}
+		if err := input.validateExistence(ctx, validator, tenant, parsedTargetRefs[i]); err != nil {
+			return &Error{"validate existence", StatusBadRequest, err}
+		}
+
 	}
 
 	obj := res.Object()
@@ -112,19 +117,27 @@ func (req *PutReferenceInput) validate(
 	principal *models.Principal,
 	v *validation.Validator,
 	sm schemaManager, tenant string,
-) error {
+) ([]*crossref.Ref, error) {
 	if err := validateReferenceName(req.Class, req.Property); err != nil {
-		return err
+		return nil, err
 	}
-	if err := v.ValidateMultipleRef(ctx, req.Refs, "validate references", tenant); err != nil {
-		return err
+	refs, err := v.ValidateMultipleRef(ctx, req.Refs, "validate references", tenant)
+	if err != nil {
+		return nil, err
 	}
 
 	schema, err := sm.GetSchema(principal)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return validateReferenceSchema(req.Class, req.Property, schema)
+	return refs, validateReferenceSchema(req.Class, req.Property, schema)
+}
+
+func (req *PutReferenceInput) validateExistence(
+	ctx context.Context,
+	v *validation.Validator, tenant string, ref *crossref.Ref,
+) error {
+	return v.ValidateExistence(ctx, ref, "validate reference", tenant)
 }
 
 // validateNames validates class and property names

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -90,6 +90,7 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 			if replace {
 				input.Refs[i].Class = toClass
 				input.Refs[i].Beacon = toBeacon
+				parsedTargetRefs[i].Class = string(toClass)
 			}
 		}
 		if err := input.validateExistence(ctx, validator, tenant, parsedTargetRefs[i]); err != nil {

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -98,18 +98,20 @@ func validateClass(class string) error {
 }
 
 // ValidateSingleRef validates a single ref based on location URL and existence of the object in the database
-func (v *Validator) ValidateSingleRef(ctx context.Context, cref *models.SingleRef,
-	errorVal string, tenant string,
-) error {
+func (v *Validator) ValidateSingleRef(cref *models.SingleRef) (*crossref.Ref, error) {
 	ref, err := crossref.ParseSingleRef(cref)
 	if err != nil {
-		return fmt.Errorf("invalid reference: %s", err)
+		return nil, fmt.Errorf("invalid reference: %s", err)
 	}
 
 	if !ref.Local {
-		return fmt.Errorf("unrecognized cross-ref ref format")
+		return nil, fmt.Errorf("unrecognized cross-ref ref format")
 	}
 
+	return ref, nil
+}
+
+func (v *Validator) ValidateExistence(ctx context.Context, ref *crossref.Ref, errorVal string, tenant string) error {
 	// locally check for object existence
 	ok, err := v.exists(ctx, ref.Class, ref.TargetID, v.replicationProps, tenant)
 	if err != nil {
@@ -134,16 +136,20 @@ func (v *Validator) ValidateSingleRef(ctx context.Context, cref *models.SingleRe
 
 func (v *Validator) ValidateMultipleRef(ctx context.Context, refs models.MultipleRef,
 	errorVal string, tenant string,
-) error {
+) ([]*crossref.Ref, error) {
+	parsedRefs := make([]*crossref.Ref, len(refs))
+
 	if refs == nil {
-		return nil
+		return parsedRefs, nil
 	}
 
-	for _, ref := range refs {
-		err := v.ValidateSingleRef(ctx, ref, errorVal, tenant)
+	for i, ref := range refs {
+		parsedRef, err := v.ValidateSingleRef(ref)
 		if err != nil {
-			return err
+			return nil, err
 		}
+		parsedRefs[i] = parsedRef
+
 	}
-	return nil
+	return parsedRefs, nil
 }

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -101,7 +101,7 @@ func validateClass(class string) error {
 func (v *Validator) ValidateSingleRef(cref *models.SingleRef) (*crossref.Ref, error) {
 	ref, err := crossref.ParseSingleRef(cref)
 	if err != nil {
-		return nil, fmt.Errorf("invalid reference: %s", err)
+		return nil, fmt.Errorf("invalid reference: %w", err)
 	}
 
 	if !ref.Local {

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -488,8 +488,12 @@ func (v *Validator) parseAndValidateSingleRef(ctx context.Context, propertyName 
 		return nil, fmt.Errorf("invalid reference: %s", err)
 	}
 	errVal := fmt.Sprintf("'cref' %s:%s", className, propertyName)
-	err = v.ValidateSingleRef(ctx, ref.SingleRef(), errVal, "")
+	ref, err = v.ValidateSingleRef(ref.SingleRef())
 	if err != nil {
+		return nil, err
+	}
+
+	if err = v.ValidateExistence(ctx, ref, errVal, ""); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### What's being changed:

Fixes two bugs:
- When using autodetection of the toClass, the validation would run before the autodetection => if there was another object with the same uuid it could grab the wrong one
- Skip references with error for class autodetection in reference batches

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

