### PR TITLE
Update schema unit tests in poc schema v2 to use mocks

### DIFF
--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -1,0 +1,142 @@
+package schema
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	command "github.com/weaviate/weaviate/cloud/proto/cluster"
+	"github.com/weaviate/weaviate/cloud/store"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+type fakeMetaHandler struct {
+	mock.Mock
+	countClassEqual bool
+}
+
+func (f *fakeMetaHandler) AddClass(cls *models.Class, ss *sharding.State) error {
+	args := f.Called(cls, ss)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) RestoreClass(cls *models.Class, ss *sharding.State) error {
+	args := f.Called(cls, ss)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) UpdateClass(cls *models.Class, ss *sharding.State) error {
+	args := f.Called(cls, ss)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) DeleteClass(name string) error {
+	args := f.Called(name)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) AddProperty(class string, p *models.Property) error {
+	args := f.Called(class, p)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) UpdateShardStatus(class, shard, status string) error {
+	args := f.Called(class, shard, status)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) AddTenants(class string, req *command.AddTenantsRequest) error {
+	args := f.Called(class, req)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) UpdateTenants(class string, req *command.UpdateTenantsRequest) error {
+	args := f.Called(class, req)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) DeleteTenants(class string, req *command.DeleteTenantsRequest) error {
+	args := f.Called(class, req)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) Join(ctx context.Context, nodeID, raftAddr string, voter bool) error {
+	args := f.Called(ctx, nodeID, raftAddr, voter)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) Remove(ctx context.Context, nodeID string) error {
+	args := f.Called(ctx, nodeID)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) Stats() map[string]string {
+	return map[string]string{}
+}
+
+func (f *fakeMetaHandler) ClassEqual(name string) string {
+	if f.countClassEqual {
+		args := f.Called(name)
+		return args.String(0)
+	}
+	return ""
+}
+
+func (f *fakeMetaHandler) MultiTenancy(class string) bool {
+	args := f.Called(class)
+	return args.Bool(0)
+}
+
+func (f *fakeMetaHandler) ClassInfo(class string) (ci store.ClassInfo) {
+	args := f.Called(class)
+	return args.Get(0).(store.ClassInfo)
+}
+
+func (f *fakeMetaHandler) ReadOnlyClass(class string) *models.Class {
+	args := f.Called(class)
+	model := args.Get(0)
+	if model == nil {
+		return nil
+	}
+	return model.(*models.Class)
+}
+
+func (f *fakeMetaHandler) ReadOnlySchema() models.Schema {
+	args := f.Called()
+	return args.Get(0).(models.Schema)
+}
+
+func (f *fakeMetaHandler) CopyShardingState(class string) *sharding.State {
+	args := f.Called(class)
+	return args.Get(0).(*sharding.State)
+}
+
+func (f *fakeMetaHandler) ShardReplicas(class, shard string) ([]string, error) {
+	args := f.Called(class, shard)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (f *fakeMetaHandler) ShardFromUUID(class string, uuid []byte) string {
+	args := f.Called(class, uuid)
+	return args.String(0)
+}
+
+func (f *fakeMetaHandler) ShardOwner(class, shard string) (string, error) {
+	args := f.Called(class, shard)
+	return args.String(0), args.Error(1)
+}
+
+func (f *fakeMetaHandler) TenantShard(class, tenant string) (string, string) {
+	args := f.Called(class, tenant)
+	return args.String(0), args.String(1)
+}
+
+func (f *fakeMetaHandler) Read(class string, reader func(*models.Class, *sharding.State) error) error {
+	args := f.Called(class, reader)
+	return args.Error(0)
+}
+
+func (f *fakeMetaHandler) GetShardsStatus(class string) (models.ShardStatusList, error) {
+	args := f.Called(class)
+	return args.Get(0).(models.ShardStatusList), args.Error(1)
+}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -45,6 +45,7 @@ func (h *Handler) AddTenants(ctx context.Context,
 	if err != nil {
 		return
 	}
+
 	if err = validateActivityStatuses(validated, true); err != nil {
 		return
 	}

--- a/usecases/schema/tenant_test.go
+++ b/usecases/schema/tenant_test.go
@@ -16,7 +16,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cloud/store"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -34,11 +36,6 @@ func TestAddTenants(t *testing.T) {
 		repConfig = &models.ReplicationConfig{Factor: 1}
 	)
 
-	handler, shutdown := newTestHandler(t, &fakeDB{})
-	defer func() {
-		shutdown()
-	}()
-
 	mtNilClass := &models.Class{
 		Class:              "MTnil",
 		MultiTenancyConfig: nil,
@@ -46,8 +43,6 @@ func TestAddTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtNilClass))
-
 	mtDisabledClass := &models.Class{
 		Class:              "MTdisabled",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false},
