### PR TITLE
Migration of brute force index's buckets to main store

### DIFF
--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -21,8 +21,8 @@ var (
 	ObjectsBucket              = []byte("objects")
 	ObjectsBucketLSM           = "objects"
 	CompressedObjectsBucketLSM = "compressed_objects"
-	VectorsBucketLSM           = "vectors"
-	VectorsCompressedBucketLSM = "vectors_compressed"
+	VectorsFlatBucketLSM       = "vectors_flat"
+	VectorsFlatBQBucketLSM     = "vectors_flat_bq"
 	DimensionsBucketLSM        = "dimensions"
 	DocIDBucket                = []byte("doc_ids")
 )

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -21,6 +21,8 @@ var (
 	ObjectsBucket              = []byte("objects")
 	ObjectsBucketLSM           = "objects"
 	CompressedObjectsBucketLSM = "compressed_objects"
+	VectorsBucketLSM           = "vectors"
+	VectorsCompressedBucketLSM = "vectors_compressed"
 	DimensionsBucketLSM        = "dimensions"
 	DocIDBucket                = []byte("doc_ids")
 )

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -20,18 +20,10 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/flat"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/noop"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
-	"github.com/weaviate/weaviate/entities/vectorindex/common"
-	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
-	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
 )
@@ -294,96 +286,12 @@ func (s *Shard) reinit(ctx context.Context) error {
 		return fmt.Errorf("shutdown shard: %w", err)
 	}
 
-	var distProv distancer.Provider
-	index := s.index
-
-	switch index.vectorIndexUserConfig.DistanceName() {
-	case "", common.DistanceCosine:
-		distProv = distancer.NewCosineDistanceProvider()
-	case common.DistanceDot:
-		distProv = distancer.NewDotProductProvider()
-	case common.DistanceL2Squared:
-		distProv = distancer.NewL2SquaredProvider()
-	case common.DistanceManhattan:
-		distProv = distancer.NewManhattanProvider()
-	case common.DistanceHamming:
-		distProv = distancer.NewHammingProvider()
-	default:
-		return fmt.Errorf("init vector index: %w",
-			errors.Errorf("unrecognized distance metric %q,"+
-				"choose one of [\"cosine\", \"dot\", \"l2-squared\", \"manhattan\",\"hamming\"]", index.vectorIndexUserConfig.DistanceName()))
-	}
-
-	switch index.vectorIndexUserConfig.IndexType() {
-	case "hnsw":
-		hnswUserConfig, ok := index.vectorIndexUserConfig.(hnswent.UserConfig)
-		if !ok {
-			return errors.Errorf("hnsw vector index: config is not hnsw.UserConfig: %T",
-				index.vectorIndexUserConfig)
-		}
-
-		if hnswUserConfig.Skip {
-			s.vectorIndex = noop.NewIndex()
-		} else {
-			// starts vector cycles if vector is configured
-			s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
-			s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
-
-			vi, err := hnsw.New(hnsw.Config{
-				Logger:               s.index.logger,
-				RootPath:             s.index.Config.RootPath,
-				ID:                   s.ID(),
-				ShardName:            s.name,
-				ClassName:            s.index.Config.ClassName.String(),
-				PrometheusMetrics:    s.promMetrics,
-				VectorForIDThunk:     s.vectorByIndexID,
-				TempVectorForIDThunk: s.readVectorByIndexIDIntoSlice,
-				DistanceProvider:     distProv,
-				MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
-					return hnsw.NewCommitLogger(s.index.Config.RootPath, s.ID(),
-						s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks)
-				},
-			}, hnswUserConfig,
-				s.cycleCallbacks.vectorTombstoneCleanupCallbacks, s.cycleCallbacks.compactionCallbacks, s.cycleCallbacks.flushCallbacks)
-			if err != nil {
-				return errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
-			}
-			s.vectorIndex = vi
-
-			defer s.vectorIndex.PostStartup()
-		}
-	case "flat":
-		flatUserConfig, ok := index.vectorIndexUserConfig.(flatent.UserConfig)
-		if !ok {
-			return errors.Errorf("flat vector index: config is not flat.UserConfig: %T",
-				index.vectorIndexUserConfig)
-		}
-		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
-		vi, err := flat.New(hnsw.Config{
-			Logger:               s.index.logger,
-			RootPath:             s.index.Config.RootPath,
-			ID:                   s.ID(),
-			ShardName:            s.name,
-			ClassName:            s.index.Config.ClassName.String(),
-			PrometheusMetrics:    s.promMetrics,
-			VectorForIDThunk:     s.vectorByIndexID,
-			TempVectorForIDThunk: s.readVectorByIndexIDIntoSlice,
-			DistanceProvider:     distProv,
-			MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
-				return hnsw.NewCommitLogger(s.index.Config.RootPath, s.ID(),
-					s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks)
-			},
-		}, flatUserConfig, s.cycleCallbacks.compactionCallbacks, s.cycleCallbacks.flushCallbacks)
-		if err != nil {
-			return errors.Wrapf(err, "init shard %q: flat index", s.ID())
-		}
-		s.vectorIndex = vi
-	default:
-		return fmt.Errorf("Unknown vector index type: %q. Choose one from [\"hnsw\", \"flat\"]", index.vectorIndexUserConfig.IndexType())
-	}
-
 	if err := s.initNonVector(ctx, nil); err != nil {
-		return fmt.Errorf("init non-vector: %w", err)
+		return fmt.Errorf("reinit non-vector: %w", err)
+	}
+
+	if err := s.initVector(ctx); err != nil {
+		return fmt.Errorf("reinit vector: %w", err)
 	}
 
 	return nil

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -37,6 +37,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -152,9 +153,35 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, err
 	}
 
