### PR TITLE
Automatically request properties that are needed for groupby

### DIFF
--- a/adapters/handlers/grpc/parse_request.go
+++ b/adapters/handlers/grpc/parse_request.go
@@ -251,7 +251,7 @@ func searchParamsFromProto(req *pb.SearchRequest, scheme schema.Schema) (dto.Get
 	}
 
 	if req.GroupBy != nil {
-		groupBy, err := extractGroupBy(req.GroupBy)
+		groupBy, err := extractGroupBy(req.GroupBy, &out)
 		if err != nil {
 			return dto.GetParams{}, err
 		}
@@ -263,7 +263,7 @@ func searchParamsFromProto(req *pb.SearchRequest, scheme schema.Schema) (dto.Get
 	return out, nil
 }
 
-func extractGroupBy(groupIn *pb.GroupBy) (*searchparams.GroupBy, error) {
+func extractGroupBy(groupIn *pb.GroupBy, out *dto.GetParams) (*searchparams.GroupBy, error) {
 	if len(groupIn.Path) != 1 {
 		return nil, fmt.Errorf("groupby path can only have one entry, received %v", groupIn.Path)
 	}
@@ -273,6 +273,13 @@ func extractGroupBy(groupIn *pb.GroupBy) (*searchparams.GroupBy, error) {
 		ObjectsPerGroup: int(groupIn.ObjectsPerGroup),
 		Groups:          int(groupIn.NumberOfGroups),
 	}
+
+	// add the property in case it was not requested as return prop - otherwise it is not resolved
+	if out.Properties.FindProperty(groupOut.Property) == nil {
+		out.Properties = append(out.Properties, search.SelectProperty{Name: groupOut.Property, IsPrimitive: true})
+	}
+	out.AdditionalProperties.NoProps = false
+
 	return groupOut, nil
 }
 

--- a/adapters/handlers/grpc/parse_request_test.go
+++ b/adapters/handlers/grpc/parse_request_test.go
@@ -666,10 +666,11 @@ func TestGRPCRequest(t *testing.T) {
 				ClassName: classname, Pagination: defaultPagination,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
-					NoProps: true,
+					NoProps: false,
 					Group:   true,
 				},
 				NearVector: &searchparams.NearVector{Vector: []float32{1, 2, 3}},
+				Properties: search.SelectProperties{{Name: "name", IsPrimitive: true}},
 				GroupBy:    &searchparams.GroupBy{Groups: 2, ObjectsPerGroup: 3, Property: "name"},
 			},
 			error: false,


### PR DESCRIPTION
### What's being changed:

Automatically add the group_by property to the search request. Otherwise the needed props are not extracted from the object store and groupby crashes.

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

