### PR TITLE
add support for vectorizing `text[]` props in `multi2vec-clip`

### DIFF
--- a/modules/multi2vec-clip/vectorizer/vectorizer.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer.go
@@ -93,6 +93,16 @@ func (v *Vectorizer) object(ctx context.Context, id strfmt.UUID,
 					vectorize = vectorize || (objDiff != nil && objDiff.IsChangedProp(prop))
 				}
 			}
+			valueArr, ok := value.([]interface{})
+			if ok {
+				for _, value := range valueArr {
+					valueString, ok := value.(string)
+					if ok {
+						texts = append(texts, valueString)
+						vectorize = vectorize || (objDiff != nil && objDiff.IsChangedProp(prop))
+					}
+				}
+			}
 		}
 	}
 

--- a/test/helper/sample-schema/books/books.go
+++ b/test/helper/sample-schema/books/books.go
@@ -58,7 +58,7 @@ func ClassTransformersVectorizerWithQnATransformersWithName(className string) *m
 func ClassCLIPVectorizer() *models.Class {
 	c := class(defaultClassName, "multi2vec-clip")
 	c.ModuleConfig.(map[string]interface{})["multi2vec-clip"] = map[string]interface{}{
-		"textFields": []string{"title", "description"},
+		"textFields": []string{"title", "tags", "description"},
 	}
 	return c
 }
@@ -93,6 +93,12 @@ func class(className, vectorizer string, additionalModules ...string) *models.Cl
 						"skip": false,
 					},
 				},
+			},
+			{
+				Name:         "tags",
+				DataType:     schema.DataTypeTextArray.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": false}},
 			},
 			{
 				Name:         "description",
@@ -143,6 +149,7 @@ func objects(className string) []*models.Object {
 			ID:    TheLordOfTheIceGarden,
 			Properties: map[string]interface{}{
 				"title":       "The Lord of the Ice Garden",
+				"tags":        []string{"three", "three", "three"},
 				"description": "The Lord of the Ice Garden (Polish: Pan Lodowego Ogrodu) is a four-volume science fiction and fantasy novel by Polish writer Jaroslaw Grzedowicz.",
 			},
 		},

--- a/test/modules/multi2vec-clip/clip_test.go
+++ b/test/modules/multi2vec-clip/clip_test.go
@@ -13,6 +13,7 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
@@ -36,34 +37,49 @@ func Test_CLIP(t *testing.T) {
 		}
 	})
 
-	t.Run("query Books data with nearText", func(t *testing.T) {
-		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
-			{
-				Get {
-					Books(
-						limit: 1
-						nearText: {
-							concepts: ["Dune"]
-							distance: 0.5
-						}
-					){
-						title
-						_additional {
-							distance
+	tests := []struct {
+		concept       string
+		expectedTitle string
+	}{
+		{
+			concept:       "Dune",
+			expectedTitle: "Dune",
+		},
+		{
+			concept:       "three",
+			expectedTitle: "The Lord of the Ice Garden",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("query Books data with nearText", func(t *testing.T) {
+			result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, fmt.Sprintf(`
+				{
+					Get {
+						Books(
+							limit: 1
+							nearText: {
+								concepts: ["%v"]
+								distance: 0.5
+							}
+						){
+							title
+							_additional {
+								distance
+							}
 						}
 					}
 				}
-			}
-		`)
-		books := result.Get("Get", "Books").AsSlice()
-		require.Len(t, books, 1)
-		title := books[0].(map[string]interface{})["title"]
-		assert.Equal(t, "Dune", title)
-		distance := books[0].(map[string]interface{})["_additional"].(map[string]interface{})["distance"].(json.Number)
-		assert.NotNil(t, distance)
-		dist, err := distance.Float64()
-		require.Nil(t, err)
-		assert.Greater(t, dist, 0.0)
-		assert.LessOrEqual(t, dist, 0.03)
-	})
+			`, tt.concept))
+			books := result.Get("Get", "Books").AsSlice()
+			require.Len(t, books, 1)
+			title := books[0].(map[string]interface{})["title"]
+			assert.Equal(t, tt.expectedTitle, title)
+			distance := books[0].(map[string]interface{})["_additional"].(map[string]interface{})["distance"].(json.Number)
+			assert.NotNil(t, distance)
+			dist, err := distance.Float64()
+			require.Nil(t, err)
+			assert.Greater(t, dist, 0.0)
+			assert.LessOrEqual(t, dist, 0.03)
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:

This PR adds support for the vectorization of `text[]` properties when using the `multi2vec-clip` module

Previously, if a user included a `text[]` property to be vectorized then it was ignored. Now the `text[]` property is looped through with each entry being added to the text to be vectorized

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
