### PR TITLE
Lazy load shards (part 3)

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -235,6 +235,8 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 		getSchema:             schemaGetter,
 		centralJobQueue:       repo.jobQueueCh,
 	}
+	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
+
 	if err = os.Mkdir(idx.path(), os.ModePerm); err != nil {
 		panic(err)
 	}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/go-openapi/strfmt"
@@ -228,17 +229,47 @@ func (l *LazyLoadShard) MultiObjectByID(ctx context.Context, query []multi.Ident
 }
 
 func (l *LazyLoadShard) ID() string {
-	l.mustLoad()
-	return l.shard.ID()
-}
-
-func (l *LazyLoadShard) DBPathLSM() string {
-	l.mustLoad()
-	return l.shard.DBPathLSM()
+	return shardId(l.shardOpts.index.ID(), l.shardOpts.name)
 }
 
 func (l *LazyLoadShard) drop() error {
-	l.mustLoad()
+	// if not loaded, execute simplified drop without loading shard:
+	// - perform required actions
+	// - remove entire shard directory
+	// use lock to prevent eventual concurrent droping and loading
+	l.mutex.Lock()
+	if !l.loaded {
+		defer l.mutex.Unlock()
+
+		idx := l.shardOpts.index
+		className := idx.Config.ClassName.String()
+		shardName := l.shardOpts.name
+
+		// cleanup metrics
+		NewMetrics(idx.logger, l.shardOpts.promMetrics, className, shardName).
+			DeleteShardLabels(className, shardName)
+
+		// cleanup dimensions
+		if idx.Config.TrackVectorDimensions {
+			clearDimensionMetrics(l.shardOpts.promMetrics, className, shardName, idx.vectorIndexUserConfig)
+		}
+
+		// cleanup queue
+		if l.shardOpts.indexCheckpoints != nil {
+			if err := l.shardOpts.indexCheckpoints.Delete(shardId(idx.ID(), shardName)); err != nil {
+				return fmt.Errorf("delete checkpoint: %w", err)
+			}
+		}
+
+		// remove shard dir
+		if err := os.RemoveAll(shardPath(idx.path(), shardName)); err != nil {
+			return fmt.Errorf("delete shard dir: %w", err)
+		}
+
+		return nil
+	}
+	l.mutex.Unlock()
+
 	return l.shard.drop()
 }
 
@@ -332,17 +363,7 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	if !l.isLoaded() {
 		return nil
 	}
-	if err := l.Load(ctx); err != nil {
-		return err
-	}
 	return l.shard.Shutdown(ctx)
-}
-
-func (l *LazyLoadShard) isLoaded() bool {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-
-	return l.loaded
 }
 
 func (l *LazyLoadShard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) {
@@ -518,4 +539,11 @@ func (l *LazyLoadShard) hasGeoIndex() bool {
 func (l *LazyLoadShard) Metrics() *Metrics {
 	l.mustLoad()
 	return l.shard.Metrics()
+}
+
+func (l *LazyLoadShard) isLoaded() bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	return l.loaded
 }

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -103,7 +103,7 @@ func TestShard_ReadOnly_HaltCompaction(t *testing.T) {
 
 	bucket := shd.Store().Bucket(bucketName)
 	require.NotNil(t, bucket)
-	dirName := path.Join(shd.DBPathLSM(), bucketName)
+	dirName := path.Join(shd.Index().path(), shd.Name(), "lsm", bucketName)
 
 	t.Run("generate random data", func(t *testing.T) {
 		for i := range keys {


### PR DESCRIPTION
### What's being changed:
- introduces simplified drop for lazy load shard, that does not require shard loading upfront (resolves flakiness of `TestSchema_Tenants` tests)
- stops shards loading by `Index` when `Index::Shutdown` or `Index::Drop` were requested


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
