### PR TITLE
Simplify nodes API

### DIFF
--- a/adapters/clients/cluster_node.go
+++ b/adapters/clients/cluster_node.go
@@ -31,13 +31,14 @@ func NewRemoteNode(httpClient *http.Client) *RemoteNode {
 	return &RemoteNode{client: httpClient}
 }
 
-func (c *RemoteNode) GetNodeStatus(ctx context.Context, hostName string, className string) (*models.NodeStatus, error) {
+func (c *RemoteNode) GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error) {
 	p := "/nodes/status"
 	if className != "" {
 		p = path.Join(p, className)
 	}
 	method := http.MethodGet
-	url := url.URL{Scheme: "http", Host: hostName, Path: p}
+	params := url.Values{"output": []string{output}}
+	url := url.URL{Scheme: "http", Host: hostName, Path: p, RawQuery: params.Encode()}
 
 	req, err := http.NewRequestWithContext(ctx, method, url.String(), nil)
 	if err != nil {

--- a/adapters/handlers/rest/clusterapi/nodes.go
+++ b/adapters/handlers/rest/clusterapi/nodes.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/verbosity"
 )
 
 type nodesManager interface {
-	GetNodeStatus(ctx context.Context, className string) (*models.NodeStatus, error)
+	GetNodeStatus(ctx context.Context, className, output string) (*models.NodeStatus, error)
 }
 
 type nodes struct {
@@ -75,7 +76,13 @@ func (s *nodes) incomingNodeStatus() http.Handler {
 			className = args[2]
 		}
 
-		nodeStatus, err := s.nodesManager.GetNodeStatus(r.Context(), className)
+		output := verbosity.OutputMinimal
+		out, found := r.URL.Query()["output"]
+		if found && len(out) > 0 {
+			output = out[0]
+		}
+
+		nodeStatus, err := s.nodesManager.GetNodeStatus(r.Context(), className, output)
 		if err != nil {
 			http.Error(w, "/nodes fulfill request: "+err.Error(),
 				http.StatusBadRequest)

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -882,6 +882,11 @@ func init() {
           "nodes"
         ],
         "operationId": "nodes.get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/CommonOutputVerbosityParameterQuery"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Nodes status successfully returned",
@@ -935,6 +940,9 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
+          },
+          {
+            "$ref": "#/parameters/CommonOutputVerbosityParameterQuery"
           }
         ],
         "responses": {
@@ -4860,6 +4868,13 @@ func init() {
       "name": "order",
       "in": "query"
     },
+    "CommonOutputVerbosityParameterQuery": {
+      "type": "string",
+      "default": "minimal",
+      "description": "Controls the verbosity of the output, possible values are: \"minimal\", \"verbose\". Defaults to \"minimal\".",
+      "name": "output",
+      "in": "query"
+    },
     "CommonSortParameterQuery": {
       "type": "string",
       "description": "Sort parameter to pass an information about the names of the sort fields",
@@ -5783,6 +5798,15 @@ func init() {
           "nodes"
         ],
         "operationId": "nodes.get",
+        "parameters": [
+          {
+            "type": "string",
+            "default": "minimal",
+            "description": "Controls the verbosity of the output, possible values are: \"minimal\", \"verbose\". Defaults to \"minimal\".",
+            "name": "output",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Nodes status successfully returned",
@@ -5836,6 +5860,13 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "default": "minimal",
+            "description": "Controls the verbosity of the output, possible values are: \"minimal\", \"verbose\". Defaults to \"minimal\".",
+            "name": "output",
+            "in": "query"
           }
         ],
         "responses": {
@@ -10047,6 +10078,13 @@ func init() {
       "type": "string",
       "description": "Order parameter to tell how to order (asc or desc) data within given field",
       "name": "order",
+      "in": "query"
+    },
+    "CommonOutputVerbosityParameterQuery": {
+      "type": "string",
+      "default": "minimal",
+      "description": "Controls the verbosity of the output, possible values are: \"minimal\", \"verbose\". Defaults to \"minimal\".",
+      "name": "output",
       "in": "query"
     },
     "CommonSortParameterQuery": {

--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/batch"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -203,7 +204,7 @@ func (h *batchObjectHandlers) objectsDeleteResponse(input *objects.BatchDeleteRe
 			successful += 1
 		}
 
-		if output == "minimal" &&
+		if output == verbosity.OutputMinimal &&
 			(status == models.BatchDeleteResponseResultsObjectsItems0StatusSUCCESS ||
 				status == models.BatchDeleteResponseResultsObjectsItems0StatusDRYRUN) {
 			// only add SUCCESS and DRYRUN results if output is "verbose"

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -50,7 +50,7 @@ func (n *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *m
 	}
 
 	n.metricRequestsTotal.logOk("")
-	return nodes.NewNodesGetOK().WithPayload(n.nodesStatusResponse(status, output))
+	return nodes.NewNodesGetOK().WithPayload(status)
 }
 
 func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, principal *models.Principal) middleware.Responder {
@@ -69,16 +69,7 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 	}
 
 	n.metricRequestsTotal.logOk("")
-	return nodes.NewNodesGetOK().WithPayload(n.nodesStatusResponse(status, output))
-}
-
-func (n *nodesHandlers) nodesStatusResponse(resp *models.NodesStatusResponse, output string) *models.NodesStatusResponse {
-	if output == verbosity.OutputMinimal {
-		for _, node := range resp.Nodes {
-			node.Shards = nil
-		}
-	}
-	return resp
+	return nodes.NewNodesGetOK().WithPayload(status)
 }
 
 func (n *nodesHandlers) handleGetNodesError(err error) middleware.Responder {

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	nodesUC "github.com/weaviate/weaviate/usecases/nodes"
@@ -33,36 +34,55 @@ type nodesHandlers struct {
 	metricRequestsTotal restApiRequestsTotal
 }
 
-func (s *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *models.Principal) middleware.Responder {
-	nodeStatuses, err := s.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, "")
+func (n *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *models.Principal) middleware.Responder {
+	output, err := verbosity.ParseOutput(params.Output)
 	if err != nil {
-		return s.handleGetNodesError(err)
+		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+	}
+
+	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, "", output)
+	if err != nil {
+		return n.handleGetNodesError(err)
 	}
 
 	status := &models.NodesStatusResponse{
 		Nodes: nodeStatuses,
 	}
 
-	s.metricRequestsTotal.logOk("")
-	return nodes.NewNodesGetOK().WithPayload(status)
+	n.metricRequestsTotal.logOk("")
+	return nodes.NewNodesGetOK().WithPayload(n.nodesStatusResponse(status, output))
 }
 
-func (s *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, principal *models.Principal) middleware.Responder {
-	nodeStatuses, err := s.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, params.ClassName)
+func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, principal *models.Principal) middleware.Responder {
+	output, err := verbosity.ParseOutput(params.Output)
 	if err != nil {
-		return s.handleGetNodesError(err)
+		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+	}
+
+	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, params.ClassName, output)
+	if err != nil {
+		return n.handleGetNodesError(err)
 	}
 
 	status := &models.NodesStatusResponse{
 		Nodes: nodeStatuses,
 	}
 
-	s.metricRequestsTotal.logOk("")
-	return nodes.NewNodesGetOK().WithPayload(status)
+	n.metricRequestsTotal.logOk("")
+	return nodes.NewNodesGetOK().WithPayload(n.nodesStatusResponse(status, output))
 }
 
