### PR TITLE
Fix for out of range panic in tombstones cleanup of PQ hnsw

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -19,8 +19,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	ssdhelpers "github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -108,22 +108,32 @@ func (h *hnsw) encodedVector(id uint64) ([]byte, error) {
 	return h.compressedVectorsCache.get(context.Background(), id)
 }
 
-func (h *hnsw) storeCompressedVector(index uint64, vector []byte) {
-	Id := make([]byte, 8)
-	binary.LittleEndian.PutUint64(Id, index)
-	h.compressedStore.Bucket(helpers.CompressedObjectsBucketLSM).Put(Id, vector)
+func (h *hnsw) storeCompressedVector(id uint64, vector []byte) {
+	key := make([]byte, 8)
+	binary.LittleEndian.PutUint64(key, id)
+	h.compressedStore.Bucket(helpers.CompressedObjectsBucketLSM).Put(key, vector)
 }
 
 func (h *hnsw) getCompressedVectorForID(ctx context.Context, id uint64) ([]byte, error) {
-	vec, err := h.vectorForID(ctx, id)
-	if err != nil {
-		return nil, errors.Wrap(err, "Getting vector for id")
-	}
-	if h.distancerProvider.Type() == "cosine-dot" {
-		// cosine-dot requires normalized vectors, as the dot product and cosine
-		// similarity are only identical if the vector is normalized
-		vec = distancer.Normalize(vec)
+	key := make([]byte, 8)
+	binary.LittleEndian.PutUint64(key, id)
+
+	if vec, err := h.compressedStore.Bucket(helpers.CompressedObjectsBucketLSM).Get(key); err == nil {
+		return vec, nil
+	} else if err != entlsmkv.NotFound {
+		return nil, fmt.Errorf("getting vector '%d' from compressed store: %w", id, err)
 	}
 
-	return h.pq.Encode(vec), nil
+	// not found, fallback to uncompressed source
+	h.logger.
+		WithField("action", "compress").
+		WithField("vector", id).
+		Warnf("Vector not found in compressed store")
+
+	vec, err := h.VectorForIDThunk(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("getting vector '%d' from store: %w", id, err)
+	}
+
+	return h.pq.Encode(h.normalizeVec(vec)), nil
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -701,3 +701,12 @@ func (h *hnsw) ContainsNode(id uint64) bool {
 func (h *hnsw) DistancerProvider() distancer.Provider {
 	return h.distancerProvider
 }
+
+func (h *hnsw) normalizeVec(vec []float32) []float32 {
+	if h.distancerProvider.Type() == "cosine-dot" {
+		// cosine-dot requires normalized vectors, as the dot product and cosine
+		// similarity are only identical if the vector is normalized
+		return distancer.Normalize(vec)
+	}
+	return vec
+}

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
 func (h *hnsw) ValidateBeforeInsert(vector []float32) error {
@@ -86,12 +85,7 @@ func (h *hnsw) AddBatch(ids []uint64, vectors [][]float32) error {
 
 		h.metrics.InsertVector()
 
-		if h.distancerProvider.Type() == "cosine-dot" {
-			// cosine-dot requires normalized vectors, as the dot product and cosine
-			// similarity are only identical if the vector is normalized
-			vector = distancer.Normalize(vector)
-		}
-
+		vector = h.normalizeVec(vector)
 		err := h.addOne(vector, node)
 		if err != nil {
 			return err

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -65,12 +65,7 @@ func (h *hnsw) SearchByVector(vector []float32, k int, allowList helpers.AllowLi
 	h.compressActionLock.RLock()
 	defer h.compressActionLock.RUnlock()
 
-	if h.distancerProvider.Type() == "cosine-dot" {
-		// cosine-dot requires normalized vectors, as the dot product and cosine
-		// similarity are only identical if the vector is normalized
-		vector = distancer.Normalize(vector)
-	}
-
+	vector = h.normalizeVec(vector)
 	flatSearchCutoff := int(atomic.LoadInt64(&h.flatSearchCutoff))
 	if allowList != nil && !h.forbidFlat && allowList.Len() < flatSearchCutoff {
 		return h.flatSearch(vector, k, allowList)
@@ -436,9 +431,7 @@ func (h *hnsw) distanceFromBytesToFloatNode(concreteDistancer *ssdhelpers.PQDist
 			return 0, false, errors.Wrapf(err, "get vector of docID %d", nodeID)
 		}
 	}
-	if h.distancerProvider.Type() == "cosine-dot" {
-		vec = distancer.Normalize(vec)
-	}
+	vec = h.normalizeVec(vec)
 	return concreteDistancer.DistanceToFloat(vec)
 }
 


### PR DESCRIPTION
### What's being changed:
Modifies `hnsw::getCompressedVectorForID` method to get compressed vectors from compressed vectors bucket, then fallback to objects bucket (skipping main vectors cache).
Previously `hnsw::vectorForId` was used resulting in `index out of range` panic due to vectors being fetched from empty main vectors cache, which is not used when PQ is enabled.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/155
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
