### PR TITLE
Fixes for GRPC filters

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -445,7 +445,7 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 		if number, ok := val.(float64); ok && dataType == schema.DataTypeInt {
 			val = int(number)
 			if float64(int(number)) != number {
-				return filters.Clause{}, fmt.Errorf("Filtering for integer, but recieved a floating point number %v", number)
+				return filters.Clause{}, fmt.Errorf("filtering for integer, but received a floating point number %v", number)
 			}
 		}
 
@@ -467,7 +467,7 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 				valInt := make([]int, len(valSlice))
 				for i := 0; i < len(valSlice); i++ {
 					if float64(int(valSlice[i])) != valSlice[i] {
-						return filters.Clause{}, fmt.Errorf("Filtering for integer, but recieved a floating point number %v", valSlice[i])
+						return filters.Clause{}, fmt.Errorf("filtering for integer, but received a floating point number %v", valSlice[i])
 					}
 					valInt[i] = int(valSlice[i])
 				}

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -437,12 +437,19 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 			return filters.Clause{}, fmt.Errorf("unknown value type %v", filterIn.TestValue)
 		}
 
-		// correct the type of value when filtering on a float property but sending an int. This is easy to get wrong
+		// correct the type of value when filtering on a float/int property but sending an int/float. This is easy to
+		// get wrong
 		if number, ok := val.(int); ok && dataType == schema.DataTypeNumber {
 			val = float64(number)
 		}
+		if number, ok := val.(float64); ok && dataType == schema.DataTypeInt {
+			val = int(number)
+			if float64(int(number)) != number {
+				return filters.Clause{}, fmt.Errorf("Filtering for integer, but recieved a floating point number %v", number)
+			}
+		}
 
-		// correct type for containsXXX in case users send int for a float array
+		// correct type for containsXXX in case users send int/float for a float/int array
 		if (returnFilter.Operator == filters.ContainsAll || returnFilter.Operator == filters.ContainsAny) && dataType == schema.DataTypeNumber {
 			valSlice, ok := val.([]int)
 			if ok {
@@ -451,6 +458,20 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 					val64[i] = float64(valSlice[i])
 				}
 				val = val64
+			}
+		}
+
+		if (returnFilter.Operator == filters.ContainsAll || returnFilter.Operator == filters.ContainsAny) && dataType == schema.DataTypeInt {
+			valSlice, ok := val.([]float64)
+			if ok {
+				valInt := make([]int, len(valSlice))
+				for i := 0; i < len(valSlice); i++ {
+					if float64(int(valSlice[i])) != valSlice[i] {
+						return filters.Clause{}, fmt.Errorf("Filtering for integer, but recieved a floating point number %v", valSlice[i])
+					}
+					valInt[i] = int(valSlice[i])
+				}
+				val = valInt
 			}
 		}
 

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -862,7 +862,7 @@ func (x *Filters) GetValueBoolean() bool {
 	return false
 }
 
