### PR TITLE
Introduce `vector_segments_metric`

### DIFF
--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -520,6 +520,20 @@ func GetDimensionsFromRepo(repo *DB, className string) int {
 	return sum
 }
 
+func GetQuantizedDimensionsFromRepo(repo *DB, className string, segments int) int {
+	if !repo.config.TrackVectorDimensions {
+		log.Printf("Vector dimensions tracking is disabled, returning 0")
+		return 0
+	}
+	index := repo.GetIndex(schema.ClassName(className))
+	sum := 0
+	index.ForEachShard(func(name string, shard *Shard) error {
+		sum += shard.quantizedDimensions(segments)
+		return nil
+	})
+	return sum
+}
+
 func Test_AddingReferenceOneByOne(t *testing.T) {
 	dirName := t.TempDir()
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -140,15 +140,16 @@ func (m *shardMap) LoadAndDelete(name string) (*Shard, bool) {
 // class. An index can be further broken up into self-contained units, called
 // Shards, to allow for easy distribution across Nodes
 type Index struct {
-	classSearcher         inverted.ClassSearcher // to allow for nested by-references searches
-	shards                shardMap
-	Config                IndexConfig
-	vectorIndexUserConfig schema.VectorIndexConfig
-	getSchema             schemaUC.SchemaGetter
-	logger                logrus.FieldLogger
-	remote                *sharding.RemoteIndex
-	stopwords             *stopwords.Detector
-	replicator            *replica.Replicator
+	classSearcher             inverted.ClassSearcher // to allow for nested by-references searches
+	shards                    shardMap
+	Config                    IndexConfig
+	vectorIndexUserConfig     schema.VectorIndexConfig
+	vectorIndexUserConfigLock sync.Mutex
+	getSchema                 schemaUC.SchemaGetter
+	logger                    logrus.FieldLogger
+	remote                    *sharding.RemoteIndex
+	stopwords                 *stopwords.Detector
+	replicator                *replica.Replicator
 
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
@@ -343,7 +344,7 @@ func (i *Index) updateVectorIndexConfig(ctx context.Context,
 	updated schema.VectorIndexConfig,
 ) error {
 	// an updated is not specific to one shard, but rather all
-	return i.ForEachShard(func(name string, shard *Shard) error {
+	err := i.ForEachShard(func(name string, shard *Shard) error {
 		// At the moment, we don't do anything in an update that could fail, but
 		// technically this should be part of some sort of a two-phase commit  or
 		// have another way to rollback if we have updates that could potentially
@@ -353,6 +354,15 @@ func (i *Index) updateVectorIndexConfig(ctx context.Context,
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	i.vectorIndexUserConfigLock.Lock()
+	defer i.vectorIndexUserConfigLock.Unlock()
+
+	i.vectorIndexUserConfig = updated
+
+	return nil
 }
 
 func (i *Index) getInvertedIndexConfig() schema.InvertedIndexConfig {

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -213,6 +213,17 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		productsIds[1], nil, additional.Properties{}, nil, "")
 	require.Nil(t, err)
 
+	// update the index vectorIndexUserConfig
+	beforeVectorConfig, ok := index.vectorIndexUserConfig.(hnsw.UserConfig)
+	require.Equal(t, -1, beforeVectorConfig.EF)
+	require.True(t, ok)
+	beforeVectorConfig.EF = 99
+	err = index.updateVectorIndexConfig(context.TODO(), beforeVectorConfig)
+	require.Nil(t, err)
+	afterVectorConfig, ok := index.vectorIndexUserConfig.(hnsw.UserConfig)
+	require.True(t, ok)
+	require.Equal(t, 99, afterVectorConfig.EF)
+
 	assert.Equal(t, 6, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
 	assert.Equal(t, 6, len(indexFilesAfterRecreate))

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -306,7 +306,7 @@ func (s *Shard) drop() error {
 		s.stopMetrics <- struct{}{}
 		if s.promMetrics != nil {
 			// send 0 in when index gets dropped
-			s.sendVectorDimensionsMetric(0)
+			s.clearDimensionMetrics()
 		}
 	}
 

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -37,7 +37,6 @@ func (s *Shard) Dimensions() int {
 }
 
 func (s *Shard) quantizedDimensions(segments int) int {
-
 	// Exit early if segments is 0 (unset), in this case PQ will use the same number of dimensions
 	// as the segment size
 	if segments <= 0 {

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 func (s *Shard) Dimensions() int {
@@ -33,6 +34,68 @@ func (s *Shard) Dimensions() int {
 	}
 
 	return sum
+}
+
+func (s *Shard) quantizedDimensions(segments int) int {
+
+	// Exit early if segments is 0 (unset), in this case PQ will use the same number of dimensions
+	// as the segment size
+	if segments <= 0 {
+		return s.Dimensions()
+	}
+
+	b := s.store.Bucket(helpers.DimensionsBucketLSM)
+	if b == nil {
+		return 0
+	}
+
+	c := b.MapCursor()
+	defer c.Close()
+	sum := 0
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		dimLength := binary.LittleEndian.Uint32(k)
+		if dimLength > 0 {
+			sum += segments * len(v)
+		}
+	}
+
+	return sum
+}
+
+func (s *Shard) getSegments() (bool, int) {
+	// Detect if vector index is HNSW
+	hnswUserConfig, ok := s.index.vectorIndexUserConfig.(hnswent.UserConfig)
+	if !ok {
+		return false, 0
+	}
+	if hnswUserConfig.PQ.Enabled {
+		return true, hnswUserConfig.PQ.Segments
+	}
+	return false, 0
+}
+
+func (s *Shard) clearDimensionMetrics() {
+	pqEnabled, _ := s.getSegments()
+	if pqEnabled {
+		s.sendVectorSegmentsMetric(0)
+		s.sendVectorDimensionsMetric(0)
+
+	} else {
+		s.sendVectorDimensionsMetric(0)
+	}
+}
+
+func (s *Shard) publishDimensionMetrics() {
+	pqEnabled, segments := s.getSegments()
+	if pqEnabled {
+		count := s.quantizedDimensions(segments)
+		s.sendVectorSegmentsMetric(count)
+		s.sendVectorDimensionsMetric(0)
+
+	} else {
+		count := s.Dimensions()
+		s.sendVectorDimensionsMetric(count)
+	}
 }
 
 func (s *Shard) sendVectorDimensionsMetric(count int) {
@@ -53,10 +116,20 @@ func (s *Shard) sendVectorDimensionsMetric(count int) {
 	}
 }
 
+func (s *Shard) sendVectorSegmentsMetric(count int) {
+	if s.promMetrics != nil {
+		metric, err := s.promMetrics.VectorSegmentsSum.
+			GetMetricWithLabelValues(s.index.Config.ClassName.String(), s.name)
+		if err == nil {
+			metric.Set(float64(count))
+		}
+	}
+}
+
 func (s *Shard) initDimensionTracking() {
 	if s.index.Config.TrackVectorDimensions {
 		// always send vector dimensions at startup if tracking is enabled
-		s.sendVectorDimensionsMetric(s.Dimensions())
+		s.publishDimensionMetrics()
 		// start tracking vector dimensions goroutine only when tracking is enabled
 		go func() {
 			t := time.NewTicker(5 * time.Minute)
@@ -66,7 +139,7 @@ func (s *Shard) initDimensionTracking() {
 				case <-s.stopMetrics:
 					return
 				case <-t.C:
-					s.sendVectorDimensionsMetric(s.Dimensions())
+					s.publishDimensionMetrics()
 				}
 			}
 		}()

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -213,10 +213,13 @@ func Test_DimensionTracking(t *testing.T) {
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
 		require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
+		require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
 	})
 
 	t.Run("import objects with d=0", func(t *testing.T) {
 		dimBefore := GetDimensionsFromRepo(repo, "Test")
+		quantDimBefore := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		for i := 100; i < 200; i++ {
 			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
 			obj := &models.Object{Class: "Test", ID: id}
@@ -225,18 +228,22 @@ func Test_DimensionTracking(t *testing.T) {
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
 		require.Equal(t, dimBefore, dimAfter, "dimensions should not have changed")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
+		require.Equal(t, quantDimBefore, quantDimAfter, "quantized dimensions should not have changed")
 	})
 
 	t.Run("verify dimensions after initial import", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard *Shard) error {
 			assert.Equal(t, 12800, shard.Dimensions())
+			assert.Equal(t, 6400, shard.quantizedDimensions(64))
 			return nil
 		})
 	})
 
 	t.Run("delete 10 objects with d=128", func(t *testing.T) {
 		dimBefore := GetDimensionsFromRepo(repo, "Test")
+		quantDimBefore := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		for i := 0; i < 10; i++ {
 			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
 			err := repo.DeleteObject(context.Background(), "Test", id, nil, "")
@@ -244,18 +251,22 @@ func Test_DimensionTracking(t *testing.T) {
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
 		require.Equal(t, dimBefore, dimAfter+10*128, "dimensions should have decreased")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
+		require.Equal(t, quantDimBefore, quantDimAfter+10*64, "dimensions should have decreased")
 	})
 
 	t.Run("verify dimensions after delete", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard *Shard) error {
 			assert.Equal(t, 11520, shard.Dimensions())
+			assert.Equal(t, 5760, shard.quantizedDimensions(64))
 			return nil
 		})
 	})
 
 	t.Run("update some of the d=128 objects with a new vector", func(t *testing.T) {
 		dimBefore := GetDimensionsFromRepo(repo, "Test")
+		quantDimBefore := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		dim := 128
 		for i := 0; i < 50; i++ {
 			vec := make([]float32, dim)
@@ -271,11 +282,14 @@ func Test_DimensionTracking(t *testing.T) {
 			require.Nil(t, err)
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		require.Equal(t, dimBefore+10*128, dimAfter, "dimensions should have been restored")
+		require.Equal(t, quantDimBefore+10*64, quantDimAfter, "dimensions should have been restored")
 	})
 
 	t.Run("update some of the d=128 objects with a nil vector", func(t *testing.T) {
 		dimBefore := GetDimensionsFromRepo(repo, "Test")
+		quantDimBefore := GetQuantizedDimensionsFromRepo(repo, "Test", 32)
 		for i := 50; i < 100; i++ {
 			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
 			obj := &models.Object{Class: "Test", ID: id}
@@ -285,19 +299,24 @@ func Test_DimensionTracking(t *testing.T) {
 			require.Nil(t, err)
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 32)
 		require.Equal(t, dimBefore, dimAfter+50*128, "dimensions should decrease")
+		require.Equal(t, quantDimBefore, quantDimAfter+50*32, "dimensions should decrease")
 	})
 
 	t.Run("verify dimensions after first set of updates", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard *Shard) error {
 			assert.Equal(t, 6400, shard.Dimensions())
+			assert.Equal(t, 3200, shard.quantizedDimensions(64))
+			assert.Equal(t, 1600, shard.quantizedDimensions(32))
 			return nil
 		})
 	})
 
 	t.Run("update some of the origin nil vector objects with a d=128 vector", func(t *testing.T) {
 		dimBefore := GetDimensionsFromRepo(repo, "Test")
+		quantDimBefore := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		dim := 128
 		for i := 100; i < 150; i++ {
 			vec := make([]float32, dim)
@@ -313,11 +332,14 @@ func Test_DimensionTracking(t *testing.T) {
 			require.Nil(t, err)
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		require.Equal(t, dimBefore+50*128, dimAfter, "dimensions should increase")
+		require.Equal(t, quantDimBefore+50*64, quantDimAfter, "dimensions should increase")
 	})
 
 	t.Run("update some of the nil objects with another nil vector", func(t *testing.T) {
 		dimBefore := GetDimensionsFromRepo(repo, "Test")
+		quantDimBefore := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		for i := 150; i < 200; i++ {
 			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
 			obj := &models.Object{Class: "Test", ID: id}
@@ -327,13 +349,17 @@ func Test_DimensionTracking(t *testing.T) {
 			require.Nil(t, err)
 		}
 		dimAfter := GetDimensionsFromRepo(repo, "Test")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(repo, "Test", 64)
 		require.Equal(t, dimBefore, dimAfter, "dimensions should not have changed")
+		require.Equal(t, quantDimBefore, quantDimAfter, "dimensions should not have changed")
 	})
 
 	t.Run("verify dimensions after more updates", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard *Shard) error {
 			assert.Equal(t, 12800, shard.Dimensions())
+			assert.Equal(t, 6400, shard.quantizedDimensions(64))
+			assert.Equal(t, 12800, shard.quantizedDimensions(0))
 			return nil
 		})
 	})

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -55,6 +55,7 @@ type PrometheusMetrics struct {
 	BackupRestoreDataTransferred       *prometheus.CounterVec
 	BackupStoreDataTransferred         *prometheus.CounterVec
 	VectorDimensionsSum                *prometheus.GaugeVec
+	VectorSegmentsSum                  *prometheus.GaugeVec
 
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.SummaryVec
@@ -260,6 +261,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		VectorDimensionsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_dimensions_sum",
 			Help: "Total dimensions in a shard",
+		}, []string{"class_name", "shard_name"}),
+		VectorSegmentsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_segments_sum",
+			Help: "Total segments in a shard if quantization enabled",
 		}, []string{"class_name", "shard_name"}),
 
 		StartupProgress: promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
### What's being changed:

Currently `vector_dimensions_sum` is used for resource usage. It calculates each  non-nil `vector * dimension` in a shard. This PR creates an additional `vector_segments_sum` metric which:
- Is only exported if PQ is enabled
- Will use the segment value instead of dimensions value. This is a more accurate measure of memory usage in the case where PQ or other quantization approaches are used.
- sets `vector_dimensions_sum = 0` if enabled to allow for simple sums of metrics for usage.
- similarly to `vector_dimensions_sum` it is only enabled if `TRACK_VECTOR_DIMENSIONS` is `true`.

This PR also makes `Index.vectorIndexUserConfig` update correctly on vector index config updates.

### Example calculation
Shard having 100 non-nil vectors with dimensions 128 (note each change can take up to 5 minutes to propagate).

```
vector_dimensions_sum{class_name=X,shard_name=Y}=12800
```
PQ is enabled with segments = 64

```
vector_dimensions_sum{class_name=X,shard_name=Y}=0
vector_segments_sum{class_name=X,shard_name=Y}=6400
```

Alternatively suppose PQ is enabled with segments = 32

```
vector_dimensions_sum{class_name=X,shard_name=Y}=0
vector_segments_sum{class_name=X,shard_name=Y}=3200
```

After class deleted

```
vector_dimensions_sum{class_name=X,shard_name=Y}=0
vector_segments_sum{class_name=X,shard_name=Y}=0
```


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
