### PR TITLE
Fix clusterapi comms when gRPC searching required UUID only

### DIFF
--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -89,6 +89,8 @@ func FromBinaryUUIDOnly(data []byte) (*Object, error) {
 		return nil, errors.Errorf("unsupported binary marshaller version %d", version)
 	}
 
+	ko.MarshallerVersion = version
+
 	ko.docID = rw.ReadUint64()
 	rw.MoveBufferPositionForward(1) // ignore kind-byte
 	uuidObj, err := uuid.FromBytes(rw.ReadBytesFromBuffer(16))


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug that occurs when performing a gRPC search requesting only the `Metadata.Uuid` field back on a replicated cluster

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
