### PR TITLE
prepare release v1.22.8

### DIFF
--- a/adapters/handlers/rest/doc.go
+++ b/adapters/handlers/rest/doc.go
@@ -18,7 +18,7 @@
 //	  https
 //	Host: localhost
 //	BasePath: /v1
-//	Version: 1.22.7
+//	Version: 1.22.8
 //	Contact: Weaviate<hello@weaviate.io> https://github.com/weaviate
 //
 //	Consumes:

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -48,7 +48,7 @@ func init() {
       "url": "https://github.com/weaviate",
       "email": "hello@weaviate.io"
     },
-    "version": "1.22.7"
+    "version": "1.22.8"
   },
   "basePath": "/v1",
   "paths": {
@@ -4937,7 +4937,7 @@ func init() {
       "url": "https://github.com/weaviate",
       "email": "hello@weaviate.io"
     },
-    "version": "1.22.7"
+    "version": "1.22.8"
   },
   "basePath": "/v1",
   "paths": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1871,7 +1871,7 @@
     },
     "description": "Cloud-native, modular vector database",
     "title": "Weaviate",
-    "version": "1.22.7"
+    "version": "1.22.8"
   },
   "parameters": {
     "CommonAfterParameterQuery": {


### PR DESCRIPTION
### What's being changed:

prepare Weaviate v1.22.8 release

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/7248440173
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
