### PR TITLE
Optional bloom filter and  count net additions calculations

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -89,6 +89,18 @@ type Bucket struct {
 	// keeping tombstones on compaction is optional
 	keepTombstones bool
 
+	// Init and use bloom filter for getting key from bucket segments.
+	// As some buckets can be accessed only with cursor (see flat index),
+	// where bloom filter is not applicable, it can be disabled.
+	// ON by default
+	useBloomFilter bool
+
+	// Net additions keep track of number of elements stored in bucket (of type replace).
+	// As some buckets don't have to provide Count info (see flat index),
+	// tracking additions can be disabled.
+	// ON by default
+	calcNetAdditions bool
+
 	forceCompaction bool
 }
 
@@ -122,6 +134,8 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 		mmapContents:      true,
 		logger:            logger,
 		metrics:           metrics,
+		useBloomFilter:    true,
+		calcNetAdditions:  true,
 	}
 
 	for _, opt := range opts {
@@ -134,9 +148,18 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 		b.memtableThreshold = uint64(b.memtableResizer.Initial())
 	}
 
-	sg, err := newSegmentGroup(dir, logger, b.legacyMapSortingBeforeCompaction,
-		metrics, b.strategy, b.monitorCount, compactionCallbacks,
-		b.mmapContents, b.keepTombstones, b.forceCompaction)
+	sg, err := newSegmentGroup(logger, metrics, compactionCallbacks,
+		sgConfig{
+			dir:                dir,
+			strategy:           b.strategy,
+			mapRequiresSorting: b.legacyMapSortingBeforeCompaction,
+			monitorCount:       b.monitorCount,
+			mmapContents:       b.mmapContents,
+			keepTombstones:     b.keepTombstones,
+			forceCompaction:    b.forceCompaction,
+			useBloomFilter:     b.useBloomFilter,
+			calcNetAdditions:   b.calcNetAdditions,
+		})
 	if err != nil {
 		return nil, errors.Wrap(err, "init disk segments")
 	}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -99,7 +99,7 @@ type Bucket struct {
 	// As some buckets don't have to provide Count info (see flat index),
 	// tracking additions can be disabled.
 	// ON by default
-	calcNetAdditions bool
+	calcCountNetAdditions bool
 
 	forceCompaction bool
 }
