### PR TITLE
Add memory guard rails for batch creation

### DIFF
--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"math"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -44,6 +46,7 @@ type DB struct {
 	shutdown          chan struct{}
 	startupComplete   atomic.Bool
 	resourceScanState *resourceScanState
+	memMonitor        *memwatch.Monitor
 
 	// indexLock is an RWMutex which allows concurrent access to various indexes,
 	// but only one modification at a time. R/W can be a bit confusing here,
@@ -112,7 +115,13 @@ func New(logger logrus.FieldLogger, config Config,
 		jobQueueCh:          make(chan job, 100000),
 		maxNumberGoroutines: int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
 		resourceScanState:   newResourceScanState(),
+		memMonitor: memwatch.NewMonitor(runtime.MemProfile,
+			debug.SetMemoryLimit, runtime.MemProfileRate, 0.97),
 	}
+
+	// make sure memMonitor has an initial state
+	db.memMonitor.Refresh()
+
 	if db.maxNumberGoroutines == 0 {
 		return db, errors.New("no workers to add batch-jobs configured.")
 	}

--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -12,15 +12,40 @@
 package memwatch
 
 import (
+	"fmt"
 	"math"
 	"runtime"
+	"sync"
 )
+
+const (
+	B   = 1
+	KiB = 1 << (10 * iota) // 2^10
+	MiB = 1 << (10 * iota) // 2^20
+	GiB = 1 << (10 * iota) // 2^30
+	TiB = 1 << (10 * iota) // 2^40
+)
+
+var ErrNotEnoughMemory = fmt.Errorf("not enough memory")
 
 // Monitor allows making statements about the memory ratio used by the application
 type Monitor struct {
 	memProfiler memProfiler
 	limitSetter limitSetter
 	rate        int64
+	maxRatio    float64
+
+	// state
+	mu    sync.Mutex
+	limit int64
+	used  int64
+}
+
+// Refresh retrieves the current memory stats from the runtime and stores them
+// in the local cache
+func (m *Monitor) Refresh() {
+	m.calculateCurrentUsage()
+	m.updateLimit()
 }
 
 type memProfiler func(p []runtime.MemProfileRecord, inUseZero bool) (int, bool)
@@ -33,45 +58,33 @@ type limitSetter func(size int64) int64
 //
 // Typically this would be called with runtime.MemProfile,
 // debug.SetMemoryLimit, and runtime.MemProfileRate
-func NewMonitor(profiler memProfiler, limitSetter limitSetter, rate int) *Monitor {
+func NewMonitor(profiler memProfiler, limitSetter limitSetter,
+	rate int, maxRatio float64,
+) *Monitor {
 	return &Monitor{
 		memProfiler: profiler,
 		limitSetter: limitSetter,
 		rate:        int64(rate),
+		maxRatio:    maxRatio,
 	}
 }
 
-// inspired by runtime/pprof/pprof.go
+func (m *Monitor) CheckAlloc(sizeInBytes int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if float64(m.used+sizeInBytes)/float64(m.limit) > m.maxRatio {
+		return ErrNotEnoughMemory
+	}
+
+	return nil
+}
+
 func (m *Monitor) Ratio() float64 {
-	var p []runtime.MemProfileRecord
-	n, _ := m.memProfiler(nil, true)
-	for {
-		// Allocate room for a slightly bigger profile,
-		// in case a few more entries have been added
-		// since the call to MemProfile.
-		p = make([]runtime.MemProfileRecord, n+50)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-		// use different var name and explicitly overwrite
-		// otherwise n from the outside is shadowed and not overwritten
-		n2, ok := m.memProfiler(p, true)
-		if ok {
-			p = p[0:n2]
-			break
-		}
-		// Profile grew; try again.
-		n = n2
-	}
-
-	var sum int64
-
-	for _, r := range p {
-		_, size := scaleHeapSample(r.InUseObjects(), r.InUseBytes(), m.rate)
-		sum += size
-	}
-
-	// setting a negative limit is the only way to obtain the current limit
-	limit := m.limitSetter(-1)
-	return float64(sum) / float64(limit)
+	return float64(m.used) / float64(m.limit)
 }
 
 // copied from runtime/pprof/protomem.go
@@ -100,4 +113,54 @@ func scaleHeapSample(count, size, rate int64) (int64, int64) {
 	scale := 1 / (1 - math.Exp(-avgSize/float64(rate)))
 
 	return int64(float64(count) * scale), int64(float64(size) * scale)
+}
+
+// calculateCurrentUsage obtains the most recent mem profile records from the
+// runtime, sums them up and scales them according to the set profiling rate.
+//
+// The logic to retrieve the records is inspired by runtime/pprof/pprof.go
+func (m *Monitor) calculateCurrentUsage() {
+	var p []runtime.MemProfileRecord
+	n, _ := m.memProfiler(nil, true)
+	for {
+		// Allocate room for a slightly bigger profile,
+		// in case a few more entries have been added
+		// since the call to MemProfile.
+		p = make([]runtime.MemProfileRecord, n+50)
+
+		// use different var name and explicitly overwrite
+		// otherwise n from the outside is shadowed and not overwritten
+		n2, ok := m.memProfiler(p, true)
+		if ok {
+			p = p[0:n2]
+			break
+		}
+		// Profile grew; try again.
+		n = n2
+	}
+
+	var sum int64
+
+	for _, r := range p {
+		_, size := scaleHeapSample(r.InUseObjects(), r.InUseBytes(), m.rate)
+		sum += size
+	}
+
+	m.setUsed(sum)
+}
+
+// setUsed is a thread-safe way way to set the current usage
+func (m *Monitor) setUsed(used int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.used = used
+}
+
+func (m *Monitor) updateLimit() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// setting a negative limit is the only way to obtain the current limit
+	m.limit = m.limitSetter(-1)
 }

--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -30,7 +30,8 @@ func TestMonitor(t *testing.T) {
 
 		limiter := &fakeLimitSetter{limit: 100000}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1)
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m.Refresh()
 
 		assert.Equal(t, 0.3, m.Ratio())
 	})
