### PR TITLE
Fix Shards function returning an error on class with no shards

### DIFF
--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -122,7 +122,8 @@ func TestBackup_DBLevel(t *testing.T) {
 		})
 
 		t.Run("node names from shards", func(t *testing.T) {
-			res := db.Shards(ctx, className)
+			res, err := db.Shards(ctx, className)
+			assert.NoError(t, err)
 			assert.Len(t, res, 1)
 			assert.Equal(t, "node1", res[0])
 		})

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -580,7 +580,8 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 	t.Run("node names by shard", func(t *testing.T) {
 		for _, n := range nodes {
 			nodeSet := make(map[string]bool)
-			foundNodes := n.repo.Shards(context.Background(), distributedClass)
+			foundNodes, err := n.repo.Shards(context.Background(), distributedClass)
+			assert.NoError(t, err)
 			for _, found := range foundNodes {
 				nodeSet[found] = true
 			}

--- a/test/helper/journey/backup_journey_tests.go
+++ b/test/helper/journey/backup_journey_tests.go
@@ -21,6 +21,9 @@ func BackupJourneyTests_SingleNode(t *testing.T, weaviateEndpoint, backend, clas
 		t.Run("multi-tenant single node backup", func(t *testing.T) {
 			singleNodeBackupJourneyTest(t, weaviateEndpoint, backend, className, backupID, tenantNames)
 		})
+		t.Run("multi-tenant single node backup with empty class", func(t *testing.T) {
+			singleNodeBackupEmptyClassJourneyTest(t, weaviateEndpoint, backend, className, backupID+"_empty", tenantNames)
+		})
 	} else {
 		// This is a simple test which covers almost the same scenario as singleNodeBackupJourneyTest
 		// but is left here to be expanded in the future with a more complex example
@@ -40,14 +43,19 @@ func BackupJourneyTests_SingleNode(t *testing.T, weaviateEndpoint, backend, clas
 func BackupJourneyTests_Cluster(t *testing.T, backend, className, backupID string,
 	tenantNames []string, weaviateEndpoints ...string,
 ) {
+	if len(weaviateEndpoints) <= 1 {
+		t.Fatal("must provide more than one node for cluster backup test")
+	}
+
 	if len(tenantNames) > 0 {
 		t.Run("multi-tenant cluster backup", func(t *testing.T) {
-			if len(weaviateEndpoints) <= 1 {
-				t.Fatal("must provide more than one node for cluster backup test")
-			}
-
 			coordinator := weaviateEndpoints[0]
 			clusterBackupJourneyTest(t, backend, className, backupID,
+				coordinator, tenantNames, weaviateEndpoints[1:]...)
+		})
+		t.Run("multi-tenant cluster backup with empty class", func(t *testing.T) {
+			coordinator := weaviateEndpoints[0]
+			clusterBackupEmptyClassJourneyTest(t, backend, className, backupID+"_empty",
 				coordinator, tenantNames, weaviateEndpoints[1:]...)
 		})
 	} else {

--- a/test/helper/journey/single_node_backup_journey.go
+++ b/test/helper/journey/single_node_backup_journey.go
@@ -44,7 +44,37 @@ func singleNodeBackupJourneyTest(t *testing.T,
 	}
 
 	t.Run("single node backup", func(t *testing.T) {
-		backupJourney(t, className, backend, backupID, singleNodeJourney, tenantNames)
+		backupJourney(t, className, backend, backupID, singleNodeJourney, checkClassAndDataPresence, tenantNames)
+	})
+
+	t.Run("cleanup", func(t *testing.T) {
+		helper.DeleteClass(t, className)
+	})
+}
+
+func singleNodeBackupEmptyClassJourneyTest(t *testing.T,
+	weaviateEndpoint, backend, className, backupID string,
+	tenantNames []string,
+) {
+	if weaviateEndpoint != "" {
+		helper.SetupClient(weaviateEndpoint)
+	}
+
+	if len(tenantNames) <= 0 {
+		t.Skip("test is only relevant with tenancy enabled")
+	}
+
+	t.Run("add test class and tenant", func(t *testing.T) {
+		addTestClass(t, className, multiTenant)
+		tenants := make([]*models.Tenant, len(tenantNames))
+		for i := range tenantNames {
+			tenants[i] = &models.Tenant{Name: tenantNames[i]}
+		}
+		helper.CreateTenants(t, className, tenants)
+	})
+
+	t.Run("single node backup", func(t *testing.T) {
+		backupJourney(t, className, backend, backupID, singleNodeJourney, checkClassPresenceOnly, tenantNames)
 	})
 
 	t.Run("cleanup", func(t *testing.T) {

--- a/test/helper/modules/modules_helper.go
+++ b/test/helper/modules/modules_helper.go
@@ -29,6 +29,18 @@ import (
 	"google.golang.org/api/option"
 )
 
+func EnsureClassExists(t *testing.T, className string, tenant string) {
+	query := fmt.Sprintf("{Aggregate{%s", className)
+	if tenant != "" {
+		query += fmt.Sprintf("(tenant:%q)", tenant)
+	}
+	query += " { meta { count}}}}"
+	resp := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
+
+	class := resp.Get("Aggregate", className).Result.([]interface{})
+	require.Len(t, class, 1)
+}
+
 func GetClassCount(t *testing.T, className string, tenant string) int64 {
 	query := fmt.Sprintf("{Aggregate{%s", className)
 	if tenant != "" {

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -61,7 +61,7 @@ type participantStatus struct {
 // selector is used to select participant nodes
 type selector interface {
 	// Shards gets all nodes on which this class is sharded
-	Shards(ctx context.Context, class string) []string
+	Shards(ctx context.Context, class string) ([]string, error)
 	// ListClasses returns a list of all existing classes
 	// This will be needed if user doesn't include any classes
 	ListClasses(ctx context.Context) []string
@@ -468,8 +468,8 @@ func (c *coordinator) abortAll(ctx context.Context, req *AbortRequest, nodes map
 func (c *coordinator) groupByShard(ctx context.Context, classes []string) (nodeMap, error) {
 	m := make(nodeMap, 32)
 	for _, cls := range classes {
-		nodes := c.selector.Shards(ctx, cls)
-		if len(nodes) == 0 {
+		nodes, err := c.selector.Shards(ctx, cls)
+		if err != nil {
 			return nil, fmt.Errorf("class %q: %w", cls, errNoShardFound)
 		}
 		for _, node := range nodes {

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -313,7 +313,7 @@ func TestSchedulerCreateBackup(t *testing.T) {
 		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
 		// first
 		fs.selector.On("Backupable", ctx, req1.Include).Return(nil)
-		fs.selector.On("Shards", ctx, cls).Return([]string{node})
+		fs.selector.On("Shards", ctx, cls).Return([]string{node}, nil)
 
 		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
 		fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
@@ -383,7 +383,7 @@ func TestSchedulerCreateBackup(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
 		fs.selector.On("Backupable", ctx, req.Include).Return(nil)
-		fs.selector.On("Shards", ctx, cls).Return([]string{node})
+		fs.selector.On("Shards", ctx, cls).Return([]string{node}, nil)
 
 		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
 		fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})


### PR DESCRIPTION
### What's being changed:

Our internal Shards function allows us to fetch the nodes containing the shards of a given class. Currently it returns an error if a class has no shards, which leads to backup failing if a class has no shards but exists.

We want to change that behaviour, so that Shards only return an error if a class has shards but no nodes assigned to them.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
