### PR TITLE
Add support for gRPC endpoint when using testcontainers

### DIFF
--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	github.com/weaviate/weaviate v1.22.4
+	github.com/weaviate/weaviate v1.22.6-0.20231203091511-9bbd792e0c06
 	github.com/weaviate/weaviate-go-client/v4 v4.11.0
 )
 

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -509,8 +509,8 @@ github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9f
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/weaviate/weaviate v1.22.4 h1:QYt3oabGqKteWQxrZypt2TEOwBVsIqkK5ZrIPcpFur0=
-github.com/weaviate/weaviate v1.22.4/go.mod h1:vh5inv9tXq31wsXMypLz31aT3YwigVzYkpY2qffajPY=
+github.com/weaviate/weaviate v1.22.6-0.20231203091511-9bbd792e0c06 h1:QVLviXyRDn53aA7hfYSjRp6JAafhX7RrfpLZjqnULWg=
+github.com/weaviate/weaviate v1.22.6-0.20231203091511-9bbd792e0c06/go.mod h1:jL1gAl+4G617FVSrN7ALF5QMt3olF7BTCS9Xi16ZtuY=
 github.com/weaviate/weaviate-go-client/v4 v4.11.0 h1:pzq2tlbd8OIsLVjzRtJbZC/7uB52l02/IzD++qujs+k=
 github.com/weaviate/weaviate-go-client/v4 v4.11.0/go.mod h1:BJHgOwLxDo0JdBfpm5uRdM1sRuXC5s8usB5CuTBXqJU=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
+++ b/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
@@ -17,11 +17,13 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/grpc"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
 )
 
 func TestGRPC_Batch(t *testing.T) {
@@ -33,7 +35,39 @@ func TestGRPC_Batch(t *testing.T) {
 	// clean DB
 	err = client.Schema().AllDeleter().Do(ctx)
 	require.NoError(t, err)
-	t.Run("all properties", func(t *testing.T) {
+	t.Run("all properties", testGRPCBatchAPI(ctx, client))
+}
+
+func TestGRPC_Batch_Cluster(t *testing.T) {
+	ctx := context.Background()
+	compose, err := docker.New().
+		WithWeaviateCluster().
+		WithText2VecContextionary().
+		Start(ctx)
+	if err != nil {
+		panic(errors.Wrapf(err, "cannot start"))
+	}
+
+	httpUri := compose.GetWeaviate().GetEndpoint(docker.HTTP)
+	grpcUri := compose.GetWeaviate().GetEndpoint(docker.GRPC)
+
+	config := wvt.Config{Scheme: "http", Host: httpUri, GrpcConfig: &grpc.Config{Host: grpcUri}}
+	client, err := wvt.NewClient(config)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	// clean DB
+	err = client.Schema().AllDeleter().Do(ctx)
+	require.NoError(t, err)
+
+	t.Run("all properties", testGRPCBatchAPI(ctx, client))
+
+	if err := compose.Terminate(ctx); err != nil {
+		panic(errors.Wrapf(err, "cannot terminate"))
+	}
+}
+
+func testGRPCBatchAPI(ctx context.Context, client *wvt.Client) func(t *testing.T) {
+	return func(t *testing.T) {
 		class := fixtures.AllPropertiesClass
 		className := fixtures.AllPropertiesClassName
 		id1 := fixtures.AllPropertiesID1
@@ -67,5 +101,5 @@ func TestGRPC_Batch(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, len(properties), len(props))
 		})
-	})
+	}
 }

--- a/test/docker/azurite.go
+++ b/test/docker/azurite.go
@@ -50,7 +50,7 @@ func startAzurite(ctx context.Context, networkName string) (*DockerContainer, er
 	if err != nil {
 		return nil, err
 	}
-	endpoint, err := container.PortEndpoint(ctx, nat.Port("10000/tcp"), "")
+	uri, err := container.PortEndpoint(ctx, nat.Port("10000/tcp"), "")
 	if err != nil {
 		return nil, err
 	}
@@ -58,5 +58,7 @@ func startAzurite(ctx context.Context, networkName string) (*DockerContainer, er
 	connectionString := "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://%s/devstoreaccount1;"
 	blobEndpoint := fmt.Sprintf("%s:%s", Azurite, "10000")
 	envSettings["AZURE_STORAGE_CONNECTION_STRING"] = fmt.Sprintf(connectionString, blobEndpoint)
-	return &DockerContainer{Azurite, endpoint, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"10000/tcp", uri}
+	return &DockerContainer{Azurite, endpoints, container, envSettings}, nil
 }

--- a/test/docker/clip.go
+++ b/test/docker/clip.go
@@ -51,11 +51,13 @@ func startM2VClip(ctx context.Context, networkName, clipImage string) (*DockerCo
 	if err != nil {
 		return nil, err
 	}
-	uri, err := container.Endpoint(ctx, "")
+	uri, err := container.PortEndpoint(ctx, nat.Port("8080/tcp"), "")
 	if err != nil {
 		return nil, err
 	}
 	envSettings := make(map[string]string)
 	envSettings["CLIP_INFERENCE_API"] = fmt.Sprintf("http://%s:%s", Multi2VecCLIP, "8080")
-	return &DockerContainer{Multi2VecCLIP, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"8080/tcp", uri}
+	return &DockerContainer{Multi2VecCLIP, endpoints, container, envSettings}, nil
 }

--- a/test/docker/container.go
+++ b/test/docker/container.go
@@ -15,8 +15,20 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 )
 
