### PR TITLE
Add support for overriding Cohere's base URL with X-Cohere-BaseURL HTTP header

### DIFF
--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -132,7 +132,7 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 
 func (v *cohere) getCohereUrl(ctx context.Context, baseURL string) (string, error) {
 	passedBaseURL := baseURL
-	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-BaseURL"); headerBaseURL != "" {
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
 		passedBaseURL = headerBaseURL
 	}
 	if passedBaseURL == "" {

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -36,8 +36,6 @@ var compile, _ = regexp.Compile(`{([\w\s]*?)}`)
 
 type cohere struct {
 	apiKey     string
-	host       string
-	path       string
 	httpClient *http.Client
 	logger     logrus.FieldLogger
 }
@@ -48,8 +46,6 @@ func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *coher
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
-		host:   "https://api.cohere.ai",
-		path:   "/v1/generate",
 		logger: logger,
 	}
 }
@@ -73,7 +69,7 @@ func (v *cohere) GenerateAllResults(ctx context.Context, textProperties []map[st
 func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string) (*generativemodels.GenerateResponse, error) {
 	settings := config.NewClassSettings(cfg)
 
-	cohereUrl, err := url.JoinPath(v.host, v.path)
+	cohereUrl, err := v.getCohereUrl(ctx, settings.BaseURL())
 	if err != nil {
 		return nil, errors.Wrap(err, "join Cohere API host and path")
 	}
@@ -134,6 +130,17 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	}, nil
 }
 
