### PR TITLE
Add support for OpenAI GPT-4 128k and GPT-3.5 preview models

### DIFF
--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -38,8 +38,10 @@ var availableOpenAILegacyModels = []string{
 var availableOpenAIModels = []string{
 	"gpt-3.5-turbo",
 	"gpt-3.5-turbo-16k",
+	"gpt-3.5-turbo-1106",
 	"gpt-4",
 	"gpt-4-32k",
+	"gpt-4-1106-preview",
 }
 
 var (
@@ -54,12 +56,14 @@ var (
 
 // todo Need to parse the tokenLimits in a smarter way, as the prompt defines the max length
 var defaultMaxTokens = map[string]float64{
-	"text-davinci-002":  4097,
-	"text-davinci-003":  4097,
-	"gpt-3.5-turbo":     4097,
-	"gpt-3.5-turbo-16k": 16384,
-	"gpt-4":             8192,
-	"gpt-4-32k":         32768,
+	"text-davinci-002":   4097,
+	"text-davinci-003":   4097,
+	"gpt-3.5-turbo":      4097,
+	"gpt-3.5-turbo-16k":  16384,
+	"gpt-3.5-turbo-1106": 16385,
+	"gpt-4":              8192,
+	"gpt-4-32k":          32768,
+	"gpt-4-1106-preview": 128000,
 }
 
 type ClassSettings interface {


### PR DESCRIPTION
### What's being changed:

This PR adds support for the newest OpenAI models announced during `OpenAI DevDay` event:
- `gpt-4-1106-preview`
- `gpt-3.5-turbo-1106`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
