### PR TITLE
Refactor implicit grpc message parsing

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -89,12 +89,10 @@ func searchParamsFromProto(req *pb.SearchRequest, scheme schema.Schema) (dto.Get
 		}
 		out.Properties = returnProps
 	}
-	if len(out.Properties) == 0 {
+	if len(out.Properties) == 0 && isIdOnlyRequest(req.Metadata) {
 		// This is a pure-ID query without any properties or additional metadata.
 		// Indicate this to the DB, so it can optimize accordingly
-		if isIdOnlyRequest(req.Metadata) {
-			out.AdditionalProperties.NoProps = true
-		}
+		out.AdditionalProperties.NoProps = true
 	}
 
 	if hs := req.HybridSearch; hs != nil {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -613,13 +613,14 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 	// certainty is only compatible with cosine distance
 	props := additional.Properties{
 		Vector:             prop.Vector,
-		Certainty:          false,
+		Certainty:          prop.Certainty,
 		ID:                 prop.Uuid,
 		CreationTimeUnix:   prop.CreationTimeUnix,
 		LastUpdateTimeUnix: prop.LastUpdateTimeUnix,
 		Distance:           prop.Distance,
 		Score:              prop.Score,
 		ExplainScore:       prop.ExplainScore,
+		IsConsistent:       prop.IsConsistent,
 	}
 
 	vectorIndex, err := hnsw.TypeAssertVectorIndex(class)
@@ -627,8 +628,10 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 		return props, err
 	}
 
-	if vectorIndex.Distance == hnsw.DistanceCosine {
+	if vectorIndex.Distance == hnsw.DistanceCosine && props.Certainty {
 		props.Certainty = true
+	} else {
+		props.Certainty = false
 	}
 
 	return props, nil

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -610,7 +610,6 @@ func extractNestedProperties(props []*pb.ObjectPropertiesRequest) []search.Selec
 }
 
 func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRequest) (additional.Properties, error) {
-	// certainty is only compatible with cosine distance
 	props := additional.Properties{
 		Vector:             prop.Vector,
 		Certainty:          prop.Certainty,
@@ -628,6 +627,7 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 		return props, err
 	}
 
+	// certainty is only compatible with cosine distance
 	if vectorIndex.Distance == hnsw.DistanceCosine && props.Certainty {
 		props.Certainty = true
 	} else {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -14,10 +14,7 @@ package v1
 import (
 	"fmt"
 
-	"github.com/weaviate/weaviate/entities/models"
-
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate"
 
@@ -27,7 +24,9 @@ import (
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents/nearImage"
 
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	nearText2 "github.com/weaviate/weaviate/usecases/modulecomponents/nearText"
 
 	"github.com/go-openapi/strfmt"
@@ -57,21 +56,9 @@ func searchParamsFromProto(req *pb.SearchRequest, scheme schema.Schema) (dto.Get
 	out.Tenant = req.Tenant
 
 	if req.Metadata != nil {
-		out.AdditionalProperties.ID = req.Metadata.Uuid
-		out.AdditionalProperties.Vector = req.Metadata.Vector
-		out.AdditionalProperties.Certainty = req.Metadata.Certainty
-		out.AdditionalProperties.Distance = req.Metadata.Distance
-		out.AdditionalProperties.LastUpdateTimeUnix = req.Metadata.LastUpdateTimeUnix
-		out.AdditionalProperties.CreationTimeUnix = req.Metadata.CreationTimeUnix
-		out.AdditionalProperties.Score = req.Metadata.Score
-		out.AdditionalProperties.ExplainScore = req.Metadata.ExplainScore
-		out.AdditionalProperties.IsConsistent = req.Metadata.IsConsistent
-	} else {
-		// No return metadata selected, return all metadata.
-		// Ignore vector to not overload the response
-		addProps, err := setAllCheapAdditionalPropsToTrue(class)
+		addProps, err := extractAdditionalPropsFromMetadata(class, req.Metadata)
 		if err != nil {
-			return dto.GetParams{}, err
+			return dto.GetParams{}, errors.Wrap(err, "extract additional props")
 		}
 		out.AdditionalProperties = addProps
 	}
@@ -550,7 +537,7 @@ func extractPropertiesRequest(reqProps *pb.PropertiesRequest, scheme schema.Sche
 				}
 			}
 			var refProperties []search.SelectProperty
-			var metaData additional.Properties
+			var addProps additional.Properties
 			if prop.Properties != nil {
 				refProperties, err = extractPropertiesRequest(prop.Properties, scheme, linkedClassName)
 				if err != nil {
@@ -558,20 +545,22 @@ func extractPropertiesRequest(reqProps *pb.PropertiesRequest, scheme schema.Sche
 				}
 			}
 			if prop.Metadata != nil {
-				metaData = extractAdditionalPropsForRefs(prop.Metadata)
+				addProps, err = extractAdditionalPropsFromMetadata(class, prop.Metadata)
+				if err != nil {
+					return nil, errors.Wrap(err, "extract additional props for refs")
+				}
 			}
 
-			if prop.Properties == nil && prop.Metadata == nil {
+			if prop.Properties == nil {
 				refProperties, err = getAllNonRefNonBlobProperties(scheme, linkedClassName)
 				if err != nil {
 					return nil, errors.Wrap(err, "get all non ref non blob properties")
 				}
-
-				linkedClass := scheme.GetClass(schema.ClassName(linkedClassName))
-				metaData, err = setAllCheapAdditionalPropsToTrue(linkedClass)
-				if err != nil {
-					return nil, errors.Wrap(err, "set all cheap additional props to true")
-				}
+			}
+			if len(refProperties) == 0 && isIdOnlyRequest(prop.Metadata) {
+				// This is a pure-ID query without any properties or additional metadata.
+				// Indicate this to the DB, so it can optimize accordingly
+				addProps.NoProps = true
 			}
 
 			props = append(props, search.SelectProperty{
@@ -581,7 +570,7 @@ func extractPropertiesRequest(reqProps *pb.PropertiesRequest, scheme schema.Sche
 				Refs: []search.SelectClass{{
 					ClassName:            linkedClassName,
 					RefProperties:        refProperties,
-					AdditionalProperties: metaData,
+					AdditionalProperties: addProps,
 				}},
 			})
 		}
@@ -620,10 +609,11 @@ func extractNestedProperties(props []*pb.ObjectPropertiesRequest) []search.Selec
 	return selectProps
 }
 
-func extractAdditionalPropsForRefs(prop *pb.MetadataRequest) additional.Properties {
-	return additional.Properties{
+func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRequest) (additional.Properties, error) {
+	// certainty is only compatible with cosine distance
+	props := additional.Properties{
 		Vector:             prop.Vector,
-		Certainty:          prop.Certainty,
+		Certainty:          false,
 		ID:                 prop.Uuid,
 		CreationTimeUnix:   prop.CreationTimeUnix,
 		LastUpdateTimeUnix: prop.LastUpdateTimeUnix,
@@ -631,6 +621,17 @@ func extractAdditionalPropsForRefs(prop *pb.MetadataRequest) additional.Properti
 		Score:              prop.Score,
 		ExplainScore:       prop.ExplainScore,
 	}
+
+	vectorIndex, err := hnsw.TypeAssertVectorIndex(class)
+	if err != nil {
+		return props, err
+	}
+
+	if vectorIndex.Distance == hnsw.DistanceCosine {
+		props.Certainty = true
+	}
+
+	return props, nil
 }
 
 func isIdOnlyRequest(metadata *pb.MetadataRequest) bool {
@@ -717,30 +718,6 @@ func getAllNonRefNonBlobNestedProperties[P schema.PropertyInterface](property P)
 		}
 	}
 	return props, nil
-}
-
-func setAllCheapAdditionalPropsToTrue(class *models.Class) (additional.Properties, error) {
-	out := additional.Properties{
-		ID:                 true,
-		Distance:           true,
-		LastUpdateTimeUnix: true,
-		CreationTimeUnix:   true,
-		Score:              true,
-		ExplainScore:       true,
-		Vector:             false, // can be expensive
-	}
-
-	// certainty is not compatible with dot distance
-	vectorIndex, err := hnsw.TypeAssertVectorIndex(class)
-	if err != nil {
-		return out, err
-	}
-
-	if vectorIndex.Distance == hnsw.DistanceCosine {
-		out.Certainty = true
-	}
-
-	return out, nil
 }
 
 func parseNearImage(ni *pb.NearImageSearch) (*nearImage.NearImageParams, error) {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -612,7 +612,6 @@ func extractNestedProperties(props []*pb.ObjectPropertiesRequest) []search.Selec
 func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRequest) (additional.Properties, error) {
 	props := additional.Properties{
 		Vector:             prop.Vector,
-		Certainty:          prop.Certainty,
 		ID:                 prop.Uuid,
 		CreationTimeUnix:   prop.CreationTimeUnix,
 		LastUpdateTimeUnix: prop.LastUpdateTimeUnix,
@@ -628,7 +627,7 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 	}
 
 	// certainty is only compatible with cosine distance
-	if vectorIndex.Distance == hnsw.DistanceCosine && props.Certainty {
+	if vectorIndex.Distance == hnsw.DistanceCosine && prop.Certainty {
 		props.Certainty = true
 	} else {
 		props.Certainty = false

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -46,18 +46,6 @@ func TestGRPCRequest(t *testing.T) {
 	dotClass := "DotClass"
 	objClass := "ObjClass"
 
-	defaultAddProps := additional.Properties{
-		Vector:             false,
-		Certainty:          true,
-		ID:                 true,
-		CreationTimeUnix:   true,
-		LastUpdateTimeUnix: true,
-		Distance:           true,
-		Score:              true,
-		ExplainScore:       true,
-		IsConsistent:       false,
-	}
-
 	defaultClassnameProps := search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "number", IsPrimitive: true}, {Name: "floats", IsPrimitive: true}, {Name: "uuid", IsPrimitive: true}}
 
 	scheme := schema.Schema{
@@ -158,7 +146,6 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: defaultClassnameProps,
-				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -167,7 +154,6 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{},
-				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -176,17 +162,6 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: dotClass},
 			out: dto.GetParams{
 				ClassName: dotClass, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "something", IsPrimitive: true}},
-				AdditionalProperties: additional.Properties{
-					Vector:             false,
-					Certainty:          false, // not compatible
-					ID:                 true,
-					CreationTimeUnix:   true,
-					LastUpdateTimeUnix: true,
-					Distance:           true,
-					Score:              true,
-					ExplainScore:       true,
-					IsConsistent:       false,
-				},
 			},
 			error: false,
 		},
@@ -224,7 +199,6 @@ func TestGRPCRequest(t *testing.T) {
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: additional.Properties{
 					Vector: true,
 				}}}}},
