### PR TITLE
Schema v2 native http handler endpoint

### DIFF
--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -15,12 +15,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/raft"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/swagger_middleware"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -56,6 +58,25 @@ func addHandleRoot(next http.Handler) http.Handler {
 		}
 
 		next.ServeHTTP(w, r)
+	})
+}
+
+// clusterv1Regexp is used to intercept requests and redirect them to a dedicated http server independent of swagger
+var clusterv1Regexp = regexp.MustCompile("/v1/cluster/*")
+
+// addClusterHandlerMiddleware will inject a middleware that will catch all requests matching clusterv1Regexp.
+// If the request match, it will route it to a dedicated http.Handler and skip the next middleware.
+// If the request doesn't match, it will continue to the next handler.
+func addClusterHandlerMiddleware(next http.Handler, appState *state.State) http.Handler {
+	// Instantiate the router outside the returned lambda to avoid re-allocating everytime a new request comes in
+	raftRouter := raft.ClusterRouter(appState.SchemaManager.Handler)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case clusterv1Regexp.MatchString(r.URL.Path):
+			raftRouter.ServeHTTP(w, r)
+		default:
+			next.ServeHTTP(w, r)
+		}
 	})
 }
 
@@ -103,8 +124,9 @@ func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Ha
 		handler = addHandleRoot(handler)
 		handler = makeAddModuleHandlers(appState.Modules)(handler)
 		handler = addInjectHeadersIntoContext(handler)
-		handler = makeCatchPanics(appState.Logger,
-			newPanicsRequestsTotal(appState.Metrics, appState.Logger))(handler)
+		handler = makeCatchPanics(appState.Logger, newPanicsRequestsTotal(appState.Metrics, appState.Logger))(handler)
+		// Must be the last middleware as it might skip the next handler
+		handler = addClusterHandlerMiddleware(handler, appState)
 
 		return handler
 	}

