### PR TITLE
Simplify Memory Monitor, reduce CPU usage from Memory Monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 ###############################################################################
 # Base build image
-FROM golang:1.20-alpine AS build_base
+FROM golang:1.21-alpine AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -143,8 +143,7 @@ func New(logger logrus.FieldLogger, config Config,
 		asyncIndexRetryInterval: 5 * time.Second,
 		maxNumberGoroutines:     int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
 		resourceScanState:       newResourceScanState(),
-		memMonitor: memwatch.NewMonitor(runtime.MemProfile,
-			debug.SetMemoryLimit, runtime.MemProfileRate, 0.97),
+		memMonitor:              memwatch.NewMonitor(memwatch.LiveHeapReader, debug.SetMemoryLimit, 0.97),
 	}
 
 	// make sure memMonitor has an initial state

--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -13,8 +13,7 @@ package memwatch
 
 import (
 	"fmt"
-	"math"
-	"runtime"
+	"runtime/metrics"
 	"sync"
 )
 
@@ -30,10 +29,9 @@ var ErrNotEnoughMemory = fmt.Errorf("not enough memory")
 
 // Monitor allows making statements about the memory ratio used by the application
 type Monitor struct {
-	memProfiler memProfiler
-	limitSetter limitSetter
-	rate        int64
-	maxRatio    float64
+	metricsReader metricsReader
+	limitSetter   limitSetter
+	maxRatio      float64
 
 	// state
 	mu    sync.Mutex
@@ -44,28 +42,26 @@ type Monitor struct {
 // Refresh retrieves the current memory stats from the runtime and stores them
 // in the local cache
 func (m *Monitor) Refresh() {
-	m.calculateCurrentUsage()
+	m.obtainCurrentUsage()
 	m.updateLimit()
 }
-
-type memProfiler func(p []runtime.MemProfileRecord, inUseZero bool) (int, bool)
 
 // we have no intentions of ever modifying the limit, but SetMemoryLimit with a
 // negative value is the only way to read the limit from the runtime
 type limitSetter func(size int64) int64
 
-// NewMonitor creates a [Monitor] with the given profiler, limitsetter and rate.
+// NewMonitor creates a [Monitor] with the given metrics reader and target
+// ratio
 //
-// Typically this would be called with runtime.MemProfile,
-// debug.SetMemoryLimit, and runtime.MemProfileRate
-func NewMonitor(profiler memProfiler, limitSetter limitSetter,
-	rate int, maxRatio float64,
+// Typically this would be called with LiveHeapReader and
+// debug.SetMemoryLimit
+func NewMonitor(metricsReader metricsReader, limitSetter limitSetter,
+	maxRatio float64,
 ) *Monitor {
 	return &Monitor{
-		memProfiler: profiler,
-		limitSetter: limitSetter,
-		rate:        int64(rate),
-		maxRatio:    maxRatio,
+		metricsReader: metricsReader,
+		limitSetter:   limitSetter,
+		maxRatio:      maxRatio,
 	}
 }
 
@@ -87,66 +83,22 @@ func (m *Monitor) Ratio() float64 {
 	return float64(m.used) / float64(m.limit)
 }
 
-// copied from runtime/pprof/protomem.go
-//
-// scaleHeapSample adjusts the data from a heap Sample to
-// account for its probability of appearing in the collected
-// data. heap profiles are a sampling of the memory allocations
-// requests in a program. We estimate the unsampled value by dividing
-// each collected sample by its probability of appearing in the
-// profile. heap profiles rely on a poisson process to determine
-// which samples to collect, based on the desired average collection
-// rate R. The probability of a sample of size S to appear in that
-// profile is 1-exp(-S/R).
-func scaleHeapSample(count, size, rate int64) (int64, int64) {
-	if count == 0 || size == 0 {
-		return 0, 0
-	}
-
-	if rate <= 1 {
-		// if rate==1 all samples were collected so no adjustment is needed.
-		// if rate<1 treat as unknown and skip scaling.
-		return count, size
-	}
-
-	avgSize := float64(size) / float64(count)
-	scale := 1 / (1 - math.Exp(-avgSize/float64(rate)))
-
-	return int64(float64(count) * scale), int64(float64(size) * scale)
+// obtainCurrentUsage obtains the most recent live heap from runtime/metrics
+func (m *Monitor) obtainCurrentUsage() {
+	m.setUsed(m.metricsReader())
 }
 
-// calculateCurrentUsage obtains the most recent mem profile records from the
-// runtime, sums them up and scales them according to the set profiling rate.
-//
-// The logic to retrieve the records is inspired by runtime/pprof/pprof.go
-func (m *Monitor) calculateCurrentUsage() {
-	var p []runtime.MemProfileRecord
-	n, _ := m.memProfiler(nil, true)
-	for {
-		// Allocate room for a slightly bigger profile,
-		// in case a few more entries have been added
-		// since the call to MemProfile.
-		p = make([]runtime.MemProfileRecord, n+50)
+func LiveHeapReader() int64 {
+	const liveHeapBytesMetric = "/gc/heap/live:bytes"
+	sample := make([]metrics.Sample, 1)
+	sample[0].Name = liveHeapBytesMetric
+	metrics.Read(sample)
 
-		// use different var name and explicitly overwrite
-		// otherwise n from the outside is shadowed and not overwritten
-		n2, ok := m.memProfiler(p, true)
-		if ok {
-			p = p[0:n2]
-			break
-		}
-		// Profile grew; try again.
-		n = n2
+	if sample[0].Value.Kind() == metrics.KindBad {
+		panic(fmt.Sprintf("metric %q no longer supported", liveHeapBytesMetric))
 	}
 
-	var sum int64
-
-	for _, r := range p {
-		_, size := scaleHeapSample(r.InUseObjects(), r.InUseBytes(), m.rate)
-		sum += size
-	}
-
-	m.setUsed(sum)
+	return int64(sample[0].Value.Uint64())
 }
 
 // setUsed is a thread-safe way way to set the current usage
@@ -164,3 +116,5 @@ func (m *Monitor) updateLimit() {
 	// setting a negative limit is the only way to obtain the current limit
 	m.limit = m.limitSetter(-1)
 }
+
+type metricsReader func() int64

--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -12,7 +12,6 @@
 package memwatch
 
 import (
-	"runtime"
 	"runtime/debug"
 	"testing"
 
@@ -21,49 +20,20 @@ import (
 
 func TestMonitor(t *testing.T) {
 	t.Run("with constant profiles (no changes)", func(t *testing.T) {
-		profiler := &fakeMemProfiler{
-			copyProfiles: [][]runtime.MemProfileRecord{
-				{sampleProfile(10000), sampleProfile(20000)},
-				{sampleProfile(10000), sampleProfile(20000)},
-			},
-		}
-
+		metrics := &fakeHeapReader{val: 30000}
 		limiter := &fakeLimitSetter{limit: 100000}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m := NewMonitor(metrics.Read, limiter.SetMemoryLimit, 0.97)
 		m.Refresh()
 
-		assert.Equal(t, 0.3, m.Ratio())
-	})
-
-	t.Run("with one more profile on second call", func(t *testing.T) {
-		profiler := &fakeMemProfiler{
-			copyProfiles: [][]runtime.MemProfileRecord{
-				{sampleProfile(10000)},
-				{sampleProfile(10000), sampleProfile(20000)},
-			},
-		}
-
-		limiter := &fakeLimitSetter{limit: 100000}
-
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
-
-		m.Refresh()
 		assert.Equal(t, 0.3, m.Ratio())
 	})
 
 	t.Run("with less memory than the threshold", func(t *testing.T) {
-		profiler := &fakeMemProfiler{
-			copyProfiles: [][]runtime.MemProfileRecord{
-				{sampleProfile(700 * MiB)},
-				{sampleProfile(700 * MiB)},
-				{sampleProfile(700 * MiB)},
-			},
-		}
-
+		metrics := &fakeHeapReader{val: 700 * MiB}
 		limiter := &fakeLimitSetter{limit: 1 * GiB}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m := NewMonitor(metrics.Read, limiter.SetMemoryLimit, 0.97)
 		m.Refresh()
 
 		err := m.CheckAlloc(100 * MiB)
@@ -77,17 +47,10 @@ func TestMonitor(t *testing.T) {
 	})
 
 	t.Run("with memory already over the threshold", func(t *testing.T) {
-		profiler := &fakeMemProfiler{
-			copyProfiles: [][]runtime.MemProfileRecord{
-				{sampleProfile(1025 * MiB)},
-				{sampleProfile(1025 * MiB)},
-				{sampleProfile(1025 * MiB)},
-			},
-		}
-
+		metrics := &fakeHeapReader{val: 1025 * MiB}
 		limiter := &fakeLimitSetter{limit: 1 * GiB}
 
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1, 0.97)
+		m := NewMonitor(metrics.Read, limiter.SetMemoryLimit, 0.97)
 		m.Refresh()
 
 		err := m.CheckAlloc(1 * B)
@@ -101,54 +64,18 @@ func TestMonitor(t *testing.T) {
 		assert.Error(t, err, "any check should fail, since we're already over the limit")
 	})
 
-	t.Run("with sampling rate", func(t *testing.T) {
-		profiler := &fakeMemProfiler{
-			copyProfiles: [][]runtime.MemProfileRecord{
-				{sampleProfile(10000)},
-				{sampleProfile(10000), sampleProfile(20000)},
-			},
-		}
-
-		limiter := &fakeLimitSetter{limit: 100000}
-
-		// sample rate is small enough to not alter the result, yet big enough to
-		// cover the calculation
-		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 5, 0.97)
-
-		m.Refresh()
-		assert.Equal(t, 0.3, m.Ratio())
-	})
-
 	t.Run("with real dependencies", func(t *testing.T) {
-		m := NewMonitor(runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate, 0.97)
+		m := NewMonitor(LiveHeapReader, debug.SetMemoryLimit, 0.97)
 		_ = m.Ratio()
 	})
 }
 
-type fakeMemProfiler struct {
-	copyProfiles [][]runtime.MemProfileRecord
-	call         int
+type fakeHeapReader struct {
+	val int64
 }
 
-func (f *fakeMemProfiler) MemProfile(p []runtime.MemProfileRecord, inUseZero bool) (int, bool) {
-	profiles := f.copyProfiles[f.call]
-	f.call++
-
-	if len(p) >= len(profiles) {
-		copy(p, profiles)
-		return len(profiles), true
-	}
-
-	return len(profiles), false
-}
-
-func sampleProfile(in int64) runtime.MemProfileRecord {
-	return runtime.MemProfileRecord{
-		AllocBytes:   in,
-		FreeBytes:    0,
-		AllocObjects: 1,
-		FreeObjects:  0,
-	}
+func (f fakeHeapReader) Read() int64 {
+	return f.val
 }
 
 type fakeLimitSetter struct {


### PR DESCRIPTION
### What's being changed:
- fixes #3777 - thanks again, @prattmic, for bringing this up
- simplifies `memwatch` logic (removes the need for manually sampling profile values)
- should be a lot more lightweight (as outlined in #3777)
- EDIT: as I found out from failing CI, this requires Go 1.21, the new metric was only added very recently.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
