### PR TITLE
add support for vectorizing `text[]` props in `multi2vec-clip`

### DIFF
--- a/modules/multi2vec-clip/vectorizer/vectorizer.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer.go
@@ -92,6 +92,16 @@ func (v *Vectorizer) object(ctx context.Context, id strfmt.UUID,
 					texts = append(texts, valueString)
 					vectorize = vectorize || (objDiff != nil && objDiff.IsChangedProp(prop))
 				}
+				valueArr, ok := value.([]interface{})
+				if ok {
+					for _, value := range valueArr {
+						valueString, ok := value.(string)
+						if ok {
+							texts = append(texts, valueString)
+							vectorize = vectorize || (objDiff != nil && objDiff.IsChangedProp(prop))
+						}
+					}
+				}
 			}
 		}
 	}

--- a/test/acceptance/nodes/nodes_api_test.go
+++ b/test/acceptance/nodes/nodes_api_test.go
@@ -60,7 +60,8 @@ func Test_NodesAPI(t *testing.T) {
 		helper.CreateClass(t, booksClass)
 		defer helper.DeleteClass(t, booksClass.Class)
 
-		for _, book := range books.Objects() {
+		booksObjects := books.Objects()
+		for _, book := range booksObjects {
 			helper.CreateObject(t, book)
 			helper.AssertGetObjectEventually(t, book.Class, book.ID)
 		}
@@ -84,10 +85,10 @@ func Test_NodesAPI(t *testing.T) {
 		shard := nodeStatus.Shards[0]
 		assert.True(t, len(shard.Name) > 0)
 		assert.Equal(t, booksClass.Class, shard.Class)
-		assert.Equal(t, int64(3), shard.ObjectCount)
+		assert.Equal(t, int64(len(booksObjects)), shard.ObjectCount)
 
 		require.NotNil(t, nodeStatus.Stats)
-		assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
+		assert.Equal(t, int64(len(booksObjects)), nodeStatus.Stats.ObjectCount)
 		assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 	})
 
@@ -133,7 +134,8 @@ func Test_NodesAPI(t *testing.T) {
 		defer helper.DeleteClass(t, booksClass.Class)
 
 		t.Run("insert and check books", func(t *testing.T) {
-			for _, book := range books.Objects() {
+			booksObjects := books.Objects()
+			for _, book := range booksObjects {
 				helper.CreateObject(t, book)
 				helper.AssertGetObjectEventually(t, book.Class, book.ID)
 			}
@@ -151,7 +153,7 @@ func Test_NodesAPI(t *testing.T) {
 			nodeStatus := respNodes[0]
 
 			require.NotNil(t, nodeStatus.Stats)
-			assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
+			assert.Equal(t, int64(len(booksObjects)), nodeStatus.Stats.ObjectCount)
 			assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 		})
 

--- a/test/acceptance/nodes/nodes_api_test.go
+++ b/test/acceptance/nodes/nodes_api_test.go
@@ -60,8 +60,7 @@ func Test_NodesAPI(t *testing.T) {
 		helper.CreateClass(t, booksClass)
 		defer helper.DeleteClass(t, booksClass.Class)
 
-		booksObjects := books.Objects()
-		for _, book := range booksObjects {
+		for _, book := range books.Objects() {
 			helper.CreateObject(t, book)
 			helper.AssertGetObjectEventually(t, book.Class, book.ID)
 		}
@@ -85,10 +84,10 @@ func Test_NodesAPI(t *testing.T) {
 		shard := nodeStatus.Shards[0]
 		assert.True(t, len(shard.Name) > 0)
 		assert.Equal(t, booksClass.Class, shard.Class)
-		assert.Equal(t, int64(len(booksObjects)), shard.ObjectCount)
+		assert.Equal(t, int64(3), shard.ObjectCount)
 
 		require.NotNil(t, nodeStatus.Stats)
-		assert.Equal(t, int64(len(booksObjects)), nodeStatus.Stats.ObjectCount)
+		assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
 		assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 	})
 
@@ -134,8 +133,7 @@ func Test_NodesAPI(t *testing.T) {
 		defer helper.DeleteClass(t, booksClass.Class)
 
 		t.Run("insert and check books", func(t *testing.T) {
-			booksObjects := books.Objects()
-			for _, book := range booksObjects {
+			for _, book := range books.Objects() {
 				helper.CreateObject(t, book)
 				helper.AssertGetObjectEventually(t, book.Class, book.ID)
 			}
@@ -153,7 +151,7 @@ func Test_NodesAPI(t *testing.T) {
 			nodeStatus := respNodes[0]
 
 			require.NotNil(t, nodeStatus.Stats)
-			assert.Equal(t, int64(len(booksObjects)), nodeStatus.Stats.ObjectCount)
+			assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
 			assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 		})
 

--- a/test/helper/sample-schema/books/books.go
+++ b/test/helper/sample-schema/books/books.go
@@ -25,6 +25,7 @@ const (
 	Dune                  strfmt.UUID = "67b79643-cf8b-4b22-b206-6e63dbb4e000"
 	ProjectHailMary       strfmt.UUID = "67b79643-cf8b-4b22-b206-6e63dbb4e001"
 	TheLordOfTheIceGarden strfmt.UUID = "67b79643-cf8b-4b22-b206-6e63dbb4e002"
+	OnlyTags              strfmt.UUID = "67b79643-cf8b-4b22-b206-6e63dbb4e003"
 )
 
 func ClassContextionaryVectorizer() *models.Class {
@@ -133,7 +134,7 @@ func objects(className string) []*models.Object {
 			ID:    Dune,
 			Properties: map[string]interface{}{
 				"title":       "Dune",
-				"tags":        []string{"favourite"},
+				"tags":        []string{"sci-fi", "epic"},
 				"description": "Dune is a 1965 epic science fiction novel by American author Frank Herbert.",
 			},
 		},
@@ -142,7 +143,7 @@ func objects(className string) []*models.Object {
 			ID:    ProjectHailMary,
 			Properties: map[string]interface{}{
 				"title":       "Project Hail Mary",
-				"tags":        []string{"decent"},
+				"tags":        []string{"sci-fi"},
 				"description": "Project Hail Mary is a 2021 science fiction novel by American novelist Andy Weir.",
 			},
 		},
@@ -151,8 +152,16 @@ func objects(className string) []*models.Object {
 			ID:    TheLordOfTheIceGarden,
 			Properties: map[string]interface{}{
 				"title":       "The Lord of the Ice Garden",
-				"tags":        []string{"unknown"},
+				"tags":        []string{"sci-fi", "fantasy"},
 				"description": "The Lord of the Ice Garden (Polish: Pan Lodowego Ogrodu) is a four-volume science fiction and fantasy novel by Polish writer Jaroslaw Grzedowicz.",
+			},
+		},
+		{
+			Class: className,
+			ID:    OnlyTags,
+			Properties: map[string]interface{}{
+				"title": "Only Tags",
+				"tags":  []string{"foo", "foo", "foo"},
 			},
 		},
 	}

--- a/test/helper/sample-schema/books/books.go
+++ b/test/helper/sample-schema/books/books.go
@@ -59,7 +59,7 @@ func ClassTransformersVectorizerWithQnATransformersWithName(className string) *m
 func ClassCLIPVectorizer() *models.Class {
 	c := class(defaultClassName, "multi2vec-clip")
 	c.ModuleConfig.(map[string]interface{})["multi2vec-clip"] = map[string]interface{}{
-		"textFields": []string{"title", "description"},
+		"textFields": []string{"title", "tags", "description"},
 	}
 	return c
 }
@@ -134,7 +134,6 @@ func objects(className string) []*models.Object {
 			ID:    Dune,
 			Properties: map[string]interface{}{
 				"title":       "Dune",
-				"tags":        []string{"sci-fi", "epic"},
 				"description": "Dune is a 1965 epic science fiction novel by American author Frank Herbert.",
 			},
 		},
@@ -143,7 +142,6 @@ func objects(className string) []*models.Object {
 			ID:    ProjectHailMary,
 			Properties: map[string]interface{}{
 				"title":       "Project Hail Mary",
-				"tags":        []string{"sci-fi"},
 				"description": "Project Hail Mary is a 2021 science fiction novel by American novelist Andy Weir.",
 			},
 		},
@@ -152,16 +150,8 @@ func objects(className string) []*models.Object {
 			ID:    TheLordOfTheIceGarden,
 			Properties: map[string]interface{}{
 				"title":       "The Lord of the Ice Garden",
-				"tags":        []string{"sci-fi", "fantasy"},
+				"tags":        []string{"three", "three", "three"},
 				"description": "The Lord of the Ice Garden (Polish: Pan Lodowego Ogrodu) is a four-volume science fiction and fantasy novel by Polish writer Jaroslaw Grzedowicz.",
-			},
-		},
-		{
-			Class: className,
-			ID:    OnlyTags,
-			Properties: map[string]interface{}{
-				"title": "Only Tags",
-				"tags":  []string{"foo", "foo", "foo"},
 			},
 		},
 	}

--- a/test/helper/sample-schema/books/books.go
+++ b/test/helper/sample-schema/books/books.go
@@ -95,6 +95,12 @@ func class(className, vectorizer string, additionalModules ...string) *models.Cl
 				},
 			},
 			{
+				Name:         "tags",
+				DataType:     schema.DataTypeTextArray.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": false}},
+			},
+			{
 				Name:         "description",
 				DataType:     schema.DataTypeText.PropString(),
 				Tokenization: models.PropertyTokenizationWhitespace,
@@ -127,6 +133,7 @@ func objects(className string) []*models.Object {
 			ID:    Dune,
 			Properties: map[string]interface{}{
 				"title":       "Dune",
+				"tags":        []string{"favourite"},
 				"description": "Dune is a 1965 epic science fiction novel by American author Frank Herbert.",
 			},
 		},
@@ -135,6 +142,7 @@ func objects(className string) []*models.Object {
 			ID:    ProjectHailMary,
 			Properties: map[string]interface{}{
 				"title":       "Project Hail Mary",
+				"tags":        []string{"decent"},
 				"description": "Project Hail Mary is a 2021 science fiction novel by American novelist Andy Weir.",
 			},
 		},
@@ -143,6 +151,7 @@ func objects(className string) []*models.Object {
 			ID:    TheLordOfTheIceGarden,
 			Properties: map[string]interface{}{
 				"title":       "The Lord of the Ice Garden",
+				"tags":        []string{"unknown"},
 				"description": "The Lord of the Ice Garden (Polish: Pan Lodowego Ogrodu) is a four-volume science fiction and fantasy novel by Polish writer Jaroslaw Grzedowicz.",
 			},
 		},

--- a/test/modules/multi2vec-clip/clip_test.go
+++ b/test/modules/multi2vec-clip/clip_test.go
@@ -66,4 +66,35 @@ func Test_CLIP(t *testing.T) {
 		assert.Greater(t, dist, 0.0)
 		assert.LessOrEqual(t, dist, 0.03)
 	})
+
+	t.Run("query Books data with nearText on text[] field", func(t *testing.T) {
+		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
+			{
+				Get {
+					Books(
+						limit: 1
+						nearText: {
+							concepts: ["unknown"]
+							distance: 0.5
+						}
+					){
+						title
+						_additional {
+							distance
+						}
+					}
+				}
+			}
+		`)
+		books := result.Get("Get", "Books").AsSlice()
+		require.Len(t, books, 1)
+		title := books[0].(map[string]interface{})["title"]
+		assert.Equal(t, "The Lord of the Ice Garden", title)
+		distance := books[0].(map[string]interface{})["_additional"].(map[string]interface{})["distance"].(json.Number)
+		assert.NotNil(t, distance)
+		dist, err := distance.Float64()
+		require.Nil(t, err)
+		assert.Greater(t, dist, 0.0)
+		assert.LessOrEqual(t, dist, 0.03)
+	})
 }

--- a/test/modules/multi2vec-clip/clip_test.go
+++ b/test/modules/multi2vec-clip/clip_test.go
@@ -38,19 +38,16 @@ func Test_CLIP(t *testing.T) {
 	})
 
 	tests := []struct {
-		concept          string
-		expectedTitle    string
-		expectedDistance float64
+		concept       string
+		expectedTitle string
 	}{
 		{
-			concept:          "Dune",
-			expectedTitle:    "Dune",
-			expectedDistance: 0.03,
+			concept:       "Dune",
+			expectedTitle: "Dune",
 		},
 		{
-			concept:          "foo",
-			expectedTitle:    "Only Tags",
-			expectedDistance: 0.1,
+			concept:       "three",
+			expectedTitle: "The Lord of the Ice Garden",
 		},
 	}
 	for _, tt := range tests {
@@ -82,7 +79,7 @@ func Test_CLIP(t *testing.T) {
 			dist, err := distance.Float64()
 			require.Nil(t, err)
 			assert.Greater(t, dist, 0.0)
-			assert.LessOrEqual(t, dist, tt.expectedDistance)
+			assert.LessOrEqual(t, dist, 0.03)
 		})
 	}
 }

--- a/test/modules/multi2vec-clip/clip_test.go
+++ b/test/modules/multi2vec-clip/clip_test.go
@@ -13,6 +13,7 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -36,65 +37,52 @@ func Test_CLIP(t *testing.T) {
 		}
 	})
 
-	t.Run("query Books data with nearText", func(t *testing.T) {
-		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
-			{
-				Get {
-					Books(
-						limit: 1
-						nearText: {
-							concepts: ["Dune"]
-							distance: 0.5
-						}
-					){
-						title
-						_additional {
-							distance
-						}
-					}
-				}
-			}
-		`)
-		books := result.Get("Get", "Books").AsSlice()
-		require.Len(t, books, 1)
-		title := books[0].(map[string]interface{})["title"]
-		assert.Equal(t, "Dune", title)
-		distance := books[0].(map[string]interface{})["_additional"].(map[string]interface{})["distance"].(json.Number)
-		assert.NotNil(t, distance)
-		dist, err := distance.Float64()
-		require.Nil(t, err)
-		assert.Greater(t, dist, 0.0)
-		assert.LessOrEqual(t, dist, 0.03)
-	})
-
-	t.Run("query Books data with nearText on text[] field", func(t *testing.T) {
-		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
-			{
-				Get {
-					Books(
-						limit: 1
-						nearText: {
-							concepts: ["unknown"]
-							distance: 0.5
-						}
-					){
-						title
-						_additional {
-							distance
+	tests := []struct {
+		concept          string
+		expectedTitle    string
+		expectedDistance float64
+	}{
+		{
+			concept:          "Dune",
+			expectedTitle:    "Dune",
+			expectedDistance: 0.03,
+		},
+		{
+			concept:          "foo",
+			expectedTitle:    "Only Tags",
+			expectedDistance: 0.1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("query Books data with nearText", func(t *testing.T) {
+			result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, fmt.Sprintf(`
+				{
+					Get {
+						Books(
+							limit: 1
+							nearText: {
+								concepts: ["%v"]
+								distance: 0.5
+							}
+						){
+							title
+							_additional {
+								distance
+							}
 						}
 					}
 				}
-			}
-		`)
-		books := result.Get("Get", "Books").AsSlice()
-		require.Len(t, books, 1)
-		title := books[0].(map[string]interface{})["title"]
-		assert.Equal(t, "The Lord of the Ice Garden", title)
-		distance := books[0].(map[string]interface{})["_additional"].(map[string]interface{})["distance"].(json.Number)
-		assert.NotNil(t, distance)
-		dist, err := distance.Float64()
-		require.Nil(t, err)
-		assert.Greater(t, dist, 0.0)
-		assert.LessOrEqual(t, dist, 0.03)
-	})
+			`, tt.concept))
+			books := result.Get("Get", "Books").AsSlice()
+			require.Len(t, books, 1)
+			title := books[0].(map[string]interface{})["title"]
+			assert.Equal(t, tt.expectedTitle, title)
+			distance := books[0].(map[string]interface{})["_additional"].(map[string]interface{})["distance"].(json.Number)
+			assert.NotNil(t, distance)
+			dist, err := distance.Float64()
+			require.Nil(t, err)
+			assert.Greater(t, dist, 0.0)
+			assert.LessOrEqual(t, dist, tt.expectedDistance)
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:

This PR adds support for the vectorization of `text[]` properties when using the `multi2vec-clip` module

Previously, if a user included a `text[]` property to be vectorized then it was ignored. Now the `text[]` property is looped through with each entry being added to the text to-be-vectorized

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