-				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -233,7 +207,6 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{NonRefProperties: []string{"name", "CapitalizedName"}}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "capitalizedName", IsPrimitive: true}},
-				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -241,8 +214,7 @@ func TestGRPCRequest(t *testing.T) {
 			name: "ref returns no values given",
 			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{RefProperties: []*pb.RefPropertiesRequest{{ReferenceProperty: "ref", TargetCollection: refClass1}}}},
 			out: dto.GetParams{
-				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: defaultAddProps}}}},
-				AdditionalProperties: defaultAddProps,
+				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}}}}},
 			},
 			error: false,
 		},
@@ -263,7 +235,6 @@ func TestGRPCRequest(t *testing.T) {
 					{Name: "multiRef", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: additional.Properties{Vector: true}}}},
 					{Name: "multiRef", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass2, RefProperties: search.SelectProperties{{Name: "else", IsPrimitive: true}}, AdditionalProperties: additional.Properties{ID: true}}}},
 				},
-				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -795,7 +766,6 @@ func TestGRPCRequest(t *testing.T) {
 						},
 					},
 				},
-				AdditionalProperties: defaultAddProps,
 			},
 		},
 		{
@@ -823,7 +793,6 @@ func TestGRPCRequest(t *testing.T) {
 						},
 					},
 				},
