### PR TITLE
Fix of vector size validation after loading hnsw from files

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -294,6 +294,10 @@ func (s *Shard) reinit(ctx context.Context) error {
 			s.index.vectorIndexUserConfig)
 	}
 
+	if err := s.initNonVector(ctx, nil); err != nil {
+		return fmt.Errorf("init non-vector: %w", err)
+	}
+
 	if hnswUserConfig.Skip {
 		s.vectorIndex = noop.NewIndex()
 	} else {
@@ -302,10 +306,6 @@ func (s *Shard) reinit(ctx context.Context) error {
 		}
 
 		defer s.vectorIndex.PostStartup()
-	}
-
-	if err := s.initNonVector(ctx, nil); err != nil {
-		return fmt.Errorf("init non-vector: %w", err)
 	}
 
 	return nil

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -151,6 +151,10 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 			index.vectorIndexUserConfig)
 	}
 
+	if err := s.initNonVector(ctx, class); err != nil {
+		return nil, errors.Wrapf(err, "init shard %q", s.ID())
+	}
+
 	if hnswUserConfig.Skip {
 		s.vectorIndex = noop.NewIndex()
 	} else {
@@ -159,10 +163,6 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		}
 
 		defer s.vectorIndex.PostStartup()
-	}
-
-	if err := s.initNonVector(ctx, class); err != nil {
-		return nil, errors.Wrapf(err, "init shard %q", s.ID())
 	}
 
 	var err error

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -44,7 +44,7 @@ func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object)
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
 		err := s.vectorIndex.ValidateBeforeInsert(object.Vector)
 		if err != nil {
-			return errors.Wrapf(err, "Validate vector index for %v", uuid)
+			return errors.Wrapf(err, "Validate vector index for %s", object.ID())
 		}
 	}
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -279,6 +279,10 @@ func New(cfg Config, uc ent.UserConfig,
 		index.compressedVectorsCache = newCompressedShardedLockCache(index.getCompressedVectorForID, uc.VectorCacheMaxObjects, cfg.Logger)
 	}
 
+	if err := index.init(cfg); err != nil {
+		return nil, errors.Wrapf(err, "init index %q", index.id)
+	}
+
 	// TODO common_cycle_manager move to poststartup?
 	id := strings.Join([]string{
 		"hnsw", "tombstone_cleanup",
@@ -286,10 +290,6 @@ func New(cfg Config, uc ent.UserConfig,
 	}, "/")
 	index.tombstoneCleanupCallbackCtrl = tombstoneCallbacks.Register(id, index.tombstoneCleanup)
 	index.insertMetrics = newInsertMetrics(index.metrics)
-
-	if err := index.init(cfg); err != nil {
-		return nil, errors.Wrapf(err, "init index %q", index.id)
-	}
 
 	return index, nil
 }

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -12,7 +12,6 @@
 package hnsw
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"sync/atomic"
@@ -24,18 +23,17 @@ import (
 )
 
 func (h *hnsw) ValidateBeforeInsert(vector []float32) error {
-	if h.isEmpty() {
+	dims := int(atomic.LoadInt32(&h.dims))
+
+	// no vectors exist
+	if dims == 0 {
 		return nil
 	}
-	// check if vector length is the same as existing nodes
-	existingNodeVector, err := h.cache.get(context.Background(), h.entryPointID)
-	if err != nil {
-		return err
-	}
 
-	if len(existingNodeVector) != len(vector) {
+	// check if vector length is the same as existing nodes
+	if dims != len(vector) {
 		return fmt.Errorf("new node has a vector with length %v. "+
-			"Existing nodes have vectors with length %v", len(vector), len(existingNodeVector))
+			"Existing nodes have vectors with length %v", len(vector), dims)
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:
Changes the way, vector size is validated - `h.dims` is used instead of cached vectors.
Sets `h.dims` value on startup when hnsw graph is loaded from files.
Changes order of index initialisation: vector after store, so store can be accessed on hnsw init.

Addresses https://github.com/weaviate/weaviate/issues/3801

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/154
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
