### PR TITLE
Add possibility to pass OpenAI BaseURL value using HTTP header

### DIFF
--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -167,7 +167,7 @@ func (v *cohere) getApiKey(ctx context.Context) (string, error) {
 	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
 	if apiKey == nil {
-		apiKey = modulecomponents.GetApiKeyFromGRPC(ctx, key)
+		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
 	}
 	if apiKeyHeader, ok := apiKey.([]string); ok &&
 		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -89,7 +89,7 @@ func (v *openai) GenerateAllResults(ctx context.Context, textProperties []map[st
 func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string) (*generativemodels.GenerateResponse, error) {
 	settings := config.NewClassSettings(cfg)
 
-	oaiUrl, err := v.buildUrl(settings.IsLegacy(), settings.ResourceName(), settings.DeploymentID(), settings.BaseURL())
+	oaiUrl, err := v.buildOpenAIUrl(ctx, settings)
 	if err != nil {
 		return nil, errors.Wrap(err, "url join path")
 	}
@@ -159,6 +159,14 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	return &generativemodels.GenerateResponse{
 		Result: nil,
 	}, nil
+}
+
+func (v *openai) buildOpenAIUrl(ctx context.Context, settings config.ClassSettings) (string, error) {
+	baseURL := settings.BaseURL()
+	if headerBaseURL := v.getValueFromContext(ctx, "X-OpenAI-BaseURL"); headerBaseURL != "" {
+		baseURL = headerBaseURL
+	}
+	return v.buildUrl(settings.IsLegacy(), settings.ResourceName(), settings.DeploymentID(), baseURL)
 }
 
 func (v *openai) generateInput(prompt string, settings config.ClassSettings) (generateInput, error) {
@@ -287,7 +295,7 @@ func (v *openai) getValueFromContext(ctx context.Context, key string) string {
 		}
 	}
 	// try getting header from GRPC if not successful
-	if apiKey := modulecomponents.GetApiKeyFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
+	if apiKey := modulecomponents.GetValueFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
 		return apiKey[0]
 	}
 

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/modules/generative-openai/config"
 	generativemodels "github.com/weaviate/weaviate/usecases/modulecomponents/additional/models"
 )
@@ -117,6 +118,24 @@ func TestGetAnswer(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Error(t, err, "connection to OpenAI failed with status: 500 error: some error from the server")
 	})
