### PR TITLE
async: share workers between queues

### DIFF
--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -69,11 +69,12 @@ type DB struct {
 	// mark a given index in use, lock that index directly.
 	indexLock sync.RWMutex
 
-	jobQueueCh          chan job
-	shutDownWg          sync.WaitGroup
-	maxNumberGoroutines int
-	batchMonitorLock    sync.Mutex
-	ratePerSecond       int
+	jobQueueCh              chan job
+	asyncIndexRetryInterval time.Duration
+	shutDownWg              sync.WaitGroup
+	maxNumberGoroutines     int
+	batchMonitorLock        sync.Mutex
+	ratePerSecond           int
 }
 
 func (db *DB) SetSchemaGetter(sg schemaUC.SchemaGetter) {
@@ -100,25 +101,39 @@ func New(logger logrus.FieldLogger, config Config,
 	promMetrics *monitoring.PrometheusMetrics,
 ) (*DB, error) {
 	db := &DB{
-		logger:              logger,
-		config:              config,
-		indices:             map[string]*Index{},
-		remoteIndex:         remoteIndex,
-		nodeResolver:        nodeResolver,
-		remoteNode:          sharding.NewRemoteNode(nodeResolver, remoteNodesClient),
-		replicaClient:       replicaClient,
-		promMetrics:         promMetrics,
-		shutdown:            make(chan struct{}),
-		jobQueueCh:          make(chan job, 100000),
-		maxNumberGoroutines: int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
-		resourceScanState:   newResourceScanState(),
+		logger:                  logger,
+		config:                  config,
+		indices:                 map[string]*Index{},
+		remoteIndex:             remoteIndex,
+		nodeResolver:            nodeResolver,
+		remoteNode:              sharding.NewRemoteNode(nodeResolver, remoteNodesClient),
+		replicaClient:           replicaClient,
+		promMetrics:             promMetrics,
+		shutdown:                make(chan struct{}),
+		asyncIndexRetryInterval: 1 * time.Second,
+		maxNumberGoroutines:     int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
+		resourceScanState:       newResourceScanState(),
 	}
 	if db.maxNumberGoroutines == 0 {
 		return db, errors.New("no workers to add batch-jobs configured.")
 	}
-	db.shutDownWg.Add(db.maxNumberGoroutines)
-	for i := 0; i < db.maxNumberGoroutines; i++ {
-		go db.worker(i == 0)
+	if !asyncEnabled() {
+		db.jobQueueCh = make(chan job, 100000)
+		db.shutDownWg.Add(db.maxNumberGoroutines)
+		for i := 0; i < db.maxNumberGoroutines; i++ {
+			go db.worker(i == 0)
+		}
+	} else {
+		w := runtime.GOMAXPROCS(0) - 1
+		db.shutDownWg.Add(w)
+		db.jobQueueCh = make(chan job)
+		for i := 0; i < w; i++ {
+			go func() {
+				defer db.shutDownWg.Done()
+
+				asyncWorker(db.jobQueueCh, db.logger, db.asyncIndexRetryInterval)
+			}()
+		}
 	}
 
 	return db, nil
@@ -206,10 +221,12 @@ func (db *DB) DeleteIndex(className schema.ClassName) error {
 func (db *DB) Shutdown(ctx context.Context) error {
 	db.shutdown <- struct{}{}
 
-	// shut down the workers that add objects to
-	for i := 0; i < db.maxNumberGoroutines; i++ {
-		db.jobQueueCh <- job{
-			index: -1,
+	if !asyncEnabled() {
+		// shut down the workers that add objects to
+		for i := 0; i < db.maxNumberGoroutines; i++ {
+			db.jobQueueCh <- job{
+				index: -1,
+			}
 		}
 	}
 
@@ -219,6 +236,11 @@ func (db *DB) Shutdown(ctx context.Context) error {
 		if err := index.Shutdown(ctx); err != nil {
 			return errors.Wrapf(err, "shutdown index %q", id)
 		}
+	}
+
+	if asyncEnabled() {
+		// shut down the async workers
+		close(db.jobQueueCh)
 	}
 
 	db.shutDownWg.Wait() // wait until job queue shutdown is completed
@@ -254,4 +276,57 @@ type job struct {
 	index   int
 	ctx     context.Context
 	batcher *objectsBatcher
+
+	// async only
+	chunk   *chunk
+	indexer BatchIndexer
+	queue   *vectorQueue
+}
+
+func asyncWorker(ch chan job, logger logrus.FieldLogger, retryInterval time.Duration) {
+	var ids []uint64
+	var vectors [][]float32
+	var deleted []uint64
+
+	for job := range ch {
+		c := job.chunk
+		for i := range c.data[:c.cursor] {
+			if job.queue.IsDeleted(c.data[i].id) {
+				deleted = append(deleted, c.data[i].id)
+			} else {
+				ids = append(ids, c.data[i].id)
+				vectors = append(vectors, c.data[i].vector)
+			}
+		}
+	LOOP:
+		for {
+			err := job.indexer.AddBatch(ids, vectors)
+			if err == nil {
+				break LOOP
+			}
+
+			logger.WithError(err).Infof("failed to index vectors, retrying in %s", retryInterval.String())
+
+			t := time.NewTimer(retryInterval)
+			select {
+			case <-job.ctx.Done():
+				// drain the timer
+				if !t.Stop() {
+					<-t.C
+				}
+				return
+			case <-t.C:
+			}
+		}
+
+		job.queue.releaseChunk(c)
+
+		if len(deleted) > 0 {
+			job.queue.ResetDeleted(deleted...)
+		}
+
+		ids = ids[:0]
+		vectors = vectors[:0]
+		deleted = deleted[:0]
+	}
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -110,7 +110,7 @@ func New(logger logrus.FieldLogger, config Config,
 		replicaClient:           replicaClient,
 		promMetrics:             promMetrics,
 		shutdown:                make(chan struct{}),
-		asyncIndexRetryInterval: 1 * time.Second,
+		asyncIndexRetryInterval: 5 * time.Second,
 		maxNumberGoroutines:     int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
 		resourceScanState:       newResourceScanState(),
 	}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -128,7 +128,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	}
 
 	var err error
-	s.queue, err = NewIndexQueue(s.vectorIndex, IndexQueueOptions{
+	s.queue, err = NewIndexQueue(s.vectorIndex, s.centralJobQueue, IndexQueueOptions{
 		Logger: s.index.logger,
 	})
 	if err != nil {
@@ -581,6 +581,10 @@ func (s *Shard) shutdown(ctx context.Context) error {
 
 	if err := s.propLengths.Close(); err != nil {
 		return errors.Wrap(err, "close prop length tracker")
+	}
+
+	if err := s.queue.Close(); err != nil {
+		return errors.Wrap(err, "shut down vector index queue")
 	}
 
 	// to ensure that all commitlog entries are written to disk.


### PR DESCRIPTION
### What's being changed:

We currently have one queue per shard and each queue has a set of workers. If I understand correctly, there's a shard per class / tenant, which means that we'll have N workers per class or tenant on the same node, competing with each other for resources.
This PR changes that and creates a fix set of workers that are shared across all the index queues.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
