### PR TITLE
Properly clean up metrics on class/shard delete [Tech Debt Cleanup]

### DIFF
--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -30,6 +30,8 @@ type Metrics struct {
 	filteredVectorVector  prometheus.Observer
 	filteredVectorObjects prometheus.Observer
 	filteredVectorSort    prometheus.Observer
+	grouped               bool
+	baseMetrics           *monitoring.PrometheusMetrics
 }
 
 func NewMetrics(
@@ -44,9 +46,12 @@ func NewMetrics(
 		return m
 	}
 
+	m.baseMetrics = prom
+
 	if prom.Group {
 		className = "n/a"
 		shardName = "n/a"
+		m.grouped = true
 	}
 
 	m.monitoring = true
@@ -92,6 +97,15 @@ func NewMetrics(
 	})
 
 	return m
+}
+
+func (m *Metrics) DeleteShardLabels(class, shard string) {
+	if m.grouped {
+		// never delete the shared label, only individual ones
+		return
+	}
+
+	m.baseMetrics.DeleteShard(class, shard)
 }
 
 func (m *Metrics) BatchObject(start time.Time, size int) {

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -200,6 +200,8 @@ func (db *DB) DeleteIndex(className schema.ClassName) error {
 		db.logger.WithField("action", "delete_index").WithField("class", className).Error(err)
 	}
 	delete(db.indices, id)
+
+	db.promMetrics.DeleteClass(className.String())
 	return nil
 }
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -262,6 +262,7 @@ func (s *Shard) initLSMStore(ctx context.Context) error {
 }
 
 func (s *Shard) drop() error {
+	s.metrics.DeleteShardLabels(s.index.Config.ClassName.String(), s.name)
 	s.replicationMap.clear()
 
 	if s.index.Config.TrackVectorDimensions {

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -63,6 +63,66 @@ type PrometheusMetrics struct {
 	Group bool
 }
 
+// Delete Shard deletes existing label combinations that match both
+// the shard and class name. If a metric is not collected at the shard
+// level it is unaffected. This is to make sure that deleting a single
+// shard (e.g. multi-tenancy) does not affect metrics for existing
+// shards.
+//
+// In addition, there are some metrics that we explicitly keep, such
+// as vector_dimensions_sum as they can be used in billing decisions.
+func (pm *PrometheusMetrics) DeleteShard(className, shardName string) error {
+	labels := prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	}
+	pm.BatchTime.DeletePartialMatch(labels)
+	pm.BatchDeleteTime.DeletePartialMatch(labels)
+	pm.ObjectsTime.DeletePartialMatch(labels)
+	pm.ObjectCount.DeletePartialMatch(labels)
+	pm.QueriesFilteredVectorDurations.DeletePartialMatch(labels)
+	pm.AsyncOperations.DeletePartialMatch(labels)
+	pm.LSMBloomFilters.DeletePartialMatch(labels)
+	pm.LSMMemtableDurations.DeletePartialMatch(labels)
+	pm.LSMMemtableSize.DeletePartialMatch(labels)
+	pm.LSMMemtableDurations.DeletePartialMatch(labels)
+	pm.LSMSegmentCount.DeletePartialMatch(labels)
+	pm.LSMSegmentSize.DeletePartialMatch(labels)
+	pm.LSMSegmentCountByLevel.DeletePartialMatch(labels)
+	pm.VectorIndexTombstones.DeletePartialMatch(labels)
+	pm.VectorIndexTombstoneCleanupThreads.DeletePartialMatch(labels)
+	pm.VectorIndexTombstoneCleanedCount.DeletePartialMatch(labels)
+	pm.VectorIndexOperations.DeletePartialMatch(labels)
+	pm.VectorIndexMaintenanceDurations.DeletePartialMatch(labels)
+	pm.VectorIndexDurations.DeletePartialMatch(labels)
+	pm.VectorIndexSize.DeletePartialMatch(labels)
+	pm.StartupProgress.DeletePartialMatch(labels)
+	pm.StartupDurations.DeletePartialMatch(labels)
+	pm.StartupDiskIO.DeletePartialMatch(labels)
+	return nil
+}
+
+// DeleteClass deletes all metrics that match the class name, but do
+// not have a shard-specific label. See [DeleteShard] for more
+// information.
+func (pm *PrometheusMetrics) DeleteClass(className string) error {
+	labels := prometheus.Labels{
+		"class_name": className,
+	}
+	pm.QueriesCount.DeletePartialMatch(labels)
+	pm.QueriesDurations.DeletePartialMatch(labels)
+	pm.GoroutinesCount.DeletePartialMatch(labels)
+	pm.BackupRestoreClassDurations.DeletePartialMatch(labels)
+	pm.BackupRestoreBackupInitDurations.DeletePartialMatch(labels)
+	pm.BackupRestoreFromStorageDurations.DeletePartialMatch(labels)
+	pm.BackupStoreDurations.DeletePartialMatch(labels)
+	pm.BackupRestoreDataTransferred.DeletePartialMatch(labels)
+	pm.BackupStoreDataTransferred.DeletePartialMatch(labels)
+	pm.QueriesFilteredVectorDurations.DeletePartialMatch(labels)
+
+	return nil
+}
+
 var (
 	msBuckets                    = []float64{10, 50, 100, 500, 1000, 5000}
 	metrics   *PrometheusMetrics = nil

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -72,6 +72,10 @@ type PrometheusMetrics struct {
 // In addition, there are some metrics that we explicitly keep, such
 // as vector_dimensions_sum as they can be used in billing decisions.
 func (pm *PrometheusMetrics) DeleteShard(className, shardName string) error {
+	if pm == nil {
+		return nil
+	}
+
 	labels := prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
@@ -106,6 +110,10 @@ func (pm *PrometheusMetrics) DeleteShard(className, shardName string) error {
 // not have a shard-specific label. See [DeleteShard] for more
 // information.
 func (pm *PrometheusMetrics) DeleteClass(className string) error {
+	if pm == nil {
+		return nil
+	}
+
 	labels := prometheus.Labels{
 		"class_name": className,
 	}


### PR DESCRIPTION
### What's being changed:
* When grouping is on, nothing changes
* When grouping is off, and a specific shard is deleted (e.g., MT), all metrics tagged with the shard name are removed
* When grouping is off, and a whole class is deleted, all metrics tagged with the class name are removed
* Some metrics are never removed (on purpose):
  * Metrics that measure request success rates (e.g. the delete of the class itself leads to a successful class delete request that should still be tracked)
  * Anything related to dimension tracking

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
