### PR TITLE
[v1.22.x] Handle vector cache miss during PQ fitting

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	ssdhelpers "github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
 	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
+	"github.com/weaviate/weaviate/entities/storobj"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -73,12 +74,30 @@ func (h *hnsw) Compress(cfg ent.PQConfig) error {
 
 	data := h.cache.all()
 	cleanData := make([][]float32, 0, len(data))
-	for _, point := range data {
-		if point == nil {
+	for i := range data {
+		// Rather than just taking the cache dump at face value, let's explicitly
+		// request the vectors. Otherwise we would miss any vector that's currently
+		// not in the cache, for example because the cache is not hot yet after a
+		// restart.
+		p, err := h.cache.get(context.Background(), uint64(i))
+		if err != nil {
+			var e storobj.ErrNotFound
+			if errors.As(err, &e) {
+				// already deleted, ignore
+				continue
+			} else {
+				return fmt.Errorf("unexpected error obtaining vectors for fitting: %w", err)
+			}
+		}
+
+		if p == nil {
+			// already deleted, ignore
 			continue
 		}
-		cleanData = append(cleanData, point)
+
+		cleanData = append(cleanData, p)
 	}
+
 	h.compressedVectorsCache.grow(uint64(len(data)))
 	h.pq.Fit(cleanData)
 

--- a/adapters/repos/db/vector/hnsw/compress_recall_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_recall_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/ssdhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -82,6 +83,9 @@ func Test_NoRaceCompressionRecall(t *testing.T) {
 				ShardName:             "shardRecallBenchmark",
 				DistanceProvider:      distancer,
 				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					if int(id) >= len(vectors) {
+						return nil, storobj.NewErrNotFoundf(id, "out of range")
+					}
 					return vectors[int(id)], nil
 				},
 				TempVectorForIDThunk: func(ctx context.Context, id uint64, container *hnsw.VectorSlice) ([]float32, error) {

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -546,6 +546,9 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 			MakeCommitLoggerThunk: MakeNoopCommitLogger,
 			DistanceProvider:      distancer.NewCosineDistanceProvider(),
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				if int(id) >= len(vectors) {
+					return nil, storobj.NewErrNotFoundf(id, "out of range")
+				}
 				return vectors[int(id)], nil
 			},
 			TempVectorForIDThunk: TempVectorForIDThunk(vectors),


### PR DESCRIPTION
### What's being changed:
- fixes #3957 
- only for v1.22 (separate PR for v1.23 because the logic is slightly different)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
