### PR TITLE
Set secondary score in searches without a query

### DIFF
--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -232,6 +232,7 @@ func sparseSubSearch(subsearch *searchparams.WeightedSearchResult, params *Param
 	out := make([]*Result, len(res))
 	for i, obj := range res {
 		sr := obj.SearchResultWithDist(additional.Properties{}, dists[i])
+		sr.SecondarySortValue = sr.Score
 		out[i] = &Result{obj.DocID(), &sr}
 	}
 
@@ -257,6 +258,7 @@ func nearTextSubSearch(ctx context.Context, subsearch *searchparams.WeightedSear
 	out := make([]*Result, len(res))
 	for i, obj := range res {
 		sr := obj.SearchResultWithDist(additional.Properties{}, dists[i])
+		sr.SecondarySortValue = 1 - sr.Dist
 		out[i] = &Result{obj.DocID(), &sr}
 	}
 
@@ -274,6 +276,7 @@ func nearVectorSubSearch(subsearch *searchparams.WeightedSearchResult, denseSear
 	out := make([]*Result, len(res))
 	for i, obj := range res {
 		sr := obj.SearchResultWithDist(additional.Properties{}, dists[i])
+		sr.SecondarySortValue = 1 - sr.Dist
 		out[i] = &Result{obj.DocID(), &sr}
 	}
 


### PR DESCRIPTION
### What's being changed:

Should fix scores being equal to zero on non-query hybrid searches

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