--- a/adapters/handlers/rest/raft/handler.go
+++ b/adapters/handlers/rest/raft/handler.go
@@ -1,0 +1,158 @@
+package raft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/weaviate/weaviate/usecases/schema"
+)
+
+// RaftHandler struct implements all the http endpoints for raft related requests
+type RaftHandler struct {
+	schemaHandler schema.Handler
+}
+
+// JoinNodeRequest defines the needed parameter for a node to join a raft cluster
+type JoinNodeRequest struct {
+	// Node is the ID of the node that will join the cluster.
+	// It needs the following format NODE_ID[:NODE_PORT]
+	// If NODE_PORT is not specified, default raft interal port will be used
+	Node string `json:"node"`
+	// Voter is whether or not the node wants to join as a voter in the raft cluster
+	Voter bool `json:"voter"`
+}
+
+// Validate ensures that r is valid.
+// If an error is returned the request should not be used.
+func (r JoinNodeRequest) Validate() error {
+	if r.Node == "" {
+		return fmt.Errorf("node parameter is empty")
+	}
+	return nil
+}
+
+// JoinNode parses the received request and body, ensures that they are valid and then forwards the parameters to the scheme handler that
+// will join the node to the cluster.
+// If the request is invalid, returns http.StatusBadRequest
+// If an internal error occurs, returns http.StatusInternalServerError
+func (h RaftHandler) JoinNode(w http.ResponseWriter, r *http.Request) {
+	var joinRequest JoinNodeRequest
+
+	// Decode the request body
+	err := json.NewDecoder(r.Body).Decode(&joinRequest)
+	if err != nil {
+		errString := err.Error()
+		if err == io.EOF {
+			// Nicer error message than "EOF"
+			errString = "request body is empty"
+		}
+		http.Error(w, errString, http.StatusBadRequest)
+		return
+	}
+
+	// Verify that the request is valid
+	err = joinRequest.Validate()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	nodeAddrs := strings.Split(joinRequest.Node, ":")
+	// This should not happen with the previous validate step, but better safe than sorry
+	if len(nodeAddrs) < 1 {
+		http.Error(w, "node parameter is empty", http.StatusBadRequest)
+		return
+	}
+	nodeAddr := nodeAddrs[0]
+	nodePort := ""
+	if len(nodeAddrs) >= 2 {
+		nodePort = nodeAddrs[1]
+	}
+
+	// Forward to the handler
+	err = h.schemaHandler.JoinNode(context.Background(), nodeAddr, nodePort, joinRequest.Voter)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// RemoveNodeRequest defines the needed parameter for a node to be removed from the raft cluster.
+type RemoveNodeRequest struct {
+	// Node is the ID of the node that will be removed from the cluster.
+	Node string `json:"node"`
+}
+
+// Validate ensures that r is valid.
+// If an error is returned the request should not be used.
+func (r RemoveNodeRequest) Validate() error {
+	if r.Node == "" {
+		return fmt.Errorf("node parameter is empty")
+	}
+	return nil
+}
+
+// RemoveNode parses the received request and body, ensures that they are valid and then forwards the parameters to the scheme handler that
+// will remove the node from the cluster.
+// If the request is invalid, returns http.StatusBadRequest
+// If an internal error occurs, returns http.StatusInternalServerError
+func (h RaftHandler) RemoveNode(w http.ResponseWriter, r *http.Request) {
+	var removeRequest RemoveNodeRequest
+
+	// Decode the request body
+	err := json.NewDecoder(r.Body).Decode(&removeRequest)
+	if err != nil {
+		errString := err.Error()
+		if err == io.EOF {
+			// Nicer error message than "EOF"
+			errString = "request body is empty"
+		}
+		http.Error(w, errString, http.StatusBadRequest)
+		return
+	}
+
+	// Verify that the request is valid
+	err = removeRequest.Validate()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = h.schemaHandler.RemoveNode(context.Background(), removeRequest.Node)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// Statistics will fetch internal statistics from the schema handler and returns them to the caller in json format.
+// If an internal error occurs, returns http.StatusInternalServerError
+func (h RaftHandler) Statistics(w http.ResponseWriter, r *http.Request) {
+	// Fetch statistics
+	stats := h.schemaHandler.Statistics()
+
+	// We are returning json
+	w.Header().Set("Content-Type", "application/json")
+
+	// Encode to json and return
+	err := json.NewEncoder(w).Encode(stats)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// ClusterRouter returns a *mux.Router that will requests starting with "/v1/cluster".
+// The schemaHandler is kept in memory internally to forward request to once parsed.
+func ClusterRouter(schemaHandler schema.Handler) *http.ServeMux {
+	raftHandler := RaftHandler{schemaHandler: schemaHandler}
+	r := http.NewServeMux()
+
+	root := "/v1/cluster"
+	r.HandleFunc(root+"/join", raftHandler.JoinNode)
+	r.HandleFunc(root+"/remove", raftHandler.RemoveNode)
+	r.HandleFunc(root+"/statistics", raftHandler.Statistics)
+
+	return r
+}

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -112,6 +112,8 @@ case $CONFIG in
         CLUSTER_GOSSIP_BIND_PORT="7106" \
         CLUSTER_DATA_BIND_PORT="7107" \
         CLUSTER_JOIN="localhost:7100" \
+        RAFT_PORT="8306" \
+        RAFT_INTERNAL_RPC_PORT="8307" \
         CONTEXTIONARY_URL=localhost:9999 \
         DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
         ENABLE_MODULES="text2vec-contextionary" \

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -173,3 +174,27 @@ func (h *Handler) ShardsStatus(ctx context.Context,
 
 	return h.metaReader.GetShardsStatus(class)
 }
+
+/// TODO-RAFT START
+/// https://semi-technology.atlassian.net/browse/WVT-33
+
+// JoinNode adds the given node to the cluster.
+// Node needs to reachable
+func (h *Handler) JoinNode(node string, voter bool) {
+	log.Println(node, voter)
+}
+
+// RemoveNode adds the given node to the cluster.
+func (h *Handler) RemoveNode(node string) {
+	log.Println(node)
+}
+
+// Statistics is used to return a map of various internal stats. This should only be used for informative purposes or debugging.
+func (h *Handler) Statistics() map[string]string {
+	return map[string]string{
+		"A": "1",
+		"B": "2",
+	}
+}
+
+/// TODO-RAFT END


### PR DESCRIPTION
### What's being changed:

Add a new middleware to swagger to intercept request matching "/raft/*" regexp. Matching requests will be re-directed to a go native http handler implementation, skipping all subsequent middleware or swagger logic.

Add RaftRouter struct that implements `JoinNode`, `RemoveNode` and `Statistics` endpoints.
Forward the parsed requests to metaSchemaHandler and forward backs the response to the client.

Tested locally that the request worked
```
Valid request:

$> curl -X POST 127.0.0.1:8080/raft/join -v -d '{"node": "123", "voter": false}'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST /raft/join HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Length: 31
> Content-Type: application/x-www-form-urlencoded
>
< HTTP/1.1 200 OK
< Date: Thu, 09 Nov 2023 11:04:14 GMT
< Content-Length: 0
<
* Connection #0 to host 127.0.0.1 left intact

Invalid request:

$> curl -X POST 127.0.0.1:8080/raft/join -v
*   Trying 127.0.0.1:8080...
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST /raft/join HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Thu, 09 Nov 2023 11:03:54 GMT
< Content-Length: 22
<
request body is empty
```

Dedicated testing should be done once we implement the endpoint so that we can build robust integration/end-to-end testing for raft related features.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