+	if err := s.initNonVector(ctx, class); err != nil {
+		return nil, errors.Wrapf(err, "init shard %q", s.ID())
+	}
+
+	if err := s.initVector(ctx); err != nil {
+		return nil, err
+	}
+
+	var err error
+	s.queue, err = NewIndexQueue(s.ID(), s, s.vectorIndex, s.centralJobQueue, s.indexCheckpoints, IndexQueueOptions{
+		Logger: s.index.logger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.queue.PreloadShard(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	s.notifyReady()
+
+	return s, nil
+}
+
+func (s *Shard) initVector(ctx context.Context) error {
 	var distProv distancer.Provider
 
-	switch index.vectorIndexUserConfig.DistanceName() {
+	switch s.index.vectorIndexUserConfig.DistanceName() {
 	case "", common.DistanceCosine:
 		distProv = distancer.NewCosineDistanceProvider()
 	case common.DistanceDot:
@@ -166,17 +193,17 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	case common.DistanceHamming:
 		distProv = distancer.NewHammingProvider()
 	default:
-		return nil, fmt.Errorf("init vector index: %w",
+		return fmt.Errorf("init vector index: %w",
 			errors.Errorf("unrecognized distance metric %q,"+
-				"choose one of [\"cosine\", \"dot\", \"l2-squared\", \"manhattan\",\"hamming\"]", index.vectorIndexUserConfig.DistanceName()))
+				"choose one of [\"cosine\", \"dot\", \"l2-squared\", \"manhattan\",\"hamming\"]", s.index.vectorIndexUserConfig.DistanceName()))
 	}
 
-	switch index.vectorIndexUserConfig.IndexType() {
-	case "hnsw":
-		hnswUserConfig, ok := index.vectorIndexUserConfig.(hnswent.UserConfig)
+	switch s.index.vectorIndexUserConfig.IndexType() {
+	case vectorindex.VectorIndexTypeHNSW:
+		hnswUserConfig, ok := s.index.vectorIndexUserConfig.(hnswent.UserConfig)
 		if !ok {
-			return nil, errors.Errorf("hnsw vector index: config is not hnsw.UserConfig: %T",
-				index.vectorIndexUserConfig)
+			return errors.Errorf("hnsw vector index: config is not hnsw.UserConfig: %T",
+				s.index.vectorIndexUserConfig)
 		}
 
 		if hnswUserConfig.Skip {
@@ -210,17 +237,17 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 			}, hnswUserConfig,
 				s.cycleCallbacks.vectorTombstoneCleanupCallbacks, s.cycleCallbacks.compactionCallbacks, s.cycleCallbacks.flushCallbacks)
 			if err != nil {
-				return nil, errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
+				return errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
 			}
 			s.vectorIndex = vi
 
 			defer s.vectorIndex.PostStartup()
 		}
-	case "flat":
-		flatUserConfig, ok := index.vectorIndexUserConfig.(flatent.UserConfig)
+	case vectorindex.VectorIndexTypeFLAT:
+		flatUserConfig, ok := s.index.vectorIndexUserConfig.(flatent.UserConfig)
 		if !ok {
-			return nil, errors.Errorf("flat vector index: config is not flat.UserConfig: %T",
-				index.vectorIndexUserConfig)
+			return errors.Errorf("flat vector index: config is not flat.UserConfig: %T",
+				s.index.vectorIndexUserConfig)
 		}
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 
@@ -232,47 +259,29 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		vecIdxID := "main"
 
 		vi, err := flat.New(hnsw.Config{
-			Logger:               s.index.logger,
-			RootPath:             s.path(),
-			ID:                   vecIdxID,
-			ShardName:            s.name,
-			ClassName:            s.index.Config.ClassName.String(),
-			PrometheusMetrics:    s.promMetrics,
-			VectorForIDThunk:     s.vectorByIndexID,
-			TempVectorForIDThunk: s.readVectorByIndexIDIntoSlice,
-			DistanceProvider:     distProv,
+			Logger:            s.index.logger,
+			RootPath:          s.path(),
+			ID:                vecIdxID,
+			ShardName:         s.name,
+			ClassName:         s.index.Config.ClassName.String(),
+			PrometheusMetrics: s.promMetrics,
+			VectorForIDThunk:  func(ctx context.Context, indexID uint64) ([]float32, error) { return nil, nil },
+			DistanceProvider:  distProv,
 			MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
 				return hnsw.NewCommitLogger(s.path(), vecIdxID,
 					s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks)
 			},
 		}, flatUserConfig, s.cycleCallbacks.compactionCallbacks, s.cycleCallbacks.flushCallbacks)
 		if err != nil {
-			return nil, errors.Wrapf(err, "init shard %q: flat index", s.ID())
+			return errors.Wrapf(err, "init shard %q: flat index", s.ID())
 		}
 		s.vectorIndex = vi
 	default:
-		return nil, fmt.Errorf("Unknown vector index type: %q. Choose one from [\"hnsw\", \"flat\"]", index.vectorIndexUserConfig.IndexType())
+		return fmt.Errorf("Unknown vector index type: %q. Choose one from [\"%s\", \"%s\"]",
+			s.index.vectorIndexUserConfig.IndexType(), vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT)
 	}
 
-	if err := s.initNonVector(ctx, class); err != nil {
-		return nil, errors.Wrapf(err, "init shard %q", s.ID())
-	}
-
-	var err error
-	s.queue, err = NewIndexQueue(s.ID(), s, s.vectorIndex, s.centralJobQueue, s.indexCheckpoints, IndexQueueOptions{
-		Logger: s.index.logger,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.queue.PreloadShard(ctx, s)
-	if err != nil {
-		return nil, err
-	}
-	s.notifyReady()
-
-	return s, nil
+	return nil
 }
 
 func (s *Shard) initNonVector(ctx context.Context, class *models.Class) error {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -271,7 +271,7 @@ func (s *Shard) initVector(ctx context.Context) error {
 				return hnsw.NewCommitLogger(s.path(), vecIdxID,
 					s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks)
 			},
-		}, flatUserConfig, s.cycleCallbacks.compactionCallbacks, s.cycleCallbacks.flushCallbacks)
+		}, flatUserConfig, s.store)
 		if err != nil {
 			return errors.Wrapf(err, "init shard %q: flat index", s.ID())
 		}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -31,7 +30,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
