### PR TITLE
Create nonexistent tenants in batch by default

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3925,6 +3925,11 @@ func init() {
     "MultiTenancyConfig": {
       "description": "Configuration related to multi-tenancy within a class",
       "properties": {
+        "autoTenantCreation": {
+          "description": "Nonexistent tenants should (not) be created implicitly",
+          "type": "boolean",
+          "x-omitempty": false
+        },
         "enabled": {
           "description": "Whether or not multi-tenancy is enabled for this class",
           "type": "boolean",
@@ -9115,6 +9120,11 @@ func init() {
     "MultiTenancyConfig": {
       "description": "Configuration related to multi-tenancy within a class",
       "properties": {
+        "autoTenantCreation": {
+          "description": "Nonexistent tenants should (not) be created implicitly",
+          "type": "boolean",
+          "x-omitempty": false
+        },
         "enabled": {
           "description": "Whether or not multi-tenancy is enabled for this class",
           "type": "boolean",

--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -19,12 +19,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/errors"
-	"github.com/weaviate/weaviate/usecases/monitoring"
-	"github.com/weaviate/weaviate/usecases/schema"
-
 	middleware "github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
 	tailorincgraphql "github.com/tailor-inc/graphql"
 	"github.com/tailor-inc/graphql/gqlerrors"
 	libgraphql "github.com/weaviate/weaviate/adapters/handlers/graphql"
@@ -32,6 +28,9 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/graphql"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/schema"
 )
 
 const error422 string = "The request is well-formed but was unable to be followed due to semantic errors."

--- a/adapters/repos/db/vector/flat/config_update_test.go
+++ b/adapters/repos/db/vector/flat/config_update_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	schema "github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/entities/schema/config"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/flat"
 )
 
@@ -25,8 +25,8 @@ func TestFlatUserConfigUpdates(t *testing.T) {
 	t.Run("various immutable and mutable fields", func(t *testing.T) {
 		type test struct {
 			name          string
-			initial       schema.VectorIndexConfig
-			update        schema.VectorIndexConfig
+			initial       config.VectorIndexConfig
+			update        config.VectorIndexConfig
 			expectedError error
 		}
 

--- a/entities/models/multi_tenancy_config.go
+++ b/entities/models/multi_tenancy_config.go
@@ -28,6 +28,9 @@ import (
 // swagger:model MultiTenancyConfig
 type MultiTenancyConfig struct {
 
+	// Nonexistent tenants should (not) be created implicitly
+	AutoTenantCreation bool `json:"autoTenantCreation"`
+
 	// Whether or not multi-tenancy is enabled for this class
 	Enabled bool `json:"enabled"`
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -418,6 +418,11 @@
           "description": "Whether or not multi-tenancy is enabled for this class",
           "type": "boolean",
           "x-omitempty": false
+        },
+        "autoTenantCreation": {
+          "description": "Nonexistent tenants should (not) be created implicitly",
+          "type": "boolean",
+          "x-omitempty": false
         }
       }
     },

--- a/test/acceptance/multi_tenancy/batch_add_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/batch_add_tenant_objects_test.go
@@ -12,25 +12,54 @@
 package test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
-
-	"github.com/weaviate/weaviate/client/batch"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/batch"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
 func TestBatchAddTenantObjects(t *testing.T) {
+	tests := []func(*testing.T, bool){
+		testBatchAddTenantObjects,
+		testBatchAddTenantObjectsWithMixedClasses,
+		testBatchWithMixedTenants,
+		testAddNonTenantBatchToMultiClass,
+		testAddBatchWithNonExistentTenant,
+	}
+
+	withImplicitTenantCreation(t, tests)
+	withExplicitTenantCreation(t, tests)
+}
+
+func withImplicitTenantCreation(t *testing.T, tests []func(*testing.T, bool)) {
+	for _, test := range tests {
+		t.Run("with implicit tenant creation", func(t *testing.T) {
+			test(t, true)
+		})
+	}
+}
+
+func withExplicitTenantCreation(t *testing.T, tests []func(*testing.T, bool)) {
+	for _, test := range tests {
+		t.Run("with explicit tenant creation", func(t *testing.T) {
+			test(t, false)
+		})
+	}
+}
+
+func testBatchAddTenantObjects(t *testing.T, implicitTenants bool) {
 	testClass := models.Class{
 		Class: "MultiTenantClass",
 		MultiTenancyConfig: &models.MultiTenancyConfig{
-			Enabled: true,
+			Enabled:            true,
+			AutoTenantCreation: implicitTenants,
 		},
 		Properties: []*models.Property{
 			{
@@ -72,7 +101,9 @@ func TestBatchAddTenantObjects(t *testing.T) {
 		helper.DeleteClass(t, testClass.Class)
 	}()
 
-	helper.CreateTenants(t, testClass.Class, []*models.Tenant{{Name: tenantName}})
+	if !implicitTenants {
+		helper.CreateTenants(t, testClass.Class, []*models.Tenant{{Name: tenantName}})
+	}
 
 	t.Run("add and get tenant objects", func(t *testing.T) {
 		helper.CreateObjectsBatch(t, tenantObjects)
@@ -87,26 +118,118 @@ func TestBatchAddTenantObjects(t *testing.T) {
 	})
 }
 
-func TestBatchWithMixedTenants(t *testing.T) {
+func testBatchAddTenantObjectsWithMixedClasses(t *testing.T, implicitTenants bool) {
+	testClass1 := models.Class{
+		Class: "MultiTenantClass1",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled:            true,
+			AutoTenantCreation: implicitTenants,
+		},
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: schema.DataTypeText.PropString(),
+			},
+		},
+	}
+	testClass2 := models.Class{
+		Class: "MultiTenantClass2",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled:            true,
+			AutoTenantCreation: implicitTenants,
+		},
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: schema.DataTypeText.PropString(),
+			},
+		},
+	}
+	tenantName := "Tenant1"
+	tenantObjects := []*models.Object{
+		{
+			ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
+			Class: testClass1.Class,
+			Properties: map[string]interface{}{
+				"name": tenantName,
+			},
+			Tenant: tenantName,
+		},
+		{
+			ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
+			Class: testClass2.Class,
+			Properties: map[string]interface{}{
+				"name": tenantName,
+			},
+			Tenant: tenantName,
+		},
+		{
+			ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
+			Class: testClass1.Class,
+			Properties: map[string]interface{}{
+				"name": tenantName,
+			},
+			Tenant: tenantName,
+		},
+		{
+			ID:    "dd5a3cdb-1bba-4a2b-b173-dad4fabd0326",
+			Class: testClass2.Class,
+			Properties: map[string]interface{}{
+				"name": tenantName,
+			},
+			Tenant: tenantName,
+		},
+	}
+
+	helper.CreateClass(t, &testClass1)
+	helper.CreateClass(t, &testClass2)
+	if !implicitTenants {
+		helper.CreateTenants(t, testClass1.Class, []*models.Tenant{{Name: tenantName}})
+		helper.CreateTenants(t, testClass2.Class, []*models.Tenant{{Name: tenantName}})
+	}
+
+	defer func() {
+		helper.DeleteClass(t, testClass1.Class)
+		helper.DeleteClass(t, testClass2.Class)
+	}()
+
+	t.Run("add and get tenant objects", func(t *testing.T) {
+		helper.CreateObjectsBatch(t, tenantObjects)
+
+		for _, obj := range tenantObjects {
+			resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantName)
+			require.Nil(t, err)
+			assert.Equal(t, obj.ID, resp.ID)
+			assert.Equal(t, obj.Class, resp.Class)
+			assert.Equal(t, obj.Tenant, resp.Tenant)
+		}
+	})
+}
+
+func testBatchWithMixedTenants(t *testing.T, implicitTenants bool) {
 	className := "MultiTenantClassMixedBatchFail"
 	classes := []models.Class{
 		{
 			Class: className + "1",
 			MultiTenancyConfig: &models.MultiTenancyConfig{
-				Enabled: true,
+				Enabled:            true,
+				AutoTenantCreation: implicitTenants,
 			},
 		}, {
 			Class: className + "2",
 			MultiTenancyConfig: &models.MultiTenancyConfig{
-				Enabled: true,
+				Enabled:            true,
+				AutoTenantCreation: implicitTenants,
 			},
 		},
 	}
 	tenants := []string{"tenant1", "tenant2", "tenant3"}
 	for i := range classes {
 		helper.CreateClass(t, &classes[i])
-		for k := range tenants {
-			helper.CreateTenants(t, classes[i].Class, []*models.Tenant{{Name: tenants[k]}})
+		if !implicitTenants {
+			for k := range tenants {
+				helper.CreateTenants(t, classes[i].Class, []*models.Tenant{{Name: tenants[k]}})
+			}
 		}
 	}
 	defer func() {
@@ -135,12 +258,13 @@ func TestBatchWithMixedTenants(t *testing.T) {
 	}
 }
 
-func TestAddNonTenantBatchToMultiClass(t *testing.T) {
+func testAddNonTenantBatchToMultiClass(t *testing.T, implicitTenants bool) {
 	className := "MultiTenantClassBatchFail"
 	testClass := models.Class{
 		Class: className,
 		MultiTenancyConfig: &models.MultiTenancyConfig{
-			Enabled: true,
+			Enabled:            true,
+			AutoTenantCreation: implicitTenants,
 		},
 	}
 	nonTenantObjects := []*models.Object{
@@ -162,7 +286,67 @@ func TestAddNonTenantBatchToMultiClass(t *testing.T) {
 	defer func() {
 		helper.DeleteClass(t, testClass.Class)
 	}()
-	helper.CreateTenants(t, className, []*models.Tenant{{Name: "randomTenant1"}})
+	if !implicitTenants {
+		helper.CreateTenants(t, className, []*models.Tenant{{Name: "randomTenant1"}})
+	}
+	params := batch.NewBatchObjectsCreateParams().
+		WithBody(batch.BatchObjectsCreateBody{
+			Objects: nonTenantObjects,
+		})
+	resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
+	if implicitTenants {
+		require.Nil(t, resp)
+		require.NotNil(t, err)
+		batchErr := &batch.BatchObjectsCreateInternalServerError{}
+		as := errors.As(err, &batchErr)
+		require.True(t, as)
+		require.NotNil(t, batchErr.Payload)
+		require.Len(t, batchErr.Payload.Error, 1)
+		require.Contains(t, batchErr.Payload.Error[0].Message, "empty tenant name")
+	} else {
+		require.NotNil(t, resp)
+		require.Nil(t, err)
+		for _, r := range resp.Payload {
+			require.NotEmpty(t, r.Result.Errors.Error[0].Message)
+		}
+	}
+}
+
+func testAddBatchWithNonExistentTenant(t *testing.T, implicitTenants bool) {
+	className := "MultiTenantClassBatchFail"
+	testClass := models.Class{
+		Class: className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled:            true,
+			AutoTenantCreation: implicitTenants,
+		},
+	}
+	nonTenantObjects := []*models.Object{
+		{
+			ID:     "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
+			Class:  testClass.Class,
+			Tenant: "something",
+		},
+		{
+			ID:     "831ae1d0-f441-44b1-bb2a-46548048e26f",
+			Class:  testClass.Class,
+			Tenant: "something",
+		},
+		{
+			ID:     "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
+			Class:  testClass.Class,
+			Tenant: "something",
+		},
+	}
+
+	helper.CreateClass(t, &testClass)
+	defer func() {
+		helper.DeleteClass(t, testClass.Class)
+	}()
+	if !implicitTenants {
+		helper.CreateTenants(t, className, []*models.Tenant{{Name: "somethingElse"}})
+	}
+
 	params := batch.NewBatchObjectsCreateParams().
 		WithBody(batch.BatchObjectsCreateBody{
 			Objects: nonTenantObjects,
@@ -170,7 +354,11 @@ func TestAddNonTenantBatchToMultiClass(t *testing.T) {
 	resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
 	require.Nil(t, err)
 	for i := range resp.Payload {
-		require.NotNil(t, resp.Payload[i].Result.Errors)
+		if !implicitTenants {
+			require.NotNil(t, resp.Payload[i].Result.Errors)
+		} else {
+			require.Nil(t, resp.Payload[i].Result.Errors)
+		}
 	}
 }
 
@@ -207,49 +395,6 @@ func TestAddBatchToNonMultiClass(t *testing.T) {
 	params := batch.NewBatchObjectsCreateParams().
 		WithBody(batch.BatchObjectsCreateBody{
 			Objects: tenantObjects,
-		})
-	resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
-	require.Nil(t, err)
-	for i := range resp.Payload {
-		require.NotNil(t, resp.Payload[i].Result.Errors)
-	}
-}
-
-func TestAddBatchWithNonExistentTenant(t *testing.T) {
-	className := "MultiTenantClassBatchFail"
-	testClass := models.Class{
-		Class: className,
-		MultiTenancyConfig: &models.MultiTenancyConfig{
-			Enabled: true,
-		},
-	}
-	nonTenantObjects := []*models.Object{
-		{
-			ID:     "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
-			Class:  testClass.Class,
-			Tenant: "something",
-		},
-		{
-			ID:     "831ae1d0-f441-44b1-bb2a-46548048e26f",
-			Class:  testClass.Class,
-			Tenant: "something",
-		},
-		{
-			ID:     "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
-			Class:  testClass.Class,
-			Tenant: "something",
-		},
-	}
-
-	helper.CreateClass(t, &testClass)
-	defer func() {
-		helper.DeleteClass(t, testClass.Class)
-	}()
-	helper.CreateTenants(t, className, []*models.Tenant{{Name: "somethingElse"}})
-
-	params := batch.NewBatchObjectsCreateParams().
-		WithBody(batch.BatchObjectsCreateBody{
-			Objects: nonTenantObjects,
 		})
 	resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
 	require.Nil(t, err)

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -96,7 +96,10 @@ func testGetSchemaWithoutClient(t *testing.T) {
 						"vectorizeClassName": true,
 					},
 				},
-				"multiTenancyConfig": map[string]interface{}{"enabled": false},
+				"multiTenancyConfig": map[string]interface{}{
+					"enabled":            false,
+					"autoTenantCreation": false,
+				},
 			},
 		},
 	}

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -33,8 +33,8 @@ require (
 	go.mongodb.org/mongo-driver v1.12.1 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/grpc v1.59.0 // indirect

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -185,6 +185,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -197,6 +198,7 @@ golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190329151228-23e29df326fe/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190416151739-9c9e1878f421/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -28,6 +28,8 @@ type schemaManager interface {
 	GetSchema(principal *models.Principal) (schema.Schema, error)
 	AddClass(ctx context.Context, principal *models.Principal,
 		class *models.Class) error
+	AddTenants(ctx context.Context, principal *models.Principal,
+		class string, tenants []*models.Tenant) (err error)
 	GetClass(ctx context.Context, principal *models.Principal,
 		name string,
 	) (*models.Class, error)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -37,6 +37,7 @@ type schemaManager interface {
 		class string, property *models.Property) error
 	MergeClassObjectProperty(ctx context.Context, principal *models.Principal,
 		class string, property *models.Property) error
+	MultiTenancy(class string) models.MultiTenancyConfig
 }
 
 // AddObject Class Instance to the connected DB.

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -492,3 +492,73 @@ func (m *autoSchemaManager) determineNestedPropertiesOfArray(valArray []interfac
 
 	return nestedProperties, nil
 }
+
+type classTenants map[*models.Class]map[string]struct{}
+
+func (m *autoSchemaManager) autoTenants(ctx context.Context,
+	principal *models.Principal, objects []*models.Object,
+) error {
+	ct := make(classTenants)
+
+	for _, obj := range objects {
+		// TODO: track the classes we have already checked
+		//       before calling getClass again
+		o := models.Object{Class: obj.Class}
+		class, err := m.getClass(principal, &o)
+		if err != nil {
+			return err
+		}
+
+		// class not found in schema. this will have already
+		// been caught by b.validateObjectsConcurrently, and
+		// will be handled accordingly, so we don't need to
+		// do anything here
+		if class == nil {
+			continue
+		}
+
+		if shouldAutoCreateTenants(class) {
+			cls, ok := ct[class]
+			if !ok {
+				ct[class] = map[string]struct{}{obj.Tenant: {}}
+				continue
+			}
+			cls[obj.Tenant] = struct{}{}
+		}
+	}
+
+	for c, ts := range ct {
+		l := make([]*models.Tenant, len(ts))
+		i := 0
+		for t := range ts {
+			l[i] = &models.Tenant{Name: t}
+			i++
+		}
+		if err := m.addTenants(ctx, principal, c, l); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *autoSchemaManager) addTenants(ctx context.Context, principal *models.Principal,
+	class *models.Class, tenants []*models.Tenant,
+) error {
+	if len(tenants) == 0 {
+		return fmt.Errorf(
+			"tenants must be included for multitenant-enabled class %q", class.Class)
+	}
+	if err := m.schemaManager.AddTenants(ctx, principal, class.Class, tenants); err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			return err
+		}
+	}
+	return nil
+}
+
+func shouldAutoCreateTenants(class *models.Class) bool {
+	if class.MultiTenancyConfig == nil {
+		return false
+	}
+	return class.MultiTenancyConfig.Enabled && class.MultiTenancyConfig.AutoTenantCreation
+}

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -493,72 +493,47 @@ func (m *autoSchemaManager) determineNestedPropertiesOfArray(valArray []interfac
 	return nestedProperties, nil
 }
 
-type classTenants map[*models.Class]map[string]struct{}
-
 func (m *autoSchemaManager) autoTenants(ctx context.Context,
 	principal *models.Principal, objects []*models.Object,
 ) error {
-	ct := make(classTenants)
+	classTenants := make(map[string]map[string]struct{})
 
 	for _, obj := range objects {
 		// TODO: track the classes we have already checked
 		//       before calling getClass again
-		o := models.Object{Class: obj.Class}
-		class, err := m.getClass(principal, &o)
-		if err != nil {
-			return err
-		}
-
-		// class not found in schema. this will have already
-		// been caught by b.validateObjectsConcurrently, and
-		// will be handled accordingly, so we don't need to
-		// do anything here
-		if class == nil {
-			continue
-		}
-
-		if shouldAutoCreateTenants(class) {
-			cls, ok := ct[class]
+		if m.schemaManager.MultiTenancy(obj.Class).AutoTenantCreation {
+			cls, ok := classTenants[obj.Class]
 			if !ok {
-				ct[class] = map[string]struct{}{obj.Tenant: {}}
+				classTenants[obj.Class] = map[string]struct{}{obj.Tenant: {}}
 				continue
 			}
 			cls[obj.Tenant] = struct{}{}
 		}
 	}
 
-	for c, ts := range ct {
-		l := make([]*models.Tenant, len(ts))
+	for class, tenantNames := range classTenants {
+		tenants := make([]*models.Tenant, len(tenantNames))
 		i := 0
-		for t := range ts {
-			l[i] = &models.Tenant{Name: t}
+		for name := range tenantNames {
+			tenants[i] = &models.Tenant{Name: name}
 			i++
 		}
-		if err := m.addTenants(ctx, principal, c, l); err != nil {
-			return err
+		if err := m.addTenants(ctx, principal, class, tenants); err != nil {
+			return fmt.Errorf("add tenants to class %q: %w", class, err)
 		}
 	}
 	return nil
 }
 
 func (m *autoSchemaManager) addTenants(ctx context.Context, principal *models.Principal,
-	class *models.Class, tenants []*models.Tenant,
+	class string, tenants []*models.Tenant,
 ) error {
 	if len(tenants) == 0 {
 		return fmt.Errorf(
-			"tenants must be included for multitenant-enabled class %q", class.Class)
+			"tenants must be included for multitenant-enabled class %q", class)
 	}
-	if err := m.schemaManager.AddTenants(ctx, principal, class.Class, tenants); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			return err
-		}
+	if err := m.schemaManager.AddTenants(ctx, principal, class, tenants); err != nil {
+		return err
 	}
 	return nil
-}
-
-func shouldAutoCreateTenants(class *models.Class) bool {
-	if class.MultiTenancyConfig == nil {
-		return false
-	}
-	return class.MultiTenancyConfig.Enabled && class.MultiTenancyConfig.AutoTenantCreation
 }

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -147,6 +147,10 @@ func (f *fakeSchemaManager) MergeClassObjectProperty(ctx context.Context, princi
 	return nil
 }
 
+func (f *fakeSchemaManager) MultiTenancy(class string) models.MultiTenancyConfig {
+	return models.MultiTenancyConfig{Enabled: f.tenantsEnabled}
+}
+
 type fakeLocks struct {
 	Err error
 }

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -45,6 +45,7 @@ type fakeSchemaManager struct {
 	}
 	GetSchemaResponse schema.Schema
 	GetschemaErr      error
+	tenantsEnabled    bool
 }
 
 func (f *fakeSchemaManager) UpdatePropertyAddDataType(ctx context.Context, principal *models.Principal,
@@ -98,6 +99,13 @@ func (f *fakeSchemaManager) AddClass(ctx context.Context, principal *models.Prin
 		classes = []*models.Class{class}
 	}
 	f.GetSchemaResponse.Objects.Classes = classes
+	return nil
+}
+
+func (f *fakeSchemaManager) AddTenants(ctx context.Context,
+	principal *models.Principal, class string, tenants []*models.Tenant,
+) error {
+	f.tenantsEnabled = true
 	return nil
 }
 

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -93,9 +93,9 @@ func (f *fakeMetaHandler) ClassEqual(name string) string {
 	return ""
 }
 
-func (f *fakeMetaHandler) MultiTenancy(class string) bool {
+func (f *fakeMetaHandler) MultiTenancy(class string) models.MultiTenancyConfig {
 	args := f.Called(class)
-	return args.Bool(0)
+	return args.Get(0).(models.MultiTenancyConfig)
 }
 
 func (f *fakeMetaHandler) ClassInfo(class string) (ci store.ClassInfo) {

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -47,7 +47,7 @@ type metaWriter interface {
 type metaReader interface {
 	ClassEqual(name string) string
 	// MultiTenancy checks for multi-tenancy support
-	MultiTenancy(class string) bool
+	MultiTenancy(class string) models.MultiTenancyConfig
 	ClassInfo(class string) (ci store.ClassInfo)
 	ReadOnlyClass(class string) *models.Class
 	ReadOnlySchema() models.Schema

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -100,8 +100,13 @@ func validateTenants(tenants []*models.Tenant) (validated []*models.Tenant, err 
 	uniq := make(map[string]*models.Tenant)
 	for i, requested := range tenants {
 		if !regexTenantName.MatchString(requested.Name) {
-			msg := "tenant name should only contain alphanumeric characters (a-z, A-Z, 0-9), " +
-				"underscore (_), and hyphen (-), with a length between 1 and 64 characters"
+			var msg string
+			if requested.Name == "" {
+				msg = "empty tenant name"
+			} else {
+				msg = "tenant name should only contain alphanumeric characters (a-z, A-Z, 0-9), " +
+					"underscore (_), and hyphen (-), with a length between 1 and 64 characters"
+			}
 			err = uco.NewErrInvalidUserInput("tenant name at index %d: %s", i, msg)
 			return
 		}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -242,7 +242,7 @@ func (h *Handler) multiTenancy(class string) (store.ClassInfo, error) {
 	if !info.Exists {
 		return info, fmt.Errorf("class %q: %w", class, ErrNotFound)
 	}
-	if !info.MultiTenancy {
+	if !info.MultiTenancy.Enabled {
 		return info, fmt.Errorf("multi-tenancy is not enabled for class %q", class)
 	}
 	return info, nil

--- a/usecases/schema/tenant_test.go
+++ b/usecases/schema/tenant_test.go
@@ -72,7 +72,8 @@ func TestAddTenants(t *testing.T) {
 			tenants: tenants,
 			errMsgs: []string{"not enabled"},
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -81,7 +82,8 @@ func TestAddTenants(t *testing.T) {
 			tenants: tenants,
 			errMsgs: []string{"not enabled"},
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -142,7 +144,8 @@ func TestAddTenants(t *testing.T) {
 			},
 			errMsgs: []string{},
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: true})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{Enabled: true}})
 				fakeMetaHandler.On("Read", mock.Anything, mock.Anything).Return(nil)
 				fakeMetaHandler.On("AddTenants", mock.Anything, mock.Anything).Return(nil)
 			},
@@ -228,7 +231,8 @@ func TestUpdateTenants(t *testing.T) {
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -238,7 +242,8 @@ func TestUpdateTenants(t *testing.T) {
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -315,7 +320,8 @@ func TestUpdateTenants(t *testing.T) {
 				{Name: tenants[1].Name, ActivityStatus: models.TenantActivityStatusCOLD},
 			},
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: true})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{Enabled: true}})
 				fakeMetaHandler.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 		},
@@ -398,7 +404,8 @@ func TestDeleteTenants(t *testing.T) {
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -408,7 +415,8 @@ func TestDeleteTenants(t *testing.T) {
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -418,7 +426,8 @@ func TestDeleteTenants(t *testing.T) {
 			errMsgs:         []string{ErrNotFound.Error()},
 			expectedTenants: tenants,
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: false, MultiTenancy: false})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: false, MultiTenancy: models.MultiTenancyConfig{}})
 			},
 		},
 		{
@@ -440,7 +449,8 @@ func TestDeleteTenants(t *testing.T) {
 			errMsgs:         []string{},
 			expectedTenants: tenants[2:],
 			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
-				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: true})
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(
+					store.ClassInfo{Exists: true, MultiTenancy: models.MultiTenancyConfig{Enabled: true}})
 				fakeMetaHandler.On("DeleteTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 		},


### PR DESCRIPTION
### What's being changed:

With `multiTenancyConfig.autoTenantCreation: true` on a multitenancy-enabled class, the autoschema creates any tenants which do not currently exist prior to inserting tenant objects.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
