### PR TITLE
async: Graceful shutdown

### DIFF
--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -28,8 +28,6 @@ import (
 // It batches vectors together before sending them to the indexing workers.
 // It is safe to use concurrently.
 type IndexQueue struct {
-	sync.RWMutex
-
 	Shard shardStatusUpdater
 	Index batchIndexer
 
@@ -269,9 +267,14 @@ func (q *IndexQueue) indexer() {
 
 func (q *IndexQueue) pushToWorkers() error {
 	chunks := q.queue.borrowAllChunks()
-	for _, c := range chunks {
+	for i, c := range chunks {
 		select {
 		case <-q.ctx.Done():
+			// release unsent borrowed chunks
+			for _, c := range chunks[i:] {
+				q.queue.releaseChunk(c)
+			}
+
 			return errors.New("index queue closed")
 		case q.indexCh <- job{
 			chunk:   c,
@@ -433,19 +436,48 @@ func newVectorQueue(batchSize int, staleTimeout time.Duration) *vectorQueue {
 }
 
 func (q *vectorQueue) getFreeChunk() *chunk {
-	return q.pool.Get().(*chunk)
+	c := q.pool.Get().(*chunk)
+	c.indexed = make(chan struct{})
+	return c
 }
 
 func (q *vectorQueue) wait() {
-	q.fullChunks.Lock()
-	e := q.fullChunks.list.Front()
-	for e != nil {
-		c := e.Value.(*chunk)
-		<-c.done
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-		e = e.Next()
+	for {
+		// get first non-closed channel
+		var ch chan struct{}
+
+		q.fullChunks.Lock()
+		e := q.fullChunks.list.Front()
+	LOOP:
+		for e != nil {
+			c := e.Value.(*chunk)
+			if c.borrowed {
+				select {
+				case <-c.indexed:
+				default:
+					ch = c.indexed
+					break LOOP
+				}
+			}
+
+			e = e.Next()
+		}
+		q.fullChunks.Unlock()
+
+		if ch == nil {
+			return
+		}
+
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
+			return
+		}
 	}
-	q.fullChunks.Unlock()
 }
 
 func (q *vectorQueue) Add(vectors []vectorDescriptor) {
@@ -529,7 +561,7 @@ func (q *vectorQueue) borrowAllChunks() []*chunk {
 }
 
 func (q *vectorQueue) releaseChunk(c *chunk) {
-	close(c.done)
+	close(c.indexed)
 
 	if c.elem != nil {
 		q.fullChunks.Lock()
@@ -541,6 +573,7 @@ func (q *vectorQueue) releaseChunk(c *chunk) {
 	c.cursor = 0
 	c.elem = nil
 	c.createdAt = nil
+	c.indexed = nil
 
 	q.pool.Put(c)
 }
@@ -607,5 +640,5 @@ type chunk struct {
 	data      []vectorDescriptor
 	elem      *list.Element
 	createdAt *time.Time
-	done      chan struct{}
+	indexed   chan struct{}
 }


### PR DESCRIPTION
### What's being changed:

This adds feedback from the workers to the queues to notify them that a batch has been successfully indexed.
This is used to ensure all in-flight batches of a given queue have been indexed before closing the shard.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