-func (x *Filters) GetValueNumber() float32 {
+func (x *Filters) GetValueNumber() float64 {
 	if x, ok := x.GetTestValue().(*Filters_ValueNumber); ok {
 		return x.ValueNumber
 	}
@@ -914,7 +914,7 @@ type Filters_ValueBoolean struct {
 }
 
 type Filters_ValueNumber struct {
-	ValueNumber float32 `protobuf:"fixed32,7,opt,name=value_number,json=valueNumber,proto3,oneof"`
+	ValueNumber float64 `protobuf:"fixed64,7,opt,name=value_number,json=valueNumber,proto3,oneof"`
 }
 
 type Filters_ValueTextArray struct {
@@ -2612,7 +2612,7 @@ var file_v1_search_get_proto_rawDesc = []byte{
 	0x6c, 0x75, 0x65, 0x5f, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x18, 0x06, 0x20, 0x01, 0x28,
 	0x08, 0x48, 0x00, 0x52, 0x0c, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x6f, 0x6f, 0x6c, 0x65, 0x61,
 	0x6e, 0x12, 0x23, 0x0a, 0x0c, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x5f, 0x6e, 0x75, 0x6d, 0x62, 0x65,
-	0x72, 0x18, 0x07, 0x20, 0x01, 0x28, 0x02, 0x48, 0x00, 0x52, 0x0b, 0x76, 0x61, 0x6c, 0x75, 0x65,
+	0x72, 0x18, 0x07, 0x20, 0x01, 0x28, 0x01, 0x48, 0x00, 0x52, 0x0b, 0x76, 0x61, 0x6c, 0x75, 0x65,
 	0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x42, 0x0a, 0x10, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x5f,
 	0x74, 0x65, 0x78, 0x74, 0x5f, 0x61, 0x72, 0x72, 0x61, 0x79, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b,
 	0x32, 0x16, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x54,
@@ -2978,49 +2978,52 @@ func file_v1_search_get_proto_rawDescGZIP() []byte {
 	return file_v1_search_get_proto_rawDescData
 }
 
-var file_v1_search_get_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_v1_search_get_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
-var file_v1_search_get_proto_goTypes = []interface{}{
-	(Filters_Operator)(0),           // 0: weaviate.v1.Filters.Operator
-	(Hybrid_FusionType)(0),          // 1: weaviate.v1.Hybrid.FusionType
-	(*SearchRequest)(nil),           // 2: weaviate.v1.SearchRequest
-	(*GroupBy)(nil),                 // 3: weaviate.v1.GroupBy
-	(*SortBy)(nil),                  // 4: weaviate.v1.SortBy
-	(*GenerativeSearch)(nil),        // 5: weaviate.v1.GenerativeSearch
-	(*TextArray)(nil),               // 6: weaviate.v1.TextArray
-	(*IntArray)(nil),                // 7: weaviate.v1.IntArray
-	(*NumberArray)(nil),             // 8: weaviate.v1.NumberArray
-	(*BooleanArray)(nil),            // 9: weaviate.v1.BooleanArray
-	(*Filters)(nil),                 // 10: weaviate.v1.Filters
-	(*MetadataRequest)(nil),         // 11: weaviate.v1.MetadataRequest
-	(*PropertiesRequest)(nil),       // 12: weaviate.v1.PropertiesRequest
-	(*ObjectPropertiesRequest)(nil), // 13: weaviate.v1.ObjectPropertiesRequest
-	(*Hybrid)(nil),                  // 14: weaviate.v1.Hybrid
-	(*NearTextSearch)(nil),          // 15: weaviate.v1.NearTextSearch
-	(*NearImageSearch)(nil),         // 16: weaviate.v1.NearImageSearch
-	(*NearAudioSearch)(nil),         // 17: weaviate.v1.NearAudioSearch
-	(*NearVideoSearch)(nil),         // 18: weaviate.v1.NearVideoSearch
-	(*BM25)(nil),                    // 19: weaviate.v1.BM25
-	(*RefPropertiesRequest)(nil),    // 20: weaviate.v1.RefPropertiesRequest
-	(*NearVector)(nil),              // 21: weaviate.v1.NearVector
-	(*NearObject)(nil),              // 22: weaviate.v1.NearObject
-	(*SearchReply)(nil),             // 23: weaviate.v1.SearchReply
-	(*GroupByResult)(nil),           // 24: weaviate.v1.GroupByResult
-	(*SearchResult)(nil),            // 25: weaviate.v1.SearchResult
-	(*MetadataResult)(nil),          // 26: weaviate.v1.MetadataResult
-	(*PropertiesResult)(nil),        // 27: weaviate.v1.PropertiesResult
-	(*RefPropertiesResult)(nil),     // 28: weaviate.v1.RefPropertiesResult
-	(*NearTextSearch_Move)(nil),     // 29: weaviate.v1.NearTextSearch.Move
-	(ConsistencyLevel)(0),           // 30: weaviate.v1.ConsistencyLevel
-	(*structpb.Struct)(nil),         // 31: google.protobuf.Struct
-	(*NumberArrayProperties)(nil),   // 32: weaviate.v1.NumberArrayProperties
-	(*IntArrayProperties)(nil),      // 33: weaviate.v1.IntArrayProperties
-	(*TextArrayProperties)(nil),     // 34: weaviate.v1.TextArrayProperties
-	(*BooleanArrayProperties)(nil),  // 35: weaviate.v1.BooleanArrayProperties
-	(*ObjectProperties)(nil),        // 36: weaviate.v1.ObjectProperties
-	(*ObjectArrayProperties)(nil),   // 37: weaviate.v1.ObjectArrayProperties
-	(*Properties)(nil),              // 38: weaviate.v1.Properties
-}
+var (
+	file_v1_search_get_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+	file_v1_search_get_proto_msgTypes  = make([]protoimpl.MessageInfo, 28)
+	file_v1_search_get_proto_goTypes   = []interface{}{
+		(Filters_Operator)(0),           // 0: weaviate.v1.Filters.Operator
+		(Hybrid_FusionType)(0),          // 1: weaviate.v1.Hybrid.FusionType
+		(*SearchRequest)(nil),           // 2: weaviate.v1.SearchRequest
+		(*GroupBy)(nil),                 // 3: weaviate.v1.GroupBy
+		(*SortBy)(nil),                  // 4: weaviate.v1.SortBy
+		(*GenerativeSearch)(nil),        // 5: weaviate.v1.GenerativeSearch
+		(*TextArray)(nil),               // 6: weaviate.v1.TextArray
+		(*IntArray)(nil),                // 7: weaviate.v1.IntArray
+		(*NumberArray)(nil),             // 8: weaviate.v1.NumberArray
+		(*BooleanArray)(nil),            // 9: weaviate.v1.BooleanArray
+		(*Filters)(nil),                 // 10: weaviate.v1.Filters
+		(*MetadataRequest)(nil),         // 11: weaviate.v1.MetadataRequest
+		(*PropertiesRequest)(nil),       // 12: weaviate.v1.PropertiesRequest
+		(*ObjectPropertiesRequest)(nil), // 13: weaviate.v1.ObjectPropertiesRequest
+		(*Hybrid)(nil),                  // 14: weaviate.v1.Hybrid
+		(*NearTextSearch)(nil),          // 15: weaviate.v1.NearTextSearch
+		(*NearImageSearch)(nil),         // 16: weaviate.v1.NearImageSearch
+		(*NearAudioSearch)(nil),         // 17: weaviate.v1.NearAudioSearch
+		(*NearVideoSearch)(nil),         // 18: weaviate.v1.NearVideoSearch
+		(*BM25)(nil),                    // 19: weaviate.v1.BM25
+		(*RefPropertiesRequest)(nil),    // 20: weaviate.v1.RefPropertiesRequest
+		(*NearVector)(nil),              // 21: weaviate.v1.NearVector
+		(*NearObject)(nil),              // 22: weaviate.v1.NearObject
+		(*SearchReply)(nil),             // 23: weaviate.v1.SearchReply
+		(*GroupByResult)(nil),           // 24: weaviate.v1.GroupByResult
+		(*SearchResult)(nil),            // 25: weaviate.v1.SearchResult
+		(*MetadataResult)(nil),          // 26: weaviate.v1.MetadataResult
+		(*PropertiesResult)(nil),        // 27: weaviate.v1.PropertiesResult
+		(*RefPropertiesResult)(nil),     // 28: weaviate.v1.RefPropertiesResult
+		(*NearTextSearch_Move)(nil),     // 29: weaviate.v1.NearTextSearch.Move
+		(ConsistencyLevel)(0),           // 30: weaviate.v1.ConsistencyLevel
+		(*structpb.Struct)(nil),         // 31: google.protobuf.Struct
+		(*NumberArrayProperties)(nil),   // 32: weaviate.v1.NumberArrayProperties
+		(*IntArrayProperties)(nil),      // 33: weaviate.v1.IntArrayProperties
+		(*TextArrayProperties)(nil),     // 34: weaviate.v1.TextArrayProperties
+		(*BooleanArrayProperties)(nil),  // 35: weaviate.v1.BooleanArrayProperties
+		(*ObjectProperties)(nil),        // 36: weaviate.v1.ObjectProperties
+		(*ObjectArrayProperties)(nil),   // 37: weaviate.v1.ObjectArrayProperties
+		(*Properties)(nil),              // 38: weaviate.v1.Properties
+	}
+)
+
 var file_v1_search_get_proto_depIdxs = []int32{
 	30, // 0: weaviate.v1.SearchRequest.consistency_level:type_name -> weaviate.v1.ConsistencyLevel
 	12, // 1: weaviate.v1.SearchRequest.properties:type_name -> weaviate.v1.PropertiesRequest

--- a/grpc/proto/v1/search_get.proto
+++ b/grpc/proto/v1/search_get.proto
@@ -113,7 +113,7 @@ message Filters {
     string value_text = 4;
     int64 value_int = 5;
     bool value_boolean = 6;
-    float value_number = 7;
+    double value_number = 7;
     TextArray value_text_array = 9;
     IntArray value_int_array = 10;
     BooleanArray value_boolean_array = 11;


### PR DESCRIPTION
### What's being changed:

Fixes:
- send floating point numbers (without floating point part) to filter ints
- use correct type for float filtering (double instead of float
- fix using contains_any/all with floating point numbers to filter int[]

