### PR TITLE
add help command to test run script that prints the available options

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -20,6 +20,14 @@ function main() {
           --integration-only) run_all_tests=false; run_integration_tests=true;;
           --benchmark-only) run_all_tests=false; run_benchmark=true;;
           --acceptance-module-tests-only) run_all_tests=false; run_module_tests=true; echo $run_module_tests ;;
+          --help|-h) printf '%s\n' \
+              "Options:"\
+              "--acceptance-only"\
+              "--unit-and-integration-only"\
+              "--unit-only-integration-only" \
+              "--benchmark-only" \
+              "--acceptance-module-tests-only"\
+              "--help|-h"; exit 1;;
           *) echo "Unknown parameter passed: $1"; exit 1 ;;
       esac
       shift


### PR DESCRIPTION
### What's being changed:

Helper test run script to add a new help command that prints the available commands.

Example output:

```
$> ./test/run.sh --help
Options:
--acceptance-only
--unit-and-integration-only
--unit-only--integration-only
--benchmark-only
--acceptance-module-tests-only
--help|-h
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