+
+	t.Run("when X-OpenAI-BaseURL header is passed", func(t *testing.T) {
+		settings := &fakeClassSettings{
+			baseURL: "http://default-url.com",
+		}
+		c := New("openAIApiKey", "", "", 0, nullLogger())
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-OpenAI-BaseURL", []string{"http://base-url-passed-in-header.com"})
+
+		buildURL, err := c.buildOpenAIUrl(ctxWithValue, settings)
+		require.NoError(t, err)
+		assert.Equal(t, "http://base-url-passed-in-header.com/v1/chat/completions", buildURL)
+
+		buildURL, err = c.buildOpenAIUrl(context.TODO(), settings)
+		require.NoError(t, err)
+		assert.Equal(t, "http://default-url.com/v1/chat/completions", buildURL)
+	})
 }
 
 type testAnswerHandler struct {
@@ -153,4 +172,70 @@ func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func ptString(in string) *string {
 	return &in
+}
+
+type fakeClassSettings struct {
+	isLegacy         bool
+	model            string
+	maxTokens        float64
+	temperature      float64
+	frequencyPenalty float64
+	presencePenalty  float64
+	topP             float64
+	resourceName     string
+	deploymentID     string
+	isAzure          bool
+	baseURL          string
+}
+
+func (s *fakeClassSettings) IsLegacy() bool {
+	return s.isLegacy
+}
+
+func (s *fakeClassSettings) Model() string {
+	return s.model
+}
+
+func (s *fakeClassSettings) MaxTokens() float64 {
+	return s.maxTokens
+}
+
+func (s *fakeClassSettings) Temperature() float64 {
+	return s.temperature
+}
+
+func (s *fakeClassSettings) FrequencyPenalty() float64 {
+	return s.frequencyPenalty
+}
+
+func (s *fakeClassSettings) PresencePenalty() float64 {
+	return s.presencePenalty
+}
+
+func (s *fakeClassSettings) TopP() float64 {
+	return s.topP
+}
+
+func (s *fakeClassSettings) ResourceName() string {
+	return s.resourceName
+}
+
+func (s *fakeClassSettings) DeploymentID() string {
+	return s.deploymentID
+}
+
+func (s *fakeClassSettings) IsAzure() bool {
+	return s.isAzure
+}
+
+func (s *fakeClassSettings) GetMaxTokensForModel(model string) float64 {
+	return 0
+}
+
+func (s *fakeClassSettings) Validate(class *models.Class) error {
+	return nil
+}
+
+func (s *fakeClassSettings) BaseURL() string {
+	return s.baseURL
 }

--- a/modules/generative-palm/clients/palm.go
+++ b/modules/generative-palm/clients/palm.go
@@ -188,7 +188,7 @@ func (v *palm) getApiKey(ctx context.Context) (string, error) {
 	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
 	if apiKey == nil {
-		apiKey = modulecomponents.GetApiKeyFromGRPC(ctx, key)
+		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
 	}
 	if apiKeyHeader, ok := apiKey.([]string); ok &&
 		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {

--- a/modules/qna-openai/clients/qna_test.go
+++ b/modules/qna-openai/clients/qna_test.go
@@ -86,6 +86,21 @@ func TestGetAnswer(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Error(t, err, "connection to OpenAI failed with status: 500 error: some error from the server")
 	})
+
+	t.Run("when X-OpenAI-BaseURL header is passed", func(t *testing.T) {
+		c := New("openAIApiKey", "", "", 0, nullLogger())
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-OpenAI-BaseURL", []string{"http://base-url-passed-in-header.com"})
+
+		buildURL, err := c.buildOpenAIUrl(ctxWithValue, "http://default-url.com", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "http://base-url-passed-in-header.com/v1/completions", buildURL)
+
+		buildURL, err = c.buildOpenAIUrl(context.TODO(), "http://default-url.com", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "http://default-url.com/v1/completions", buildURL)
+	})
 }
 
 type testAnswerHandler struct {

--- a/modules/reranker-cohere/clients/ranker.go
+++ b/modules/reranker-cohere/clients/ranker.go
@@ -199,7 +199,7 @@ func (c *client) getApiKey(ctx context.Context) (string, error) {
 	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
 	if apiKey == nil {
-		apiKey = modulecomponents.GetApiKeyFromGRPC(ctx, key)
+		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
 	}
 	if apiKeyHeader, ok := apiKey.([]string); ok &&
 		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {

--- a/modules/text2vec-cohere/clients/vectorizer.go
+++ b/modules/text2vec-cohere/clients/vectorizer.go
@@ -141,7 +141,7 @@ func (v *vectorizer) getApiKey(ctx context.Context) (string, error) {
 	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
 	if apiKey == nil {
-		apiKey = modulecomponents.GetApiKeyFromGRPC(ctx, key)
+		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
 	}
 	if apiKeyHeader, ok := apiKey.([]string); ok &&
 		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {

--- a/modules/text2vec-huggingface/clients/vectorizer.go
+++ b/modules/text2vec-huggingface/clients/vectorizer.go
@@ -201,7 +201,7 @@ func (v *vectorizer) getApiKey(ctx context.Context) string {
 	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
 	if apiKey == nil {
-		apiKey = modulecomponents.GetApiKeyFromGRPC(ctx, key)
+		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
 	}
 
 	if apiKeyHeader, ok := apiKey.([]string); ok &&

--- a/modules/text2vec-jinaai/clients/vectorizer.go
+++ b/modules/text2vec-jinaai/clients/vectorizer.go
@@ -187,7 +187,7 @@ func (v *vectorizer) getValueFromContext(ctx context.Context, key string) string
 		}
 	}
 	// try getting header from GRPC if not successful
-	if apiKey := modulecomponents.GetApiKeyFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
+	if apiKey := modulecomponents.GetValueFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
 		return apiKey[0]
 	}
 

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -52,15 +52,15 @@ type openAIApiError struct {
 	Code    string `json:"code"`
 }
 
-func buildUrl(config ent.VectorizationConfig) (string, error) {
-	if config.IsAzure {
-		host := "https://" + config.ResourceName + ".openai.azure.com"
-		path := "openai/deployments/" + config.DeploymentID + "/embeddings"
+func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
+	if isAzure {
+		host := "https://" + resourceName + ".openai.azure.com"
+		path := "openai/deployments/" + deploymentID + "/embeddings"
 		queryParam := "api-version=2022-12-01"
 		return fmt.Sprintf("%s/%s?%s", host, path, queryParam), nil
 	}
 
-	host := config.BaseURL
+	host := baseURL
 	path := "/v1/embeddings"
 	return url.JoinPath(host, path)
 }
@@ -70,7 +70,7 @@ type vectorizer struct {
 	openAIOrganization string
 	azureApiKey        string
 	httpClient         *http.Client
-	buildUrlFn         func(config ent.VectorizationConfig) (string, error)
+	buildUrlFn         func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error)
 	logger             logrus.FieldLogger
 }
 
@@ -105,7 +105,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string, model string
 		return nil, errors.Wrap(err, "marshal body")
 	}
 
-	endpoint, err := v.buildUrlFn(config)
+	endpoint, err := v.buildURL(ctx, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "join OpenAI API host and path")
 	}
@@ -157,6 +157,14 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string, model string
 		Dimensions: len(resBody.Data[0].Embedding),
 		Vector:     embeddings,
 	}, nil
+}
+
+func (v *vectorizer) buildURL(ctx context.Context, config ent.VectorizationConfig) (string, error) {
+	baseURL, resourceName, deploymentID, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.IsAzure
+	if headerBaseURL := v.getValueFromContext(ctx, "X-OpenAI-BaseURL"); headerBaseURL != "" {
+		baseURL = headerBaseURL
+	}
+	return v.buildUrlFn(baseURL, resourceName, deploymentID, isAzure)
 }
 
 func (v *vectorizer) getError(statusCode int, resBodyError *openAIApiError, isAzure bool) error {
@@ -225,7 +233,7 @@ func (v *vectorizer) getValueFromContext(ctx context.Context, key string) string
 		}
 	}
 	// try getting header from GRPC if not successful
