### PR TITLE
ensure name is passed correctly when pulling weights from schema in `multi2vec-clip`

### DIFF
--- a/modules/multi2vec-clip/vectorizer/class_settings.go
+++ b/modules/multi2vec-clip/vectorizer/class_settings.go
@@ -181,7 +181,7 @@ func (ic *classSettings) getWeightsArray(weights []interface{}) ([]float32, erro
 }
 
 func (ic *classSettings) getFieldsWeights(name string) ([]float32, error) {
-	weights, ok := ic.getWeights("image")
+	weights, ok := ic.getWeights(name)
 	if ok {
 		return ic.getWeightsArray(weights)
 	}

--- a/modules/multi2vec-clip/vectorizer/vectorizer_test.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer_test.go
@@ -166,7 +166,7 @@ func TestVectorizerWithDiff(t *testing.T) {
 			if test.expectedVectorize {
 				assert.Equal(t, models.C11yVector{5.5, 11, 16.5, 22, 27.5}, test.input.Vector)
 				// vectors are defined in Vectorize within fakes_for_test.go
-				// result calulated without weights as (textVectors[0][i]+imageVectors[0][i]) / 2
+				// result calculated without weights as (textVectors[0][i]+imageVectors[0][i]) / 2
 			} else {
 				assert.Equal(t, models.C11yVector{0, 0, 0, 0, 0}, test.input.Vector)
 			}
@@ -198,7 +198,7 @@ func TestVectorizerWithWeights(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, models.C11yVector{3.2, 6.4, 9.6, 12.8, 16}, input.Vector)
 	// vectors are defined in Vectorize within fakes_for_test.go
-	// result calulated with above weights as (textVectors[0][i]*0.4+imageVectors[0][i]*0.6) / 2
+	// result calculated with above weights as (textVectors[0][i]*0.4+imageVectors[0][i]*0.6) / 2
 }
 
 func TestVectorizer_normalizeWeights(t *testing.T) {

--- a/modules/multi2vec-clip/vectorizer/vectorizer_test.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer_test.go
@@ -174,7 +174,7 @@ func TestVectorizerWithDiff(t *testing.T) {
 	}
 }
 
-func TestVectorizer_withWeights(t *testing.T) {
+func TestVectorizerWithWeights(t *testing.T) {
 	client := &fakeClient{}
 	vectorizer := &Vectorizer{client}
 	config := newConfigBuilder().

--- a/modules/multi2vec-clip/vectorizer/vectorizer_test.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer_test.go
@@ -165,6 +165,8 @@ func TestVectorizerWithDiff(t *testing.T) {
 			require.Nil(t, err)
 			if test.expectedVectorize {
 				assert.Equal(t, models.C11yVector{5.5, 11, 16.5, 22, 27.5}, test.input.Vector)
+				// vectors are defined in Vectorize within fakes_for_test.go
+				// result calulated without weights as (textVectors[0][i]+imageVectors[0][i]) / 2
 			} else {
 				assert.Equal(t, models.C11yVector{0, 0, 0, 0, 0}, test.input.Vector)
 			}
@@ -195,6 +197,8 @@ func TestVectorizerWithWeights(t *testing.T) {
 
 	require.Nil(t, err)
 	assert.Equal(t, models.C11yVector{3.2, 6.4, 9.6, 12.8, 16}, input.Vector)
+	// vectors are defined in Vectorize within fakes_for_test.go
+	// result calulated with above weights as (textVectors[0][i]*0.4+imageVectors[0][i]*0.6) / 2
 }
 
 func TestVectorizer_normalizeWeights(t *testing.T) {

--- a/modules/multi2vec-clip/vectorizer/vectorizer_test.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer_test.go
@@ -13,7 +13,6 @@ package vectorizer
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -165,7 +164,6 @@ func TestVectorizerWithDiff(t *testing.T) {
 
 			require.Nil(t, err)
 			if test.expectedVectorize {
-				fmt.Println(test.input.Vector)
 				assert.Equal(t, models.C11yVector{5.5, 11, 16.5, 22, 27.5}, test.input.Vector)
 			} else {
 				assert.Equal(t, models.C11yVector{0, 0, 0, 0, 0}, test.input.Vector)


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug with the `multi2vec-clip` module whereby varying the weights in the `textFields` and `imageFields` had no effect upon vectorisation

The previous server behaviour was to effectively ignore any user-defined weights and assume each weighting of the image and text fields are the same. As such, this change will likely affect current users of `multi2vec-clip` if they have their weights set other than `0.5,0.5` since their search performances will change (for the better!) between versions

Resolves https://github.com/weaviate/weaviate/issues/2582

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