@@ -55,8 +50,6 @@ func TestAddTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtDisabledClass))
-
 	mtEnabledClass := &models.Class{
 		Class:              "MTenabled",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
@@ -64,13 +57,12 @@ func TestAddTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtEnabledClass))
-
 	type test struct {
-		name    string
-		class   string
-		tenants []*models.Tenant
-		errMsgs []string
+		name      string
+		class     string
+		tenants   []*models.Tenant
+		errMsgs   []string
+		mockCalls func(fakeMetaHandler *fakeMetaHandler)
 	}
 
 	tests := []test{
@@ -79,18 +71,27 @@ func TestAddTenants(t *testing.T) {
 			class:   mtNilClass.Class,
 			tenants: tenants,
 			errMsgs: []string{"not enabled"},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+			},
 		},
 		{
 			name:    "MTDisabled",
 			class:   mtDisabledClass.Class,
 			tenants: tenants,
 			errMsgs: []string{"not enabled"},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+			},
 		},
 		{
 			name:    "UnknownClass",
 			class:   "UnknownClass",
 			tenants: tenants,
 			errMsgs: []string{ErrNotFound.Error()},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: false})
+			},
 		},
 		{
 			name:  "EmptyTenantValue",
@@ -100,7 +101,8 @@ func TestAddTenants(t *testing.T) {
 				{Name: ""},
 				{Name: "Bbbb"},
 			},
-			errMsgs: []string{"tenant"},
+			errMsgs:   []string{"tenant"},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "InvalidActivityStatus",
@@ -114,6 +116,7 @@ func TestAddTenants(t *testing.T) {
 				"DOES_NOT_EXIST_1",
 				"DOES_NOT_EXIST_2",
 			},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "UnsupportedActivityStatus",
@@ -127,6 +130,7 @@ func TestAddTenants(t *testing.T) {
 				models.TenantActivityStatusWARM,
 				models.TenantActivityStatusFROZEN,
 			},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "Success",
@@ -137,6 +141,11 @@ func TestAddTenants(t *testing.T) {
 				{Name: "Cccc", ActivityStatus: models.TenantActivityStatusCOLD},
 			},
 			errMsgs: []string{},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: true})
+				fakeMetaHandler.On("Read", mock.Anything, mock.Anything).Return(nil)
+				fakeMetaHandler.On("AddTenants", mock.Anything, mock.Anything).Return(nil)
+			},
 		},
 		// TODO test with replication factor >= 2
 	}
@@ -144,29 +153,20 @@ func TestAddTenants(t *testing.T) {
 	// AddTenants
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// Isolate schema for each tests
+			handler, fakeMetaHandler := newTestHandler(t, &fakeDB{})
+
+			test.mockCalls(fakeMetaHandler)
+
 			err := handler.AddTenants(ctx, nil, test.class, test.tenants)
+
+			fakeMetaHandler.AssertExpectations(t)
+
 			if len(test.errMsgs) == 0 {
 				require.NoError(t, err)
-
-				existingTenants, err := handler.GetTenants(ctx, nil, test.class)
-				require.NoError(t, err)
-				existingTenantsMap := map[string]struct{}{}
-				for i := range existingTenants {
-					existingTenantsMap[existingTenants[i].Name] = struct{}{}
-				}
-
-				for i := range test.tenants {
-					assert.Contains(t, existingTenantsMap, test.tenants[i].Name)
-				}
 			} else {
 				for _, msg := range test.errMsgs {
 					assert.ErrorContains(t, err, msg)
-				}
-
-				if test.class == mtEnabledClass.Class {
-					existingTenants, err := handler.GetTenants(ctx, nil, test.class)
-					require.NoError(t, err)
-					assert.Len(t, existingTenants, 0)
 				}
 			}
 		})
@@ -189,11 +189,6 @@ func TestUpdateTenants(t *testing.T) {
 		repConfig = &models.ReplicationConfig{Factor: 1}
 	)
 
-	handler, shutdown := newTestHandler(t, &fakeDB{})
-	defer func() {
-		shutdown()
-	}()
-
 	mtNilClass := &models.Class{
 		Class:              "MTnil",
 		MultiTenancyConfig: nil,
@@ -201,8 +196,6 @@ func TestUpdateTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtNilClass))
-
 	mtDisabledClass := &models.Class{
 		Class:              "MTdisabled",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false},
