### PR TITLE
Merge buckets

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -55,6 +55,8 @@ jobs:
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
+      - name: Unit test merged buckets
+        run: ENABLE_MERGED_PROPERTY_BUCKETS=true ./test/run.sh --unit-only
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -70,6 +72,8 @@ jobs:
         with:
           go-version: '1.20'
           cache: true
+      - name: Integration test merged buckets
+        run: ENABLE_MERGED_PROPERTY_BUCKETS=true ./test/run.sh --integration-only
       - name: Integration test
         run: ./test/run.sh --integration-only
       - name: Archive code coverage results
@@ -104,27 +108,22 @@ jobs:
           WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
           WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}
         run: ./test/run.sh --acceptance-only
-  Codecov:
-    needs: [Unit-Tests, Integration-Tests]
-    name: codecov
+  Acceptance-Tests-Merged-Buckets:
+    name: acceptance-tests-merged-buckets  
     runs-on: ubuntu-latest
-    if: ${{ (github.ref_type == 'branch') && (github.ref_name != 'master') }}
     steps:
       - uses: actions/checkout@v4
-      - name: Download coverage artifacts integration
-        uses: actions/download-artifact@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          name: coverage-report-unit
-      - name: Download coverage unit
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage-report-integration
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
-          files: ./coverage-integration.txt, ./coverage-unit.txt
-          verbose: true
+          go-version: '1.20'
+          cache: true
+      - name: Acceptance tests with merged buckets
+        env:
+          ENABLE_MERGED_PROPERTY_BUCKETS: true
+          WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
+          WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}
+        run: ./test/run.sh --acceptance-only
   Compile-and-upload-binaries:
     name: compile-and-upload-binaries
     runs-on: ubuntu-latest-8-cores

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -36,6 +36,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/classifications"
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	modulestorage "github.com/weaviate/weaviate/adapters/repos/modules"
 	schemarepo "github.com/weaviate/weaviate/adapters/repos/schema"
 	txstore "github.com/weaviate/weaviate/adapters/repos/transactions"
@@ -110,8 +111,18 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	config.ServerVersion = parseVersionFromSwaggerSpec()
 
+	if os.Getenv("ENABLE_MERGED_PROPERTY_BUCKETS") != "" && strings.ToLower(os.Getenv("ENABLE_MERGED_PROPERTY_BUCKETS")) != "false" {
+		lsmkv.FeatureUseMergedBuckets = true
+	} else {
+		lsmkv.FeatureUseMergedBuckets = false
+	}
+
 	appState := startupRoutine(ctx)
 	setupGoProfiling(appState.ServerConfig.Config)
+
+	if lsmkv.FeatureUseMergedBuckets {
+		appState.Logger.WithField("action", "startup").Warnf("Merged property buckets are enabled. This is an experimental feature and may be removed in the future. Please report any issues you encounter.")
+	}
 
 	if appState.ServerConfig.Config.Monitoring.Enabled {
 		// only monitoring tool supported at the moment is prometheus

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -25,11 +25,23 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
+func Test_KeyHelpers(t *testing.T) {
+	prefix := []byte("testprefix")
+	data := []byte("testdata")
+
+	composite_key := helpers.MakePropertyKey(prefix, data)
+	assert.True(t, helpers.MatchesPropertyKeyPostfix(prefix, composite_key))
+	recovered_key := helpers.UnMakePropertyKey(prefix, composite_key)
+
+	assert.Equal(t, data, recovered_key)
+}
 
 func Test_Aggregations(t *testing.T) {
 	dirName := t.TempDir()

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/tracker"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -43,18 +44,14 @@ type Aggregator struct {
 	stopwords              stopwords.StopwordDetector
 	shardVersion           uint16
 	propLengths            *inverted.JsonPropertyLengthTracker
+	propertyIds            *tracker.JsonPropertyIdTracker
 	isFallbackToSearchable inverted.IsFallbackToSearchable
 	tenant                 string
 	nestedCrossRefLimit    int64
+	PropertyName           string
 }
 
-func New(store *lsmkv.Store, params aggregation.Params,
-	getSchema schemaUC.SchemaGetter, classSearcher inverted.ClassSearcher,
-	deletedDocIDs inverted.DeletedDocIDChecker, stopwords stopwords.StopwordDetector,
-	shardVersion uint16, vectorIndex vectorIndex, logger logrus.FieldLogger,
-	propLengths *inverted.JsonPropertyLengthTracker, isFallbackToSearchable inverted.IsFallbackToSearchable,
-	tenant string, nestedCrossRefLimit int64,
-) *Aggregator {
+func New(store *lsmkv.Store, params aggregation.Params, getSchema schemaUC.SchemaGetter, classSearcher inverted.ClassSearcher, deletedDocIDs inverted.DeletedDocIDChecker, stopwords stopwords.StopwordDetector, shardVersion uint16, vectorIndex vectorIndex, logger logrus.FieldLogger, propLengths *inverted.JsonPropertyLengthTracker, isFallbackToSearchable inverted.IsFallbackToSearchable, tenant string, propertyIds *tracker.JsonPropertyIdTracker, nestedCrossRefLimit int64) *Aggregator {
 	return &Aggregator{
 		logger:                 logger,
 		store:                  store,
@@ -68,6 +65,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 		propLengths:            propLengths,
 		isFallbackToSearchable: isFallbackToSearchable,
 		tenant:                 tenant,
+		propertyIds:            propertyIds,
 		nestedCrossRefLimit:    nestedCrossRefLimit,
 	}
 }

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -121,7 +121,7 @@ func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.
 	)
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, s,
 		propertyspecific.Indices{}, fa.classSearcher,
-		nil, fa.propLengths, fa.logger, fa.shardVersion,
+		nil, fa.propLengths, fa.logger, fa.shardVersion, fa.propertyIds,
 	).BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -152,12 +152,16 @@ func (g *grouper) hybrid(ctx context.Context, allowList helpers.AllowList) ([]ui
 	return ids, nil
 }
 
