### PR TITLE
Fix object ownership before consistency check during search

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1117,27 +1117,32 @@ func (i *Index) objectSearchByShard(ctx context.Context, limit int, filters *fil
 		shardName := shardName
 
 		eg.Go(func() error {
-			var objs []*storobj.Object
-			var scores []float32
-			var err error
+			var (
+				objs     []*storobj.Object
+				scores   []float32
+				nodeName string
+				err      error
+			)
 
 			if shard := i.localShard(shardName); shard != nil {
+				nodeName = i.getSchema.NodeName()
 				objs, scores, err = shard.objectSearch(ctx, limit, filters, keywordRanking, sort, cursor, addlProps)
 				if err != nil {
 					return fmt.Errorf(
 						"local shard object search %s: %w", shard.ID(), err)
 				}
-				if i.replicationEnabled() {
-					storobj.AddOwnership(objs, i.getSchema.NodeName(), shardName)
-				}
 			} else {
-				objs, scores, err = i.remote.SearchShard(
+				objs, scores, nodeName, err = i.remote.SearchShard(
 					ctx, shardName, nil, limit, filters, keywordRanking,
 					sort, cursor, nil, addlProps, i.replicationEnabled())
 				if err != nil {
 					return fmt.Errorf(
 						"remote shard object search %s: %w", shardName, err)
 				}
+			}
+
+			if i.replicationEnabled() {
+				storobj.AddOwnership(objs, nodeName, shardName)
 			}
 
 			shardResultLock.Lock()
@@ -1286,26 +1291,31 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 	for _, shardName := range shardNames {
 		shardName := shardName
 		eg.Go(func() error {
-			var res []*storobj.Object
-			var resDists []float32
-			var err error
+			var (
+				res      []*storobj.Object
+				resDists []float32
+				nodeName string
+				err      error
+			)
 
 			if shard := i.localShard(shardName); shard != nil {
+				nodeName = i.getSchema.NodeName()
 				res, resDists, err = shard.objectVectorSearch(
 					ctx, searchVector, dist, limit, filters, sort, groupBy, additional)
 				if err != nil {
 					return errors.Wrapf(err, "shard %s", shard.ID())
 				}
-				if i.replicationEnabled() {
-					storobj.AddOwnership(res, i.getSchema.NodeName(), shardName)
-				}
+
 			} else {
-				res, resDists, err = i.remote.SearchShard(ctx,
+				res, resDists, nodeName, err = i.remote.SearchShard(ctx,
 					shardName, searchVector, limit, filters,
 					nil, sort, nil, groupBy, additional, i.replicationEnabled())
 				if err != nil {
 					return errors.Wrapf(err, "remote shard %s", shardName)
 				}
+			}
+			if i.replicationEnabled() {
+				storobj.AddOwnership(res, nodeName, shardName)
 			}
 
 			m.Lock()

--- a/usecases/sharding/remote_index_test.go
+++ b/usecases/sharding/remote_index_test.go
@@ -61,7 +61,7 @@ func TestQueryReplica(t *testing.T) {
 
 	for _, test := range tests {
 		rindex := RemoteIndex{"C", &test.schema, nil, &test.resolver}
-		got, err := rindex.queryReplicas(test.ctx, "S", doIf(test.targetNode))
+		got, lastNode, err := rindex.queryReplicas(test.ctx, "S", doIf(test.targetNode))
 		if !test.success {
 			if got != nil {
 				t.Errorf("%s: want: nil, got: %v", test.name, got)
@@ -69,10 +69,6 @@ func TestQueryReplica(t *testing.T) {
 				t.Errorf("%s: must return an error", test.name)
 			}
 			continue
-		}
-		lastNode, ok := got.(string)
-		if !ok {
-			t.Errorf("%s: result type want: string, got: %t", test.name, got)
 		}
 		if lastNode != test.targetNode {
 			t.Errorf("%s: last responding node want:%s got:%s", test.name, test.targetNode, lastNode)


### PR DESCRIPTION
### What's being changed:
[issue](https://forum.weaviate.io/t/missing-node-or-shard-error/998/2)

This hotfix addresses a bug where object ownership wasn’t set when searching a remote shard. Now, it ensures object ownership is set whether the shard is local or remote
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