@@ -45,9 +46,59 @@ func TestMonitor(t *testing.T) {
 
 		limiter := &fakeLimitSetter{limit: 100000}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1)
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
 
+		m.Refresh()
 		assert.Equal(t, 0.3, m.Ratio())
+	})
+
+	t.Run("with less memory than the threshold", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(700 * MiB)},
+				{sampleProfile(700 * MiB)},
+				{sampleProfile(700 * MiB)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 1 * GiB}
+
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m.Refresh()
+
+		err := m.CheckAlloc(100 * MiB)
+		assert.NoError(t, err, "with 700 allocated, an additional 100 would be about 80% which is not a problem")
+
+		err = m.CheckAlloc(299 * MiB)
+		assert.Error(t, err, "with 700 allocated, an additional 299 would be about 97.5% which is not allowed")
+
+		err = m.CheckAlloc(400 * MiB)
+		assert.Error(t, err, "with 700 allocated, an additional 400 would be about 110% which is not allowed")
+	})
+
+	t.Run("with memory already over the threshold", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(1025 * MiB)},
+				{sampleProfile(1025 * MiB)},
+				{sampleProfile(1025 * MiB)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 1 * GiB}
+
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m.Refresh()
+
+		err := m.CheckAlloc(1 * B)
+		assert.Error(t, err,
+			"any check should fail, since we're already over the limit")
+
+		err = m.CheckAlloc(10 * MiB)
+		assert.Error(t, err, "any check should fail, since we're already over the limit")
+
+		err = m.CheckAlloc(1 * TiB)
+		assert.Error(t, err, "any check should fail, since we're already over the limit")
 	})
 
 	t.Run("with sampling rate", func(t *testing.T) {
@@ -62,13 +113,14 @@ func TestMonitor(t *testing.T) {
 
 		// sample rate is small enough to not alter the result, yet big enough to
 		// cover the calculation
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 5)
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 5, 0.97)
 
+		m.Refresh()
 		assert.Equal(t, 0.3, m.Ratio())
 	})
 
 	t.Run("with real dependencies", func(t *testing.T) {
-		m := NewMonitor(runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate)
+		m := NewMonitor(runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate, 0.97)
 		_ = m.Ratio()
 	})
 }


### PR DESCRIPTION
### What's being changed:

#### Contained
* The resource monitor frequency increases from once every 30s to once every 500ms
* The memwatch.Monitor is now stateful and thread-safe. It separates the calls to update the state at a fixed frequency and check available memory (against the local state)
* Creating a batch estimates the amount of memory that a batch would require based on the no. of objects and the dimension of the vectors.
* If the sum of the current heap and estimated batch is more than 97% of `GOMEMLIMIT` the batch is declined

#### Not yet contained (will follow in future PR)
* Set GOMEMLIMIT/GOMAXPROCS automatically
* Apply the same alloc check as outlined above for background processes
* Check before creating tenants
* Add monitoring (no. of failed requests due to mem pressure, current pressure, etc.)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
