### PR TITLE
[v1.23.x] Fix issue with deleted node before PQ fitting started

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -451,7 +451,9 @@ func (h *hnsw) distBetweenNodes(a, b uint64) (float32, bool, error) {
 			}
 		}
 		if len(v1) == 0 {
-			return 0, false, fmt.Errorf("got a nil or zero-length vector at docID %d", a)
+			// https://github.com/weaviate/weaviate/pull/3955
+			h.handleDeletedNode(a)
+			return 0, false, nil
 		}
 
 		v2, err := h.compressedVectorsCache.Get(context.Background(), b)
@@ -463,11 +465,13 @@ func (h *hnsw) distBetweenNodes(a, b uint64) (float32, bool, error) {
 			} else {
 				// not a typed error, we can recover from, return with err
 				return 0, false, errors.Wrapf(err,
-					"could not get vector of object at docID %d", a)
+					"could not get vector of object at docID %d", b)
 			}
 		}
 		if len(v2) == 0 {
-			return 0, false, fmt.Errorf("got a nil or zero-length vector at docID %d", b)
+			// see https://github.com/weaviate/weaviate/pull/3955
+			h.handleDeletedNode(b)
+			return 0, false, nil
 		}
 
 		return h.pq.DistanceBetweenCompressedVectors(v1, v2), true, nil
@@ -526,7 +530,9 @@ func (h *hnsw) distBetweenNodeAndVec(node uint64, vecB []float32) (float32, bool
 			}
 		}
 		if len(v1) == 0 {
-			return 0, false, fmt.Errorf("got a nil or zero-length vector at docID %d", node)
+			// see https://github.com/weaviate/weaviate/pull/3955
+			h.handleDeletedNode(node)
+			return 0, false, nil
 		}
 
 		return h.pq.DistanceBetweenCompressedAndUncompressedVectors(vecB, v1), true, nil

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -415,6 +415,15 @@ func (h *hnsw) distanceToByteNode(distancer *ssdhelpers.PQDistancer,
 			return 0, false, errors.Wrapf(err, "get vector of docID %d", nodeID)
 		}
 	}
+
+	if vec == nil {
+		// if the vector was already deleted (but not cleaned up) before PQ fitting
+		// started, we don't have an entry for this vector. In this case we need to
+		// treat it like a deleted node.
+		h.handleDeletedNode(nodeID)
+		return 0, false, nil
+	}
+
 	return distancer.Distance(vec)
 }
 


### PR DESCRIPTION
### What's being changed:

- Object is deleted
- Weaviate is restarted, therefore the deleted object is never loaded in the cache again (impossible because it’s gone from disk)
- delete cleanup hasn’t completed yet (because there is a ton of cleanup to do, so we still have references to this id in the HNSW graph) because it’s not in the cache it will never get compressed when we turn on PQ
- the PQ distance logic only checks for a `NotFound` error, but it doesn’t check for getting a nil vector
- now it does :-)



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
