### PR TITLE
Fix for GraphQL ref search between MT and non-MT classes

### DIFF
--- a/adapters/repos/db/inverted/searcher_ref_filter.go
+++ b/adapters/repos/db/inverted/searcher_ref_filter.go
@@ -93,6 +93,7 @@ func (r *refFilterExtractor) paramsForNestedRequest() (dto.GetParams, error) {
 		// the root query
 		AdditionalProperties: additional.Properties{ReferenceQuery: true},
 		Tenant:               r.tenant,
+		IsRefOrigin:          true,
 	}, nil
 }
 

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -67,9 +67,16 @@ func (db *DB) SparseObjectSearch(ctx context.Context, params dto.GetParams) ([]*
 		return nil, nil, errors.Wrapf(err, "invalid pagination params")
 	}
 
+	// if this is reference search and tenant is given (as origin class is MT)
+	// but searched class is non-MT, then skip tenant to pass validation
+	tenant := params.Tenant
+	if !idx.partitioningEnabled && params.IsRefOrigin {
+		tenant = ""
+	}
+
 	res, dist, err := idx.objectSearch(ctx, totalLimit,
 		params.Filters, params.KeywordRanking, params.Sort, params.Cursor,
-		params.AdditionalProperties, params.ReplicationProperties, params.Tenant, params.Pagination.Autocut)
+		params.AdditionalProperties, params.ReplicationProperties, tenant, params.Pagination.Autocut)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "object search at index %s", idx.ID())
 	}

--- a/entities/dto/dto.go
+++ b/entities/dto/dto.go
@@ -41,4 +41,5 @@ type GetParams struct {
 	AdditionalProperties  additional.Properties
 	ReplicationProperties *additional.ReplicationProperties
 	Tenant                string
+	IsRefOrigin           bool // is created by ref filter
 }

--- a/test/acceptance_with_go_client/multi_tenancy_tests/batch_reference_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/batch_reference_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/filters"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -108,6 +110,25 @@ func TestBatchReferenceCreate_MultiTenancy(t *testing.T) {
 					assert.Len(t, objects[0].Properties.(map[string]interface{})["relatedToPizza"].([]interface{}),
 						len(pizzaIds))
 				}
+			}
+		})
+
+		t.Run("verify graphql search", func(t *testing.T) {
+			for _, tenant := range tenants {
+				resp, err := client.GraphQL().Get().
+					WithClassName("Soup").
+					WithTenant(tenant.Name).
+					WithFields(graphql.Field{
+						Name: "_additional", Fields: []graphql.Field{{Name: "id"}},
+					}).
+					WithWhere(filters.Where().
+						WithPath([]string{"relatedToPizza", "Pizza", "name"}).
+						WithOperator(filters.Equal).
+						WithValueString("Quattro Formaggi")).
+					Do(context.Background())
+
+				require.NoError(t, err)
+				assertGraphqlGetIds(t, resp, "Soup", soupIds)
 			}
 		})
 	})
@@ -822,6 +843,23 @@ func TestBatchReferenceCreate_MultiTenancy(t *testing.T) {
 				assert.Len(t, objects[0].Properties.(map[string]interface{})["relatedToPizza"].([]interface{}),
 					len(pizzaIds))
 			}
+		})
+
+		t.Run("verify graphql search", func(t *testing.T) {
+			resp, err := client.GraphQL().Get().
+				WithClassName("Soup").
+				WithTenant(tenantSoup.Name).
+				WithFields(graphql.Field{
+					Name: "_additional", Fields: []graphql.Field{{Name: "id"}},
+				}).
+				WithWhere(filters.Where().
+					WithPath([]string{"relatedToPizza", "Pizza", "name"}).
+					WithOperator(filters.Equal).
+					WithValueString("Quattro Formaggi")).
+				Do(context.Background())
+
+			require.NoError(t, err)
+			assertGraphqlGetIds(t, resp, "Soup", soupIds)
 		})
 	})
 


### PR DESCRIPTION
### What's being changed:
GraphQL query using references, where MT class is referencing non-MT class resulted with validation error stating that tenant was provided for non-MT class:
`'explorer: list class: search: object search at index test2: local shard object search test2_t1: nested request to fetch matching IDs: object search at index test1: class Test1 has multi-tenancy disabled, but request was with tenant'`.

Now whenever reference search on non-MT class is performed tenant is unset.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
