### PR TITLE
TypeAssertVectorIndex fix to work with hnsw and flat index

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
-	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate"
 
@@ -714,13 +713,13 @@ func setAllCheapAdditionalPropsToTrue(class *models.Class) (additional.Propertie
 		Vector:             false, // can be expensive
 	}
 
-	// certainty is not compatible with dot distance
-	vectorIndex, err := hnsw.TypeAssertVectorIndex(class)
+	vectorIndex, err := schema.TypeAssertVectorIndex(class)
 	if err != nil {
 		return out, err
 	}
 
-	if vectorIndex.Distance == common.DistanceCosine {
+	// certainty is not compatible with dot distance
+	if vectorIndex.DistanceName() == common.DistanceCosine {
 		out.Certainty = true
 	}
 

--- a/entities/schema/vector_index_config.go
+++ b/entities/schema/vector_index_config.go
@@ -11,7 +11,22 @@
 
 package schema
 
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
 type VectorIndexConfig interface {
 	IndexType() string
 	DistanceName() string
+}
+
+func TypeAssertVectorIndex(class *models.Class) (VectorIndexConfig, error) {
+	if config, ok := class.VectorIndexConfig.(VectorIndexConfig); ok {
+		return config, nil
+	}
+
+	return nil, fmt.Errorf("class '%s' vector index: config is not schema.VectorIndexConfig: %T",
+		class.Class, class.VectorIndexConfig)
 }

--- a/entities/vectorindex/flat/config.go
+++ b/entities/vectorindex/flat/config.go
@@ -14,7 +14,6 @@ package flat
 import (
 	"fmt"
 
-	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	vectorindexcommon "github.com/weaviate/weaviate/entities/vectorindex/common"
 )
@@ -101,14 +100,4 @@ func NewDefaultUserConfig() UserConfig {
 	uc := UserConfig{}
 	uc.SetDefaults()
 	return uc
-}
-
-func TypeAssertVectorIndex(class *models.Class) (UserConfig, error) {
-	flatConfig, ok := class.VectorIndexConfig.(UserConfig)
-	if !ok {
-		return UserConfig{}, fmt.Errorf("class '%s' vector index: config is not flat.UserConfig: %T",
-			class.Class, class.VectorIndexConfig)
-	}
-
-	return flatConfig, nil
 }

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/weaviate/weaviate/entities/models"
 	vectorIndexCommon "github.com/weaviate/weaviate/entities/vectorindex/common"
 
 	"github.com/weaviate/weaviate/entities/schema"
@@ -206,14 +205,4 @@ func NewDefaultUserConfig() UserConfig {
 	uc := UserConfig{}
 	uc.SetDefaults()
 	return uc
-}
-
-func TypeAssertVectorIndex(class *models.Class) (UserConfig, error) {
-	hnswConfig, ok := class.VectorIndexConfig.(UserConfig)
-	if !ok {
-		return UserConfig{}, fmt.Errorf("class '%s' vector index: config is not hnsw.UserConfig: %T",
-			class.Class, class.VectorIndexConfig)
-	}
-
-	return hnswConfig, nil
 }

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -32,7 +32,6 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
-	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
 	uc "github.com/weaviate/weaviate/usecases/schema"
@@ -749,12 +748,12 @@ func (e *Explorer) checkCertaintyCompatibility(className string) error {
 	if class == nil {
 		return errors.Errorf("failed to get class: %s", className)
 	}
-	hnswConfig, err := hnsw.TypeAssertVectorIndex(class)
+	vectorConfig, err := schema.TypeAssertVectorIndex(class)
 	if err != nil {
 		return err
 	}
-	if hnswConfig.Distance != common.DistanceCosine {
-		return certaintyUnsupportedError(hnswConfig.Distance)
+	if dn := vectorConfig.DistanceName(); dn != common.DistanceCosine {
+		return certaintyUnsupportedError(dn)
 	}
 
 	return nil

--- a/usecases/traverser/traverser_validate_distance_metrics.go
+++ b/usecases/traverser/traverser_validate_distance_metrics.go
@@ -19,7 +19,6 @@ import (
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
-	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 func (t *Traverser) validateExploreDistance(params ExploreParams) error {
@@ -58,14 +57,14 @@ func (t *Traverser) validateCrossClassDistanceCompatibility() (distType string, 
 			continue
 		}
 
-		hnswConfig, assertErr := hnsw.TypeAssertVectorIndex(class)
+		vectorConfig, assertErr := schema.TypeAssertVectorIndex(class)
 		if assertErr != nil {
 			err = assertErr
 			return
 		}
 
-		distancerTypes[hnswConfig.Distance] = struct{}{}
-		classDistanceConfigs[class.Class] = hnswConfig.Distance
+		distancerTypes[vectorConfig.DistanceName()] = struct{}{}
+		classDistanceConfigs[class.Class] = vectorConfig.DistanceName()
 	}
 
 	if len(distancerTypes) != 1 {
@@ -103,13 +102,13 @@ func (t *Traverser) validateGetDistanceParams(params dto.GetParams) error {
 		return fmt.Errorf("failed to find class '%s' in schema", params.ClassName)
 	}
 
-	hnswConfig, err := hnsw.TypeAssertVectorIndex(class)
+	vectorConfig, err := schema.TypeAssertVectorIndex(class)
 	if err != nil {
 		return err
 	}
 
-	if hnswConfig.Distance != common.DistanceCosine {
-		return certaintyUnsupportedError(hnswConfig.Distance)
+	if dn := vectorConfig.DistanceName(); dn != common.DistanceCosine {
+		return certaintyUnsupportedError(dn)
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:

hnsw's `TypeAssertVectorIndex` method calls replaced with common interface's `TypeAssertVectorIndex` to work with hnsw and flat indexes


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
