### PR TITLE
async: Improve import time using leaky bucket strategy

### DIFF
--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -15,7 +15,10 @@ import (
 	"container/list"
 	"context"
 	"encoding/binary"
+	"math"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -51,6 +54,9 @@ type IndexQueue struct {
 
 	// queue of not-yet-indexed vectors
 	queue *vectorQueue
+
+	// keeps track of the last call to Push()
+	lastPushed atomic.Pointer[time.Time]
 
 	pqMaxPool *pqMaxPool
 
@@ -189,6 +195,10 @@ func (q *IndexQueue) Push(ctx context.Context, vectors ...vectorDescriptor) erro
 	if q.ctx.Err() != nil {
 		return errors.New("index queue closed")
 	}
+
+	// store the time of the last push
+	now := time.Now()
+	q.lastPushed.Store(&now)
 
 	q.queue.Add(vectors)
 	return nil
@@ -334,6 +344,8 @@ func (q *IndexQueue) Drop() error {
 func (q *IndexQueue) indexer() {
 	t := time.NewTicker(q.IndexInterval)
 
+	workerNb := runtime.GOMAXPROCS(0) - 1
+
 	for {
 		select {
 		case <-t.C:
@@ -343,10 +355,23 @@ func (q *IndexQueue) indexer() {
 			}
 			status, err := q.Shard.compareAndSwapStatus(storagestate.StatusReady.String(), storagestate.StatusIndexing.String())
 			if status != storagestate.StatusIndexing || err != nil {
-				q.Logger.WithField("status", status).WithError(err).Error("failed to set shard status to indexing")
+				q.Logger.WithField("status", status).WithError(err).Warn("failed to set shard status to 'indexing', trying again in " + q.IndexInterval.String())
 				continue
 			}
-			q.pushToWorkers()
+
+			lastPushed := q.lastPushed.Load()
+			if lastPushed == nil || time.Since(*lastPushed) > time.Second {
+				// send at most 2 times the number of workers in one go,
+				// then wait for the next tick in case more vectors
+				// are added to the queue
+				q.pushToWorkers(2 * workerNb)
+			} else {
+				// send only one batch per tick
+				// to avoid competing for resources with the Push() method.
+				// This ensures the resources are used for queueing vectors in priority,
+				// then for indexing them.
+				q.pushToWorkers(1)
+			}
 		case <-q.ctx.Done():
 			// stop the ticker
 			t.Stop()
@@ -355,8 +380,8 @@ func (q *IndexQueue) indexer() {
 	}
 }
 
-func (q *IndexQueue) pushToWorkers() {
-	chunks := q.queue.borrowAllChunks()
+func (q *IndexQueue) pushToWorkers(max int) {
+	chunks := q.queue.borrowChunks(max)
 	for i, c := range chunks {
 		select {
 		case <-q.ctx.Done():
@@ -636,14 +661,19 @@ func (q *vectorQueue) ensureHasSpace() *chunk {
 	return c
 }
 
-func (q *vectorQueue) borrowAllChunks() []*chunk {
-	q.fullChunks.Lock()
+func (q *vectorQueue) borrowChunks(max int) []*chunk {
+	if max <= 0 {
+		max = math.MaxInt64
+	}
 
+	q.fullChunks.Lock()
 	var chunks []*chunk
 	e := q.fullChunks.list.Front()
-	for e != nil {
+	count := 0
+	for e != nil && count < max {
 		c := e.Value.(*chunk)
 		if !c.borrowed {
+			count++
 			c.borrowed = true
 			chunks = append(chunks, c)
 		}
@@ -652,13 +682,15 @@ func (q *vectorQueue) borrowAllChunks() []*chunk {
 	}
 	q.fullChunks.Unlock()
 
-	q.curBatch.Lock()
-	if q.curBatch.c != nil && time.Since(*q.curBatch.c.createdAt) > q.IndexQueue.StaleTimeout && q.curBatch.c.cursor > 0 {
-		q.curBatch.c.borrowed = true
-		chunks = append(chunks, q.curBatch.c)
-		q.curBatch.c = nil
+	if count < max {
+		q.curBatch.Lock()
+		if q.curBatch.c != nil && time.Since(*q.curBatch.c.createdAt) > q.IndexQueue.StaleTimeout && q.curBatch.c.cursor > 0 {
+			q.curBatch.c.borrowed = true
+			chunks = append(chunks, q.curBatch.c)
+			q.curBatch.c = nil
+		}
+		q.curBatch.Unlock()
 	}
-	q.curBatch.Unlock()
 
 	return chunks
 }

--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -390,7 +390,7 @@ func TestIndexQueue(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		before, err := q.checkpoints.Get("1")
 		require.NoError(t, err)
-		q.pushToWorkers(-1)
+		q.pushToWorkers(-1, false)
 		// the checkpoint should be: 0, then 0
 		// the cursor should not be updated
 		wait(100 * time.Millisecond)
@@ -402,7 +402,7 @@ func TestIndexQueue(t *testing.T) {
 		writeIDs(q, 30, 40) // [4, 15, 16, 17, 18], [19, 20, 21, 22, 23], [24, 30, 31, 32, 33], [34, 35, 36, 37, 38], [39]
 		time.Sleep(100 * time.Millisecond)
 		// the checkpoint should be: 0, then 4, then 14, then 29
-		q.pushToWorkers(-1)
+		q.pushToWorkers(-1, false)
 		// 0
 		wait()
 		// 4
@@ -512,7 +512,7 @@ func TestIndexQueue(t *testing.T) {
 			pushVector(t, ctx, q, i+1, 1, 2, 3)
 		}
 
-		q.pushToWorkers(-1)
+		q.pushToWorkers(-1, false)
 		q.Close()
 
 		require.EqualValues(t, 20, count)
@@ -533,7 +533,7 @@ func TestIndexQueue(t *testing.T) {
 			pushVector(t, ctx, q, i+1, randVector(1536)...)
 		}
 
-		q.pushToWorkers(-1)
+		q.pushToWorkers(-1, false)
 
 		_, distances, err := q.SearchByVector(randVector(1536), 10, nil)
 		require.NoError(t, err)

--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -390,7 +390,7 @@ func TestIndexQueue(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		before, err := q.checkpoints.Get("1")
 		require.NoError(t, err)
-		q.pushToWorkers()
+		q.pushToWorkers(-1)
 		// the checkpoint should be: 0, then 0
 		// the cursor should not be updated
 		wait(100 * time.Millisecond)
@@ -402,7 +402,7 @@ func TestIndexQueue(t *testing.T) {
 		writeIDs(q, 30, 40) // [4, 15, 16, 17, 18], [19, 20, 21, 22, 23], [24, 30, 31, 32, 33], [34, 35, 36, 37, 38], [39]
 		time.Sleep(100 * time.Millisecond)
 		// the checkpoint should be: 0, then 4, then 14, then 29
-		q.pushToWorkers()
+		q.pushToWorkers(-1)
 		// 0
 		wait()
 		// 4
@@ -512,7 +512,7 @@ func TestIndexQueue(t *testing.T) {
 			pushVector(t, ctx, q, i+1, 1, 2, 3)
 		}
 
-		q.pushToWorkers()
+		q.pushToWorkers(-1)
 		q.Close()
 
 		require.EqualValues(t, 20, count)
@@ -533,7 +533,7 @@ func TestIndexQueue(t *testing.T) {
 			pushVector(t, ctx, q, i+1, randVector(1536)...)
 		}
 
-		q.pushToWorkers()
+		q.pushToWorkers(-1)
 
 		_, distances, err := q.SearchByVector(randVector(1536), 10, nil)
 		require.NoError(t, err)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -162,7 +162,7 @@ func New(logger logrus.FieldLogger, config Config,
 	} else {
 		w := runtime.GOMAXPROCS(0) - 1
 		db.shutDownWg.Add(w)
-		db.jobQueueCh = make(chan job)
+		db.jobQueueCh = make(chan job, w)
 		for i := 0; i < w; i++ {
 			go func() {
 				defer db.shutDownWg.Done()


### PR DESCRIPTION
### What's being changed:

When importing a large dataset, the upstream LSM store competes with HNSW for disk. This causes the import to slow down because the background workers are indexing at full speed.
This is the opposite of the goal of the async indexing, which should focus in priority on making imports fast.

This PR modifies the queue to dequeue items using a leaky bucket strategy.
When the throughput is high, the queue slows down the indexing to give more disk resources to the LSM tree.
The indexing is limited to one batch at a time until the throughput gets lower, then the queue dequeues as fast as possible.

### Results with Sift

| Method                  | Import Time     | Indexing Time  |
|-------------------------|-----------------|----------------|
| Sync                    | 6m02s           |                |
| Async                   | 4m31s           | 4m39s          |
| Async with leaky bucket | 1m39s (-3m51s)  | 5m36s (+57s)   |

### Results with Sphere 1M

| Method                  | Import Time       | Indexing Time     |
|-------------------------|-------------------|-------------------|
| Sync                    | 33m14s            | -                 |
| Async                   | 19m26s            | 23m48s            |
| Async with leaky bucket | 9m35s (diff: -9m51) | 26m32s (diff: +2m46) |

With this strategy, the import speed is very fast 🚀 , and surprisingly the indexing time is not impacted that much.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
