### PR TITLE
add support for vectorizing `text[]` props in `multi2vec-bind`

### DIFF
--- a/modules/multi2vec-bind/vectorizer/vectorizer.go
+++ b/modules/multi2vec-bind/vectorizer/vectorizer.go
@@ -145,6 +145,16 @@ func (v *Vectorizer) object(ctx context.Context, id strfmt.UUID,
 					texts = append(texts, valueString)
 					vectorize = vectorize || (objDiff != nil && objDiff.IsChangedProp(prop))
 				}
+				valueArr, ok := value.([]interface{})
+				if ok {
+					for _, value := range valueArr {
+						valueString, ok := value.(string)
+						if ok {
+							texts = append(texts, valueString)
+							vectorize = vectorize || (objDiff != nil && objDiff.IsChangedProp(prop))
+						}
+					}
+				}
 			}
 			if ichek.AudioField(prop) {
 				valueString, ok := value.(string)


### PR DESCRIPTION
### What's being changed:

This PR adds support for the vectorization of `text[]` properties when using the `multi2vec-bind` module

Previously, if a user included a `text[]` property to be vectorized then it was ignored. Now the `text[]` property is looped through with each entry being added to the text to be vectorized

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
