### PR TITLE
Add support for new 002 and 003 Gecko models

### DIFF
--- a/modules/text2vec-palm/clients/palm_test.go
+++ b/modules/text2vec-palm/clients/palm_test.go
@@ -53,7 +53,7 @@ func TestClient(t *testing.T) {
 				ApiEndpoint: "endpoint",
 				ProjectID:   "project",
 				Model:       "model",
-			})
+			}, "")
 
 		assert.Nil(t, err)
 		assert.Equal(t, expected, res)
@@ -73,7 +73,7 @@ func TestClient(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
 		defer cancel()
 
-		_, err := c.Vectorize(ctx, []string{"This is my text"}, ent.VectorizationConfig{})
+		_, err := c.Vectorize(ctx, []string{"This is my text"}, ent.VectorizationConfig{}, "")
 
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "context deadline exceeded")
@@ -94,7 +94,7 @@ func TestClient(t *testing.T) {
 			logger: nullLogger(),
 		}
 		_, err := c.Vectorize(context.Background(), []string{"This is my text"},
-			ent.VectorizationConfig{})
+			ent.VectorizationConfig{}, "")
 
 		require.NotNil(t, err)
 		assert.EqualError(t, err, "connection to Google PaLM failed with status: 500 error: nope, not gonna happen")
@@ -119,7 +119,7 @@ func TestClient(t *testing.T) {
 			Vectors:    [][]float32{{0.1, 0.2, 0.3}},
 			Dimensions: 3,
 		}
-		res, err := c.Vectorize(ctxWithValue, []string{"This is my text"}, ent.VectorizationConfig{})
+		res, err := c.Vectorize(ctxWithValue, []string{"This is my text"}, ent.VectorizationConfig{}, "")
 
 		require.Nil(t, err)
 		assert.Equal(t, expected, res)
@@ -139,7 +139,7 @@ func TestClient(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
 		defer cancel()
 
-		_, err := c.Vectorize(ctx, []string{"This is my text"}, ent.VectorizationConfig{})
+		_, err := c.Vectorize(ctx, []string{"This is my text"}, ent.VectorizationConfig{}, "")
 
 		require.NotNil(t, err)
 		assert.Equal(t, err.Error(), "Palm API Key: no api key found "+
@@ -159,7 +159,7 @@ func TestClient(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Palm-Api-Key", []string{""})
 
-		_, err := c.Vectorize(ctxWithValue, []string{"This is my text"}, ent.VectorizationConfig{})
+		_, err := c.Vectorize(ctxWithValue, []string{"This is my text"}, ent.VectorizationConfig{}, "")
 
 		require.NotNil(t, err)
 		assert.Equal(t, err.Error(), "Palm API Key: no api key found "+

--- a/modules/text2vec-palm/config/class_settings.go
+++ b/modules/text2vec-palm/config/class_settings.go
@@ -28,6 +28,7 @@ const (
 	apiEndpointProperty = "apiEndpoint"
 	projectIDProperty   = "projectId"
 	modelIDProperty     = "modelId"
+	titleProperty       = "titleProperty"
 )
 
 const (
@@ -44,6 +45,10 @@ var availablePalmModels = []string{
 	DefaultModelID,
 	"textembedding-gecko@latest",
 	"textembedding-gecko-multilingual@latest",
+	"textembedding-gecko@003",
+	"textembedding-gecko@002",
+	"textembedding-gecko-multilingual@001",
+	"textembedding-gecko@001",
 }
 
 var availableGenerativeAIModels = []string{
@@ -230,4 +235,8 @@ func (ic *classSettings) ProjectID() string {
 
 func (ic *classSettings) ModelID() string {
 	return ic.getStringProperty(modelIDProperty, ic.getDefaultModel(ic.ApiEndpoint()))
+}
+
+func (ic *classSettings) TitleProperty() string {
+	return ic.getStringProperty(titleProperty, "")
 }

--- a/modules/text2vec-palm/config/class_settings_test.go
+++ b/modules/text2vec-palm/config/class_settings_test.go
@@ -26,6 +26,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantApiEndpoint string
 		wantProjectID   string
 		wantModelID     string
+		wantTitle       string
 		wantErr         error
 	}{
 		{
@@ -44,13 +45,15 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "custom values",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"apiEndpoint": "google.com",
-					"projectId":   "projectId",
+					"apiEndpoint":   "google.com",
+					"projectId":     "projectId",
+					"titleProperty": "title",
 				},
 			},
 			wantApiEndpoint: "google.com",
 			wantProjectID:   "projectId",
 			wantModelID:     "textembedding-gecko@001",
+			wantTitle:       "title",
 			wantErr:         nil,
 		},
 		{
@@ -70,7 +73,10 @@ func Test_classSettings_Validate(t *testing.T) {
 					"modelId":   "wrong-model",
 				},
 			},
-			wantErr: errors.Errorf("wrong modelId available model names are: [textembedding-gecko@001 textembedding-gecko@latest textembedding-gecko-multilingual@latest]"),
+			wantErr: errors.Errorf("wrong modelId available model names are: " +
+				"[textembedding-gecko@001 textembedding-gecko@latest " +
+				"textembedding-gecko-multilingual@latest textembedding-gecko@003 " +
+				"textembedding-gecko@002 textembedding-gecko-multilingual@001 textembedding-gecko@001]"),
 		},
 		{
 			name: "all wrong",
@@ -82,7 +88,9 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 			wantErr: errors.Errorf("projectId cannot be empty, " +
 				"wrong modelId available model names are: " +
-				"[textembedding-gecko@001 textembedding-gecko@latest textembedding-gecko-multilingual@latest]"),
+				"[textembedding-gecko@001 textembedding-gecko@latest " +
+				"textembedding-gecko-multilingual@latest textembedding-gecko@003 " +
+				"textembedding-gecko@002 textembedding-gecko-multilingual@001 textembedding-gecko@001]"),
 		},
 		{
 			name: "Generative AI",
@@ -129,6 +137,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				assert.Equal(t, tt.wantApiEndpoint, ic.ApiEndpoint())
 				assert.Equal(t, tt.wantProjectID, ic.ProjectID())
 				assert.Equal(t, tt.wantModelID, ic.ModelID())
+				assert.Equal(t, tt.wantTitle, ic.TitleProperty())
 			}
 		})
 	}