@@ -125,17 +125,17 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 	}
 
 	b := &Bucket{
-		dir:               dir,
-		rootDir:           rootDir,
-		memtableThreshold: defaultMemTableThreshold,
-		walThreshold:      defaultWalThreshold,
-		flushAfterIdle:    defaultFlushAfterIdle,
-		strategy:          defaultStrategy,
-		mmapContents:      true,
-		logger:            logger,
-		metrics:           metrics,
-		useBloomFilter:    true,
-		calcNetAdditions:  true,
+		dir:                   dir,
+		rootDir:               rootDir,
+		memtableThreshold:     defaultMemTableThreshold,
+		walThreshold:          defaultWalThreshold,
+		flushAfterIdle:        defaultFlushAfterIdle,
+		strategy:              defaultStrategy,
+		mmapContents:          true,
+		logger:                logger,
+		metrics:               metrics,
+		useBloomFilter:        true,
+		calcCountNetAdditions: true,
 	}
 
 	for _, opt := range opts {
@@ -150,15 +150,15 @@ func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogg
 
 	sg, err := newSegmentGroup(logger, metrics, compactionCallbacks,
 		sgConfig{
-			dir:                dir,
-			strategy:           b.strategy,
-			mapRequiresSorting: b.legacyMapSortingBeforeCompaction,
-			monitorCount:       b.monitorCount,
-			mmapContents:       b.mmapContents,
-			keepTombstones:     b.keepTombstones,
-			forceCompaction:    b.forceCompaction,
-			useBloomFilter:     b.useBloomFilter,
-			calcNetAdditions:   b.calcNetAdditions,
+			dir:                   dir,
+			strategy:              b.strategy,
+			mapRequiresSorting:    b.legacyMapSortingBeforeCompaction,
+			monitorCount:          b.monitorCount,
+			mmapContents:          b.mmapContents,
+			keepTombstones:        b.keepTombstones,
+			forceCompaction:       b.forceCompaction,
+			useBloomFilter:        b.useBloomFilter,
+			calcCountNetAdditions: b.calcCountNetAdditions,
 		})
 	if err != nil {
 		return nil, errors.Wrap(err, "init disk segments")

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -126,6 +126,20 @@ func WithKeepTombstones(keepTombstones bool) BucketOption {
 	}
 }
 
+func WithUseBloomFilter(useBloomFilter bool) BucketOption {
+	return func(b *Bucket) error {
+		b.useBloomFilter = useBloomFilter
+		return nil
+	}
+}
+
+func WithCalcNetAdditions(calcNetAdditions bool) BucketOption {
+	return func(b *Bucket) error {
+		b.calcNetAdditions = calcNetAdditions
+		return nil
+	}
+}
+
 /*
 Background for this option:
 

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -133,9 +133,9 @@ func WithUseBloomFilter(useBloomFilter bool) BucketOption {
 	}
 }
 
-func WithCalcNetAdditions(calcNetAdditions bool) BucketOption {
+func WithCalcCountNetAdditions(calcCountNetAdditions bool) BucketOption {
 	return func(b *Bucket) error {
-		b.calcNetAdditions = calcNetAdditions
+		b.calcCountNetAdditions = calcCountNetAdditions
 		return nil
 	}
 }

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -26,26 +26,27 @@ import (
 )
 
 type segment struct {
-	path                  string
-	level                 uint16
-	secondaryIndexCount   uint16
-	version               uint16
-	segmentStartPos       uint64
-	segmentEndPos         uint64
-	dataStartPos          uint64
-	dataEndPos            uint64
-	contents              []byte
-	contentFile           *os.File
+	path                string
+	level               uint16
+	secondaryIndexCount uint16
+	version             uint16
+	segmentStartPos     uint64
+	segmentEndPos       uint64
+	dataStartPos        uint64
+	dataEndPos          uint64
+	contents            []byte
+	contentFile         *os.File
+	strategy            segmentindex.Strategy
+	index               diskIndex
+	secondaryIndices    []diskIndex
+	logger              logrus.FieldLogger
+	metrics             *Metrics
+	size                int64
+	mmapContents        bool
+
 	bloomFilter           *bloom.BloomFilter
 	secondaryBloomFilters []*bloom.BloomFilter
-	strategy              segmentindex.Strategy
-	index                 diskIndex
-	secondaryIndices      []diskIndex
-	logger                logrus.FieldLogger
-	metrics               *Metrics
 	bloomFilterMetrics    *bloomFilterMetrics
-	size                  int64
-	mmapContents          bool
 
 	// the net addition this segment adds with respect to all previous segments
 	countNetAdditions int
@@ -69,6 +70,7 @@ type diskIndex interface {
 
 func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	existsLower existsOnLowerSegmentsFn, mmapContents bool,
+	useBloomFilter bool, calcNetAdditions bool,
 ) (*segment, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -118,7 +120,6 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		index:               primaryDiskIndex,
 		logger:              logger,
 		metrics:             metrics,
-		bloomFilterMetrics:  newBloomFilterMetrics(metrics),
 		size:                fileInfo.Size(),
 		mmapContents:        mmapContents,
 	}
@@ -132,26 +133,24 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 
 	if seg.secondaryIndexCount > 0 {
 		seg.secondaryIndices = make([]diskIndex, seg.secondaryIndexCount)
-		seg.secondaryBloomFilters = make([]*bloom.BloomFilter, seg.secondaryIndexCount)
 		for i := range seg.secondaryIndices {
 			secondary, err := header.SecondaryIndex(contents, uint16(i))
 			if err != nil {
 				return nil, fmt.Errorf("get position for secondary index at %d: %w", i, err)
 			}
-
 			seg.secondaryIndices[i] = segmentindex.NewDiskTree(secondary)
-			if err := seg.initSecondaryBloomFilter(i); err != nil {
-				return nil, fmt.Errorf("init bloom filter for secondary index at %d: %w", i, err)
-			}
 		}
 	}
 
-	if err := seg.initBloomFilter(); err != nil {
-		return nil, err
+	if useBloomFilter {
+		if err := seg.initBloomFilters(metrics); err != nil {
+			return nil, err
+		}
 	}
-
-	if err := seg.initCountNetAdditions(existsLower); err != nil {
-		return nil, err
+	if calcNetAdditions {
+		if err := seg.initCountNetAdditions(existsLower); err != nil {
+			return nil, err
+		}
 	}
 
 	return seg, nil

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -324,6 +324,171 @@ func TestLoadWithChecksumErrorCases(t *testing.T) {
 	})
 }
 
+func TestBloom_OFF(t *testing.T) {
+	ctx := context.Background()
+	tests := bucketTests{
+		{
+			name: "dontCreateBloom",
+			f:    dontCreateBloom,
+			opts: []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithSecondaryIndices(1),
+				WithUseBloomFilter(false),
+			},
+		},
+		{
+			name: "dontRecreateBloom",
+			f:    dontRecreateBloom,
+			opts: []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithSecondaryIndices(1),
+				WithUseBloomFilter(false),
+			},
+		},
+		{
+			name: "dontPrecomputeBloom",
+			f:    dontPrecomputeBloom,
+			opts: []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithSecondaryIndices(1),
+				WithUseBloomFilter(false),
+			},
+		},
+	}
+	tests.run(ctx, t)
+}
+
+func dontCreateBloom(ctx context.Context, t *testing.T, opts []BucketOption) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		opts...)
+	require.NoError(t, err)
+	defer b.Shutdown(ctx)
+
+	t.Run("populate", func(t *testing.T) {
+		require.NoError(t, b.Put([]byte("hello"), []byte("world"),
+			WithSecondaryKey(0, []byte("bonjour"))))
+		require.NoError(t, b.FlushMemtable())
+	})
+
+	t.Run("check files", func(t *testing.T) {
+		files, err := os.ReadDir(dirName)
+		require.NoError(t, err)
+
+		_, ok := findFileWithExt(files, ".bloom")
+		assert.False(t, ok)
+		_, ok = findFileWithExt(files, "secondary.0.bloom")
+		assert.False(t, ok)
+	})
+
+	t.Run("search", func(t *testing.T) {
+		valuePrimary, err := b.Get([]byte("hello"))
+		require.NoError(t, err)
+		valueSecondary, err := b.GetBySecondary(0, []byte("bonjour"))
+		require.NoError(t, err)
+
+		assert.Equal(t, []byte("world"), valuePrimary)
+		assert.Equal(t, []byte("world"), valueSecondary)
+	})
+}
+
+func dontRecreateBloom(ctx context.Context, t *testing.T, opts []BucketOption) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	t.Run("create, populate, shutdown", func(t *testing.T) {
+		b, err := NewBucket(ctx, dirName, "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			opts...)
+		require.NoError(t, err)
+		defer b.Shutdown(ctx)
+
+		require.NoError(t, b.Put([]byte("hello"), []byte("world"),
+			WithSecondaryKey(0, []byte("bonjour"))))
+		require.NoError(t, b.FlushMemtable())
+	})
+
+	b2, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		opts...)
+	require.NoError(t, err)
+	defer b2.Shutdown(ctx)
+
+	t.Run("check files", func(t *testing.T) {
+		files, err := os.ReadDir(dirName)
+		require.NoError(t, err)
+
+		_, ok := findFileWithExt(files, ".bloom")
+		assert.False(t, ok)
+		_, ok = findFileWithExt(files, "secondary.0.bloom")
+		assert.False(t, ok)
+	})
+
+	t.Run("search", func(t *testing.T) {
+		valuePrimary, err := b2.Get([]byte("hello"))
+		require.NoError(t, err)
+		valueSecondary, err := b2.GetBySecondary(0, []byte("bonjour"))
+		require.NoError(t, err)
+
+		assert.Equal(t, []byte("world"), valuePrimary)
+		assert.Equal(t, []byte("world"), valueSecondary)
+	})
+}
+
+func dontPrecomputeBloom(ctx context.Context, t *testing.T, opts []BucketOption) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		opts...)
+	require.NoError(t, err)
+	defer b.Shutdown(ctx)
+
+	t.Run("populate, compact", func(t *testing.T) {
+		require.NoError(t, b.Put([]byte("hello"), []byte("world"),
+			WithSecondaryKey(0, []byte("bonjour"))))
+		require.NoError(t, b.FlushMemtable())
+
+		require.NoError(t, b.Put([]byte("hello2"), []byte("world2"),
+			WithSecondaryKey(0, []byte("bonjour2"))))
+		require.NoError(t, b.FlushMemtable())
+
+		compacted, err := b.disk.compactOnce()
+		require.NoError(t, err)
+		require.True(t, compacted)
+	})
+
+	t.Run("check files", func(t *testing.T) {
+		files, err := os.ReadDir(dirName)
+		require.NoError(t, err)
+
+		_, ok := findFileWithExt(files, ".bloom")
+		assert.False(t, ok)
+		_, ok = findFileWithExt(files, "secondary.0.bloom")
+		assert.False(t, ok)
+	})
+
+	t.Run("search", func(t *testing.T) {
+		valuePrimary, err := b.Get([]byte("hello"))
+		require.NoError(t, err)
+		valueSecondary, err := b.GetBySecondary(0, []byte("bonjour"))
+		require.NoError(t, err)
+		value2Primary, err := b.Get([]byte("hello2"))
+		require.NoError(t, err)
+		value2Secondary, err := b.GetBySecondary(0, []byte("bonjour2"))
+		require.NoError(t, err)
+
+		assert.Equal(t, []byte("world"), valuePrimary)
+		assert.Equal(t, []byte("world"), valueSecondary)
+		assert.Equal(t, []byte("world2"), value2Primary)
+		assert.Equal(t, []byte("world2"), value2Secondary)
+	})
+}
+
 func corruptBloomFile(fname string) error {
 	f, err := os.Open(fname)
 	if err != nil {

--- a/adapters/repos/db/lsmkv/segment_collection_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_collection_strategy.go
@@ -26,7 +26,7 @@ func (s *segment) getCollection(key []byte) ([]value, error) {
 			StrategySetCollection, StrategyMapCollection)
 	}
 
-	if !s.bloomFilter.Test(key) {
+	if s.bloomFilter != nil && !s.bloomFilter.Test(key) {
 		return nil, lsmkv.NotFound
 	}
 

--- a/adapters/repos/db/lsmkv/segment_collection_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_collection_strategy.go
@@ -26,7 +26,7 @@ func (s *segment) getCollection(key []byte) ([]value, error) {
 			StrategySetCollection, StrategyMapCollection)
 	}
 
-	if s.bloomFilter != nil && !s.bloomFilter.Test(key) {
+	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return nil, lsmkv.NotFound
 	}
 

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -58,20 +58,20 @@ type SegmentGroup struct {
 	mmapContents            bool
 	keepTombstones          bool // see bucket for more datails
 	useBloomFilter          bool // see bucket for more datails
-	calcNetAdditions        bool // see bucket for more datails
+	calcCountNetAdditions   bool // see bucket for more datails
 	compactLeftOverSegments bool // see bucket for more datails
 }
 
 type sgConfig struct {
-	dir                string
-	strategy           string
-	mapRequiresSorting bool
-	monitorCount       bool
-	mmapContents       bool
-	keepTombstones     bool
-	useBloomFilter     bool
-	calcNetAdditions   bool
-	forceCompaction    bool
+	dir                   string
+	strategy              string
+	mapRequiresSorting    bool
+	monitorCount          bool
+	mmapContents          bool
+	keepTombstones        bool
+	useBloomFilter        bool
+	calcCountNetAdditions bool
+	forceCompaction       bool
 }
 
 func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
@@ -93,7 +93,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 		mmapContents:            cfg.mmapContents,
 		keepTombstones:          cfg.keepTombstones,
 		useBloomFilter:          cfg.useBloomFilter,
-		calcNetAdditions:        cfg.calcNetAdditions,
+		calcCountNetAdditions:   cfg.calcCountNetAdditions,
 		compactLeftOverSegments: cfg.forceCompaction,
 	}
 
@@ -139,7 +139,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 
 		segment, err := newSegment(filepath.Join(sg.dir, entry.Name()), logger,
 			metrics, sg.makeExistsOnLower(segmentIndex),
-			sg.mmapContents, sg.useBloomFilter, sg.calcNetAdditions)
+			sg.mmapContents, sg.useBloomFilter, sg.calcCountNetAdditions)
 		if err != nil {
 			return nil, errors.Wrapf(err, "init segment %s", entry.Name())
 		}
@@ -185,7 +185,7 @@ func (sg *SegmentGroup) add(path string) error {
 	newSegmentIndex := len(sg.segments)
 	segment, err := newSegment(path, sg.logger,
 		sg.metrics, sg.makeExistsOnLower(newSegmentIndex),
-		sg.mmapContents, sg.useBloomFilter, sg.calcNetAdditions)
+		sg.mmapContents, sg.useBloomFilter, sg.calcCountNetAdditions)
 	if err != nil {
 		return errors.Wrapf(err, "init segment %s", path)
 	}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -57,30 +57,44 @@ type SegmentGroup struct {
 
 	mmapContents            bool
 	keepTombstones          bool // see bucket for more datails
+	useBloomFilter          bool // see bucket for more datails
+	calcNetAdditions        bool // see bucket for more datails
 	compactLeftOverSegments bool // see bucket for more datails
 }
 
-func newSegmentGroup(dir string, logger logrus.FieldLogger,
-	mapRequiresSorting bool, metrics *Metrics, strategy string,
-	monitorCount bool, compactionCallbacks cyclemanager.CycleCallbackGroup,
-	mmapContents bool, keepTombstones bool, compactLeftOvers bool,
+type sgConfig struct {
+	dir                string
+	strategy           string
+	mapRequiresSorting bool
+	monitorCount       bool
+	mmapContents       bool
+	keepTombstones     bool
+	useBloomFilter     bool
+	calcNetAdditions   bool
+	forceCompaction    bool
+}
+
+func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
+	compactionCallbacks cyclemanager.CycleCallbackGroup, cfg sgConfig,
 ) (*SegmentGroup, error) {
-	list, err := os.ReadDir(dir)
+	list, err := os.ReadDir(cfg.dir)
 	if err != nil {
 		return nil, err
 	}
 
-	out := &SegmentGroup{
+	sg := &SegmentGroup{
 		segments:                make([]*segment, len(list)),
-		dir:                     dir,
+		dir:                     cfg.dir,
 		logger:                  logger,
 		metrics:                 metrics,
-		monitorCount:            monitorCount,
-		mapRequiresSorting:      mapRequiresSorting,
-		strategy:                strategy,
-		mmapContents:            mmapContents,
-		keepTombstones:          keepTombstones,
-		compactLeftOverSegments: compactLeftOvers,
+		monitorCount:            cfg.monitorCount,
+		mapRequiresSorting:      cfg.mapRequiresSorting,
+		strategy:                cfg.strategy,
+		mmapContents:            cfg.mmapContents,
+		keepTombstones:          cfg.keepTombstones,
+		useBloomFilter:          cfg.useBloomFilter,
+		calcNetAdditions:        cfg.calcNetAdditions,
+		compactLeftOverSegments: cfg.forceCompaction,
 	}
 
 	segmentIndex := 0
@@ -94,19 +108,19 @@ func newSegmentGroup(dir string, logger logrus.FieldLogger,
 		// If yes, we must assume that the flush never finished, as otherwise the
 		// WAL would have been lsmkv.Deleted. Thus we must remove it.
 		potentialWALFileName := strings.TrimSuffix(entry.Name(), ".db") + ".wal"
-		ok, err := fileExists(filepath.Join(dir, potentialWALFileName))
+		ok, err := fileExists(filepath.Join(sg.dir, potentialWALFileName))
 		if err != nil {
 			return nil, errors.Wrapf(err, "check for presence of wals for segment %s",
 				entry.Name())
 		}
 
 		if ok {
-			if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil {
+			if err := os.Remove(filepath.Join(sg.dir, entry.Name())); err != nil {
 				return nil, errors.Wrapf(err, "delete corrupt segment %s", entry.Name())
 			}
 
 			logger.WithField("action", "lsm_segment_init").
-				WithField("path", filepath.Join(dir, entry.Name())).
+				WithField("path", filepath.Join(sg.dir, entry.Name())).
 				WithField("wal_path", potentialWALFileName).
 				Info("Discarded (partially written) LSM segment, because an active WAL for " +
 					"the same segment was found. A recovery from the WAL will follow.")
@@ -123,26 +137,27 @@ func newSegmentGroup(dir string, logger logrus.FieldLogger,
 			continue
 		}
 
-		segment, err := newSegment(filepath.Join(dir, entry.Name()), logger,
-			metrics, out.makeExistsOnLower(segmentIndex), mmapContents)
+		segment, err := newSegment(filepath.Join(sg.dir, entry.Name()), logger,
+			metrics, sg.makeExistsOnLower(segmentIndex),
+			sg.mmapContents, sg.useBloomFilter, sg.calcNetAdditions)
 		if err != nil {
 			return nil, errors.Wrapf(err, "init segment %s", entry.Name())
 		}
 
-		out.segments[segmentIndex] = segment
+		sg.segments[segmentIndex] = segment
 		segmentIndex++
 	}
 
-	out.segments = out.segments[:segmentIndex]
+	sg.segments = sg.segments[:segmentIndex]
 
-	if out.monitorCount {
-		out.metrics.ObjectCount(out.count())
+	if sg.monitorCount {
+		sg.metrics.ObjectCount(sg.count())
 	}
 
-	id := "segmentgroup/compaction/" + out.dir
-	out.compactionCallbackCtrl = compactionCallbacks.Register(id, out.compactIfLevelsMatch)
+	id := "segmentgroup/compaction/" + sg.dir
+	sg.compactionCallbackCtrl = compactionCallbacks.Register(id, sg.compactIfLevelsMatch)
 
-	return out, nil
+	return sg, nil
 }
 
 func (sg *SegmentGroup) makeExistsOnLower(nextSegmentIndex int) existsOnLowerSegmentsFn {
@@ -168,8 +183,9 @@ func (sg *SegmentGroup) add(path string) error {
 	defer sg.maintenanceLock.Unlock()
 
 	newSegmentIndex := len(sg.segments)
-	segment, err := newSegment(path, sg.logger, sg.metrics,
-		sg.makeExistsOnLower(newSegmentIndex), sg.mmapContents)
+	segment, err := newSegment(path, sg.logger,
+		sg.metrics, sg.makeExistsOnLower(newSegmentIndex),
+		sg.mmapContents, sg.useBloomFilter, sg.calcNetAdditions)
 	if err != nil {
 		return errors.Wrapf(err, "init segment %s", path)
 	}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -225,7 +225,8 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	sg.maintenanceLock.RUnlock()
 
 	precomputedFiles, err := preComputeSegmentMeta(newPathTmp,
-		updatedCountNetAdditions, sg.logger)
+		updatedCountNetAdditions, sg.logger,
+		sg.useBloomFilter, sg.calcNetAdditions)
 	if err != nil {
 		return fmt.Errorf("precompute segment meta: %w", err)
 	}
@@ -268,7 +269,8 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 		}
 	}
 
-	seg, err := newSegment(newPath, sg.logger, sg.metrics, nil, sg.mmapContents)
+	seg, err := newSegment(newPath, sg.logger, sg.metrics, nil,
+		sg.mmapContents, sg.useBloomFilter, sg.calcNetAdditions)
 	if err != nil {
 		return errors.Wrap(err, "create new segment")
 	}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -226,7 +226,7 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 
 	precomputedFiles, err := preComputeSegmentMeta(newPathTmp,
 		updatedCountNetAdditions, sg.logger,
-		sg.useBloomFilter, sg.calcNetAdditions)
+		sg.useBloomFilter, sg.calcCountNetAdditions)
 	if err != nil {
 		return fmt.Errorf("precompute segment meta: %w", err)
 	}
@@ -270,7 +270,7 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	}
 
 	seg, err := newSegment(newPath, sg.logger, sg.metrics, nil,
-		sg.mmapContents, sg.useBloomFilter, sg.calcNetAdditions)
+		sg.mmapContents, sg.useBloomFilter, sg.calcCountNetAdditions)
 	if err != nil {
 		return errors.Wrap(err, "create new segment")
 	}

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -152,20 +152,6 @@ func repairCorruptedCNAOnInit(ctx context.Context, t *testing.T, opts []BucketOp
 	assert.Equal(t, 1, b2.Count())
 }
 
-func TestPrefillCountNetAdditions(t *testing.T) {
-	dirName := t.TempDir()
-	segmentName := path.Join(dirName, "foo.db")
-	expectedFileName := path.Join(dirName, "foo.cna")
-
-	err := prefillCountNetAdditions(segmentName, 20)
-	require.Nil(t, err)
-
-	data, err := loadWithChecksum(expectedFileName, 12)
-	require.Nil(t, err)
-	count := binary.LittleEndian.Uint64(data)
-	assert.Equal(t, 20, int(count))
-}
-
 func findFileWithExt(files []os.DirEntry, ext string) (string, bool) {
 	for _, file := range files {
 		fname := file.Name()

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -160,7 +160,7 @@ func TestCNA_OFF(t *testing.T) {
 			f:    dontCreateCNA,
 			opts: []BucketOption{
 				WithStrategy(StrategyReplace),
-				WithCalcNetAdditions(false),
+				WithCalcCountNetAdditions(false),
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func TestCNA_OFF(t *testing.T) {
 			f:    dontRecreateCNA,
 			opts: []BucketOption{
 				WithStrategy(StrategyReplace),
-				WithCalcNetAdditions(false),
+				WithCalcCountNetAdditions(false),
 			},
 		},
 		{
@@ -176,7 +176,7 @@ func TestCNA_OFF(t *testing.T) {
 			f:    dontPrecomputeCNA,
 			opts: []BucketOption{
 				WithStrategy(StrategyReplace),
-				WithCalcNetAdditions(false),
+				WithCalcCountNetAdditions(false),
 			},
 		},
 	}

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -91,7 +91,7 @@ func precomputeSegmentMeta_Replace(ctx context.Context, t *testing.T, opts []Buc
 	err = os.Rename(path.Join(dirName, fname), segmentTmp)
 	require.Nil(t, err)
 
-	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger)
+	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger, true, true)
 	require.Nil(t, err)
 
 	// there should be 4 files and they should all have a .tmp suffix:
@@ -148,7 +148,7 @@ func precomputeSegmentMeta_Set(ctx context.Context, t *testing.T, opts []BucketO
 	err = os.Rename(path.Join(dirName, fname), segmentTmp)
 	require.Nil(t, err)
 
-	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger)
+	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger, true, true)
 	require.Nil(t, err)
 
 	// there should be 2 files and they should all have a .tmp suffix:
@@ -163,14 +163,14 @@ func precomputeSegmentMeta_Set(ctx context.Context, t *testing.T, opts []BucketO
 func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 	t.Run("file without .tmp suffix", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
-		_, err := preComputeSegmentMeta("a-path-without-the-required-suffix", 7, logger)
+		_, err := preComputeSegmentMeta("a-path-without-the-required-suffix", 7, logger, true, true)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "expects a .tmp segment")
 	})
 
 	t.Run("file does not exist", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
-		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger)
+		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger, true, true)
 		require.NotNil(t, err)
 		unixErr := "no such file or directory"
 		windowsErr := "The system cannot find the file specified."
@@ -195,7 +195,7 @@ func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 		err = f.Close()
 		require.Nil(t, err)
 
-		_, err = preComputeSegmentMeta(segmentName, 7, logger)
+		_, err = preComputeSegmentMeta(segmentName, 7, logger, true, true)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parse header")
 	})
@@ -219,7 +219,7 @@ func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 		err = f.Close()
 		require.Nil(t, err)
 
-		_, err = preComputeSegmentMeta(segmentName, 7, logger)
+		_, err = preComputeSegmentMeta(segmentName, 7, logger, true, true)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "unsupported strategy")
 	})

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -26,7 +26,7 @@ func (s *segment) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
 		return out, fmt.Errorf("need strategy %s", StrategyRoaringSet)
 	}
 
-	if !s.bloomFilter.Test(key) {
+	if s.bloomFilter != nil && !s.bloomFilter.Test(key) {
 		return out, lsmkv.NotFound
 	}
 

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -26,7 +26,7 @@ func (s *segment) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
 		return out, fmt.Errorf("need strategy %s", StrategyRoaringSet)
 	}
 
-	if s.bloomFilter != nil && !s.bloomFilter.Test(key) {
+	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return out, lsmkv.NotFound
 	}
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -98,7 +98,7 @@ func (index *flat) initBuckets(ctx context.Context) error {
 	if err := index.store.CreateOrLoadBucket(ctx, helpers.VectorsFlatBucketLSM,
 		lsmkv.WithForceCompation(true),
 		lsmkv.WithUseBloomFilter(false),
-		lsmkv.WithCalcNetAdditions(false),
+		lsmkv.WithCalcCountNetAdditions(false),
 	); err != nil {
 		return fmt.Errorf("Create or load flat vectors bucket: %w", err)
 	}
@@ -106,7 +106,7 @@ func (index *flat) initBuckets(ctx context.Context) error {
 		if err := index.store.CreateOrLoadBucket(ctx, helpers.VectorsFlatBQBucketLSM,
 			lsmkv.WithForceCompation(true),
 			lsmkv.WithUseBloomFilter(false),
-			lsmkv.WithCalcNetAdditions(false),
+			lsmkv.WithCalcCountNetAdditions(false),
 		); err != nil {
 			return fmt.Errorf("Create or load flat compressed vectors bucket: %w", err)
 		}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -96,12 +96,18 @@ func (index *flat) storeGenericVector(id uint64, vector []byte, bucket string) {
 
 func (index *flat) initBuckets(ctx context.Context) error {
 	if err := index.store.CreateOrLoadBucket(ctx, helpers.VectorsFlatBucketLSM,
-		lsmkv.WithForceCompation(true)); err != nil {
+		lsmkv.WithForceCompation(true),
+		lsmkv.WithUseBloomFilter(false),
+		lsmkv.WithCalcNetAdditions(false),
+	); err != nil {
 		return fmt.Errorf("Create or load flat vectors bucket: %w", err)
 	}
 	if index.compression == flatent.CompressionBQ {
 		if err := index.store.CreateOrLoadBucket(ctx, helpers.VectorsFlatBQBucketLSM,
-			lsmkv.WithForceCompation(true)); err != nil {
+			lsmkv.WithForceCompation(true),
+			lsmkv.WithUseBloomFilter(false),
+			lsmkv.WithCalcNetAdditions(false),
+		); err != nil {
 			return fmt.Errorf("Create or load flat compressed vectors bucket: %w", err)
 		}
 	}


### PR DESCRIPTION
### What's being changed:
Introduces 2 buckets options to turn OFF (ON by default) bloom filter usage and count net calculations.
Both setting are applied (OFF) for flat index buckets.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