-	if apiKey := modulecomponents.GetApiKeyFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
+	if apiKey := modulecomponents.GetValueFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
 		return apiKey[0]
 	}
 

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -39,7 +39,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "https://api.openai.com",
 			IsAzure:      false,
 		}
-		url, err := buildUrl(config)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://api.openai.com/v1/embeddings", url)
 	})
@@ -53,7 +53,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "",
 			IsAzure:      true,
 		}
-		url, err := buildUrl(config)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/embeddings?api-version=2022-12-01", url)
 	})
@@ -68,7 +68,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "https://foobar.some.proxy",
 			IsAzure:      false,
 		}
-		url, err := buildUrl(config)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://foobar.some.proxy/v1/embeddings", url)
 	})
@@ -80,7 +80,7 @@ func TestClient(t *testing.T) {
 		defer server.Close()
 
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -103,7 +103,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -123,7 +123,7 @@ func TestClient(t *testing.T) {
 		})
 		defer server.Close()
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -138,7 +138,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
-		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -164,7 +164,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
-		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -183,7 +183,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
-		c.buildUrlFn = func(config ent.VectorizationConfig) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -200,6 +200,29 @@ func TestClient(t *testing.T) {
 		assert.EqualError(t, err, "API Key: no api key found "+
 			"neither in request header: X-Openai-Api-Key "+
 			"nor in environment variable under OPENAI_APIKEY")
+	})
+
+	t.Run("when X-OpenAI-BaseURL header is passed", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := New("", "", "", 0, nullLogger())
+
+		config := ent.VectorizationConfig{
+			Type:    "text",
+			Model:   "ada",
+			BaseURL: "http://default-url.com",
+		}
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-OpenAI-BaseURL", []string{"http://base-url-passed-in-header.com"})
+
+		buildURL, err := c.buildURL(ctxWithValue, config)
+		require.NoError(t, err)
+		assert.Equal(t, "http://base-url-passed-in-header.com/v1/embeddings", buildURL)
+
+		buildURL, err = c.buildURL(context.TODO(), config)
+		require.NoError(t, err)
+		assert.Equal(t, "http://default-url.com/v1/embeddings", buildURL)
 	})
 }
 

--- a/modules/text2vec-palm/clients/palm.go
+++ b/modules/text2vec-palm/clients/palm.go
@@ -136,7 +136,7 @@ func (v *palm) getApiKey(ctx context.Context) (string, error) {
 	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
 	if apiKey == nil {
-		apiKey = modulecomponents.GetApiKeyFromGRPC(ctx, key)
+		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
 	}
 	if apiKeyHeader, ok := apiKey.([]string); ok &&
 		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -252,7 +252,7 @@ type CORS struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Cohere-Api-Key, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-BaseURL, X-Cohere-Api-Key, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key"
 )
 
 func (r ResourceUsage) Validate() error {

--- a/usecases/modulecomponents/grpc_metadata.go
+++ b/usecases/modulecomponents/grpc_metadata.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func GetApiKeyFromGRPC(ctx context.Context, key string) []string {
+func GetValueFromGRPC(ctx context.Context, key string) []string {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		// the grpc library will lowercase all md keys, so we need to make sure to check a lowercase key


### PR DESCRIPTION
### What's being changed:

This PR adds a possibility to pass OpenAI BaseURL setting using `X-OpenAI-BaseURL` header during request.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
