### PR TITLE
Add gpt-3.5-turbo-instruct to available qna-openai models

### DIFF
--- a/modules/qna-openai/config/class_settings.go
+++ b/modules/qna-openai/config/class_settings.go
@@ -44,6 +44,7 @@ var maxTokensForModel = map[string]float64{
 	"text-curie-001":   2048,
 	"text-davinci-002": 4000,
 	"text-davinci-003": 4000,
+	"gpt-3.5-turbo-instruct": 4000,
 }
 
 var availableOpenAIModels = []string{
@@ -52,6 +53,7 @@ var availableOpenAIModels = []string{
 	"text-curie-001",
 	"text-davinci-002",
 	"text-davinci-003",
+	"gpt-3.5-turbo-instruct",
 }
 
 type classSettings struct {

--- a/modules/qna-openai/config/class_settings.go
+++ b/modules/qna-openai/config/class_settings.go
@@ -39,11 +39,11 @@ var (
 )
 
 var maxTokensForModel = map[string]float64{
-	"text-ada-001":     2048,
-	"text-babbage-001": 2048,
-	"text-curie-001":   2048,
-	"text-davinci-002": 4000,
-	"text-davinci-003": 4000,
+	"text-ada-001":           2048,
+	"text-babbage-001":       2048,
+	"text-curie-001":         2048,
+	"text-davinci-002":       4000,
+	"text-davinci-003":       4000,
 	"gpt-3.5-turbo-instruct": 4000,
 }
 


### PR DESCRIPTION
text-davinci-003 will be deprecated in Jan 2024, and the recommended replacement is gpt-3.5-turbo-instruct.

### What's being changed:

Add `gpt-3.5-turbo-instruct` to available `qna-openai` models. OpenAI has [announced](https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings) that `text-davinci-003` will be deprecated in Jan 2024.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
