### PR TITLE
Setting optimal segments on default, based on the dimensions

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -52,7 +52,13 @@ func (h *hnsw) Compress(cfg ent.PQConfig) error {
 
 	// segments == 0 (default value) means use as many segments as dimensions
 	if cfg.Segments <= 0 {
-		cfg.Segments = dims
+		for i := 6; i > 0; i-- {
+			if dims%i == 0 {
+				cfg.Segments = dims / i
+				break
+			}
+		}
+		h.logger.Error(dims, cfg.Segments)
 	}
 
 	h.pq, err = ssdhelpers.NewProductQuantizer(cfg, h.distancerProvider, dims)

--- a/adapters/repos/db/vector/hnsw/compress_segments_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_segments_test.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	ssdhelpers "github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+func Test_NoRaceCompressAdaptsSegments(t *testing.T) {
+	efConstruction := 64
+	ef := 32
+	maxNeighbors := 32
+
+	dimensionsSet := []int{768, 125, 64, 27, 2, 19}
+	expectedSegmentsSet := []int{128, 25, 16, 9, 1, 19}
+	vectors_size := 1000
+
+	for i, dimensions := range dimensionsSet {
+		expectedSegments := expectedSegmentsSet[i]
+		vectors, _ := testinghelpers.RandomVecs(vectors_size, 1, dimensions)
+		distancer := distancer.NewL2SquaredProvider()
+
+		uc := ent.UserConfig{}
+		uc.MaxConnections = maxNeighbors
+		uc.EFConstruction = efConstruction
+		uc.EF = ef
+		uc.VectorCacheMaxObjects = 10e12
+		uc.PQ = ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         "title",
+				Distribution: "normal",
+			},
+		}
+
+		index, _ := New(
+			Config{
+				RootPath:              t.TempDir(),
+				ID:                    "recallbenchmark",
+				MakeCommitLoggerThunk: MakeNoopCommitLogger,
+				DistanceProvider:      distancer,
+				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					return vectors[int(id)], nil
+				},
+				TempVectorForIDThunk: func(ctx context.Context, id uint64, container *common.VectorSlice) ([]float32, error) {
+					copy(container.Slice, vectors[int(id)])
+					return container.Slice, nil
+				},
+			}, uc,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+		defer index.Shutdown(context.Background())
+		ssdhelpers.Concurrently(uint64(len(vectors)), func(id uint64) {
+			index.Add(uint64(id), vectors[id])
+		})
+		cfg := ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeKMeans,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+			Segments:  0,
+			Centroids: 256,
+		}
+		index.Compress(cfg)
+		assert.Equal(t, expectedSegments, int(index.pq.ExposeFields().M))
+	}
+}


### PR DESCRIPTION
### What's being changed:

When the PQConfig contains a zero value in the segments parameter, it folds back to setting the default value. The default value used to be the dimensions. This is far from optimal. In some experiments we identified 6 as a good default number for this setting but still, it has to be an integer divisor of the dimensions. In this PR we set the segments to the closest integer divisor to 6 which is not bigger than 6.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
