### PR TITLE
Improvements of HNSW locks

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -43,7 +43,11 @@ func (h *hnsw) compressedStoreLSMPath() string {
 }
 
 func (h *hnsw) Compress(cfg ent.PQConfig) error {
-	if h.nodes[0] == nil {
+	h.shardedNodeLocks.RLock(0)
+	node := h.nodes[0]
+	h.shardedNodeLocks.RUnlock(0)
+
+	if node == nil {
 		return errors.New("Compress command cannot be executed before inserting some data. Please, insert your data first.")
 	}
 	err := h.initCompressedStore()
@@ -51,7 +55,7 @@ func (h *hnsw) Compress(cfg ent.PQConfig) error {
 		return errors.Wrap(err, "Initializing compressed vector store")
 	}
 
-	vec, err := h.vectorForID(context.Background(), h.nodes[0].id)
+	vec, err := h.vectorForID(context.Background(), node.id)
 	if err != nil {
 		return errors.Wrap(err, "Inferring data dimensions")
 	}

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -590,9 +590,9 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 
 		h.resetLock.Lock()
 		if !breakCleanUpTombstonedNodes() {
-			h.shardedNodeLocks[id%NodeLockStripe].Lock()
+			h.shardedNodeLocks.Lock(id)
 			h.nodes[id] = nil
-			h.shardedNodeLocks[id%NodeLockStripe].Unlock()
+			h.shardedNodeLocks.Unlock(id)
 			if h.compressed.Load() {
 				h.compressedVectorsCache.Delete(context.TODO(), id)
 			} else {

--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -36,6 +36,7 @@ func (h *hnsw) flatSearch(queryVector []float32, limit int,
 		if len(h.nodes) <= int(candidate) { // if index hasn't grown yet for a newly inserted node
 			continue
 		}
+
 		h.shardedNodeLocks.RLock(candidate)
 		c := h.nodes[candidate]
 		h.shardedNodeLocks.RUnlock(candidate)

--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -36,9 +36,9 @@ func (h *hnsw) flatSearch(queryVector []float32, limit int,
 		if len(h.nodes) <= int(candidate) { // if index hasn't grown yet for a newly inserted node
 			continue
 		}
-		h.shardedNodeLocks[candidate%NodeLockStripe].RLock()
+		h.shardedNodeLocks.RLock(candidate)
 		c := h.nodes[candidate]
-		h.shardedNodeLocks[candidate%NodeLockStripe].RUnlock()
+		h.shardedNodeLocks.RUnlock(candidate)
 
 		if c == nil || h.hasTombstone(candidate) {
 			h.RUnlock()

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -246,7 +246,10 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 		return errors.Wrapf(err, "grow HNSW index to accommodate node %d", node.id)
 	}
 
+	h.shardedNodeLocks.Lock(node.id)
 	h.nodes[node.id] = node
+	h.shardedNodeLocks.Unlock(node.id)
+
 	if h.compressed.Load() {
 		compressed := h.pq.Encode(nodeVec)
 		h.storeCompressedVector(node.id, compressed)

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -161,9 +161,9 @@ func (h *hnsw) addOne(vector []float32, node *vertex) error {
 
 	nodeId := node.id
 
-	h.shardedNodeLocks[nodeId%NodeLockStripe].Lock()
+	h.shardedNodeLocks.Lock(nodeId)
 	h.nodes[nodeId] = node
-	h.shardedNodeLocks[nodeId%NodeLockStripe].Unlock()
+	h.shardedNodeLocks.Unlock(nodeId)
 
 	if h.compressed.Load() {
 		compressed := h.pq.Encode(vector)

--- a/adapters/repos/db/vector/hnsw/maintenance.go
+++ b/adapters/repos/db/vector/hnsw/maintenance.go
@@ -67,7 +67,9 @@ func (h *hnsw) growIndexToAccomodateNode(id uint64, logger logrus.FieldLogger) e
 	h.pools.visitedLists = visited.NewPool(1, len(newIndex)+512)
 	h.pools.visitedListsLock.Unlock()
 
+	h.shardedNodeLocks.LockAll()
 	h.nodes = newIndex
+	h.shardedNodeLocks.UnlockAll()
 
 	return nil
 }

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -215,9 +215,9 @@ func (h *hnsw) searchLayerByVectorWithDistancer(queryVector []float32,
 			break
 		}
 		h.RLock()
-		h.shardedNodeLocks[candidate.ID%NodeLockStripe].RLock()
+		h.shardedNodeLocks.RLock(candidate.ID)
 		candidateNode := h.nodes[candidate.ID]
-		h.shardedNodeLocks[candidate.ID%NodeLockStripe].RUnlock()
+		h.shardedNodeLocks.RUnlock(candidate.ID)
 		h.RUnlock()
 		if candidateNode == nil {
 			// could have been a node that already had a tombstone attached and was

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -214,11 +214,11 @@ func (h *hnsw) searchLayerByVectorWithDistancer(queryVector []float32,
 		if dist > worstResultDistance && results.Len() >= ef {
 			break
 		}
-		h.RLock()
+
 		h.shardedNodeLocks.RLock(candidate.ID)
 		candidateNode := h.nodes[candidate.ID]
 		h.shardedNodeLocks.RUnlock(candidate.ID)
-		h.RUnlock()
+
 		if candidateNode == nil {
 			// could have been a node that already had a tombstone attached and was
 			// just cleaned up while we were waiting for a read lock

--- a/adapters/repos/db/vector/hnsw/sharded_node_locks.go
+++ b/adapters/repos/db/vector/hnsw/sharded_node_locks.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import "sync"
+
+const nodeLockStripe = uint64(512)
+
+type shardedNodeLocks []*sync.RWMutex
+
+func newShardedNodeLocks() shardedNodeLocks {
+	snl := make([]*sync.RWMutex, nodeLockStripe)
+	for i := range snl {
+		snl[i] = new(sync.RWMutex)
+	}
+	return snl
+}
+
+func (snl shardedNodeLocks) LockAll() {
+	for i := range snl {
+		snl[i].Lock()
+	}
+}
+
+func (snl shardedNodeLocks) UnlockAll() {
+	for i := range snl {
+		snl[i].Unlock()
+	}
+}
+
+func (snl shardedNodeLocks) Lock(id uint64) {
+	snl[id%nodeLockStripe].Lock()
+}
+
+func (snl shardedNodeLocks) Unlock(id uint64) {
+	snl[id%nodeLockStripe].Unlock()
+}
+
+func (snl shardedNodeLocks) RLockAll() {
+	for i := range snl {
+		snl[i].RLock()
+	}
+}
+
+func (snl shardedNodeLocks) RUnlockAll() {
+	for i := range snl {
+		snl[i].RUnlock()
+	}
+}
+
+func (snl shardedNodeLocks) RLock(id uint64) {
+	snl[id%nodeLockStripe].RLock()
+}
+
+func (snl shardedNodeLocks) RUnlock(id uint64) {
+	snl[id%nodeLockStripe].RUnlock()
+}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -117,7 +117,9 @@ func (h *hnsw) restoreFromDisk() error {
 	}
 
 	h.Lock()
+	h.shardedNodeLocks.LockAll()
 	h.nodes = state.Nodes
+	h.shardedNodeLocks.UnlockAll()
 	h.Unlock()
 
 	h.currentMaximumLayer = int(state.Level)

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -76,10 +76,9 @@ func (pf *vectorCachePrefiller[T]) prefillLevel(ctx context.Context,
 		}
 
 		pf.index.Lock()
-		pf.index.shardedNodeLocks[i%int(NodeLockStripe)].RLock()
+		pf.index.shardedNodeLocks.RLock(uint64(i))
 		node := pf.index.nodes[i]
-		pf.index.shardedNodeLocks[i%int(NodeLockStripe)].RUnlock()
-
+		pf.index.shardedNodeLocks.RUnlock(uint64(i))
 		pf.index.Unlock()
 
 		if node == nil {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -75,11 +75,9 @@ func (pf *vectorCachePrefiller[T]) prefillLevel(ctx context.Context,
 			return false, err
 		}
 
-		pf.index.Lock()
 		pf.index.shardedNodeLocks.RLock(uint64(i))
 		node := pf.index.nodes[i]
 		pf.index.shardedNodeLocks.RUnlock(uint64(i))
-		pf.index.Unlock()
 
 		if node == nil {
 			continue

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -13,7 +13,6 @@ package hnsw
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -25,10 +24,7 @@ func TestVectorCachePrefilling(t *testing.T) {
 	index := &hnsw{
 		nodes:               generateDummyVertices(100),
 		currentMaximumLayer: 3,
-		shardedNodeLocks:    make([]sync.RWMutex, NodeLockStripe),
-	}
-	for i := uint64(0); i < NodeLockStripe; i++ {
-		index.shardedNodeLocks[i] = sync.RWMutex{}
+		shardedNodeLocks:    newShardedNodeLocks(),
 	}
 
 	logger, _ := test.NewNullLogger()


### PR DESCRIPTION
### What's being changed:
Fixes race condition:
```
WARNING: DATA RACE
Read at 0x00c002b65f28 by goroutine 11296:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:310 +0x0
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.growIndexToAccomodateNode()
      /Users/etiennedilocker/code/github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/maintainance.go:98 +0x190
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).growIndexToAccomodateNode()
```

Improves locking on `h.nodes` slice: adds missing striped locks, removes unnecessary global locks.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/152
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