+func (v *cohere) getCohereUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL := baseURL
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-BaseURL"); headerBaseURL != "" {
+		passedBaseURL = headerBaseURL
+	}
+	if passedBaseURL == "" {
+		passedBaseURL = "https://api.cohere.ai"
+	}
+	return url.JoinPath(passedBaseURL, "/v1/generate")
+}
+
 func (v *cohere) generatePromptForTask(textProperties []map[string]string, task string) (string, error) {
 	marshal, err := json.Marshal(textProperties)
 	if err != nil {
@@ -158,20 +165,25 @@ func (v *cohere) generateForPrompt(textProperties map[string]string, prompt stri
 	return prompt, nil
 }
 
-func (v *cohere) getApiKey(ctx context.Context) (string, error) {
-	if len(v.apiKey) > 0 {
-		return v.apiKey, nil
+func (v *cohere) getValueFromContext(ctx context.Context, key string) string {
+	if value := ctx.Value(key); value != nil {
+		if keyHeader, ok := value.([]string); ok && len(keyHeader) > 0 && len(keyHeader[0]) > 0 {
+			return keyHeader[0]
+		}
 	}
-	key := "X-Cohere-Api-Key"
-
-	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
-	if apiKey == nil {
-		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
+	if apiKey := modulecomponents.GetValueFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
+		return apiKey[0]
 	}
-	if apiKeyHeader, ok := apiKey.([]string); ok &&
-		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {
-		return apiKeyHeader[0], nil
+	return ""
+}
+
+func (v *cohere) getApiKey(ctx context.Context) (string, error) {
+	if apiKey := v.getValueFromContext(ctx, "X-Cohere-Api-Key"); apiKey != "" {
+		return apiKey, nil
+	}
+	if v.apiKey != "" {
+		return v.apiKey, nil
 	}
 	return "", errors.New("no api key found " +
 		"neither in request header: X-Cohere-Api-Key " +

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -135,9 +135,6 @@ func (v *cohere) getCohereUrl(ctx context.Context, baseURL string) (string, erro
 	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
 		passedBaseURL = headerBaseURL
 	}
-	if passedBaseURL == "" {
-		passedBaseURL = "https://api.cohere.ai"
-	}
 	return url.JoinPath(passedBaseURL, "/v1/generate")
 }
 

--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -90,7 +90,7 @@ func TestGetAnswer(t *testing.T) {
 
 		baseURL := "http://default-url.com"
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-Cohere-BaseURL", []string{"http://base-url-passed-in-header.com"})
+			"X-Cohere-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
 		buildURL, err := c.getCohereUrl(ctxWithValue, baseURL)
 		require.NoError(t, err)

--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -99,10 +99,6 @@ func TestGetAnswer(t *testing.T) {
 		buildURL, err = c.getCohereUrl(context.TODO(), baseURL)
 		require.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/v1/generate", buildURL)
-
-		buildURL, err = c.getCohereUrl(context.TODO(), "")
-		require.NoError(t, err)
-		assert.Equal(t, "https://api.cohere.ai/v1/generate", buildURL)
 	})
 }
 

--- a/modules/generative-cohere/config/class_settings.go
+++ b/modules/generative-cohere/config/class_settings.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	baseURLProperty           = "baseURL"
 	modelProperty             = "model"
 	temperatureProperty       = "temperature"
 	maxTokensProperty         = "maxTokens"
@@ -36,6 +37,7 @@ var availableCohereModels = []string{
 
 // note it might not like this -- might want int values for e.g. MaxTokens
 var (
+	DefaultBaseURL                 = "https://api.cohere.ai"
 	DefaultCohereModel             = "command-nightly"
 	DefaultCohereTemperature       = 0
 	DefaultCohereMaxTokens         = 2048
@@ -140,6 +142,10 @@ func (ic *classSettings) GetMaxTokensForModel(model string) int {
 
 func (ic *classSettings) validateModel(model string) bool {
 	return contains(availableCohereModels, model)
+}
+
+func (ic *classSettings) BaseURL() string {
+	return *ic.getStringProperty(baseURLProperty, DefaultBaseURL)
 }
 
 func (ic *classSettings) Model() string {

--- a/modules/generative-cohere/config/class_settings_test.go
+++ b/modules/generative-cohere/config/class_settings_test.go
@@ -29,6 +29,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantK                 int
 		wantStopSequences     []string
 		wantReturnLikelihoods string
+		wantBaseURL           string
 		wantErr               error
 	}{
 		{
@@ -42,6 +43,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantK:                 0,
 			wantStopSequences:     []string{},
 			wantReturnLikelihoods: "NONE",
+			wantBaseURL:           "https://api.cohere.ai",
 			wantErr:               nil,
 		},
 		{
@@ -62,6 +64,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantK:                 2,
 			wantStopSequences:     []string{"stop1", "stop2"},
 			wantReturnLikelihoods: "NONE",
+			wantBaseURL:           "https://api.cohere.ai",
 			wantErr:               nil,
 		},
 		{
@@ -88,6 +91,24 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantK:                 0,
 			wantStopSequences:     []string{},
 			wantReturnLikelihoods: "NONE",
+			wantBaseURL:           "https://api.cohere.ai",
+			wantErr:               nil,
+		},
+		{
+			name: "default settings with command-light-nightly and baseURL",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":   "command-light-nightly",
+					"baseURL": "http://custom-url.com",
+				},
+			},
+			wantModel:             "command-light-nightly",
+			wantMaxTokens:         2048,
+			wantTemperature:       0,
+			wantK:                 0,
+			wantStopSequences:     []string{},
+			wantReturnLikelihoods: "NONE",
+			wantBaseURL:           "http://custom-url.com",
 			wantErr:               nil,
 		},
 	}

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -163,7 +163,7 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 
 func (v *openai) buildOpenAIUrl(ctx context.Context, settings config.ClassSettings) (string, error) {
 	baseURL := settings.BaseURL()
-	if headerBaseURL := v.getValueFromContext(ctx, "X-OpenAI-BaseURL"); headerBaseURL != "" {
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		baseURL = headerBaseURL
 	}
 	return v.buildUrl(settings.IsLegacy(), settings.ResourceName(), settings.DeploymentID(), baseURL)

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -126,7 +126,7 @@ func TestGetAnswer(t *testing.T) {
 		c := New("openAIApiKey", "", "", 0, nullLogger())
 
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-OpenAI-BaseURL", []string{"http://base-url-passed-in-header.com"})
+			"X-Openai-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
 		buildURL, err := c.buildOpenAIUrl(ctxWithValue, settings)
 		require.NoError(t, err)

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -139,7 +139,7 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 
 func (v *qna) buildOpenAIUrl(ctx context.Context, baseURL, resourceName, deploymentID string) (string, error) {
 	passedBaseURL := baseURL
-	if headerBaseURL := v.getValueFromContext(ctx, "X-OpenAI-BaseURL"); headerBaseURL != "" {
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		passedBaseURL = headerBaseURL
 	}
 	return v.buildUrlFn(passedBaseURL, resourceName, deploymentID)

--- a/modules/qna-openai/clients/qna_test.go
+++ b/modules/qna-openai/clients/qna_test.go
@@ -91,7 +91,7 @@ func TestGetAnswer(t *testing.T) {
 		c := New("openAIApiKey", "", "", 0, nullLogger())
 
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-OpenAI-BaseURL", []string{"http://base-url-passed-in-header.com"})
+			"X-Openai-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
 		buildURL, err := c.buildOpenAIUrl(ctxWithValue, "http://default-url.com", "", "")
 		require.NoError(t, err)

--- a/modules/text2vec-cohere/clients/url.go
+++ b/modules/text2vec-cohere/clients/url.go
@@ -25,6 +25,9 @@ func newCohereUrlBuilder() *cohereUrlBuilder {
 	}
 }
 
-func (c *cohereUrlBuilder) url() string {
+func (c *cohereUrlBuilder) url(baseURL string) string {
+	if baseURL != "" {
+		return fmt.Sprintf("%s%s", baseURL, c.pathMask)
+	}
 	return fmt.Sprintf("%s%s", c.origin, c.pathMask)
 }

--- a/modules/text2vec-cohere/clients/vectorizer.go
+++ b/modules/text2vec-cohere/clients/vectorizer.go
@@ -128,7 +128,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 
 func (v *vectorizer) getCohereUrl(ctx context.Context, baseURL string) string {
 	passedBaseURL := baseURL
-	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-BaseURL"); headerBaseURL != "" {
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
 		passedBaseURL = headerBaseURL
 	}
 	return v.urlBuilder.url(passedBaseURL)

--- a/modules/text2vec-cohere/clients/vectorizer.go
+++ b/modules/text2vec-cohere/clients/vectorizer.go
@@ -59,17 +59,17 @@ func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *vecto
 func (v *vectorizer) Vectorize(ctx context.Context, input []string,
 	config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
-	return v.vectorize(ctx, input, v.url(), v.getModel(config), v.getTruncate(config))
+	return v.vectorize(ctx, input, config.Model, config.Truncate, config.BaseURL)
 }
 
 func (v *vectorizer) VectorizeQuery(ctx context.Context, input []string,
 	config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
-	return v.vectorize(ctx, input, v.url(), v.getModel(config), v.getTruncate(config))
+	return v.vectorize(ctx, input, config.Model, config.Truncate, config.BaseURL)
 }
 
 func (v *vectorizer) vectorize(ctx context.Context, input []string,
-	url string, model string, truncate string,
+	model, truncate, baseURL string,
 ) (*ent.VectorizationResult, error) {
 	body, err := json.Marshal(embeddingsRequest{
 		Input:    input,
@@ -80,6 +80,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
+	url := v.getCohereUrl(ctx, baseURL)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))
 	if err != nil {
@@ -125,6 +126,14 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	}, nil
 }
 
+func (v *vectorizer) getCohereUrl(ctx context.Context, baseURL string) string {
+	passedBaseURL := baseURL
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-BaseURL"); headerBaseURL != "" {
+		passedBaseURL = headerBaseURL
+	}
+	return v.urlBuilder.url(passedBaseURL)
+}
+
 func getErrorMessage(statusCode int, resBodyError string, errorTemplate string) string {
 	if resBodyError != "" {
 		return fmt.Sprintf(errorTemplate, statusCode, resBodyError)
@@ -132,34 +141,27 @@ func getErrorMessage(statusCode int, resBodyError string, errorTemplate string) 
 	return fmt.Sprintf(errorTemplate, statusCode)
 }
 
-func (v *vectorizer) getApiKey(ctx context.Context) (string, error) {
-	if len(v.apiKey) > 0 {
-		return v.apiKey, nil
+func (v *vectorizer) getValueFromContext(ctx context.Context, key string) string {
+	if value := ctx.Value(key); value != nil {
+		if keyHeader, ok := value.([]string); ok && len(keyHeader) > 0 && len(keyHeader[0]) > 0 {
+			return keyHeader[0]
+		}
 	}
-	key := "X-Cohere-Api-Key"
-
-	apiKey := ctx.Value(key)
 	// try getting header from GRPC if not successful
-	if apiKey == nil {
-		apiKey = modulecomponents.GetValueFromGRPC(ctx, key)
+	if apiKey := modulecomponents.GetValueFromGRPC(ctx, key); len(apiKey) > 0 && len(apiKey[0]) > 0 {
+		return apiKey[0]
 	}
-	if apiKeyHeader, ok := apiKey.([]string); ok &&
-		len(apiKeyHeader) > 0 && len(apiKeyHeader[0]) > 0 {
-		return apiKeyHeader[0], nil
+	return ""
+}
+
+func (v *vectorizer) getApiKey(ctx context.Context) (string, error) {
+	if apiKey := v.getValueFromContext(ctx, "X-Cohere-Api-Key"); apiKey != "" {
+		return apiKey, nil
+	}
+	if v.apiKey != "" {
+		return v.apiKey, nil
 	}
 	return "", errors.New("no api key found " +
 		"neither in request header: X-Cohere-Api-Key " +
 		"nor in environment variable under COHERE_APIKEY")
-}
-
-func (v *vectorizer) url() string {
-	return v.urlBuilder.url()
-}
-
-func (v *vectorizer) getModel(config ent.VectorizationConfig) string {
-	return config.Model
-}
-
-func (v *vectorizer) getTruncate(config ent.VectorizationConfig) string {
-	return config.Truncate
 }

--- a/modules/text2vec-cohere/clients/vectorizer_test.go
+++ b/modules/text2vec-cohere/clients/vectorizer_test.go
@@ -191,7 +191,7 @@ func TestClient(t *testing.T) {
 
 		baseURL := "http://default-url.com"
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-Cohere-BaseURL", []string{"http://base-url-passed-in-header.com"})
+			"X-Cohere-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
 		buildURL := c.getCohereUrl(ctxWithValue, baseURL)
 		assert.Equal(t, "http://base-url-passed-in-header.com/embed", buildURL)

--- a/modules/text2vec-cohere/ent/vectorization_config.go
+++ b/modules/text2vec-cohere/ent/vectorization_config.go
@@ -14,4 +14,5 @@ package ent
 type VectorizationConfig struct {
 	Model    string
 	Truncate string
+	BaseURL  string
 }

--- a/modules/text2vec-cohere/vectorizer/class_settings.go
+++ b/modules/text2vec-cohere/vectorizer/class_settings.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	DefaultBaseURL               = "https://api.cohere.ai"
 	DefaultCohereModel           = "embed-multilingual-v2.0"
 	DefaultTruncate              = "RIGHT"
 	DefaultVectorizeClassName    = true
@@ -91,6 +92,10 @@ func (cs *classSettings) Model() string {
 
 func (cs *classSettings) Truncate() string {
 	return cs.getProperty("truncate", DefaultTruncate)
+}
+
+func (cs *classSettings) BaseURL() string {
+	return cs.getProperty("baseURL", DefaultBaseURL)
 }
 
 func (cs *classSettings) VectorizeClassName() bool {

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -52,6 +52,7 @@ type fakeSettings struct {
 	excludedProperty   string
 	cohereModel        string
 	truncateType       string
+	baseURL            string
 }
 
 func (f *fakeSettings) PropertyIndexed(propName string) bool {
@@ -72,4 +73,8 @@ func (f *fakeSettings) Model() string {
 
 func (f *fakeSettings) Truncate() string {
 	return f.truncateType
+}
+
+func (f *fakeSettings) BaseURL() string {
+	return f.baseURL
 }

--- a/modules/text2vec-cohere/vectorizer/objects.go
+++ b/modules/text2vec-cohere/vectorizer/objects.go
@@ -47,6 +47,7 @@ type ClassSettings interface {
 	VectorizeClassName() bool
 	Model() string
 	Truncate() string
+	BaseURL() string
 }
 
 func sortStringKeys(schemaMap map[string]interface{}) []string {
@@ -132,7 +133,8 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 
 	text := []string{strings.Join(corpi, " ")}
 	res, err := v.client.Vectorize(ctx, text, ent.VectorizationConfig{
-		Model: icheck.Model(),
+		Model:   icheck.Model(),
+		BaseURL: icheck.BaseURL(),
 	})
 	if err != nil {
 		return nil, err

--- a/modules/text2vec-cohere/vectorizer/texts.go
+++ b/modules/text2vec-cohere/vectorizer/texts.go
@@ -24,6 +24,7 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	res, err := v.client.VectorizeQuery(ctx, inputs, ent.VectorizationConfig{
 		Model:    settings.Model(),
 		Truncate: settings.Truncate(),
+		BaseURL:  settings.BaseURL(),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "remote client vectorize")

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -161,7 +161,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string, model string
 
 func (v *vectorizer) buildURL(ctx context.Context, config ent.VectorizationConfig) (string, error) {
 	baseURL, resourceName, deploymentID, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.IsAzure
-	if headerBaseURL := v.getValueFromContext(ctx, "X-OpenAI-BaseURL"); headerBaseURL != "" {
+	if headerBaseURL := v.getValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		baseURL = headerBaseURL
 	}
 	return v.buildUrlFn(baseURL, resourceName, deploymentID, isAzure)

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -214,7 +214,7 @@ func TestClient(t *testing.T) {
 		}
 
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-OpenAI-BaseURL", []string{"http://base-url-passed-in-header.com"})
+			"X-Openai-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
 		buildURL, err := c.buildURL(ctxWithValue, config)
 		require.NoError(t, err)

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -252,7 +252,7 @@ type CORS struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-BaseURL, X-Cohere-Api-Key, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-BaseURL, X-Cohere-Api-Key, X-Cohere-BaseURL, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key"
 )
 
 func (r ResourceUsage) Validate() error {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -252,7 +252,7 @@ type CORS struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-BaseURL, X-Cohere-Api-Key, X-Cohere-BaseURL, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key"
 )
 
 func (r ResourceUsage) Validate() error {


### PR DESCRIPTION
### What's being changed:

This PR adds a possibility to pass of overriding Cohere's base URL either through `moduleConfig` using `baseURL` setting or through `X-Cohere-BaseURL` HTTP header.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