@@ -210,8 +203,6 @@ func TestUpdateTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtDisabledClass))
-
 	mtEnabledClass := &models.Class{
 		Class:              "MTenabled",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
@@ -219,8 +210,6 @@ func TestUpdateTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtEnabledClass))
-	require.NoError(t, handler.AddTenants(ctx, nil, mtEnabledClass.Class, tenants))
 
 	type test struct {
 		name            string
@@ -228,6 +217,7 @@ func TestUpdateTenants(t *testing.T) {
 		updateTenants   []*models.Tenant
 		errMsgs         []string
 		expectedTenants []*models.Tenant
+		mockCalls       func(fakeMetaHandler *fakeMetaHandler)
 	}
 
 	tests := []test{
@@ -237,6 +227,9 @@ func TestUpdateTenants(t *testing.T) {
 			updateTenants:   tenants,
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+			},
 		},
 		{
 			name:            "MTDisabled",
@@ -244,6 +237,9 @@ func TestUpdateTenants(t *testing.T) {
 			updateTenants:   tenants,
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+			},
 		},
 		{
 			name:            "UnknownClass",
@@ -251,6 +247,9 @@ func TestUpdateTenants(t *testing.T) {
 			updateTenants:   tenants,
 			errMsgs:         []string{ErrNotFound.Error()},
 			expectedTenants: tenants,
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: false})
+			},
 		},
 		{
 			name:  "EmptyTenantValue",
@@ -260,6 +259,7 @@ func TestUpdateTenants(t *testing.T) {
 			},
 			errMsgs:         []string{"tenant"},
 			expectedTenants: tenants,
+			mockCalls:       func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "InvalidActivityStatus",
@@ -274,6 +274,7 @@ func TestUpdateTenants(t *testing.T) {
 				"DOES_NOT_EXIST_2",
 			},
 			expectedTenants: tenants,
+			mockCalls:       func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "UnsupportedActivityStatus",
@@ -288,6 +289,7 @@ func TestUpdateTenants(t *testing.T) {
 				models.TenantActivityStatusFROZEN,
 			},
 			expectedTenants: tenants,
+			mockCalls:       func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "EmptyActivityStatus",
@@ -298,6 +300,7 @@ func TestUpdateTenants(t *testing.T) {
 			},
 			errMsgs:         []string{"invalid activity status"},
 			expectedTenants: tenants,
+			mockCalls:       func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:  "Success",
@@ -311,13 +314,20 @@ func TestUpdateTenants(t *testing.T) {
 				{Name: tenants[0].Name, ActivityStatus: models.TenantActivityStatusCOLD},
 				{Name: tenants[1].Name, ActivityStatus: models.TenantActivityStatusCOLD},
 			},
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: true})
+				fakeMetaHandler.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := handler.UpdateTenants(ctx, nil, test.class, test.updateTenants)
+			// Isolate schema for each tests
+			handler, fakeMetaHandler := newTestHandler(t, &fakeDB{})
+			test.mockCalls(fakeMetaHandler)
 
+			err := handler.UpdateTenants(ctx, nil, test.class, test.updateTenants)
 			if len(test.errMsgs) == 0 {
 				require.NoError(t, err)
 			} else {
@@ -326,16 +336,7 @@ func TestUpdateTenants(t *testing.T) {
 				}
 			}
 
-			existingTenants, err := handler.GetTenants(ctx, nil, mtEnabledClass.Class)
-			require.NoError(t, err)
-			existingTenantsMap := map[string]*models.Tenant{}
-			for i := range existingTenants {
-				existingTenantsMap[existingTenants[i].Name] = existingTenants[i]
-			}
-
-			for _, tenant := range test.expectedTenants {
-				assert.Equal(t, tenant, existingTenantsMap[tenant.Name])
-			}
+			fakeMetaHandler.AssertExpectations(t)
 		})
 	}
 }
@@ -358,11 +359,6 @@ func TestDeleteTenants(t *testing.T) {
 		repConfig = &models.ReplicationConfig{Factor: 1}
 	)
 
-	handler, shutdown := newTestHandler(t, &fakeDB{})
-	defer func() {
-		shutdown()
-	}()
-
 	mtNilClass := &models.Class{
 		Class:              "MTnil",
 		MultiTenancyConfig: nil,
@@ -370,8 +366,6 @@ func TestDeleteTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtNilClass))
-
 	mtDisabledClass := &models.Class{
 		Class:              "MTdisabled",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false},
