### PR TITLE
Fix batch deletions when replication is enabled

### DIFF
--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -484,10 +484,10 @@ func (c *RemoteIndex) Aggregate(ctx context.Context, hostName, index,
 	return resp.Result, err
 }
 
-func (c *RemoteIndex) FindDocIDs(ctx context.Context, hostName, indexName,
+func (c *RemoteIndex) FindUUIDs(ctx context.Context, hostName, indexName,
 	shardName string, filters *filters.LocalFilter,
-) ([]uint64, error) {
-	paramsBytes, err := clusterapi.IndicesPayloads.FindDocIDsParams.Marshal(filters)
+) ([]strfmt.UUID, error) {
+	paramsBytes, err := clusterapi.IndicesPayloads.FindUUIDsParams.Marshal(filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal request payload")
 	}
@@ -502,7 +502,7 @@ func (c *RemoteIndex) FindDocIDs(ctx context.Context, hostName, indexName,
 		return nil, errors.Wrap(err, "open http request")
 	}
 
-	clusterapi.IndicesPayloads.FindDocIDsParams.SetContentTypeHeaderReq(req)
+	clusterapi.IndicesPayloads.FindUUIDsParams.SetContentTypeHeaderReq(req)
 	res, err := c.client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "send http request")
@@ -520,26 +520,26 @@ func (c *RemoteIndex) FindDocIDs(ctx context.Context, hostName, indexName,
 		return nil, errors.Wrap(err, "read body")
 	}
 
-	ct, ok := clusterapi.IndicesPayloads.FindDocIDsResults.CheckContentTypeHeader(res)
+	ct, ok := clusterapi.IndicesPayloads.FindUUIDsResults.CheckContentTypeHeader(res)
 	if !ok {
 		return nil, errors.Errorf("unexpected content type: %s", ct)
 	}
 
-	docIDs, err := clusterapi.IndicesPayloads.FindDocIDsResults.Unmarshal(resBytes)
+	uuids, err := clusterapi.IndicesPayloads.FindUUIDsResults.Unmarshal(resBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal body")
 	}
-	return docIDs, nil
+	return uuids, nil
 }
 
 func (c *RemoteIndex) DeleteObjectBatch(ctx context.Context, hostName, indexName, shardName string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) objects.BatchSimpleObjects {
 	path := fmt.Sprintf("/indices/%s/shards/%s/objects", indexName, shardName)
 	method := http.MethodDelete
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
 
-	marshalled, err := clusterapi.IndicesPayloads.BatchDeleteParams.Marshal(docIDs, dryRun)
+	marshalled, err := clusterapi.IndicesPayloads.BatchDeleteParams.Marshal(uuids, dryRun)
 	if err != nil {
 		err := errors.Wrap(err, "marshal payload")
 		return objects.BatchSimpleObjects{objects.BatchSimpleObject{Err: err}}

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -204,9 +204,9 @@ func (c *replicationClient) AddReferences(ctx context.Context, host, index,
 }
 
 func (c *replicationClient) DeleteObjects(ctx context.Context, host, index, shard, requestID string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) (resp replica.SimpleResponse, err error) {
-	body, err := clusterapi.IndicesPayloads.BatchDeleteParams.Marshal(docIDs, dryRun)
+	body, err := clusterapi.IndicesPayloads.BatchDeleteParams.Marshal(uuids, dryRun)
 	if err != nil {
 		return resp, fmt.Errorf("encode request: %w", err)
 	}

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -308,27 +308,27 @@ func TestReplicationDeleteObjects(t *testing.T) {
 	defer ts.Close()
 	client := newReplicationClient(ts.Client())
 
-	docs := []uint64{1, 2}
+	uuids := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 	t.Run("ConnectionError", func(t *testing.T) {
-		_, err := client.DeleteObjects(ctx, "", "C1", "S1", "", docs, false)
+		_, err := client.DeleteObjects(ctx, "", "C1", "S1", "", uuids, false)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "connect")
 	})
 
 	t.Run("Error", func(t *testing.T) {
-		resp, err := client.DeleteObjects(ctx, fs.host, "C1", "S1", RequestError, docs, false)
+		resp, err := client.DeleteObjects(ctx, fs.host, "C1", "S1", RequestError, uuids, false)
 		assert.Nil(t, err)
 		assert.Equal(t, replica.SimpleResponse{Errors: fs.RequestError.Errors}, resp)
 	})
 
 	t.Run("DecodeResponse", func(t *testing.T) {
-		_, err := client.DeleteObjects(ctx, fs.host, "C1", "S1", RequestMalFormedResponse, docs, false)
+		_, err := client.DeleteObjects(ctx, fs.host, "C1", "S1", RequestMalFormedResponse, uuids, false)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "decode response")
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
-		_, err := client.DeleteObjects(ctx, fs.host, "C1", "S1", RequestInternalError, docs, false)
+		_, err := client.DeleteObjects(ctx, fs.host, "C1", "S1", RequestInternalError, uuids, false)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "status code")
 	})

--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"net/http"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -43,8 +44,8 @@ type indicesPayloads struct {
 	ReferenceList             referenceListPayload
 	AggregationParams         aggregationParamsPayload
 	AggregationResult         aggregationResultPayload
-	FindDocIDsParams          findDocIDsParamsPayload
-	FindDocIDsResults         findDocIDsResultsPayload
+	FindUUIDsParams           findUUIDsParamsPayload
+	FindUUIDsResults          findUUIDsResultsPayload
 	BatchDeleteParams         batchDeleteParamsPayload
 	BatchDeleteResults        batchDeleteResultsPayload
 	GetShardQueueSizeParams   getShardQueueSizeParamsPayload
@@ -553,9 +554,9 @@ func (p aggregationResultPayload) Unmarshal(in []byte) (*aggregation.Result, err
 	return &out, err
 }
 
-type findDocIDsParamsPayload struct{}
+type findUUIDsParamsPayload struct{}
 
-func (p findDocIDsParamsPayload) Marshal(filter *filters.LocalFilter) ([]byte, error) {
+func (p findUUIDsParamsPayload) Marshal(filter *filters.LocalFilter) ([]byte, error) {
 	type params struct {
 		Filters *filters.LocalFilter `json:"filters"`
 	}
@@ -564,73 +565,73 @@ func (p findDocIDsParamsPayload) Marshal(filter *filters.LocalFilter) ([]byte, e
 	return json.Marshal(par)
 }
 
-func (p findDocIDsParamsPayload) Unmarshal(in []byte) (*filters.LocalFilter, error) {
-	type findDocIDsParametersPayload struct {
+func (p findUUIDsParamsPayload) Unmarshal(in []byte) (*filters.LocalFilter, error) {
+	type findUUIDsParametersPayload struct {
 		Filters *filters.LocalFilter `json:"filters"`
 	}
-	var par findDocIDsParametersPayload
+	var par findUUIDsParametersPayload
 	err := json.Unmarshal(in, &par)
 	return par.Filters, err
 }
 
-func (p findDocIDsParamsPayload) MIME() string {
-	return "vnd.weaviate.finddocidsparams+json"
+func (p findUUIDsParamsPayload) MIME() string {
+	return "vnd.weaviate.finduuidsparams+json"
 }
 
-func (p findDocIDsParamsPayload) CheckContentTypeHeaderReq(r *http.Request) (string, bool) {
+func (p findUUIDsParamsPayload) CheckContentTypeHeaderReq(r *http.Request) (string, bool) {
 	ct := r.Header.Get("content-type")
 	return ct, ct == p.MIME()
 }
 
-func (p findDocIDsParamsPayload) SetContentTypeHeaderReq(r *http.Request) {
+func (p findUUIDsParamsPayload) SetContentTypeHeaderReq(r *http.Request) {
 	r.Header.Set("content-type", p.MIME())
 }
 
-type findDocIDsResultsPayload struct{}
+type findUUIDsResultsPayload struct{}
 
-func (p findDocIDsResultsPayload) Unmarshal(in []byte) ([]uint64, error) {
-	var out []uint64
+func (p findUUIDsResultsPayload) Unmarshal(in []byte) ([]strfmt.UUID, error) {
+	var out []strfmt.UUID
 	err := json.Unmarshal(in, &out)
 	return out, err
 }
 
-func (p findDocIDsResultsPayload) Marshal(in []uint64) ([]byte, error) {
+func (p findUUIDsResultsPayload) Marshal(in []strfmt.UUID) ([]byte, error) {
 	return json.Marshal(in)
 }
 
-func (p findDocIDsResultsPayload) MIME() string {
-	return "application/vnd.weaviate.finddocidsresults+octet-stream"
+func (p findUUIDsResultsPayload) MIME() string {
+	return "application/vnd.weaviate.findUUIDsresults+octet-stream"
 }
 
-func (p findDocIDsResultsPayload) SetContentTypeHeader(w http.ResponseWriter) {
+func (p findUUIDsResultsPayload) SetContentTypeHeader(w http.ResponseWriter) {
 	w.Header().Set("content-type", p.MIME())
 }
 
-func (p findDocIDsResultsPayload) CheckContentTypeHeader(r *http.Response) (string, bool) {
+func (p findUUIDsResultsPayload) CheckContentTypeHeader(r *http.Response) (string, bool) {
 	ct := r.Header.Get("content-type")
 	return ct, ct == p.MIME()
 }
 
 type batchDeleteParamsPayload struct{}
 
-func (p batchDeleteParamsPayload) Marshal(docIDs []uint64, dryRun bool) ([]byte, error) {
+func (p batchDeleteParamsPayload) Marshal(uuids []strfmt.UUID, dryRun bool) ([]byte, error) {
 	type params struct {
-		DocIDs []uint64 `json:"docIDs"`
-		DryRun bool     `json:"dryRun"`
+		UUIDs  []strfmt.UUID `json:"uuids"`
+		DryRun bool          `json:"dryRun"`
 	}
 
-	par := params{docIDs, dryRun}
+	par := params{uuids, dryRun}
 	return json.Marshal(par)
 }
 
-func (p batchDeleteParamsPayload) Unmarshal(in []byte) ([]uint64, bool, error) {
+func (p batchDeleteParamsPayload) Unmarshal(in []byte) ([]strfmt.UUID, bool, error) {
 	type batchDeleteParametersPayload struct {
-		DocIDs []uint64 `json:"docIDs"`
-		DryRun bool     `json:"dryRun"`
+		UUIDs  []strfmt.UUID `json:"uuids"`
+		DryRun bool          `json:"dryRun"`
 	}
 	var par batchDeleteParametersPayload
 	err := json.Unmarshal(in, &par)
-	return par.DocIDs, par.DryRun, err
+	return par.UUIDs, par.DryRun, err
 }
 
 func (p batchDeleteParamsPayload) MIME() string {

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -38,7 +38,7 @@ type replicator interface {
 	ReplicateDeletion(ctx context.Context, indexName, shardName,
 		requestID string, uuid strfmt.UUID) replica.SimpleResponse
 	ReplicateDeletions(ctx context.Context, indexName, shardName,
-		requestID string, docIDs []uint64, dryRun bool) replica.SimpleResponse
+		requestID string, uuids []strfmt.UUID, dryRun bool) replica.SimpleResponse
 	ReplicateReferences(ctx context.Context, indexName, shardName,
 		requestID string, refs []objects.BatchReference) replica.SimpleResponse
 	CommitReplication(indexName,
@@ -478,13 +478,13 @@ func (i *replicatedIndices) deleteObjects() http.Handler {
 		}
 		defer r.Body.Close()
 
-		docIDs, dryRun, err := IndicesPayloads.BatchDeleteParams.Unmarshal(bodyBytes)
+		uuids, dryRun, err := IndicesPayloads.BatchDeleteParams.Unmarshal(bodyBytes)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		resp := i.shards.ReplicateDeletions(r.Context(), index, shard, requestID, docIDs, dryRun)
+		resp := i.shards.ReplicateDeletions(r.Context(), index, shard, requestID, uuids, dryRun)
 		if localIndexNotReady(resp) {
 			http.Error(w, resp.FirstError().Error(), http.StatusServiceUnavailable)
 			return

--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -167,12 +168,12 @@ func (db *DB) BatchDeleteObjects(ctx context.Context, params objects.BatchDelete
 	}
 
 	// find all DocIDs in all shards that match the filter
-	shardDocIDs, err := idx.findDocIDs(ctx, params.Filters, tenant)
+	shardDocIDs, err := idx.findUUIDs(ctx, params.Filters, tenant)
 	if err != nil {
 		return objects.BatchDeleteResult{}, errors.Wrapf(err, "cannot find objects")
 	}
 	// prepare to be deleted list of DocIDs from all shards
-	toDelete := map[string][]uint64{}
+	toDelete := map[string][]strfmt.UUID{}
 	limit := db.config.QueryMaximumResults
 
 	matches := int64(0)

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -215,14 +215,14 @@ func (f *fakeRemoteClient) BatchAddReferences(ctx context.Context, hostName,
 	return nil
 }
 
-func (f *fakeRemoteClient) FindDocIDs(ctx context.Context, hostName, indexName, shardName string,
+func (f *fakeRemoteClient) FindUUIDs(ctx context.Context, hostName, indexName, shardName string,
 	filters *filters.LocalFilter,
-) ([]uint64, error) {
+) ([]strfmt.UUID, error) {
 	return nil, nil
 }
 
 func (f *fakeRemoteClient) DeleteObjectBatch(ctx context.Context, hostName, indexName, shardName string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) objects.BatchSimpleObjects {
 	return nil
 }
@@ -290,7 +290,7 @@ func (f *fakeReplicationClient) MergeObject(ctx context.Context, host, index, sh
 }
 
 func (f *fakeReplicationClient) DeleteObjects(ctx context.Context, host, index, shard, requestID string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) (replica.SimpleResponse, error) {
 	return replica.SimpleResponse{}, nil
 }

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -40,7 +40,7 @@ type Replicator interface {
 	ReplicateDeletion(ctx context.Context, shardName, requestID string,
 		uuid strfmt.UUID) replica.SimpleResponse
 	ReplicateDeletions(ctx context.Context, shardName, requestID string,
-		docIDs []uint64, dryRun bool) replica.SimpleResponse
+		uuids []strfmt.UUID, dryRun bool) replica.SimpleResponse
 	ReplicateReferences(ctx context.Context, shard, requestID string,
 		refs []objects.BatchReference) replica.SimpleResponse
 	CommitReplication(shard,
@@ -94,14 +94,14 @@ func (db *DB) ReplicateDeletion(ctx context.Context, class,
 }
 
 func (db *DB) ReplicateDeletions(ctx context.Context, class,
-	shard, requestID string, docIDs []uint64, dryRun bool,
+	shard, requestID string, uuids []strfmt.UUID, dryRun bool,
 ) replica.SimpleResponse {
 	index, pr := db.replicatedIndex(class)
 	if pr != nil {
 		return *pr
 	}
 
-	return index.ReplicateDeletions(ctx, shard, requestID, docIDs, dryRun)
+	return index.ReplicateDeletions(ctx, shard, requestID, uuids, dryRun)
 }
 
 func (db *DB) ReplicateReferences(ctx context.Context, class,
@@ -199,12 +199,12 @@ func (i *Index) ReplicateObjects(ctx context.Context, shard, requestID string, o
 	return localShard.preparePutObjects(ctx, requestID, objects)
 }
 
-func (i *Index) ReplicateDeletions(ctx context.Context, shard, requestID string, docIDs []uint64, dryRun bool) replica.SimpleResponse {
+func (i *Index) ReplicateDeletions(ctx context.Context, shard, requestID string, uuids []strfmt.UUID, dryRun bool) replica.SimpleResponse {
 	localShard, pr := i.writableShard(shard)
 	if pr != nil {
 		return *pr
 	}
-	return localShard.prepareDeleteObjects(ctx, requestID, docIDs, dryRun)
+	return localShard.prepareDeleteObjects(ctx, requestID, uuids, dryRun)
 }
 
 func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string, refs []objects.BatchReference) replica.SimpleResponse {

--- a/adapters/repos/db/shard_replication.go
+++ b/adapters/repos/db/shard_replication.go
@@ -150,9 +150,9 @@ func (s *Shard) preparePutObjects(ctx context.Context, requestID string, objects
 	return replica.SimpleResponse{}
 }
 
-func (s *Shard) prepareDeleteObjects(ctx context.Context, requestID string, docIDs []uint64, dryRun bool) replica.SimpleResponse {
+func (s *Shard) prepareDeleteObjects(ctx context.Context, requestID string, uuids []strfmt.UUID, dryRun bool) replica.SimpleResponse {
 	task := func(ctx context.Context) interface{} {
-		result := newDeleteObjectsBatcher(s).Delete(ctx, docIDs, dryRun)
+		result := newDeleteObjectsBatcher(s).Delete(ctx, uuids, dryRun)
 		resp := replica.DeleteBatchResponse{
 			Batch: make([]replica.UUID2Error, len(result)),
 		}

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -13,9 +13,11 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -25,15 +27,13 @@ import (
 )
 
 // return value map[int]error gives the error for the index as it received it
-func (s *Shard) deleteObjectBatch(ctx context.Context,
-	docIDs []uint64, dryRun bool,
-) objects.BatchSimpleObjects {
+func (s *Shard) DeleteObjectBatch(ctx context.Context, uuids []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects {
 	if s.isReadOnly() {
 		return objects.BatchSimpleObjects{
 			objects.BatchSimpleObject{Err: storagestate.ErrStatusReadOnly},
 		}
 	}
-	return newDeleteObjectsBatcher(s).Delete(ctx, docIDs, dryRun)
+	return newDeleteObjectsBatcher(s).Delete(ctx, uuids, dryRun)
 }
 
 type deleteObjectsBatcher struct {
@@ -46,23 +46,17 @@ func newDeleteObjectsBatcher(shard *Shard) *deleteObjectsBatcher {
 	return &deleteObjectsBatcher{shard: shard}
 }
 
-func (b *deleteObjectsBatcher) Delete(ctx context.Context,
-	docIDs []uint64, dryRun bool,
-) objects.BatchSimpleObjects {
-	b.delete(ctx, docIDs, dryRun)
+func (b *deleteObjectsBatcher) Delete(ctx context.Context, uuids []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects {
+	b.delete(ctx, uuids, dryRun)
 	b.flushWALs(ctx)
 	return b.objects
 }
 
-func (b *deleteObjectsBatcher) delete(ctx context.Context,
-	docIDs []uint64, dryRun bool,
-) {
-	b.objects = b.deleteSingleBatchInLSM(ctx, docIDs, dryRun)
+func (b *deleteObjectsBatcher) delete(ctx context.Context, uuids []strfmt.UUID, dryRun bool) {
+	b.objects = b.deleteSingleBatchInLSM(ctx, uuids, dryRun)
 }
 
-func (b *deleteObjectsBatcher) deleteSingleBatchInLSM(ctx context.Context,
-	batch []uint64, dryRun bool,
-) objects.BatchSimpleObjects {
+func (b *deleteObjectsBatcher) deleteSingleBatchInLSM(ctx context.Context, batch []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects {
 	before := time.Now()
 	defer b.shard.metrics.BatchDelete(before, "shard_delete_all")
 
@@ -80,10 +74,10 @@ func (b *deleteObjectsBatcher) deleteSingleBatchInLSM(ctx context.Context,
 	wg := &sync.WaitGroup{}
 	for j, docID := range batch {
 		wg.Add(1)
-		go func(index int, docID uint64, dryRun bool) {
+		go func(index int, uuid strfmt.UUID, dryRun bool) {
 			defer wg.Done()
 			// perform delete
-			obj := b.deleteObjectOfBatchInLSM(ctx, docID, dryRun)
+			obj := b.deleteObjectOfBatchInLSM(ctx, uuid, dryRun)
 			objLock.Lock()
 			result[index] = obj
 			objLock.Unlock()
@@ -94,17 +88,7 @@ func (b *deleteObjectsBatcher) deleteSingleBatchInLSM(ctx context.Context,
 	return result
 }
 
-func (b *deleteObjectsBatcher) deleteObjectOfBatchInLSM(ctx context.Context,
-	docID uint64, dryRun bool,
-) objects.BatchSimpleObject {
-	before := time.Now()
-	defer b.shard.metrics.BatchDelete(before, "shard_delete_individual_total")
-
-	uuid, err := b.shard.uuidFromDocID(docID)
-	if err != nil {
-		return objects.BatchSimpleObject{UUID: uuid, Err: err}
-	}
-
+func (b *deleteObjectsBatcher) deleteObjectOfBatchInLSM(ctx context.Context, uuid strfmt.UUID, dryRun bool) objects.BatchSimpleObject {
 	if !dryRun {
 		err := b.shard.batchDeleteObject(ctx, uuid)
 		return objects.BatchSimpleObject{UUID: uuid, Err: err}
@@ -155,4 +139,19 @@ func (s *Shard) findDocIDs(ctx context.Context,
 		return nil, err
 	}
 	return allowList.Slice(), nil
+}
+
+func (s *Shard) FindUUIDs(ctx context.Context, filters *filters.LocalFilter) ([]strfmt.UUID, error) {
+	docs, err := s.findDocIDs(ctx, filters)
+	if err != nil {
+		return nil, err
+	}
+	uuids := make([]strfmt.UUID, len(docs))
+	for i, doc := range docs {
+		uuids[i], err = s.uuidFromDocID(doc)
+		if err != nil {
+			return nil, fmt.Errorf("could not get uuid from doc_id=%v", doc)
+		}
+	}
+	return uuids, nil
 }

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -447,14 +447,14 @@ func (f *fakeRemoteClient) Aggregate(ctx context.Context, hostName, indexName,
 	return nil, nil
 }
 
-func (f *fakeRemoteClient) FindDocIDs(ctx context.Context, hostName, indexName, shardName string,
+func (f *fakeRemoteClient) FindUUIDs(ctx context.Context, hostName, indexName, shardName string,
 	filters *filters.LocalFilter,
-) ([]uint64, error) {
+) ([]strfmt.UUID, error) {
 	return nil, nil
 }
 
 func (f *fakeRemoteClient) DeleteObjectBatch(ctx context.Context, hostName, indexName, shardName string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) objects.BatchSimpleObjects {
 	return nil
 }
@@ -522,7 +522,7 @@ func (f *fakeReplicationClient) MergeObject(ctx context.Context, host, index, sh
 }
 
 func (f *fakeReplicationClient) DeleteObjects(ctx context.Context, host, index, shard, requestID string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) (replica.SimpleResponse, error) {
 	return replica.SimpleResponse{}, nil
 }

--- a/usecases/replica/mocks_test.go
+++ b/usecases/replica/mocks_test.go
@@ -89,9 +89,9 @@ func (f *fakeClient) PutObjects(ctx context.Context, host, index, shard, request
 }
 
 func (f *fakeClient) DeleteObjects(ctx context.Context, host, index, shard, requestID string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) (SimpleResponse, error) {
-	args := f.Called(ctx, host, index, shard, requestID, docIDs, dryRun)
+	args := f.Called(ctx, host, index, shard, requestID, uuids, dryRun)
 	return args.Get(0).(SimpleResponse), args.Error(1)
 }
 

--- a/usecases/replica/remote_incoming.go
+++ b/usecases/replica/remote_incoming.go
@@ -30,7 +30,7 @@ type RemoteIncomingRepo interface {
 	ReplicateDeletion(ctx context.Context, indexName,
 		shardName, requestID string, uuid strfmt.UUID) SimpleResponse
 	ReplicateDeletions(ctx context.Context, indexName,
-		shardName, requestID string, docIDs []uint64, dryRun bool) SimpleResponse
+		shardName, requestID string, uuids []strfmt.UUID, dryRun bool) SimpleResponse
 	ReplicateReferences(ctx context.Context, indexName,
 		shardName, requestID string, refs []objects.BatchReference) SimpleResponse
 	CommitReplication(indexName,
@@ -83,9 +83,9 @@ func (rri *RemoteReplicaIncoming) ReplicateDeletion(ctx context.Context, indexNa
 }
 
 func (rri *RemoteReplicaIncoming) ReplicateDeletions(ctx context.Context, indexName,
-	shardName, requestID string, docIDs []uint64, dryRun bool,
+	shardName, requestID string, uuids []strfmt.UUID, dryRun bool,
 ) SimpleResponse {
-	return rri.repo.ReplicateDeletions(ctx, indexName, shardName, requestID, docIDs, dryRun)
+	return rri.repo.ReplicateDeletions(ctx, indexName, shardName, requestID, uuids, dryRun)
 }
 
 func (rri *RemoteReplicaIncoming) ReplicateReferences(ctx context.Context, indexName,

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -215,14 +215,14 @@ func (r *Replicator) PutObjects(ctx context.Context,
 
 func (r *Replicator) DeleteObjects(ctx context.Context,
 	shard string,
-	docIDs []uint64,
+	uuids []strfmt.UUID,
 	dryRun bool,
 	l ConsistencyLevel,
 ) []objects.BatchSimpleObject {
 	coord := newCoordinator[DeleteBatchResponse](r, shard, r.requestID(opDeleteObjects), r.log)
 	op := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.DeleteObjects(
-			ctx, host, r.class, shard, requestID, docIDs, dryRun)
+			ctx, host, r.class, shard, requestID, uuids, dryRun)
 		if err == nil {
 			err = resp.FirstError()
 		}
@@ -248,13 +248,13 @@ func (r *Replicator) DeleteObjects(ctx context.Context,
 		r.log.WithField("op", "push.deletes").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
 		err = fmt.Errorf("%s %q: %w", msgCLevel, l, errReplicas)
-		errs := make([]objects.BatchSimpleObject, len(docIDs))
-		for i := 0; i < len(docIDs); i++ {
+		errs := make([]objects.BatchSimpleObject, len(uuids))
+		for i := 0; i < len(uuids); i++ {
 			errs[i].Err = err
 		}
 		return errs
 	}
-	rs := r.stream.readDeletions(len(docIDs), level, replyCh)
+	rs := r.stream.readDeletions(len(uuids), level, replyCh)
 	if err := firstBatchError(rs); err != nil {
 		r.log.WithField("op", "put.many").WithField("class", r.class).
 			WithField("shard", shard).Error(rs)

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -72,7 +72,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 	t.Run("DeleteObjects", func(t *testing.T) {
 		f := newFakeFactory("C1", "S", []string{})
 		rep := f.newReplicator()
-		xs := rep.DeleteObjects(ctx, "S", []uint64{1, 2, 3}, false, All)
+		xs := rep.DeleteObjects(ctx, "S", []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2"), strfmt.UUID("3")}, false, All)
 		assert.Equal(t, 3, len(xs))
 		for _, x := range xs {
 			assert.ErrorIs(t, x.Err, errReplicas)
@@ -358,7 +358,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 	t.Run("PhaseOneConnectionError", func(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
-		docIDs := []uint64{1, 2}
+		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		client.On("DeleteObjects", ctx, nodes[0], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
 		client.On("DeleteObjects", ctx, nodes[1], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, errAny)
 		for _, n := range nodes {
@@ -374,7 +374,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 	t.Run("PhaseTwoDecodingError", func(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
-		docIDs := []uint64{1, 2}
+		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		for _, n := range nodes {
 			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
 			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(errAny)
@@ -386,7 +386,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
 		rep := factory.newReplicator()
-		docIDs := []uint64{1, 2}
+		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		for _, n := range nodes {
 			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
@@ -406,7 +406,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
 		rep := factory.newReplicator()
-		docIDs := []uint64{1, 2}
+		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		for _, n := range nodes {
 			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
@@ -427,7 +427,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
 		rep := factory.newReplicator()
-		docIDs := []uint64{1, 2}
+		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		client.On("DeleteObjects", ctx, nodes[0], cls, shard, anyVal, docIDs, false).Return(resp1, nil)
 		client.On("DeleteObjects", ctx, nodes[1], cls, shard, anyVal, docIDs, false).Return(resp1, errAny)
@@ -446,7 +446,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
 		rep := factory.newReplicator()
-		docIDs := []uint64{1, 2}
+		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		for _, n := range nodes {
 			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -174,7 +174,7 @@ type wClient interface {
 	MergeObject(ctx context.Context, host, index, shard, requestID string,
 		mergeDoc *objects.MergeDocument) (SimpleResponse, error)
 	DeleteObjects(ctx context.Context, host, index, shard, requestID string,
-		docIDs []uint64, dryRun bool) (SimpleResponse, error)
+		uuids []strfmt.UUID, dryRun bool) (SimpleResponse, error)
 	AddReferences(ctx context.Context, host, index, shard, requestID string,
 		refs []objects.BatchReference) (SimpleResponse, error)
 	Commit(ctx context.Context, host, index, shard, requestID string, resp interface{}) error

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -59,10 +59,11 @@ type RemoteIndexIncomingRepo interface {
 	) ([]*storobj.Object, []float32, error)
 	IncomingAggregate(ctx context.Context, shardName string,
 		params aggregation.Params) (*aggregation.Result, error)
-	IncomingFindDocIDs(ctx context.Context, shardName string,
-		filters *filters.LocalFilter) ([]uint64, error)
+
+	IncomingFindUUIDs(ctx context.Context, shardName string,
+		filters *filters.LocalFilter) ([]strfmt.UUID, error)
 	IncomingDeleteObjectBatch(ctx context.Context, shardName string,
-		docIDs []uint64, dryRun bool) objects.BatchSimpleObjects
+		uuids []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects
 	IncomingGetShardQueueSize(ctx context.Context, shardName string) (int64, error)
 	IncomingGetShardStatus(ctx context.Context, shardName string) (string, error)
 	IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string) error
@@ -204,19 +205,19 @@ func (rii *RemoteIndexIncoming) Aggregate(ctx context.Context, indexName, shardN
 	return index.IncomingAggregate(ctx, shardName, params)
 }
 
-func (rii *RemoteIndexIncoming) FindDocIDs(ctx context.Context, indexName, shardName string,
+func (rii *RemoteIndexIncoming) FindUUIDs(ctx context.Context, indexName, shardName string,
 	filters *filters.LocalFilter,
-) ([]uint64, error) {
+) ([]strfmt.UUID, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
 		return nil, errors.Errorf("local index %q not found", indexName)
 	}
 
-	return index.IncomingFindDocIDs(ctx, shardName, filters)
+	return index.IncomingFindUUIDs(ctx, shardName, filters)
 }
 
 func (rii *RemoteIndexIncoming) DeleteObjectBatch(ctx context.Context, indexName, shardName string,
-	docIDs []uint64, dryRun bool,
+	uuids []strfmt.UUID, dryRun bool,
 ) objects.BatchSimpleObjects {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
@@ -224,7 +225,7 @@ func (rii *RemoteIndexIncoming) DeleteObjectBatch(ctx context.Context, indexName
 		return objects.BatchSimpleObjects{objects.BatchSimpleObject{Err: err}}
 	}
 
-	return index.IncomingDeleteObjectBatch(ctx, shardName, docIDs, dryRun)
+	return index.IncomingDeleteObjectBatch(ctx, shardName, uuids, dryRun)
 }
 
 func (rii *RemoteIndexIncoming) GetShardQueueSize(ctx context.Context,


### PR DESCRIPTION
Replace doc-id based selection with uuid-based selection to ensure unique deletion of objects in replicas

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
