### PR TITLE
[Performance] Reduce Allocations by pooling memory in `storobj.ObjectsByDocID`

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -316,6 +316,16 @@ func (b *Bucket) GetBySecondary(pos int, key []byte) ([]byte, error) {
 	return bytes, err
 }
 
+// GetBySecondaryWithBuffer is like [Bucket.GetBySecondary], but also takes a
+// buffer. It's in the response of the caller to pool the buffer, since the
+// bucket does not know when the caller is done using it. The return bytes will
+// likely point to the same memory that's part of the buffer. However, if the
+// buffer is to small, a larger buffer may also be returned (second arg).
+func (b *Bucket) GetBySecondaryWithBuffer(pos int, key []byte, buf []byte) ([]byte, []byte, error) {
+	bytes, newBuf, err := b.GetBySecondaryIntoMemory(pos, key, buf)
+	return bytes, newBuf, err
+}
+
 // GetBySecondaryIntoMemory copies into the specified memory, and retrieves
 // an object using one of its secondary keys. A bucket
 // can have an infinite number of secondary keys. Specify the secondary key

--- a/entities/storobj/buffer_pool.go
+++ b/entities/storobj/buffer_pool.go
@@ -1,0 +1,31 @@
+package storobj
+
+import "sync"
+
+func newBufferPool(initialSize int) *bufferPool {
+	return &bufferPool{
+		pool: sync.Pool{
+			New: func() any {
+				return make([]byte, initialSize)
+			},
+		},
+	}
+}
+
+type bufferPool struct {
+	pool sync.Pool
+}
+
+func (b *bufferPool) Get() []byte {
+	buf := b.pool.Get().([]byte)
+
+	return buf
+}
+
+func (b *bufferPool) Put(buf []byte) {
+	// make sure the length is reset before putting it back into the pool. This
+	// way all buffers will always have len=0, either because they are brand-new
+	// or because they have been reset.
+	buf = buf[:0]
+	b.pool.Put(buf)
+}

--- a/entities/storobj/buffer_pool.go
+++ b/entities/storobj/buffer_pool.go
@@ -17,7 +17,10 @@ func newBufferPool(initialSize int) *bufferPool {
 	return &bufferPool{
 		pool: sync.Pool{
 			New: func() any {
-				return make([]byte, initialSize)
+				// initialize with len=0 to make sure we get a consistent result
+				// whether it's a new or used buffer. Every buffer will always have
+				// len=0 and cap>=initialSize
+				return make([]byte, 0, initialSize)
 			},
 		},
 	}

--- a/entities/storobj/buffer_pool.go
+++ b/entities/storobj/buffer_pool.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package storobj
 
 import "sync"
@@ -27,5 +38,10 @@ func (b *bufferPool) Put(buf []byte) {
 	// way all buffers will always have len=0, either because they are brand-new
 	// or because they have been reset.
 	buf = buf[:0]
+
+	//nolint:staticcheck // I disagree with the linter, this doesn't need to be a
+	//pointer. Even if we copy the slicestruct header, the backing array is
+	//what's allocation-heavy and that will be reused. The profiles in the PR
+	//description prove this.
 	b.pool.Put(buf)
 }

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -227,7 +227,9 @@ func ObjectsByDocID(bucket bucket, ids []uint64,
 		lsmBuf   = bufPool.Get()
 	)
 
-	defer bufPool.Put(lsmBuf)
+	defer func() {
+		bufPool.Put(lsmBuf)
+	}()
 
 	for _, id := range ids {
 		binary.LittleEndian.PutUint64(docIDBuf, id)

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -30,6 +30,16 @@ import (
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
+var bufPool *bufferPool
+
+func init() {
+	// a 10kB buffer should be large enough for typical cases, it can fit a
+	// 1536d uncompressed vector and about 3kB of object payload. If the
+	// initial size is not large enoug, the caller can always allocate a larger
+	// buffer and return that to the pool instead.
+	bufPool = newBufferPool(10 * 1024)
+}
+
 type Object struct {
 	MarshallerVersion uint8
 	Object            models.Object `json:"object"`
@@ -200,6 +210,7 @@ func FromBinaryOptional(data []byte,
 
 type bucket interface {
 	GetBySecondary(int, []byte) ([]byte, error)
+	GetBySecondaryWithBuffer(int, []byte, []byte) ([]byte, []byte, error)
 }
 
 func ObjectsByDocID(bucket bucket, ids []uint64,
@@ -213,14 +224,19 @@ func ObjectsByDocID(bucket bucket, ids []uint64,
 		docIDBuf = make([]byte, 8)
 		out      = make([]*Object, len(ids))
 		i        = 0
+		lsmBuf   = bufPool.Get()
 	)
+
+	defer bufPool.Put(lsmBuf)
 
 	for _, id := range ids {
 		binary.LittleEndian.PutUint64(docIDBuf, id)
-		res, err := bucket.GetBySecondary(0, docIDBuf)
+		res, newBuf, err := bucket.GetBySecondaryWithBuffer(0, docIDBuf, lsmBuf)
 		if err != nil {
 			return nil, err
 		}
+
+		lsmBuf = newBuf // may have changed, e.g. because it was grown
 
 		if res == nil {
 			continue


### PR DESCRIPTION
## What's being changed:

- merge #3824 first, this builds on top of it
- reduces allocs by pooling memory in `storobj.GetObjectsByDocID`
- with 1536d embeddings this is quite noticeable because we need ~7kB per object. With a request of limit 10, that's 10 such buffers. At 1000QPS that's 10,000 such allocations per second.
- About a 4% increase in QPS for low ef values

The flame graph visualizes it nicely:

### Before

<img width="2556" alt="Screenshot 2023-11-29 at 8 44 52 PM" src="https://github.com/weaviate/weaviate/assets/8974479/9578fece-c2e0-4e8a-a116-c3d359b37149">

### After

<img width="2558" alt="Screenshot 2023-11-29 at 8 30 15 PM" src="https://github.com/weaviate/weaviate/assets/8974479/46b152aa-9907-4f79-8fe1-858777726f0a">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
