### PR TITLE
Introduce cloud service interfaces

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -260,14 +260,14 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup, is
 	}
 
 	appState.CloudService = cloud.New(rConfig)
-	executor, err := schema.NewExecutor(migrator, appState.CloudService.SchemaReader(), appState.Logger)
+	executor, err := schema.NewExecutor(migrator, appState.CloudService.GetClusterMetaStore().SchemaReader(), appState.Logger)
 	if err != nil {
 		appState.Logger.Errorf("could not init executor %v:", err)
 		os.Exit(1)
 	}
 	schemaManager, err := schemaUC.NewManager(migrator,
-		appState.CloudService.Service,
-		appState.CloudService.SchemaReader(),
+		appState.CloudService.GetClusterMetaStore(),
+		appState.CloudService.GetClusterMetaStore().SchemaReader(),
 		schemaRepo,
 		appState.Logger, appState.Authorizer, appState.ServerConfig.Config,
 		vectorIndex.ParseAndValidateConfig, appState.Modules, inverted.ValidateConfig,

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -69,7 +69,7 @@ type State struct {
 	ClusterHttpClient  *http.Client
 	ReindexCtxCancel   context.CancelFunc
 	/// TODO-RAFT START
-	CloudService cloud.Service
+	CloudService cloud.ClusterService
 	/// TODO-RAFT END
 }
 

--- a/cloud/store/schema.go
+++ b/cloud/store/schema.go
@@ -29,6 +29,22 @@ var (
 	errShardNotFound = errors.New("shard not found")
 )
 
+type ClusterSchema interface {
+	ClassInfo(string) ClassInfo
+	MultiTenancy(string) bool
+	Read(string, func(*models.Class, *sharding.State) error) error
+	ReadOnlyClass(string) *models.Class
+	ReadOnlySchema() models.Schema
+	ClassEqual(string) string
+
+	ShardOwner(string, string) (string, error)
+	ShardFromUUID(string, []byte) string
+	ShardReplicas(string, string) ([]string, error)
+	TenantShard(string, string) (string, string)
+	CopyShardingState(string) *sharding.State
+	GetShardsStatus(string) (models.ShardStatusList, error)
+}
+
 type schema struct {
 	nodeID      string
 	shardReader shardReader

--- a/cloud/store/service.go
+++ b/cloud/store/service.go
@@ -23,6 +23,28 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type ClusterMetaStore interface {
+	Open(context.Context, DB) error
+	Close(ctx context.Context) (err error)
+	Ready() bool
+
+	SchemaReader() *schema
+	AddClass(*models.Class, *sharding.State) error
+	UpdateClass(*models.Class, *sharding.State) error
+	DeleteClass(string) error
+	RestoreClass(*models.Class, *sharding.State) error
+	AddProperty(string, *models.Property) error
+	UpdateShardStatus(string, string, string) error
+	AddTenants(string, *cmd.AddTenantsRequest) error
+	UpdateTenants(string, *cmd.UpdateTenantsRequest) error
+	DeleteTenants(string, *cmd.DeleteTenantsRequest) error
+	Execute(*cmd.ApplyRequest) error
+	Join(context.Context, string, string, bool) error
+	Remove(context.Context, string) error
+	Stats() map[string]string
+	WaitUntilDBRestored(context.Context, time.Duration) error
+}
+
 // Service abstracts away the Raft store, providing clients with an interface that encompasses all write operations.
 // It ensures that these operations are executed on the current leader, regardless of the specific leader in the cluster.
 type Service struct {

--- a/usecases/schema/helpers_for_test.go
+++ b/usecases/schema/helpers_for_test.go
@@ -40,7 +40,7 @@ import (
 func newTestHandler(t *testing.T, db store.DB) (*Handler, func()) {
 	cfg := config.Config{}
 	srv := startRaftCluster(t, db)
-	reader := srv.SchemaReader()
+	metaStore := srv.GetClusterMetaStore()
 	logger, _ := test.NewNullLogger()
 	vectorizerValidator := &fakeVectorizerValidator{
 		valid: []string{
@@ -48,14 +48,14 @@ func newTestHandler(t *testing.T, db store.DB) (*Handler, func()) {
 		},
 	}
 	handler, err := NewHandler(
-		srv.Service, reader, &fakeValidator{}, logger, &fakeAuthorizer{nil},
+		metaStore, metaStore.SchemaReader(), &fakeValidator{}, logger, &fakeAuthorizer{nil},
 		cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, newFakeClusterState(), &fakeScaleOutManager{})
 	require.Nil(t, err)
 	return &handler, func() { srv.Close(context.TODO()) }
 }
 
-func startRaftCluster(t *testing.T, db store.DB) cloud.Service {
+func startRaftCluster(t *testing.T, db store.DB) cloud.ClusterService {
 	node := "node-1"
 	nodeUrl := newRandomHostURL(t)
 	raftUrl := newRandomHostURL(t)


### PR DESCRIPTION
### What's being changed:

Add new interfaces for the cloud service (and underlying schema/store service). The goal of these interfaces is to ease future mocking in unit test to avoid having to start a raft cluster for schema unit tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
