### PR TITLE
Update Nodes API with `indexingStatus` field for shard

### DIFF
--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -145,6 +145,7 @@ func (i *Index) getShardsNodeStatus(status *[]*models.NodeShardStatus) (totalCou
 			Name:              name,
 			Class:             shard.index.Config.ClassName.String(),
 			ObjectCount:       objectCount,
+			Status:            shard.getStatus().String(),
 			VectorQueueLength: shard.queue.Size(),
 		}
 		totalCount += objectCount

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -144,8 +144,8 @@ func (i *Index) getShardsNodeStatus(status *[]*models.NodeShardStatus) (totalCou
 		shardStatus := &models.NodeShardStatus{
 			Name:              name,
 			Class:             shard.index.Config.ClassName.String(),
+			IndexingStatus:    shard.getStatus().String(),
 			ObjectCount:       objectCount,
-			Status:            shard.getStatus().String(),
 			VectorQueueLength: shard.queue.Size(),
 		}
 		totalCount += objectCount

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -131,6 +131,8 @@ func TestNodesAPI_Journey(t *testing.T) {
 	assert.Equal(t, "ClassNodesAPI", nodeStatus.Shards[0].Class)
 	assert.True(t, len(nodeStatus.Shards[0].Name) > 0)
 	assert.Equal(t, int64(2), nodeStatus.Shards[0].ObjectCount)
+	assert.Equal(t, "READY", nodeStatus.Shards[0].Status)
+	assert.Equal(t, int64(0), nodeStatus.Shards[0].VectorQueueLength)
 	assert.Equal(t, int64(2), nodeStatus.Stats.ObjectCount)
 	assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 }

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -131,7 +131,7 @@ func TestNodesAPI_Journey(t *testing.T) {
 	assert.Equal(t, "ClassNodesAPI", nodeStatus.Shards[0].Class)
 	assert.True(t, len(nodeStatus.Shards[0].Name) > 0)
 	assert.Equal(t, int64(2), nodeStatus.Shards[0].ObjectCount)
-	assert.Equal(t, "READY", nodeStatus.Shards[0].Status)
+	assert.Equal(t, "READY", nodeStatus.Shards[0].IndexingStatus)
 	assert.Equal(t, int64(0), nodeStatus.Shards[0].VectorQueueLength)
 	assert.Equal(t, int64(2), nodeStatus.Stats.ObjectCount)
 	assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)

--- a/entities/models/node_shard_status.go
+++ b/entities/models/node_shard_status.go
@@ -37,7 +37,10 @@ type NodeShardStatus struct {
 	// The number of objects in shard.
 	ObjectCount int64 `json:"objectCount"`
 
-	// The length of the vector queue.
+	// The vector indexing status of the shard.
+	Status string `json:"status"`
+
+	// The length of the vector indexing queue.
 	VectorQueueLength int64 `json:"vectorQueueLength"`
 }
 

--- a/entities/models/node_shard_status.go
+++ b/entities/models/node_shard_status.go
@@ -31,14 +31,15 @@ type NodeShardStatus struct {
 	// The name of shard's class.
 	Class string `json:"class"`
 
+
+	// The vector indexing status of the shard.
+	IndexingStatus string `json:"indexingStatus"`
+
 	// The name of the shard.
 	Name string `json:"name"`
 
 	// The number of objects in shard.
 	ObjectCount int64 `json:"objectCount"`
-
-	// The vector indexing status of the shard.
-	Status string `json:"status"`
 
 	// The length of the vector indexing queue.
 	VectorQueueLength int64 `json:"vectorQueueLength"`


### PR DESCRIPTION
### What's being changed:

This PR adds the `nodes.shards.indexingStatus` field to the Nodes API alongside the new `nodes.shards.vectorQueueLength` field so that the clients can long-poll Weaviate when waiting for indexing to finish using one HTTP request rather than `N+1` split over the `/schema/{className}/shards` endpoint for `N` classes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
