### PR TITLE
Fix: only coordinator node should respond to search request for replicated class

### DIFF
--- a/test/acceptance/replication/consistency_level_test.go
+++ b/test/acceptance/replication/consistency_level_test.go
@@ -1,0 +1,83 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+	"github.com/weaviate/weaviate/usecases/replica"
+)
+
+func consistencyLevel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster().
+		WithText2VecContextionary().
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("create schema", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
+			Factor: 2,
+		}
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("stop node 2", func(t *testing.T) {
+		stopNode(ctx, t, compose, compose.GetWeaviateNode2().Name())
+		time.Sleep(10 * time.Second)
+	})
+
+	t.Run("insert paragraphs", func(t *testing.T) {
+		batch := make([]*models.Object, len(paragraphIDs))
+		for i, id := range paragraphIDs {
+			batch[i] = articles.NewParagraph().
+				WithID(id).
+				WithContents(fmt.Sprintf("paragraph#%d", i)).
+				Object()
+		}
+		createObjectsCL(t, compose.GetWeaviate().URI(), batch, replica.One)
+	})
+
+	t.Run("restart node 2", func(t *testing.T) {
+		err = compose.Start(ctx, compose.GetWeaviateNode2().Name())
+		require.Nil(t, err)
+	})
+
+	// With consistencyLevel == ONE, node2 should return empty right away,
+	// instead of timing out trying to contact node1
+	t.Run("search to show that node2 wont attempt to contact node1 with cl ONE", func(t *testing.T) {
+		resp := gqlGet(t, compose.GetWeaviateNode2().URI(), paragraphClass.Class, replica.One)
+		// Because all paragraphs were added to node1 when node2 was down, the
+		// response here should be empty since node2 does not contain any data
+		assert.Empty(t, resp)
+	})
+}

--- a/test/acceptance/replication/crud_ops.go
+++ b/test/acceptance/replication/crud_ops.go
@@ -59,6 +59,11 @@ func createObjects(t *testing.T, host string, batch []*models.Object) {
 	helper.CreateObjectsBatch(t, batch)
 }
 
+func createObjectsCL(t *testing.T, host string, batch []*models.Object, cl replica.ConsistencyLevel) {
+	helper.SetupClient(host)
+	helper.CreateObjectsBatchCL(t, batch, cl)
+}
+
 func createTenantObjects(t *testing.T, host string, batch []*models.Object) {
 	helper.SetupClient(host)
 	helper.CreateObjectsBatch(t, batch)

--- a/test/acceptance/replication/setup_test.go
+++ b/test/acceptance/replication/setup_test.go
@@ -20,4 +20,5 @@ func TestReplication(t *testing.T) {
 	t.Run("read repair", readRepair)
 	t.Run("graphql search", graphqlSearch)
 	t.Run("multi-tenancy enabled", multiTenancyEnabled)
+	t.Run("consistency level", consistencyLevel)
 }

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -79,6 +79,17 @@ func CreateObjectsBatch(t *testing.T, objects []*models.Object) {
 	CheckObjectsBatchResponse(t, resp.Payload, err)
 }
 
+func CreateObjectsBatchCL(t *testing.T, objects []*models.Object, cl replica.ConsistencyLevel) {
+	cls := string(cl)
+	params := batch.NewBatchObjectsCreateParams().
+		WithBody(batch.BatchObjectsCreateBody{
+			Objects: objects,
+		}).WithConsistencyLevel(&cls)
+	resp, err := Client(t).Batch.BatchObjectsCreate(params, nil)
+	AssertRequestOk(t, resp, err, nil)
+	CheckObjectsBatchResponse(t, resp.Payload, err)
+}
+
 func CheckObjectsBatchResponse(t *testing.T, resp []*models.ObjectsGetResponse, err error) {
 	AssertRequestOk(t, resp, err, nil)
 	for _, elem := range resp {


### PR DESCRIPTION
### What's being changed:

Fixes a bug where a search query made with consistency level `ONE` still attempts to contact other nodes. This is a problem because the expected behavior for a request made with `ONE` is that if receiving node is alive, it should respond without error regardless of the state of the other nodes in the cluster.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
