### PR TITLE
Update raft parameters and bootstrap procedure

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -377,42 +377,88 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		migrator.RecountProperties(ctx)
 	}
 
-	// TODO_RAFT START
+	// TODO-RAFT START
 	appState.MetaStore = &fsm
 
-	boostrapper := false
+	// If bootstrap expect is bigger than 0, we are bootstraping a new cluster
+	bootstrapper := appState.ServerConfig.Config.Raft.BootstrapExpect > 0
 
-	// Create candidate list from config join parameter
-	candidateList := make([]schemav2.Candidate, 0, len(appState.ServerConfig.Config.Raft.Join))
-	for i, addr := range appState.ServerConfig.Config.Raft.Join {
-		candidateList = append(candidateList, schemav2.Candidate{
-			ID: fmt.Sprintf("node%d", i+1), Address: addr, NonVoter: false,
-		})
+	if bootstrapper {
+		// The bootstrap process follows these steps:
+		// 1. Ensure all the nodes we expect are running and joined in memberlist
+		// 2. Ensure we can resolve an address for the nodes in raft join
+		// 3. Build a candidate list from the address in memberlist and the port listed in join parameter
+		// 4. Open the FSM store and bootstrap the raft cluster
+
+		waitForNodeToBeInMemberList := func(nodeName string) string {
+			timeout := time.After(appState.ServerConfig.Config.Raft.BootstrapTimeout)
+			ticker := time.NewTicker(time.Second * 1)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-timeout:
+					appState.Logger.
+						WithField("action", "startup").
+						Fatalf("waited for node %s for %s raft nodes to join gossip", nodeName, appState.ServerConfig.Config.Raft.BootstrapTimeout)
+				case <-ticker.C:
+					hostnameAndPort, ok := appState.Cluster.NodeHostname(nodeName)
+					if ok {
+						return hostnameAndPort
+					}
+					appState.Logger.
+						WithField("action", "startup").
+						Infof("waiting for node %s for raft bootstrap", nodeName)
+				}
+			}
+		}
+
+		// Add nodes from bootstrap join parameter to the raft candidate list
+		candidateList := make([]schemav2.Candidate, 0, len(appState.ServerConfig.Config.Raft.Join))
+		for _, joinNodeNameAndPort := range appState.ServerConfig.Config.Raft.Join {
+			joinNodeNameAndPortSplitted := strings.Split(joinNodeNameAndPort, ":")
+			// shorter names for clearer usage below
+			joinNodeName := joinNodeNameAndPortSplitted[0]
+			joinNodePort := joinNodeNameAndPortSplitted[1]
+
+			// We need to find the node by it's name in the memberlist and remove the port appended to the hostname, as this port is the
+			// memberlist gossip port, not the raft port.
+			joinNodeAddrAndGossipPort := waitForNodeToBeInMemberList(joinNodeName)
+			joinNodeAddr := strings.Split(joinNodeAddrAndGossipPort, ":")[0] + ":" + joinNodePort
+
+			candidateList = append(candidateList, schemav2.Candidate{ID: joinNodeName, Address: joinNodeAddr})
+			appState.Logger.
+				WithField("action", "startup").
+				Debugf("added node %s with address %s to initial raft bootstrap list", joinNodeName, joinNodeAddr)
+		}
+
+		raftNode, err := fsm.Open(bootstrapper, candidateList)
+		if err != nil {
+			appState.Logger.
+				WithField("action", "startup").
+				WithError(err).
+				Fatal("could not open fsm store")
+		}
+
+		cAddr := addrs[0] + ":" + fmt.Sprintf("%d", appState.ServerConfig.Config.Raft.InternalRPCPort)
+		cluster := schemav2.NewCluster(raftNode, cAddr)
+		if err := cluster.Open(); err != nil {
+			appState.Logger.
+				WithField("action", "startup").
+				WithError(err).
+				Fatal("could not start raft cluster")
+		}
+	} else {
+		//serverAddress := addrs[0] + ":2" + "7101"
+		//raftAddress := addrs[0] + ":1" + addrs[1]
+		//cl := schemav2.NewClient(cluster)
+		//joinReq := proto.JoinPeerRequest{Id: nodeName, Address: raftAddress, Voter: true}
+		//err := cl.Join(serverAddress, &joinReq)
+		//if err != nil {
+		//	fmt.Printf("cluster.join %v", err.Error())
+		// os.Exit(1)
+		//}
 	}
