### PR TITLE
async: prevent sending empty batches to addBatch

### DIFF
--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -543,6 +543,29 @@ func TestIndexQueue(t *testing.T) {
 			require.True(t, dist >= 0 && dist <= 1)
 		}
 	})
+
+	t.Run("sending batch with deleted ids to worker", func(t *testing.T) {
+		var idx mockBatchIndexer
+		idx.addBatchFn = func(id []uint64, vector [][]float32) error {
+			t.Fatal("should not have been called")
+			return nil
+		}
+
+		q, err := NewIndexQueue("1", new(mockShard), &idx, startWorker(t), newCheckpointManager(t), IndexQueueOptions{
+			BatchSize:     2,
+			IndexInterval: 100 * time.Second,
+		})
+		require.NoError(t, err)
+		defer q.Close()
+
+		pushVector(t, ctx, q, 0, []float32{1, 2, 3})
+		pushVector(t, ctx, q, 1, []float32{1, 2, 3})
+
+		err = q.Delete(0, 1)
+		require.NoError(t, err)
+
+		q.pushToWorkers(-1, true)
+	})
 }
 
 func BenchmarkPush(b *testing.B) {


### PR DESCRIPTION
### What's being changed:

Before sending vectors to the index, each async worker filters out all vectors that have been deleted. If all vectors of a batch have been deleted, we can end up sending an empty batch to `addBatch`, which then returns an error.
We now make sure the batch is never empty right before the call to `addBatch`.

Fixes https://github.com/weaviate/weaviate/issues/3767

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
