### PR TITLE
Adding Mixtral-8x7B-Instruct-v0.1

### DIFF
--- a/modules/generative-anyscale/config/class_settings.go
+++ b/modules/generative-anyscale/config/class_settings.go
@@ -31,6 +31,7 @@ var availableAnyscaleModels = []string{
 	"meta-llama/Llama-2-7b-chat-hf",
 	"codellama/CodeLlama-34b-Instruct-hf",
 	"mistralai/Mistral-7B-Instruct-v0.1",
+	"mistralai/Mixtral-8x7B-Instruct-v0.1",
 }
 
 // note we might want to separate the baseURL and completions URL in the future. Fine-tuned models also use this URL. 12/3/23

--- a/modules/generative-anyscale/config/class_settings_test.go
+++ b/modules/generative-anyscale/config/class_settings_test.go
@@ -74,7 +74,7 @@ func Test_classSettings_Validate(t *testing.T) {
 					"baseURL":     "https://custom.endpoint.com",
 				},
 			},
-			wantErr: errors.New("wrong Anyscale model name, available model names are: [meta-llama/Llama-2-70b-chat-hf meta-llama/Llama-2-13b-chat-hf meta-llama/Llama-2-7b-chat-hf codellama/CodeLlama-34b-Instruct-hf mistralai/Mistral-7B-Instruct-v0.1]"),
+			wantErr: errors.New("wrong Anyscale model name, available model names are: [meta-llama/Llama-2-70b-chat-hf meta-llama/Llama-2-13b-chat-hf meta-llama/Llama-2-7b-chat-hf codellama/CodeLlama-34b-Instruct-hf mistralai/Mistral-7B-Instruct-v0.1 mistralai/Mixtral-8x7B-Instruct-v0.1]"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
New Mixtral 8x7B LLM from Mistral, now supported on Anyscale endpoints!

### What's being changed:

Adding the Mixtral 8x7B model to `availableAnyscaleModels`, very small change.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.