-	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/schema"
 	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
@@ -52,16 +50,10 @@ type flat struct {
 	pqResults   *common.PqMaxPool
 	pool        *pools
 
-	shardCompactionCallbacks cyclemanager.CycleCallbackGroup
-	shardFlushCallbacks      cyclemanager.CycleCallbackGroup
-
 	compression string
 }
 
-func New(
-	cfg hnsw.Config, uc flatent.UserConfig,
-	shardCompactionCallbacks, shardFlushCallbacks cyclemanager.CycleCallbackGroup,
-) (*flat, error) {
+func New(cfg hnsw.Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config")
 	}
@@ -73,29 +65,28 @@ func New(
 	}
 
 	index := &flat{
-		id:                       cfg.ID,
-		logger:                   cfg.Logger,
-		distancerProvider:        cfg.DistanceProvider,
-		ef:                       int64(uc.EF),
-		shardName:                cfg.ShardName,
-		tempVectors:              common.NewTempVectorsPool(),
-		pqResults:                common.NewPqMaxPool(100),
-		compression:              uc.Compression,
-		shardCompactionCallbacks: shardCompactionCallbacks,
-		shardFlushCallbacks:      shardFlushCallbacks,
-		pool:                     newPools(),
+		id:                cfg.ID,
+		logger:            cfg.Logger,
+		distancerProvider: cfg.DistanceProvider,
+		ef:                int64(uc.EF),
+		shardName:         cfg.ShardName,
+		tempVectors:       common.NewTempVectorsPool(),
+		pqResults:         common.NewPqMaxPool(100),
+		compression:       uc.Compression,
+		pool:              newPools(),
+		store:             store,
 	}
-	index.initStore(cfg.RootPath, cfg.ClassName)
+	index.initBuckets(context.Background())
 
 	return index, nil
 }
 
 func (h *flat) storeCompressedVector(index uint64, vector []byte) {
-	h.storeGenericVector(index, vector, helpers.CompressedObjectsBucketLSM)
+	h.storeGenericVector(index, vector, helpers.VectorsCompressedBucketLSM)
 }
 
 func (h *flat) storeVector(index uint64, vector []byte) {
-	h.storeGenericVector(index, vector, helpers.ObjectsBucketLSM)
+	h.storeGenericVector(index, vector, helpers.VectorsBucketLSM)
 }
 
 func (h *flat) storeGenericVector(index uint64, vector []byte, bucket string) {
@@ -104,26 +95,17 @@ func (h *flat) storeGenericVector(index uint64, vector []byte, bucket string) {
 	h.store.Bucket(bucket).Put(Id, vector)
 }
 
-func (index *flat) initStore(rootPath, className string) error {
-	ctx := context.Background()
-
-	storeDir := path.Join(rootPath, "flat")
-	store, err := lsmkv.New(storeDir, rootPath, index.logger, nil,
-		index.shardCompactionCallbacks, index.shardFlushCallbacks)
-	if err != nil {
-		return errors.Wrap(err, "Init lsmkv (compressed vectors store)")
-	}
-	err = store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM, lsmkv.WithForceCompation(true))
-	if err != nil {
-		return errors.Wrapf(err, "Create or load bucket (vectors store)")
+func (index *flat) initBuckets(ctx context.Context) error {
+	if err := index.store.CreateOrLoadBucket(ctx, helpers.VectorsBucketLSM,
+		lsmkv.WithForceCompation(true)); err != nil {
+		return fmt.Errorf("Create or load flat vectors bucket: %w", err)
 	}
 	if index.compression != flatent.CompressionNone {
-		err = store.CreateOrLoadBucket(ctx, helpers.CompressedObjectsBucketLSM, lsmkv.WithForceCompation(true))
-		if err != nil {
-			return errors.Wrapf(err, "Create or load bucket (compressed vectors store)")
+		if err := index.store.CreateOrLoadBucket(ctx, helpers.VectorsCompressedBucketLSM,
+			lsmkv.WithForceCompation(true)); err != nil {
+			return fmt.Errorf("Create or load flat compressed vectors bucket: %w", err)
 		}
 	}
-	index.store = store
 	return nil
 }
 
@@ -203,14 +185,14 @@ func (index *flat) Delete(ids ...uint64) error {
 	for _, i := range ids {
 		id := make([]byte, 8)
 		binary.BigEndian.PutUint64(id, uint64(i))
-		err := index.store.Bucket(helpers.ObjectsBucketLSM).Delete(id)
+		err := index.store.Bucket(helpers.VectorsBucketLSM).Delete(id)
 		if err != nil {
 			return err
 		}
 		if index.compression == flatent.CompressionNone {
 			continue
 		}
-		err = index.store.Bucket(helpers.CompressedObjectsBucketLSM).Delete(id)
+		err = index.store.Bucket(helpers.VectorsCompressedBucketLSM).Delete(id)
 		if err != nil {
 			return err
 		}
@@ -248,7 +230,7 @@ func (index *flat) searchByVector(vector []float32, k int, allow helpers.AllowLi
 	vector = index.normalized(vector)
 
 	if err := index.findTopVectors(heap, allow, k,
-		index.store.Bucket(helpers.ObjectsBucketLSM).Cursor,
+		index.store.Bucket(helpers.VectorsBucketLSM).Cursor,
 		index.distanceFn(vector),
 	); err != nil {
 		return nil, nil, err
@@ -281,7 +263,7 @@ func (index *flat) searchByVectorBQ(vector []float32, k int, allow helpers.Allow
 	}
 
 	if err := index.findTopVectors(heap, allow, ef,
-		index.store.Bucket(helpers.CompressedObjectsBucketLSM).Cursor,
+		index.store.Bucket(helpers.VectorsCompressedBucketLSM).Cursor,
 		index.distanceFnBQ(vectorBQ),
 	); err != nil {
 		return nil, nil, err
@@ -325,7 +307,7 @@ func (index *flat) vectorById(id uint64) ([]byte, error) {
 	defer index.pool.byteSlicePool.Put(idSlice)
 
 	binary.BigEndian.PutUint64(idSlice.slice, id)
-	return index.store.Bucket(helpers.ObjectsBucketLSM).Get(idSlice.slice)
+	return index.store.Bucket(helpers.VectorsBucketLSM).Get(idSlice.slice)
 }
 
 // populates given heap with smallest distances and corresponding ids calculated by
@@ -484,6 +466,8 @@ func (index *flat) UpdateUserConfig(updated schema.VectorIndexConfig, callback f
 }
 
 func (index *flat) Drop(ctx context.Context) error {
+	// nothing to do here
+	// Shard::drop will take care of handling store's buckets
 	return nil
 }
 
@@ -492,10 +476,9 @@ func (index *flat) Flush() error {
 }
 
 func (index *flat) Shutdown(ctx context.Context) error {
-	if err := index.store.Shutdown(ctx); err != nil {
-		return errors.Wrap(err, "flat shutdown")
-	}
-	return index.Drop(ctx)
+	// nothing to do here
+	// Shard::shutdown will take care of handling store's buckets
+	return nil
 }
 
 func (index *flat) SwitchCommitLogs(context.Context) error {
@@ -503,7 +486,9 @@ func (index *flat) SwitchCommitLogs(context.Context) error {
 }
 
 func (index *flat) ListFiles(ctx context.Context, basePath string) ([]string, error) {
-	return nil, nil
+	// nothing to do here
+	// Shard::listBackupFiles will take care of handling store's buckets
+	return []string{}, nil
 }
 
 func (i *flat) ValidateBeforeInsert(vector []float32) error {

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/flat"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
@@ -55,6 +56,12 @@ func run(dirName string, logger *logrus.Logger, compression string,
 	queries_size := len(queries)
 	runId := uuid.New().String()
 
+	store, err := lsmkv.New(dirName, dirName, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	if err != nil {
+		return 0, 0, err
+	}
+
 	index, err := flat.New(hnsw.Config{
 		RootPath:              dirName,
 		ID:                    runId,
@@ -65,7 +72,7 @@ func run(dirName string, logger *logrus.Logger, compression string,
 	}, flatent.UserConfig{
 		Compression: compression,
 		EF:          100 * k,
-	}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	}, store)
 	if err != nil {
 		return 0, 0, err
 	}


### PR DESCRIPTION
### What's being changed:
Brute force index's buckets will be created inside `data/{class}/{shard}/lsm` directory as ~~`vectors`~~ `vectors_flat` and ~~`vectors_compressed`~~ `vectors_flat_bq` subdirectories (next to `objects`, `dimensions`, `property_xyz`)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
