### PR TITLE
Re-enable Sagemaker service in AWS modules

### DIFF
--- a/modules/generative-aws/config/class_settings.go
+++ b/modules/generative-aws/config/class_settings.go
@@ -63,6 +63,7 @@ var (
 
 var availableAWSServices = []string{
 	DefaultService,
+	"sagemaker",
 }
 
 var availableBedrockModels = []string{

--- a/modules/text2vec-aws/vectorizer/class_settings.go
+++ b/modules/text2vec-aws/vectorizer/class_settings.go
@@ -40,6 +40,7 @@ const (
 
 var availableAWSServices = []string{
 	"bedrock",
+	"sagemaker",
 }
 
 var availableAWSBedrockModels = []string{

--- a/modules/text2vec-aws/vectorizer/class_settings_test.go
+++ b/modules/text2vec-aws/vectorizer/class_settings_test.go
@@ -46,6 +46,20 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantErr:     nil,
 		},
 		{
+			name: "happy flow - SageMaker",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"service":  "sagemaker",
+					"region":   "us-east-1",
+					"endpoint": "my-sagemaker",
+				},
+			},
+			wantService:  "sagemaker",
+			wantRegion:   "us-east-1",
+			wantEndpoint: "my-sagemaker",
+			wantErr:      nil,
+		},
+		{
 			name: "empty service",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
@@ -87,7 +101,7 @@ func Test_classSettings_Validate(t *testing.T) {
 					"model":   "",
 				},
 			},
-			wantErr: errors.Errorf("wrong service, available services are: [bedrock], " +
+			wantErr: errors.Errorf("wrong service, available services are: [bedrock sagemaker], " +
 				"region cannot be empty"),
 		},
 	}


### PR DESCRIPTION
### What's being changed:

This PR re-enables Sagemaker service in AWS modules.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
