### PR TITLE
[flat] Fix rescoreLimit update

### DIFF
--- a/adapters/repos/db/vector/flat/config_update_test.go
+++ b/adapters/repos/db/vector/flat/config_update_test.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/schema"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+)
+
+func TestFlatUserConfigUpdates(t *testing.T) {
+	t.Run("various immutable and mutable fields", func(t *testing.T) {
+		type test struct {
+			name          string
+			initial       schema.VectorIndexConfig
+			update        schema.VectorIndexConfig
+			expectedError error
+		}
+
+		tests := []test{
+			{
+				name:    "attempting to change pq enabled",
+				initial: ent.UserConfig{PQ: ent.CompressionUserConfig{Enabled: true}},
+				update:  ent.UserConfig{PQ: ent.CompressionUserConfig{Enabled: false}},
+				expectedError: errors.Errorf(
+					"pq is immutable: " +
+						"attempted change from \"true\" to \"false\""),
+			},
+			{
+				name:    "attempting to change bq enabled",
+				initial: ent.UserConfig{BQ: ent.CompressionUserConfig{Enabled: true}},
+				update:  ent.UserConfig{BQ: ent.CompressionUserConfig{Enabled: false}},
+				expectedError: errors.Errorf(
+					"bq is immutable: " +
+						"attempted change from \"true\" to \"false\""),
+			},
+			{
+				name:    "attempting to change distance",
+				initial: ent.UserConfig{Distance: "cosine"},
+				update:  ent.UserConfig{Distance: "l2-squared"},
+				expectedError: errors.Errorf(
+					"distance is immutable: " +
+						"attempted change from \"cosine\" to \"l2-squared\""),
+			},
+			{
+				name:          "changing rescoreLimit",
+				initial:       ent.UserConfig{BQ: ent.CompressionUserConfig{RescoreLimit: 10}},
+				update:        ent.UserConfig{BQ: ent.CompressionUserConfig{RescoreLimit: 100}},
+				expectedError: nil,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				err := ValidateUserConfigUpdate(test.initial, test.update)
+				if test.expectedError == nil {
+					assert.Nil(t, err)
+				} else {
+					require.NotNil(t, err, "update validation must error")
+					assert.Equal(t, test.expectedError.Error(), err.Error())
+				}
+			})
+		}
+	})
+}

