### PR TITLE
Add vector_info metric

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -93,6 +93,7 @@ func (h *hnsw) Compress(cfg ent.PQConfig) error {
 
 	h.compressed.Store(true)
 	h.cache.drop()
+	h.metrics.VectorInfo(int(h.dims), int(h.pq.ExposeFields().M), h.distancerProvider.Type(), true)
 	return nil
 }
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -634,6 +634,7 @@ func (h *hnsw) Drop(ctx context.Context) error {
 		h.cache.drop()
 	}
 
+	h.metrics.Drop()
 	// cancel commit logger last, as the tombstone cleanup cycle might still
 	// write while it's still running
 	err := h.commitLog.Drop(ctx)

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -95,6 +95,8 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 		h.compressedVectorsCache.preload(node.id, compressed)
 	} else {
 		h.cache.preload(node.id, nodeVec)
+		atomic.StoreInt32(&h.dims, int32(len(nodeVec)))
+		h.metrics.VectorInfo(int(h.dims), 0, h.distancerProvider.Type(), false)
 	}
 
 	// go h.insertHook(node.id, 0, node.connections)

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -46,6 +46,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 
 	// VectorInfo must have class granularity
 	info := prom.VectorInfo
+	originalClassName := className
 
 	if prom.Group {
 		className = "n/a"
@@ -120,7 +121,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 
 	return &Metrics{
 		enabled:          true,
-		className:        className,
+		className:        originalClassName,
 		tombstones:       tombstones,
 		threads:          threads,
 		cleaned:          cleaned,

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -38,6 +38,7 @@ type PrometheusMetrics struct {
 	VectorIndexDurations               *prometheus.SummaryVec
 	VectorIndexSize                    *prometheus.GaugeVec
 	VectorIndexMaintenanceDurations    *prometheus.SummaryVec
+	VectorInfo                         *prometheus.GaugeVec
 	ObjectCount                        *prometheus.GaugeVec
 	QueriesCount                       *prometheus.GaugeVec
 	RequestsTotal                      *prometheus.GaugeVec
@@ -193,6 +194,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "vector_dimensions_sum",
 			Help: "Total dimensions in a shard",
 		}, []string{"class_name", "shard_name"}),
+		VectorInfo: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_info",
+			Help: "An info metric with dimensions and segments of a vector index",
+		}, []string{"class_name", "dimensions", "segments", "metric", "pq"}),
 
 		StartupProgress: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "startup_progress",


### PR DESCRIPTION
### What's being changed:

- Adds new `vector_info` prometheus info style metric
- The metric is per class and provides distance metric, pq status, segments, and dimensions
- The metric is cleaned up on class deletion and can only change once (when pq is enabled).

Example with `pq` disabled:
```
vector_info{class_name="Vector",dimensions="1536",metric="dot",pq="false",segments="0"} 1
```

Example with `pq` enabled:
```
vector_info{class_name="Vector",dimensions="1536",metric="dot",pq="true",segments="384"} 1
```