-func (s *nodesHandlers) handleGetNodesError(err error) middleware.Responder {
-	s.metricRequestsTotal.logError("", err)
+func (n *nodesHandlers) nodesStatusResponse(resp *models.NodesStatusResponse, output string) *models.NodesStatusResponse {
+	if output == verbosity.OutputMinimal {
+		for _, node := range resp.Nodes {
+			node.Shards = nil
+		}
+	}
+	return resp
+}
+
+func (n *nodesHandlers) handleGetNodesError(err error) middleware.Responder {
+	n.metricRequestsTotal.logError("", err)
 	if errors.As(err, &enterrors.ErrNotFound{}) {
 		return nodes.NewNodesGetClassNotFound().
 			WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/operations/nodes/nodes_get_class_parameters.go
+++ b/adapters/handlers/rest/operations/nodes/nodes_get_class_parameters.go
@@ -20,16 +20,24 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 )
 
 // NewNodesGetClassParams creates a new NodesGetClassParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewNodesGetClassParams() NodesGetClassParams {
 
-	return NodesGetClassParams{}
+	var (
+		// initialize parameters with default values
+
+		outputDefault = string("minimal")
+	)
+
+	return NodesGetClassParams{
+		Output: &outputDefault,
+	}
 }
 
 // NodesGetClassParams contains all the bound params for the nodes get class operation
@@ -46,6 +54,11 @@ type NodesGetClassParams struct {
 	  In: path
 	*/
 	ClassName string
+	/*Controls the verbosity of the output, possible values are: "minimal", "verbose". Defaults to "minimal".
+	  In: query
+	  Default: "minimal"
+	*/
+	Output *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -57,8 +70,15 @@ func (o *NodesGetClassParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
 	rClassName, rhkClassName, _ := route.Params.GetOK("className")
 	if err := o.bindClassName(rClassName, rhkClassName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOutput, qhkOutput, _ := qs.GetOK("output")
+	if err := o.bindOutput(qOutput, qhkOutput, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -77,6 +97,25 @@ func (o *NodesGetClassParams) bindClassName(rawData []string, hasKey bool, forma
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.ClassName = raw
+
+	return nil
+}
+
+// bindOutput binds and validates parameter Output from query.
+func (o *NodesGetClassParams) bindOutput(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewNodesGetClassParams()
+		return nil
+	}
+	o.Output = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/nodes/nodes_get_class_urlbuilder.go
+++ b/adapters/handlers/rest/operations/nodes/nodes_get_class_urlbuilder.go
@@ -27,6 +27,8 @@ import (
 type NodesGetClassURL struct {
 	ClassName string
 
+	Output *string
+
 	_basePath string
 	// avoid unkeyed usage
 	_ struct{}
@@ -65,6 +67,18 @@ func (o *NodesGetClassURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var outputQ string
+	if o.Output != nil {
+		outputQ = *o.Output
+	}
+	if outputQ != "" {
+		qs.Set("output", outputQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/handlers/rest/operations/nodes/nodes_get_parameters.go
+++ b/adapters/handlers/rest/operations/nodes/nodes_get_parameters.go
@@ -20,15 +20,24 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 )
 
 // NewNodesGetParams creates a new NodesGetParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewNodesGetParams() NodesGetParams {
 
-	return NodesGetParams{}
+	var (
+		// initialize parameters with default values
+
+		outputDefault = string("minimal")
+	)
+
+	return NodesGetParams{
+		Output: &outputDefault,
+	}
 }
 
 // NodesGetParams contains all the bound params for the nodes get operation
@@ -39,6 +48,12 @@ type NodesGetParams struct {
 
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
+
+	/*Controls the verbosity of the output, possible values are: "minimal", "verbose". Defaults to "minimal".
+	  In: query
+	  Default: "minimal"
+	*/
+	Output *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -50,8 +65,33 @@ func (o *NodesGetParams) BindRequest(r *http.Request, route *middleware.MatchedR
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qOutput, qhkOutput, _ := qs.GetOK("output")
+	if err := o.bindOutput(qOutput, qhkOutput, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindOutput binds and validates parameter Output from query.
+func (o *NodesGetParams) bindOutput(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewNodesGetParams()
+		return nil
+	}
+	o.Output = &raw
+
 	return nil
 }

--- a/adapters/handlers/rest/operations/nodes/nodes_get_urlbuilder.go
+++ b/adapters/handlers/rest/operations/nodes/nodes_get_urlbuilder.go
@@ -24,7 +24,11 @@ import (
 
 // NodesGetURL generates an URL for the nodes get operation
 type NodesGetURL struct {
+	Output *string
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -53,6 +57,18 @@ func (o *NodesGetURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var outputQ string
+	if o.Output != nil {
+		outputQ = *o.Output
+	}
+	if outputQ != "" {
+		qs.Set("output", outputQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -259,7 +259,7 @@ func (f *fakeNodeResolver) NodeHostname(string) (string, bool) {
 
 type fakeRemoteNodeClient struct{}
 
-func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName string, className string) (*models.NodeStatus, error) {
+func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error) {
 	return &models.NodeStatus{}, nil
 }
 

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -644,7 +645,7 @@ func makeTestSortingClass(repo *DB) func(t *testing.T) {
 
 func testNodesAPI(repo *DB) func(t *testing.T) {
 	return func(t *testing.T) {
-		nodeStatues, err := repo.GetNodeStatus(context.Background(), "")
+		nodeStatues, err := repo.GetNodeStatus(context.Background(), "", verbosity.OutputVerbose)
 		require.Nil(t, err)
 		require.NotNil(t, nodeStatues)
 

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -22,7 +22,7 @@ import (
 )
 
 // GetNodeStatus returns the status of all Weaviate nodes.
-func (db *DB) GetNodeStatus(ctx context.Context, className string) ([]*models.NodeStatus, error) {
+func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity string) ([]*models.NodeStatus, error) {
 	nodeStatuses := make([]*models.NodeStatus, len(db.schemaGetter.Nodes()))
 	for i, nodeName := range db.schemaGetter.Nodes() {
 		status, err := db.getNodeStatus(ctx, nodeName, className)

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -19,13 +19,14 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/verbosity"
 )
 
 // GetNodeStatus returns the status of all Weaviate nodes.
 func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity string) ([]*models.NodeStatus, error) {
 	nodeStatuses := make([]*models.NodeStatus, len(db.schemaGetter.Nodes()))
 	for i, nodeName := range db.schemaGetter.Nodes() {
-		status, err := db.getNodeStatus(ctx, nodeName, className)
+		status, err := db.getNodeStatus(ctx, nodeName, className, verbosity)
 		if err != nil {
 			return nil, fmt.Errorf("node: %v: %w", nodeName, err)
 		}
@@ -42,11 +43,11 @@ func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity str
 	return nodeStatuses, nil
 }
 
-func (db *DB) getNodeStatus(ctx context.Context, nodeName string, className string) (*models.NodeStatus, error) {
+func (db *DB) getNodeStatus(ctx context.Context, nodeName string, className, output string) (*models.NodeStatus, error) {
 	if db.schemaGetter.NodeName() == nodeName {
-		return db.localNodeStatus(className), nil
+		return db.localNodeStatus(className, output), nil
 	}
-	status, err := db.remoteNode.GetNodeStatus(ctx, nodeName, className)
+	status, err := db.remoteNode.GetNodeStatus(ctx, nodeName, className, output)
 	if err != nil {
 		switch err.(type) {
 		case enterrors.ErrOpenHttpRequest, enterrors.ErrSendHttpRequest:
@@ -60,13 +61,14 @@ func (db *DB) getNodeStatus(ctx context.Context, nodeName string, className stri
 }
 
 // IncomingGetNodeStatus returns the index if it exists or nil if it doesn't
-func (db *DB) IncomingGetNodeStatus(ctx context.Context, className string) (*models.NodeStatus, error) {
-	return db.localNodeStatus(className), nil
+func (db *DB) IncomingGetNodeStatus(ctx context.Context, className, verbosity string) (*models.NodeStatus, error) {
+	return db.localNodeStatus(className, verbosity), nil
 }
 
-func (db *DB) localNodeStatus(className string) *models.NodeStatus {
+func (db *DB) localNodeStatus(className, output string) *models.NodeStatus {
 	var (
 		objectCount int64
+		shardCount  int64
 		shards      []*models.NodeShardStatus
 	)
 
@@ -76,9 +78,9 @@ func (db *DB) localNodeStatus(className string) *models.NodeStatus {
 	}
 
 	if className == "" {
-		objectCount = db.localNodeStatusAll(&shards)
+		objectCount, shardCount = db.localNodeStatusAll(&shards, output)
 	} else {
-		objectCount = db.localNodeStatusForClass(&shards, className)
+		objectCount, shardCount = db.localNodeStatusForClass(&shards, className, output)
 	}
 
 	clusterHealthStatus := models.NodeStatusStatusHEALTHY
@@ -96,7 +98,7 @@ func (db *DB) localNodeStatus(className string) *models.NodeStatus {
 		Status:  &clusterHealthStatus,
 		Shards:  shards,
 		Stats: &models.NodeStats{
-			ShardCount:  int64(len(shards)),
+			ShardCount:  shardCount,
 			ObjectCount: objectCount,
 		},
 		BatchStats: &models.BatchStats{
@@ -112,7 +114,7 @@ func (db *DB) localNodeStatus(className string) *models.NodeStatus {
 	return &status
 }
 
-func (db *DB) localNodeStatusAll(status *[]*models.NodeShardStatus) (totalCount int64) {
+func (db *DB) localNodeStatusAll(status *[]*models.NodeShardStatus, output string) (totalCount, shardCount int64) {
 	db.indexLock.RLock()
 	defer db.indexLock.RUnlock()
 	for name, idx := range db.indices {
@@ -121,35 +123,39 @@ func (db *DB) localNodeStatusAll(status *[]*models.NodeShardStatus) (totalCount 
 				Warningf("no resource found for index %q", name)
 			continue
 		}
-		totalCount += idx.getShardsNodeStatus(status)
+		total, shard := idx.getShardsNodeStatus(status, output)
+		totalCount, shardCount = totalCount+total, shardCount+shard
 	}
 	return
 }
 
 func (db *DB) localNodeStatusForClass(status *[]*models.NodeShardStatus,
-	className string,
-) (totalCount int64) {
+	className, output string,
+) (totalCount, shardCount int64) {
 	idx := db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		db.logger.WithField("action", "local_node_status_for_class").
 			Warningf("no index found for class %q", className)
-		return 0
+		return 0, 0
 	}
-	return idx.getShardsNodeStatus(status)
+	return idx.getShardsNodeStatus(status, output)
 }
 
-func (i *Index) getShardsNodeStatus(status *[]*models.NodeShardStatus) (totalCount int64) {
+func (i *Index) getShardsNodeStatus(status *[]*models.NodeShardStatus, output string) (totalCount, shardCount int64) {
 	i.ForEachShard(func(name string, shard ShardLike) error {
 		objectCount := int64(shard.ObjectCount())
-		shardStatus := &models.NodeShardStatus{
-			Name:                 name,
-			Class:                shard.Index().Config.ClassName.String(),
-			ObjectCount:          objectCount,
-			VectorIndexingStatus: shard.GetStatus().String(),
-			VectorQueueLength:    shard.Queue().Size(),
-		}
 		totalCount += objectCount
-		*status = append(*status, shardStatus)
+		if output == verbosity.OutputVerbose {
+			shardStatus := &models.NodeShardStatus{
+				Name:                 name,
+				Class:                shard.Index().Config.ClassName.String(),
+				ObjectCount:          objectCount,
+				VectorIndexingStatus: shard.GetStatus().String(),
+				VectorQueueLength:    shard.Queue().Size(),
+			}
+			*status = append(*status, shardStatus)
+		}
+		shardCount++
 		return nil
 	})
 	return

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -121,7 +121,7 @@ func TestNodesAPI_Journey(t *testing.T) {
 	assert.Nil(t, batchRes[1].Err)
 
 	// check nodes api after importing 2 objects to DB
-	nodeStatues, err = repo.GetNodeStatus(context.Background(), "", verbosity.OutputMinimal)
+	nodeStatues, err = repo.GetNodeStatus(context.Background(), "", verbosity.OutputVerbose)
 	require.Nil(t, err)
 	require.NotNil(t, nodeStatues)
 

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
@@ -52,7 +53,7 @@ func TestNodesAPI_Journey(t *testing.T) {
 	migrator := NewMigrator(repo, logger)
 
 	// check nodes api response on empty DB
-	nodeStatues, err := repo.GetNodeStatus(context.Background(), "")
+	nodeStatues, err := repo.GetNodeStatus(context.Background(), "", verbosity.OutputVerbose)
 	require.Nil(t, err)
 	require.NotNil(t, nodeStatues)
 
@@ -120,7 +121,7 @@ func TestNodesAPI_Journey(t *testing.T) {
 	assert.Nil(t, batchRes[1].Err)
 
 	// check nodes api after importing 2 objects to DB
-	nodeStatues, err = repo.GetNodeStatus(context.Background(), "")
+	nodeStatues, err = repo.GetNodeStatus(context.Background(), "", verbosity.OutputMinimal)
 	require.Nil(t, err)
 	require.NotNil(t, nodeStatues)
 

--- a/client/nodes/nodes_get_class_parameters.go
+++ b/client/nodes/nodes_get_class_parameters.go
@@ -75,6 +75,14 @@ type NodesGetClassParams struct {
 	// ClassName.
 	ClassName string
 
+	/* Output.
+
+	   Controls the verbosity of the output, possible values are: "minimal", "verbose". Defaults to "minimal".
+
+	   Default: "minimal"
+	*/
+	Output *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -92,7 +100,18 @@ func (o *NodesGetClassParams) WithDefaults() *NodesGetClassParams {
 //
 // All values with no default are reset to their zero value.
 func (o *NodesGetClassParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		outputDefault = string("minimal")
+	)
+
+	val := NodesGetClassParams{
+		Output: &outputDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the nodes get class params
@@ -139,6 +158,17 @@ func (o *NodesGetClassParams) SetClassName(className string) {
 	o.ClassName = className
 }
 
+// WithOutput adds the output to the nodes get class params
+func (o *NodesGetClassParams) WithOutput(output *string) *NodesGetClassParams {
+	o.SetOutput(output)
+	return o
+}
+
+// SetOutput adds the output to the nodes get class params
+func (o *NodesGetClassParams) SetOutput(output *string) {
+	o.Output = output
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *NodesGetClassParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -150,6 +180,23 @@ func (o *NodesGetClassParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 	// path param className
 	if err := r.SetPathParam("className", o.ClassName); err != nil {
 		return err
+	}
+
+	if o.Output != nil {
+
+		// query param output
+		var qrOutput string
+
+		if o.Output != nil {
+			qrOutput = *o.Output
+		}
+		qOutput := qrOutput
+		if qOutput != "" {
+
+			if err := r.SetQueryParam("output", qOutput); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/client/nodes/nodes_get_parameters.go
+++ b/client/nodes/nodes_get_parameters.go
@@ -71,6 +71,15 @@ NodesGetParams contains all the parameters to send to the API endpoint
 	Typically these are written to a http.Request.
 */
 type NodesGetParams struct {
+
+	/* Output.
+
+	   Controls the verbosity of the output, possible values are: "minimal", "verbose". Defaults to "minimal".
+
+	   Default: "minimal"
+	*/
+	Output *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -88,7 +97,18 @@ func (o *NodesGetParams) WithDefaults() *NodesGetParams {
 //
 // All values with no default are reset to their zero value.
 func (o *NodesGetParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		outputDefault = string("minimal")
+	)
+
+	val := NodesGetParams{
+		Output: &outputDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the nodes get params
@@ -124,6 +144,17 @@ func (o *NodesGetParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithOutput adds the output to the nodes get params
+func (o *NodesGetParams) WithOutput(output *string) *NodesGetParams {
+	o.SetOutput(output)
+	return o
+}
+
+// SetOutput adds the output to the nodes get params
+func (o *NodesGetParams) SetOutput(output *string) {
+	o.Output = output
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *NodesGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -131,6 +162,23 @@ func (o *NodesGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		return err
 	}
 	var res []error
+
+	if o.Output != nil {
+
+		// query param output
+		var qrOutput string
+
+		if o.Output != nil {
+			qrOutput = *o.Output
+		}
+		qOutput := qrOutput
+		if qOutput != "" {
+
+			if err := r.SetQueryParam("output", qOutput); err != nil {
+				return err
+			}
+		}
+	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/entities/verbosity/verbosity.go
+++ b/entities/verbosity/verbosity.go
@@ -1,0 +1,34 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package verbosity
+
+import "fmt"
+
+const (
+	OutputMinimal = "minimal"
+	OutputVerbose = "verbose"
+)
+
+// ParseOutput extracts the verbosity value from the provided nullable string
+// If `output` is nil, the default selection is "minimal"
+func ParseOutput(output *string) (string, error) {
+	if output != nil {
+		switch *output {
+		case OutputMinimal, OutputVerbose:
+			return *output, nil
+		default:
+			return "", fmt.Errorf(`invalid output: "%s", possible values are: "%s", "%s"`,
+				*output, OutputMinimal, OutputVerbose)
+		}
+	}
+	return OutputMinimal, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -45,9 +45,11 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
+	github.com/KimMachineGun/automemlimit v0.3.0
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/googleapis/gax-go/v2 v2.12.0
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pkoukk/tiktoken-go v0.1.6
 	github.com/tailor-inc/graphql v0.2.1
 	github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d
@@ -64,7 +66,6 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/KimMachineGun/automemlimit v0.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
@@ -126,7 +127,6 @@ require (
 	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,7 +133,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
 github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
@@ -188,6 +187,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
+github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -620,6 +621,8 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1946,6 +1946,14 @@
       "name": "class",
       "required": false,
       "type": "string"
+    },
+    "CommonOutputVerbosityParameterQuery": {
+      "description": "Controls the verbosity of the output, possible values are: \"minimal\", \"verbose\". Defaults to \"minimal\".",
+      "in": "query",
+      "name": "output",
+      "required": false,
+      "type": "string",
+      "default": "minimal"
     }
   },
   "paths": {
@@ -4657,6 +4665,11 @@
         "tags": [
           "nodes"
         ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/CommonOutputVerbosityParameterQuery"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Nodes status successfully returned",
@@ -4710,6 +4723,9 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "$ref": "#/parameters/CommonOutputVerbosityParameterQuery"
           }
         ],
         "responses": {

--- a/test/acceptance/actions/setup_test.go
+++ b/test/acceptance/actions/setup_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -157,7 +158,8 @@ func Test_Delete_ReadOnly_Classes(t *testing.T) {
 	})
 
 	t.Run("set shard to readonly", func(t *testing.T) {
-		nodesResp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		verbose := verbosity.OutputVerbose
+		nodesResp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(&verbose), nil)
 		require.Nil(t, err)
 		require.NotNil(t, nodesResp.Payload)
 		require.Len(t, nodesResp.Payload.Nodes, 1)

--- a/test/acceptance/multi_tenancy/create_and_delete_tenants_test.go
+++ b/test/acceptance/multi_tenancy/create_and_delete_tenants_test.go
@@ -19,8 +19,11 @@ import (
 	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/helper"
 )
+
+var verbose = verbosity.OutputVerbose
 
 func TestCreateTenants(t *testing.T) {
 	testClass := models.Class{
@@ -60,7 +63,7 @@ func TestCreateTenants(t *testing.T) {
 		require.NotNil(t, respGet)
 		require.ElementsMatch(t, respGet.Payload, tenants)
 
-		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(&verbose), nil)
 		require.Nil(t, err)
 		require.NotNil(t, resp.Payload)
 		require.NotNil(t, resp.Payload.Nodes)
@@ -126,7 +129,7 @@ func TestDeleteTenants(t *testing.T) {
 		require.Nil(t, err)
 
 		// deleted once
-		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(&verbose), nil)
 		require.Nil(t, err)
 		require.NotNil(t, resp.Payload)
 		require.NotNil(t, resp.Payload.Nodes)
@@ -146,7 +149,7 @@ func TestDeleteTenants(t *testing.T) {
 		require.Nil(t, err)
 
 		// deleted once
-		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(&verbose), nil)
 		require.Nil(t, err)
 		require.NotNil(t, resp.Payload)
 		require.NotNil(t, resp.Payload.Nodes)
@@ -159,7 +162,7 @@ func TestDeleteTenants(t *testing.T) {
 		require.Nil(t, err)
 
 		// idempotent - deleting multiple times works - tenant1 is removed
-		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(&verbose), nil)
 		require.Nil(t, err)
 		require.NotNil(t, resp.Payload)
 		require.NotNil(t, resp.Payload.Nodes)
@@ -172,7 +175,7 @@ func TestDeleteTenants(t *testing.T) {
 		require.Nil(t, err)
 
 		// successfully deleted
-		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(&verbose), nil)
 		require.Nil(t, err)
 		require.NotNil(t, resp.Payload)
 		require.NotNil(t, resp.Payload.Nodes)

--- a/test/acceptance/multi_tenancy/gql_aggregate_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/gql_aggregate_tenant_objects_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/nodes"
@@ -82,7 +81,7 @@ func TestGQLAggregateTenantObjects(t *testing.T) {
 	})
 
 	t.Run("Get global tenant objects count", func(t *testing.T) {
-		params := nodes.NewNodesGetClassParams().WithClassName(testClass.Class)
+		params := nodes.NewNodesGetClassParams().WithClassName(testClass.Class).WithOutput(&verbose)
 		resp, err := helper.Client(t).Nodes.NodesGetClass(params, nil)
 		require.Nil(t, err)
 

--- a/test/acceptance/replication/crud_ops.go
+++ b/test/acceptance/replication/crud_ops.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -264,8 +265,9 @@ func countTenantObjects(t *testing.T, host, class string,
 
 func getNodes(t *testing.T, host string) *models.NodesStatusResponse {
 	helper.SetupClient(host)
-
-	resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+	verbose := verbosity.OutputVerbose
+	params := nodes.NewNodesGetParams().WithOutput(&verbose)
+	resp, err := helper.Client(t).Nodes.NodesGet(params, nil)
 	helper.AssertRequestOk(t, resp, err, nil)
 	return resp.Payload
 }

--- a/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
+++ b/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/books"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/multishard"
@@ -48,7 +49,9 @@ func Test_WeaviateCluster_NodesAPI(t *testing.T) {
 		for _, endpoint := range []string{weaviateNode1Endpoint, weaviateNode2Endpoint} {
 			t.Run(endpoint, func(t *testing.T) {
 				helper.SetupClient(os.Getenv(endpoint))
-				resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+				verbose := verbosity.OutputVerbose
+				params := nodes.NewNodesGetParams().WithOutput(&verbose)
+				resp, err := helper.Client(t).Nodes.NodesGet(params, nil)
 				require.Nil(t, err)
 
 				nodeStatusResp := resp.GetPayload()

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -491,7 +491,7 @@ func (f *fakeNodeResolver) NodeHostname(string) (string, bool) {
 
 type fakeRemoteNodeClient struct{}
 
-func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName string, className string) (*models.NodeStatus, error) {
+func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error) {
 	return &models.NodeStatus{}, nil
 }
 

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -13,6 +13,7 @@ package nodes
 
 import (
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -13,7 +13,6 @@ package nodes
 
 import (
 	"context"
-
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -24,7 +23,7 @@ type authorizer interface {
 }
 
 type db interface {
-	GetNodeStatus(ctx context.Context, className string) ([]*models.NodeStatus, error)
+	GetNodeStatus(ctx context.Context, className, verbosity string) ([]*models.NodeStatus, error)
 }
 
 type Manager struct {
@@ -41,10 +40,10 @@ func NewManager(logger logrus.FieldLogger, authorizer authorizer,
 }
 
 func (m *Manager) GetNodeStatus(ctx context.Context,
-	principal *models.Principal, className string,
+	principal *models.Principal, className string, verbosity string,
 ) ([]*models.NodeStatus, error) {
 	if err := m.authorizer.Authorize(principal, "list", "nodes"); err != nil {
 		return nil, err
 	}
-	return m.db.GetNodeStatus(ctx, className)
+	return m.db.GetNodeStatus(ctx, className, verbosity)
 }

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -13,19 +13,15 @@ package objects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/filterext"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-)
-
-const (
-	OutputMinimal = "minimal"
-	OutputVerbose = "verbose"
+	"github.com/weaviate/weaviate/entities/verbosity"
 )
 
 // DeleteObjects deletes objects in batch based on the match filter
@@ -124,15 +120,9 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 		dryRunParam = *dryRun
 	}
 
-	outputParam := OutputMinimal
-	if output != nil {
-		switch *output {
-		case OutputMinimal, OutputVerbose:
-			outputParam = *output
-		default:
-			return nil, fmt.Errorf(`invalid output: "%s", possible values are: "%s", "%s"`,
-				*output, OutputMinimal, OutputVerbose)
-		}
+	outputParam, err := verbosity.ParseOutput(output)
+	if err != nil {
+		return nil, err
 	}
 
 	params := &BatchDeleteParams{

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -83,7 +84,7 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			{
 				input: &models.BatchDelete{
 					DryRun: ptBool(false),
-					Output: ptString(OutputVerbose),
+					Output: ptString(verbosity.OutputVerbose),
 					Match: &models.BatchDeleteMatch{
 						Class: "SomeClass",
 						Where: &models.WhereFilter{
@@ -98,7 +99,7 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			{
 				input: &models.BatchDelete{
 					DryRun: ptBool(false),
-					Output: ptString(OutputVerbose),
+					Output: ptString(verbosity.OutputVerbose),
 					Match: &models.BatchDeleteMatch{
 						Class: "Foo",
 						Where: &models.WhereFilter{
@@ -114,14 +115,14 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			{
 				input: &models.BatchDelete{
 					DryRun: ptBool(false),
-					Output: ptString(OutputVerbose),
+					Output: ptString(verbosity.OutputVerbose),
 				},
 				expectedError: "validate: empty match clause",
 			},
 			{
 				input: &models.BatchDelete{
 					DryRun: ptBool(false),
-					Output: ptString(OutputVerbose),
+					Output: ptString(verbosity.OutputVerbose),
 					Match: &models.BatchDeleteMatch{
 						Class: "",
 					},
@@ -131,7 +132,7 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			{
 				input: &models.BatchDelete{
 					DryRun: ptBool(false),
-					Output: ptString(OutputVerbose),
+					Output: ptString(verbosity.OutputVerbose),
 					Match: &models.BatchDeleteMatch{
 						Class: "Foo",
 					},
@@ -141,7 +142,7 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			{
 				input: &models.BatchDelete{
 					DryRun: ptBool(false),
-					Output: ptString(OutputVerbose),
+					Output: ptString(verbosity.OutputVerbose),
 					Match: &models.BatchDeleteMatch{
 						Class: "Foo",
 						Where: &models.WhereFilter{

--- a/usecases/sharding/remote_node.go
+++ b/usecases/sharding/remote_node.go
@@ -19,7 +19,7 @@ import (
 )
 
 type RemoteNodeClient interface {
-	GetNodeStatus(ctx context.Context, hostName string, className string) (*models.NodeStatus, error)
+	GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error)
 }
 
 type RemoteNode struct {
@@ -34,10 +34,10 @@ func NewRemoteNode(nodeResolver nodeResolver, client RemoteNodeClient) *RemoteNo
 	}
 }
 
-func (rn *RemoteNode) GetNodeStatus(ctx context.Context, nodeName string, className string) (*models.NodeStatus, error) {
+func (rn *RemoteNode) GetNodeStatus(ctx context.Context, nodeName, className, output string) (*models.NodeStatus, error) {
 	host, ok := rn.nodeResolver.NodeHostname(nodeName)
 	if !ok {
 		return nil, fmt.Errorf("resolve node name %q to host", nodeName)
 	}
-	return rn.client.GetNodeStatus(ctx, host, className)
+	return rn.client.GetNodeStatus(ctx, host, className, output)
 }

--- a/usecases/sharding/remote_node_incoming.go
+++ b/usecases/sharding/remote_node_incoming.go
@@ -18,7 +18,7 @@ import (
 )
 
 type RemoteNodeIncomingRepo interface {
-	IncomingGetNodeStatus(ctx context.Context, className string) (*models.NodeStatus, error)
+	IncomingGetNodeStatus(ctx context.Context, className, output string) (*models.NodeStatus, error)
 }
 
 type RemoteNodeIncoming struct {
@@ -31,6 +31,6 @@ func NewRemoteNodeIncoming(repo RemoteNodeIncomingRepo) *RemoteNodeIncoming {
 	}
 }
 
-func (rni *RemoteNodeIncoming) GetNodeStatus(ctx context.Context, className string) (*models.NodeStatus, error) {
-	return rni.repo.IncomingGetNodeStatus(ctx, className)
+func (rni *RemoteNodeIncoming) GetNodeStatus(ctx context.Context, className, output string) (*models.NodeStatus, error) {
+	return rni.repo.IncomingGetNodeStatus(ctx, className, output)
 }


### PR DESCRIPTION
### What's being changed:

This PR adds an output verbosity parameter to the nodes API, defaulting to a value of `minimal`. The motivation behind this change are the massive response payloads for classes with 1000s of tenants.  When a full nodes status response is required, the `output` can be set to `verbose`.

### Example requests

Get a digest response for all nodes/classes:
```http
GET /v1/nodes?output=minimal
```

Get a full response for a particular class:
```http
GET /v1/nodes/ClassName?output=verbose
```

### Response changes

The nodes status response prior to this change is now classified as a `verbose` response. It contains per-shard information for each class:
```json
{
	"nodes": [
		{
			"batchStats": {
				"queueLength": 0,
				"ratePerSecond": 30
			},
			"gitHash": "5e9580a8a",
			"name": "node1",
			"shards": [
				{
					"class": "SomeClass",
					"name": "1Nq94Cj1B0Kd",
					"objectCount": 6,
					"vectorIndexingStatus": "READY",
					"vectorQueueLength": 0
				}
			],
			"stats": {
				"objectCount": 6,
				"shardCount": 1
			},
			"status": "HEALTHY",
			"version": "1.22.6"
		}
	]
}
```

The new response classification of `minimal` omits the `shards` property:
```json
{
	"nodes": [
		{
			"batchStats": {
				"queueLength": 0,
				"ratePerSecond": 30
			},
			"gitHash": "5e9580a8a",
			"name": "node1",
			"shards": null,
			"stats": {
				"objectCount": 6,
				"shardCount": 1
			},
			"status": "HEALTHY",
			"version": "1.22.6"
		}
	]
}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
