### PR TITLE
Improve Cursor Performance by reusing memory

### DIFF
--- a/adapters/repos/db/lsmkv/segment_replace_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_replace_strategy.go
@@ -144,24 +144,3 @@ func (s *segment) replaceStratParseDataWithKey(in []byte) (segmentReplaceNode, e
 
 	return out, nil
 }
-
-func (s *segment) replaceStratParseDataWithKeyInto(in []byte,
-	node *segmentReplaceNode,
-) error {
-	if len(in) == 0 {
-		return lsmkv.NotFound
-	}
-
-	r := bytes.NewReader(in)
-
-	err := ParseReplaceNodeInto(r, s.secondaryIndexCount, node)
-	if err != nil {
-		return err
-	}
-
-	if node.tombstone {
-		return lsmkv.Deleted
-	}
-
-	return nil
-}

--- a/adapters/repos/db/lsmkv/segment_serialization.go
+++ b/adapters/repos/db/lsmkv/segment_serialization.go
@@ -243,7 +243,14 @@ func ParseReplaceNodeInto(r *byteops.ReadWriter, secondaryIndexCount uint16, out
 		return err
 	}
 
-	// TODO: previously this was a copy. Do we need a copy or is sharing fine?
+	// Note: In a previous version (prior to
+	// https://github.com/weaviate/weaviate/pull/3660) this was a copy. The
+	// mentioned PR optimizes the Replace Cursor which led to this now being
+	// shared memory. After internal review, we believe this is safe to do. The
+	// cursor gives no guarantees about memory after calling .next(). Before
+	// .next() is called, this should be safe. Nevertheless, we are leaving this
+	// note in case a future bug appears, as this should make this spot easier to
+	// find.
 	out.primaryKey = r.ReadBytesFromBufferWithUint32LengthIndicator()
 
 	if secondaryIndexCount > 0 {
@@ -251,8 +258,14 @@ func ParseReplaceNodeInto(r *byteops.ReadWriter, secondaryIndexCount uint16, out
 	}
 
 	for j := 0; j < int(secondaryIndexCount); j++ {
-		// TODO: previously this was a copy. Do we need a copy or is sharing
-		// fine?
+		// Note: In a previous version (prior to
+		// https://github.com/weaviate/weaviate/pull/3660) this was a copy. The
+		// mentioned PR optimizes the Replace Cursor which led to this now being
+		// shared memory. After internal review, we believe this is safe to do. The
+		// cursor gives no guarantees about memory after calling .next(). Before
+		// .next() is called, this should be safe. Nevertheless, we are leaving this
+		// note in case a future bug appears, as this should make this spot easier to
+		// find.
 		out.secondaryKeys[j] = r.ReadBytesFromBufferWithUint32LengthIndicator()
 	}
 

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -43,6 +43,11 @@ func NewReadWriter(buf []byte, opts ...func(writer *ReadWriter)) ReadWriter {
 	return rw
 }
 
+func (bo *ReadWriter) ResetBuffer(buf []byte) {
+	bo.Buffer = buf
+	bo.Position = 0
+}
+
 func (bo *ReadWriter) ReadUint64() uint64 {
 	bo.Position += uint64Len
 	return binary.LittleEndian.Uint64(bo.Buffer[bo.Position-uint64Len : bo.Position])
@@ -101,6 +106,10 @@ func (bo *ReadWriter) DiscardBytesFromBufferWithUint64LengthIndicator() uint64 {
 func (bo *ReadWriter) ReadBytesFromBufferWithUint32LengthIndicator() []byte {
 	bo.Position += uint32Len
 	bufLen := uint64(binary.LittleEndian.Uint32(bo.Buffer[bo.Position-uint32Len : bo.Position]))
+
+	if bufLen == 0 {
+		return nil
+	}
 
 	bo.Position += bufLen
 	subslice := bo.Buffer[bo.Position-bufLen : bo.Position]


### PR DESCRIPTION
### What's being changed:

This PR reduces memory allocations in the "Replace" cursor of the LSM store. It was validated doing an LSM-based brute force vector search with 1e6 384d embeddings (randomly generated). The test ran 100 random queries.

## Memory allocations

Reduced allocations from 9GB to 45MB 

### Before
![before](https://github.com/weaviate/weaviate/assets/8974479/ce2172d8-d25f-4956-a21f-70bb275a6960)

### After
![after](https://github.com/weaviate/weaviate/assets/8974479/05a36070-a52d-4689-bb9d-18d70c2f9ae1)

## Speed

Improved average latency from ~700ms to ~590ms (note that this test also performs scoring which takes up the majority of the time).

closes #3648 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/6675935610/job/18144484778
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