-				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -45,6 +45,21 @@ func TestGRPCRequest(t *testing.T) {
 	refClass2 := "AnotherClass"
 	dotClass := "DotClass"
 	objClass := "ObjClass"
+
+	defaultAddProps := additional.Properties{
+		Vector:             false,
+		Certainty:          true,
+		ID:                 true,
+		CreationTimeUnix:   true,
+		LastUpdateTimeUnix: true,
+		Distance:           true,
+		Score:              true,
+		ExplainScore:       true,
+		IsConsistent:       false,
+	}
+
+	defaultClassnameProps := search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "number", IsPrimitive: true}, {Name: "floats", IsPrimitive: true}, {Name: "uuid", IsPrimitive: true}}
+
 	scheme := schema.Schema{
 		Objects: &models.Schema{
 			Classes: []*models.Class{
@@ -142,18 +157,8 @@ func TestGRPCRequest(t *testing.T) {
 			name: "No return values given",
 			req:  &pb.SearchRequest{Collection: classname},
 			out: dto.GetParams{
-				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "number", IsPrimitive: true}, {Name: "floats", IsPrimitive: true}, {Name: "uuid", IsPrimitive: true}},
-				AdditionalProperties: additional.Properties{
-					Vector:             false,
-					Certainty:          true,
-					ID:                 true,
-					CreationTimeUnix:   true,
-					LastUpdateTimeUnix: true,
-					Distance:           true,
-					Score:              true,
-					ExplainScore:       true,
-					IsConsistent:       false,
-				},
+				ClassName: classname, Pagination: defaultPagination, Properties: defaultClassnameProps,
+				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -181,6 +186,7 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname, Metadata: &pb.MetadataRequest{Vector: true, Certainty: false, IsConsistent: true}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties: defaultClassnameProps,
 				AdditionalProperties: additional.Properties{
 					Vector:       true,
 					NoProps:      false,
@@ -194,6 +200,7 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname, Metadata: &pb.MetadataRequest{Uuid: true}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties: defaultClassnameProps,
 				AdditionalProperties: additional.Properties{
 					ID:      true,
 					NoProps: true,
@@ -208,7 +215,7 @@ func TestGRPCRequest(t *testing.T) {
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: additional.Properties{
 					Vector: true,
 				}}}}},
-				AdditionalProperties: additional.Properties{},
+				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -217,17 +224,7 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{NonRefProperties: []string{"name", "CapitalizedName"}}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "capitalizedName", IsPrimitive: true}},
-				AdditionalProperties: additional.Properties{
-					Vector:             false,
-					Certainty:          false,
-					ID:                 false,
-					CreationTimeUnix:   false,
-					LastUpdateTimeUnix: false,
-					Distance:           false,
-					Score:              false,
-					ExplainScore:       false,
-					NoProps:            false,
-				},
+				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -235,18 +232,8 @@ func TestGRPCRequest(t *testing.T) {
 			name: "ref returns no values given",
 			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{RefProperties: []*pb.RefPropertiesRequest{{ReferenceProperty: "ref", TargetCollection: refClass1}}}},
 			out: dto.GetParams{
-				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: additional.Properties{
-					Vector:             false,
-					Certainty:          true,
-					ID:                 true,
-					CreationTimeUnix:   true,
-					LastUpdateTimeUnix: true,
-					Distance:           true,
-					Score:              true,
-					ExplainScore:       true,
-					IsConsistent:       false,
-				}}}}},
-				AdditionalProperties: additional.Properties{},
+				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: defaultAddProps}}}},
+				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -267,7 +254,7 @@ func TestGRPCRequest(t *testing.T) {
 					{Name: "multiRef", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass1, RefProperties: search.SelectProperties{{Name: "something", IsPrimitive: true}}, AdditionalProperties: additional.Properties{Vector: true}}}},
 					{Name: "multiRef", IsPrimitive: false, Refs: []search.SelectClass{{ClassName: refClass2, RefProperties: search.SelectProperties{{Name: "else", IsPrimitive: true}}, AdditionalProperties: additional.Properties{ID: true}}}},
 				},