+type EndpointName string
+
+var (
+	HTTP EndpointName = "http"
+	GRPC EndpointName = "grpc"
+)
+
+type endpoint struct {
+	port, uri string
+}
+
 type DockerContainer struct {
-	name, uri   string
+	name        string
+	endpoints   map[EndpointName]endpoint
 	container   testcontainers.Container
 	envSettings map[string]string
 }
@@ -26,5 +38,12 @@ func (d *DockerContainer) Name() string {
 }
 
 func (d *DockerContainer) URI() string {
-	return d.uri
+	return d.GetEndpoint(HTTP)
+}
+
+func (d *DockerContainer) GetEndpoint(name EndpointName) string {
+	if endpoint, ok := d.endpoints[name]; ok {
+		return endpoint.uri
+	}
+	return ""
 }

--- a/test/docker/contextionary.go
+++ b/test/docker/contextionary.go
@@ -54,5 +54,7 @@ func startT2VContextionary(ctx context.Context, networkName, contextionaryImage 
 	}
 	envSettings := make(map[string]string)
 	envSettings["CONTEXTIONARY_URL"] = fmt.Sprintf("%s:%s", Text2VecContextionary, "9999")
-	return &DockerContainer{Text2VecContextionary, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"9999/tcp", uri}
+	return &DockerContainer{Text2VecContextionary, endpoints, container, envSettings}, nil
 }

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -61,11 +62,13 @@ func (d *DockerCompose) Start(ctx context.Context, container string) error {
 			if err := c.container.Start(ctx); err != nil {
 				return fmt.Errorf("cannot start %q: %w", c.name, err)
 			}
-			newURI, err := c.container.Endpoint(context.Background(), "")
-			if err != nil {
-				return fmt.Errorf("failed to get new uri for container %q: %w", c.name, err)
+			for name, e := range c.endpoints {
+				newURI, err := c.container.PortEndpoint(context.Background(), nat.Port(e.port), "")
+				if err != nil {
+					return fmt.Errorf("failed to get new uri for container %q: %w", c.name, err)
+				}
+				c.endpoints[name] = endpoint{e.port, newURI}
 			}
-			c.uri = newURI
 		}
 	}
 	return nil

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -62,13 +62,15 @@ func (d *DockerCompose) Start(ctx context.Context, container string) error {
 			if err := c.container.Start(ctx); err != nil {
 				return fmt.Errorf("cannot start %q: %w", c.name, err)
 			}
+			newEndpoints := map[EndpointName]endpoint{}
 			for name, e := range c.endpoints {
 				newURI, err := c.container.PortEndpoint(context.Background(), nat.Port(e.port), "")
 				if err != nil {
 					return fmt.Errorf("failed to get new uri for container %q: %w", c.name, err)
 				}
-				c.endpoints[name] = endpoint{e.port, newURI}
+				newEndpoints[name] = endpoint{e.port, newURI}
 			}
+			c.endpoints = newEndpoints
 		}
 	}
 	return nil

--- a/test/docker/gcs.go
+++ b/test/docker/gcs.go
@@ -56,7 +56,7 @@ func startGCS(ctx context.Context, networkName string) (*DockerContainer, error)
 	if err != nil {
 		return nil, err
 	}
-	endpoint, err := container.Endpoint(ctx, "")
+	uri, err := container.PortEndpoint(ctx, nat.Port("9090/tcp"), "")
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,9 @@ func startGCS(ctx context.Context, networkName string) (*DockerContainer, error)
 	envSettings["GOOGLE_CLOUD_PROJECT"] = projectID
 	envSettings["STORAGE_EMULATOR_HOST"] = fmt.Sprintf("%s:%s", GCS, "9090")
 	envSettings["BACKUP_GCS_USE_AUTH"] = "false"