@@ -379,8 +373,6 @@ func TestDeleteTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtDisabledClass))
-
 	mtEnabledClass := &models.Class{
 		Class:              "MTenabled",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
@@ -388,8 +380,6 @@ func TestDeleteTenants(t *testing.T) {
 		ReplicationConfig:  repConfig,
 		Vectorizer:         "none",
 	}
-	require.NoError(t, handler.AddClass(ctx, nil, mtEnabledClass))
-	require.NoError(t, handler.AddTenants(ctx, nil, mtEnabledClass.Class, tenants))
 
 	type test struct {
 		name            string
@@ -397,6 +387,7 @@ func TestDeleteTenants(t *testing.T) {
 		tenants         []*models.Tenant
 		errMsgs         []string
 		expectedTenants []*models.Tenant
+		mockCalls       func(fakeMetaHandler *fakeMetaHandler)
 	}
 
 	tests := []test{
@@ -406,6 +397,9 @@ func TestDeleteTenants(t *testing.T) {
 			tenants:         tenants,
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+			},
 		},
 		{
 			name:            "MTDisabled",
@@ -413,6 +407,9 @@ func TestDeleteTenants(t *testing.T) {
 			tenants:         tenants,
 			errMsgs:         []string{"not enabled"},
 			expectedTenants: tenants,
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: false})
+			},
 		},
 		{
 			name:            "UnknownClass",
@@ -420,6 +417,9 @@ func TestDeleteTenants(t *testing.T) {
 			tenants:         tenants,
 			errMsgs:         []string{ErrNotFound.Error()},
 			expectedTenants: tenants,
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: false, MultiTenancy: false})
+			},
 		},
 		{
 			name:  "EmptyTenantValue",
@@ -431,6 +431,7 @@ func TestDeleteTenants(t *testing.T) {
 			},
 			errMsgs:         []string{"empty tenant name at index 1"},
 			expectedTenants: tenants,
+			mockCalls:       func(fakeMetaHandler *fakeMetaHandler) {},
 		},
 		{
 			name:            "Success",
@@ -438,11 +439,19 @@ func TestDeleteTenants(t *testing.T) {
 			tenants:         tenants[:2],
 			errMsgs:         []string{},
 			expectedTenants: tenants[2:],
+			mockCalls: func(fakeMetaHandler *fakeMetaHandler) {
+				fakeMetaHandler.On("ClassInfo", mock.Anything).Return(store.ClassInfo{Exists: true, MultiTenancy: true})
+				fakeMetaHandler.On("DeleteTenants", mock.Anything, mock.Anything).Return(nil)
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// Isolate schema for each tests
+			handler, fakeMetaHandler := newTestHandler(t, &fakeDB{})
+			test.mockCalls(fakeMetaHandler)
+
 			tenantNames := make([]string, len(test.tenants))
 			for i := range test.tenants {
 				tenantNames[i] = test.tenants[i].Name
@@ -455,17 +464,6 @@ func TestDeleteTenants(t *testing.T) {
 				for i := range test.errMsgs {
 					assert.ErrorContains(t, err, test.errMsgs[i])
 				}
-			}
-
-			existingTenants, err := handler.GetTenants(ctx, nil, mtEnabledClass.Class)
-			require.NoError(t, err)
-			existingTenantsMap := map[string]struct{}{}
-			for i := range existingTenants {
-				existingTenantsMap[existingTenants[i].Name] = struct{}{}
-			}
-
-			for i := range test.expectedTenants {
-				assert.Contains(t, existingTenantsMap, test.expectedTenants[i].Name)
 			}
 		})
 	}

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -1,0 +1,159 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+type validatorNestedProperty func(property *models.NestedProperty,
+	primitiveDataType, nestedDataType schema.DataType,
+	isPrimitive, isNested bool, propNamePrefix string) error
+
+var validatorsNestedProperty = []validatorNestedProperty{
+	validateNestedPropertyName,
+	validateNestedPropertyDataType,
+	validateNestedPropertyTokenization,
+	validateNestedPropertyIndexFilterable,
+	validateNestedPropertyIndexSearchable,
+}
+
+func validateNestedProperties(properties []*models.NestedProperty, propNamePrefix string) error {
+	if len(properties) == 0 {
+		return fmt.Errorf("Property '%s': At least one nested property is required for data type object/object[]",
+			propNamePrefix)
+	}
+
+	for _, property := range properties {
+		primitiveDataType, isPrimitive := schema.AsPrimitive(property.DataType)
+		nestedDataType, isNested := schema.AsNested(property.DataType)
+
+		for _, validator := range validatorsNestedProperty {
+			if err := validator(property, primitiveDataType, nestedDataType, isPrimitive, isNested, propNamePrefix); err != nil {
+				return err
+			}
+		}
+		if isNested {
+			if err := validateNestedProperties(property.NestedProperties, propNamePrefix+"."+property.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateNestedPropertyName(property *models.NestedProperty,
+	_, _ schema.DataType,
+	_, _ bool, propNamePrefix string,
+) error {
+	return schema.ValidateNestedPropertyName(property.Name, propNamePrefix)
+}
+
+func validateNestedPropertyDataType(property *models.NestedProperty,
+	primitiveDataType, _ schema.DataType,
+	isPrimitive, isNested bool, propNamePrefix string,
+) error {
+	propName := propNamePrefix + "." + property.Name
+
+	if isPrimitive {
+		// DataTypeString and DataTypeStringArray as deprecated since 1.19 are not allowed
+		switch primitiveDataType {
+		case schema.DataTypeString, schema.DataTypeStringArray:
+			return fmt.Errorf("Property '%s': data type '%s' is deprecated and not allowed as nested property", propName, primitiveDataType)
+		case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber:
+			return fmt.Errorf("Property '%s': data type '%s' not allowed as nested property", propName, primitiveDataType)
+		default:
+			// do nothing
+		}
+		return nil
+	}
+	if isNested {
+		return nil
+	}
+	return fmt.Errorf("Property '%s': reference data type not allowed", propName)
+}
+
+// Tokenization allowed only for text/text[] data types
+func validateNestedPropertyTokenization(property *models.NestedProperty,
+	primitiveDataType, _ schema.DataType,
+	isPrimitive, isNested bool, propNamePrefix string,
+) error {
+	propName := propNamePrefix + "." + property.Name
+
+	if isPrimitive {
+		switch primitiveDataType {
+		case schema.DataTypeText, schema.DataTypeTextArray:
+			switch property.Tokenization {
+			case models.PropertyTokenizationField, models.PropertyTokenizationWord,
+				models.PropertyTokenizationWhitespace, models.PropertyTokenizationLowercase:
+				return nil
+			}
+			return fmt.Errorf("Property '%s': Tokenization '%s' is not allowed for data type '%s'",
+				propName, property.Tokenization, primitiveDataType)
+		default:
+			if property.Tokenization == "" {
+				return nil
+			}
+			return fmt.Errorf("Property '%s': Tokenization is not allowed for data type '%s'",
+				propName, primitiveDataType)
+		}
+	}
+	if property.Tokenization == "" {
+		return nil
+	}
+	if isNested {
+		return fmt.Errorf("Property '%s': Tokenization is not allowed for object/object[] data types", propName)
+	}
+	return fmt.Errorf("Property '%s': Tokenization is not allowed for reference data type", propName)
+}
+
+// indexFilterable allowed for primitive & ref data types
+func validateNestedPropertyIndexFilterable(property *models.NestedProperty,
+	primitiveDataType, _ schema.DataType,
+	isPrimitive, _ bool, propNamePrefix string,
+) error {
+	propName := propNamePrefix + "." + property.Name
+
+	// at this point indexSearchable should be set (either by user or by defaults)
+	if property.IndexFilterable == nil {
+		return fmt.Errorf("Property '%s': `indexFilterable` not set", propName)
+	}
+
+	if isPrimitive && primitiveDataType == schema.DataTypeBlob {
+		if *property.IndexFilterable {
+			return fmt.Errorf("Property: '%s': indexFilterable is not allowed for blob data type",
+				propName)
+		}
+	}
+
+	return nil
+}
+
+// indexSearchable allowed for text/text[] data types
+func validateNestedPropertyIndexSearchable(property *models.NestedProperty,
+	primitiveDataType, _ schema.DataType,
+	isPrimitive, _ bool, propNamePrefix string,
+) error {
+	propName := propNamePrefix + "." + property.Name
+
+	// at this point indexSearchable should be set (either by user or by defaults)
+	if property.IndexSearchable == nil {
+		return fmt.Errorf("Property '%s': `indexSearchable` not set", propName)
+	}
+
+	if isPrimitive {
+		switch primitiveDataType {
+		case schema.DataTypeText, schema.DataTypeTextArray:
+			return nil
+		default:
+			// do nothing
+		}
+	}
+	if *property.IndexSearchable {
+		return fmt.Errorf("Property '%s': `indexSearchable` is not allowed for other than text/text[] data types",
+			propName)
+	}
+
+	return nil
+}

--- a/usecases/schema/validation_test.go
+++ b/usecases/schema/validation_test.go
@@ -1,0 +1,742 @@
+package schema
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func Test_Validation_NestedProperties(t *testing.T) {
+	vFalse := false
+	vTrue := true
+
+	t.Run("does not validate wrong names", func(t *testing.T) {
+		for _, name := range []string{"prop@1", "prop-2", "prop$3", "4prop"} {
+			t.Run(name, func(t *testing.T) {
+				nestedProperties := []*models.NestedProperty{
+					{
+						Name:            name,
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vFalse,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+				}
+
+				for _, ndt := range schema.NestedDataTypes {
+					t.Run(ndt.String(), func(t *testing.T) {
+						propPrimitives := &models.Property{
+							Name:             "objectProp",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						}
+						propLvl2Primitives := &models.Property{
+							Name:            "objectPropLvl2",
+							DataType:        ndt.PropString(),
+							IndexFilterable: &vFalse,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:             "nested_object",
+									DataType:         ndt.PropString(),
+									IndexFilterable:  &vFalse,
+									IndexSearchable:  &vFalse,
+									Tokenization:     "",
+									NestedProperties: nestedProperties,
+								},
+							},
+						}
+
+						for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+							t.Run(prop.Name, func(t *testing.T) {
+								err := validateNestedProperties(prop.NestedProperties, prop.Name)
+								assert.ErrorContains(t, err, prop.Name)
+								assert.ErrorContains(t, err, "is not a valid nested property name")
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("validates primitive data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{}
+		for _, pdt := range schema.PrimitiveDataTypes {
+			tokenization := ""
+			switch pdt {
+			case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber:
+				// skip - not supported as nested
+				continue
+			case schema.DataTypeText, schema.DataTypeTextArray:
+				tokenization = models.PropertyTokenizationWord
+			default:
+				// do nothing
+			}
+
+			nestedProperties = append(nestedProperties, &models.NestedProperty{
+				Name:            "nested_" + pdt.AsName(),
+				DataType:        pdt.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    tokenization,
+			})
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propPrimitives := &models.Property{
+					Name:             "objectProp",
+					DataType:         ndt.PropString(),
+					IndexFilterable:  &vFalse,
+					IndexSearchable:  &vFalse,
+					Tokenization:     "",
+					NestedProperties: nestedProperties,
+				}
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.NoError(t, err)
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate deprecated primitive types", func(t *testing.T) {
+		for _, pdt := range schema.DeprecatedPrimitiveDataTypes {
+			t.Run(pdt.String(), func(t *testing.T) {
+				nestedProperties := []*models.NestedProperty{
+					{
+						Name:            "nested_" + pdt.AsName(),
+						DataType:        pdt.PropString(),
+						IndexFilterable: &vFalse,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+				}
+
+				for _, ndt := range schema.NestedDataTypes {
+					t.Run(ndt.String(), func(t *testing.T) {
+						propPrimitives := &models.Property{
+							Name:             "objectProp",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						}
+						propLvl2Primitives := &models.Property{
+							Name:            "objectPropLvl2",
+							DataType:        ndt.PropString(),
+							IndexFilterable: &vFalse,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:             "nested_object",
+									DataType:         ndt.PropString(),
+									IndexFilterable:  &vFalse,
+									IndexSearchable:  &vFalse,
+									Tokenization:     "",
+									NestedProperties: nestedProperties,
+								},
+							},
+						}
+
+						for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+							t.Run(prop.Name, func(t *testing.T) {
+								err := validateNestedProperties(prop.NestedProperties, prop.Name)
+								assert.ErrorContains(t, err, prop.Name)
+								assert.ErrorContains(t, err, fmt.Sprintf("data type '%s' is deprecated and not allowed as nested property", pdt.String()))
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate unsupported primitive types", func(t *testing.T) {
+		for _, pdt := range []schema.DataType{schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber} {
+			t.Run(pdt.String(), func(t *testing.T) {
+				nestedProperties := []*models.NestedProperty{
+					{
+						Name:            "nested_" + pdt.AsName(),
+						DataType:        pdt.PropString(),
+						IndexFilterable: &vFalse,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+				}
+
+				for _, ndt := range schema.NestedDataTypes {
+					t.Run(ndt.String(), func(t *testing.T) {
+						propPrimitives := &models.Property{
+							Name:             "objectProp",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						}
+						propLvl2Primitives := &models.Property{
+							Name:            "objectPropLvl2",
+							DataType:        ndt.PropString(),
+							IndexFilterable: &vFalse,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:             "nested_object",
+									DataType:         ndt.PropString(),
+									IndexFilterable:  &vFalse,
+									IndexSearchable:  &vFalse,
+									Tokenization:     "",
+									NestedProperties: nestedProperties,
+								},
+							},
+						}
+
+						for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+							t.Run(prop.Name, func(t *testing.T) {
+								err := validateNestedProperties(prop.NestedProperties, prop.Name)
+								assert.ErrorContains(t, err, prop.Name)
+								assert.ErrorContains(t, err, fmt.Sprintf("data type '%s' not allowed as nested property", pdt.String()))
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate ref types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{
+			{
+				Name:            "nested_ref",
+				DataType:        []string{"SomeClass"},
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propPrimitives := &models.Property{
+					Name:             "objectProp",
+					DataType:         ndt.PropString(),
+					IndexFilterable:  &vFalse,
+					IndexSearchable:  &vFalse,
+					Tokenization:     "",
+					NestedProperties: nestedProperties,
+				}
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.ErrorContains(t, err, prop.Name)
+						assert.ErrorContains(t, err, "reference data type not allowed")
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate empty nested properties", func(t *testing.T) {
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propPrimitives := &models.Property{
+					Name:            "objectProp",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				}
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:            "nested_object",
+							DataType:        ndt.PropString(),
+							IndexFilterable: &vFalse,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.ErrorContains(t, err, prop.Name)
+						assert.ErrorContains(t, err, "At least one nested property is required for data type object/object[]")
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate tokenization on non text/text[] primitive data types", func(t *testing.T) {
+		for _, pdt := range schema.PrimitiveDataTypes {
+			switch pdt {
+			case schema.DataTypeText, schema.DataTypeTextArray:
+				continue
+			case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber:
+				// skip - not supported as nested
+				continue
+			default:
+				// do nothing
+			}
+
+			t.Run(pdt.String(), func(t *testing.T) {
+				nestedProperties := []*models.NestedProperty{
+					{
+						Name:            "nested_" + pdt.AsName(),
+						DataType:        pdt.PropString(),
+						IndexFilterable: &vFalse,
+						IndexSearchable: &vFalse,
+						Tokenization:    models.PropertyTokenizationWord,
+					},
+				}
+
+				for _, ndt := range schema.NestedDataTypes {
+					t.Run(ndt.String(), func(t *testing.T) {
+						propPrimitives := &models.Property{
+							Name:             "objectProp",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						}
+						propLvl2Primitives := &models.Property{
+							Name:            "objectPropLvl2",
+							DataType:        ndt.PropString(),
+							IndexFilterable: &vFalse,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:             "nested_object",
+									DataType:         ndt.PropString(),
+									IndexFilterable:  &vFalse,
+									IndexSearchable:  &vFalse,
+									Tokenization:     "",
+									NestedProperties: nestedProperties,
+								},
+							},
+						}
+
+						for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+							t.Run(prop.Name, func(t *testing.T) {
+								err := validateNestedProperties(prop.NestedProperties, prop.Name)
+								assert.ErrorContains(t, err, prop.Name)
+								assert.ErrorContains(t, err, fmt.Sprintf("Tokenization is not allowed for data type '%s'", pdt.String()))
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate tokenization on nested data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{
+			{
+				Name:            "nested_int",
+				DataType:        schema.DataTypeInt.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     models.PropertyTokenizationWord,
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.ErrorContains(t, err, prop.Name)
+						assert.ErrorContains(t, err, "Tokenization is not allowed for object/object[] data types")
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("validates indexFilterable on primitive data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{}
+		for _, pdt := range schema.PrimitiveDataTypes {
+			tokenization := ""
+			switch pdt {
+			case schema.DataTypeBlob:
+				// skip - not indexable
+				continue
+			case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber:
+				// skip - not supported as nested
+				continue
+			case schema.DataTypeText, schema.DataTypeTextArray:
+				tokenization = models.PropertyTokenizationWord
+			default:
+				// do nothing
+			}
+
+			nestedProperties = append(nestedProperties, &models.NestedProperty{
+				Name:            "nested_" + pdt.AsName(),
+				DataType:        pdt.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
+				Tokenization:    tokenization,
+			})
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propPrimitives := &models.Property{
+					Name:             "objectProp",
+					DataType:         ndt.PropString(),
+					IndexFilterable:  &vFalse,
+					IndexSearchable:  &vFalse,
+					Tokenization:     "",
+					NestedProperties: nestedProperties,
+				}
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.NoError(t, err)
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate indexFilterable on blob data type", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{
+			{
+				Name:            "nested_blob",
+				DataType:        schema.DataTypeBlob.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propPrimitives := &models.Property{
+					Name:             "objectProp",
+					DataType:         ndt.PropString(),
+					IndexFilterable:  &vFalse,
+					IndexSearchable:  &vFalse,
+					Tokenization:     "",
+					NestedProperties: nestedProperties,
+				}
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.ErrorContains(t, err, prop.Name)
+						assert.ErrorContains(t, err, "indexFilterable is not allowed for blob data type")
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("validates indexFilterable on nested data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{
+			{
+				Name:            "nested_int",
+				DataType:        schema.DataTypeInt.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.NoError(t, err)
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("validates indexSearchable on text/text[] data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{}
+		for _, pdt := range []schema.DataType{schema.DataTypeText, schema.DataTypeTextArray} {
+			nestedProperties = append(nestedProperties, &models.NestedProperty{
+				Name:            "nested_" + pdt.AsName(),
+				DataType:        pdt.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vTrue,
+				Tokenization:    models.PropertyTokenizationWord,
+			})
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propPrimitives := &models.Property{
+					Name:             "objectProp",
+					DataType:         ndt.PropString(),
+					IndexFilterable:  &vFalse,
+					IndexSearchable:  &vFalse,
+					Tokenization:     "",
+					NestedProperties: nestedProperties,
+				}
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.NoError(t, err)
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate indexSearchable on primitive data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{}
+		for _, pdt := range schema.PrimitiveDataTypes {
+			switch pdt {
+			case schema.DataTypeText, schema.DataTypeTextArray:
+				continue
+			case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber:
+				// skip - not supported as nested
+				continue
+			default:
+				// do nothing
+			}
+
+			t.Run(pdt.String(), func(t *testing.T) {
+				nestedProperties = append(nestedProperties, &models.NestedProperty{
+					Name:            "nested_" + pdt.AsName(),
+					DataType:        pdt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vTrue,
+					Tokenization:    "",
+				})
+
+				for _, ndt := range schema.NestedDataTypes {
+					t.Run(ndt.String(), func(t *testing.T) {
+						propPrimitives := &models.Property{
+							Name:             "objectProp",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vFalse,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						}
+						propLvl2Primitives := &models.Property{
+							Name:            "objectPropLvl2",
+							DataType:        ndt.PropString(),
+							IndexFilterable: &vFalse,
+							IndexSearchable: &vFalse,
+							Tokenization:    "",
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:             "nested_object",
+									DataType:         ndt.PropString(),
+									IndexFilterable:  &vFalse,
+									IndexSearchable:  &vFalse,
+									Tokenization:     "",
+									NestedProperties: nestedProperties,
+								},
+							},
+						}
+
+						for _, prop := range []*models.Property{propPrimitives, propLvl2Primitives} {
+							t.Run(prop.Name, func(t *testing.T) {
+								err := validateNestedProperties(prop.NestedProperties, prop.Name)
+								assert.ErrorContains(t, err, prop.Name)
+								assert.ErrorContains(t, err, "`indexSearchable` is not allowed for other than text/text[] data types")
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("does not validate indexSearchable on nested data types", func(t *testing.T) {
+		nestedProperties := []*models.NestedProperty{
+			{
+				Name:            "nested_int",
+				DataType:        schema.DataTypeInt.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+		}
+
+		for _, ndt := range schema.NestedDataTypes {
+			t.Run(ndt.String(), func(t *testing.T) {
+				propLvl2Primitives := &models.Property{
+					Name:            "objectPropLvl2",
+					DataType:        ndt.PropString(),
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:             "nested_object",
+							DataType:         ndt.PropString(),
+							IndexFilterable:  &vFalse,
+							IndexSearchable:  &vTrue,
+							Tokenization:     "",
+							NestedProperties: nestedProperties,
+						},
+					},
+				}
+
+				for _, prop := range []*models.Property{propLvl2Primitives} {
+					t.Run(prop.Name, func(t *testing.T) {
+						err := validateNestedProperties(prop.NestedProperties, prop.Name)
+						assert.ErrorContains(t, err, prop.Name)
+						assert.ErrorContains(t, err, "`indexSearchable` is not allowed for other than text/text[] data types")
+					})
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
### What's being changed:

* Remove routine to start a standalone RAFT cluster for schema unit tests
* Add fakes with mocks to emulate metaWriter and metaReader
* Update all tests to use mocks
* Re-add removed tests and validation code compared to master

In terms of functionality changes:
* Re add validation that was removed for nested properties
* Re add node mapping on backup restore that was removed


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
