### PR TITLE
Remove grpc_health_probe from Weaviate docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,18 +31,9 @@ COPY . .
 ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 
 ###############################################################################
-# This image gets grpc health check probe
-FROM build_base AS grpc_health_probe_builder
-ARG TARGETARCH
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.19 && \
-      wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
-      chmod +x /bin/grpc_health_probe
-
-###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)
 FROM alpine AS weaviate
 ENTRYPOINT ["/bin/weaviate"]
-COPY --from=grpc_health_probe_builder /bin/grpc_health_probe /bin/
 COPY --from=server_builder /weaviate-server /bin/weaviate
 RUN apk add --no-cache --upgrade ca-certificates openssl
 RUN mkdir ./modules


### PR DESCRIPTION
### What's being changed:

Removing unnecessary `grpc_health_probe` dependency as K8s bc starting from [K8s v1.27](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe) gRPC probing is built-in and there's no need for including `grpc_health_probe` in Weaviate's image.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
