### PR TITLE
3rd party module timeout

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -729,7 +729,7 @@ func initModules(ctx context.Context, appState *state.State) error {
 	// TODO: gh-1481 don't pass entire appState in, but only what's needed. Probably only
 	// config?
 	moduleParams := moduletools.NewInitParams(storageProvider, appState,
-		appState.Logger)
+		appState.ServerConfig.Config, appState.Logger)
 
 	appState.Logger.
 		WithField("action", "startup").

--- a/entities/moduletools/init_params.go
+++ b/entities/moduletools/init_params.go
@@ -11,24 +11,29 @@
 
 package moduletools
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/usecases/config"
+)
 
 type ModuleInitParams interface {
 	GetStorageProvider() StorageProvider
 	GetAppState() interface{}
 	GetLogger() logrus.FieldLogger
+	GetConfig() config.Config
 }
 
 type InitParams struct {
 	storageProvider StorageProvider
 	appState        interface{}
+	config          config.Config
 	logger          logrus.FieldLogger
 }
 
 func NewInitParams(storageProvider StorageProvider, appState interface{},
-	logger logrus.FieldLogger,
+	config config.Config, logger logrus.FieldLogger,
 ) ModuleInitParams {
-	return &InitParams{storageProvider, appState, logger}
+	return &InitParams{storageProvider, appState, config, logger}
 }
 
 func (p *InitParams) GetStorageProvider() StorageProvider {
@@ -41,4 +46,8 @@ func (p *InitParams) GetAppState() interface{} {
 
 func (p *InitParams) GetLogger() logrus.FieldLogger {
 	return p.logger
+}
+
+func (p *InitParams) GetConfig() config.Config {
+	return p.config
 }

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -40,11 +40,11 @@ type cohere struct {
 	logger     logrus.FieldLogger
 }
 
-func New(apiKey string, logger logrus.FieldLogger) *cohere {
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *cohere {
 	return &cohere{
 		apiKey: apiKey,
 		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: timeout,
 		},
 		host:   "https://api.cohere.ai",
 		path:   "/v1/generate",

--- a/modules/generative-cohere/clients/cohere_meta_test.go
+++ b/modules/generative-cohere/clients/cohere_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -18,12 +18,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	generativemodels "github.com/weaviate/weaviate/usecases/modulecomponents/additional/models"
 )
 
 func nullLogger() logrus.FieldLogger {
@@ -33,64 +33,71 @@ func nullLogger() logrus.FieldLogger {
 
 func TestGetAnswer(t *testing.T) {
 	textProperties := []map[string]string{{"prop": "My name is john"}}
-	t.Run("when the server has a successful answer ", func(t *testing.T) {
-		handler := &testAnswerHandler{
-			t: t,
+
+	tests := []struct {
+		name           string
+		answer         generateResponse
+		timeout        time.Duration
+		expectedResult string
+	}{
+		{
+			name: "when the server has a successful aner",
 			answer: generateResponse{
-				Generations: []generation{
-					{
-						Text: "John",
-					},
-				},
-				Error: nil,
+				Generations: []generation{{Text: "John"}},
+				Error:       nil,
 			},
-		}
-		server := httptest.NewServer(handler)
-		defer server.Close()
-
-		c := New("apiKey", nullLogger())
-		c.host = server.URL
-
-		expected := generativemodels.GenerateResponse{
-			Result: ptString("John"),
-		}
-
-		res, err := c.GenerateAllResults(context.Background(), textProperties, "What is my name?", nil)
-
-		assert.Nil(t, err)
-		assert.Equal(t, expected, *res)
-	})
-
-	t.Run("when the server has a an error", func(t *testing.T) {
-		server := httptest.NewServer(&testAnswerHandler{
-			t: t,
+			expectedResult: "John",
+		},
+		{
+			name: "when the server has a an error",
 			answer: generateResponse{
 				Error: &cohereApiError{
 					Message: "some error from the server",
 				},
 			},
+		},
+		{
+			name:    "when the server does not respond in time",
+			answer:  generateResponse{Error: &cohereApiError{Message: "context deadline exceeded"}},
+			timeout: time.Second,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &testAnswerHandler{
+				t:       t,
+				answer:  test.answer,
+				timeout: test.timeout,
+			}
+			server := httptest.NewServer(handler)
+			defer server.Close()
+
+			c := New("apiKey", test.timeout, nullLogger())
+			c.host = server.URL
+
+			res, err := c.GenerateAllResults(context.Background(), textProperties, "What is my name?", nil)
+
+			if test.answer.Error != nil {
+				assert.Contains(t, err.Error(), test.answer.Error.Message)
+			} else {
+				assert.Equal(t, test.expectedResult, *res.Result)
+			}
 		})
-		defer server.Close()
-
-		c := New("apiKey", nullLogger())
-		c.host = server.URL
-
-		_, err := c.GenerateAllResults(context.Background(), textProperties, "What is my name?", nil)
-
-		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "some error from the server")
-	})
+	}
 }
 
 type testAnswerHandler struct {
 	t *testing.T
 	// the test handler will report as not ready before the time has passed
-	answer generateResponse
+	answer  generateResponse
+	timeout time.Duration
 }
 
 func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	assert.Equal(f.t, "/v1/generate", r.URL.String())
 	assert.Equal(f.t, http.MethodPost, r.Method)
+
+	time.Sleep(f.timeout)
 
 	if f.answer.Error != nil && f.answer.Error.Message != "" {
 		outBytes, err := json.Marshal(f.answer)
@@ -112,8 +119,4 @@ func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	require.Nil(f.t, err)
 
 	w.Write(outBytes)
-}
-
-func ptString(in string) *string {
-	return &in
 }

--- a/modules/generative-cohere/module.go
+++ b/modules/generative-cohere/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -54,19 +55,19 @@ func (m *GenerativeCohereModule) Type() modulecapabilities.ModuleType {
 func (m *GenerativeCohereModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init q/a")
 	}
 
 	return nil
 }
 
-func (m *GenerativeCohereModule) initAdditional(ctx context.Context,
+func (m *GenerativeCohereModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	apiKey := os.Getenv("COHERE_APIKEY")
 
-	client := clients.New(apiKey, logger)
+	client := clients.New(apiKey, timeout, logger)
 
 	m.generative = client
 

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -56,13 +56,13 @@ type openai struct {
 	logger             logrus.FieldLogger
 }
 
-func New(openAIApiKey, openAIOrganization, azureApiKey string, logger logrus.FieldLogger) *openai {
+func New(openAIApiKey, openAIOrganization, azureApiKey string, timeout time.Duration, logger logrus.FieldLogger) *openai {
 	return &openai{
 		openAIApiKey:       openAIApiKey,
 		openAIOrganization: openAIOrganization,
 		azureApiKey:        azureApiKey,
 		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: timeout,
 		},
 		buildUrl: buildUrlFn,
 		logger:   logger,

--- a/modules/generative-openai/clients/openai_meta_test.go
+++ b/modules/generative-openai/clients/openai_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New("", "", "", nullLogger())
+		c := New("", "", "", 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -59,7 +59,7 @@ func TestGetAnswer(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		c := New("openAIApiKey", "", "", nullLogger())
+		c := New("openAIApiKey", "", "", 0, nullLogger())
 		c.buildUrl = func(isLegacy bool, resourceName, deploymentID string) (string, error) {
 			return fakeBuildUrl(server.URL, isLegacy, resourceName, deploymentID)
 		}
@@ -85,7 +85,7 @@ func TestGetAnswer(t *testing.T) {
 		})
 		defer server.Close()
 
-		c := New("openAIApiKey", "", "", nullLogger())
+		c := New("openAIApiKey", "", "", 0, nullLogger())
 		c.buildUrl = func(isLegacy bool, resourceName, deploymentID string) (string, error) {
 			return fakeBuildUrl(server.URL, isLegacy, resourceName, deploymentID)
 		}

--- a/modules/generative-openai/module.go
+++ b/modules/generative-openai/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -54,21 +55,21 @@ func (m *GenerativeOpenAIModule) Type() modulecapabilities.ModuleType {
 func (m *GenerativeOpenAIModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init q/a")
 	}
 
 	return nil
 }
 
-func (m *GenerativeOpenAIModule) initAdditional(ctx context.Context,
+func (m *GenerativeOpenAIModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	openAIApiKey := os.Getenv("OPENAI_APIKEY")
 	openAIOrganization := os.Getenv("OPENAI_ORGANIZATION")
 	azureApiKey := os.Getenv("AZURE_APIKEY")
 
-	client := clients.New(openAIApiKey, openAIOrganization, azureApiKey, logger)
+	client := clients.New(openAIApiKey, openAIOrganization, azureApiKey, timeout, logger)
 
 	m.generative = client
 

--- a/modules/generative-palm/clients/palm.go
+++ b/modules/generative-palm/clients/palm.go
@@ -43,11 +43,11 @@ type palm struct {
 	logger     logrus.FieldLogger
 }
 
-func New(apiKey string, logger logrus.FieldLogger) *palm {
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *palm {
 	return &palm{
 		apiKey: apiKey,
 		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: timeout,
 		},
 		buildUrlFn: buildURL,
 		logger:     logger,

--- a/modules/generative-palm/clients/palm_meta_test.go
+++ b/modules/generative-palm/clients/palm_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/generative-palm/module.go
+++ b/modules/generative-palm/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -54,19 +55,19 @@ func (m *GenerativePaLMModule) Type() modulecapabilities.ModuleType {
 func (m *GenerativePaLMModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init q/a")
 	}
 
 	return nil
 }
 
-func (m *GenerativePaLMModule) initAdditional(ctx context.Context,
+func (m *GenerativePaLMModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	apiKey := os.Getenv("PALM_APIKEY")
 
-	client := clients.New(apiKey, logger)
+	client := clients.New(apiKey, timeout, logger)
 
 	m.generative = client
 

--- a/modules/img2vec-neural/clients/startup_test.go
+++ b/modules/img2vec-neural/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/img2vec-neural/clients/vectorizer.go
+++ b/modules/img2vec-neural/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,11 +31,13 @@ type vectorizer struct {
 	logger     logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *vectorizer {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
-		origin:     origin,
-		httpClient: &http.Client{},
-		logger:     logger,
+		origin: origin,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/img2vec-neural/module.go
+++ b/modules/img2vec-neural/module.go
@@ -54,7 +54,7 @@ func (m *ImageModule) Type() modulecapabilities.ModuleType {
 func (m *ImageModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initVectorizer(ctx, params.GetLogger()); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -65,7 +65,7 @@ func (m *ImageModule) Init(ctx context.Context,
 	return nil
 }
 
-func (m *ImageModule) initVectorizer(ctx context.Context,
+func (m *ImageModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	// TODO: proper config management
@@ -74,7 +74,7 @@ func (m *ImageModule) initVectorizer(ctx context.Context,
 		return errors.Errorf("required variable IMAGE_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, logger)
+	client := clients.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote vectorizer")
 	}

--- a/modules/multi2vec-bind/clients/meta_test.go
+++ b/modules/multi2vec-bind/clients/meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/multi2vec-bind/clients/startup_test.go
+++ b/modules/multi2vec-bind/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/multi2vec-bind/clients/vectorizer.go
+++ b/modules/multi2vec-bind/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,11 +31,13 @@ type vectorizer struct {
 	logger     logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *vectorizer {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
-		origin:     origin,
-		httpClient: &http.Client{},
-		logger:     logger,
+		origin: origin,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/multi2vec-bind/clients/vectorizer_test.go
+++ b/modules/multi2vec-bind/clients/vectorizer_test.go
@@ -37,7 +37,7 @@ func TestVectorize(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.Vectorize(context.Background(), []string{"hello"},
 			[]string{"image-encoding"}, nil, nil, nil, nil, nil)
 
@@ -68,7 +68,7 @@ func TestVectorize(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		_, err := c.Vectorize(context.Background(), []string{"hello"},
 			[]string{"image-encoding"}, []string{}, []string{}, []string{}, []string{}, []string{})
 

--- a/modules/multi2vec-bind/module.go
+++ b/modules/multi2vec-bind/module.go
@@ -87,7 +87,7 @@ func (m *BindModule) Type() modulecapabilities.ModuleType {
 func (m *BindModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initVectorizer(ctx, params.GetLogger()); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -137,7 +137,7 @@ func (m *BindModule) InitExtension(modules []modulecapabilities.Module) error {
 	return nil
 }
 
-func (m *BindModule) initVectorizer(ctx context.Context,
+func (m *BindModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	// TODO: proper config management
@@ -146,7 +146,7 @@ func (m *BindModule) initVectorizer(ctx context.Context,
 		return errors.Errorf("required variable BIND_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, logger)
+	client := clients.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote vectorizer")
 	}

--- a/modules/multi2vec-clip/clients/meta_test.go
+++ b/modules/multi2vec-clip/clients/meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/multi2vec-clip/clients/startup_test.go
+++ b/modules/multi2vec-clip/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/multi2vec-clip/clients/vectorizer.go
+++ b/modules/multi2vec-clip/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,11 +31,13 @@ type vectorizer struct {
 	logger     logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *vectorizer {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
-		origin:     origin,
-		httpClient: &http.Client{},
-		logger:     logger,
+		origin: origin,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/multi2vec-clip/clients/vectorizer_test.go
+++ b/modules/multi2vec-clip/clients/vectorizer_test.go
@@ -37,7 +37,7 @@ func TestVectorize(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.Vectorize(context.Background(), []string{"hello"},
 			[]string{"image-encoding"})
 
@@ -60,7 +60,7 @@ func TestVectorize(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		_, err := c.Vectorize(context.Background(), []string{"hello"},
 			[]string{"image-encoding"})
 

--- a/modules/multi2vec-clip/module.go
+++ b/modules/multi2vec-clip/module.go
@@ -70,7 +70,7 @@ func (m *ClipModule) Type() modulecapabilities.ModuleType {
 func (m *ClipModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initVectorizer(ctx, params.GetLogger()); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -100,7 +100,7 @@ func (m *ClipModule) InitExtension(modules []modulecapabilities.Module) error {
 	return nil
 }
 
-func (m *ClipModule) initVectorizer(ctx context.Context,
+func (m *ClipModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	// TODO: proper config management
@@ -109,7 +109,7 @@ func (m *ClipModule) initVectorizer(ctx context.Context,
 		return errors.Errorf("required variable CLIP_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, logger)
+	client := clients.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote vectorizer")
 	}

--- a/modules/ner-transformers/clients/ner.go
+++ b/modules/ner-transformers/clients/ner.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -50,10 +51,10 @@ type nerResponse struct {
 	Tokens []tokenResponse `json:"tokens"`
 }
 
-func New(origin string, logger logrus.FieldLogger) *ner {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *ner {
 	return &ner{
 		origin:     origin,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: timeout},
 		logger:     logger,
 	}
 }

--- a/modules/ner-transformers/clients/ner_meta_test.go
+++ b/modules/ner-transformers/clients/ner_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/ner-transformers/clients/ner_test.go
+++ b/modules/ner-transformers/clients/ner_test.go
@@ -43,7 +43,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.GetTokens(context.Background(), "prop",
 			"I work at Apple")
 
@@ -79,7 +79,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.GetTokens(context.Background(), "prop",
 			"I work at Apple")
 
@@ -104,7 +104,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		_, err := c.GetTokens(context.Background(), "prop",
 			"I work at Apple")
 

--- a/modules/ner-transformers/clients/startup_test.go
+++ b/modules/ner-transformers/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/ner-transformers/module.go
+++ b/modules/ner-transformers/module.go
@@ -52,13 +52,13 @@ func (m *NERModule) Type() modulecapabilities.ModuleType {
 func (m *NERModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init additional")
 	}
 	return nil
 }
 
-func (m *NERModule) initAdditional(ctx context.Context,
+func (m *NERModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	uri := os.Getenv("NER_INFERENCE_API")
@@ -66,7 +66,7 @@ func (m *NERModule) initAdditional(ctx context.Context,
 		return errors.Errorf("required variable NER_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, logger)
+	client := clients.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote ner module")
 	}

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -49,12 +50,12 @@ type qna struct {
 	logger             logrus.FieldLogger
 }
 
-func New(openAIApiKey, openAIOrganization, azureApiKey string, logger logrus.FieldLogger) *qna {
+func New(openAIApiKey, openAIOrganization, azureApiKey string, timeout time.Duration, logger logrus.FieldLogger) *qna {
 	return &qna{
 		openAIApiKey:       openAIApiKey,
 		openAIOrganization: openAIOrganization,
 		azureApiKey:        azureApiKey,
-		httpClient:         &http.Client{},
+		httpClient:         &http.Client{Timeout: timeout},
 		buildUrlFn:         buildUrl,
 		logger:             logger,
 	}

--- a/modules/qna-openai/clients/qna_meta_test.go
+++ b/modules/qna-openai/clients/qna_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New("", "", "", nullLogger())
+		c := New("", "", "", 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/qna-openai/clients/qna_test.go
+++ b/modules/qna-openai/clients/qna_test.go
@@ -58,7 +58,7 @@ func TestGetAnswer(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		c := New("openAIApiKey", "", "", nullLogger())
+		c := New("openAIApiKey", "", "", 0, nullLogger())
 		c.buildUrlFn = func(resourceName, deploymentID string) (string, error) {
 			return fakeBuildUrl(server.URL, resourceName, deploymentID)
 		}
@@ -86,7 +86,7 @@ func TestGetAnswer(t *testing.T) {
 		})
 		defer server.Close()
 
-		c := New("openAIApiKey", "", "", nullLogger())
+		c := New("openAIApiKey", "", "", 0, nullLogger())
 		c.buildUrlFn = func(resourceName, deploymentID string) (string, error) {
 			return fakeBuildUrl(server.URL, resourceName, deploymentID)
 		}

--- a/modules/qna-openai/module.go
+++ b/modules/qna-openai/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -59,7 +60,7 @@ func (m *QnAModule) Type() modulecapabilities.ModuleType {
 func (m *QnAModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init q/a")
 	}
 
@@ -129,14 +130,14 @@ func (m *QnAModule) InitDependency(modules []modulecapabilities.Module) error {
 	return nil
 }
 
-func (m *QnAModule) initAdditional(ctx context.Context,
+func (m *QnAModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	openAIApiKey := os.Getenv("OPENAI_APIKEY")
 	openAIOrganization := os.Getenv("OPENAI_ORGANIZATION")
 	azureApiKey := os.Getenv("AZURE_APIKEY")
 
-	client := clients.New(openAIApiKey, openAIOrganization, azureApiKey, logger)
+	client := clients.New(openAIApiKey, openAIOrganization, azureApiKey, timeout, logger)
 
 	m.qna = client
 

--- a/modules/qna-transformers/clients/qna.go
+++ b/modules/qna-transformers/clients/qna.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -31,10 +32,10 @@ type qna struct {
 	logger     logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *qna {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *qna {
 	return &qna{
 		origin:     origin,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: timeout},
 		logger:     logger,
 	}
 }

--- a/modules/qna-transformers/clients/qna_meta_test.go
+++ b/modules/qna-transformers/clients/qna_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/qna-transformers/clients/qna_test.go
+++ b/modules/qna-transformers/clients/qna_test.go
@@ -39,7 +39,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.Answer(context.Background(), "My name is John",
 			"What is my name?")
 		assert.Nil(t, err)
@@ -72,7 +72,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.Answer(context.Background(), "My name is John",
 			"What is my name?")
 
@@ -94,7 +94,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		_, err := c.Answer(context.Background(), "My name is John",
 			"What is my name?")
 

--- a/modules/qna-transformers/clients/startup_test.go
+++ b/modules/qna-transformers/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/qna-transformers/module.go
+++ b/modules/qna-transformers/module.go
@@ -59,7 +59,7 @@ func (m *QnAModule) Type() modulecapabilities.ModuleType {
 func (m *QnAModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -129,7 +129,7 @@ func (m *QnAModule) InitDependency(modules []modulecapabilities.Module) error {
 	return nil
 }
 
-func (m *QnAModule) initAdditional(ctx context.Context,
+func (m *QnAModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	// TODO: proper config management
@@ -138,7 +138,7 @@ func (m *QnAModule) initAdditional(ctx context.Context,
 		return errors.Errorf("required variable QNA_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, logger)
+	client := clients.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote vectorizer")
 	}

--- a/modules/ref2vec-centroid/module_test.go
+++ b/modules/ref2vec-centroid/module_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func TestRef2VecCentroid(t *testing.T) {
@@ -36,7 +37,7 @@ func TestRef2VecCentroid(t *testing.T) {
 	defer cancel()
 	sp := newFakeStorageProvider(t)
 	logger, _ := test.NewNullLogger()
-	params := moduletools.NewInitParams(sp, nil, logger)
+	params := moduletools.NewInitParams(sp, nil, config.Config{}, logger)
 
 	mod := New()
 	classConfig := fakeClassConfig(mod.ClassConfigDefaults())

--- a/modules/reranker-cohere/clients/ranker.go
+++ b/modules/reranker-cohere/clients/ranker.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -42,10 +43,10 @@ type client struct {
 	logger       logrus.FieldLogger
 }
 
-func New(apiKey string, logger logrus.FieldLogger) *client {
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *client {
 	return &client{
 		apiKey:       apiKey,
-		httpClient:   &http.Client{},
+		httpClient:   &http.Client{Timeout: timeout},
 		host:         "https://api.cohere.ai",
 		path:         "/v1/rerank",
 		maxDocuments: 1000,

--- a/modules/reranker-cohere/clients/ranker_test.go
+++ b/modules/reranker-cohere/clients/ranker_test.go
@@ -48,7 +48,7 @@ func TestRank(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		c := New("apiKey", nullLogger())
+		c := New("apiKey", 0, nullLogger())
 		c.host = server.URL
 
 		expected := &ent.RankResult{
@@ -78,7 +78,7 @@ func TestRank(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		c := New("apiKey", nullLogger())
+		c := New("apiKey", 0, nullLogger())
 		c.host = server.URL
 
 		_, err := c.Rank(context.Background(), "I work at Apple", []string{"Where do I work?"}, nil)
@@ -132,7 +132,7 @@ func TestRank(t *testing.T) {
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
-		c := New("apiKey", nullLogger())
+		c := New("apiKey", 0, nullLogger())
 		c.host = server.URL
 		// this will trigger 4 go routines
 		c.maxDocuments = 2

--- a/modules/reranker-cohere/module.go
+++ b/modules/reranker-cohere/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -52,18 +53,18 @@ func (m *ReRankerCohereModule) Type() modulecapabilities.ModuleType {
 func (m *ReRankerCohereModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init cross encoder")
 	}
 
 	return nil
 }
 
-func (m *ReRankerCohereModule) initAdditional(ctx context.Context,
+func (m *ReRankerCohereModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	apiKey := os.Getenv("COHERE_APIKEY")
-	client := clients.New(apiKey, logger)
+	client := clients.New(apiKey, timeout, logger)
 	m.reranker = client
 	m.additionalPropertiesProvider = rerankeradditional.NewRankerProvider(m.reranker)
 	return nil

--- a/modules/reranker-transformers/clients/ranker.go
+++ b/modules/reranker-transformers/clients/ranker.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -38,10 +39,10 @@ type client struct {
 	logger       logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *client {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *client {
 	return &client{
 		origin:       origin,
-		httpClient:   &http.Client{},
+		httpClient:   &http.Client{Timeout: timeout},
 		maxDocuments: 32,
 		logger:       logger,
 	}

--- a/modules/reranker-transformers/clients/ranker_meta_test.go
+++ b/modules/reranker-transformers/clients/ranker_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/reranker-transformers/clients/ranker_test.go
+++ b/modules/reranker-transformers/clients/ranker_test.go
@@ -40,7 +40,7 @@ func TestGetScore(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.Rank(context.Background(), "Where do I work?", []string{"I work at Apple"}, nil)
 
 		assert.Nil(t, err)
@@ -63,7 +63,7 @@ func TestGetScore(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		_, err := c.Rank(context.Background(), "prop",
 			[]string{"I work at Apple"}, nil)
 
@@ -124,7 +124,7 @@ func TestGetScore(t *testing.T) {
 		})
 		defer server.Close()
 
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		c.maxDocuments = 2
 
 		query := "Where do I work?"

--- a/modules/reranker-transformers/clients/startup_test.go
+++ b/modules/reranker-transformers/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/reranker-transformers/module.go
+++ b/modules/reranker-transformers/module.go
@@ -53,14 +53,14 @@ func (m *ReRankerModule) Type() modulecapabilities.ModuleType {
 func (m *ReRankerModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init re encoder")
 	}
 
 	return nil
 }
 
-func (m *ReRankerModule) initAdditional(ctx context.Context,
+func (m *ReRankerModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	uri := os.Getenv("RERANKER_INFERENCE_API")
@@ -68,7 +68,7 @@ func (m *ReRankerModule) initAdditional(ctx context.Context,
 		return errors.Errorf("required variable RERANKER_INFERENCE_API is not set")
 	}
 
-	client := client.New(uri, logger)
+	client := client.New(uri, timeout, logger)
 
 	m.reranker = client
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {

--- a/modules/sum-transformers/client/client.go
+++ b/modules/sum-transformers/client/client.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -45,11 +46,13 @@ type sumResponse struct {
 	Summary []summaryResponse `json:"summary"`
 }
 
-func New(origin string, logger logrus.FieldLogger) *client {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *client {
 	return &client{
-		origin:     origin,
-		httpClient: &http.Client{},
-		logger:     logger,
+		origin: origin,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/sum-transformers/client/startup_test.go
+++ b/modules/sum-transformers/client/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/sum-transformers/client/sum_meta_test.go
+++ b/modules/sum-transformers/client/sum_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/sum-transformers/client/sum_test.go
+++ b/modules/sum-transformers/client/sum_test.go
@@ -39,7 +39,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		res, err := c.GetSummary(context.Background(), "prop",
 			"I work at Apple")
 
@@ -60,7 +60,7 @@ func TestGetAnswer(t *testing.T) {
 			},
 		})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		_, err := c.GetSummary(context.Background(), "prop",
 			"I work at Apple")
 

--- a/modules/sum-transformers/module.go
+++ b/modules/sum-transformers/module.go
@@ -52,13 +52,13 @@ func (m *SUMModule) Type() modulecapabilities.ModuleType {
 func (m *SUMModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	if err := m.initAdditional(ctx, params.GetLogger()); err != nil {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
 		return errors.Wrap(err, "init additional")
 	}
 	return nil
 }
 
-func (m *SUMModule) initAdditional(ctx context.Context,
+func (m *SUMModule) initAdditional(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	uri := os.Getenv("SUM_INFERENCE_API")
@@ -66,7 +66,7 @@ func (m *SUMModule) initAdditional(ctx context.Context,
 		return errors.Errorf("required variable SUM_INFERENCE_API is not set")
 	}
 
-	client := client.New(uri, logger)
+	client := client.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote sum module")
 	}

--- a/modules/text-spellcheck/clients/spellcheck.go
+++ b/modules/text-spellcheck/clients/spellcheck.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -44,11 +45,13 @@ type spellCheck struct {
 	logger     logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *spellCheck {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *spellCheck {
 	return &spellCheck{
-		origin:     origin,
-		httpClient: &http.Client{},
-		logger:     logger,
+		origin: origin,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/text-spellcheck/clients/spellcheck_meta_test.go
+++ b/modules/text-spellcheck/clients/spellcheck_meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/text-spellcheck/clients/startup_test.go
+++ b/modules/text-spellcheck/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/text-spellcheck/module.go
+++ b/modules/text-spellcheck/module.go
@@ -59,7 +59,7 @@ func (m *SpellCheckModule) Init(ctx context.Context,
 		return errors.Errorf("required variable SPELLCHECK_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, params.GetLogger())
+	client := clients.New(uri, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger())
 
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote spell check module")

--- a/modules/text2vec-cohere/clients/vectorizer.go
+++ b/modules/text2vec-cohere/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -42,10 +43,12 @@ type vectorizer struct {
 	logger     logrus.FieldLogger
 }
 
-func New(apiKey string, logger logrus.FieldLogger) *vectorizer {
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
-		apiKey:     apiKey,
-		httpClient: &http.Client{},
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
 		urlBuilder: newCohereUrlBuilder(),
 		logger:     logger,
 	}

--- a/modules/text2vec-cohere/module.go
+++ b/modules/text2vec-cohere/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -71,7 +72,7 @@ func (m *CohereModule) Init(ctx context.Context,
 ) error {
 	m.logger = params.GetLogger()
 
-	if err := m.initVectorizer(ctx, m.logger); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, m.logger); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -100,11 +101,11 @@ func (m *CohereModule) InitExtension(modules []modulecapabilities.Module) error 
 	return nil
 }
 
-func (m *CohereModule) initVectorizer(ctx context.Context,
+func (m *CohereModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	apiKey := os.Getenv("COHERE_APIKEY")
-	client := clients.New(apiKey, logger)
+	client := clients.New(apiKey, timeout, logger)
 
 	m.vectorizer = vectorizer.New(client)
 	m.metaProvider = client

--- a/modules/text2vec-gpt4all/clients/meta_test.go
+++ b/modules/text2vec-gpt4all/clients/meta_test.go
@@ -25,7 +25,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when the server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		meta, err := c.MetaInfo()
 
 		assert.Nil(t, err)

--- a/modules/text2vec-gpt4all/clients/startup_test.go
+++ b/modules/text2vec-gpt4all/clients/startup_test.go
@@ -28,14 +28,14 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when the server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		err := c.WaitForStartup(context.Background(), 50*time.Millisecond)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("when the server is down", func(t *testing.T) {
-		c := New("http://nothing-running-at-this-url", nullLogger())
+		c := New("http://nothing-running-at-this-url", 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := c.WaitForStartup(ctx, 150*time.Millisecond)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(1 * time.Minute),
 		})
-		c := New(server.URL, nullLogger())
+		c := New(server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -65,7 +65,7 @@ func TestWaitForStartup(t *testing.T) {
 				t:         t,
 				readyTime: time.Now().Add(100 * time.Millisecond),
 			})
-			c := New(server.URL, nullLogger())
+			c := New(server.URL, 0, nullLogger())
 			defer server.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()

--- a/modules/text2vec-gpt4all/clients/vectorizer.go
+++ b/modules/text2vec-gpt4all/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,11 +31,13 @@ type client struct {
 	logger     logrus.FieldLogger
 }
 
-func New(origin string, logger logrus.FieldLogger) *client {
+func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *client {
 	return &client{
-		origin:     origin,
-		httpClient: &http.Client{},
-		logger:     logger,
+		origin: origin,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/text2vec-gpt4all/module.go
+++ b/modules/text2vec-gpt4all/module.go
@@ -73,7 +73,7 @@ func (m *GPT4AllModule) Init(ctx context.Context,
 ) error {
 	m.logger = params.GetLogger()
 
-	if err := m.initVectorizer(ctx, m.logger); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, m.logger); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -102,7 +102,7 @@ func (m *GPT4AllModule) InitExtension(modules []modulecapabilities.Module) error
 	return nil
 }
 
-func (m *GPT4AllModule) initVectorizer(ctx context.Context,
+func (m *GPT4AllModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	uri := os.Getenv("GPT4ALL_INFERENCE_API")
@@ -110,7 +110,7 @@ func (m *GPT4AllModule) initVectorizer(ctx context.Context,
 		return errors.New("required variable GPT4ALL_INFERENCE_API is not set")
 	}
 
-	client := clients.New(uri, logger)
+	client := clients.New(uri, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote vectorizer")
 	}

--- a/modules/text2vec-huggingface/clients/vectorizer.go
+++ b/modules/text2vec-huggingface/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -57,10 +58,12 @@ type vectorizer struct {
 	logger                logrus.FieldLogger
 }
 
-func New(apiKey string, logger logrus.FieldLogger) *vectorizer {
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
-		apiKey:                apiKey,
-		httpClient:            &http.Client{},
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
 		bertEmbeddingsDecoder: newBertEmbeddingsDecoder(),
 		logger:                logger,
 	}

--- a/modules/text2vec-huggingface/module.go
+++ b/modules/text2vec-huggingface/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -71,7 +72,7 @@ func (m *HuggingFaceModule) Init(ctx context.Context,
 ) error {
 	m.logger = params.GetLogger()
 
-	if err := m.initVectorizer(ctx, m.logger); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, m.logger); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -100,11 +101,11 @@ func (m *HuggingFaceModule) InitExtension(modules []modulecapabilities.Module) e
 	return nil
 }
 
-func (m *HuggingFaceModule) initVectorizer(ctx context.Context,
+func (m *HuggingFaceModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	apiKey := os.Getenv("HUGGINGFACE_APIKEY")
-	client := clients.New(apiKey, logger)
+	client := clients.New(apiKey, timeout, logger)
 
 	m.vectorizer = vectorizer.New(client)
 	m.metaProvider = client

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -70,14 +71,16 @@ type vectorizer struct {
 	logger             logrus.FieldLogger
 }
 
-func New(openAIApiKey, openAIOrganization, azureApiKey string, logger logrus.FieldLogger) *vectorizer {
+func New(openAIApiKey, openAIOrganization, azureApiKey string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
 		openAIApiKey:       openAIApiKey,
 		openAIOrganization: openAIOrganization,
 		azureApiKey:        azureApiKey,
-		httpClient:         &http.Client{},
-		buildUrlFn:         buildUrl,
-		logger:             logger,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		buildUrlFn: buildUrl,
+		logger:     logger,
 	}
 }
 

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -33,7 +33,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 
-		c := New("apiKey", "", "", nullLogger())
+		c := New("apiKey", "", "", 0, nullLogger())
 		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
 			return server.URL, nil
 		}
@@ -56,7 +56,7 @@ func TestClient(t *testing.T) {
 	t.Run("when the context is expired", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
-		c := New("apiKey", "", "", nullLogger())
+		c := New("apiKey", "", "", 0, nullLogger())
 		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
 			return server.URL, nil
 		}
@@ -76,7 +76,7 @@ func TestClient(t *testing.T) {
 			serverError: errors.Errorf("nope, not gonna happen"),
 		})
 		defer server.Close()
-		c := New("apiKey", "", "", nullLogger())
+		c := New("apiKey", "", "", 0, nullLogger())
 		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
 			return server.URL, nil
 		}
@@ -91,7 +91,7 @@ func TestClient(t *testing.T) {
 	t.Run("when OpenAI key is passed using X-Openai-Api-Key header", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
-		c := New("", "", "", nullLogger())
+		c := New("", "", "", 0, nullLogger())
 		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
 			return server.URL, nil
 		}
@@ -117,7 +117,7 @@ func TestClient(t *testing.T) {
 	t.Run("when OpenAI key is empty", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
-		c := New("", "", "", nullLogger())
+		c := New("", "", "", 0, nullLogger())
 		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
 			return server.URL, nil
 		}
@@ -136,7 +136,7 @@ func TestClient(t *testing.T) {
 	t.Run("when X-Openai-Api-Key header is passed but empty", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
-		c := New("", "", "", nullLogger())
+		c := New("", "", "", 0, nullLogger())
 		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
 			return server.URL, nil
 		}
@@ -285,7 +285,7 @@ func Test_getModelString(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				v := New("apiKey", "", "", nullLogger())
+				v := New("apiKey", "", "", 0, nullLogger())
 				if got := v.getModelString(tt.args.docType, tt.args.model, "document", tt.args.version); got != tt.want {
 					t.Errorf("vectorizer.getModelString() = %v, want %v", got, tt.want)
 				}
@@ -355,7 +355,7 @@ func Test_getModelString(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				v := New("apiKey", "", "", nullLogger())
+				v := New("apiKey", "", "", 0, nullLogger())
 				if got := v.getModelString(tt.args.docType, tt.args.model, "query", tt.args.version); got != tt.want {
 					t.Errorf("vectorizer.getModelString() = %v, want %v", got, tt.want)
 				}

--- a/modules/text2vec-openai/module.go
+++ b/modules/text2vec-openai/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -72,7 +73,7 @@ func (m *OpenAIModule) Init(ctx context.Context,
 ) error {
 	m.logger = params.GetLogger()
 
-	if err := m.initVectorizer(ctx, m.logger); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, m.logger); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -101,14 +102,14 @@ func (m *OpenAIModule) InitExtension(modules []modulecapabilities.Module) error 
 	return nil
 }
 
-func (m *OpenAIModule) initVectorizer(ctx context.Context,
+func (m *OpenAIModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	openAIApiKey := os.Getenv("OPENAI_APIKEY")
 	openAIOrganization := os.Getenv("OPENAI_ORGANIZATION")
 	azureApiKey := os.Getenv("AZURE_APIKEY")
 
-	client := clients.New(openAIApiKey, openAIOrganization, azureApiKey, logger)
+	client := clients.New(openAIApiKey, openAIOrganization, azureApiKey, timeout, logger)
 
 	m.vectorizer = vectorizer.New(client)
 	m.metaProvider = client

--- a/modules/text2vec-palm/clients/palm.go
+++ b/modules/text2vec-palm/clients/palm.go
@@ -37,11 +37,11 @@ type palm struct {
 	logger       logrus.FieldLogger
 }
 
-func New(apiKey string, logger logrus.FieldLogger) *palm {
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *palm {
 	return &palm{
 		apiKey: apiKey,
 		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
+			Timeout: timeout,
 		},
 		urlBuilderFn: buildURL,
 		logger:       logger,

--- a/modules/text2vec-palm/module.go
+++ b/modules/text2vec-palm/module.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/weaviate/weaviate/modules/text2vec-palm/config"
 
@@ -73,7 +74,7 @@ func (m *PalmModule) Init(ctx context.Context,
 ) error {
 	m.logger = params.GetLogger()
 
-	if err := m.initVectorizer(ctx, m.logger); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, m.logger); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -102,11 +103,11 @@ func (m *PalmModule) InitExtension(modules []modulecapabilities.Module) error {
 	return nil
 }
 
-func (m *PalmModule) initVectorizer(ctx context.Context,
+func (m *PalmModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	apiKey := os.Getenv("PALM_APIKEY")
-	client := clients.New(apiKey, logger)
+	client := clients.New(apiKey, timeout, logger)
 
 	m.vectorizer = vectorizer.New(client)
 	m.metaProvider = client

--- a/modules/text2vec-transformers/clients/meta_test.go
+++ b/modules/text2vec-transformers/clients/meta_test.go
@@ -24,7 +24,7 @@ func TestGetMeta(t *testing.T) {
 	t.Run("when common server is providing meta", func(t *testing.T) {
 		server := httptest.NewServer(&testMetaHandler{t: t})
 		defer server.Close()
-		v := New(server.URL, server.URL, nullLogger())
+		v := New(server.URL, server.URL, 0, nullLogger())
 		meta, err := v.MetaInfo()
 
 		assert.Nil(t, err)
@@ -44,7 +44,7 @@ func TestGetMeta(t *testing.T) {
 		serverQuery := httptest.NewServer(&testMetaHandler{t: t, modelType: "query"})
 		defer serverPassage.Close()
 		defer serverQuery.Close()
-		v := New(serverPassage.URL, serverQuery.URL, nullLogger())
+		v := New(serverPassage.URL, serverQuery.URL, 0, nullLogger())
 		meta, err := v.MetaInfo()
 
 		assert.Nil(t, err)
@@ -75,7 +75,7 @@ func TestGetMeta(t *testing.T) {
 		serverQuery := httptest.NewServer(&testMetaHandler{t: t, modelType: "query", readyTime: rt})
 		defer serverPassage.Close()
 		defer serverQuery.Close()
-		v := New(serverPassage.URL, serverQuery.URL, nullLogger())
+		v := New(serverPassage.URL, serverQuery.URL, 0, nullLogger())
 		meta, err := v.MetaInfo()
 
 		assert.NotNil(t, err)

--- a/modules/text2vec-transformers/clients/startup_test.go
+++ b/modules/text2vec-transformers/clients/startup_test.go
@@ -30,7 +30,7 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when common server is immediately ready", func(t *testing.T) {
 		server := httptest.NewServer(&testReadyHandler{t: t})
 		defer server.Close()
-		v := New(server.URL, server.URL, nullLogger())
+		v := New(server.URL, server.URL, 0, nullLogger())
 		err := v.WaitForStartup(context.Background(), 150*time.Millisecond)
 
 		assert.Nil(t, err)
@@ -41,7 +41,7 @@ func TestWaitForStartup(t *testing.T) {
 		serverQuery := httptest.NewServer(&testReadyHandler{t: t})
 		defer serverPassage.Close()
 		defer serverQuery.Close()
-		v := New(serverPassage.URL, serverQuery.URL, nullLogger())
+		v := New(serverPassage.URL, serverQuery.URL, 0, nullLogger())
 		err := v.WaitForStartup(context.Background(), 150*time.Millisecond)
 
 		assert.Nil(t, err)
@@ -49,7 +49,7 @@ func TestWaitForStartup(t *testing.T) {
 
 	t.Run("when common server is down", func(t *testing.T) {
 		url := "http://nothing-running-at-this-url"
-		v := New(url, url, nullLogger())
+		v := New(url, url, 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := v.WaitForStartup(ctx, 150*time.Millisecond)
@@ -64,7 +64,7 @@ func TestWaitForStartup(t *testing.T) {
 	t.Run("when passage and query servers are down", func(t *testing.T) {
 		urlPassage := "http://nothing-running-at-this-url"
 		urlQuery := "http://nothing-running-at-this-url-either"
-		v := New(urlPassage, urlQuery, nullLogger())
+		v := New(urlPassage, urlQuery, 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := v.WaitForStartup(ctx, 50*time.Millisecond)
@@ -81,7 +81,7 @@ func TestWaitForStartup(t *testing.T) {
 			readyTime: time.Now().Add(time.Hour),
 		})
 		defer server.Close()
-		v := New(server.URL, server.URL, nullLogger())
+		v := New(server.URL, server.URL, 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := v.WaitForStartup(ctx, 50*time.Millisecond)
@@ -105,7 +105,7 @@ func TestWaitForStartup(t *testing.T) {
 		})
 		defer serverPassage.Close()
 		defer serverQuery.Close()
-		v := New(serverPassage.URL, serverQuery.URL, nullLogger())
+		v := New(serverPassage.URL, serverQuery.URL, 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := v.WaitForStartup(ctx, 50*time.Millisecond)
@@ -124,7 +124,7 @@ func TestWaitForStartup(t *testing.T) {
 		})
 		defer serverPassage.Close()
 		defer serverQuery.Close()
-		v := New(serverPassage.URL, serverQuery.URL, nullLogger())
+		v := New(serverPassage.URL, serverQuery.URL, 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := v.WaitForStartup(ctx, 50*time.Millisecond)
@@ -140,7 +140,7 @@ func TestWaitForStartup(t *testing.T) {
 			t:         t,
 			readyTime: time.Now().Add(100 * time.Millisecond),
 		})
-		v := New(server.URL, server.URL, nullLogger())
+		v := New(server.URL, server.URL, 0, nullLogger())
 		defer server.Close()
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
@@ -160,7 +160,7 @@ func TestWaitForStartup(t *testing.T) {
 		})
 		defer serverPassage.Close()
 		defer serverQuery.Close()
-		v := New(serverPassage.URL, serverQuery.URL, nullLogger())
+		v := New(serverPassage.URL, serverQuery.URL, 0, nullLogger())
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 		err := v.WaitForStartup(ctx, 50*time.Millisecond)

--- a/modules/text2vec-transformers/clients/vectorizer.go
+++ b/modules/text2vec-transformers/clients/vectorizer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -31,12 +32,14 @@ type vectorizer struct {
 	logger        logrus.FieldLogger
 }
 
-func New(originPassage, originQuery string, logger logrus.FieldLogger) *vectorizer {
+func New(originPassage, originQuery string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
 	return &vectorizer{
 		originPassage: originPassage,
 		originQuery:   originQuery,
-		httpClient:    &http.Client{},
-		logger:        logger,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		logger: logger,
 	}
 }
 

--- a/modules/text2vec-transformers/clients/vectorizer_test.go
+++ b/modules/text2vec-transformers/clients/vectorizer_test.go
@@ -31,7 +31,7 @@ func TestClient(t *testing.T) {
 	t.Run("when all is fine", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, server.URL, nullLogger())
+		c := New(server.URL, server.URL, 0, nullLogger())
 		expected := &ent.VectorizationResult{
 			Text:       "This is my text",
 			Vector:     []float32{0.1, 0.2, 0.3},
@@ -49,7 +49,7 @@ func TestClient(t *testing.T) {
 	t.Run("when the context is expired", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
-		c := New(server.URL, server.URL, nullLogger())
+		c := New(server.URL, server.URL, 0, nullLogger())
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
 		defer cancel()
 
@@ -65,7 +65,7 @@ func TestClient(t *testing.T) {
 			serverError: errors.Errorf("nope, not gonna happen"),
 		})
 		defer server.Close()
-		c := New(server.URL, server.URL, nullLogger())
+		c := New(server.URL, server.URL, 0, nullLogger())
 		_, err := c.VectorizeObject(context.Background(), "This is my text",
 			ent.VectorizationConfig{})
 

--- a/modules/text2vec-transformers/module.go
+++ b/modules/text2vec-transformers/module.go
@@ -71,7 +71,7 @@ func (m *TransformersModule) Init(ctx context.Context,
 ) error {
 	m.logger = params.GetLogger()
 
-	if err := m.initVectorizer(ctx, m.logger); err != nil {
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, m.logger); err != nil {
 		return errors.Wrap(err, "init vectorizer")
 	}
 
@@ -100,7 +100,7 @@ func (m *TransformersModule) InitExtension(modules []modulecapabilities.Module) 
 	return nil
 }
 
-func (m *TransformersModule) initVectorizer(ctx context.Context,
+func (m *TransformersModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	logger logrus.FieldLogger,
 ) error {
 	// TODO: gh-1486 proper config management
@@ -126,7 +126,7 @@ func (m *TransformersModule) initVectorizer(ctx context.Context,
 		uriQuery = uriCommon
 	}
 
-	client := clients.New(uriPassage, uriQuery, logger)
+	client := clients.New(uriPassage, uriQuery, timeout, logger)
 	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
 		return errors.Wrap(err, "init remote vectorizer")
 	}

--- a/test/modules/backup-azure/backup_backend_test.go
+++ b/test/modules/backup-azure/backup_backend_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_AzureBackend_Backup(t *testing.T) {
@@ -227,6 +228,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 type fakeModuleParams struct {
 	logger   logrus.FieldLogger
 	provider fakeStorageProvider
+	config   config.Config
 }
 
 func newFakeModuleParams(dataPath string) *fakeModuleParams {
@@ -247,6 +249,10 @@ func (f *fakeModuleParams) GetAppState() interface{} {
 
 func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
 	return f.logger
+}
+
+func (f *fakeModuleParams) GetConfig() config.Config {
+	return f.config
 }
 
 type fakeStorageProvider struct {

--- a/test/modules/backup-filesystem/backup_backend_test.go
+++ b/test/modules/backup-filesystem/backup_backend_test.go
@@ -28,6 +28,7 @@ import (
 	modstgfs "github.com/weaviate/weaviate/modules/backup-filesystem"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_FilesystemBackend_Backup(t *testing.T) {
@@ -51,7 +52,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 	t.Run("store backup meta in fs", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		sp := fakeStorageProvider{dataDir}
-		params := moduletools.NewInitParams(sp, nil, logger)
+		params := moduletools.NewInitParams(sp, nil, config.Config{}, logger)
 
 		fs := modstgfs.New()
 		err := fs.Init(testCtx, params)
@@ -110,7 +111,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 	t.Run("copy objects", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		sp := fakeStorageProvider{dataDir}
-		params := moduletools.NewInitParams(sp, nil, logger)
+		params := moduletools.NewInitParams(sp, nil, config.Config{}, logger)
 
 		fs := modstgfs.New()
 		err := fs.Init(testCtx, params)
@@ -149,7 +150,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 
 		logger, _ := test.NewNullLogger()
 		sp := fakeStorageProvider{dataDir}
-		params := moduletools.NewInitParams(sp, nil, logger)
+		params := moduletools.NewInitParams(sp, nil, config.Config{}, logger)
 
 		fs := modstgfs.New()
 		err = fs.Init(testCtx, params)

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_GCSBackend_Backup(t *testing.T) {
@@ -238,6 +239,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 type fakeModuleParams struct {
 	logger   logrus.FieldLogger
 	provider fakeStorageProvider
+	config   config.Config
 }
 
 func newFakeModuleParams(dataPath string) *fakeModuleParams {
@@ -258,6 +260,10 @@ func (f *fakeModuleParams) GetAppState() interface{} {
 
 func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
 	return f.logger
+}
+
+func (f *fakeModuleParams) GetConfig() config.Config {
+	return f.config
 }
 
 type fakeStorageProvider struct {

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_S3Backend_Backup(t *testing.T) {
@@ -232,6 +233,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 type fakeModuleParams struct {
 	logger   logrus.FieldLogger
 	provider fakeStorageProvider
+	config   config.Config
 }
 
 func newFakeModuleParams(dataPath string) *fakeModuleParams {
@@ -252,6 +254,10 @@ func (f *fakeModuleParams) GetAppState() interface{} {
 
 func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
 	return f.logger
+}
+
+func (f *fakeModuleParams) GetConfig() config.Config {
+	return f.config
 }
 
 type fakeStorageProvider struct {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/go-openapi/swag"
 	"github.com/pkg/errors"
@@ -83,6 +84,7 @@ type Config struct {
 	DefaultVectorDistanceMetric         string                   `json:"default_vector_distance_metric" yaml:"default_vector_distance_metric"`
 	EnableModules                       string                   `json:"enable_modules" yaml:"enable_modules"`
 	ModulesPath                         string                   `json:"modules_path" yaml:"modules_path"`
+	ModuleHttpClientTimeout             time.Duration            `json:"modules_client_timeout" yaml:"modules_client_timeout"`
 	AutoSchema                          AutoSchema               `json:"auto_schema" yaml:"auto_schema"`
 	Cluster                             cluster.Config           `json:"cluster" yaml:"cluster"`
 	Replication                         replication.GlobalConfig `json:"replication" yaml:"replication"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -216,6 +217,16 @@ func FromEnv(config *Config) error {
 		if config.DefaultVectorizerModule == "" {
 			config.DefaultVectorizerModule = VectorizerModuleNone
 		}
+	}
+
+	if v := os.Getenv("MODULES_CLIENT_TIMEOUT"); v != "" {
+		timeout, err := time.ParseDuration(v)
+		if err != nil {
+			return errors.Wrapf(err, "parse MODULES_CLIENT_TIMEOUT as time.Duration")
+		}
+		config.ModuleHttpClientTimeout = timeout
+	} else {
+		config.ModuleHttpClientTimeout = 60 * time.Second
 	}
 
 	if v := os.Getenv("DEFAULT_VECTOR_DISTANCE_METRIC"); v != "" {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -226,7 +226,7 @@ func FromEnv(config *Config) error {
 		}
 		config.ModuleHttpClientTimeout = timeout
 	} else {
-		config.ModuleHttpClientTimeout = 60 * time.Second
+		config.ModuleHttpClientTimeout = 50 * time.Second
 	}
 
 	if v := os.Getenv("DEFAULT_VECTOR_DISTANCE_METRIC"); v != "" {


### PR DESCRIPTION
### What's being changed:
Closes https://github.com/weaviate/weaviate/issues/3165. Adds a strict vectorization timeout to third party modules. The error message should now be a timed out context, making it clear that this is not an issue with weaviate.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: not necessary.
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable. not necessary.
- [ ] Performance tests have been run or not necessary. not necessary.
