### PR TITLE
Custom OpenAi host

### DIFF
--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -53,15 +53,21 @@ type openAIApiError struct {
 }
 
 func buildUrl(config ent.VectorizationConfig) (string, error) {
+	defaultOpenAIHost := "https://api.openai.com"
+	
+	if customOpenAIHost := os.Getenv("OPENAI_HOST"); customOpenAIHost != "" {
+		defaultOpenAIHost = customOpenAIHost
+	}
+	
 	if config.IsAzure {
 		host := "https://" + config.ResourceName + ".openai.azure.com"
 		path := "openai/deployments/" + config.DeploymentID + "/embeddings"
 		queryParam := "api-version=2022-12-01"
 		return fmt.Sprintf("%s/%s?%s", host, path, queryParam), nil
 	}
-	host := "https://api.openai.com"
+	
 	path := "/v1/embeddings"
-	return url.JoinPath(host, path)
+	return url.JoinPath(defaultOpenAIHost, path)
 }
 
 type vectorizer struct {


### PR DESCRIPTION
Possible to configure a custom host in text2vec-openai for a mock OpenAI server using vLLM with my Llama2 embedding.

Example: for vLLM 
https://vllm.readthedocs.io/en/latest/getting_started/quickstart.html#openai-compatible-server

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