--- a/adapters/repos/db/vector/flat/config_update_test.go
+++ b/adapters/repos/db/vector/flat/config_update_test.go
@@ -33,11 +33,11 @@ func TestFlatUserConfigUpdates(t *testing.T) {
 		tests := []test{
 			{
 				name:    "attempting to change pq enabled",
-				initial: ent.UserConfig{PQ: ent.CompressionUserConfig{Enabled: true}},
-				update:  ent.UserConfig{PQ: ent.CompressionUserConfig{Enabled: false}},
+				initial: ent.UserConfig{PQ: ent.CompressionUserConfig{Enabled: false}},
+				update:  ent.UserConfig{PQ: ent.CompressionUserConfig{Enabled: true}},
 				expectedError: errors.Errorf(
 					"pq is immutable: " +
-						"attempted change from \"true\" to \"false\""),
+						"attempted change from \"false\" to \"true\""),
 			},
 			{
 				name:    "attempting to change bq enabled",

--- a/entities/vectorindex/flat/config.go
+++ b/entities/vectorindex/flat/config.go
@@ -150,6 +150,10 @@ func parseCompressionMap(in map[string]interface{}, uc *UserConfig) error {
 		}
 
 	}
+	// TODO: remove once PQ is supported
+	if uc.PQ.Enabled {
+		return errors.New("PQ is not currently supported for flat indices")
+	}
 	if uc.PQ.Cache && !uc.PQ.Enabled {
 		return errors.New("not possible to use the cache without compression")
 	}

--- a/entities/vectorindex/flat/config.go
+++ b/entities/vectorindex/flat/config.go
@@ -117,7 +117,7 @@ func parseCompressionMap(in map[string]interface{}, uc *UserConfig) error {
 				return err
 			}
 
-			if err := vectorindexcommon.OptionalIntFromMap(pqConfigMap, "rescore", func(v int) {
+			if err := vectorindexcommon.OptionalIntFromMap(pqConfigMap, "rescoreLimit", func(v int) {
 				uc.PQ.RescoreLimit = v
 			}); err != nil {
 				return err
@@ -143,7 +143,7 @@ func parseCompressionMap(in map[string]interface{}, uc *UserConfig) error {
 			return err
 		}
 
-		if err := vectorindexcommon.OptionalIntFromMap(bqConfigMap, "rescore", func(v int) {
+		if err := vectorindexcommon.OptionalIntFromMap(bqConfigMap, "rescoreLimit", func(v int) {
 			uc.BQ.RescoreLimit = v
 		}); err != nil {
 			return err

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -1,0 +1,117 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+)
+
+func Test_FlatUserConfig(t *testing.T) {
+	type test struct {
+		name         string
+		input        interface{}
+		expected     UserConfig
+		expectErr    bool
+		expectErrMsg string
+	}
+
+	tests := []test{
+		{
+			name:  "nothing specified, all defaults",
+			input: nil,
+			expected: UserConfig{
+				VectorCacheMaxObjects: common.DefaultVectorCacheMaxObjects,
+				Distance:              common.DefaultDistanceMetric,
+				PQ: CompressionUserConfig{
+					Enabled:      DefaultCompressionEnabled,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+				},
+				BQ: CompressionUserConfig{
+					Enabled:      DefaultCompressionEnabled,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+				},
+			},
+		},
+		{
+			name: "bq enabled",
+			input: map[string]interface{}{
+				"vectorCacheMaxObjects": float64(100),
+				"distance":              "cosine",
+				"bq": map[string]interface{}{
+					"enabled":      true,
+					"rescoreLimit": float64(100),
+					"cache":        true,
+				},
+			},
+			expected: UserConfig{
+				VectorCacheMaxObjects: 100,
+				Distance:              common.DefaultDistanceMetric,
+				PQ: CompressionUserConfig{
+					Enabled:      false,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+				},
+				BQ: CompressionUserConfig{
+					Enabled:      true,
+					RescoreLimit: 100,
+					Cache:        true,
+				},
+			},
+		},
+		{
+			name: "pq enabled",
+			input: map[string]interface{}{
+				"vectorCacheMaxObjects": float64(100),
+				"distance":              "cosine",
+				"pq": map[string]interface{}{
+					"enabled":      true,
+					"rescoreLimit": float64(100),
+					"cache":        true,
+				},
+			},
+			expected: UserConfig{
+				VectorCacheMaxObjects: 100,
+				Distance:              common.DefaultDistanceMetric,
+				PQ: CompressionUserConfig{
+					Enabled:      true,
+					RescoreLimit: 100,
+					Cache:        true,
+				},
+				BQ: CompressionUserConfig{
+					Enabled:      false,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := ParseAndValidateConfig(test.input)
+			if test.expectErr {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), test.expectErrMsg)
+				return
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.expected, cfg)
+			}
+		})
+	}
+}

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -85,7 +85,7 @@ func Test_FlatUserConfig(t *testing.T) {
 				},
 			},
 			expectErr:    true,
-			expectErrMsg: "pq is not currently supported for flat indices",
+			expectErrMsg: "PQ is not currently supported for flat indices",
 			// expected: UserConfig{
 			// 	VectorCacheMaxObjects: 100,
 			// 	Distance:              common.DefaultDistanceMetric,

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -84,20 +84,22 @@ func Test_FlatUserConfig(t *testing.T) {
 					"cache":        true,
 				},
 			},
-			expected: UserConfig{
-				VectorCacheMaxObjects: 100,
-				Distance:              common.DefaultDistanceMetric,
-				PQ: CompressionUserConfig{
-					Enabled:      true,
-					RescoreLimit: 100,
-					Cache:        true,
-				},
-				BQ: CompressionUserConfig{
-					Enabled:      false,
-					RescoreLimit: DefaultCompressionRescore,
-					Cache:        DefaultVectorCache,
-				},
-			},
+			expectErr:    true,
+			expectErrMsg: "pq is not currently supported for flat indices",
+			// expected: UserConfig{
+			// 	VectorCacheMaxObjects: 100,
+			// 	Distance:              common.DefaultDistanceMetric,
+			// 	PQ: CompressionUserConfig{
+			// 		Enabled:      true,
+			// 		RescoreLimit: 100,
+			// 		Cache:        true,
+			// 	},
+			// 	BQ: CompressionUserConfig{
+			// 		Enabled:      false,
+			// 		RescoreLimit: DefaultCompressionRescore,
+			// 		Cache:        DefaultVectorCache,
+			// 	},
+			// },
 		},
 	}
 


### PR DESCRIPTION
### What's being changed:
- `rescoreLimit` was not being correctly updated
- Additionally tests are added similar to HNSW

rebased version of https://github.com/weaviate/weaviate/pull/3873

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