-				AdditionalProperties: additional.Properties{},
+				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},
@@ -279,6 +266,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion, Alpha: 0.75, Properties: []string{"name", "capitalizedName"}},
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -291,6 +279,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRelativeScoreFusion},
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -303,6 +292,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion},
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -316,6 +306,7 @@ func TestGRPCRequest(t *testing.T) {
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
 				KeywordRanking:       &searchparams.KeywordRanking{Query: "query", Properties: []string{"name", "capitalizedName"}, Type: "bm25"},
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -328,6 +319,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -347,6 +339,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -369,6 +362,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -398,6 +392,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -421,6 +416,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -472,6 +468,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -502,6 +499,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -528,6 +526,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -554,6 +553,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearText": &nearText2.NearTextParams{
@@ -601,6 +601,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearAudio": &nearAudio.NearAudioParams{
@@ -620,6 +621,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearVideo": &nearVideo.NearVideoParams{
@@ -639,6 +641,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultClassnameProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearImage": &nearImage.NearImageParams{
@@ -656,6 +659,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties:            defaultClassnameProps,
 				AdditionalProperties:  additional.Properties{Vector: true, NoProps: false},
 				ReplicationProperties: &additional.ReplicationProperties{ConsistencyLevel: "QUORUM"},
 			},
