### PR TITLE
Add config and support for gRPC TLS credentials

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -20,6 +20,7 @@ import (
 	pbv1 "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/composer"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	v0 "github.com/weaviate/weaviate/adapters/handlers/grpc/v0"
@@ -29,10 +30,23 @@ import (
 const maxMsgSize = 104858000 // 10mb, needs to be synchronized with clients
 
 func CreateGRPCServer(state *state.State) *GRPCServer {
-	s := grpc.NewServer(
+	o := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(maxMsgSize),
-		grpc.MaxSendMsgSize(maxMsgSize),
-	)
+		grpc.MaxSendMsgSize(maxMsgSize)}
+
+	// Add TLS creds for the GRPC connection, if defined.
+	if len(state.ServerConfig.Config.GRPC.CertFile) > 0 && len(state.ServerConfig.Config.GRPC.KeyFile) > 0 {
+		c, err := credentials.NewServerTLSFromFile(state.ServerConfig.Config.GRPC.CertFile,
+			state.ServerConfig.Config.GRPC.KeyFile)
+		if err != nil {
+			state.Logger.WithField("action", "grpc_startup").
+				Errorf("grpc server TLS credential error: %s", err)
+			return nil
+		}
+		o = append(o, grpc.Creds(c))
+	}
+
+	s := grpc.NewServer(o...)
 	weaviateV0 := v0.NewService()
 	weaviateV1 := v1.NewService(
 		state.Traverser,

--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -32,7 +32,8 @@ const maxMsgSize = 104858000 // 10mb, needs to be synchronized with clients
 func CreateGRPCServer(state *state.State) *GRPCServer {
 	o := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(maxMsgSize),
-		grpc.MaxSendMsgSize(maxMsgSize)}
+		grpc.MaxSendMsgSize(maxMsgSize),
+	}
 
 	// Add TLS creds for the GRPC connection, if defined.
 	if len(state.ServerConfig.Config.GRPC.CertFile) > 0 && len(state.ServerConfig.Config.GRPC.KeyFile) > 0 {

--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -36,13 +36,12 @@ func CreateGRPCServer(state *state.State) *GRPCServer {
 	}
 
 	// Add TLS creds for the GRPC connection, if defined.
-	if len(state.ServerConfig.Config.GRPC.CertFile) > 0 && len(state.ServerConfig.Config.GRPC.KeyFile) > 0 {
+	if len(state.ServerConfig.Config.GRPC.CertFile) > 0 || len(state.ServerConfig.Config.GRPC.KeyFile) > 0 {
 		c, err := credentials.NewServerTLSFromFile(state.ServerConfig.Config.GRPC.CertFile,
 			state.ServerConfig.Config.GRPC.KeyFile)
 		if err != nil {
 			state.Logger.WithField("action", "grpc_startup").
-				Errorf("grpc server TLS credential error: %s", err)
-			return nil
+				Fatalf("grpc server TLS credential error: %s", err)
 		}
 		o = append(o, grpc.Creds(c))
 	}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -179,8 +179,11 @@ type Monitoring struct {
 	Group   bool   `json:"group_classes" yaml:"group_classes"`
 }
 
+// Support independent TLS credentials for gRPC
 type GRPC struct {
-	Port int `json:"port" yaml:"port"`
+	Port     int    `json:"port" yaml:"port"`
+	CertFile string `json:"certFile" yaml:"certFile"`
+	KeyFile  string `json:"keyFile" yaml:"keyFile"`
 }
 
 type Profiling struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -308,6 +308,14 @@ func FromEnv(config *Config) error {
 	); err != nil {
 		return err
 	}
+	config.GRPC.CertFile = ""
+	if v := os.Getenv("GRPC_CERT_FILE"); v != "" {
+		config.GRPC.CertFile = v
+	}
+	config.GRPC.KeyFile = ""
+	if v := os.Getenv("GRPC_KEY_FILE"); v != "" {
+		config.GRPC.KeyFile = v
+	}
 
 	config.DisableGraphQL = enabled(os.Getenv("DISABLE_GRAPHQL"))
 


### PR DESCRIPTION
### What's being changed:

gRPC server can be provided with optional TLS credentials via the GRPC_KEY_FILE and GRPC_CERT_FILE environment variables.

These are separate from the HTTP credentials so the gRPC server can be served from a different hostname, and to prevent any side effects of configuring HTTPS forcing a secure gRPC connection or vice versa.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
