### PR TITLE
Fix gRPC Batch API AutoSchema

### DIFF
--- a/test/acceptance_with_go_client/fixtures/allproperties.go
+++ b/test/acceptance_with_go_client/fixtures/allproperties.go
@@ -1,0 +1,186 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package fixtures
+
+import (
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+var (
+	AllPropertiesClassName = "AllProperties"
+	AllPropertiesID1       = "00000000-0000-0000-0000-000000000001"
+	vTrue                  = true
+	vFalse                 = false
+)
+
+var AllPropertiesClass = &models.Class{
+	Class: AllPropertiesClassName,
+	Properties: []*models.Property{
+		{
+			Name:            "objectProperty",
+			DataType:        schema.DataTypeObject.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:     "text",
+					DataType: schema.DataTypeText.PropString(),
+				},
+				{
+					Name:     "texts",
+					DataType: schema.DataTypeTextArray.PropString(),
+				},
+				{
+					Name:     "number",
+					DataType: schema.DataTypeNumber.PropString(),
+				},
+				{
+					Name:     "numbers",
+					DataType: schema.DataTypeNumberArray.PropString(),
+				},
+				{
+					Name:     "int",
+					DataType: schema.DataTypeInt.PropString(),
+				},
+				{
+					Name:     "ints",
+					DataType: schema.DataTypeIntArray.PropString(),
+				},
+				{
+					Name:     "date",
+					DataType: schema.DataTypeDate.PropString(),
+				},
+				{
+					Name:     "dates",
+					DataType: schema.DataTypeDateArray.PropString(),
+				},
+				{
+					Name:     "bool",
+					DataType: schema.DataTypeBoolean.PropString(),
+				},
+				{
+					Name:     "bools",
+					DataType: schema.DataTypeBooleanArray.PropString(),
+				},
+				{
+					Name:     "uuid",
+					DataType: schema.DataTypeUUID.PropString(),
+				},
+				{
+					Name:     "uuids",
+					DataType: schema.DataTypeUUIDArray.PropString(),
+				},
+				{
+					Name:            "nested_int",
+					DataType:        schema.DataTypeInt.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+				{
+					Name:            "nested_number",
+					DataType:        schema.DataTypeNumber.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+				{
+					Name:            "nested_text",
+					DataType:        schema.DataTypeText.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vTrue,
+					Tokenization:    models.PropertyTokenizationWord,
+				},
+				{
+					Name:            "nested_objects",
+					DataType:        schema.DataTypeObject.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:            "nested_bool_lvl2",
+							DataType:        schema.DataTypeBoolean.PropString(),
+							IndexFilterable: &vTrue,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+						},
+						{
+							Name:            "nested_numbers_lvl2",
+							DataType:        schema.DataTypeNumberArray.PropString(),
+							IndexFilterable: &vTrue,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+						},
+					},
+				},
+				{
+					Name:            "nested_array_objects",
+					DataType:        schema.DataTypeObjectArray.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:            "nested_bool_lvl2",
+							DataType:        schema.DataTypeBoolean.PropString(),
+							IndexFilterable: &vTrue,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+						},
+						{
+							Name:            "nested_numbers_lvl2",
+							DataType:        schema.DataTypeNumberArray.PropString(),
+							IndexFilterable: &vTrue,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var AllPropertiesProperties = map[string]interface{}{
+	"text":          "red",
+	"texts":         []string{"red", "blue"},
+	"number":        float64(1.1),
+	"numbers":       []float64{1.1, 2.2},
+	"int":           int64(1),
+	"ints":          []int64{1, 2},
+	"uuid":          AllPropertiesID1,
+	"uuids":         []string{AllPropertiesID1},
+	"date":          "2009-11-01T23:00:00Z",
+	"dates":         []string{"2009-11-01T23:00:00Z"},
+	"bool":          true,
+	"bools":         []bool{true, false},
+	"nested_int":    int64(11),
+	"nested_number": float64(11.11),
+	"nested_text":   "nested text",
+	"nested_objects": map[string]interface{}{
+		"nested_bool_lvl2":    true,
+		"nested_numbers_lvl2": []float64{11.1, 22.1},
+	},
+	"nested_array_objects": []interface{}{
+		map[string]interface{}{
+			"nested_bool_lvl2":    true,
+			"nested_numbers_lvl2": []float64{111.1, 222.1},
+		},
+		map[string]interface{}{
+			"nested_bool_lvl2":    false,
+			"nested_numbers_lvl2": []float64{112.1, 222.1},
+		},
+	},
+}

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	github.com/weaviate/weaviate v1.21.5-0.20230928125248-5870ac955396
-	github.com/weaviate/weaviate-go-client/v4 v4.10.1-0.20230928141813-32e58b808a0a
+	github.com/weaviate/weaviate v1.22.0-rc.0
+	github.com/weaviate/weaviate-go-client/v4 v4.10.1-0.20231020143649-d4ad9be95463
 )
 
 require (

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -478,10 +478,10 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/weaviate/weaviate v1.21.5-0.20230928125248-5870ac955396 h1:C3GCf01165AYOurSLP3lDpA/4blH3efHPNAvoajhErc=
-github.com/weaviate/weaviate v1.21.5-0.20230928125248-5870ac955396/go.mod h1:kTSqWp/m1HY2J9WdzyMFjl5SXkhaI9Jw3jZUu7kQTHM=
-github.com/weaviate/weaviate-go-client/v4 v4.10.1-0.20230928141813-32e58b808a0a h1:1k4Zb1JbUGNu3lCdBzXDQxwTIh0/lz0gXzkc+at5Lz4=
-github.com/weaviate/weaviate-go-client/v4 v4.10.1-0.20230928141813-32e58b808a0a/go.mod h1:ND82Mn4ZqO/IA/iE0zId7od5sYhd9JdRiUYeuLRTw3o=
+github.com/weaviate/weaviate v1.22.0-rc.0 h1:sD8TAZIP5ObrowjWVOLzQD4joyNnOVpWd6C1c9Vkad4=
+github.com/weaviate/weaviate v1.22.0-rc.0/go.mod h1:d6P+Hhn0oDzjZv539ZGdCEbTYlFIAtElpKXTN/WmEF4=
+github.com/weaviate/weaviate-go-client/v4 v4.10.1-0.20231020143649-d4ad9be95463 h1:z0lUxrm4A/5jzsJOkEpa7QH2c85xq+iJjWE65kG5Zog=
+github.com/weaviate/weaviate-go-client/v4 v4.10.1-0.20231020143649-d4ad9be95463/go.mod h1:lKVRr5kCCfKt80b7SyhRpsoddZZm8NAs2kaO7tkJ318=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=

--- a/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
+++ b/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
@@ -1,0 +1,71 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package grpc_tests
+
+import (
+	"acceptance_tests_with_client/fixtures"
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/grpc"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestGRPC_Batch(t *testing.T) {
+	ctx := context.Background()
+	config := wvt.Config{Scheme: "http", Host: "localhost:8080", GrpcConfig: grpc.Config{Enabled: true, Host: "localhost:50051"}}
+	client, err := wvt.NewClient(config)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	// clean DB
+	err = client.Schema().AllDeleter().Do(ctx)
+	require.NoError(t, err)
+	t.Run("all properties", func(t *testing.T) {
+		class := fixtures.AllPropertiesClass
+		className := fixtures.AllPropertiesClassName
+		id1 := fixtures.AllPropertiesID1
+		properties := fixtures.AllPropertiesProperties
+		t.Run("create schema", func(t *testing.T) {
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+		})
+		t.Run("grpc batch import", func(t *testing.T) {
+			objects := []*models.Object{
+				{
+					Class:      className,
+					ID:         strfmt.UUID(id1),
+					Properties: properties,
+				},
+			}
+			resp, err := client.Batch().ObjectsBatcher().WithObjects(objects...).Do(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Len(t, resp, 1)
+			require.NotNil(t, resp[0].Result)
+			assert.Nil(t, resp[0].Result.Errors)
+		})
+		t.Run("check", func(t *testing.T) {
+			objs, err := client.Data().ObjectsGetter().WithClassName(className).WithID(id1).Do(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, objs)
+			require.Len(t, objs, 1)
+			assert.Equal(t, className, objs[0].Class)
+			props, ok := objs[0].Properties.(map[string]interface{})
+			require.True(t, ok)
+			require.Equal(t, len(properties), len(props))
+		})
+	})
+}

--- a/test/acceptance_with_go_client/object_property_tests/batch_test.go
+++ b/test/acceptance_with_go_client/object_property_tests/batch_test.go
@@ -22,126 +22,85 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/grpc"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
 func TestObjectProperty_Batch(t *testing.T) {
 	ctx := context.Background()
-	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: "localhost:8080"})
-	require.Nil(t, err)
 
-	id1 := strfmt.UUID("00000000-0000-0000-0000-000000000001")
-	id2 := strfmt.UUID("00000000-0000-0000-0000-000000000002")
+	tests := []struct {
+		name   string
+		config wvt.Config
+	}{
+		{
+			name:   "rest api",
+			config: wvt.Config{Scheme: "http", Host: "localhost:8080"},
+		},
+		{
+			name:   "grpc api",
+			config: wvt.Config{Scheme: "http", Host: "localhost:8080", GrpcConfig: grpc.Config{Enabled: true, Host: "localhost:50051"}},
+		},
+	}
+	for _, tt := range tests {
+		client, err := wvt.NewClient(tt.config)
+		require.Nil(t, err)
 
-	// clean up DB
-	err = client.Schema().AllDeleter().Do(context.Background())
-	require.Nil(t, err)
+		id1 := strfmt.UUID("00000000-0000-0000-0000-000000000001")
+		id2 := strfmt.UUID("00000000-0000-0000-0000-000000000002")
 
-	t.Run("batch import object property", func(t *testing.T) {
-		resp, err := client.Batch().ObjectsBatcher().
-			WithObjects(
-				&models.Object{
-					Class: "Person",
-					ID:    id1,
-					Properties: map[string]interface{}{
-						"name": "John Doe",
-						"json": map[string]interface{}{
-							"firstName":   "John",
-							"lastName":    "Doe",
-							"proffession": "Accountant",
-							"birthdate":   "2012-05-05T07:16:30+02:00",
-							"phoneNumber": map[string]interface{}{
-								"input":                  "020 1234567",
-								"defaultCountry":         "nl",
-								"internationalFormatted": "+31 20 1234567",
-								"countryCode":            31,
-								"national":               201234567,
-								"nationalFormatted":      "020 1234567",
-								"valid":                  true,
-							},
-							"location": map[string]interface{}{
-								"latitude":  52.366667,
-								"longitude": 4.9,
-							},
-						},
-					},
-				},
-				&models.Object{
-					Class: "Person",
-					ID:    id2,
-					Properties: map[string]interface{}{
-						"name": "Stacey Spears",
-						"json": map[string]interface{}{
-							"firstName":   "Stacey",
-							"lastName":    "Spears",
-							"proffession": "Accountant",
-							"birthdate":   "2011-05-05T07:16:30+02:00",
-							"phoneNumber": map[string]interface{}{
-								"input":                  "020 1555444",
-								"defaultCountry":         "nl",
-								"internationalFormatted": "+31 20 1555444",
-								"countryCode":            31,
-								"national":               201555444,
-								"nationalFormatted":      "020 1555444",
-								"valid":                  true,
-							},
-							"location": map[string]interface{}{
-								"latitude":  51.366667,
-								"longitude": 5.9,
-							},
-						},
-					},
-				}).
-			Do(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Len(t, resp, 2)
-		properties, ok := resp[0].Object.Properties.(map[string]interface{})
-		require.True(t, ok)
-		require.NotNil(t, properties)
-		jsonProp, ok := properties["json"].(map[string]interface{})
-		require.True(t, ok)
-		require.NotNil(t, jsonProp)
-		phone, ok := jsonProp["phoneNumber"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, 7, len(phone))
-		location, ok := jsonProp["location"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, 2, len(location))
-	})
+		// clean up DB
+		err = client.Schema().AllDeleter().Do(context.Background())
+		require.Nil(t, err)
 
-	t.Run("batch import object array property", func(t *testing.T) {
-		resp, err := client.Batch().ObjectsBatcher().
-			WithObjects(
-				&models.Object{
-					Class: "People",
-					ID:    id1,
-					Properties: map[string]interface{}{
-						"country": "United Kingdom",
-						"people": []interface{}{
-							map[string]interface{}{
+		t.Run("batch import object property", func(t *testing.T) {
+			resp, err := client.Batch().ObjectsBatcher().
+				WithObjects(
+					&models.Object{
+						Class: "Person",
+						ID:    id1,
+						Properties: map[string]interface{}{
+							"name": "John Doe",
+							"json": map[string]interface{}{
 								"firstName":   "John",
 								"lastName":    "Doe",
 								"proffession": "Accountant",
 								"birthdate":   "2012-05-05T07:16:30+02:00",
 								"phoneNumber": map[string]interface{}{
-									"input":          "020 1234567",
-									"defaultCountry": "nl",
+									"input":                  "020 1234567",
+									"defaultCountry":         "nl",
+									"internationalFormatted": "+31 20 1234567",
+									"countryCode":            31,
+									"national":               201234567,
+									"nationalFormatted":      "020 1234567",
+									"valid":                  true,
 								},
 								"location": map[string]interface{}{
 									"latitude":  52.366667,
 									"longitude": 4.9,
 								},
 							},
-							map[string]interface{}{
+						},
+					},
+					&models.Object{
+						Class: "Person",
+						ID:    id2,
+						Properties: map[string]interface{}{
+							"name": "Stacey Spears",
+							"json": map[string]interface{}{
 								"firstName":   "Stacey",
 								"lastName":    "Spears",
 								"proffession": "Accountant",
 								"birthdate":   "2011-05-05T07:16:30+02:00",
 								"phoneNumber": map[string]interface{}{
-									"input":          "020 1555444",
-									"defaultCountry": "nl",
+									"input":                  "020 1555444",
+									"defaultCountry":         "nl",
+									"internationalFormatted": "+31 20 1555444",
+									"countryCode":            31,
+									"national":               201555444,
+									"nationalFormatted":      "020 1555444",
+									"valid":                  true,
 								},
 								"location": map[string]interface{}{
 									"latitude":  51.366667,
@@ -149,191 +108,253 @@ func TestObjectProperty_Batch(t *testing.T) {
 								},
 							},
 						},
-					},
-				},
-				&models.Object{
-					Class: "People",
-					ID:    id2,
-					Properties: map[string]interface{}{
-						"country": "United States of America",
-						"people": []interface{}{
-							map[string]interface{}{
-								"firstName":   "Robert",
-								"lastName":    "Junior",
-								"proffession": "Accountant",
-								"birthdate":   "2002-05-05T07:16:30+02:00",
-								"phoneNumber": map[string]interface{}{
-									"input":          "020 1234567",
-									"defaultCountry": "nl",
-								},
-								"location": map[string]interface{}{
-									"latitude":  52.366667,
-									"longitude": 4.9,
-								},
-							},
-							map[string]interface{}{
-								"firstName":   "Steven",
-								"lastName":    "Spears",
-								"proffession": "Accountant",
-								"birthdate":   "2009-05-05T07:16:30+02:00",
-								"phoneNumber": map[string]interface{}{
-									"input":          "020 1555444",
-									"defaultCountry": "nl",
-								},
-								"location": map[string]interface{}{
-									"latitude":  51.366667,
-									"longitude": 5.9,
-								},
-							},
-						},
-					},
-				},
-			).
-			Do(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Len(t, resp, 2)
-		objs, err := client.Data().ObjectsGetter().WithClassName("People").Do(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, objs)
-		require.Len(t, objs, 2)
-		properties, ok := objs[0].Properties.(map[string]interface{})
-		require.True(t, ok)
-		require.NotNil(t, properties)
-		people, ok := properties["people"].([]interface{})
-		require.True(t, ok)
-		assert.Equal(t, 2, len(people))
-		person, ok := people[0].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, 6, len(person))
-	})
-
-	t.Run("load json array file using batch api", func(t *testing.T) {
-		loadJson := func(t *testing.T) []interface{} {
-			jsonFile, err := os.Open("./batch.json")
+					}).
+				Do(ctx)
 			require.NoError(t, err)
-			require.NotNil(t, jsonFile)
-			byteValue, err := io.ReadAll(jsonFile)
+			require.NotNil(t, resp)
+			require.Len(t, resp, 2)
+			objs, err := client.Data().ObjectsGetter().WithClassName("Person").WithID(id1.String()).Do(ctx)
 			require.NoError(t, err)
-			require.NotNil(t, byteValue)
-			var result []interface{}
-			json.Unmarshal([]byte(byteValue), &result)
-			return result
-		}
-		checkData := func(t *testing.T, className string) {
-			res, err := client.Data().ObjectsGetter().WithClassName(className).WithID(id1.String()).Do(ctx)
-			require.Nil(t, err)
-			require.Len(t, res, 1)
-			props, ok := res[0].Properties.(map[string]interface{})
+			require.NotNil(t, objs)
+			require.Len(t, objs, 1)
+			properties, ok := objs[0].Properties.(map[string]interface{})
 			require.True(t, ok)
-			assert.NotNil(t, props)
-			assert.Equal(t, 1, len(props))
-			objectArrayProp, ok := props["objectArray"].([]interface{})
+			require.NotNil(t, properties)
+			jsonProp, ok := properties["json"].(map[string]interface{})
 			require.True(t, ok)
-			assert.NotNil(t, objectArrayProp)
-			assert.Equal(t, 10, len(objectArrayProp))
-			data, ok := objectArrayProp[0].(map[string]interface{})
+			require.NotNil(t, jsonProp)
+			phone, ok := jsonProp["phoneNumber"].(map[string]interface{})
 			require.True(t, ok)
-			assert.NotNil(t, data)
-			assert.Equal(t, 7, len(data))
-			phone, ok := data["phone"].(map[string]interface{})
+			assert.Equal(t, 7, len(phone))
+			location, ok := jsonProp["location"].(map[string]interface{})
 			require.True(t, ok)
-			assert.NotNil(t, phone)
-			assert.Equal(t, 2, len(phone))
-			location, ok := data["location"].(map[string]interface{})
-			require.True(t, ok)
-			assert.NotNil(t, location)
 			assert.Equal(t, 2, len(location))
-		}
-		// parse batch.json
-		loadedJson := loadJson(t)
-		t.Run("with auto schema", func(t *testing.T) {
-			className := "BatchArrayJsonAutoSchema"
-			resp, err := client.Batch().ObjectsBatcher().
-				WithObjects(&models.Object{
-					Class: className,
-					ID:    id1,
-					Properties: map[string]interface{}{
-						"objectArray": loadedJson,
-					},
-				}).Do(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			checkData(t, className)
 		})
-		t.Run("without auto schema", func(t *testing.T) {
-			className := "BatchArrayJsonWithoutAutoSchema"
-			err := client.Schema().ClassCreator().WithClass(&models.Class{
-				Class: className,
-				Properties: []*models.Property{
-					{
-						Name:     "objectArray",
-						DataType: schema.DataTypeObjectArray.PropString(),
-						NestedProperties: []*models.NestedProperty{
-							{
-								Name:     "firstName",
-								DataType: schema.DataTypeText.PropString(),
-							},
-							{
-								Name:     "lastName",
-								DataType: schema.DataTypeText.PropString(),
-							},
-							{
-								Name:     "profession",
-								DataType: schema.DataTypeText.PropString(),
-							},
-							{
-								Name:     "description",
-								DataType: schema.DataTypeText.PropString(),
-							},
-							{
-								Name:     "phone",
-								DataType: schema.DataTypeObject.PropString(),
-								NestedProperties: []*models.NestedProperty{
-									{
-										Name:     "input",
-										DataType: schema.DataTypeText.PropString(),
+
+		t.Run("batch import object array property", func(t *testing.T) {
+			resp, err := client.Batch().ObjectsBatcher().
+				WithObjects(
+					&models.Object{
+						Class: "People",
+						ID:    id1,
+						Properties: map[string]interface{}{
+							"country": "United Kingdom",
+							"people": []interface{}{
+								map[string]interface{}{
+									"firstName":   "John",
+									"lastName":    "Doe",
+									"proffession": "Accountant",
+									"birthdate":   "2012-05-05T07:16:30+02:00",
+									"phoneNumber": map[string]interface{}{
+										"input":          "020 1234567",
+										"defaultCountry": "nl",
 									},
-									{
-										Name:     "defaultCountry",
-										DataType: schema.DataTypeText.PropString(),
+									"location": map[string]interface{}{
+										"latitude":  52.366667,
+										"longitude": 4.9,
 									},
 								},
-							},
-							{
-								Name:     "location",
-								DataType: schema.DataTypeObject.PropString(),
-								NestedProperties: []*models.NestedProperty{
-									{
-										Name:     "latitude",
-										DataType: schema.DataTypeNumber.PropString(),
+								map[string]interface{}{
+									"firstName":   "Stacey",
+									"lastName":    "Spears",
+									"proffession": "Accountant",
+									"birthdate":   "2011-05-05T07:16:30+02:00",
+									"phoneNumber": map[string]interface{}{
+										"input":          "020 1555444",
+										"defaultCountry": "nl",
 									},
-									{
-										Name:     "longitude",
-										DataType: schema.DataTypeNumber.PropString(),
+									"location": map[string]interface{}{
+										"latitude":  51.366667,
+										"longitude": 5.9,
 									},
 								},
-							},
-							{
-								Name:     "city",
-								DataType: schema.DataTypeText.PropString(),
 							},
 						},
 					},
-				},
-			}).Do(ctx)
-			require.NoError(t, err)
-			resp, err := client.Batch().ObjectsBatcher().
-				WithObjects(&models.Object{
-					Class: className,
-					ID:    id1,
-					Properties: map[string]interface{}{
-						"objectArray": loadedJson,
+					&models.Object{
+						Class: "People",
+						ID:    id2,
+						Properties: map[string]interface{}{
+							"country": "United States of America",
+							"people": []interface{}{
+								map[string]interface{}{
+									"firstName":   "Robert",
+									"lastName":    "Junior",
+									"proffession": "Accountant",
+									"birthdate":   "2002-05-05T07:16:30+02:00",
+									"phoneNumber": map[string]interface{}{
+										"input":          "020 1234567",
+										"defaultCountry": "nl",
+									},
+									"location": map[string]interface{}{
+										"latitude":  52.366667,
+										"longitude": 4.9,
+									},
+								},
+								map[string]interface{}{
+									"firstName":   "Steven",
+									"lastName":    "Spears",
+									"proffession": "Accountant",
+									"birthdate":   "2009-05-05T07:16:30+02:00",
+									"phoneNumber": map[string]interface{}{
+										"input":          "020 1555444",
+										"defaultCountry": "nl",
+									},
+									"location": map[string]interface{}{
+										"latitude":  51.366667,
+										"longitude": 5.9,
+									},
+								},
+							},
+						},
 					},
-				}).Do(ctx)
+				).
+				Do(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			checkData(t, className)
+			require.Len(t, resp, 2)
+			objs, err := client.Data().ObjectsGetter().WithClassName("People").Do(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, objs)
+			require.Len(t, objs, 2)
+			properties, ok := objs[0].Properties.(map[string]interface{})
+			require.True(t, ok)
+			require.NotNil(t, properties)
+			people, ok := properties["people"].([]interface{})
+			require.True(t, ok)
+			assert.Equal(t, 2, len(people))
+			person, ok := people[0].(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, 6, len(person))
 		})
-	})
+
+		t.Run("load json array file using batch api", func(t *testing.T) {
+			loadJson := func(t *testing.T) []interface{} {
+				jsonFile, err := os.Open("./batch.json")
+				require.NoError(t, err)
+				require.NotNil(t, jsonFile)
+				byteValue, err := io.ReadAll(jsonFile)
+				require.NoError(t, err)
+				require.NotNil(t, byteValue)
+				var result []interface{}
+				json.Unmarshal([]byte(byteValue), &result)
+				return result
+			}
+			checkData := func(t *testing.T, className string) {
+				res, err := client.Data().ObjectsGetter().WithClassName(className).WithID(id1.String()).Do(ctx)
+				require.Nil(t, err)
+				require.Len(t, res, 1)
+				props, ok := res[0].Properties.(map[string]interface{})
+				require.True(t, ok)
+				assert.NotNil(t, props)
+				assert.Equal(t, 1, len(props))
+				objectArrayProp, ok := props["objectArray"].([]interface{})
+				require.True(t, ok)
+				assert.NotNil(t, objectArrayProp)
+				assert.Equal(t, 10, len(objectArrayProp))
+				data, ok := objectArrayProp[0].(map[string]interface{})
+				require.True(t, ok)
+				assert.NotNil(t, data)
+				assert.Equal(t, 7, len(data))
+				phone, ok := data["phone"].(map[string]interface{})
+				require.True(t, ok)
+				assert.NotNil(t, phone)
+				assert.Equal(t, 2, len(phone))
+				location, ok := data["location"].(map[string]interface{})
+				require.True(t, ok)
+				assert.NotNil(t, location)
+				assert.Equal(t, 2, len(location))
+			}
+			// parse batch.json
+			loadedJson := loadJson(t)
+			t.Run("with auto schema", func(t *testing.T) {
+				className := "BatchArrayJsonAutoSchema"
+				resp, err := client.Batch().ObjectsBatcher().
+					WithObjects(&models.Object{
+						Class: className,
+						ID:    id1,
+						Properties: map[string]interface{}{
+							"objectArray": loadedJson,
+						},
+					}).Do(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				checkData(t, className)
+			})
+			t.Run("without auto schema", func(t *testing.T) {
+				className := "BatchArrayJsonWithoutAutoSchema"
+				err := client.Schema().ClassCreator().WithClass(&models.Class{
+					Class: className,
+					Properties: []*models.Property{
+						{
+							Name:     "objectArray",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "firstName",
+									DataType: schema.DataTypeText.PropString(),
+								},
+								{
+									Name:     "lastName",
+									DataType: schema.DataTypeText.PropString(),
+								},
+								{
+									Name:     "profession",
+									DataType: schema.DataTypeText.PropString(),
+								},
+								{
+									Name:     "description",
+									DataType: schema.DataTypeText.PropString(),
+								},
+								{
+									Name:     "phone",
+									DataType: schema.DataTypeObject.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{
+											Name:     "input",
+											DataType: schema.DataTypeText.PropString(),
+										},
+										{
+											Name:     "defaultCountry",
+											DataType: schema.DataTypeText.PropString(),
+										},
+									},
+								},
+								{
+									Name:     "location",
+									DataType: schema.DataTypeObject.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{
+											Name:     "latitude",
+											DataType: schema.DataTypeNumber.PropString(),
+										},
+										{
+											Name:     "longitude",
+											DataType: schema.DataTypeNumber.PropString(),
+										},
+									},
+								},
+								{
+									Name:     "city",
+									DataType: schema.DataTypeText.PropString(),
+								},
+							},
+						},
+					},
+				}).Do(ctx)
+				require.NoError(t, err)
+				resp, err := client.Batch().ObjectsBatcher().
+					WithObjects(&models.Object{
+						Class: className,
+						ID:    id1,
+						Properties: map[string]interface{}{
+							"objectArray": loadedJson,
+						},
+					}).Do(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				checkData(t, className)
+			})
+		})
+	}
 }

--- a/test/acceptance_with_go_client/object_property_tests/data_test.go
+++ b/test/acceptance_with_go_client/object_property_tests/data_test.go
@@ -12,6 +12,7 @@
 package object_property_tests
 
 import (
+	"acceptance_tests_with_client/fixtures"
 	"context"
 	"encoding/json"
 	"io"
@@ -21,8 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
-	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 func TestObjectProperty_Data(t *testing.T) {
@@ -30,178 +29,17 @@ func TestObjectProperty_Data(t *testing.T) {
 	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: "localhost:8080"})
 	require.Nil(t, err)
 
-	vTrue := true
-	vFalse := false
+	className := fixtures.AllPropertiesClassName
+	id1 := fixtures.AllPropertiesID1
 
-	className := "ObjectPropertyClass"
-	id1 := "00000000-0000-0000-0000-000000000001"
-
-	properties := map[string]interface{}{
-		"text":          "red",
-		"texts":         []string{"red", "blue"},
-		"number":        float64(1.1),
-		"numbers":       []float64{1.1, 2.2},
-		"int":           int64(1),
-		"ints":          []int64{1, 2},
-		"uuid":          id1,
-		"uuids":         []string{id1},
-		"date":          "2009-11-01T23:00:00Z",
-		"dates":         []string{"2009-11-01T23:00:00Z"},
-		"bool":          true,
-		"bools":         []bool{true, false},
-		"nested_int":    int64(11),
-		"nested_number": float64(11.11),
-		"nested_text":   "nested text",
-		"nested_objects": map[string]interface{}{
-			"nested_bool_lvl2":    true,
-			"nested_numbers_lvl2": []float64{11.1, 22.1},
-		},
-		"nested_array_objects": []interface{}{
-			map[string]interface{}{
-				"nested_bool_lvl2":    true,
-				"nested_numbers_lvl2": []float64{111.1, 222.1},
-			},
-			map[string]interface{}{
-				"nested_bool_lvl2":    false,
-				"nested_numbers_lvl2": []float64{112.1, 222.1},
-			},
-		},
-	}
+	properties := fixtures.AllPropertiesProperties
 
 	// clean up DB
 	err = client.Schema().AllDeleter().Do(context.Background())
 	require.Nil(t, err)
 
 	t.Run("create schema and import object", func(t *testing.T) {
-		class := &models.Class{
-			Class: className,
-			Properties: []*models.Property{
-				{
-					Name:            "objectProperty",
-					DataType:        schema.DataTypeObject.PropString(),
-					IndexFilterable: &vTrue,
-					IndexSearchable: &vFalse,
-					Tokenization:    "",
-					NestedProperties: []*models.NestedProperty{
-						{
-							Name:     "text",
-							DataType: schema.DataTypeText.PropString(),
-						},
-						{
-							Name:     "texts",
-							DataType: schema.DataTypeTextArray.PropString(),
-						},
-						{
-							Name:     "number",
-							DataType: schema.DataTypeNumber.PropString(),
-						},
-						{
-							Name:     "numbers",
-							DataType: schema.DataTypeNumberArray.PropString(),
-						},
-						{
-							Name:     "int",
-							DataType: schema.DataTypeInt.PropString(),
-						},
-						{
-							Name:     "ints",
-							DataType: schema.DataTypeIntArray.PropString(),
-						},
-						{
-							Name:     "date",
-							DataType: schema.DataTypeDate.PropString(),
-						},
-						{
-							Name:     "dates",
-							DataType: schema.DataTypeDateArray.PropString(),
-						},
-						{
-							Name:     "bool",
-							DataType: schema.DataTypeBoolean.PropString(),
-						},
-						{
-							Name:     "bools",
-							DataType: schema.DataTypeBooleanArray.PropString(),
-						},
-						{
-							Name:     "uuid",
-							DataType: schema.DataTypeUUID.PropString(),
-						},
-						{
-							Name:     "uuids",
-							DataType: schema.DataTypeUUIDArray.PropString(),
-						},
-						{
-							Name:            "nested_int",
-							DataType:        schema.DataTypeInt.PropString(),
-							IndexFilterable: &vTrue,
-							IndexSearchable: &vFalse,
-							Tokenization:    "",
-						},
-						{
-							Name:            "nested_number",
-							DataType:        schema.DataTypeNumber.PropString(),
-							IndexFilterable: &vTrue,
-							IndexSearchable: &vFalse,
-							Tokenization:    "",
-						},
-						{
-							Name:            "nested_text",
-							DataType:        schema.DataTypeText.PropString(),
-							IndexFilterable: &vTrue,
-							IndexSearchable: &vTrue,
-							Tokenization:    models.PropertyTokenizationWord,
-						},
-						{
-							Name:            "nested_objects",
-							DataType:        schema.DataTypeObject.PropString(),
-							IndexFilterable: &vTrue,
-							IndexSearchable: &vFalse,
-							Tokenization:    "",
-							NestedProperties: []*models.NestedProperty{
-								{
-									Name:            "nested_bool_lvl2",
-									DataType:        schema.DataTypeBoolean.PropString(),
-									IndexFilterable: &vTrue,
-									IndexSearchable: &vFalse,
-									Tokenization:    "",
-								},
-								{
-									Name:            "nested_numbers_lvl2",
-									DataType:        schema.DataTypeNumberArray.PropString(),
-									IndexFilterable: &vTrue,
-									IndexSearchable: &vFalse,
-									Tokenization:    "",
-								},
-							},
-						},
-						{
-							Name:            "nested_array_objects",
-							DataType:        schema.DataTypeObjectArray.PropString(),
-							IndexFilterable: &vTrue,
-							IndexSearchable: &vFalse,
-							Tokenization:    "",
-							NestedProperties: []*models.NestedProperty{
-								{
-									Name:            "nested_bool_lvl2",
-									DataType:        schema.DataTypeBoolean.PropString(),
-									IndexFilterable: &vTrue,
-									IndexSearchable: &vFalse,
-									Tokenization:    "",
-								},
-								{
-									Name:            "nested_numbers_lvl2",
-									DataType:        schema.DataTypeNumberArray.PropString(),
-									IndexFilterable: &vTrue,
-									IndexSearchable: &vFalse,
-									Tokenization:    "",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		class := fixtures.AllPropertiesClass
 		err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
 		require.NoError(t, err)
 		// add object

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -224,6 +224,10 @@ func (m *autoSchemaManager) determineType(value interface{}, ofNestedProp bool) 
 		return []schema.DataType{schema.DataTypeText}, nil
 	case json.Number:
 		return []schema.DataType{schema.DataType(m.config.DefaultNumber)}, nil
+	case float64:
+		return []schema.DataType{schema.DataTypeNumber}, nil
+	case int64:
+		return []schema.DataType{schema.DataTypeInt}, nil
 	case bool:
 		return []schema.DataType{schema.DataTypeBoolean}, nil
 	case map[string]interface{}:
@@ -322,6 +326,10 @@ func (m *autoSchemaManager) determineArrayType(value interface{}, ofNestedProp b
 			return schema.DataTypeIntArray, "", nil
 		}
 		return schema.DataTypeNumberArray, "", nil
+	case float64:
+		return schema.DataTypeNumberArray, "", nil
+	case int64:
+		return schema.DataTypeIntArray, "", nil
 	case bool:
 		return schema.DataTypeBooleanArray, "", nil
 	case map[string]interface{}:


### PR DESCRIPTION
### What's being changed:

Fix for AutoSchema and Batch API where the API is strongly typed and we send `float64` (for `Number` and `NumberArray` types) and `int64` (for `Int` and `IntArray`)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