-func (g *grouper) addElementById(s *models.PropertySchema, docID uint64) error {
-	if s == nil {
+func (g *grouper) addElementById(propertySchemaP *models.PropertySchema, docID uint64) error {
+	if propertySchemaP == nil {
 		return nil
 	}
 
-	item, ok := (*s).(map[string]interface{})[g.params.GroupBy.Property.String()]
+	key := g.params.GroupBy.Property.String()
+	S := *propertySchemaP
+	m := S.(map[string]interface{})
+	item, ok := m[key]
+
 	if !ok {
 		return nil
 	}

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -51,10 +51,7 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 		cfg   = inverted.ConfigFromModel(class.InvertedIndexConfig)
 	)
 
-	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, s,
-		propertyspecific.Indices{}, a.classSearcher,
-		nil, a.propLengths, a.logger, a.shardVersion,
-	).BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw)
+	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, s, propertyspecific.Indices{}, a.classSearcher, nil, a.propLengths, a.logger, a.shardVersion, a.propertyIds).BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
 	}

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -90,11 +90,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 
 	if a.params.Filters != nil {
 		s := a.getSchema.GetSchemaSkipAuth()
-		allow, err = inverted.NewSearcher(a.logger, a.store, s, nil,
-			a.classSearcher, a.deletedDocIDs, a.stopwords, a.shardVersion,
-			a.isFallbackToSearchable, a.tenant, a.nestedCrossRefLimit).
-			DocIDs(ctx, a.params.Filters, additional.Properties{},
-				a.params.ClassName)
+		allow, err = inverted.NewSearcher(a.logger, a.store, s, nil, a.propertyIds, a.classSearcher, a.deletedDocIDs, a.stopwords, a.shardVersion, a.isFallbackToSearchable, a.tenant, a.nestedCrossRefLimit).DocIDs(ctx, a.params.Filters, additional.Properties{}, a.params.ClassName)
 		if err != nil {
 			return nil, fmt.Errorf("retrieve doc IDs from searcher: %w", err)
 		}

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -181,7 +181,7 @@ func TestBackup_BucketLevel(t *testing.T) {
 	shard, _ := testShard(t, ctx, className)
 
 	t.Run("insert data", func(t *testing.T) {
-		err := shard.putObject(ctx, &storobj.Object{
+		err := shard.PutObject(ctx, &storobj.Object{
 			MarshallerVersion: 1,
 			Object: models.Object{
 				ID:    "8c29da7a-600a-43dc-85fb-83ab2b08c294",

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -148,7 +149,13 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		})
 
 		require.NotNil(t, err)
-		assert.Contains(t, err.Error(),
-			"Timestamps must be indexed to be filterable! Add `IndexTimestamps: true` to the InvertedIndexConfig in")
+		if lsmkv.FeatureUseMergedBuckets {
+			assert.Contains(t, err.Error(),
+				"Timestamps must be indexed to be filterable! Add `IndexTimestamps: true` to the InvertedIndexConfig in")
+		} else {
+			assert.Contains(t, err.Error(),
+				"timestamps must be indexed to be filterable! "+
+					"add `indexTimestamps: true` to the invertedIndexConfig")
+		}
 	})
 }

--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -106,11 +106,11 @@ func (os *objectScannerLSM) scan() error {
 		}
 
 		if len(os.properties) > 0 {
-			err = storobj.UnmarshalPropertiesFromObject(res, &propertiesTyped, os.properties, propStrings)
+			typedProperties, err := storobj.UnmarshalPropertiesFromObject(res, os.properties, propStrings)
 			if err != nil {
 				return errors.Wrapf(err, "unmarshal data object")
 			}
-			properties = propertiesTyped
+			properties = *typedProperties
 		}
 
 		continueScan, err := os.scanFn(&properties, id)

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -157,25 +158,28 @@ func testPrimitivePropsWithNoLengthIndex(repo *DB) func(t *testing.T) {
 			ErrMsg      string
 		}
 
-		tests := []test{
-			{
-				name:        "Filter by unsupported geo-coordinates",
-				filter:      buildFilter("len(parkedAt)", 0, eq, dtInt),
-				expectedIDs: []strfmt.UUID{},
-				ErrMsg:      "Property length must be indexed to be filterable! add `IndexPropertyLength: true` to the invertedIndexConfig in",
-			},
-			{
-				name:        "Filter by unsupported number",
-				filter:      buildFilter("len(horsepower)", 1, eq, dtInt),
-				expectedIDs: []strfmt.UUID{},
-				ErrMsg:      "Property length must be indexed to be filterable",
-			},
-			{
-				name:        "Filter by unsupported date",
-				filter:      buildFilter("len(released)", 1, eq, dtInt),
-				expectedIDs: []strfmt.UUID{},
-				ErrMsg:      "Property length must be indexed to be filterable! add `IndexPropertyLength: true` to the invertedIndexConfig in",
-			},
+		var tests []test
+		if !lsmkv.FeatureUseMergedBuckets {
+			tests = []test{
+				{
+					name:        "Filter by unsupported geo-coordinates",
+					filter:      buildFilter("len(parkedAt)", 0, eq, dtInt),
+					expectedIDs: []strfmt.UUID{},
+					ErrMsg:      "Property length must be indexed to be filterable",
+				},
+				{
+					name:        "Filter by unsupported number",
+					filter:      buildFilter("len(horsepower)", 1, eq, dtInt),
+					expectedIDs: []strfmt.UUID{},
+					ErrMsg:      "Property length must be indexed to be filterable",
+				},
+				{
+					name:        "Filter by unsupported date",
+					filter:      buildFilter("len(released)", 1, eq, dtInt),
+					expectedIDs: []strfmt.UUID{},
+					ErrMsg:      "Property length must be indexed to be filterable",
+				},
+			}
 		}
 
 		for _, test := range tests {

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -12,8 +12,11 @@
 package helpers
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/tracker"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -25,49 +28,83 @@ var (
 	DocIDBucket                = []byte("doc_ids")
 )
 
+func MakeByteEncodedPropertyPostfix(propertyName string, propertyIds *tracker.JsonPropertyIdTracker) []byte {
+	propertyid := propertyIds.GetIdForProperty(propertyName)
+	propertyid_bytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(propertyid_bytes, propertyid)
+	return propertyid_bytes
+}
+
 // BucketFromPropName creates the byte-representation used as the bucket name
 // for a particular prop in the inverted index
 func BucketFromPropName(propName string) []byte {
 	return []byte(fmt.Sprintf("property_%s", propName))
 }
 
-// MetaCountProp helps create an internally used propName for meta props that
-// don't explicitly exist in the user schema, but are required for proper
-// indexing, such as the count of arrays.
-func MetaCountProp(propName string) string {
-	return fmt.Sprintf("%s__meta_count", propName)
+func MakePropertyKey(byteEncodedPropertyId []byte, key []byte) []byte {
+	b := make([]byte, len(byteEncodedPropertyId))
+	copy(b, byteEncodedPropertyId)
+
+	k := make([]byte, len(key))
+	copy(k, key)
+
+	jointKey := append(k, b...)
+	return jointKey
 }
 
-func PropLength(propName string) string {
-	return propName + filters.InternalPropertyLength
+func MatchesPropertyKeyPostfix(byteEncodedPropertyId []byte, prefixed_key []byte) bool {
+	// Allows accessing every key
+	if len(byteEncodedPropertyId) == 0 {
+		return true
+	}
+
+	return bytes.HasSuffix(prefixed_key, byteEncodedPropertyId)
 }
 
-func PropNull(propName string) string {
-	return propName + filters.InternalNullIndex
+func UnMakePropertyKey(byteEncodedPropertyId []byte, postfixed_key []byte) []byte {
+	//For postfix propid
+	out := make([]byte, len(postfixed_key)-len(byteEncodedPropertyId))
+	copy(out, postfixed_key[:len(postfixed_key)-len(byteEncodedPropertyId)])
+
+	return out
 }
 
-// BucketFromPropName creates string used as the bucket name
-// for a particular prop in the inverted index
-func BucketFromPropNameLSM(propName string) string {
-	return fmt.Sprintf("property_%s", propName)
+func BucketFromPropertyName(propertyName string) []byte {
+	return []byte(fmt.Sprintf("property_%s", propertyName))
 }
 
-func BucketFromPropNameLengthLSM(propName string) string {
-	return BucketFromPropNameLSM(PropLength(propName))
+func MetaCountProperty(propertyName string) string {
+	return fmt.Sprintf("%s__meta_count", propertyName)
 }
 
-func BucketFromPropNameNullLSM(propName string) string {
-	return BucketFromPropNameLSM(PropNull(propName))
+func PropertyLength(propertyName string) string {
+	return propertyName + filters.InternalPropertyLength
 }
 
-func BucketFromPropNameMetaCountLSM(propName string) string {
-	return BucketFromPropNameLSM(MetaCountProp(propName))
+func PropertyNull(propertyName string) string {
+	return propertyName + filters.InternalNullIndex
+}
+
+func BucketFromPropertyNameLSM(propertyName string) string {
+	return fmt.Sprintf("property_%s", propertyName)
+}
+
+func BucketFromPropertyNameLengthLSM(propertyName string) string {
+	return BucketFromPropertyNameLSM(PropertyLength(propertyName))
+}
+
+func BucketFromPropertyNameNullLSM(propertyName string) string {
+	return BucketFromPropertyNameLSM(PropertyNull(propertyName))
+}
+
+func BucketFromPropertyNameMetaCountLSM(propertyName string) string {
+	return BucketFromPropertyNameLSM(MetaCountProperty(propertyName))
 }
 
 func TempBucketFromBucketName(bucketName string) string {
 	return bucketName + "_temp"
 }
 
-func BucketSearchableFromPropNameLSM(propName string) string {
-	return BucketFromPropNameLSM(propName + "_searchable")
+func BucketSearchableFromPropertyNameLSM(propertyName string) string {
+	return BucketFromPropertyNameLSM(propertyName + "_searchable")
 }

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -62,7 +62,7 @@ func MatchesPropertyKeyPostfix(byteEncodedPropertyId []byte, prefixed_key []byte
 }
 
 func UnMakePropertyKey(byteEncodedPropertyId []byte, postfixed_key []byte) []byte {
-	//For postfix propid
+	// For postfix propid
 	out := make([]byte, len(postfixed_key)-len(byteEncodedPropertyId))
 	copy(out, postfixed_key[:len(postfixed_key)-len(byteEncodedPropertyId)])
 

--- a/adapters/repos/db/helpers/helpers_test.go
+++ b/adapters/repos/db/helpers/helpers_test.go
@@ -1,0 +1,121 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package helpers
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/tracker"
+)
+
+func TestMakePropertyPrefix(t *testing.T) {
+	path := t.TempDir() + "/test.json"
+	tracker, err := tracker.NewJsonPropertyIdTracker(path)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	_, err = tracker.CreateProperty("property")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	prefix := MakeByteEncodedPropertyPostfix("property", tracker)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	expectedPrefix := make([]byte, 8)
+	binary.LittleEndian.PutUint64(expectedPrefix, 1)
+
+	if !bytes.Equal(prefix, expectedPrefix) {
+		t.Fatalf("Expected prefix to be %v, got %v", expectedPrefix, prefix)
+	}
+}
+
+func TestMakePropertyKey(t *testing.T) {
+	prefix := []byte{1, 2, 3}
+	key := []byte{4, 5, 6}
+
+	propertyKey := MakePropertyKey(prefix, key)
+	expectedKey := []byte{4, 5, 6, 1, 2, 3}
+
+	if !bytes.Equal(propertyKey, expectedKey) {
+		t.Fatalf("Expected key to be %v, got %v", expectedKey, propertyKey)
+	}
+}
+
+func TestMatchesPropertyKeyPrefix(t *testing.T) {
+	prefix := []byte{1, 2, 3}
+	key := []byte{4, 5, 6, 1, 2, 3}
+
+	matches := MatchesPropertyKeyPostfix(prefix, key)
+	if !matches {
+		t.Fatalf("Expected key to match prefix, but it didn't")
+	}
+}
+
+func TestUnMakePropertyKey(t *testing.T) {
+	prefix := []byte{1, 2, 3}
+	key := []byte{4, 5, 6, 1, 2, 3}
+
+	unmadeKey := UnMakePropertyKey(prefix, key)
+	expectedKey := []byte{4, 5, 6}
+
+	if !bytes.Equal(unmadeKey, expectedKey) {
+		t.Fatalf("Expected key to be %v, got %v", expectedKey, unmadeKey)
+	}
+}
+
+func TestMakePropertyKeyWithEmptyPrefix(t *testing.T) {
+	prefix := []byte{}
+	expectedKey := []byte{4, 5, 6}
+
+	propertyKey := MakePropertyKey(prefix, expectedKey)
+	if !bytes.Equal(propertyKey, expectedKey) {
+		t.Fatalf("Expected key to be %v, got %v", expectedKey, propertyKey)
+	}
+}
+
+func TestMatchesPropertyKeyPrefixWithEmptyPrefix(t *testing.T) {
+	prefix := []byte{}
+	key := []byte{4, 5, 6, 1, 2, 3}
+
+	matches := MatchesPropertyKeyPostfix(prefix, key)
+	if !matches {
+		t.Fatalf("Expected false for empty prefix, got true")
+	}
+}
+
+func TestUnMakePropertyKeyWithEmptyPrefix(t *testing.T) {
+	prefix := []byte{}
+	key := []byte{4, 5, 6, 1, 2, 3}
+
+	unmadeKey := UnMakePropertyKey(prefix, key)
+	if !bytes.Equal(unmadeKey, key) {
+		t.Fatalf("Expected key to be %v, got %v", key, unmadeKey)
+	}
+}
+
+func TestMakePropertyKey2(t *testing.T) {
+	prefix := make([]byte, 2, 10)
+	prefix[0] = 'b'
+	prefix[1] = 'a'
+
+	a1 := MakePropertyKey(prefix, []byte("key1"))
+	a2 := MakePropertyKey(prefix, []byte("key2"))
+	if bytes.Equal(a1, a2) {
+		t.Fatalf("Expected a1 and a2 to be different, but they are equal")
+	}
+}

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -47,7 +47,7 @@ func TestIndex_DropIndex(t *testing.T) {
 	indexFilesAfterDelete, err := getIndexFilenames(dirName, class.Class)
 	require.Nil(t, err)
 
-	assert.Equal(t, 6, len(indexFilesBeforeDelete))
+	assert.Equal(t, 8, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
 }
 
@@ -71,9 +71,9 @@ func TestIndex_DropEmptyAndRecreateEmptyIndex(t *testing.T) {
 	indexFilesAfterRecreate, err := getIndexFilenames(dirName, class.Class)
 	require.Nil(t, err)
 
-	assert.Equal(t, 6, len(indexFilesBeforeDelete))
+	assert.Equal(t, 8, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
-	assert.Equal(t, 6, len(indexFilesAfterRecreate))
+	assert.Equal(t, 8, len(indexFilesAfterRecreate))
 
 	err = index.drop()
 	require.Nil(t, err)
@@ -213,9 +213,9 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		productsIds[1], nil, additional.Properties{}, nil, "")
 	require.Nil(t, err)
 
-	assert.Equal(t, 6, len(indexFilesBeforeDelete))
+	assert.Equal(t, 8, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
-	assert.Equal(t, 6, len(indexFilesAfterRecreate))
+	assert.Equal(t, 8, len(indexFilesAfterRecreate))
 	assert.Equal(t, indexFilesBeforeDelete, indexFilesAfterRecreate)
 	assert.NotNil(t, beforeDeleteObj1)
 	assert.NotNil(t, beforeDeleteObj2)

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -511,7 +511,7 @@ func (a *Analyzer) analyzeRefPropCount(prop *models.Property,
 	}
 
 	return &Property{
-		Name:               helpers.MetaCountProp(prop.Name),
+		Name:               helpers.MetaCountProperty(prop.Name),
 		Items:              items,
 		Length:             len(value),
 		HasFilterableIndex: HasFilterableIndex(prop),

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -477,7 +477,7 @@ func TestAnalyzeObject(t *testing.T) {
 
 			for _, elem := range res {
 				switch elem.Name {
-				case helpers.MetaCountProp("myRef"):
+				case helpers.MetaCountProperty("myRef"):
 					actualRefCount = elem.Items
 				case "_id":
 					actualUUID = elem.Items
@@ -537,7 +537,7 @@ func TestAnalyzeObject(t *testing.T) {
 
 			for _, elem := range res {
 				switch elem.Name {
-				case helpers.MetaCountProp("myRef"):
+				case helpers.MetaCountProperty("myRef"):
 					actualRefCount = elem.Items
 				case "_id":
 					actualUUID = elem.Items
@@ -580,7 +580,7 @@ func TestAnalyzeObject(t *testing.T) {
 			var actualUUID []Countable
 
 			for _, elem := range res {
-				if elem.Name == helpers.MetaCountProp("myRef") {
+				if elem.Name == helpers.MetaCountProperty("myRef") {
 					actualRefCount = elem.Items
 				}
 				if elem.Name == "_id" {

--- a/adapters/repos/db/inverted/prop_length_tracker.go
+++ b/adapters/repos/db/inverted/prop_length_tracker.go
@@ -243,8 +243,7 @@ func (t *PropertyLengthTracker) addProperty(propName string) (uint16, uint16, er
 			page++
 			// overflow of uint16 variable that tracks the size of the tracker
 			if page > 15 {
-				return 0, 0, fmt.Errorf("could not add property %v, to PropertyLengthTracker, because the total"+
-					"length of all properties is too long", propName)
+				return 0, 0, fmt.Errorf("could not add property %v, to PropertyLengthTracker, because the total length of all properties is too long", propName)
 			}
 			continue
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/roaringset"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -30,7 +31,7 @@ type propValuePair struct {
 
 	// set for all values that can be served by an inverted index, i.e. anything
 	// that's not a geoRange
-	value []byte
+	_value []byte
 
 	// only set if operator=OperatorWithinGeoRange, as that cannot be served by a
 	// byte value from an inverted index
@@ -39,47 +40,67 @@ type propValuePair struct {
 	children           []*propValuePair
 	hasFilterableIndex bool
 	hasSearchableIndex bool
-	Class              *models.Class // The schema
+
+	Class *models.Class // The schema
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
 	if class == nil {
 		return nil, errors.Errorf("class must not be nil")
 	}
+
 	return &propValuePair{docIDs: newDocBitmap(), Class: class}, nil
 }
 
-func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
+func (pv *propValuePair) SetValue(value []byte) {
+	pv._value = value
+}
+
+func (pv *propValuePair) Value() []byte {
+	// copy pv.value so other code can't modify it
+	if pv._value == nil {
+		return nil
+	}
+	value := make([]byte, len(pv._value))
+	copy(value, pv._value)
+	return value
+}
+
+func (pv *propValuePair) DocIds() []uint64 {
+	return pv.docIDs.IDs()
+}
+
+func (pv *propValuePair) fetchDocIDs_old(s *Searcher, limit int) error {
 	if pv.operator.OnValue() {
-
-		// TODO text_rbm_inverted_index find better way check whether prop len
-		if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
-			!pv.Class.InvertedIndexConfig.IndexPropertyLength {
-			return errors.Errorf("Property length must be indexed to be filterable! add `IndexPropertyLength: true` to the invertedIndexConfig in %v.  Geo-coordinates, phone numbers and data blobs are not supported by property length.", pv.Class.Class)
-		}
-
-		if pv.operator == filters.OperatorIsNull && !pv.Class.InvertedIndexConfig.IndexNullState {
-			return errors.Errorf("Nullstate must be indexed to be filterable! Add `indexNullState: true` to the invertedIndexConfig")
-		}
-
-		if (pv.prop == filters.InternalPropCreationTimeUnix ||
-			pv.prop == filters.InternalPropLastUpdateTimeUnix) &&
-			!pv.Class.InvertedIndexConfig.IndexTimestamps {
-			return errors.Errorf("Timestamps must be indexed to be filterable! Add `IndexTimestamps: true` to the InvertedIndexConfig in %v", pv.Class.Class)
-		}
-
 		var bucketName string
 		if pv.hasFilterableIndex {
-			bucketName = helpers.BucketFromPropNameLSM(pv.prop)
+			bucketName = helpers.BucketFromPropertyNameLSM(pv.prop)
 		} else if pv.hasSearchableIndex {
-			bucketName = helpers.BucketSearchableFromPropNameLSM(pv.prop)
+			bucketName = helpers.BucketSearchableFromPropertyNameLSM(pv.prop)
 		} else {
 			return errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
 		}
 
 		b := s.store.Bucket(bucketName)
 
-		// TODO:  I think we can delete this check entirely.  The bucket will never be nill, and routines should now check if their particular feature is active in the schema.  However, not all those routines have checks yet.
+		// TODO text_rbm_inverted_index find better way check whether prop len
+		if b == nil && strings.HasSuffix(bucketName, filters.InternalPropertyLength) {
+			return errors.Errorf("Property length must be indexed to be filterable! " +
+				"add `IndexPropertyLength: true` to the invertedIndexConfig." +
+				"Geo-coordinates, phone numbers and data blobs are not supported by property length.")
+		}
+
+		if b == nil && pv.operator == filters.OperatorIsNull {
+			return errors.Errorf("Nullstate must be indexed to be filterable! " +
+				"add `indexNullState: true` to the invertedIndexConfig")
+		}
+
+		if b == nil && (pv.prop == filters.InternalPropCreationTimeUnix ||
+			pv.prop == filters.InternalPropLastUpdateTimeUnix) {
+			return errors.Errorf("timestamps must be indexed to be filterable! " +
+				"add `indexTimestamps: true` to the invertedIndexConfig")
+		}
+
 		if b == nil && pv.operator != filters.OperatorWithinGeoRange {
 			// a nil bucket is ok for a WithinGeoRange filter, as this query is not
 			// served by the inverted index, but propagated to a secondary index in
@@ -88,7 +109,7 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
 		}
 
 		ctx := context.TODO() // TODO: pass through instead of spawning new
-		dbm, err := s.docBitmap(ctx, b, limit, pv)
+		dbm, err := s.docBitmap(ctx, []byte{}, b, limit, pv)
 		if err != nil {
 			return err
 		}
@@ -121,6 +142,95 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
 	return nil
 }
 
+func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
+	if !lsmkv.FeatureUseMergedBuckets {
+		return pv.fetchDocIDs_old(s, limit)
+	}
+	if pv.operator.OnValue() {
+
+		// TODO text_rbm_inverted_index find better way check whether prop len
+		if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
+			!pv.Class.InvertedIndexConfig.IndexPropertyLength {
+			return errors.Errorf("Property length must be indexed to be filterable! add `IndexPropertyLength: true` to the invertedIndexConfig in %v.  Geo-coordinates, phone numbers and data blobs are not supported by property length.", pv.Class.Class)
+		}
+
+		if pv.operator == filters.OperatorIsNull && !pv.Class.InvertedIndexConfig.IndexNullState {
+			return errors.Errorf("Nullstate must be indexed to be filterable! Add `indexNullState: true` to the invertedIndexConfig")
+		}
+
+		if (pv.prop == filters.InternalPropCreationTimeUnix ||
+			pv.prop == filters.InternalPropLastUpdateTimeUnix) &&
+			!pv.Class.InvertedIndexConfig.IndexTimestamps {
+			return errors.Errorf("Timestamps must be indexed to be filterable! Add `IndexTimestamps: true` to the InvertedIndexConfig in %v", pv.Class.Class)
+		}
+
+		var mergedName string
+		if pv.hasFilterableIndex {
+			mergedName = "filterable_properties"
+		} else if pv.hasSearchableIndex {
+			mergedName = "searchable_properties"
+		} else {
+			return errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
+		}
+
+		var bucketName string
+		if pv.hasFilterableIndex {
+			bucketName = helpers.BucketFromPropertyNameLSM(pv.prop)
+		} else if pv.hasSearchableIndex {
+			bucketName = helpers.BucketSearchableFromPropertyNameLSM(pv.prop)
+		} else {
+			return errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
+		}
+
+		// TODO text_rbm_inverted_index find better way check whether prop len
+		if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
+			!pv.Class.InvertedIndexConfig.IndexPropertyLength {
+			return errors.Errorf("Property length must be indexed to be filterable! add `IndexPropertyLength: true` to the invertedIndexConfig. Geo-coordinates, phone numbers and data blobs are not supported by property length.")
+		}
+
+		// TODO how to check if prop is phone number or data blob?
+
+		if pv.operator == filters.OperatorIsNull {
+			if !pv.Class.InvertedIndexConfig.IndexNullState {
+				return errors.Errorf("Nullstate must be indexed to be filterable! add `indexNullState: true` to the invertedIndexConfig")
+			}
+		}
+
+		if pv.prop == filters.InternalPropCreationTimeUnix || pv.prop == filters.InternalPropLastUpdateTimeUnix {
+			if !pv.Class.InvertedIndexConfig.IndexTimestamps {
+				return errors.Errorf("timestamps must be indexed to be filterable! add `indexTimestamps: true` to the invertedIndexConfig")
+			}
+		}
+
+		bproxy, err := lsmkv.FetchMeABucket(s.store, mergedName, bucketName, pv.prop, s.propIds) // "" - old file is handled in _old
+		if err != nil {
+			return err
+		}
+
+		ctx := context.TODO() // TODO: pass through instead of spawning new
+		dbm, err := s.docBitmap(ctx, []byte(pv.prop), bproxy, limit, pv)
+		if err != nil {
+			return err
+		}
+		pv.docIDs = dbm
+	} else {
+		for i, child := range pv.children {
+			i, child := i, child
+			// Explicitly set the limit to 0 (=unlimited) as this is a nested filter,
+			// otherwise we run into situations where each subfilter on their own
+			// runs into the limit, possibly yielding in "less than limit" results
+			// after merging.
+			err := child.fetchDocIDs(s, 0)
+			if err != nil {
+				return errors.Wrapf(err, "nested child %d", i)
+			}
+
+		}
+	}
+
+	return nil
+}
+
 func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 	if pv.operator.OnValue() {
 		return &pv.docIDs, nil
@@ -142,17 +252,17 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 		dbms[i] = dbm
 	}
 
-	mergeRes := dbms[0].docIDs.Clone()
+	mergeRes := dbms[0].DocIDs.Clone()
 	mergeFn := mergeRes.And
 	if pv.operator == filters.OperatorOr {
 		mergeFn = mergeRes.Or
 	}
 
 	for i := 1; i < len(dbms); i++ {
-		mergeFn(dbms[i].docIDs)
+		mergeFn(dbms[i].DocIDs)
 	}
 
 	return &docBitmap{
-		docIDs: roaringset.Condense(mergeRes),
+		DocIDs: roaringset.Condense(mergeRes),
 	}, nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -93,7 +93,7 @@ func TestPropValuePairs_Merging(t *testing.T) {
 					pv.children[i] = &propValuePair{
 						operator: filters.OperatorEqual,
 						docIDs: docBitmap{
-							docIDs: tc.bitmaps[i],
+							DocIDs: tc.bitmaps[i],
 						},
 					}
 				}
@@ -102,9 +102,9 @@ func TestPropValuePairs_Merging(t *testing.T) {
 
 				require.Nil(t, err)
 				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())
-				assert.False(t, tc.bitmaps[0] == dbm.docIDs)
-				assert.False(t, tc.bitmaps[1] == dbm.docIDs)
-				assert.False(t, tc.bitmaps[2] == dbm.docIDs)
+				assert.False(t, tc.bitmaps[0] == dbm.DocIDs)
+				assert.False(t, tc.bitmaps[1] == dbm.DocIDs)
+				assert.False(t, tc.bitmaps[2] == dbm.DocIDs)
 			})
 		}
 	})

--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/filters"
 )
@@ -25,16 +26,17 @@ import (
 // RowReaderRoaringSet reads one or many row(s) depending on the specified
 // operator
 type RowReaderRoaringSet struct {
-	value     []byte
-	operator  filters.Operator
-	newCursor func() lsmkv.CursorRoaringSet
-	getter    func(key []byte) (*sroar.Bitmap, error)
+	value      []byte
+	operator   filters.Operator
+	newCursor  func() lsmkv.CursorRoaringSet
+	getter     func(key []byte) (*sroar.Bitmap, error)
+	PropPrefix []byte
 }
 
 // If keyOnly is set, the RowReaderRoaringSet will request key-only cursors
 // wherever cursors are used, the specified value arguments in the
 // RoaringSetReadFn will always be empty
-func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte,
+func NewRowReaderRoaringSet(bucket lsmkv.BucketInterface, value []byte,
 	operator filters.Operator, keyOnly bool,
 ) *RowReaderRoaringSet {
 	getter := bucket.RoaringSetGet
@@ -44,10 +46,11 @@ func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte,
 	}
 
 	return &RowReaderRoaringSet{
-		value:     value,
-		operator:  operator,
-		newCursor: newCursor,
-		getter:    getter,
+		value:      value,
+		operator:   operator,
+		newCursor:  newCursor,
+		getter:     getter,
+		PropPrefix: bucket.PropertyPrefix(),
 	}
 }
 
@@ -98,7 +101,6 @@ func (rr *RowReaderRoaringSet) equal(ctx context.Context,
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-
 	v, err := rr.getter(rr.value)
 	if err != nil {
 		return err
@@ -116,7 +118,14 @@ func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 	c := rr.newCursor()
 	defer c.Close()
 
-	for k, v := c.Seek(rr.value); k != nil; k, v = c.Next() {
+	value_with_prop := helpers.MakePropertyKey(rr.PropPrefix, rr.value)
+
+	for compositeKey, v := c.Seek(value_with_prop); compositeKey != nil; compositeKey, v = c.Next() {
+		if !helpers.MatchesPropertyKeyPostfix(rr.PropPrefix, compositeKey) {
+			continue
+		}
+		k := helpers.UnMakePropertyKey(rr.PropPrefix, compositeKey)
+
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -144,7 +153,11 @@ func (rr *RowReaderRoaringSet) lessThan(ctx context.Context,
 	c := rr.newCursor()
 	defer c.Close()
 
-	for k, v := c.First(); k != nil && bytes.Compare(k, rr.value) < 1; k, v = c.Next() {
+	for compositeKey, v := c.First(); compositeKey != nil && bytes.Compare(helpers.UnMakePropertyKey(rr.PropPrefix, compositeKey), rr.value) < 1; compositeKey, v = c.Next() {
+		if !helpers.MatchesPropertyKeyPostfix(rr.PropPrefix, compositeKey) {
+			continue
+		}
+		k := helpers.UnMakePropertyKey(rr.PropPrefix, compositeKey)
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -171,7 +184,13 @@ func (rr *RowReaderRoaringSet) notEqual(ctx context.Context,
 	c := rr.newCursor()
 	defer c.Close()
 
-	for k, v := c.First(); k != nil; k, v = c.Next() {
+	for compositeKey, v := c.First(); compositeKey != nil; compositeKey, v = c.Next() {
+		if !helpers.MatchesPropertyKeyPostfix(rr.PropPrefix, compositeKey) {
+			continue
+		}
+
+		k := helpers.UnMakePropertyKey(rr.PropPrefix, compositeKey)
+
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -214,10 +233,16 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 		initialK, initialV = c.First()
 	}
 
-	for k, v := initialK, initialV; k != nil; k, v = c.Next() {
+	for compositeKey, v := initialK, initialV; compositeKey != nil; compositeKey, v = c.Next() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+
+		if !helpers.MatchesPropertyKeyPostfix(rr.PropPrefix, compositeKey) {
+			continue
+		}
+
+		k := helpers.UnMakePropertyKey(rr.PropPrefix, compositeKey)
 
 		if like.optimizable {
 			// if the query is optimizable, i.e. it doesn't start with a wildcard, we

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -22,9 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
-func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
-	pv *propValuePair,
-) (docBitmap, error) {
+func (s *Searcher) docBitmap(ctx context.Context, property []byte, b lsmkv.BucketInterface, limit int, pv *propValuePair) (docBitmap, error) {
 	// geo props cannot be served by the inverted index and they require an
 	// external index. So, instead of trying to serve this chunk of the filter
 	// request internally, we can pass it to an external geo index
@@ -41,38 +39,36 @@ func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
 		}
 
 		// bucket with strategy set serves docIds used to build bitmap
-		return s.docBitmapInvertedSet(ctx, b, limit, pv)
+		return s.docBitmapInvertedSet(ctx, property, b, limit, pv)
 	}
 
 	if pv.hasSearchableIndex {
 		// bucket with strategy map serves docIds used to build bitmap
 		// and frequencies, which are ignored for filtering
-		return s.docBitmapInvertedMap(ctx, b, limit, pv)
+		return s.docBitmapInvertedMap(ctx, property, b, limit, pv)
 	}
 
 	return docBitmap{}, fmt.Errorf("property '%s' is neither filterable nor searchable", pv.prop)
 }
 
-func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Bucket,
-	limit int, pv *propValuePair,
-) (docBitmap, error) {
+func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b lsmkv.BucketInterface, limit int, pv *propValuePair) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
 	var readFn RoaringSetReadFn = func(k []byte, docIDs *sroar.Bitmap) (bool, error) {
 		if isEmpty {
-			out.docIDs = docIDs
+			out.DocIDs = docIDs
 			isEmpty = false
 		} else {
-			out.docIDs.Or(docIDs)
+			out.DocIDs.Or(docIDs)
 		}
 
-		if limit > 0 && out.docIDs.GetCardinality() >= limit {
+		if limit > 0 && out.DocIDs.GetCardinality() >= limit {
 			return false, nil
 		}
 		return true, nil
 	}
 
-	rr := NewRowReaderRoaringSet(b, pv.value, pv.operator, false)
+	rr := NewRowReaderRoaringSet(b, pv.Value(), pv.operator, false)
 	if err := rr.Read(ctx, readFn); err != nil {
 		return out, errors.Wrap(err, "read row")
 	}
@@ -83,22 +79,20 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 	return out, nil
 }
 
-func (s *Searcher) docBitmapInvertedSet(ctx context.Context, b *lsmkv.Bucket,
-	limit int, pv *propValuePair,
-) (docBitmap, error) {
+func (s *Searcher) docBitmapInvertedSet(ctx context.Context, property []byte, b lsmkv.BucketInterface, limit int, pv *propValuePair) (docBitmap, error) {
 	out := newDocBitmap()
 	var readFn ReadFn = func(k []byte, ids [][]byte) (bool, error) {
 		for _, asBytes := range ids {
-			out.docIDs.Set(binary.LittleEndian.Uint64(asBytes))
+			out.DocIDs.Set(binary.LittleEndian.Uint64(asBytes))
 		}
 
-		if limit > 0 && out.docIDs.GetCardinality() >= limit {
+		if limit > 0 && out.DocIDs.GetCardinality() >= limit {
 			return false, nil
 		}
 		return true, nil
 	}
 
-	rr := NewRowReader(b, pv.value, pv.operator, false)
+	rr := NewRowReader(b, pv.Value(), pv.operator, false)
 	if err := rr.Read(ctx, readFn); err != nil {
 		return out, errors.Wrap(err, "read row")
 	}
@@ -106,28 +100,26 @@ func (s *Searcher) docBitmapInvertedSet(ctx context.Context, b *lsmkv.Bucket,
 	return out, nil
 }
 
-func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
-	limit int, pv *propValuePair,
-) (docBitmap, error) {
+func (s *Searcher) docBitmapInvertedMap(ctx context.Context, property []byte, b lsmkv.BucketInterface, limit int, pv *propValuePair) (docBitmap, error) {
 	out := newDocBitmap()
 	var readFn ReadFnFrequency = func(k []byte, pairs []lsmkv.MapPair) (bool, error) {
 		for _, pair := range pairs {
 			// this entry has a frequency, but that's only used for bm25, not for
 			// pure filtering, so we can ignore it here
 			if s.shardVersion < 2 {
-				out.docIDs.Set(binary.LittleEndian.Uint64(pair.Key))
+				out.DocIDs.Set(binary.LittleEndian.Uint64(pair.Key))
 			} else {
-				out.docIDs.Set(binary.BigEndian.Uint64(pair.Key))
+				out.DocIDs.Set(binary.BigEndian.Uint64(pair.Key))
 			}
 		}
 
-		if limit > 0 && out.docIDs.GetCardinality() >= limit {
+		if limit > 0 && out.DocIDs.GetCardinality() >= limit {
 			return false, nil
 		}
 		return true, nil
 	}
 
-	rr := NewRowReaderFrequency(b, pv.value, pv.operator, false, s.shardVersion)
+	rr := NewRowReaderFrequency(b, pv.Value(), pv.operator, false, s.shardVersion)
 	if err := rr.Read(ctx, readFn); err != nil {
 		return out, errors.Wrap(err, "read row")
 	}
@@ -148,6 +140,6 @@ func (s *Searcher) docBitmapGeo(ctx context.Context, pv *propValuePair) (docBitm
 		return out, errors.Wrapf(err, "geo index range search on prop %q", pv.prop)
 	}
 
-	out.docIDs.SetMany(res)
+	out.DocIDs.SetMany(res)
 	return out, nil
 }

--- a/adapters/repos/db/inverted/searcher_ref_filter.go
+++ b/adapters/repos/db/inverted/searcher_ref_filter.go
@@ -145,7 +145,7 @@ func (r *refFilterExtractor) resultsToPropValuePairs(ids []classUUIDPair,
 func (r *refFilterExtractor) emptyPropValuePair() *propValuePair {
 	return &propValuePair{
 		prop:               r.property.Name,
-		value:              nil,
+		_value:             nil,
 		operator:           filters.OperatorEqual,
 		hasFilterableIndex: HasFilterableIndex(r.property),
 		hasSearchableIndex: HasSearchableIndex(r.property),
@@ -173,7 +173,7 @@ func (r *refFilterExtractor) idToPropValuePairWithValue(v []byte,
 ) (*propValuePair, error) {
 	return &propValuePair{
 		prop:               r.property.Name,
-		value:              v,
+		_value:             v,
 		operator:           filters.OperatorEqual,
 		hasFilterableIndex: hasFilterableIndex,
 		hasSearchableIndex: hasSearchableIndex,

--- a/adapters/repos/db/inverted/searcher_test.go
+++ b/adapters/repos/db/inverted/searcher_test.go
@@ -30,7 +30,7 @@ func TestDocBitmap(t *testing.T) {
 		ids := []uint64{1, 2, 3, 4, 5}
 
 		dbm := newDocBitmap()
-		dbm.docIDs.SetMany(ids)
+		dbm.DocIDs.SetMany(ids)
 
 		assert.Equal(t, 5, dbm.count())
 		assert.ElementsMatch(t, ids, dbm.IDs())
@@ -75,10 +75,10 @@ func TestDocBitmap_IDsWithLimit(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dbm := docBitmap{
-				docIDs: sroar.NewBitmap(),
+				DocIDs: sroar.NewBitmap(),
 			}
 
-			dbm.docIDs.SetMany(test.input)
+			dbm.DocIDs.SetMany(test.input)
 
 			res := dbm.IDsWithLimit(test.limit)
 			assert.Equal(t, test.expectedOutput, res)

--- a/adapters/repos/db/inverted/tracker/property_id_tracker.go
+++ b/adapters/repos/db/inverted/tracker/property_id_tracker.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+)
+
+type JsonPropertyIdTracker struct {
+	Path        string
+	LastId      uint64
+	PropertyIds map[string]uint64
+	sync.Mutex
+}
+
+func NewJsonPropertyIdTracker(path string) (*JsonPropertyIdTracker, error) {
+	t := &JsonPropertyIdTracker{
+		Path:        path,
+		PropertyIds: make(map[string]uint64),
+		LastId:      0,
+	}
+
+	// read the file into memory
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Flush(false)
+			return t, nil
+		}
+		return nil, err
+	}
+
+	// Unmarshal the data
+
+	if err := json.Unmarshal(bytes, &t); err != nil {
+		return nil, err
+	}
+	t.Path = path
+
+	return t, nil
+}
+
+// Writes the current state of the tracker to disk.  (flushBackup = true) will only write the backup file
+func (t *JsonPropertyIdTracker) Flush(flushBackup bool) error {
+	if !flushBackup { // Write the backup file first
+		t.Flush(true)
+	}
+
+	t.Lock()
+	defer t.Unlock()
+
+	bytes, err := json.Marshal(t)
+	if err != nil {
+		return err
+	}
+
+	filename := t.Path
+	if flushBackup {
+		filename = t.Path + ".bak"
+	}
+
+	// Do a write+rename to avoid corrupting the file if we crash while writing
+	tempfile := filename + ".tmp"
+
+	err = os.WriteFile(tempfile, bytes, 0o666)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(tempfile, filename)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Drop removes the tracker from disk
+func (t *JsonPropertyIdTracker) Drop() error {
+	t.Lock()
+	defer t.Unlock()
+
+	if err := os.Remove(t.Path); err != nil {
+		return fmt.Errorf("remove prop length tracker state from disk:%v, %w", t.Path, err)
+	}
+	if err := os.Remove(t.Path + ".bak"); err != nil {
+		return fmt.Errorf("remove prop length tracker state from disk:%v, %w", t.Path+".bak", err)
+	}
+
+	return nil
+}
+
+// Closes the tracker and removes the backup file
+func (t *JsonPropertyIdTracker) Close() error {
+	if err := t.Flush(false); err != nil {
+		return fmt.Errorf("flush before closing: %w", err)
+	}
+
+	t.Lock()
+	defer t.Unlock()
+
+	t.PropertyIds = nil
+
+	return nil
+}
+
+func (t *JsonPropertyIdTracker) GetIdForProperty(property string) uint64 {
+	t.Lock()
+	defer t.Unlock()
+
+	if id, ok := t.PropertyIds[property]; ok {
+		return id
+	}
+
+	id, _ := t.doCreateProperty(property)
+	return id
+}
+
+func (t *JsonPropertyIdTracker) CreateProperty(property string) (uint64, error) {
+	t.Lock()
+	defer t.Unlock()
+
+	return t.doCreateProperty(property)
+}
+
+func (t *JsonPropertyIdTracker) doCreateProperty(property string) (uint64, error) {
+	if id, ok := t.PropertyIds[property]; ok {
+		return id, fmt.Errorf("property %v already exists\n", property)
+	}
+
+	t.LastId++
+	t.PropertyIds[property] = t.LastId
+
+	return t.LastId, nil
+}

--- a/adapters/repos/db/inverted/tracker/property_id_tracker_test.go
+++ b/adapters/repos/db/inverted/tracker/property_id_tracker_test.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestJsonPropertyIdTracker(t *testing.T) {
+	path := t.TempDir() + "/test.json"
+
+	t.Run("NewJsonPropertyIdTracker", func(t *testing.T) {
+		tracker, err := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		if tracker.LastId != 0 {
+			t.Fatalf("expected LastId 0, got %v", tracker.LastId)
+		}
+	})
+
+	t.Run("Flush", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+		err := tracker.Flush(false)
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Fatalf("expected file to exist")
+		}
+	})
+
+	t.Run("FlushBackup", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+		err := tracker.Flush(true)
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		_, err = os.Stat(path + ".bak")
+		if os.IsNotExist(err) {
+			t.Fatalf("expected backup file to exist")
+		}
+	})
+
+	t.Run("Drop", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		err := tracker.Drop()
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		_, err = os.Stat(path)
+		if !os.IsNotExist(err) {
+			t.Fatalf("expected file to not exist")
+		}
+	})
+
+	t.Run("GetIdForProperty", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+
+		id := tracker.GetIdForProperty("test")
+		if id != 1 {
+			t.Fatalf("expected 1, got %v", id)
+		}
+	})
+
+	t.Run("CreateProperty", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+		id, err := tracker.CreateProperty("test")
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		tracker.Flush(false)
+
+		fileBytes, _ := os.ReadFile(path)
+		fileContents := &JsonPropertyIdTracker{}
+		json.Unmarshal(fileBytes, fileContents)
+
+		if fileContents.PropertyIds["test"] != id {
+			t.Fatalf("expected property id to match, got %v and %v", fileContents.PropertyIds["test"], id)
+		}
+	})
+
+	t.Run("CreateExistingProperty", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+		tracker.CreateProperty("test")
+		_, err := tracker.CreateProperty("test")
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+}
+
+func TestJsonPropertyIdTracker_ConcurrentAccess(t *testing.T) {
+	path := t.TempDir() + "/test.json"
+
+	t.Run("ConcurrentCreateProperty", func(t *testing.T) {
+		tracker, _ := NewJsonPropertyIdTracker(path)
+		defer tracker.Drop()
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				property := fmt.Sprintf("property%v", i)
+				_, err := tracker.CreateProperty(property)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}(i)
+		}
+		wg.Wait()
+
+		if len(tracker.PropertyIds) != 100 {
+			t.Fatalf("expected 100 properties, got %v", len(tracker.PropertyIds))
+		}
+	})
+}

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -23,13 +23,15 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 )
 
 func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
@@ -112,34 +114,37 @@ func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
 		IndexSearchable: &vFalse,
 	}))
 
-	t.Run("check for additional buckets", func(t *testing.T) {
-		for _, idx := range migrator.db.indices {
-			idx.ForEachShard(func(_ string, shd *Shard) error {
-				createBucket := shd.store.Bucket("property__creationTimeUnix")
-				assert.NotNil(t, createBucket)
+	if !lsmkv.FeatureUseMergedBuckets {
+		t.Run("check for additional buckets", func(t *testing.T) {
+			for _, idx := range migrator.db.indices {
+				idx.ForEachShard(func(_ string, shd *Shard) error {
+					createBucket := shd.store.Bucket("property__creationTimeUnix")
+					assert.NotNil(t, createBucket)
 
-				updateBucket := shd.store.Bucket("property__lastUpdateTimeUnix")
-				assert.NotNil(t, updateBucket)
+					updateBucket := shd.store.Bucket("property__lastUpdateTimeUnix")
+					assert.NotNil(t, updateBucket)
 
-				cases := []struct {
-					prop        string
-					compareFunc func(t assert.TestingT, object interface{}, msgAndArgs ...interface{}) bool
-				}{
-					{prop: "initialWithIINil", compareFunc: assert.NotNil},
-					{prop: "initialWithIITrue", compareFunc: assert.NotNil},
-					{prop: "initialWithoutII", compareFunc: assert.Nil},
-					{prop: "updateWithIINil", compareFunc: assert.NotNil},
-					{prop: "updateWithIITrue", compareFunc: assert.NotNil},
-					{prop: "updateWithoutII", compareFunc: assert.Nil},
-				}
-				for _, tt := range cases {
-					tt.compareFunc(t, shd.store.Bucket("property_"+tt.prop+filters.InternalNullIndex))
-					tt.compareFunc(t, shd.store.Bucket("property_"+tt.prop+filters.InternalPropertyLength))
-				}
-				return nil
-			})
-		}
-	})
+					cases := []struct {
+						prop        string
+						compareFunc func(t assert.TestingT, object interface{}, msgAndArgs ...interface{}) bool
+					}{
+						{prop: "initialWithIINil", compareFunc: assert.NotNil},
+						{prop: "initialWithIITrue", compareFunc: assert.NotNil},
+						{prop: "initialWithoutII", compareFunc: assert.Nil},
+						{prop: "updateWithIINil", compareFunc: assert.NotNil},
+						{prop: "updateWithIITrue", compareFunc: assert.NotNil},
+						{prop: "updateWithoutII", compareFunc: assert.Nil},
+					}
+					for _, tt := range cases {
+						tt.compareFunc(t, shd.store.Bucket("property_"+tt.prop+filters.InternalNullIndex))
+						tt.compareFunc(t, shd.store.Bucket("property_"+tt.prop+filters.InternalNullIndex))
+						tt.compareFunc(t, shd.store.Bucket("property_"+tt.prop+filters.InternalPropertyLength))
+					}
+					return nil
+				})
+			}
+		})
+	}
 
 	t.Run("Add Objects", func(t *testing.T) {
 		testID1 := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a62")
@@ -306,17 +311,33 @@ func TestIndexNullState_GetClass(t *testing.T) {
 		}
 	})
 
-	t.Run("check buckets exist", func(t *testing.T) {
-		index := repo.indices["testclass"]
-		n := 0
-		index.ForEachShard(func(_ string, shard *Shard) error {
-			bucketNull := shard.store.Bucket(helpers.BucketFromPropNameNullLSM("name"))
-			require.NotNil(t, bucketNull)
-			n++
-			return nil
+	if !lsmkv.FeatureUseMergedBuckets {
+		t.Run("check buckets exist", func(t *testing.T) {
+			index := repo.indices["testclass"]
+			n := 0
+			index.ForEachShard(func(_ string, shard *Shard) error {
+				bucketNull := shard.store.Bucket(helpers.BucketFromPropertyNameNullLSM("name"))
+				require.NotNil(t, bucketNull)
+				n++
+				return nil
+			})
+			require.Equal(t, 1, n)
 		})
-		require.Equal(t, 1, n)
-	})
+	} else {
+		t.Run("check buckets exist", func(t *testing.T) {
+			index := repo.indices["testclass"]
+			n := 0
+			index.ForEachShard(func(_ string, shard *Shard) error {
+				bucketProps := shard.store.Bucket("filterable_properties")
+				require.NotNil(t, bucketProps)
+				bucketNull := shard.store.Bucket(helpers.BucketFromPropertyNameNullLSM("name"))
+				require.NotNil(t, bucketNull)
+				n++
+				return nil
+			})
+			require.Equal(t, 1, n)
+		})
+	}
 
 	type testCase struct {
 		name        string
@@ -527,6 +548,34 @@ func TestIndexPropLength_GetClass(t *testing.T) {
 		schemaGetter.schema.Objects.Classes = append(schemaGetter.schema.Objects.Classes, class, refClass)
 	})
 
+	if lsmkv.FeatureUseMergedBuckets {
+		t.Run("check buckets exist", func(t *testing.T) {
+			index := repo.indices["testclass"]
+			n := 0
+			index.ForEachShard(func(_ string, shard *Shard) error {
+				bucketNull := shard.store.Bucket("filterable_properties")
+				require.NotNil(t, bucketNull)
+				n++
+				return nil
+			})
+			require.Equal(t, 1, n)
+		})
+	} else {
+		t.Run("check buckets exist", func(t *testing.T) {
+			index := repo.indices["testclass"]
+			n := 0
+			index.ForEachShard(func(_ string, shard *Shard) error {
+				bucketPropLengthName := shard.store.Bucket(helpers.BucketFromPropertyNameLengthLSM("name"))
+				require.NotNil(t, bucketPropLengthName)
+				bucketPropLengthIntArray := shard.store.Bucket(helpers.BucketFromPropertyNameLengthLSM("int_array"))
+				require.NotNil(t, bucketPropLengthIntArray)
+				n++
+				return nil
+			})
+			require.Equal(t, 1, n)
+		})
+	}
+
 	t.Run("insert test objects", func(t *testing.T) {
 		vec := []float32{1, 2, 3}
 		for _, obj := range []*models.Object{
@@ -574,20 +623,6 @@ func TestIndexPropLength_GetClass(t *testing.T) {
 			err := repo.PutObject(context.Background(), obj, vec, nil)
 			require.Nil(t, err)
 		}
-	})
-
-	t.Run("check buckets exist", func(t *testing.T) {
-		index := repo.indices["testclass"]
-		n := 0
-		index.ForEachShard(func(_ string, shard *Shard) error {
-			bucketPropLengthName := shard.store.Bucket(helpers.BucketFromPropNameLengthLSM("name"))
-			require.NotNil(t, bucketPropLengthName)
-			bucketPropLengthIntArray := shard.store.Bucket(helpers.BucketFromPropNameLengthLSM("int_array"))
-			require.NotNil(t, bucketPropLengthIntArray)
-			n++
-			return nil
-		})
-		require.Equal(t, 1, n)
 	})
 
 	type testCase struct {
@@ -928,18 +963,34 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 		}
 	})
 
-	t.Run("check buckets exist", func(t *testing.T) {
-		index := repo.indices["testclass"]
-		n := 0
-		index.ForEachShard(func(_ string, shard *Shard) error {
-			bucketCreated := shard.store.Bucket("property_" + filters.InternalPropCreationTimeUnix)
-			require.NotNil(t, bucketCreated)
-			bucketUpdated := shard.store.Bucket("property_" + filters.InternalPropLastUpdateTimeUnix)
-			require.NotNil(t, bucketUpdated)
-			n++
-			return nil
+	t.Run("by creation date 2", func(t *testing.T) {
+		res, err := repo.Search(context.Background(), dto.GetParams{
+			ClassName:  "TestClass",
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters: &filters.LocalFilter{
+				Root: &filters.Clause{
+					// since RFC3339 is limited to seconds,
+					// >= operator is used to match object with timestamp containing milliseconds
+					Operator: filters.OperatorGreaterThanEqual,
+					On: &filters.Path{
+						Class:    "TestClass",
+						Property: "_creationTimeUnix",
+					},
+					Value: &filters.Value{
+						Value: time2.Format(time.RFC3339),
+						Type:  schema.DataTypeDate,
+					},
+				},
+			},
 		})
-		require.Equal(t, 1, n)
+		require.Nil(t, err)
+		require.Len(t, res, 2)
+
+		ids := make([]strfmt.UUID, len(res))
+		for i := range res {
+			ids[i] = res[i].ID
+		}
+		assert.ElementsMatch(t, ids, []strfmt.UUID{testID1, testID2})
 	})
 
 	type testCase struct {
@@ -950,6 +1001,25 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 
 	t.Run("get object with timestamp filters", func(t *testing.T) {
 		testCases := []testCase{
+			{
+				name: "by creation date 1",
+				filter: &filters.LocalFilter{
+					Root: &filters.Clause{
+						// since RFC3339 is limited to seconds,
+						// >= operator is used to match object with timestamp containing milliseconds
+						Operator: filters.OperatorGreaterThanEqual,
+						On: &filters.Path{
+							Class:    "TestClass",
+							Property: "_creationTimeUnix",
+						},
+						Value: &filters.Value{
+							Value: time1.Format(time.RFC3339),
+							Type:  schema.DataTypeDate,
+						},
+					},
+				},
+				expectedIds: []strfmt.UUID{testID1},
+			},
 			{
 				name: "by creation timestamp 1",
 				filter: &filters.LocalFilter{
@@ -984,25 +1054,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 				},
 				expectedIds: []strfmt.UUID{testID2},
 			},
-			{
-				name: "by creation date 1",
-				filter: &filters.LocalFilter{
-					Root: &filters.Clause{
-						// since RFC3339 is limited to seconds,
-						// >= operator is used to match object with timestamp containing milliseconds
-						Operator: filters.OperatorGreaterThanEqual,
-						On: &filters.Path{
-							Class:    "TestClass",
-							Property: "_creationTimeUnix",
-						},
-						Value: &filters.Value{
-							Value: time1.Format(time.RFC3339),
-							Type:  schema.DataTypeDate,
-						},
-					},
-				},
-				expectedIds: []strfmt.UUID{testID1},
-			},
+
 			{
 				name: "by creation date 2",
 				filter: &filters.LocalFilter{
@@ -1114,6 +1166,39 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 				assert.ElementsMatch(t, ids, tc.expectedIds)
 			})
 		}
+	})
+	t.Run("get referencing object with timestamp filters - by creation date 2", func(t *testing.T) {
+		res, err := repo.Search(context.Background(), dto.GetParams{
+			ClassName:  "RefClass",
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters: &filters.LocalFilter{
+				Root: &filters.Clause{
+					// since RFC3339 is limited to seconds,
+					// >= operator is used to match object with timestamp containing milliseconds
+					Operator: filters.OperatorGreaterThanEqual,
+					On: &filters.Path{
+						Class:    "RefClass",
+						Property: "toTest",
+						Child: &filters.Path{
+							Class:    "TestClass",
+							Property: "_creationTimeUnix",
+						},
+					},
+					Value: &filters.Value{
+						Value: time2.Format(time.RFC3339),
+						Type:  schema.DataTypeDate,
+					},
+				},
+			},
+		})
+		require.Nil(t, err)
+		require.Len(t, res, 2)
+
+		ids := make([]strfmt.UUID, len(res))
+		for i := range res {
+			ids[i] = res[i].ID
+		}
+		assert.ElementsMatch(t, ids, []strfmt.UUID{refID1, refID2})
 	})
 
 	t.Run("get referencing object with timestamp filters", func(t *testing.T) {

--- a/adapters/repos/db/inverted_migrator_filter_to_search.go
+++ b/adapters/repos/db/inverted_migrator_filter_to_search.go
@@ -225,8 +225,8 @@ func (m *filterableToSearchableMigrator) migrateShard(ctx context.Context, shard
 	defer m.resumeStoreActivity(ctx, shard)
 
 	for propName := range props {
-		srcBucketName := helpers.BucketFromPropNameLSM(propName)
-		dstBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
+		srcBucketName := helpers.BucketFromPropertyNameLSM(propName)
+		dstBucketName := helpers.BucketSearchableFromPropertyNameLSM(propName)
 
 		m.logShard(shard).
 			WithField("bucketSrc", srcBucketName).
@@ -244,12 +244,12 @@ func (m *filterableToSearchableMigrator) migrateShard(ctx context.Context, shard
 }
 
 func (m *filterableToSearchableMigrator) isPropToFix(prop *models.Property, shard *Shard) (bool, error) {
-	bucketFilterable := shard.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
+	bucketFilterable := shard.store.Bucket(helpers.BucketFromPropertyNameLSM(prop.Name))
 	if bucketFilterable != nil &&
 		bucketFilterable.Strategy() == lsmkv.StrategyMapCollection &&
 		bucketFilterable.DesiredStrategy() == lsmkv.StrategyRoaringSet {
 
-		bucketSearchable := shard.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop.Name))
+		bucketSearchable := shard.store.Bucket(helpers.BucketSearchableFromPropertyNameLSM(prop.Name))
 		if bucketSearchable != nil &&
 			bucketSearchable.Strategy() == lsmkv.StrategyMapCollection {
 

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -410,13 +410,13 @@ func (r *ShardInvertedReindexer) bucketName(propName string, indexType PropertyI
 
 	switch indexType {
 	case IndexTypePropValue:
-		return helpers.BucketFromPropNameLSM(propName)
+		return helpers.BucketFromPropertyNameLSM(propName)
 	case IndexTypePropSearchableValue:
-		return helpers.BucketSearchableFromPropNameLSM(propName)
+		return helpers.BucketSearchableFromPropertyNameLSM(propName)
 	case IndexTypePropLength:
-		return helpers.BucketFromPropNameLengthLSM(propName)
+		return helpers.BucketFromPropertyNameLengthLSM(propName)
 	case IndexTypePropNull:
-		return helpers.BucketFromPropNameNullLSM(propName)
+		return helpers.BucketFromPropertyNameNullLSM(propName)
 	default:
 		return ""
 	}

--- a/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
+++ b/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
@@ -68,8 +68,8 @@ func (t *shardInvertedReindexTaskMissingTextFilterable) GetPropertiesToReindex(c
 	}
 
 	for propName := range props {
-		bucketNameSearchable := helpers.BucketSearchableFromPropNameLSM(propName)
-		bucketNameFilterable := helpers.BucketFromPropNameLSM(propName)
+		bucketNameSearchable := helpers.BucketSearchableFromPropertyNameLSM(propName)
+		bucketNameFilterable := helpers.BucketFromPropertyNameLSM(propName)
 
 		bucketSearchable := shard.store.Bucket(bucketNameSearchable)
 		bucketFilterable := shard.store.Bucket(bucketNameFilterable)

--- a/adapters/repos/db/inverted_reindexer_utils.go
+++ b/adapters/repos/db/inverted_reindexer_utils.go
@@ -28,19 +28,19 @@ func GetPropNameAndIndexTypeFromBucketName(bucketName string) (string, PropertyI
 	}{
 		{
 			IndexTypePropNull,
-			helpers.BucketFromPropNameNullLSM,
+			helpers.BucketFromPropertyNameNullLSM,
 		},
 		{
 			IndexTypePropLength,
-			helpers.BucketFromPropNameLengthLSM,
+			helpers.BucketFromPropertyNameLengthLSM,
 		},
 		{
 			IndexTypePropSearchableValue,
-			helpers.BucketSearchableFromPropNameLSM,
+			helpers.BucketSearchableFromPropertyNameLSM,
 		},
 		{
 			IndexTypePropValue,
-			helpers.BucketFromPropNameLSM,
+			helpers.BucketFromPropertyNameLSM,
 		},
 	}
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -164,8 +164,6 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 		return nil, err
 	}
 
-	logger.Errorf("creating bucket in directory: %v", dir)
-
 	b := &Bucket{
 		dir:               dir,
 		rootDir:           rootDir,

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -19,6 +19,13 @@ import (
 
 type BucketOption func(b *Bucket) error
 
+func WithRegisteredName(name string) BucketOption {
+	return func(b *Bucket) error {
+		b.RegisteredName = name
+		return nil
+	}
+}
+
 func WithStrategy(strategy string) BucketOption {
 	return func(b *Bucket) error {
 		switch strategy {

--- a/adapters/repos/db/lsmkv/proxy_bucket.go
+++ b/adapters/repos/db/lsmkv/proxy_bucket.go
@@ -1,0 +1,241 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+/*
+Proxy Buckets wrap the current buckets and modify the key value as requests are passed through, adding the property id as a prefix.
+
+This is the core part of the effort to merge property buckets into 2 buckets.  At the moment, each property can have around 5 bucket files: index, filter, length, timestamp and probably more I don't remember.  This causes issues for the operating system when there are many properties, as the OS can only have a certain number of open files.  Therefore, we want to merge all the properties into 2 buckets: one for the index and one for filters.
+
+However, the original bucket class needs to continue operating as before, because there are still parts of the code that do not need to be merged.
+
+In order to accommodate this, we need to modify the keys of the requests as they access the bucket.  This is what the proxy bucket does.  It takes a legacy bucket and a property name, and then it intercepts calls to the bucket, modifies the keys of the requests to add the property id as a prefix to every call, and then passes the request on to the legacy bucket.
+
+Then we have to go through the code and alter every line that creates or loads a property bucket, and wrap it with a proxy bucket (and a property name).  Then the rest of the code will perform identical calls to the proxy bucket as it would to the real bucket, but the keys will be quietly modified.
+
+From now on, all property data MUST go through a proxy bucket. e.g.
+
+    	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+		if err != nil {
+			t.Fatalf("Failed to create bucket: %v", err)
+		}
+
+		bp := WrapBucketWithProp(b, propName, propids)
+
+In order to speed up access, the property name is not used as a prefix, instead each property is given a number and that is used as a prefix.  The property name is only used for debugging.
+
+*/
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/storobj"
+
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/tracker"
+)
+
+type BucketProxy struct {
+	realBucket     BucketInterface // the real storage bucket
+	propertyPrefix []byte          // the property id as a byte prefix, only keys with this prefix will be  accessed
+	PropertyName   string          // the property name, used mainly for debugging
+}
+
+var FeatureUseMergedBuckets = true // if true, use the merged buckets, if false, use the legacy buckets
+
+// Wraps a bucket with a property prefixer.  Only used for tests
+func WrapBucketWithProp(bucket *Bucket, propName string, propIds *tracker.JsonPropertyIdTracker) (BucketInterface, error) {
+	bucketValue, err := NewBucketProxy(bucket, propName, propIds)
+	if err != nil {
+		return nil, fmt.Errorf("cannot wrap raw bucket with property prefixer '%s': %v", propName, err)
+	}
+
+	return bucketValue, nil
+}
+
+func (b *BucketProxy) GetRegisteredName() string {
+	return b.realBucket.GetRegisteredName()
+}
+
+// Returns either a real bucket or a proxy bucket, depending on whether the merged bucket feature is active or not
+func FetchMeABucket(store *Store, mergedName string, bucketFileName string, propName string, propids *tracker.JsonPropertyIdTracker) (BucketInterface, error) {
+	if !FeatureUseMergedBuckets {
+		bucket := store.Bucket(bucketFileName)
+		if bucket == nil {
+			return nil, fmt.Errorf("could not find separate bucket for property %s (for property %v)", bucketFileName, propName)
+		}
+		return bucket, nil
+	}
+	bucket := store.Bucket(mergedName)
+	if bucket == nil {
+		return nil, fmt.Errorf("could not find merged bucket %s (for property %v)", mergedName, propName)
+	}
+	proxyBucket, err := NewBucketProxy(bucket, bucketFileName, propids)
+	if err != nil {
+		return nil, fmt.Errorf("could not create proxy bucket for prop %s: %v", propName, err)
+	}
+	return proxyBucket, nil
+}
+
+func NewBucketProxy(realB BucketInterface, propName string, propids *tracker.JsonPropertyIdTracker) (*BucketProxy, error) {
+	if propids == nil {
+		return nil, fmt.Errorf("propids is nil")
+	}
+	propid_bytes := helpers.MakeByteEncodedPropertyPostfix(propName, propids)
+
+	return &BucketProxy{
+		realBucket:     realB,
+		propertyPrefix: propid_bytes,
+		PropertyName:   propName,
+	}, nil
+}
+
+func (b *BucketProxy) CheckBucket() {
+	b.realBucket.CheckBucket()
+}
+
+func (b *BucketProxy) PropertyPrefix() []byte {
+	return b.propertyPrefix
+}
+
+func (b *BucketProxy) RoaringSetRemoveOne(key []byte, value uint64) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.RoaringSetRemoveOne(real_key, value)
+}
+
+func (b *BucketProxy) RoaringSetAddList(key []byte, values []uint64) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.RoaringSetAddList(real_key, values)
+}
+
+func (b *BucketProxy) makePropertyKey(key []byte) []byte {
+	return helpers.MakePropertyKey(b.propertyPrefix, key)
+}
+
+func (b *BucketProxy) CursorRoaringSet() CursorRoaringSet {
+	return b.realBucket.CursorRoaringSet()
+}
+
+func (b *BucketProxy) CursorRoaringSetKeyOnly() CursorRoaringSet {
+	return b.realBucket.CursorRoaringSetKeyOnly()
+}
+
+func (b *BucketProxy) MapCursorKeyOnly(cfgs ...MapListOption) *CursorMap {
+	return b.realBucket.MapCursorKeyOnly(cfgs...)
+}
+
+func (b *BucketProxy) MapCursor(cfgs ...MapListOption) *CursorMap {
+	return b.realBucket.MapCursor(cfgs...)
+}
+
+func (b *BucketProxy) RoaringSetGet(key []byte) (*sroar.Bitmap, error) {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.RoaringSetGet(real_key)
+}
+
+func (b *BucketProxy) SetCursor() *CursorSet {
+	return b.realBucket.SetCursor()
+}
+
+func (b *BucketProxy) SetCursorKeyOnly() *CursorSet {
+	return b.realBucket.SetCursorKeyOnly()
+}
+
+func (b *BucketProxy) Strategy() string {
+	return b.realBucket.Strategy()
+}
+
+func (b *BucketProxy) IterateObjects(ctx context.Context, f func(object *storobj.Object) error) error {
+	return b.realBucket.IterateObjects(ctx, f)
+}
+
+func (b *BucketProxy) SetMemtableThreshold(size uint64) {
+	b.realBucket.SetMemtableThreshold(size)
+}
+
+func (b *BucketProxy) Get(key []byte) ([]byte, error) {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.Get(real_key)
+}
+
+func (b *BucketProxy) GetBySecondary(pos int, key []byte) ([]byte, error) {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.GetBySecondary(pos, real_key)
+}
+
+func (b *BucketProxy) SetList(key []byte) ([][]byte, error) {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.SetList(real_key)
+}
+
+func (b *BucketProxy) Put(key, value []byte, opts ...SecondaryKeyOption) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.Put(real_key, value, opts...)
+}
+
+func (b *BucketProxy) SetAdd(key []byte, values [][]byte) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.SetAdd(real_key, values)
+}
+
+func (b *BucketProxy) SetDeleteSingle(key []byte, valueToDelete []byte) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.SetDeleteSingle(real_key, valueToDelete)
+}
+
+func (b *BucketProxy) WasDeleted(key []byte) (bool, error) {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.WasDeleted(real_key)
+}
+
+func (b *BucketProxy) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.MapList(real_key, cfgs...)
+}
+
+func (b *BucketProxy) MapSet(rowKey []byte, kv MapPair) error {
+	real_key := b.makePropertyKey(rowKey)
+	return b.realBucket.MapSet(real_key, kv)
+}
+
+func (b *BucketProxy) MapDeleteKey(rowKey, mapKey []byte) error {
+	real_key := b.makePropertyKey(rowKey)
+	return b.realBucket.MapDeleteKey(real_key, mapKey)
+}
+
+func (b *BucketProxy) Delete(key []byte, opts ...SecondaryKeyOption) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.Delete(real_key, opts...)
+}
+
+func (b *BucketProxy) Count() int {
+	panic("Not allowed for BucketProx")
+}
+
+func (b *BucketProxy) Shutdown(ctx context.Context) error {
+	return b.realBucket.Shutdown(ctx)
+}
+
+func (b *BucketProxy) FlushAndSwitch() error {
+	return b.realBucket.FlushAndSwitch()
+}
+
+func (b *BucketProxy) RoaringSetAddOne(key []byte, value uint64) error {
+	real_key := b.makePropertyKey(key)
+	return b.realBucket.RoaringSetAddOne(real_key, value)
+}
+
+func (b *BucketProxy) Cursor() *CursorReplace {
+	return b.realBucket.Cursor()
+}

--- a/adapters/repos/db/lsmkv/proxy_bucket_test.go
+++ b/adapters/repos/db/lsmkv/proxy_bucket_test.go
@@ -1,0 +1,275 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/tracker"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestBucketProxyCreation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	propName := "testPropertyName"
+	propids, err := tracker.NewJsonPropertyIdTracker(tmpDir + "/ids5.json")
+	if err != nil {
+		t.Fatalf("Failed to create tracker: %v", err)
+	}
+
+	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	if err != nil {
+		t.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	bp, err := WrapBucketWithProp(b, propName, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	if bp == nil {
+		t.Fatal("Failed to create BucketProxy")
+	}
+
+	propid_bytes := helpers.MakeByteEncodedPropertyPostfix(propName, propids)
+
+	if !bytes.Equal(bp.PropertyPrefix(), propid_bytes) {
+		t.Fatalf("BucketProxy PropertyPrefix() does not match expected '%s', got '%s'", propName, bp.PropertyPrefix())
+	}
+}
+
+func TestBucketProxyGetAndPut(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	propName := "testPropertyName"
+	propids, err := tracker.NewJsonPropertyIdTracker(tmpDir + "/ids6.json")
+	if err != nil {
+		t.Fatalf("Failed to create tracker: %v", err)
+	}
+
+	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	if err != nil {
+		t.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	bp, err := WrapBucketWithProp(b, propName, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	// Put a value into the BucketProxy
+	key := []byte("testKey")
+	value := []byte("testValue")
+	err = bp.Put(key, value)
+	if err != nil {
+		t.Fatalf("Failed to put value into BucketProxy: %v", err)
+	}
+
+	// Retrieve the value from the BucketProxy
+	retrieved, err := bp.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get value from BucketProxy: %v", err)
+	}
+
+	// Check that the retrieved value matches the put value
+	if string(retrieved) != string(value) {
+		t.Fatalf("Retrieved value does not match put value: expected '%s', got '%s'", string(value), string(retrieved))
+	}
+}
+
+func TestBucketProxyGetNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	propName := "testPropertyName"
+	propids, err := tracker.NewJsonPropertyIdTracker(tmpDir + "/ids1.json")
+	if err != nil {
+		t.Fatalf("Failed to create tracker: %v", err)
+	}
+
+	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	if err != nil {
+		t.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	bp, err := WrapBucketWithProp(b, propName, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	// Attempt to retrieve a value that doesn't exist
+	key := []byte("nonexistentKey")
+	val, err := bp.Get(key)
+
+	if !(val == nil && err == nil) {
+		t.Fatalf("Expected nil value and nil error, got '%s' and '%s'", string(val), err)
+	}
+}
+
+func TestBucketProxyDelete(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	propName := "testPropertyName"
+	propids, err := tracker.NewJsonPropertyIdTracker(tmpDir + "/ids2.json")
+	if err != nil {
+		t.Fatalf("Failed to create tracker: %v", err)
+	}
+
+	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	if err != nil {
+		t.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	bp, err := WrapBucketWithProp(b, propName, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	// Put a value into the BucketProxy
+	key := []byte("testKey")
+	value := []byte("testValue")
+	err = bp.Put(key, value)
+	if err != nil {
+		t.Fatalf("Failed to put value into BucketProxy: %v", err)
+	}
+
+	// Delete the value from the BucketProxy
+	err = bp.Delete(key)
+	if err != nil {
+		t.Fatalf("Failed to delete value from BucketProxy: %v", err)
+	}
+
+	// Attempt to retrieve the deleted value
+	val, err := bp.Get(key)
+	if !(val == nil && err == nil) {
+		t.Fatalf("Expected nil value and nil error, got '%s' and '%s'", string(val), err)
+	}
+}
+
+func TestBucketProxyMapSetAndGet(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	propName := "testPropertyName"
+	propids, err := tracker.NewJsonPropertyIdTracker(tmpDir + "/ids3.json")
+	if err != nil {
+		t.Fatalf("Failed to create tracker: %v", err)
+	}
+
+	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyMapCollection))
+	if err != nil {
+		t.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	bp, err := WrapBucketWithProp(b, propName, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	// Create a MapPair to set
+	key := []byte("testKey")
+	value := MapPair{Key: []byte("innerKey"), Value: []byte("innerValue")}
+
+	// Set the MapPair into the BucketProxy
+	err = bp.MapSet(key, value)
+	if err != nil {
+		t.Fatalf("Failed to set MapPair into BucketProxy: %v", err)
+	}
+
+	// Retrieve the MapPair from the BucketProxy
+	retrieved, err := bp.MapList(key)
+	if err != nil {
+		t.Fatalf("Failed to get MapPair from BucketProxy: %v", err)
+	}
+
+	// Check that the retrieved MapPair matches the set MapPair
+	if len(retrieved) != 1 || string(retrieved[0].Key) != string(value.Key) || string(retrieved[0].Value) != string(value.Value) {
+		t.Fatalf("Retrieved MapPair does not match set MapPair: expected '%s:%s', got '%s:%s'",
+			string(value.Key), string(value.Value), string(retrieved[0].Key), string(retrieved[0].Value))
+	}
+}
+
+func TestMultiplePrefixes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	propName1 := "testPropertyName"
+	propName2 := "mnsdakjhfklew"
+	propids, err := tracker.NewJsonPropertyIdTracker(tmpDir + "/ids6.json")
+	if err != nil {
+		t.Fatalf("Failed to create tracker: %v", err)
+	}
+
+	b, err := NewBucket(ctx, tmpDir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	if err != nil {
+		t.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	bucketProxy1, err := WrapBucketWithProp(b, propName1, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	bucketProxy2, err := WrapBucketWithProp(b, propName2, propids)
+	if err != nil {
+		t.Fatalf("Failed to create BucketProxy: %v", err)
+	}
+
+	// Put the same key and different values into the BucketProxies
+	key := []byte("testKey")
+	value := []byte("testValue")
+	value2 := []byte("testValue2")
+	err = bucketProxy1.Put(key, value)
+	if err != nil {
+		t.Fatalf("Failed to put value into BucketProxy: %v", err)
+	}
+
+	err = bucketProxy2.Put(key, value2)
+	if err != nil {
+		t.Fatalf("Failed to put value into BucketProxy: %v", err)
+	}
+
+	// Retrieve the value from the BucketProxy
+	retrieved1, err := bucketProxy1.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get value from BucketProxy: %v", err)
+	}
+
+	retrieved2, err := bucketProxy2.Get(key)
+	if err != nil {
+		t.Fatalf("Failed to get value from BucketProxy: %v", err)
+	}
+
+	// Check that the retrieved value matches the put value
+	if string(retrieved1) != string(value) {
+		t.Fatalf("Retrieved value does not match put value: expected '%s', got '%s'", string(value), string(retrieved1))
+	}
+
+	if string(retrieved2) != string(value2) {
+		t.Fatalf("Retrieved value does not match put value: expected '%s', got '%s'", string(value), string(retrieved2))
+	}
+}

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -45,9 +45,7 @@ type Store struct {
 // New initializes a new [Store] based on the root dir. If state is present on
 // disk, it is loaded, if the folder is empty a new store is initialized in
 // there.
-func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
-	shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbackGroup,
-) (*Store, error) {
+func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics, shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbackGroup) (*Store, error) {
 	s := &Store{
 		dir:           dir,
 		rootDir:       rootDir,
@@ -58,6 +56,14 @@ func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
 	s.initCycleCallbacks(shardCompactionCallbacks, shardFlushCallbacks)
 
 	return s, s.init()
+}
+
+func (s *Store) GetStrategyFromOpts(opts []BucketOption) string {
+	fb := &Bucket{}
+	for _, opt := range opts {
+		opt(fb)
+	}
+	return fb.strategy
 }
 
 func (s *Store) Bucket(name string) *Bucket {
@@ -111,7 +117,51 @@ func (s *Store) bucketDir(bucketName string) string {
 //
 //	// you can now access the bucket using store.Bucket()
 //	b := store.Bucket("my_bucket_name")
-func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
+func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketFile string, opts ...BucketOption) error {
+	if !FeatureUseMergedBuckets {
+		return s.CreateOrLoadBucket_old(ctx, bucketFile, opts...)
+	}
+
+	if b := s.Bucket(bucketFile); b != nil {
+		// If the merged bucket as bucketFile already exists, we don't need to create it, but we do need to register it to the "RegisteredName"
+		// So first we create a fake bucket to get the registered name :O
+		fb := &Bucket{}
+		for _, opt := range opts {
+			opt(fb)
+		}
+		registeredName := fb.RegisteredName
+		if b.RegisteredName == "property__id" {
+			// panic("property__id")
+			fmt.Printf("Registered bucket %v as '%v'\n", bucketFile, registeredName)
+		}
+		if registeredName != "" {
+			s.SetBucket(registeredName, b)
+		}
+		return nil
+	}
+
+	b, err := NewBucket(ctx, s.bucketDir(bucketFile), s.rootDir, s.logger, s.metrics,
+		s.cycleCallbacks.compactionCallbacks, s.cycleCallbacks.flushCallbacks, opts...)
+	if err != nil {
+		return err
+	}
+
+	s.SetBucket(bucketFile, b)
+
+	if b.RegisteredName == "property__id" {
+		// panic("property__id")
+		fmt.Printf("Created bucket %v as '%v'\n", bucketFile, b.RegisteredName)
+	}
+	if b.RegisteredName != "" {
+		s.SetBucket(b.RegisteredName, b)
+
+		fmt.Printf("Created bucket %v as '%v'\n", bucketFile, b.RegisteredName)
+	}
+
+	return nil
+}
+
+func (s *Store) CreateOrLoadBucket_old(ctx context.Context, bucketName string,
 	opts ...BucketOption,
 ) error {
 	if b := s.Bucket(bucketName); b != nil {
@@ -124,11 +174,11 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
 		return err
 	}
 
-	s.setBucket(bucketName, b)
+	s.SetBucket(bucketName, b)
 	return nil
 }
 
-func (s *Store) setBucket(name string, b *Bucket) {
+func (s *Store) SetBucket(name string, b *Bucket) {
 	s.bucketAccessLock.Lock()
 	defer s.bucketAccessLock.Unlock()
 
@@ -287,7 +337,7 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 		return err
 	}
 
-	s.setBucket(bucketName, b)
+	s.SetBucket(bucketName, b)
 	return nil
 }
 

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"strings"
@@ -123,7 +124,7 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketFile string, opts 
 	}
 
 	if b := s.Bucket(bucketFile); b != nil {
-		// If the merged bucket as bucketFile already exists, we don't need to create it, but we do need to register it to the "RegisteredName"
+		// If the bucketFile already exists in a merged bucket, we don't need to create it, but we do need to register it to the "RegisteredName"
 		// So first we create a fake bucket to get the registered name :O
 		fb := &Bucket{}
 		for _, opt := range opts {
@@ -132,10 +133,10 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketFile string, opts 
 		registeredName := fb.RegisteredName
 		if b.RegisteredName == "property__id" {
 			// panic("property__id")
-			fmt.Printf("Registered bucket %v as '%v'\n", bucketFile, registeredName)
 		}
 		if registeredName != "" {
 			s.SetBucket(registeredName, b)
+			log.Printf("Registered existing bucket %v as '%v'\n", bucketFile, registeredName)
 		}
 		return nil
 	}
@@ -150,12 +151,11 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketFile string, opts 
 
 	if b.RegisteredName == "property__id" {
 		// panic("property__id")
-		fmt.Printf("Created bucket %v as '%v'\n", bucketFile, b.RegisteredName)
 	}
 	if b.RegisteredName != "" {
 		s.SetBucket(b.RegisteredName, b)
 
-		fmt.Printf("Created bucket %v as '%v'\n", bucketFile, b.RegisteredName)
+		log.Printf("Created bucket %v and registered it as '%v'\n", bucketFile, b.RegisteredName)
 	}
 
 	return nil

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -53,8 +53,8 @@ func IsExpectedStrategy(strategy string, expectedStrategies ...string) bool {
 	return false
 }
 
-func CheckExpectedStrategy(strategy string, expectedStrategies ...string) {
+func CheckExpectedStrategy(name, strategy string, expectedStrategies ...string) {
 	if !IsExpectedStrategy(strategy, expectedStrategies...) {
-		panic(fmt.Sprintf("one of strategies %v expected, strategy '%s' found", expectedStrategies, strategy))
+		panic(fmt.Sprintf("Error accessing %v one of strategies %v expected, strategy '%s' found", name, expectedStrategies, strategy))
 	}
 }

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -131,6 +131,9 @@ func (m *Metrics) VectorIndex(start time.Time) {
 }
 
 func (m *Metrics) PutObject(start time.Time) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "store_object_store_single_object_in_tx").
 		WithField("took", took).
@@ -147,6 +150,9 @@ func (m *Metrics) PutObject(start time.Time) {
 }
 
 func (m *Metrics) PutObjectDetermineStatus(start time.Time) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "store_object_store_determine_status").
 		WithField("took", took).
@@ -163,6 +169,9 @@ func (m *Metrics) PutObjectDetermineStatus(start time.Time) {
 }
 
 func (m *Metrics) PutObjectUpsertObject(start time.Time) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "store_object_store_upsert_object_data").
 		WithField("took", took).
@@ -179,6 +188,9 @@ func (m *Metrics) PutObjectUpsertObject(start time.Time) {
 }
 
 func (m *Metrics) PutObjectUpdateInverted(start time.Time) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "store_object_store_update_inverted").
 		WithField("took", took).
@@ -195,6 +207,9 @@ func (m *Metrics) PutObjectUpdateInverted(start time.Time) {
 }
 
 func (m *Metrics) InvertedDeleteOld(start time.Time) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "inverted_delete_old").
 		WithField("took", took).
@@ -210,6 +225,9 @@ func (m *Metrics) InvertedDeleteOld(start time.Time) {
 }
 
 func (m *Metrics) InvertedDeleteDelta(start time.Time) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "inverted_delete_delta").
 		WithField("took", took).
@@ -217,6 +235,9 @@ func (m *Metrics) InvertedDeleteDelta(start time.Time) {
 }
 
 func (m *Metrics) InvertedExtend(start time.Time, propCount int) {
+	if m == nil {
+		return
+	}
 	took := time.Since(start)
 	m.logger.WithField("action", "inverted_extend").
 		WithField("took", took).
@@ -234,6 +255,9 @@ func (m *Metrics) InvertedExtend(start time.Time, propCount int) {
 }
 
 func (m *Metrics) ShardStartup(start time.Time) {
+	if m == nil {
+		return
+	}
 	if !m.monitoring {
 		return
 	}

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -350,7 +350,7 @@ func (i *Index) overwriteObjects(ctx context.Context,
 		case curUpdateTime == u.StaleUpdateTime:
 			// the stored object is not the most recent version. in
 			// this case, we overwrite it with the more recent one.
-			err := s.putObject(ctx, storobj.FromObject(data, u.Vector))
+			err := s.PutObject(ctx, storobj.FromObject(data, u.Vector))
 			if err != nil {
 				r.Err = fmt.Sprintf("overwrite stale object: %v", err)
 			}

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"math"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -44,6 +46,7 @@ type DB struct {
 	shutdown          chan struct{}
 	startupComplete   atomic.Bool
 	resourceScanState *resourceScanState
+	memMonitor        *memwatch.Monitor
 
 	// indexLock is an RWMutex which allows concurrent access to various indexes,
 	// but only one modification at a time. R/W can be a bit confusing here,
@@ -112,7 +115,13 @@ func New(logger logrus.FieldLogger, config Config,
 		jobQueueCh:          make(chan job, 100000),
 		maxNumberGoroutines: int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
 		resourceScanState:   newResourceScanState(),
+		memMonitor: memwatch.NewMonitor(runtime.MemProfile,
+			debug.SetMemoryLimit, runtime.MemProfileRate, 0.97),
 	}
+
+	// make sure memMonitor has an initial state
+	db.memMonitor.Refresh()
+
 	if db.maxNumberGoroutines == 0 {
 		return db, errors.New("no workers to add batch-jobs configured.")
 	}

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -23,7 +23,6 @@ func (s *Shard) aggregate(ctx context.Context,
 ) (*aggregation.Result, error) {
 	return aggregator.New(s.store, params, s.index.getSchema,
 		s.index.classSearcher, s.deletedDocIDs, s.index.stopwords, s.versioner.Version(),
-		s.vectorIndex, s.index.logger, s.propLengths, s.isFallbackToSearchable, s.tenant(),
-		s.index.Config.QueryNestedRefLimit).
+		s.vectorIndex, s.index.logger, s.propLengths, s.isFallbackToSearchable, s.tenant(), s.propIds, s.index.Config.QueryNestedRefLimit).
 		Do(ctx)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -183,7 +183,7 @@ func (s *Shard) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 		if filters != nil {
 			objs, err = inverted.NewSearcher(s.index.logger, s.store,
 				s.index.getSchema.GetSchemaSkipAuth(),
-				s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
+				s.propertyIndices, s.propIds, s.index.classSearcher, s.deletedDocIDs,
 				s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable,
 				s.tenant(), s.index.Config.QueryNestedRefLimit).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
@@ -196,7 +196,7 @@ func (s *Shard) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 
 		className := s.index.Config.ClassName
 		bm25Config := s.index.getInvertedIndexConfig().BM25
-		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store, s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices, s.index.classSearcher, s.deletedDocIDs, s.propLengths, s.index.logger, s.versioner.Version())
+		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store, s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices, s.index.classSearcher, s.deletedDocIDs, s.propLengths, s.index.logger, s.versioner.Version(), s.propIds)
 		bm25objs, bm25count, err = bm25searcher.BM25F(ctx, filterDocIds, className, limit, *keywordRanking)
 		if err != nil {
 			return nil, nil, err
@@ -212,7 +212,7 @@ func (s *Shard) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 	}
 	objs, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(),
-		s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
+		s.propertyIndices, s.propIds, s.index.classSearcher, s.deletedDocIDs,
 		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable,
 		s.tenant(), s.index.Config.QueryNestedRefLimit).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName)
@@ -382,7 +382,7 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 ) (helpers.AllowList, error) {
 	list, err := inverted.NewSearcher(s.index.logger, s.store,
 		s.index.getSchema.GetSchemaSkipAuth(),
-		s.propertyIndices, s.index.classSearcher, s.deletedDocIDs,
+		s.propertyIndices, s.propIds, s.index.classSearcher, s.deletedDocIDs,
 		s.index.stopwords, s.versioner.Version(), s.isFallbackToSearchable,
 		s.tenant(), s.index.Config.QueryNestedRefLimit).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -146,7 +146,7 @@ func (s *Shard) findDocIDs(ctx context.Context,
 	filters *filters.LocalFilter,
 ) ([]uint64, error) {
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store,
-		s.index.getSchema.GetSchemaSkipAuth(), nil,
+		s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices, s.propIds,
 		s.index.classSearcher, s.deletedDocIDs, s.index.stopwords,
 		s.versioner.version, s.isFallbackToSearchable,
 		s.tenant(), s.index.Config.QueryNestedRefLimit).

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -70,9 +70,9 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []n
 
 func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property) error {
 	if property.HasFilterableIndex {
-		bucketValue := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
-		if bucketValue == nil {
-			return errors.Errorf("no bucket for prop '%s' found", property.Name)
+		bucketValue, err := lsmkv.FetchMeABucket(s.store, "filterable_properties", helpers.BucketFromPropertyNameLSM(property.Name), property.Name, s.propIds)
+		if err != nil {
+			return errors.Wrapf(err, "no bucket filterable for prop '%s' found", property.Name)
 		}
 
 		for _, item := range property.Items {
@@ -84,9 +84,9 @@ func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property
 	}
 
 	if property.HasSearchableIndex {
-		bucketValue := s.store.Bucket(helpers.BucketSearchableFromPropNameLSM(property.Name))
-		if bucketValue == nil {
-			return errors.Errorf("no bucket searchable for prop '%s' found", property.Name)
+		bucketValue, err := lsmkv.FetchMeABucket(s.store, "searchable_properties", helpers.BucketSearchableFromPropertyNameLSM(property.Name), property.Name, s.propIds)
+		if err != nil {
+			return errors.Wrapf(err, "no bucket searchable for prop '%s' found", property.Name)
 		}
 
 		propLen := float32(len(property.Items))
@@ -94,7 +94,7 @@ func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property
 			key := item.Data
 			pair := s.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
 			if err := s.addToPropertyMapBucket(bucketValue, pair, key); err != nil {
-				return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+				return errors.Wrapf(err, "failed adding to prop '%s' value bucket (searchable properties)", property.Name)
 			}
 		}
 	}
@@ -103,10 +103,11 @@ func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property
 }
 
 func (s *Shard) addToPropertyLengthIndex(propName string, docID uint64, length int) error {
-	bucketLength := s.store.Bucket(helpers.BucketFromPropNameLengthLSM(propName))
-	if bucketLength == nil {
-		return errors.Errorf("no bucket for prop '%s' length found", propName)
+	bucketLength, err := lsmkv.FetchMeABucket(s.store, "filterable_properties", helpers.BucketFromPropertyNameLengthLSM(propName), propName, s.propIds)
+	if err != nil {
+		return errors.Errorf("no bucket for prop '%s' length found: %v", propName, err)
 	}
+	bucketLength.CheckBucket()
 
 	key, err := s.keyPropertyLength(length)
 	if err != nil {
@@ -119,15 +120,16 @@ func (s *Shard) addToPropertyLengthIndex(propName string, docID uint64, length i
 }
 
 func (s *Shard) addToPropertyNullIndex(propName string, docID uint64, isNull bool) error {
-	bucketNull := s.store.Bucket(helpers.BucketFromPropNameNullLSM(propName))
-	if bucketNull == nil {
-		return errors.Errorf("no bucket for prop '%s' null found", propName)
-	}
-
 	key, err := s.keyPropertyNull(isNull)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating key for prop '%s' null", propName)
 	}
+
+	bucketNull, err := lsmkv.FetchMeABucket(s.store, "filterable_properties", helpers.BucketFromPropertyNameNullLSM(propName), propName, s.propIds)
+	if err != nil {
+		return errors.Errorf("no bucket for prop '%s' null found", propName)
+	}
+
 	if err := s.addToPropertySetBucket(bucketNull, docID, key); err != nil {
 		return errors.Wrapf(err, "failed adding to prop '%s' null bucket", propName)
 	}
@@ -165,14 +167,15 @@ func (s *Shard) keyPropertyNull(isNull bool) ([]byte, error) {
 	return []byte{uint8(filters.InternalNotNullState)}, nil
 }
 
-func (s *Shard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
+func (s *Shard) addToPropertyMapBucket(bucket lsmkv.BucketInterface, pair lsmkv.MapPair, key []byte) error {
+	lsmkv.CheckExpectedStrategy(bucket.GetRegisteredName(), bucket.Strategy(), lsmkv.StrategyMapCollection)
 
 	return bucket.MapSet(key, pair)
 }
 
-func (s *Shard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
+func (s *Shard) addToPropertySetBucket(bucket lsmkv.BucketInterface, docID uint64, key []byte) error {
+	bucket.CheckBucket()
+	lsmkv.CheckExpectedStrategy(bucket.GetRegisteredName(), bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
 
 	if bucket.Strategy() == lsmkv.StrategySetCollection {
 		docIDBytes := make([]byte, 8)
@@ -184,7 +187,7 @@ func (s *Shard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key [
 	return bucket.RoaringSetAddOne(key, docID)
 }
 
-func (s *Shard) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket,
+func (s *Shard) batchExtendInvertedIndexItemsLSMNoFrequency(b lsmkv.BucketInterface,
 	item inverted.MergeItem,
 ) error {
 	if b.Strategy() != lsmkv.StrategySetCollection && b.Strategy() != lsmkv.StrategyRoaringSet {

--- a/docker-compose/Readme.md
+++ b/docker-compose/Readme.md
@@ -5,4 +5,4 @@ languages. Instead you can now configure your own docker-compose file - on the
 fly - using Weaviate's documentation.
 
 Click here to [generate a `docker-compose.yml` file with your desired
-configuration](https://www.semi.technology/documentation/weaviate/current/getting-started/installation.html#docker-compose).
+configuration](https://weaviate.io/developers/weaviate/installation/docker-compose).

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -548,10 +548,11 @@ func (ko *Object) MarshalBinary() ([]byte, error) {
 // UnmarshalPropertiesFromObject only unmarshals and returns the properties part of the object
 //
 // Check MarshalBinary for the order of elements in the input array
-func UnmarshalPropertiesFromObject(data []byte, properties *map[string]interface{}, aggregationProperties []string, propStrings [][]string) error {
+func UnmarshalPropertiesFromObject(data []byte, aggregationProperties []string, propStrings [][]string) (*map[string]interface{}, error) {
 	if data[0] != uint8(1) {
-		return errors.Errorf("unsupported binary marshaller version %d", data[0])
+		return nil, errors.Errorf("unsupported binary marshaller version %d", data[0])
 	}
+	properties := &map[string]interface{}{}
 
 	// clear out old values in case an object misses values. This should NOT shrink the capacity of the map, eg there
 	// are no allocations when adding the properties of the next object again
@@ -615,7 +616,7 @@ func UnmarshalPropertiesFromObject(data []byte, properties *map[string]interface
 		}
 	}, propStrings...)
 
-	return nil
+	return properties, nil
 }
 
 func parseValues(dt jsonparser.ValueType, value []byte) (interface{}, error) {

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -382,13 +382,12 @@ func TestExtractionOfSingleProperties(t *testing.T) {
 		propStrings = append(propStrings, []string{key})
 	}
 
-	extractedProperties := map[string]interface{}{}
-
 	// test with reused property map
 	for i := 0; i < 2; i++ {
-		require.Nil(t, UnmarshalPropertiesFromObject(byteObject, &extractedProperties, propertyNames, propStrings))
+		extractedProperties, err := UnmarshalPropertiesFromObject(byteObject, propertyNames, propStrings)
+		require.Nil(t, err)
 		for key := range expected {
-			require.Equal(t, expected[key], extractedProperties[key])
+			require.Equal(t, expected[key], (*extractedProperties)[key])
 		}
 
 	}

--- a/test/acceptance/graphql_resolvers/aggregate_response_assert.go
+++ b/test/acceptance/graphql_resolvers/aggregate_response_assert.go
@@ -50,10 +50,11 @@ func (a *aggregateResponseAssert) groupedBy(value string, path ...interface{}) a
 			return false
 		}
 		aggMap := response[groupedByKey].(map[string]interface{})
-		return combinedAssert(
+		out := combinedAssert(
 			a.hasString(aggMap, groupedByKey, "value", value),
 			a.hasArray(aggMap, groupedByKey, "path", path),
 		)
+		return out
 	}
 }
 

--- a/test/acceptance/replication/scale_test.go
+++ b/test/acceptance/replication/scale_test.go
@@ -103,7 +103,7 @@ func multiShardScaleOut(t *testing.T) {
 		for _, node := range n.Nodes {
 			for _, shard := range node.Shards {
 				if shard.Class == paragraphClass.Class {
-					assert.EqualValues(t, 10, shard.ObjectCount)
+					assert.EqualValues(t, uint64(10), shard.ObjectCount)
 					shardsFound++
 				}
 			}

--- a/test/acceptance_with_go_client/filters_tests/where_test.go
+++ b/test/acceptance_with_go_client/filters_tests/where_test.go
@@ -12,11 +12,12 @@
 package filters_tests
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"

--- a/tools/release_template/main.go
+++ b/tools/release_template/main.go
@@ -48,7 +48,7 @@ func printRelaeseNotes(languages []language, version string) {
 	fmt.Printf("See also: example docker-compose files in %s. ", makeLinks(languages, version))
 	fmt.Printf("If you need to configure additional settings, you can also generate " +
 		"a custom `docker-compose.yml` file [using the documentation]" +
-		"(https://www.semi.technology/documentation/weaviate/current/getting-started/installation.html#docker-compose).")
+		"(https://weaviate.io/developers/weaviate/installation/docker-compose).")
 	fmt.Printf("\n## Breaking Changes\n*none*\n")
 	fmt.Printf("\n## New Features\n*none*\n")
 	fmt.Printf("\n## Fixes\n*none*\n")

--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -12,15 +12,40 @@
 package memwatch
 
 import (
+	"fmt"
 	"math"
 	"runtime"
+	"sync"
 )
+
+const (
+	B   = 1
+	KiB = 1 << (10 * iota) // 2^10
+	MiB = 1 << (10 * iota) // 2^20
+	GiB = 1 << (10 * iota) // 2^30
+	TiB = 1 << (10 * iota) // 2^40
+)
+
+var ErrNotEnoughMemory = fmt.Errorf("not enough memory")
 
 // Monitor allows making statements about the memory ratio used by the application
 type Monitor struct {
 	memProfiler memProfiler
 	limitSetter limitSetter
 	rate        int64
+	maxRatio    float64
+
+	// state
+	mu    sync.Mutex
+	limit int64
+	used  int64
+}
+
+// Refresh retrieves the current memory stats from the runtime and stores them
+// in the local cache
+func (m *Monitor) Refresh() {
+	m.calculateCurrentUsage()
+	m.updateLimit()
 }
 
 type memProfiler func(p []runtime.MemProfileRecord, inUseZero bool) (int, bool)
@@ -33,45 +58,33 @@ type limitSetter func(size int64) int64
 //
 // Typically this would be called with runtime.MemProfile,
 // debug.SetMemoryLimit, and runtime.MemProfileRate
-func NewMonitor(profiler memProfiler, limitSetter limitSetter, rate int) *Monitor {
+func NewMonitor(profiler memProfiler, limitSetter limitSetter,
+	rate int, maxRatio float64,
+) *Monitor {
 	return &Monitor{
 		memProfiler: profiler,
 		limitSetter: limitSetter,
 		rate:        int64(rate),
+		maxRatio:    maxRatio,
 	}
 }
 
-// inspired by runtime/pprof/pprof.go
+func (m *Monitor) CheckAlloc(sizeInBytes int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if float64(m.used+sizeInBytes)/float64(m.limit) > m.maxRatio {
+		return ErrNotEnoughMemory
+	}
+
+	return nil
+}
+
 func (m *Monitor) Ratio() float64 {
-	var p []runtime.MemProfileRecord
-	n, _ := m.memProfiler(nil, true)
-	for {
-		// Allocate room for a slightly bigger profile,
-		// in case a few more entries have been added
-		// since the call to MemProfile.
-		p = make([]runtime.MemProfileRecord, n+50)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-		// use different var name and explicitly overwrite
-		// otherwise n from the outside is shadowed and not overwritten
-		n2, ok := m.memProfiler(p, true)
-		if ok {
-			p = p[0:n2]
-			break
-		}
-		// Profile grew; try again.
-		n = n2
-	}
-
-	var sum int64
-
-	for _, r := range p {
-		_, size := scaleHeapSample(r.InUseObjects(), r.InUseBytes(), m.rate)
-		sum += size
-	}
-
-	// setting a negative limit is the only way to obtain the current limit
-	limit := m.limitSetter(-1)
-	return float64(sum) / float64(limit)
+	return float64(m.used) / float64(m.limit)
 }
 
 // copied from runtime/pprof/protomem.go
@@ -100,4 +113,54 @@ func scaleHeapSample(count, size, rate int64) (int64, int64) {
 	scale := 1 / (1 - math.Exp(-avgSize/float64(rate)))
 
 	return int64(float64(count) * scale), int64(float64(size) * scale)
+}
+
+// calculateCurrentUsage obtains the most recent mem profile records from the
+// runtime, sums them up and scales them according to the set profiling rate.
+//
+// The logic to retrieve the records is inspired by runtime/pprof/pprof.go
+func (m *Monitor) calculateCurrentUsage() {
+	var p []runtime.MemProfileRecord
+	n, _ := m.memProfiler(nil, true)
+	for {
+		// Allocate room for a slightly bigger profile,
+		// in case a few more entries have been added
+		// since the call to MemProfile.
+		p = make([]runtime.MemProfileRecord, n+50)
+
+		// use different var name and explicitly overwrite
+		// otherwise n from the outside is shadowed and not overwritten
+		n2, ok := m.memProfiler(p, true)
+		if ok {
+			p = p[0:n2]
+			break
+		}
+		// Profile grew; try again.
+		n = n2
+	}
+
+	var sum int64
+
+	for _, r := range p {
+		_, size := scaleHeapSample(r.InUseObjects(), r.InUseBytes(), m.rate)
+		sum += size
+	}
+
+	m.setUsed(sum)
+}
+
+// setUsed is a thread-safe way way to set the current usage
+func (m *Monitor) setUsed(used int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.used = used
+}
+
+func (m *Monitor) updateLimit() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// setting a negative limit is the only way to obtain the current limit
+	m.limit = m.limitSetter(-1)
 }

--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -30,7 +30,8 @@ func TestMonitor(t *testing.T) {
 
 		limiter := &fakeLimitSetter{limit: 100000}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1)
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m.Refresh()
 
 		assert.Equal(t, 0.3, m.Ratio())
 	})
@@ -45,9 +46,59 @@ func TestMonitor(t *testing.T) {
 
 		limiter := &fakeLimitSetter{limit: 100000}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1)
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
 
+		m.Refresh()
 		assert.Equal(t, 0.3, m.Ratio())
+	})
+
+	t.Run("with less memory than the threshold", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(700 * MiB)},
+				{sampleProfile(700 * MiB)},
+				{sampleProfile(700 * MiB)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 1 * GiB}
+
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m.Refresh()
+
+		err := m.CheckAlloc(100 * MiB)
+		assert.NoError(t, err, "with 700 allocated, an additional 100 would be about 80% which is not a problem")
+
+		err = m.CheckAlloc(299 * MiB)
+		assert.Error(t, err, "with 700 allocated, an additional 299 would be about 97.5% which is not allowed")
+
+		err = m.CheckAlloc(400 * MiB)
+		assert.Error(t, err, "with 700 allocated, an additional 400 would be about 110% which is not allowed")
+	})
+
+	t.Run("with memory already over the threshold", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(1025 * MiB)},
+				{sampleProfile(1025 * MiB)},
+				{sampleProfile(1025 * MiB)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 1 * GiB}
+
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m.Refresh()
+
+		err := m.CheckAlloc(1 * B)
+		assert.Error(t, err,
+			"any check should fail, since we're already over the limit")
+
+		err = m.CheckAlloc(10 * MiB)
+		assert.Error(t, err, "any check should fail, since we're already over the limit")
+
+		err = m.CheckAlloc(1 * TiB)
+		assert.Error(t, err, "any check should fail, since we're already over the limit")
 	})
 
 	t.Run("with sampling rate", func(t *testing.T) {
@@ -62,13 +113,14 @@ func TestMonitor(t *testing.T) {
 
 		// sample rate is small enough to not alter the result, yet big enough to
 		// cover the calculation
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 5)
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 5, 0.97)
 
+		m.Refresh()
 		assert.Equal(t, 0.3, m.Ratio())
 	})
 
 	t.Run("with real dependencies", func(t *testing.T) {
-		m := NewMonitor(runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate)
+		m := NewMonitor(runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate, 0.97)
 		_ = m.Ratio()
 	})
 }

--- a/usecases/schema/migrate/migrator.go
+++ b/usecases/schema/migrate/migrator.go
@@ -60,5 +60,6 @@ type Migrator interface {
 	RecalculateVectorDimensions(ctx context.Context) error
 	RecountProperties(ctx context.Context) error
 	InvertedReindex(ctx context.Context, taskNames ...string) error
+
 	AdjustFilterablePropSettings(ctx context.Context) error
 }


### PR DESCRIPTION
### What's being changed:

Due to the fact that these changes are very large and touch most parts of the (sparse) search, I'm writing up the changes to make them more comprehensible.

As usual, I attempted to make the minimum changes that would deliver the goal of merging the buckets. There were many places where I noticed that it would be possible to improve code by refactoring, but if I did, this would have turned into a complete rewrite of the sparse search. That might be a good thing, but it wasn't part of the task.

I did make the following notable changes.

All property (and internal property) buckets were merged based on their type. Filterable buckets were merged into "filterable_buckets", searchable buckets were merged into "searchable_buckets". The objectsLSM buckets was left entirely unchanged, as was any code that accesses it directly.

As a result of merging the buckets, it is no longer possible to check for an index by looking for a file. Going forward, all checks for configuration must consult the schema. There are no other ways to divine the current settings.

All indexes are available, by default, because they are all stored in the same bucket. So e.g. lengths, timestamps, etc, can be read or written at any time. The only question is if they were active during data load, which is why it is necessary to consult the schema.

To keep the properties separate in the merged buckets, weaviate now creates postfixes for keys. Because property names can be large, each property is assigned a number, then the byte wise representation of that number is used as a postfix for the key. To make this manageable, I created a bucketProxy class, which automatically adds the postfix before passing the call to the real bucket store.

All property access must go through a BucketProxy. A BucketProxy wraps a bucket and a prefix, and modifies the key to retrieve only the correct properties. The object store is completely unchanged, and you still access this directly.

A new adjunct index called "propids" was created to map property names to property ids. BucketProxy only works with id numbers, not the property names.

Any damage to the property id index will corrupt or lose data from the main indexes, i.e. filterable_properties and searchable_properties.

Further work:

Across the whole weaviate codebase, code should always and only check settings by looking them up in the schema.
The schema is the only place that has the correct information. Looking anywhere else risks running the wrong code due to a second error somewhere else in the code. In particular, do not check for the presence of a file to see if the schema has an index. This results in situations where, if the file can't be found, weaviate will run the wrong code, but when the user checks, the schema shows the correct information.

Especially do not attempt to detect the type of the bucket from its filename. If you need to know the type, look in the schema. If you don't have access to the schema, then you need to refactor the code until you do have access to the schema.

One effect of this is that there are tests that expect a fail when they try to load e.g. the length bucket and it isn't there. I had to remove them because we now always have a bucket to record the lengths, it's the merged bucket. The only question is, did we record the lengths when the data was loaded? The answer can only be in the schema.

Stop doing in place modifications
I found at least one instance of corruption caused by modifying values on a structure, there are certainly more possibilities in the code. Unless the function is obviously the owner of the struct, it shouldn't modify it.

Use types
Currently there are multiple types of buckets, which function differently and are incompatible. They should be put in their own separate classes, so that they cannot be used in the wrong place. The presence of functions like CursorRoaringSetKeyOnly() is a clear code smell.

pass the schema everywhere
Almost every part of the code needs to have access to the schema to make decisions about how to process data, so that should be available. It should be available in a form that is easier to access than the current situation, where even figuring out which properties and their types, are present is a significant challenge.



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
