### PR TITLE
Update gRPC Health Probe to 0.4.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 # This image gets grpc health check probe
 FROM build_base AS grpc_health_probe_builder
 ARG TARGETARCH
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.19 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
       wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
       chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
### What's being changed:

Update Dockerfile GRPC_HEALTH_PROBE_VERSION from 0.4.19 to 0.4.22.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