-	// TODO-RAFT: Bootstrapper boolean is currently unused in fsm.Open and below. Should we keep it ?
-	// If yes then how do we determine who is bootstrapper/leader based on the flags ?
-	raftNode, err := fsm.Open(boostrapper, candidateList)
-	if err != nil {
-		fmt.Printf("fsm.open %v", err.Error())
-		os.Exit(1)
-	}
-	cAddr := addrs[0] + ":" + fmt.Sprintf("%d", appState.ServerConfig.Config.Raft.InternalRPCPort)
-	cluster := schemav2.NewCluster(raftNode, cAddr)
-	if err := cluster.Open(); err != nil {
-		fmt.Printf("cluster.open %v", err.Error())
-		os.Exit(1)
-	}
-	//if !boostrapper {
-	//serverAddress := addrs[0] + ":2" + "7101"
-	//raftAddress := addrs[0] + ":1" + addrs[1]
-	//cl := schemav2.NewClient(cluster)
-	//joinReq := proto.JoinPeerRequest{Id: nodeName, Address: raftAddress, Voter: true}
-	//err := cl.Join(serverAddress, &joinReq)
-	//if err != nil {
-	//	fmt.Printf("cluster.join %v", err.Error())
-	// os.Exit(1)
-	//}
-	//}
 	// TODO-RAFT END
 
 	return appState

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -45,10 +45,8 @@ case $CONFIG in
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
-      RAFT_PORT="8300" \
-      RAFT_INTERNAL_RPC_PORT="8301" \
-      RAFT_BOOTSTRAP_EXPECT="3" \
-      RAFT_JOIN="127.0.0.1:8300,127.0.0.1:8302,127.0.0.1:8304" \
+      RAFT_JOIN="node1,node2:8302,node3:8304" \
+      RAFT_BOOTSTRAP_EXPECT=3 \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -68,8 +66,8 @@ case $CONFIG in
       CLUSTER_JOIN="localhost:7100" \
       RAFT_PORT="8302" \
       RAFT_INTERNAL_RPC_PORT="8303" \
-      RAFT_BOOTSTRAP_EXPECT="3" \
-      RAFT_JOIN="127.0.0.1:8300,127.0.0.1:8302,127.0.0.1:8304" \
+      RAFT_JOIN="node1:8300,node2:8302,node3:8304" \
+      RAFT_BOOTSTRAP_EXPECT=3 \
       CONTEXTIONARY_URL=localhost:9999 \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
@@ -91,9 +89,9 @@ case $CONFIG in
         CLUSTER_DATA_BIND_PORT="7105" \
         CLUSTER_JOIN="localhost:7100" \
         RAFT_PORT="8304" \
-        RAFT_INTERNAL_PORT="8305" \
-        RAFT_BOOTSTRAP_EXPECT="3" \
-        RAFT_JOIN="127.0.0.1:8300,127.0.0.1:8302,127.0.0.1:8304" \
+        RAFT_INTERNAL_RPC_PORT="8305" \
+        RAFT_JOIN="node1:8300,node2:8302,node3:8304" \
+        RAFT_BOOTSTRAP_EXPECT=3 \
         CONTEXTIONARY_URL=localhost:9999 \
         DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
         ENABLE_MODULES="text2vec-contextionary" \

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -37,12 +37,11 @@ const (
 	DefaultGRPCPort                           = 50051
 	DefaultMinimumReplicationFactor           = 1
 
-	DefaultRaftPort         = 3000
-	DefaultRaftInternalPort = 3001
-	DefaultRaftExpect       = 1
+	DefaultRaftPort             = 8300
+	DefaultRaftInternalPort     = 8301
+	DefaultRaftBootstrapTimeout = 10
+	DefaultRaftBootstrapExpect  = 1
 )
-
-var DefaultRaftJoin = []string{"localhost:3000"}
 
 const VectorizerModuleNone = "none"
 
@@ -358,13 +357,23 @@ func FromEnv(config *Config) error {
 	parseStringList(
 		"RAFT_JOIN",
 		func(val []string) { config.Raft.Join = val },
-		DefaultRaftJoin,
+		// Default RAFT_JOIN must be the configured node name and the configured raft port. This allows us to have a one-node raft cluster
+		// able to bootstrap itself if the user doesn't pass any raft parameter.
+		[]string{fmt.Sprintf("%s:%d", config.Cluster.Hostname, config.Raft.InternalRPCPort)},
 	)
 
 	if err := parsePositiveInt(
+		"RAFT_BOOTSTRAP_TIMEOUT",
+		func(val int) { config.Raft.BootstrapTimeout = time.Second * time.Duration(val) },
+		DefaultRaftBootstrapTimeout,
+	); err != nil {
+		return err
+	}
+
+	if err := parsePositiveInt(
 		"RAFT_BOOTSTRAP_EXPECT",
-		func(val int) { config.Raft.BootstrapExcept = val },
-		DefaultRaftExpect,
+		func(val int) { config.Raft.BootstrapExpect = val },
+		DefaultRaftBootstrapExpect,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What's being changed:

Update raft parameters and bootstrap procedure

* Change raft join format, it now expect NODE_NAME:NODE_PORT and will resolve the node address using NODE_NAME
* Change raft bootstrap procedure to wait for bootstrap-expect nodes to be online and using memberlist before attempting to bootstrap the cluster


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
