### PR TITLE
Bugfix/fix openai error response decoding alt

### DIFF
--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -46,10 +46,10 @@ type embeddingData struct {
 }
 
 type openAIApiError struct {
-	Message string `json:"message"`
-	Type    string `json:"type"`
-	Param   string `json:"param"`
-	Code    string `json:"code"`
+	Message string      `json:"message"`
+	Type    string      `json:"type"`
+	Param   string      `json:"param"`
+	Code    json.Number `json:"code"`
 }
 
 func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -62,11 +62,12 @@ func (e *openAIApiError) UnmarshalJSON(b []byte) error {
 		Param   string      `json:"param"`
 		Code    json.Number `json:"code"`
 	}
-	var err error
+
 	var alias openAIApiErrorAlias
-	if err = json.Unmarshal(b, &alias); err != nil {
+	if err := json.Unmarshal(b, &alias); err != nil {
 		return err
 	}
+	
 	*e = openAIApiError{
 		Message: alias.Message,
 		Type:    alias.Type,

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -46,10 +46,34 @@ type embeddingData struct {
 }
 
 type openAIApiError struct {
-	Message string      `json:"message"`
-	Type    string      `json:"type"`
-	Param   string      `json:"param"`
-	Code    json.Number `json:"code"`
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Param   string `json:"param"`
+	Code    string `json:"code"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface and ensures that the
+// openAIApiError struct correctly handles the code field, which can be either string
+// or number.
+func (e *openAIApiError) UnmarshalJSON(b []byte) error {
+	type openAIApiErrorAlias struct {
+		Message string      `json:"message"`
+		Type    string      `json:"type"`
+		Param   string      `json:"param"`
+		Code    json.Number `json:"code"`
+	}
+	var err error
+	var alias openAIApiErrorAlias
+	if err = json.Unmarshal(b, &alias); err != nil {
+		return err
+	}
+	*e = openAIApiError{
+		Message: alias.Message,
+		Type:    alias.Type,
+		Param:   alias.Param,
+		Code:    alias.Code.String(),
+	}
+	return nil
 }
 
 func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -471,7 +471,7 @@ func Test_openAIApiErrorDecode(t *testing.T) {
 				err := json.Unmarshal(tt.args.response, &got)
 				require.NoError(t, err)
 
-				if got.Code.String() != tt.want {
+				if got.Code != tt.want {
 					t.Errorf("OpenAIerror.code = %v, want %v", got.Code, tt.want)
 				}
 			})

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -432,3 +432,50 @@ func Test_getModelString(t *testing.T) {
 		}
 	})
 }
+
+func Test_openAIApiErrorDecode(t *testing.T) {
+	t.Run("getModelStringQuery", func(t *testing.T) {
+		type args struct {
+			response []byte
+		}
+		tests := []struct {
+			name string
+			args args
+			want string
+		}{
+			{
+				name: "Error code: missing property",
+				args: args{
+					response: []byte(`{"message": "failed", "type": "error", "param": "arg..."}`),
+				},
+				want: "",
+			},
+			{
+				name: "Error code: as int",
+				args: args{
+					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": 500}`),
+				},
+				want: "500",
+			},
+			{
+				name: "Error code as string",
+				args: args{
+					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "500"}`),
+				},
+				want: "500",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var got *openAIApiError
+				err := json.Unmarshal(tt.args.response, &got)
+				if err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if got.Code.String() != tt.want {
+					t.Errorf("vectorizer.getModelString() = %v, want %v", got.Code, tt.want)
+				}
+			})
+		}
+	})
+}

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -469,11 +469,10 @@ func Test_openAIApiErrorDecode(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				var got *openAIApiError
 				err := json.Unmarshal(tt.args.response, &got)
-				if err != nil {
-					t.Fatalf("failed to unmarshal response: %v", err)
-				}
+				require.NoError(t, err)
+
 				if got.Code.String() != tt.want {
-					t.Errorf("vectorizer.getModelString() = %v, want %v", got.Code, tt.want)
+					t.Errorf("OpenAIerror.code = %v, want %v", got.Code, tt.want)
 				}
 			})
 		}


### PR DESCRIPTION
### What's being changed:

- OpenAI error responses are not processable when the `"code"` key is the response is a number. This PR updates the OpenAIError struct to use `json.Number` which handles both string and int values.

Error:
```
&{update vector: unmarshal response body: json: cannot unmarshal number into Go struct field openAIApiError.error.code of type string}
```

NB: This is an alternative of https://github.com/weaviate/weaviate/pull/3804 which avoids changing the openaiError struct.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
