### PR TITLE
Add `vectorQueueSize` to `/schema/{className}/shards` response

### DIFF
--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -591,7 +591,7 @@ func (c *RemoteIndex) DeleteObjectBatch(ctx context.Context, hostName, indexName
 func (c *RemoteIndex) GetShardQueueSize(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (int64, error) {
-	path := fmt.Sprintf("/indices/%s/shards/%s/queue", indexName, shardName)
+	path := fmt.Sprintf("/indices/%s/shards/%s/queuesize", indexName, shardName)
 	method := http.MethodGet
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
 

--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -588,6 +588,49 @@ func (c *RemoteIndex) DeleteObjectBatch(ctx context.Context, hostName, indexName
 	return batchDeleteResults
 }
 
+func (c *RemoteIndex) GetShardQueueSize(ctx context.Context,
+	hostName, indexName, shardName string,
+) (int64, error) {
+	path := fmt.Sprintf("/indices/%s/shards/%s/queue", indexName, shardName)
+	method := http.MethodGet
+	url := url.URL{Scheme: "http", Host: hostName, Path: path}
+
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), nil)
+	if err != nil {
+		return 0, errors.Wrap(err, "open http request")
+	}
+	var size int64
+	clusterapi.IndicesPayloads.GetShardQueueSizeParams.SetContentTypeHeaderReq(req)
+	try := func(ctx context.Context) (bool, error) {
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
+
+		if code := res.StatusCode; code != http.StatusOK {
+			body, _ := io.ReadAll(res.Body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
+		}
+		resBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, errors.Wrap(err, "read body")
+		}
+
+		ct, ok := clusterapi.IndicesPayloads.GetShardQueueSizeResults.CheckContentTypeHeader(res)
+		if !ok {
+			return false, errors.Errorf("unexpected content type: %s", ct)
+		}
+
+		size, err = clusterapi.IndicesPayloads.GetShardQueueSizeResults.Unmarshal(resBytes)
+		if err != nil {
+			return false, errors.Wrap(err, "unmarshal body")
+		}
+		return false, nil
+	}
+	return size, c.retry(ctx, 9, try)
+}
+
 func (c *RemoteIndex) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {

--- a/adapters/handlers/rest/clusterapi/fakes_for_test.go
+++ b/adapters/handlers/rest/clusterapi/fakes_for_test.go
@@ -202,11 +202,11 @@ func (n *NilMigrator) UpdateClass(ctx context.Context, className string, newClas
 	return nil
 }
 
-func (n *NilMigrator) GetShardsStatus(ctx context.Context, className string) (map[string]string, error) {
+func (n *NilMigrator) GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error) {
 	return nil, nil
 }
 
-func (n *NilMigrator) GetTenantShardStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
+func (n *NilMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -45,6 +45,7 @@ type indices struct {
 	regexpObjectsAggregations *regexp.Regexp
 	regexpObject              *regexp.Regexp
 	regexpReferences          *regexp.Regexp
+	regexpShardsQueueSize     *regexp.Regexp
 	regexpShardsStatus        *regexp.Regexp
 	regexpShardFiles          *regexp.Regexp
 	regexpShard               *regexp.Regexp
@@ -72,6 +73,8 @@ const (
 		`\/shards\/(` + sh + `)\/objects\/(` + ob + `)`
 	urlPatternReferences = `\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/references`
+	urlPatternShardsQueueSize = `\/indices\/(` + cl + `)` +
+		`\/shards\/(` + sh + `)\/queuesize`
 	urlPatternShardsStatus = `\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/status`
 	urlPatternShardFiles = `\/indices\/(` + cl + `)` +
@@ -112,6 +115,7 @@ type shards interface {
 		filters *filters.LocalFilter) ([]uint64, error)
 	DeleteObjectBatch(ctx context.Context, indexName, shardName string,
 		docIDs []uint64, dryRun bool) objects.BatchSimpleObjects
+	GetShardQueueSize(ctx context.Context, indexName, shardName string) (int64, error)
 	GetShardStatus(ctx context.Context, indexName, shardName string) (string, error)
 	UpdateShardStatus(ctx context.Context, indexName, shardName,
 		targetStatus string) error
@@ -143,6 +147,7 @@ func NewIndices(shards shards, db db, auth auth) *indices {
 		regexpObjectsAggregations: regexp.MustCompile(urlPatternObjectsAggregations),
 		regexpObject:              regexp.MustCompile(urlPatternObject),
 		regexpReferences:          regexp.MustCompile(urlPatternReferences),
+		regexpShardsQueueSize:     regexp.MustCompile(urlPatternShardsQueueSize),
 		regexpShardsStatus:        regexp.MustCompile(urlPatternShardsStatus),
 		regexpShardFiles:          regexp.MustCompile(urlPatternShardFiles),
 		regexpShard:               regexp.MustCompile(urlPatternShard),
@@ -238,7 +243,13 @@ func (i *indices) indicesHandler() http.HandlerFunc {
 
 			i.postReferences().ServeHTTP(w, r)
 			return
-
+		case i.regexpShardsStatus.MatchString(path):
+			if r.Method == http.MethodGet {
+				i.getGetShardQueueSize().ServeHTTP(w, r)
+				return
+			}
+			http.Error(w, "405 Method not Allowed", http.StatusMethodNotAllowed)
+			return
 		case i.regexpShardsStatus.MatchString(path):
 			if r.Method == http.MethodGet {
 				i.getGetShardStatus().ServeHTTP(w, r)
@@ -893,6 +904,33 @@ func (i *indices) deleteObjects() http.Handler {
 
 		IndicesPayloads.BatchDeleteResults.SetContentTypeHeader(w)
 		w.Write(resBytes)
+	})
+}
+
+func (i *indices) getGetShardQueueSize() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		args := i.regexpShardsStatus.FindStringSubmatch(r.URL.Path)
+		if len(args) != 3 {
+			http.Error(w, "invalid URI", http.StatusBadRequest)
+			return
+		}
+
+		index, shard := args[1], args[2]
+
+		defer r.Body.Close()
+
+		size, err := i.shards.GetShardQueueSize(r.Context(), index, shard)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		sizeBytes, err := IndicesPayloads.GetShardQueueSizeResults.Marshal(size)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		IndicesPayloads.GetShardQueueSizeResults.SetContentTypeHeader(w)
+		w.Write(sizeBytes)
 	})
 }
 

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -243,7 +243,7 @@ func (i *indices) indicesHandler() http.HandlerFunc {
 
 			i.postReferences().ServeHTTP(w, r)
 			return
-		case i.regexpShardsStatus.MatchString(path):
+		case i.regexpShardsQueueSize.MatchString(path):
 			if r.Method == http.MethodGet {
 				i.getGetShardQueueSize().ServeHTTP(w, r)
 				return

--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -47,6 +47,8 @@ type indicesPayloads struct {
 	FindDocIDsResults         findDocIDsResultsPayload
 	BatchDeleteParams         batchDeleteParamsPayload
 	BatchDeleteResults        batchDeleteResultsPayload
+	GetShardQueueSizeParams   getShardQueueSizeParamsPayload
+	GetShardQueueSizeResults  getShardQueueSizeResultsPayload
 	GetShardStatusParams      getShardStatusParamsPayload
 	GetShardStatusResults     getShardStatusResultsPayload
 	UpdateShardStatusParams   updateShardStatusParamsPayload
@@ -665,6 +667,46 @@ func (p batchDeleteResultsPayload) SetContentTypeHeader(w http.ResponseWriter) {
 }
 
 func (p batchDeleteResultsPayload) CheckContentTypeHeader(r *http.Response) (string, bool) {
+	ct := r.Header.Get("content-type")
+	return ct, ct == p.MIME()
+}
+
+type getShardQueueSizeParamsPayload struct{}
+
+func (p getShardQueueSizeParamsPayload) MIME() string {
+	return "vnd.weaviate.getshardqueuesizeparams+json"
+}
+
+func (p getShardQueueSizeParamsPayload) CheckContentTypeHeaderReq(r *http.Request) (string, bool) {
+	ct := r.Header.Get("content-type")
+	return ct, ct == p.MIME()
+}
+
+func (p getShardQueueSizeParamsPayload) SetContentTypeHeaderReq(r *http.Request) {
+	r.Header.Set("content-type", p.MIME())
+}
+
+type getShardQueueSizeResultsPayload struct{}
+
+func (p getShardQueueSizeResultsPayload) Unmarshal(in []byte) (int64, error) {
+	var out int64
+	err := json.Unmarshal(in, &out)
+	return out, err
+}
+
+func (p getShardQueueSizeResultsPayload) Marshal(in int64) ([]byte, error) {
+	return json.Marshal(in)
+}
+
+func (p getShardQueueSizeResultsPayload) MIME() string {
+	return "application/vnd.weaviate.getshardqueuesizeresults+octet-stream"
+}
+
+func (p getShardQueueSizeResultsPayload) SetContentTypeHeader(w http.ResponseWriter) {
+	w.Header().Set("content-type", p.MIME())
+}
+
+func (p getShardQueueSizeResultsPayload) CheckContentTypeHeader(r *http.Response) (string, bool) {
 	ct := r.Header.Get("content-type")
 	return ct, ct == p.MIME()
 }

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4537,6 +4537,11 @@ func init() {
         "status": {
           "description": "Status of the shard",
           "type": "string"
+        },
+        "vectorQueueSize": {
+          "description": "Size of the vector queue of the shard",
+          "type": "integer",
+          "x-omitempty": false
         }
       }
     },
@@ -9712,6 +9717,11 @@ func init() {
         "status": {
           "description": "Status of the shard",
           "type": "string"
+        },
+        "vectorQueueSize": {
+          "description": "Size of the vector queue of the shard",
+          "type": "integer",
+          "x-omitempty": false
         }
       }
     },

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -227,6 +227,12 @@ func (f *fakeRemoteClient) DeleteObjectBatch(ctx context.Context, hostName, inde
 	return nil
 }
 
+func (f *fakeRemoteClient) GetShardQueueSize(ctx context.Context,
+	hostName, indexName, shardName string,
+) (int64, error) {
+	return 0, nil
+}
+
 func (f *fakeRemoteClient) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -130,25 +130,22 @@ func (m *Migrator) UpdateProperty(ctx context.Context, className string, propNam
 	return nil
 }
 
-func (m *Migrator) GetShardsStatus(ctx context.Context, className string) (map[string]string, error) {
+func (m *Migrator) GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error) {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		return nil, errors.Errorf("cannot get shards status for a non-existing index for %s", className)
 	}
 
-	return idx.getShardsStatus(ctx)
+	return idx.getShardsQueueSize(ctx, tenant)
 }
 
-func (m *Migrator) GetTenantShardStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
+func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
-		return nil, errors.Errorf("cannot get tenant shard status for a non-existing index for %s", className)
-	}
-	if err := idx.validateMultiTenancy(tenant); err != nil {
-		return nil, errors.Wrap(err, "get tenant shard status: validate multi tenancy:")
+		return nil, errors.Errorf("cannot get shards status for a non-existing index for %s", className)
 	}
 
-	return idx.getTenantShardStatus(ctx, tenant)
+	return idx.getShardsStatus(ctx, tenant)
 }
 
 func (m *Migrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string) error {

--- a/entities/models/shard_status_get_response.go
+++ b/entities/models/shard_status_get_response.go
@@ -33,6 +33,9 @@ type ShardStatusGetResponse struct {
 
 	// Status of the shard
 	Status string `json:"status,omitempty"`
+
+	// Size of the vector queue of the shard
+	VectorQueueSize int64 `json:"vectorQueueSize"`
 }
 
 // Validate validates this shard status get response

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -781,6 +781,11 @@
         "status": {
           "description": "Status of the shard",
           "type": "string"
+        },
+        "vectorQueueSize": {
+          "description": "Size of the vector queue of the shard",
+          "type": "integer",
+          "x-omitempty": false
         }
       }
     },

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -459,6 +459,12 @@ func (f *fakeRemoteClient) DeleteObjectBatch(ctx context.Context, hostName, inde
 	return nil
 }
 
