### PR TITLE
change wait strategy to survive restart of testcontainers

### DIFF
--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -512,8 +512,9 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	config1["CLUSTER_DATA_BIND_PORT"] = "7101"
 	eg := errgroup.Group{}
 	eg.Go(func() (err error) {
-		if cs[0], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
-			config1, networkName, image, Weaviate1, d.withWeaviateExposeGRPCPort); err != nil {
+		cs[0], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
+			config1, networkName, image, Weaviate1, d.withWeaviateExposeGRPCPort)
+		if err != nil {
 			return errors.Wrapf(err, "start %s", Weaviate1)
 		}
 		return nil
@@ -544,8 +545,9 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		config3["CLUSTER_JOIN"] = fmt.Sprintf("%s:7100", Weaviate1)
 		eg.Go(func() (err error) {
 			time.Sleep(time.Second * 3)
-			if cs[2], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
-				config3, networkName, image, Weaviate3, d.withWeaviateExposeGRPCPort); err != nil {
+			cs[2], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
+				config3, networkName, image, Weaviate3, d.withWeaviateExposeGRPCPort)
+			if err != nil {
 				return errors.Wrapf(err, "start %s", Weaviate3)
 			}
 			return nil

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -103,7 +103,7 @@ func (d *DockerCompose) ContainerURI(index int) string {
 	return d.containers[index].URI()
 }
 
-func (d *DockerCompose) ConatinerAt(index int) (*DockerContainer, error) {
+func (d *DockerCompose) ContainerAt(index int) (*DockerContainer, error) {
 	if index > len(d.containers) {
 		return nil, fmt.Errorf("container at index %d does not exit", index)
 	}

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -110,7 +110,25 @@ func startWeaviate(ctx context.Context,
 		},
 		ExposedPorts: exposedPorts,
 		Env:          env,
-		WaitingFor:   wait.ForAll(waitStrategies...).WithStartupTimeoutDefault(120 * time.Second),
+		LifecycleHooks: []testcontainers.ContainerLifecycleHooks{
+			{
+				// Use wait strategies as part of the lifecycle hooks as this gets propagated to the underlying container,
+				// which survives stop/start commands
+				PostStarts: []testcontainers.ContainerHook{
+					func(ctx context.Context, container testcontainers.Container) error {
+						for _, waitStrategy := range waitStrategies {
+							ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+							defer cancel()
+
+							if err := waitStrategy.WaitUntilReady(ctx, container); err != nil {
+								return err
+							}
+						}
+						return nil
+					},
+				},
+			},
+		},
 	}
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -132,5 +150,10 @@ func startWeaviate(ctx context.Context,
 		}
 		endpoints[GRPC] = endpoint{grpcPort, grpcUri}
 	}
-	return &DockerContainer{containerName, endpoints, c, nil}, nil
+	return &DockerContainer{
+		name:        containerName,
+		endpoints:   endpoints,
+		container:   c,
+		envSettings: nil,
+	}, nil
 }


### PR DESCRIPTION
### What's being changed:

Currently we use testcontainers with WaitStrategies defined in the ContainerRequest sent to testcontainers to ensure that the container is healthy when available.

The problem is this method is that it doesn't "survive" the restart of a container. That means doing a Stop/Start will make the code not check the health again. Currently there is not a feature to have that in test containers https://github.com/testcontainers/testcontainers-java/issues/606#issuecomment-372816119. (Java codebase, but I'm assuming similar for the go code base).

The workaround I found is to use `LifecycleHooks` instead, as they stay "attached" to a container struct and will be re-executed on stop/start.

This is a re-open of https://github.com/weaviate/weaviate/pull/3937 that was lost during a branch update.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