-	return &DockerContainer{GCS, endpoint, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"9090/tcp", uri}
+	return &DockerContainer{GCS, endpoints, container, envSettings}, nil
 }
 
 func dockerFileFromString(dockerFile string) (testcontainers.FromDockerfile, error) {

--- a/test/docker/image.go
+++ b/test/docker/image.go
@@ -51,11 +51,13 @@ func startI2VNeural(ctx context.Context, networkName, img2vecImage string) (*Doc
 	if err != nil {
 		return nil, err
 	}
-	uri, err := container.Endpoint(ctx, "")
+	uri, err := container.PortEndpoint(ctx, nat.Port("8080/tcp"), "")
 	if err != nil {
 		return nil, err
 	}
 	envSettings := make(map[string]string)
 	envSettings["IMAGE_INFERENCE_API"] = fmt.Sprintf("http://%s:%s", Img2VecNeural, "8080")
-	return &DockerContainer{Img2VecNeural, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"8080/tcp", uri}
+	return &DockerContainer{Img2VecNeural, endpoints, container, envSettings}, nil
 }

--- a/test/docker/qna.go
+++ b/test/docker/qna.go
@@ -51,11 +51,13 @@ func startQnATransformers(ctx context.Context, networkName, qnaImage string) (*D
 	if err != nil {
 		return nil, err
 	}
-	uri, err := container.Endpoint(ctx, "")
+	uri, err := container.PortEndpoint(ctx, nat.Port("8080/tcp"), "")
 	if err != nil {
 		return nil, err
 	}
 	envSettings := make(map[string]string)
 	envSettings["QNA_INFERENCE_API"] = fmt.Sprintf("http://%s:%s", QnATransformers, "8080")
-	return &DockerContainer{QnATransformers, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"8080/tcp", uri}
+	return &DockerContainer{QnATransformers, endpoints, container, envSettings}, nil
 }

--- a/test/docker/reranker.go
+++ b/test/docker/reranker.go
@@ -51,11 +51,13 @@ func startRerankerTransformers(ctx context.Context, networkName, rerankerTransfo
 	if err != nil {
 		return nil, err
 	}
-	uri, err := container.Endpoint(ctx, "")
+	uri, err := container.PortEndpoint(ctx, nat.Port("8080/tcp"), "")
 	if err != nil {
 		return nil, err
 	}
 	envSettings := make(map[string]string)
 	envSettings["RERANKER_INFERENCE_API"] = fmt.Sprintf("http://%s:%s", RerankerTransformers, "8080")
-	return &DockerContainer{RerankerTransformers, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"8080/tcp", uri}
+	return &DockerContainer{RerankerTransformers, endpoints, container, envSettings}, nil
 }

--- a/test/docker/sum.go
+++ b/test/docker/sum.go
@@ -57,5 +57,7 @@ func startSUMTransformers(ctx context.Context, networkName, sumImage string) (*D
 	}
 	envSettings := make(map[string]string)
 	envSettings["SUM_INFERENCE_API"] = fmt.Sprintf("http://%s:%s", SUMTransformers, "8080")
-	return &DockerContainer{SUMTransformers, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"8080/tcp", uri}
+	return &DockerContainer{SUMTransformers, endpoints, container, envSettings}, nil
 }

--- a/test/docker/transformers.go
+++ b/test/docker/transformers.go
@@ -24,7 +24,7 @@ import (
 const Text2VecTransformers = "text2vec-transformers"
 
 func startT2VTransformers(ctx context.Context, networkName, transformersImage string) (*DockerContainer, error) {
-	image := "semitechnologies/transformers-inference:sentence-transformers-gtr-t5-base-1.5.1"
+	image := "semitechnologies/transformers-inference:baai-bge-small-en-v1.5-onnx"
 	if len(transformersImage) > 0 {
 		image = transformersImage
 	}

--- a/test/docker/transformers.go
+++ b/test/docker/transformers.go
@@ -57,5 +57,7 @@ func startT2VTransformers(ctx context.Context, networkName, transformersImage st
 	}
 	envSettings := make(map[string]string)
 	envSettings["TRANSFORMERS_INFERENCE_API"] = fmt.Sprintf("http://%s:%s", Text2VecTransformers, "8080")
-	return &DockerContainer{Text2VecTransformers, uri, container, envSettings}, nil
+	endpoints := make(map[EndpointName]endpoint)
+	endpoints[HTTP] = endpoint{"8080/tcp", uri}
+	return &DockerContainer{Text2VecTransformers, endpoints, container, envSettings}, nil
 }

--- a/test/modules/text2vec-transformers/transformers_test.go
+++ b/test/modules/text2vec-transformers/transformers_test.go
@@ -41,7 +41,7 @@ func Test_T2VTransformers(t *testing.T) {
 					Books(
 						nearText: {
 							concepts: ["Frank Herbert"]
-							distance: 0.7
+							distance: 0.3
 						}
 					){
 						title

--- a/test/run.sh
+++ b/test/run.sh
@@ -101,6 +101,7 @@ function main() {
     docker build --build-arg GITHASH="$GIT_HASH" -t $module_test_image .
     export "TEST_WEAVIATE_IMAGE"=$module_test_image
 
+    echo_green "Weaviate image successfully built, run module tests..."
     run_module_tests "$@"
     echo_green "Module acceptance tests successful"
   fi
@@ -132,7 +133,7 @@ function run_acceptance_tests() {
 function run_module_tests() {
   # for now we need to run the tests sequentially, there seems to be some sort of issues with running them in parallel
     for pkg in $(go list ./... | grep 'test/modules'); do
-      if ! go test -v -count 1 -race "$pkg"; then
+      if ! go test -count 1 -race "$pkg"; then
         echo "Test for $pkg failed" >&2
         return 1
       fi


### PR DESCRIPTION
### What's being changed:

This PR improves our testcontainers docker compose implementation:
- replaces usage for `Endpoint` method in favor of `PortEndpoint` method where you have to explicitly pass `port` for which you want to get the `mapped endpoint uri` back
- if a container exposes more then one port now we can get all of those mapped ports for containers
- added `Batch API` cluster tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