--- a/modules/text2vec-palm/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-palm/vectorizer/fakes_for_test.go
@@ -23,7 +23,7 @@ type fakeClient struct {
 }
 
 func (c *fakeClient) Vectorize(ctx context.Context,
-	text []string, cfg ent.VectorizationConfig,
+	text []string, cfg ent.VectorizationConfig, titlePropertyValue string,
 ) (*ent.VectorizationResult, error) {
 	c.lastInput = text
 	c.lastConfig = cfg
@@ -82,4 +82,8 @@ func (f *fakeSettings) ProjectID() string {
 
 func (f *fakeSettings) ModelID() string {
 	return f.truncateType
+}
+
+func (f *fakeSettings) TitleProperty() string {
+	return ""
 }

--- a/modules/text2vec-palm/vectorizer/objects.go
+++ b/modules/text2vec-palm/vectorizer/objects.go
@@ -35,7 +35,7 @@ func New(client Client) *Vectorizer {
 
 type Client interface {
 	Vectorize(ctx context.Context, input []string,
-		config ent.VectorizationConfig) (*ent.VectorizationResult, error)
+		config ent.VectorizationConfig, titlePropertyValue string) (*ent.VectorizationResult, error)
 	VectorizeQuery(ctx context.Context, input []string,
 		config ent.VectorizationConfig) (*ent.VectorizationResult, error)
 }
@@ -48,6 +48,7 @@ type ClassSettings interface {
 	ApiEndpoint() string
 	ProjectID() string
 	ModelID() string
+	TitleProperty() string
 }
 
 func sortStringKeys(schema_map map[string]interface{}) []string {
@@ -88,11 +89,21 @@ func appendPropIfText(icheck ClassSettings, list *[]string, propName string,
 	return false
 }
 
+func appendTitlePropIfText(icheck ClassSettings, list *[]string, propName string,
+	value interface{},
+) bool {
+	if icheck.TitleProperty() == propName {
+		return appendPropIfText(icheck, list, propName, value)
+	}
+	return false
+}
+
 func (v *Vectorizer) object(ctx context.Context, className string,
 	schema interface{}, objDiff *moduletools.ObjectDiff, icheck ClassSettings,
 ) ([]float32, error) {
 	vectorize := objDiff == nil || objDiff.GetVec() == nil
 
+	var titlePropertyValue []string
 	var corpi []string
 	if icheck.VectorizeClassName() {
 		corpi = append(corpi, camelCaseToLower(className))
@@ -109,13 +120,16 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 			case []string:
 				for _, elem := range val {
 					appended = appendPropIfText(icheck, &corpi, prop, elem) || appended
+					appendTitlePropIfText(icheck, &titlePropertyValue, prop, elem)
 				}
 			case []interface{}:
 				for _, elem := range val {
 					appended = appendPropIfText(icheck, &corpi, prop, elem) || appended
+					appendTitlePropIfText(icheck, &titlePropertyValue, prop, elem)
 				}
 			default:
 				appended = appendPropIfText(icheck, &corpi, prop, val)
+				appendTitlePropIfText(icheck, &titlePropertyValue, prop, val)
 			}
 
 			vectorize = vectorize || (appended && objDiff != nil && objDiff.IsChangedProp(prop))
@@ -132,11 +146,12 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 	}
 
 	text := []string{strings.Join(corpi, " ")}
+	titleProperty := strings.Join(titlePropertyValue, " ")
 	res, err := v.client.Vectorize(ctx, text, ent.VectorizationConfig{
 		ApiEndpoint: icheck.ApiEndpoint(),
 		ProjectID:   icheck.ProjectID(),
 		Model:       icheck.ModelID(),
-	})
+	}, titleProperty)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

This PR adjusts PaLM module API calls to Vertex AI to include `task_type` parameter.

This PR also introduces new setting: `titleProperty` which is used to point the property which value should be passed to Google's API call as `title` property value.

This PR also adds support for `002` and `003` versions of gecko models.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
