### PR TITLE
Fix gRPC filtering on reference properties with `ContainsXXX`

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -475,7 +475,7 @@ func extractDataType(scheme schema.Schema, operator filters.Operator, classname 
 		if err != nil {
 			return dataType, err
 		}
-		return schema.DataType(prop.DataType[0]), nil
+		dataType = schema.DataType(prop.DataType[0])
 	} else {
 		propToCheck := on[0]
 		_, isPropLengthFilter := schema.IsPropertyLength(propToCheck, 0)


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug seen when attempting to filter on a reference property using the `ContainsXXX` filter

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
