### PR TITLE
undo premature optimisation of grpc message parsing

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -637,12 +637,13 @@ func isIdOnlyRequest(metadata *pb.MetadataRequest) bool {
 	return (metadata != nil &&
 		metadata.Uuid &&
 		!metadata.Vector &&
-		!metadata.Certainty &&
-		!metadata.Distance &&
-		!metadata.LastUpdateTimeUnix &&
 		!metadata.CreationTimeUnix &&
+		!metadata.LastUpdateTimeUnix &&
+		!metadata.Distance &&
+		!metadata.Certainty &&
 		!metadata.Score &&
-		!metadata.ExplainScore)
+		!metadata.ExplainScore &&
+		!metadata.IsConsistent)
 }
 
 func getAllNonRefNonBlobProperties(scheme schema.Schema, className string) ([]search.SelectProperty, error) {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -634,7 +634,15 @@ func extractAdditionalPropsForRefs(prop *pb.MetadataRequest) additional.Properti
 
 func isIdOnlyRequest(metadata *pb.MetadataRequest) bool {
 	// could also use reflect here but this is more explicit
-	return metadata != nil && metadata.Uuid && !metadata.Vector && !metadata.Certainty && !metadata.Distance && !metadata.LastUpdateTimeUnix && !metadata.CreationTimeUnix && !metadata.Score && !metadata.ExplainScore
+	return (metadata != nil &&
+		metadata.Uuid &&
+		!metadata.Vector &&
+		!metadata.Certainty &&
+		!metadata.Distance &&
+		!metadata.LastUpdateTimeUnix &&
+		!metadata.CreationTimeUnix &&
+		!metadata.Score &&
+		!metadata.ExplainScore)
 }
 
 func getAllNonRefNonBlobProperties(scheme schema.Schema, className string) ([]search.SelectProperty, error) {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -75,7 +75,12 @@ func searchParamsFromProto(req *pb.SearchRequest, scheme schema.Schema) (dto.Get
 	if len(out.Properties) == 0 && req.Metadata != nil {
 		// This is a pure-ID query without any props. Indicate this to the DB, so
 		// it can optimize accordingly
-		out.AdditionalProperties.NoProps = true
+		// out.AdditionalProperties.NoProps = true
+		returnProps, err := getAllNonRefNonBlobProperties(scheme, req.Collection)
+		if err != nil {
+			return dto.GetParams{}, err
+		}
+		out.Properties = returnProps
 	} else if len(out.Properties) == 0 && req.Metadata == nil {
 		// no return values selected, return all properties and metadata. Ignore blobs and refs to not overload the
 		// response

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -183,8 +183,20 @@ func TestGRPCRequest(t *testing.T) {
 				ClassName: classname, Pagination: defaultPagination,
 				AdditionalProperties: additional.Properties{
 					Vector:       true,
-					NoProps:      true,
+					NoProps:      false,
 					IsConsistent: true,
+				},
+			},
+			error: false,
+		},
+		{
+			name: "Metadata ID only query",
+			req:  &pb.SearchRequest{Collection: classname, Metadata: &pb.MetadataRequest{Uuid: true}},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination,
+				AdditionalProperties: additional.Properties{
+					ID:      true,
+					NoProps: true,
 				},
 			},
 			error: false,
@@ -267,7 +279,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion, Alpha: 0.75, Properties: []string{"name", "capitalizedName"}},
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
 		},
@@ -279,7 +291,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRelativeScoreFusion},
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
 		},
@@ -291,7 +303,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion},
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
 		},
@@ -304,7 +316,7 @@ func TestGRPCRequest(t *testing.T) {
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
 				KeywordRanking:       &searchparams.KeywordRanking{Query: "query", Properties: []string{"name", "capitalizedName"}, Type: "bm25"},
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
 		},
@@ -316,7 +328,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On:       &filters.Path{Class: schema.ClassName(classname), Property: "name"},
@@ -335,7 +347,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On:       &filters.Path{Class: schema.ClassName(classname), Property: "uuid"},
@@ -357,7 +369,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						Operator: filters.OperatorOr,
@@ -386,7 +398,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On: &filters.Path{
@@ -409,7 +421,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On: &filters.Path{
@@ -460,7 +472,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On: &filters.Path{
@@ -490,7 +502,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On: &filters.Path{
@@ -516,7 +528,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
 						On: &filters.Path{
@@ -542,7 +554,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearText": &nearText2.NearTextParams{
 						Values: []string{"first and", "second", "query"},
@@ -589,7 +601,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearAudio": &nearAudio.NearAudioParams{
 						Audio: "audio file",
@@ -608,7 +620,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearVideo": &nearVideo.NearVideoParams{
 						Video: "video file",
@@ -627,7 +639,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties: additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearImage": &nearImage.NearImageParams{
 						Image: "image file",
@@ -644,7 +656,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				AdditionalProperties:  additional.Properties{Vector: true, NoProps: true},
+				AdditionalProperties:  additional.Properties{Vector: true, NoProps: false},
 				ReplicationProperties: &additional.ReplicationProperties{ConsistencyLevel: "QUORUM"},
 			},
 			error: false,
@@ -659,7 +671,7 @@ func TestGRPCRequest(t *testing.T) {
 				ClassName: classname, Pagination: defaultPagination,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
-					NoProps: true,
+					NoProps: false,
 					ModuleParams: map[string]interface{}{
 						"generate": &generate.Params{Prompt: &someString1, Task: &someString2, Properties: []string{"one", "two"}},
 					},
@@ -677,7 +689,7 @@ func TestGRPCRequest(t *testing.T) {
 				ClassName: classname, Pagination: defaultPagination,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
-					NoProps: true,
+					NoProps: false,
 				},
 				Sort: []filters.Sort{{Order: "desc", Path: []string{"name"}}},
 			},


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug where the gRPC message parsing was too optimistic of the payload. As a result, it would cause unexpected behaviours when trying to optimise data transfer in the case of nil return properties and non-nil metadata. Such an event is in fact a common use-case when a user requests an object's vector only.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