+func (f *fakeRemoteClient) GetShardQueueSize(ctx context.Context,
+	hostName, indexName, shardName string,
+) (int64, error) {
+	return 0, nil
+}
+
 func (f *fakeRemoteClient) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -49,7 +49,7 @@ func Test_Schema_Authorization(t *testing.T) {
 			expectedResource: "schema/*",
 		},
 		{
-			methodName:       "GetShardsStatus",
+			methodName:       "GetShardsOverview",
 			additionalArgs:   []interface{}{"className", "tenant"},
 			expectedVerb:     "list",
 			expectedResource: "schema/className/shards",

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -49,7 +49,7 @@ func Test_Schema_Authorization(t *testing.T) {
 			expectedResource: "schema/*",
 		},
 		{
-			methodName:       "GetShardsOverview",
+			methodName:       "GetShardsStatus",
 			additionalArgs:   []interface{}{"className", "tenant"},
 			expectedVerb:     "list",
 			expectedResource: "schema/className/shards",

--- a/usecases/schema/get.go
+++ b/usecases/schema/get.go
@@ -111,12 +111,11 @@ func (m *Manager) GetShardsStatus(ctx context.Context, principal *models.Princip
 		return nil, err
 	}
 
-	var shardsStatus map[string]string
-	if tenant != "" {
-		shardsStatus, err = m.migrator.GetTenantShardStatus(ctx, className, tenant)
-	} else {
-		shardsStatus, err = m.migrator.GetShardsStatus(ctx, className)
+	shardsStatus, err := m.migrator.GetShardsStatus(ctx, className, tenant)
+	if err != nil {
+		return nil, err
 	}
+	shardsQueueSize, err := m.migrator.GetShardsQueueSize(ctx, className, tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +124,9 @@ func (m *Manager) GetShardsStatus(ctx context.Context, principal *models.Princip
 
 	for name, status := range shardsStatus {
 		resp = append(resp, &models.ShardStatusGetResponse{
-			Name:   name,
-			Status: status,
+			Name:            name,
+			Status:          status,
+			VectorQueueSize: shardsQueueSize[name],
 		})
 	}
 

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -45,11 +45,11 @@ func (n *NilMigrator) UpdateClass(ctx context.Context, className string, newClas
 	return nil
 }
 
-func (n *NilMigrator) GetShardsStatus(ctx context.Context, className string) (map[string]string, error) {
+func (n *NilMigrator) GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error) {
 	return nil, nil
 }
 
-func (n *NilMigrator) GetTenantShardStatus(ctx context.Context, className string, tenant string) (map[string]string, error) {
+func (n *NilMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/usecases/schema/migrate/migrator.go
+++ b/usecases/schema/migrate/migrator.go
@@ -38,8 +38,8 @@ type Migrator interface {
 	DropClass(ctx context.Context, className string) error
 	UpdateClass(ctx context.Context, className string,
 		newClassName *string) error
-	GetShardsStatus(ctx context.Context, className string) (map[string]string, error)
-	GetTenantShardStatus(ctx context.Context, className, tenant string) (map[string]string, error)
+	GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error)
+	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string) error
 	AddProperty(ctx context.Context, className string,
 		prop *models.Property) error

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -63,6 +63,7 @@ type RemoteIndexIncomingRepo interface {
 		filters *filters.LocalFilter) ([]uint64, error)
 	IncomingDeleteObjectBatch(ctx context.Context, shardName string,
 		docIDs []uint64, dryRun bool) objects.BatchSimpleObjects
+	IncomingGetShardQueueSize(ctx context.Context, shardName string) (int64, error)
 	IncomingGetShardStatus(ctx context.Context, shardName string) (string, error)
 	IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string) error
 	IncomingOverwriteObjects(ctx context.Context, shard string,
@@ -224,6 +225,17 @@ func (rii *RemoteIndexIncoming) DeleteObjectBatch(ctx context.Context, indexName
 	}
 
 	return index.IncomingDeleteObjectBatch(ctx, shardName, docIDs, dryRun)
+}
+
+func (rii *RemoteIndexIncoming) GetShardQueueSize(ctx context.Context,
+	indexName, shardName string,
+) (int64, error) {
+	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if index == nil {
+		return 0, errors.Errorf("local index %q not found", indexName)
+	}
+
+	return index.IncomingGetShardQueueSize(ctx, shardName)
 }
 
 func (rii *RemoteIndexIncoming) GetShardStatus(ctx context.Context,


### PR DESCRIPTION
### What's being changed:

Odd behaviour was observed when running Python testing of async index waiting just on the shard status alone. Sometimes, the status would be `READY` when the there were vectors in the queue ready to be indexed and thus the client would incorrectly judge the indexing to have completed.

As such, this PR adds the `vectorQueueSize` value to the endpoint so that clients can wait appropriately. _I.e.,_ they will only consider the vectors successfully loaded if `status=="READY"` and `vectorQueueSize==0`.

It also unifies some of the changes in a previous PR so that `GetShards...()` functions accept a `tenant` argument to be handled appropriately in an effort to reduce boilerplate.

@parkerduckworth please critique this as closely as possible since I made changes to many aspects of the fundamental server, e.g. clusterapi and communication between nodes. With this in mind, do these changes touch at all on the coming changes to RAFT consensus in relation to the vector queue?

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
