### PR TITLE
Generic backoff timer to limit any behavior, currently log messages

### DIFF
--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -65,6 +65,12 @@ func (s *Shard) updateStatusUnlocked(in string) error {
 	s.status = targetStatus
 	s.updateStoreStatus(targetStatus)
 
+	s.index.logger.
+		WithField("action", "update shard status").
+		WithField("class", s.index.Config.ClassName).
+		WithField("shard", s.name).
+		WithField("status", in)
+
 	return nil
 }
 

--- a/entities/interval/backoff.go
+++ b/entities/interval/backoff.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+const maxInterval = 24 * time.Hour
+
 var defaultBackoffs = []time.Duration{
 	time.Duration(0),
 	30 * time.Second,
@@ -59,18 +61,18 @@ func (b *BackoffTimer) IncreaseInterval() {
 // IntervalElapsed returns if the current interval has elapsed
 func (b *BackoffTimer) IntervalElapsed() bool {
 	return time.Since(b.lastInterval) >
-		b.getWarningInterval()
+		b.calculateInterval()
 }
 
-// Reset returns BackoffTimer to it's original empty state
+// Reset returns BackoffTimer to its original empty state
 func (b *BackoffTimer) Reset() {
 	b.lastInterval = time.Time{}
 	b.backoffLevel = 0
 }
 
-func (b *BackoffTimer) getWarningInterval() time.Duration {
+func (b *BackoffTimer) calculateInterval() time.Duration {
 	if b.backoffLevel >= len(b.backoffs) {
-		return time.Hour * 24
+		return maxInterval
 	}
 
 	interval := b.backoffs[b.backoffLevel]

--- a/entities/interval/backoff.go
+++ b/entities/interval/backoff.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package interval
+
+import (
+	"sort"
+	"time"
+)
+
+var defaultBackoffs = []time.Duration{
+	time.Duration(0),
+	30 * time.Second,
+	2 * time.Minute,
+	10 * time.Minute,
+	1 * time.Hour,
+	12 * time.Hour,
+}
+
+// BackoffTimer tracks a given range of intervals with increasing duration
+type BackoffTimer struct {
+	backoffLevel int
+	backoffs     []time.Duration
+	lastInterval time.Time
+}
+
+// NewBackoffTimer constructs and returns a *BackoffTimer instance
+// If no backoffs are provided, defaultBackoffs is used. When the
+// final backoff duration is elapsed, a maximum duration of 24 hrs
+// is used for the remainder of the BackoffTimer's lifetime
+func NewBackoffTimer(backoffs ...time.Duration) *BackoffTimer {
+	boff := &BackoffTimer{backoffs: backoffs}
+	if len(backoffs) == 0 {
+		boff.backoffs = defaultBackoffs
+	} else {
+		sort.Slice(backoffs, func(i, j int) bool {
+			return backoffs[i] < backoffs[j]
+		})
+	}
+	return boff
+}
+
+// IncreaseInterval bumps the duration of the interval up to the next given value
+func (b *BackoffTimer) IncreaseInterval() {
+	b.lastInterval = time.Now()
+	if b.backoffLevel < len(b.backoffs) {
+		b.backoffLevel += 1
+	}
+}
+
+// IntervalElapsed returns if the current interval has elapsed
+func (b *BackoffTimer) IntervalElapsed() bool {
+	return time.Since(b.lastInterval) >
+		b.getWarningInterval()
+}
+
+// Reset returns BackoffTimer to it's original empty state
+func (b *BackoffTimer) Reset() {
+	b.lastInterval = time.Time{}
+	b.backoffLevel = 0
+}
+
+func (b *BackoffTimer) getWarningInterval() time.Duration {
+	if b.backoffLevel >= len(b.backoffs) {
+		return time.Hour * 24
+	}
+
+	interval := b.backoffs[b.backoffLevel]
+
+	return interval
+}

--- a/entities/interval/backoff.go
+++ b/entities/interval/backoff.go
@@ -16,8 +16,6 @@ import (
 	"time"
 )
 
-const maxInterval = 24 * time.Hour
-
 var defaultBackoffs = []time.Duration{
 	time.Duration(0),
 	30 * time.Second,
@@ -60,8 +58,7 @@ func (b *BackoffTimer) IncreaseInterval() {
 
 // IntervalElapsed returns if the current interval has elapsed
 func (b *BackoffTimer) IntervalElapsed() bool {
-	return time.Since(b.lastInterval) >
-		b.calculateInterval()
+	return time.Since(b.lastInterval) > b.calculateInterval()
 }
 
 // Reset returns BackoffTimer to its original empty state
@@ -72,7 +69,7 @@ func (b *BackoffTimer) Reset() {
 
 func (b *BackoffTimer) calculateInterval() time.Duration {
 	if b.backoffLevel >= len(b.backoffs) {
-		return maxInterval
+		return b.backoffs[len(b.backoffs)-1]
 	}
 
 	interval := b.backoffs[b.backoffLevel]

--- a/entities/interval/backoff.go
+++ b/entities/interval/backoff.go
@@ -34,8 +34,8 @@ type BackoffTimer struct {
 
 // NewBackoffTimer constructs and returns a *BackoffTimer instance
 // If no backoffs are provided, defaultBackoffs is used. When the
-// final backoff duration is elapsed, a maximum duration of 24 hrs
-// is used for the remainder of the BackoffTimer's lifetime
+// last backoff duration has elapsed, the timer will use the final
+// duration for the remainder of the BackoffTimer's lifetime
 func NewBackoffTimer(backoffs ...time.Duration) *BackoffTimer {
 	boff := &BackoffTimer{backoffs: backoffs}
 	if len(backoffs) == 0 {

--- a/entities/interval/backoff_test.go
+++ b/entities/interval/backoff_test.go
@@ -26,7 +26,7 @@ func TestBackoffInterval(t *testing.T) {
 		assert.Equal(t, boff.backoffs, defaultBackoffs)
 		assert.Zero(t, boff.backoffLevel)
 		assert.Zero(t, boff.lastInterval)
-		assert.Equal(t, time.Duration(0), boff.getWarningInterval())
+		assert.Equal(t, time.Duration(0), boff.calculateInterval())
 		assert.True(t, boff.IntervalElapsed())
 
 		i := 1
@@ -34,13 +34,13 @@ func TestBackoffInterval(t *testing.T) {
 			boff.IncreaseInterval()
 			assert.False(t, boff.IntervalElapsed())
 			assert.Equal(t, i, boff.backoffLevel)
-			assert.Equal(t, defaultBackoffs[i], boff.getWarningInterval())
+			assert.Equal(t, defaultBackoffs[i], boff.calculateInterval())
 		}
 
 		boff.IncreaseInterval()
 		assert.False(t, boff.IntervalElapsed())
 		assert.Equal(t, i, boff.backoffLevel)
-		assert.Equal(t, 24*time.Hour, boff.getWarningInterval())
+		assert.Equal(t, 24*time.Hour, boff.calculateInterval())
 	})
 
 	t.Run("with custom backoffs", func(t *testing.T) {
@@ -57,22 +57,22 @@ func TestBackoffInterval(t *testing.T) {
 		boff := NewBackoffTimer(durations...)
 		assert.Equal(t, boff.backoffs, sorted)
 		assert.True(t, boff.IntervalElapsed())
-		assert.Equal(t, sorted[0], boff.getWarningInterval())
+		assert.Equal(t, sorted[0], boff.calculateInterval())
 
 		boff.IncreaseInterval()
 		time.Sleep(time.Millisecond)
 		assert.True(t, boff.IntervalElapsed())
-		assert.Equal(t, sorted[1], boff.getWarningInterval())
+		assert.Equal(t, sorted[1], boff.calculateInterval())
 
 		boff.IncreaseInterval()
 		assert.False(t, boff.IntervalElapsed())
 		time.Sleep(time.Second)
 		assert.True(t, boff.IntervalElapsed())
-		assert.Equal(t, sorted[2], boff.getWarningInterval())
+		assert.Equal(t, sorted[2], boff.calculateInterval())
 
 		boff.IncreaseInterval()
 		assert.False(t, boff.IntervalElapsed())
 		assert.False(t, boff.IntervalElapsed())
-		assert.Equal(t, 24*time.Hour, boff.getWarningInterval())
+		assert.Equal(t, 24*time.Hour, boff.calculateInterval())
 	})
 }

--- a/entities/interval/backoff_test.go
+++ b/entities/interval/backoff_test.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package interval
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffInterval(t *testing.T) {
+	t.Run("with default backoffs", func(t *testing.T) {
+		boff := NewBackoffTimer()
+
+		assert.Equal(t, boff.backoffs, defaultBackoffs)
+		assert.Zero(t, boff.backoffLevel)
+		assert.Zero(t, boff.lastInterval)
+		assert.Equal(t, time.Duration(0), boff.getWarningInterval())
+		assert.True(t, boff.IntervalElapsed())
+
+		i := 1
+		for ; i < len(defaultBackoffs); i++ {
+			boff.IncreaseInterval()
+			assert.False(t, boff.IntervalElapsed())
+			assert.Equal(t, i, boff.backoffLevel)
+			assert.Equal(t, defaultBackoffs[i], boff.getWarningInterval())
+		}
+
+		boff.IncreaseInterval()
+		assert.False(t, boff.IntervalElapsed())
+		assert.Equal(t, i, boff.backoffLevel)
+		assert.Equal(t, 24*time.Hour, boff.getWarningInterval())
+	})
+
+	t.Run("with custom backoffs", func(t *testing.T) {
+		var (
+			durations = []time.Duration{time.Second, time.Nanosecond, time.Millisecond}
+			sorted    = make([]time.Duration, len(durations))
+		)
+
+		copy(sorted, durations)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i] < sorted[j]
+		})
+
+		boff := NewBackoffTimer(durations...)
+		assert.Equal(t, boff.backoffs, sorted)
+		assert.True(t, boff.IntervalElapsed())
+		assert.Equal(t, sorted[0], boff.getWarningInterval())
+
+		boff.IncreaseInterval()
+		time.Sleep(time.Millisecond)
+		assert.True(t, boff.IntervalElapsed())
+		assert.Equal(t, sorted[1], boff.getWarningInterval())
+
+		boff.IncreaseInterval()
+		assert.False(t, boff.IntervalElapsed())
+		time.Sleep(time.Second)
+		assert.True(t, boff.IntervalElapsed())
+		assert.Equal(t, sorted[2], boff.getWarningInterval())
+
+		boff.IncreaseInterval()
+		assert.False(t, boff.IntervalElapsed())
+		assert.False(t, boff.IntervalElapsed())
+		assert.Equal(t, 24*time.Hour, boff.getWarningInterval())
+	})
+}

--- a/entities/interval/backoff_test.go
+++ b/entities/interval/backoff_test.go
@@ -40,7 +40,7 @@ func TestBackoffInterval(t *testing.T) {
 		boff.IncreaseInterval()
 		assert.False(t, boff.IntervalElapsed())
 		assert.Equal(t, i, boff.backoffLevel)
-		assert.Equal(t, 24*time.Hour, boff.calculateInterval())
+		assert.Equal(t, defaultBackoffs[len(defaultBackoffs)-1], boff.calculateInterval())
 	})
 
 	t.Run("with custom backoffs", func(t *testing.T) {
@@ -73,6 +73,6 @@ func TestBackoffInterval(t *testing.T) {
 		boff.IncreaseInterval()
 		assert.False(t, boff.IntervalElapsed())
 		assert.False(t, boff.IntervalElapsed())
-		assert.Equal(t, 24*time.Hour, boff.calculateInterval())
+		assert.Equal(t, sorted[len(sorted)-1], boff.calculateInterval())
 	})
 }


### PR DESCRIPTION
### What's being changed:

Abstracted from resource scans, generalized, and improved. Also applied to flush cycle readonly warning, since 1 log per second, per bucket are a lot of messages.

The constructor takes variadic arg of `time.Duration`, sorts it, and each iteration of interval-increase will take the next duration. Once the duration slice is exhausted, an interval of the longest duration is used for the remaining lifetime of the timer.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
