### PR TITLE
cyclemanager: abort routine if running while attempting to unregister

### DIFF
--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -136,7 +136,22 @@ func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCall
 		func() {
 			// cancel called in recover, regardless of panic occurred or not
 			defer c.recover(meta.customId, cancel)
-			executed := meta.cycleCallback(shouldAbort)
+			executed := meta.cycleCallback(func() bool {
+				if shouldAbort() {
+					return true
+				}
+
+				// abort if callback deactivated or being unregistered
+				c.Lock()
+				defer c.Unlock()
+
+				meta, ok := c.callbacks[callbackId]
+				if !ok || !meta.active || meta.unregisterRequested {
+					return true
+				}
+
+				return false
+			})
 			anyExecuted = executed || anyExecuted
 
 			if meta.intervals != nil {
@@ -269,6 +284,7 @@ func (c *cycleCallbackGroup) mutateCallback(ctx context.Context, callbackId uint
 			c.Unlock()
 			return err
 		}
+		meta.unregisterRequested = true
 		runningCtx := meta.runningCtx
 		if runningCtx == nil || runningCtx.Err() != nil {
 			err := onFound(callbackId, meta)
@@ -356,6 +372,8 @@ type cycleCallbackMeta struct {
 	runningCtx context.Context
 	started    time.Time
 	intervals  CycleIntervals
+	// set to true if callback is being unregistered, but still running
+	unregisterRequested bool
 }
 
 type cycleCallbackGroupNoop struct{}


### PR DESCRIPTION
### What's being changed:

This notifies long-running tasks that the server is about to shutdown so that they can gracefully exit.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
