### PR TITLE
Refactor all `lsmkv` error equality checks to use `errors.Is`

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -13,9 +13,10 @@ package lsmkv
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -102,13 +103,13 @@ func (c *CursorMap) seekAll(target []byte) {
 	state := make([]cursorStateMap, len(c.innerCursors))
 	for i, cur := range c.innerCursors {
 		key, value, err := cur.seek(target)
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			state[i].err = err
 			continue
 		}
 
 		if err != nil {
-			panic(errors.Wrap(err, "unexpected error in seek"))
+			panic(fmt.Errorf("unexpected error in seek: %w", err))
 		}
 
 		state[i].key = key
@@ -124,13 +125,13 @@ func (c *CursorMap) firstAll() {
 	state := make([]cursorStateMap, len(c.innerCursors))
 	for i, cur := range c.innerCursors {
 		key, value, err := cur.first()
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			state[i].err = err
 			continue
 		}
 
 		if err != nil {
-			panic(errors.Wrap(err, "unexpected error in seek"))
+			panic(fmt.Errorf("unexpected error in seek: %w", err))
 		}
 
 		state[i].key = key
@@ -145,7 +146,7 @@ func (c *CursorMap) firstAll() {
 func (c *CursorMap) serveCurrentStateAndAdvance() ([]byte, []MapPair) {
 	id, err := c.cursorWithLowestKey()
 	if err != nil {
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			return nil, nil
 		}
 	}
@@ -167,7 +168,7 @@ func (c *CursorMap) cursorWithLowestKey() (int, error) {
 	var lowest []byte
 
 	for i, res := range c.state {
-		if res.err == lsmkv.NotFound {
+		if errors.Is(res.err, lsmkv.NotFound) {
 			continue
 		}
 
@@ -238,7 +239,7 @@ func (c *CursorMap) mergeDuplicatesInCurrentStateAndAdvance(ids []int) ([]byte, 
 
 	merged, err := newSortedMapMerger().do(perSegmentResults)
 	if err != nil {
-		panic(errors.Wrap(err, "unexpected error decoding map values"))
+		panic(fmt.Errorf("unexpected error decoding map values: %w", err))
 	}
 	if len(merged) == 0 {
 		// all values deleted, skip key
@@ -255,14 +256,14 @@ func (c *CursorMap) mergeDuplicatesInCurrentStateAndAdvance(ids []int) ([]byte, 
 
 func (c *CursorMap) advanceInner(id int) {
 	k, v, err := c.innerCursors[id].next()
-	if err == lsmkv.NotFound {
+	if errors.Is(err, lsmkv.NotFound) {
 		c.state[id].err = err
 		c.state[id].key = nil
 		c.state[id].value = nil
 		return
 	}
 
-	if err == lsmkv.Deleted {
+	if errors.Is(err, lsmkv.Deleted) {
 		c.state[id].err = err
 		c.state[id].key = k
 		c.state[id].value = nil
@@ -270,7 +271,7 @@ func (c *CursorMap) advanceInner(id int) {
 	}
 
 	if err != nil {
-		panic(errors.Wrap(err, "unexpected error in advance"))
+		panic(fmt.Errorf("unexpected error in advance: %w", err))
 	}
 
 	c.state[id].key = k

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -78,12 +78,12 @@ func (c *CursorReplace) seekAll(target []byte) {
 	state := make([]cursorStateReplace, len(c.innerCursors))
 	for i, cur := range c.innerCursors {
 		key, value, err := cur.seek(target)
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			state[i].err = err
 			continue
 		}
 
-		if err == lsmkv.Deleted {
+		if errors.Is(err, lsmkv.Deleted) {
 			state[i].err = err
 			state[i].key = key
 			continue
@@ -103,7 +103,7 @@ func (c *CursorReplace) seekAll(target []byte) {
 func (c *CursorReplace) serveCurrentStateAndAdvance() ([]byte, []byte) {
 	id, err := c.cursorWithLowestKey()
 	if err != nil {
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			return nil, nil
 		}
 	}
@@ -150,7 +150,7 @@ func (c *CursorReplace) mergeDuplicatesInCurrentStateAndAdvance(ids []int) ([]by
 		c.advanceInner(id)
 	}
 
-	if c.serveCache.err == lsmkv.Deleted {
+	if errors.Is(c.serveCache.err, lsmkv.Deleted) {
 		// element was deleted, proceed with next round
 		return c.Next()
 	}
@@ -188,7 +188,7 @@ func (c *CursorReplace) cursorWithLowestKey() (int, error) {
 	var lowest []byte
 
 	for i, res := range c.state {
-		if res.err == lsmkv.NotFound {
+		if errors.Is(res.err, lsmkv.NotFound) {
 			continue
 		}
 
@@ -208,14 +208,14 @@ func (c *CursorReplace) cursorWithLowestKey() (int, error) {
 
 func (c *CursorReplace) advanceInner(id int) {
 	k, v, err := c.innerCursors[id].next()
-	if err == lsmkv.NotFound {
+	if errors.Is(err, lsmkv.NotFound) {
 		c.state[id].err = err
 		c.state[id].key = nil
 		c.state[id].value = nil
 		return
 	}
 
-	if err == lsmkv.Deleted {
+	if errors.Is(err, lsmkv.Deleted) {
 		c.state[id].err = err
 		c.state[id].key = k
 		c.state[id].value = nil
@@ -239,11 +239,11 @@ func (c *CursorReplace) firstAll() {
 	state := make([]cursorStateReplace, len(c.innerCursors))
 	for i, cur := range c.innerCursors {
 		key, value, err := cur.first()
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			state[i].err = err
 			continue
 		}
-		if err == lsmkv.Deleted {
+		if errors.Is(err, lsmkv.Deleted) {
 			state[i].err = err
 			state[i].key = key
 			continue

--- a/adapters/repos/db/lsmkv/roaringset/cursor.go
+++ b/adapters/repos/db/lsmkv/roaringset/cursor.go
@@ -13,8 +13,9 @@ package roaringset
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
@@ -77,11 +78,11 @@ func (c *CombinedCursor) runAll(cursorRun cursorRun) []innerCursorState {
 }
 
 func (c *CombinedCursor) createState(key []byte, layer BitmapLayer, err error) innerCursorState {
-	if err == lsmkv.NotFound {
+	if errors.Is(err, lsmkv.NotFound) {
 		return innerCursorState{err: err}
 	}
 	if err != nil {
-		panic(errors.Wrap(err, "unexpected error")) // TODO necessary?
+		panic(fmt.Errorf("unexpected error: %w", err)) // TODO necessary?
 	}
 	state := innerCursorState{key: key}
 	state.layer = layer
@@ -132,7 +133,7 @@ func (c *CombinedCursor) getCursorIdsWithLowestKey(states []innerCursorState) ([
 	allNotFound := true
 
 	for id, state := range states {
-		if state.err == lsmkv.NotFound {
+		if errors.Is(state.err, lsmkv.NotFound) {
 			continue
 		}
 		allNotFound = false

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -13,6 +13,7 @@ package segmentindex
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -149,7 +150,7 @@ func (t *DiskTree) seekAt(offset int64, key []byte) (Node, error) {
 			return left, nil
 		}
 
-		if err == lsmkv.NotFound {
+		if errors.Is(err, lsmkv.NotFound) {
 			return self, nil
 		}
 


### PR DESCRIPTION
### What's being changed:

To prevent ineffective equality checks, since `==` will not detect wrapped errors.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
