### PR TITLE
Fix clusterapi communications when resolving vector queue size

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -909,7 +909,7 @@ func (i *indices) deleteObjects() http.Handler {
 
 func (i *indices) getGetShardQueueSize() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		args := i.regexpShardsStatus.FindStringSubmatch(r.URL.Path)
+		args := i.regexpShardsQueueSize.FindStringSubmatch(r.URL.Path)
 		if len(args) != 3 {
 			http.Error(w, "invalid URI", http.StatusBadRequest)
 			return


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug with the clusterapi communications introduced in `v1.22.0` when resolving the `vectorQueueSize` field for the `/schema{className}/shards` endpoint

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