@@ -669,6 +673,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties: defaultClassnameProps,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,
@@ -687,6 +692,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties: defaultClassnameProps,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,
@@ -714,13 +720,13 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
+				Properties: defaultClassnameProps,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,
 					Group:   true,
 				},
 				NearVector: &searchparams.NearVector{Vector: []float32{1, 2, 3}},
-				Properties: search.SelectProperties{{Name: "name", IsPrimitive: true}},
 				GroupBy:    &searchparams.GroupBy{Groups: 2, ObjectsPerGroup: 3, Property: "name"},
 			},
 			error: false,
@@ -780,6 +786,7 @@ func TestGRPCRequest(t *testing.T) {
 						},
 					},
 				},
+				AdditionalProperties: defaultAddProps,
 			},
 		},
 		{
@@ -807,17 +814,7 @@ func TestGRPCRequest(t *testing.T) {
 						},
 					},
 				},
-				AdditionalProperties: additional.Properties{
-					Vector:             false,
-					Certainty:          true,
-					ID:                 true,
-					CreationTimeUnix:   true,
-					LastUpdateTimeUnix: true,
-					Distance:           true,
-					Score:              true,
-					ExplainScore:       true,
-					IsConsistent:       false,
-				},
+				AdditionalProperties: defaultAddProps,
 			},
 			error: false,
 		},

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -163,6 +163,15 @@ func TestGRPCRequest(t *testing.T) {
 			error: false,
 		},
 		{
+			name: "Empty return properties given",
+			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{}},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{},
+				AdditionalProperties: defaultAddProps,
+			},
+			error: false,
+		},
+		{
 			name: "No return values given for dot distance",
 			req:  &pb.SearchRequest{Collection: dotClass},
 			out: dto.GetParams{
@@ -197,10 +206,10 @@ func TestGRPCRequest(t *testing.T) {
 		},
 		{
 			name: "Metadata ID only query",
-			req:  &pb.SearchRequest{Collection: classname, Metadata: &pb.MetadataRequest{Uuid: true}},
+			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{}, Metadata: &pb.MetadataRequest{Uuid: true}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties: defaultClassnameProps,
+				Properties: search.SelectProperties{},
 				AdditionalProperties: additional.Properties{
 					ID:      true,
 					NoProps: true,

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -46,7 +46,7 @@ func TestGRPCRequest(t *testing.T) {
 	dotClass := "DotClass"
 	objClass := "ObjClass"
 
-	defaultClassnameProps := search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "number", IsPrimitive: true}, {Name: "floats", IsPrimitive: true}, {Name: "uuid", IsPrimitive: true}}
+	defaultTestClassProps := search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "number", IsPrimitive: true}, {Name: "floats", IsPrimitive: true}, {Name: "uuid", IsPrimitive: true}}
 
 	scheme := schema.Schema{
 		Objects: &models.Schema{
@@ -145,7 +145,7 @@ func TestGRPCRequest(t *testing.T) {
 			name: "No return values given",
 			req:  &pb.SearchRequest{Collection: classname},
 			out: dto.GetParams{
-				ClassName: classname, Pagination: defaultPagination, Properties: defaultClassnameProps,
+				ClassName: classname, Pagination: defaultPagination, Properties: defaultTestClassProps,
 			},
 			error: false,
 		},
@@ -170,7 +170,7 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname, Metadata: &pb.MetadataRequest{Vector: true, Certainty: false, IsConsistent: true}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties: defaultClassnameProps,
+				Properties: defaultTestClassProps,
 				AdditionalProperties: additional.Properties{
 					Vector:       true,
 					NoProps:      false,
@@ -246,7 +246,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion, Alpha: 0.75, Properties: []string{"name", "capitalizedName"}},
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -259,7 +259,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRelativeScoreFusion},
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -272,7 +272,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion},
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -286,7 +286,7 @@ func TestGRPCRequest(t *testing.T) {
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
 				KeywordRanking:       &searchparams.KeywordRanking{Query: "query", Properties: []string{"name", "capitalizedName"}, Type: "bm25"},
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 			},
 			error: false,
@@ -299,7 +299,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -319,7 +319,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -342,7 +342,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -372,7 +372,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -396,7 +396,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -448,7 +448,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -479,7 +479,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -506,7 +506,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				Filters: &filters.LocalFilter{
 					Root: &filters.Clause{
@@ -533,7 +533,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearText": &nearText2.NearTextParams{
@@ -581,7 +581,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearAudio": &nearAudio.NearAudioParams{
@@ -601,7 +601,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearVideo": &nearVideo.NearVideoParams{
@@ -621,7 +621,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:           defaultClassnameProps,
+				Properties:           defaultTestClassProps,
 				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
 				ModuleParams: map[string]interface{}{
 					"nearImage": &nearImage.NearImageParams{
@@ -639,7 +639,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties:            defaultClassnameProps,
+				Properties:            defaultTestClassProps,
 				AdditionalProperties:  additional.Properties{Vector: true, NoProps: false},
 				ReplicationProperties: &additional.ReplicationProperties{ConsistencyLevel: "QUORUM"},
 			},
@@ -653,7 +653,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties: defaultClassnameProps,
+				Properties: defaultTestClassProps,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,
@@ -672,7 +672,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties: defaultClassnameProps,
+				Properties: defaultTestClassProps,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,
@@ -700,7 +700,7 @@ func TestGRPCRequest(t *testing.T) {
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties: defaultClassnameProps,
+				Properties: defaultTestClassProps,
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -122,7 +122,7 @@ func extractAdditionalProps(asMap map[string]any, additionalPropsParams addition
 	}
 	generativeGroupResults := ""
 	// id is part of the _additional map in case of generative search - don't aks me why
-	if additionalPropsParams.ID && generativeSearchEnabled || fromGroup {
+	if additionalPropsParams.ID && (generativeSearchEnabled || fromGroup) {
 		idRaw, ok := additionalPropertiesMap["id"]
 		if !ok {
 			return nil, "", errors.Wrap(err, "get id generative")

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -122,7 +122,7 @@ func extractAdditionalProps(asMap map[string]any, additionalPropsParams addition
 	}
 	generativeGroupResults := ""
 	// id is part of the _additional map in case of generative search - don't aks me why
-	if generativeSearchEnabled || fromGroup {
+	if additionalPropsParams.ID && generativeSearchEnabled || fromGroup {
 		idRaw, ok := additionalPropertiesMap["id"]
 		if !ok {
 			return nil, "", errors.Wrap(err, "get id generative")

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -551,6 +551,10 @@ func extractArrayTypes(scheme schema.Schema, rawProps map[string]interface{}, pr
 		case schema.DataTypeIntArray:
 			propIntAsFloat, ok := prop.([]float64)
 			if !ok {
+				emptyArr, ok := prop.([]interface{})
+				if ok && len(emptyArr) == 0 {
+					continue
+				}
 				return fmt.Errorf("property %v with datatype %v needs to be []float64, got %T", propName, dataType, prop)
 			}
 			propInt := make([]int64, len(propIntAsFloat))
@@ -563,18 +567,26 @@ func extractArrayTypes(scheme schema.Schema, rawProps map[string]interface{}, pr
 			props.IntArrayProperties = append(props.IntArrayProperties, &pb.IntArrayProperties{PropName: propName, Values: propInt})
 			delete(rawProps, propName)
 		case schema.DataTypeNumberArray:
-			propIntAsFloat, ok := prop.([]float64)
+			propFloat, ok := prop.([]float64)
 			if !ok {
+				emptyArr, ok := prop.([]interface{})
+				if ok && len(emptyArr) == 0 {
+					continue
+				}
 				return fmt.Errorf("property %v with datatype %v needs to be []float64, got %T", propName, dataType, prop)
 			}
 			if props.NumberArrayProperties == nil {
 				props.NumberArrayProperties = make([]*pb.NumberArrayProperties, 0)
 			}
-			props.NumberArrayProperties = append(props.NumberArrayProperties, &pb.NumberArrayProperties{PropName: propName, Values: propIntAsFloat})
+			props.NumberArrayProperties = append(props.NumberArrayProperties, &pb.NumberArrayProperties{PropName: propName, Values: propFloat})
 			delete(rawProps, propName)
 		case schema.DataTypeStringArray, schema.DataTypeTextArray, schema.DataTypeDateArray, schema.DataTypeUUIDArray:
 			propString, ok := prop.([]string)
 			if !ok {
+				emptyArr, ok := prop.([]interface{})
+				if ok && len(emptyArr) == 0 {
+					continue
+				}
 				return fmt.Errorf("property %v with datatype %v needs to be []string, got %T", propName, dataType, prop)
 			}
 			if props.TextArrayProperties == nil {
@@ -585,6 +597,10 @@ func extractArrayTypes(scheme schema.Schema, rawProps map[string]interface{}, pr
 		case schema.DataTypeBooleanArray:
 			propBool, ok := prop.([]bool)
 			if !ok {
+				emptyArr, ok := prop.([]interface{})
+				if ok && len(emptyArr) == 0 {
+					continue
+				}
 				return fmt.Errorf("property %v with datatype %v needs to be []bool, got %T", propName, dataType, prop)
 			}
 			if props.BooleanArrayProperties == nil {
@@ -597,7 +613,6 @@ func extractArrayTypes(scheme schema.Schema, rawProps map[string]interface{}, pr
 			if isArray {
 				return fmt.Errorf("property %v with array type not handled %v", propName, dataType)
 			}
-			continue
 		}
 	}
 	return nil

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -474,7 +474,7 @@ func TestGRPCReply(t *testing.T) {
 			},
 		},
 		{
-			name: "generative single only",
+			name: "generative single only with ID",
 			res: []interface{}{
 				map[string]interface{}{
 					"_additional": map[string]interface{}{
@@ -505,6 +505,40 @@ func TestGRPCReply(t *testing.T) {
 				{
 					Metadata: &pb.MetadataResult{
 						Id:                string(UUID2),
+						Generative:        refClass2,
+						GenerativePresent: true,
+					},
+					Properties: &pb.PropertiesResult{},
+				},
+			},
+		},
+		{
+			name: "generative single only without ID",
+			res: []interface{}{
+				map[string]interface{}{
+					"_additional": map[string]interface{}{ // different place for generative
+						"generate": &addModels.GenerateResult{SingleResult: &refClass1}, // just use some string
+					},
+				},
+				map[string]interface{}{
+					"_additional": map[string]interface{}{
+						"generate": &addModels.GenerateResult{SingleResult: &refClass2},
+					},
+				},
+			},
+			searchParams: dto.GetParams{AdditionalProperties: additional.Properties{
+				ModuleParams: map[string]interface{}{"generate": "must be present for extraction"},
+			}},
+			outSearch: []*pb.SearchResult{
+				{
+					Metadata: &pb.MetadataResult{
+						Generative:        refClass1,
+						GenerativePresent: true,
+					},
+					Properties: &pb.PropertiesResult{},
+				},
+				{
+					Metadata: &pb.MetadataResult{
 						Generative:        refClass2,
 						GenerativePresent: true,
 					},

--- a/test/acceptance/grpc/grpc_test.go
+++ b/test/acceptance/grpc/grpc_test.go
@@ -88,6 +88,9 @@ func TestGRPC(t *testing.T) {
 			name: "Search without props",
 			req: &pb.SearchRequest{
 				Collection: booksClass.Class,
+				Metadata: &pb.MetadataRequest{
+					Uuid: true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### What's being changed:

This PR refactors the implicit behaviour of the gRPC message parsing to decouple the Properties and Metadata fields from one another. Previously, in order for the whole object to be returned, both would have to be absent from the message. Now, if either are absent then they will be fully populated independently.

This allows the client-driven use-case of performing a query requesting only the vector included but returning all the properties also. This was previously impossible.

This PR also refactors the implicit returning of all `AdditionalProperties` when `MetadataRequest` is `nil`. Now, the client must be explicit in its messages when requesting `nil`, `non-nil`, and `empty` metadata returns

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
