### PR TITLE
Revert default hostname setting to prevent conflicts in k9s clustering

### DIFF
--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -29,7 +29,6 @@ const (
 )
 
 const (
-	DefaultHostname                           = "weaviate-0"
 	DefaultPersistenceFlushIdleMemtablesAfter = 60
 	DefaultPersistenceMemtablesMaxSize        = 200
 	DefaultPersistenceMemtablesMinDuration    = 15
@@ -563,8 +562,6 @@ func parseClusterConfig() (cluster.Config, error) {
 
 	if v := os.Getenv("CLUSTER_HOSTNAME"); v != "" {
 		cfg.Hostname = v
-	} else {
-		cfg.Hostname = DefaultHostname
 	}
 	cfg.Join = os.Getenv("CLUSTER_JOIN")
 


### PR DESCRIPTION
This reverts the change that set a default hostname, preventing potential conflicts among nodes in k9s clustering, all being labeled as 'weaviate-0'
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
