### PR TITLE
Skip vector reindex

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -17,7 +17,6 @@ package db
 import (
 	"context"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -25,6 +24,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -207,19 +209,26 @@ func getRandomSeed() *rand.Rand {
 }
 
 func testShard(t *testing.T, ctx context.Context, className string, indexOpts ...func(*Index)) (ShardLike, *Index) {
+	return testShardWithSettings(t, ctx, &models.Class{Class: className}, enthnsw.UserConfig{Skip: true},
+		false, false, indexOpts...)
+}
+
+func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Class,
+	vic schema.VectorIndexConfig, withStopwords, withCheckpoints bool, indexOpts ...func(*Index),
+) (ShardLike, *Index) {
 	tmpDir := t.TempDir()
 	logger, _ := test.NewNullLogger()
+	maxResults := int64(10_000)
 
 	repo, err := New(logger, Config{
 		MemtablesFlushIdleAfter:   60,
-		RootPath:                  t.TempDir(),
-		QueryMaximumResults:       10000,
+		RootPath:                  tmpDir,
+		QueryMaximumResults:       maxResults,
 		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil)
 	require.Nil(t, err)
 
 	shardState := singleShardState()
-	class := &models.Class{Class: className}
 	sch := schema.Schema{
 		Objects: &models.Schema{
 			Classes: []*models.Class{class},
@@ -227,33 +236,46 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 	}
 	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: sch}
 
+	iic := schema.InvertedIndexConfig{}
+	if class.InvertedIndexConfig != nil {
+		iic = inverted.ConfigFromModel(class.InvertedIndexConfig)
+	}
+	var sd *stopwords.Detector
+	if withStopwords {
+		sd, err = stopwords.NewDetectorFromConfig(iic.Stopwords)
+		require.NoError(t, err)
+	}
+	var checkpts *indexcheckpoint.Checkpoints
+	if withCheckpoints {
+		checkpts, err = indexcheckpoint.New(tmpDir, logger)
+		require.NoError(t, err)
+	}
+
 	idx := &Index{
-		Config:                IndexConfig{RootPath: tmpDir, ClassName: schema.ClassName(className)},
-		invertedIndexConfig:   schema.InvertedIndexConfig{},
-		vectorIndexUserConfig: enthnsw.UserConfig{Skip: true},
+		Config: IndexConfig{
+			RootPath:            tmpDir,
+			ClassName:           schema.ClassName(class.Class),
+			QueryMaximumResults: maxResults,
+		},
+		invertedIndexConfig:   iic,
+		vectorIndexUserConfig: vic,
 		logger:                logger,
 		getSchema:             schemaGetter,
 		centralJobQueue:       repo.jobQueueCh,
+		stopwords:             sd,
+		indexCheckpoints:      checkpts,
 	}
 	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
-
-	if err = os.Mkdir(idx.path(), os.ModePerm); err != nil {
-		panic(err)
-	}
 	idx.initCycleCallbacksNoop()
-
 	for _, opt := range indexOpts {
 		opt(idx)
 	}
 
 	shardName := shardState.AllPhysicalShards()[0]
-
 	shard, err := idx.initShard(ctx, shardName, class, nil)
-	if err != nil {
-		panic(err)
-	}
-	idx.shards.Store(shardName, shard)
+	require.NoError(t, err)
 
+	idx.shards.Store(shardName, shard)
 	return shard, idx
 }
 

--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -35,6 +35,26 @@ type Property struct {
 	HasSearchableIndex bool // map index (with frequencies)
 }
 
+func DedupItems(props []Property) []Property {
+	for i := range props {
+		seen := map[string]struct{}{}
+		items := props[i].Items
+
+		var key string
+		// reverse order to keep latest elements
+		for j := len(items) - 1; j >= 0; j-- {
+			key = string(items[j].Data)
+			if _, ok := seen[key]; ok {
+				// remove element already seen
+				items = append(items[:j], items[j+1:]...)
+			}
+			seen[key] = struct{}{}
+		}
+		props[i].Items = items
+	}
+	return props
+}
+
 type Analyzer struct {
 	isFallbackToSearchable IsFallbackToSearchable
 }

--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -35,6 +35,11 @@ type Property struct {
 	HasSearchableIndex bool // map index (with frequencies)
 }
 
+type NilProperty struct {
+	Name                string
+	AddToPropertyLength bool
+}
+
 func DedupItems(props []Property) []Property {
 	for i := range props {
 		seen := map[string]struct{}{}

--- a/adapters/repos/db/inverted/analyzer_test.go
+++ b/adapters/repos/db/inverted/analyzer_test.go
@@ -535,3 +535,64 @@ type fakeStopwordDetector struct{}
 func (fsd fakeStopwordDetector) IsStopword(word string) bool {
 	return false
 }
+
+func TestDedupItems(t *testing.T) {
+	props := []Property{
+		{
+			Name: "propNothingToDo",
+			Items: []Countable{
+				{Data: []byte("fff"), TermFrequency: 3},
+				{Data: []byte("eee"), TermFrequency: 2},
+				{Data: []byte("ddd"), TermFrequency: 1},
+			},
+		},
+		{
+			Name: "propToDedup1",
+			Items: []Countable{
+				{Data: []byte("aaa"), TermFrequency: 1},
+				{Data: []byte("bbb"), TermFrequency: 2},
+				{Data: []byte("ccc"), TermFrequency: 3},
+				{Data: []byte("aaa"), TermFrequency: 4},
+				{Data: []byte("ccc"), TermFrequency: 0},
+			},
+		},
+		{
+			Name: "propToDedup2",
+			Items: []Countable{
+				{Data: []uint8{1}, TermFrequency: 5},
+				{Data: []uint8{1}, TermFrequency: 4},
+				{Data: []uint8{1}, TermFrequency: 3},
+				{Data: []uint8{1}, TermFrequency: 2},
+				{Data: []uint8{1}, TermFrequency: 1},
+			},
+		},
+	}
+
+	expectedProps := []Property{
+		{
+			Name: "propNothingToDo",
+			Items: []Countable{
+				{Data: []byte("fff"), TermFrequency: 3},
+				{Data: []byte("eee"), TermFrequency: 2},
+				{Data: []byte("ddd"), TermFrequency: 1},
+			},
+		},
+		{
+			Name: "propToDedup1",
+			Items: []Countable{
+				{Data: []byte("bbb"), TermFrequency: 2},
+				{Data: []byte("aaa"), TermFrequency: 4},
+				{Data: []byte("ccc"), TermFrequency: 0},
+			},
+		},
+		{
+			Name: "propToDedup2",
+			Items: []Countable{
+				{Data: []uint8{1}, TermFrequency: 1},
+			},
+		},
+	}
+
+	dedupProps := DedupItems(props)
+	assert.Equal(t, expectedProps, dedupProps)
+}

--- a/adapters/repos/db/inverted/delta_analyzer.go
+++ b/adapters/repos/db/inverted/delta_analyzer.go
@@ -21,6 +21,9 @@ type DeltaResults struct {
 func Delta(previous, next []Property) DeltaResults {
 	out := DeltaResults{}
 
+	previous = DedupItems(previous)
+	next = DedupItems(next)
+
 	if previous == nil {
 		out.ToAdd = next
 		return out
@@ -32,25 +35,27 @@ func Delta(previous, next []Property) DeltaResults {
 	}
 
 	for _, nextProp := range next {
-		prev, ok := previousByProp[nextProp.Name]
+		prevProp, ok := previousByProp[nextProp.Name]
 		if !ok {
 			// this prop didn't exist before so we can add all of it
 			out.ToAdd = append(out.ToAdd, nextProp)
 		}
+		delete(previousByProp, nextProp.Name)
 
 		// there is a chance they're identical, such a check is pretty cheap and
 		// it could prevent us from running an expensive merge, so let's try our
 		// luck
-		if listsIdentical(prev.Items, nextProp.Items) {
+		if listsIdentical(prevProp.Items, nextProp.Items) {
 			// then we don't need to do anything about this prop
 			continue
 		}
 
-		toAdd, toDelete := countableDelta(prev.Items, nextProp.Items)
+		toAdd, toDelete := countableDelta(prevProp.Items, nextProp.Items)
 		if len(toAdd) > 0 {
 			out.ToAdd = append(out.ToAdd, Property{
 				Name:               nextProp.Name,
 				Items:              toAdd,
+				Length:             nextProp.Length,
 				HasFilterableIndex: nextProp.HasFilterableIndex,
 				HasSearchableIndex: nextProp.HasSearchableIndex,
 			})
@@ -59,9 +64,29 @@ func Delta(previous, next []Property) DeltaResults {
 			out.ToDelete = append(out.ToDelete, Property{
 				Name:               nextProp.Name,
 				Items:              toDelete,
+				Length:             prevProp.Length,
 				HasFilterableIndex: nextProp.HasFilterableIndex,
 				HasSearchableIndex: nextProp.HasSearchableIndex,
 			})
+		}
+		// special case to update optional length/nil indexes on
+		// all values removed
+		if len(toAdd) == 0 && len(toDelete) > 0 &&
+			nextProp.Length == 0 && prevProp.Length > 0 {
+			out.ToAdd = append(out.ToAdd, Property{
+				Name:               nextProp.Name,
+				Items:              []Countable{},
+				Length:             0,
+				HasFilterableIndex: nextProp.HasFilterableIndex,
+				HasSearchableIndex: nextProp.HasSearchableIndex,
+			})
+		}
+	}
+
+	// extend ToDelete with props from previous missing in next
+	for _, prevProp := range previous {
+		if _, ok := previousByProp[prevProp.Name]; ok {
+			out.ToDelete = append(out.ToDelete, prevProp)
 		}
 	}
 
@@ -96,8 +121,10 @@ func countableDelta(prev, next []Countable) ([]Countable, []Countable) {
 	// it either
 	// - is no longer present
 	// - is still present, but with updated values
-	for _, toDel := range seenInPrev {
-		del = append(del, toDel)
+	for _, prevItem := range prev {
+		if _, ok := seenInPrev[string(prevItem.Data)]; ok {
+			del = append(del, prevItem)
+		}
 	}
 
 	return add, del

--- a/adapters/repos/db/inverted/delta_analyzer.go
+++ b/adapters/repos/db/inverted/delta_analyzer.go
@@ -39,6 +39,7 @@ func Delta(previous, next []Property) DeltaResults {
 		if !ok {
 			// this prop didn't exist before so we can add all of it
 			out.ToAdd = append(out.ToAdd, nextProp)
+			continue
 		}
 		delete(previousByProp, nextProp.Name)
 
@@ -148,4 +149,40 @@ func listsIdentical(a []Countable, b []Countable) bool {
 	// while O(n) is the worst case for this check it prevents us from running a
 	// considerably more expensive merge
 	return true
+}
+
+type DeltaNilResults struct {
+	ToDelete []NilProperty
+	ToAdd    []NilProperty
+}
+
+func DeltaNil(previous, next []NilProperty) DeltaNilResults {
+	out := DeltaNilResults{}
+
+	if previous == nil {
+		out.ToAdd = next
+		return out
+	}
+
+	previousByProp := map[string]NilProperty{}
+	for _, prevProp := range previous {
+		previousByProp[prevProp.Name] = prevProp
+	}
+
+	for _, nextProp := range next {
+		if _, ok := previousByProp[nextProp.Name]; !ok {
+			out.ToAdd = append(out.ToAdd, nextProp)
+			continue
+		}
+		delete(previousByProp, nextProp.Name)
+	}
+
+	// extend ToDelete with props from previous missing in next
+	for _, prevProp := range previous {
+		if _, ok := previousByProp[prevProp.Name]; ok {
+			out.ToDelete = append(out.ToDelete, prevProp)
+		}
+	}
+
+	return out
 }

--- a/adapters/repos/db/inverted/delta_analyzer_test.go
+++ b/adapters/repos/db/inverted/delta_analyzer_test.go
@@ -450,7 +450,6 @@ func TestDeltaAnalyzer_Arrays(t *testing.T) {
 				HasSearchableIndex: false,
 			},
 		}
-
 		expectedDelete := []Property{
 			{
 				Name: "ints",
@@ -504,4 +503,60 @@ func TestDeltaAnalyzer_Arrays(t *testing.T) {
 		assert.Equal(t, expectedAdd, delta.ToAdd)
 		assert.Equal(t, expectedDelete, delta.ToDelete)
 	})
+}
+
+func TestDeltaNilAnalyzer(t *testing.T) {
+	previous := []NilProperty{
+		{
+			Name:                "ints",
+			AddToPropertyLength: false,
+		},
+		{
+			Name:                "booleans",
+			AddToPropertyLength: true,
+		},
+		{
+			Name:                "numbers",
+			AddToPropertyLength: true,
+		},
+	}
+	next := []NilProperty{
+		{
+			Name:                "booleans",
+			AddToPropertyLength: true,
+		},
+		{
+			Name:                "texts",
+			AddToPropertyLength: true,
+		},
+		{
+			Name:                "dates",
+			AddToPropertyLength: false,
+		},
+	}
+
+	expectedAdd := []NilProperty{
+		{
+			Name:                "texts",
+			AddToPropertyLength: true,
+		},
+		{
+			Name:                "dates",
+			AddToPropertyLength: false,
+		},
+	}
+	expectedDelete := []NilProperty{
+		{
+			Name:                "ints",
+			AddToPropertyLength: false,
+		},
+		{
+			Name:                "numbers",
+			AddToPropertyLength: true,
+		},
+	}
+
+	deltaNil := DeltaNil(previous, next)
+	assert.Equal(t, expectedAdd, deltaNil.ToAdd)
+	assert.Equal(t, expectedDelete, deltaNil.ToDelete)
 }

--- a/adapters/repos/db/inverted/delta_analyzer_test.go
+++ b/adapters/repos/db/inverted/delta_analyzer_test.go
@@ -277,3 +277,231 @@ func TestDeltaAnalyzer(t *testing.T) {
 		assert.Equal(t, expectedDelete, res.ToDelete)
 	})
 }
+
+func TestDeltaAnalyzer_Arrays(t *testing.T) {
+	lexInt64 := func(val int64) []byte {
+		bytes, _ := LexicographicallySortableInt64(val)
+		return bytes
+	}
+	lexBool := func(val bool) []byte {
+		if val {
+			return []uint8{1}
+		}
+		return []uint8{0}
+	}
+
+	t.Run("with previous indexing - both additions and deletions", func(t *testing.T) {
+		previous := []Property{
+			{
+				Name: "ints",
+				Items: []Countable{
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(102)},
+					{Data: lexInt64(103)},
+					{Data: lexInt64(104)},
+				},
+				Length:             9,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "booleans",
+				Items: []Countable{
+					{Data: lexBool(true)},
+					{Data: lexBool(true)},
+					{Data: lexBool(true)},
+					{Data: lexBool(false)},
+				},
+				Length:             4,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name:               "numbers",
+				Items:              []Countable{},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "texts",
+				Items: []Countable{
+					{Data: []byte("aaa")},
+					{Data: []byte("bbb")},
+					{Data: []byte("ccc")},
+				},
+				Length:             3,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "dates",
+				Items: []Countable{
+					{Data: []byte("2021-06-01T22:18:59.640162Z")},
+					{Data: []byte("2022-06-01T22:18:59.640162Z")},
+				},
+				Length:             2,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "_creationTimeUnix",
+				Items: []Countable{
+					{Data: []byte("1703778000000")},
+				},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "_lastUpdateTimeUnix",
+				Items: []Countable{
+					{Data: []byte("1703778000000")},
+				},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+		}
+		next := []Property{
+			{
+				Name: "ints",
+				Items: []Countable{
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(101)},
+					{Data: lexInt64(103)},
+					{Data: lexInt64(104)},
+					{Data: lexInt64(105)},
+				},
+				Length:             7,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "booleans",
+				Items: []Countable{
+					{Data: lexBool(true)},
+					{Data: lexBool(true)},
+					{Data: lexBool(true)},
+					{Data: lexBool(false)},
+				},
+				Length:             4,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name:               "texts",
+				Items:              []Countable{},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "_creationTimeUnix",
+				Items: []Countable{
+					{Data: []byte("1703778000000")},
+				},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "_lastUpdateTimeUnix",
+				Items: []Countable{
+					{Data: []byte("1703778500000")},
+				},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+		}
+
+		expectedAdd := []Property{
+			{
+				Name: "ints",
+				Items: []Countable{
+					{Data: lexInt64(105)},
+				},
+				Length:             7,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name:               "texts",
+				Items:              []Countable{},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "_lastUpdateTimeUnix",
+				Items: []Countable{
+					{Data: []byte("1703778500000")},
+				},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+		}
+
+		expectedDelete := []Property{
+			{
+				Name: "ints",
+				Items: []Countable{
+					{Data: lexInt64(102)},
+				},
+				Length:             9,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "texts",
+				Items: []Countable{
+					{Data: []byte("aaa")},
+					{Data: []byte("bbb")},
+					{Data: []byte("ccc")},
+				},
+				Length:             3,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "_lastUpdateTimeUnix",
+				Items: []Countable{
+					{Data: []byte("1703778000000")},
+				},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name:               "numbers",
+				Items:              []Countable{},
+				Length:             0,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+			{
+				Name: "dates",
+				Items: []Countable{
+					{Data: []byte("2021-06-01T22:18:59.640162Z")},
+					{Data: []byte("2022-06-01T22:18:59.640162Z")},
+				},
+				Length:             2,
+				HasFilterableIndex: true,
+				HasSearchableIndex: false,
+			},
+		}
+
+		delta := Delta(previous, next)
+		assert.Equal(t, expectedAdd, delta.ToAdd)
+		assert.Equal(t, expectedDelete, delta.ToDelete)
+	})
+}

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -368,7 +368,7 @@ func (r *ShardInvertedReindexer) handleProperty(ctx context.Context, checker *re
 }
 
 func (r *ShardInvertedReindexer) handleNilProperty(ctx context.Context, checker *reindexablePropertyChecker,
-	docID uint64, nilProperty nilProp,
+	docID uint64, nilProperty inverted.NilProperty,
 ) error {
 	if r.shard.Index().invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
 		key, err := r.shard.keyPropertyLength(0)

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -333,7 +333,7 @@ func (r *ShardInvertedReindexer) handleProperty(ctx context.Context, checker *re
 
 	// properties where defining a length does not make sense (floats etc.) have a negative entry as length
 	if r.shard.Index().invertedIndexConfig.IndexPropertyLength && property.Length >= 0 {
-		key, err := r.shard.keyPropertyLength(property.Length)
+		key, err := bucketKeyPropertyLength(property.Length)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' length", property.Name)
 		}
@@ -349,7 +349,7 @@ func (r *ShardInvertedReindexer) handleProperty(ctx context.Context, checker *re
 	}
 
 	if r.shard.Index().invertedIndexConfig.IndexNullState {
-		key, err := r.shard.keyPropertyNull(property.Length == 0)
+		key, err := bucketKeyPropertyNull(property.Length == 0)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' null", property.Name)
 		}
@@ -371,7 +371,7 @@ func (r *ShardInvertedReindexer) handleNilProperty(ctx context.Context, checker 
 	docID uint64, nilProperty inverted.NilProperty,
 ) error {
 	if r.shard.Index().invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
-		key, err := r.shard.keyPropertyLength(0)
+		key, err := bucketKeyPropertyLength(0)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' length", nilProperty.Name)
 		}
@@ -387,7 +387,7 @@ func (r *ShardInvertedReindexer) handleNilProperty(ctx context.Context, checker 
 	}
 
 	if r.shard.Index().invertedIndexConfig.IndexNullState {
-		key, err := r.shard.keyPropertyNull(true)
+		key, err := bucketKeyPropertyNull(true)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' null", nilProperty.Name)
 		}

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -677,6 +677,257 @@ func Test_Merge_UntouchedPropsCorrectlyIndexed(t *testing.T) {
 	})
 }
 
+func Test_MergeDocIdPreserved_PropsCorrectlyIndexed(t *testing.T) {
+	dirName := t.TempDir()
+
+	logger := logrus.New()
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: singleShardState(),
+	}
+	repo, err := New(logger, Config{
+		MemtablesFlushIdleAfter:   60,
+		RootPath:                  dirName,
+		MaxImportGoroutinesFactor: 1,
+		QueryMaximumResults:       10000,
+		TrackVectorDimensions:     true,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil)
+	require.Nil(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.Nil(t, repo.WaitForStartup(testCtx()))
+	defer repo.Shutdown(context.Background())
+	migrator := NewMigrator(repo, logger)
+	hnswConfig := enthnsw.NewDefaultUserConfig()
+	hnswConfig.Skip = true
+	sch := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class:               "TestClass",
+					VectorIndexConfig:   hnswConfig,
+					InvertedIndexConfig: invertedConfig(),
+					Properties: []*models.Property{ // tries to have "one of each property type"
+						{
+							Name:         "untouched_string",
+							DataType:     schema.DataTypeText.PropString(),
+							Tokenization: models.PropertyTokenizationWhitespace,
+						},
+						{
+							Name:         "touched_string",
+							DataType:     schema.DataTypeText.PropString(),
+							Tokenization: models.PropertyTokenizationWhitespace,
+						},
+						{
+							Name:         "untouched_string_array",
+							DataType:     schema.DataTypeTextArray.PropString(),
+							Tokenization: models.PropertyTokenizationWhitespace,
+						},
+						{
+							Name:         "touched_string_array",
+							DataType:     schema.DataTypeTextArray.PropString(),
+							Tokenization: models.PropertyTokenizationWhitespace,
+						},
+						{
+							Name: "untouched_text", Tokenization: "word",
+							DataType: []string{"text"},
+						},
+						{
+							Name: "touched_text", Tokenization: "word",
+							DataType: []string{"text"},
+						},
+						{
+							Name: "untouched_text_array", Tokenization: "word",
+							DataType: []string{"text[]"},
+						},
+						{
+							Name: "touched_text_array", Tokenization: "word",
+							DataType: []string{"text[]"},
+						},
+						{Name: "untouched_number", DataType: []string{"number"}},
+						{Name: "touched_number", DataType: []string{"number"}},
+						{Name: "untouched_number_array", DataType: []string{"number[]"}},
+						{Name: "touched_number_array", DataType: []string{"number[]"}},
+						{Name: "untouched_int", DataType: []string{"int"}},
+						{Name: "touched_int", DataType: []string{"int"}},
+						{Name: "untouched_int_array", DataType: []string{"int[]"}},
+						{Name: "touched_int_array", DataType: []string{"int[]"}},
+						{Name: "untouched_date", DataType: []string{"date"}},
+						{Name: "touched_date", DataType: []string{"date"}},
+						{Name: "untouched_date_array", DataType: []string{"date[]"}},
+						{Name: "touched_date_array", DataType: []string{"date[]"}},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("add required classes", func(t *testing.T) {
+		for _, class := range sch.Objects.Classes {
+			t.Run(fmt.Sprintf("add %s", class.Class), func(t *testing.T) {
+				err := migrator.AddClass(context.Background(), class, schemaGetter.shardState)
+				require.Nil(t, err)
+			})
+		}
+	})
+
+	schemaGetter.schema = sch
+
+	t.Run("add initial object", func(t *testing.T) {
+		id := 0
+		err := repo.PutObject(context.Background(), &models.Object{
+			ID:    uuidFromInt(id),
+			Class: "TestClass",
+			Properties: map[string]interface{}{
+				"untouched_number":       float64(id),
+				"untouched_number_array": []interface{}{float64(id)},
+				"untouched_int":          id,
+				"untouched_int_array":    []interface{}{int64(id)},
+				"untouched_string":       fmt.Sprintf("%d", id),
+				"untouched_string_array": []string{fmt.Sprintf("%d", id)},
+				"untouched_text":         fmt.Sprintf("%d", id),
+				"untouched_text_array":   []string{fmt.Sprintf("%d", id)},
+				"untouched_date":         time.Unix(0, 0).Add(time.Duration(id) * time.Hour),
+				"untouched_date_array":   []time.Time{time.Unix(0, 0).Add(time.Duration(id) * time.Hour)},
+
+				"touched_number":       float64(id),
+				"touched_number_array": []interface{}{float64(id)},
+				"touched_int":          id,
+				"touched_int_array":    []interface{}{int64(id)},
+				"touched_string":       fmt.Sprintf("%d", id),
+				"touched_string_array": []string{fmt.Sprintf("%d", id)},
+				"touched_text":         fmt.Sprintf("%d", id),
+				"touched_text_array":   []string{fmt.Sprintf("%d", id)},
+				"touched_date":         time.Unix(0, 0).Add(time.Duration(id) * time.Hour),
+				"touched_date_array":   []time.Time{time.Unix(0, 0).Add(time.Duration(id) * time.Hour)},
+			},
+			CreationTimeUnix:   int64(id),
+			LastUpdateTimeUnix: int64(id),
+		}, []float32{0.5}, nil)
+		require.Nil(t, err)
+	})
+
+	t.Run("patch half the props (all that contain 'touched')", func(t *testing.T) {
+		updateID := 28
+		md := objects.MergeDocument{
+			Class: "TestClass",
+			ID:    uuidFromInt(0),
+			PrimitiveSchema: map[string]interface{}{
+				"touched_number":       float64(updateID),
+				"touched_number_array": []interface{}{float64(updateID)},
+				"touched_int":          updateID,
+				"touched_int_array":    []interface{}{int64(updateID)},
+				"touched_string":       fmt.Sprintf("%d", updateID),
+				"touched_string_array": []string{fmt.Sprintf("%d", updateID)},
+				"touched_text":         fmt.Sprintf("%d", updateID),
+				"touched_text_array":   []string{fmt.Sprintf("%d", updateID)},
+				"touched_date":         time.Unix(0, 0).Add(time.Duration(updateID) * time.Hour),
+				"touched_date_array":   []time.Time{time.Unix(0, 0).Add(time.Duration(updateID) * time.Hour)},
+			},
+			References: nil,
+		}
+		err = repo.Merge(context.Background(), md, nil, "")
+		assert.Nil(t, err)
+	})
+
+	t.Run("retrieve by each individual prop", func(t *testing.T) {
+		retrieve := func(prefix string, id int) func(t *testing.T) {
+			return func(t *testing.T) {
+				type test struct {
+					name   string
+					filter *filters.LocalFilter
+				}
+
+				tests := []test{
+					{
+						name: "string filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_string", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							schema.DataTypeText),
+					},
+					{
+						name: "string array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_string_array", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							schema.DataTypeText),
+					},
+					{
+						name: "text filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_text", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							dtText),
+					},
+					{
+						name: "text array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_text_array", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							dtText),
+					},
+					{
+						name: "int filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_int", prefix), id, eq, dtInt),
+					},
+					{
+						name: "int array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_int_array", prefix), id, eq, dtInt),
+					},
+					{
+						name: "number filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_number", prefix), float64(id), eq, dtNumber),
+					},
+					{
+						name: "number array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_number_array", prefix), float64(id), eq, dtNumber),
+					},
+					{
+						name: "date filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_date", prefix),
+							time.Unix(0, 0).Add(time.Duration(id)*time.Hour),
+							eq, dtDate),
+					},
+					{
+						name: "date array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_date_array", prefix),
+							time.Unix(0, 0).Add(time.Duration(id)*time.Hour),
+							eq, dtDate),
+					},
+				}
+
+				for _, tc := range tests {
+					t.Run(tc.name, func(t *testing.T) {
+						params := dto.GetParams{
+							ClassName:  "TestClass",
+							Pagination: &filters.Pagination{Limit: 5},
+							Filters:    tc.filter,
+						}
+						res, err := repo.VectorSearch(context.Background(), params)
+						require.Nil(t, err)
+						require.Len(t, res, 1)
+
+						// hard-code the only uuid
+						assert.Equal(t, uuidFromInt(0), res[0].ID)
+					})
+				}
+			}
+		}
+		t.Run("using untouched", retrieve("untouched", 0))
+		t.Run("using touched", retrieve("touched", 28))
+	})
+}
+
 func uuidFromInt(in int) strfmt.UUID {
 	return strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", in)).String())
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -136,7 +136,7 @@ type ShardLike interface {
 	batchDeleteObject(ctx context.Context, id strfmt.UUID) error
 	putObjectLSM(object *storobj.Object, idBytes []byte) (objectInsertStatus, error)
 	mutableMergeObjectLSM(merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error)
-	deleteInvertedIndexItemLSM(bucket *lsmkv.Bucket, item inverted.Countable, docID uint64) error
+	deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error
 	updatePropertySpecificIndices(object *storobj.Object, status objectInsertStatus) error
 	updateVectorIndexIgnoreDelete(vector []float32, status objectInsertStatus) error

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -91,7 +91,7 @@ type ShardLike interface {
 	ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor) error //
 	resumeMaintenanceCycles(ctx context.Context) error
 	SetPropertyLengths(props []inverted.Property) error
-	AnalyzeObject(*storobj.Object) ([]inverted.Property, []nilProp, error) //
+	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) //
 
 	// TODO tests only
 	Dimensions() int // dim(vector)*number vectors

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -127,8 +127,6 @@ type ShardLike interface {
 	addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error
 	pairPropertyWithFrequency(docID uint64, freq, propLen float32) lsmkv.MapPair
-	keyPropertyNull(isNull bool) ([]byte, error)
-	keyPropertyLength(length int) ([]byte, error)
 
 	setFallbackToSearchable(fallback bool)
 	addJobToQueue(job job)
@@ -823,4 +821,15 @@ func shardId(indexId, shardName string) string {
 
 func shardPath(indexPath, shardName string) string {
 	return path.Join(indexPath, shardName)
+}
+
+func bucketKeyPropertyLength(length int) ([]byte, error) {
+	return inverted.LexicographicallySortableInt64(int64(length))
+}
+
+func bucketKeyPropertyNull(isNull bool) ([]byte, error) {
+	if isNull {
+		return []byte{uint8(filters.InternalNullState)}, nil
+	}
+	return []byte{uint8(filters.InternalNotNullState)}, nil
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -510,16 +510,6 @@ func (l *LazyLoadShard) pairPropertyWithFrequency(docID uint64, freq, propLen fl
 	return l.shard.pairPropertyWithFrequency(docID, freq, propLen)
 }
 
-func (l *LazyLoadShard) keyPropertyNull(isNull bool) ([]byte, error) {
-	l.mustLoad()
-	return l.shard.keyPropertyNull(isNull)
-}
-
-func (l *LazyLoadShard) keyPropertyLength(length int) ([]byte, error) {
-	l.mustLoad()
-	return l.shard.keyPropertyLength(length)
-}
-
 func (l *LazyLoadShard) setFallbackToSearchable(fallback bool) {
 	l.mustLoad()
 	l.shard.setFallbackToSearchable(fallback)

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -552,9 +552,9 @@ func (l *LazyLoadShard) mutableMergeObjectLSM(merge objects.MergeDocument, idByt
 	return l.shard.mutableMergeObjectLSM(merge, idBytes)
 }
 
-func (l *LazyLoadShard) deleteInvertedIndexItemLSM(bucket *lsmkv.Bucket, item inverted.Countable, docID uint64) error {
+func (l *LazyLoadShard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
 	l.mustLoad()
-	return l.shard.deleteInvertedIndexItemLSM(bucket, item, docID)
+	return l.shard.deleteFromPropertySetBucket(bucket, docID, key)
 }
 
 func (l *LazyLoadShard) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -366,7 +366,7 @@ func (l *LazyLoadShard) SetPropertyLengths(props []inverted.Property) error {
 	return l.shard.SetPropertyLengths(props)
 }
 
-func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []nilProp, error) {
+func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) {
 	l.mustLoad()
 	return l.shard.AnalyzeObject(object)
 }

--- a/adapters/repos/db/shard_skip_vector_reindex_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_test.go
@@ -1,0 +1,838 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+func TestShard_SkipVectorReindex(t *testing.T) {
+	ctx := context.Background()
+	searchLimit := 10
+	vectorSearchLimit := -1 // negative to limit results by distance
+	vectorSearchDist := float32(1)
+
+	class := &models.Class{
+		Class: "TestClass",
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			IndexTimestamps:     true,
+			IndexNullState:      true,
+			IndexPropertyLength: true,
+		},
+		Properties: []*models.Property{
+			{
+				Name:         "texts",
+				DataType:     schema.DataTypeTextArray.PropString(),
+				Tokenization: models.PropertyTokenizationWord,
+			},
+			{
+				Name:     "numbers",
+				DataType: schema.DataTypeNumberArray.PropString(),
+			},
+			{
+				Name:     "ints",
+				DataType: schema.DataTypeIntArray.PropString(),
+			},
+			{
+				Name:     "booleans",
+				DataType: schema.DataTypeBooleanArray.PropString(),
+			},
+			{
+				Name:     "dates",
+				DataType: schema.DataTypeDateArray.PropString(),
+			},
+			{
+				Name:     "uuids",
+				DataType: schema.DataTypeUUIDArray.PropString(),
+			},
+			{
+				Name:         "text",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWord,
+			},
+			{
+				Name:     "number",
+				DataType: schema.DataTypeNumber.PropString(),
+			},
+			{
+				Name:     "int",
+				DataType: schema.DataTypeInt.PropString(),
+			},
+			{
+				Name:     "boolean",
+				DataType: schema.DataTypeBoolean.PropString(),
+			},
+			{
+				Name:     "date",
+				DataType: schema.DataTypeDate.PropString(),
+			},
+			{
+				Name:     "uuid",
+				DataType: schema.DataTypeUUID.PropString(),
+			},
+		},
+	}
+	vectorIndexConfig := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
+
+	uuid := strfmt.UUID(uuid.NewString())
+	vector := []float32{1, 2, 3}
+	altVector := []float32{10, 0, -20}
+
+	origObj := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:    uuid,
+			Class: class.Class,
+			Properties: map[string]interface{}{
+				"texts": []interface{}{
+					"aaa",
+					"bbb",
+					"ccc",
+				},
+				"numbers": []interface{}{},
+				"ints": []interface{}{
+					asJsonNumber(101), asJsonNumber(101), asJsonNumber(101), asJsonNumber(101), asJsonNumber(101), asJsonNumber(101),
+					asJsonNumber(102),
+					asJsonNumber(103),
+					asJsonNumber(104),
+				},
+				"booleans": []interface{}{
+					true, true, true,
+					false,
+				},
+				"dates": []interface{}{
+					"2001-06-01T12:00:00.000000Z",
+					"2002-06-02T12:00:00.000000Z",
+				},
+				// no uuids
+				"text": "ddd",
+				// no number
+				"int":     int64(201),
+				"boolean": false,
+				"date":    asTime("2003-06-01T12:00:00.000000Z"),
+				// no uuid
+			},
+		},
+		Vector: vector,
+	}
+
+	updObj := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:    uuid,
+			Class: class.Class,
+			Properties: map[string]interface{}{
+				"texts": []interface{}{},
+				// no numbers
+				"ints": []interface{}{
+					asJsonNumber(101), asJsonNumber(101), asJsonNumber(101), asJsonNumber(101),
+					asJsonNumber(103),
+					asJsonNumber(104),
+					asJsonNumber(105),
+				},
+				"booleans": []interface{}{
+					true, true, true,
+					false,
+				},
+				// no dates
+				"uuids": []interface{}{
+					asUuid("d726c960-aede-411c-85d3-2c77e9290a6e"),
+				},
+				"text": "",
+				// no number
+				"int":     int64(202),
+				"boolean": true,
+				// no date
+				"uuid": asUuid("7fabaf01-9e10-458a-acea-cc627376c506"),
+			},
+		},
+		Vector: vector,
+	}
+
+	mergeDoc := objects.MergeDocument{
+		ID:    uuid,
+		Class: class.Class,
+		PrimitiveSchema: map[string]interface{}{
+			"texts": []interface{}{},
+			"ints": []interface{}{
+				asJsonNumber(101), asJsonNumber(101), asJsonNumber(101), asJsonNumber(101),
+				asJsonNumber(103),
+				asJsonNumber(104),
+				asJsonNumber(105),
+			},
+			"uuids": []interface{}{
+				asUuid("d726c960-aede-411c-85d3-2c77e9290a6e"),
+			},
+			"text":    "",
+			"int":     int64(202),
+			"boolean": true,
+			"uuid":    asUuid("7fabaf01-9e10-458a-acea-cc627376c506"),
+		},
+		PropertiesToDelete: []string{"numbers", "dates", "date"},
+		Vector:             vector,
+	}
+
+	filterTextsEqAAA := filterEqual[string]("aaa", schema.DataTypeText, class.Class, "texts")
+	filterTextsLen3 := filterEqual[int](3, schema.DataTypeInt, class.Class, "len(texts)")
+	filterTextsLen0 := filterEqual[int](0, schema.DataTypeInt, class.Class, "len(texts)")
+	filterTextsNotNil := filterNil(false, class.Class, "texts")
+	filterTextsNil := filterNil(true, class.Class, "texts")
+
+	filterNumbersEq123 := filterEqual[float64](1.23, schema.DataTypeNumber, class.Class, "numbers")
+	filterNumbersLen1 := filterEqual[int](1, schema.DataTypeInt, class.Class, "len(numbers)")
+	filterNumbersLen0 := filterEqual[int](0, schema.DataTypeInt, class.Class, "len(numbers)")
+	filterNumbersNotNil := filterNil(false, class.Class, "numbers")
+	filterNumbersNil := filterNil(true, class.Class, "numbers")
+
+	filterIntsEq102 := filterEqual[int](102, schema.DataTypeInt, class.Class, "ints")
+	filterIntsEq105 := filterEqual[int](105, schema.DataTypeInt, class.Class, "ints")
+	filterIntsLen9 := filterEqual[int](9, schema.DataTypeInt, class.Class, "len(ints)")
+	filterIntsLen7 := filterEqual[int](7, schema.DataTypeInt, class.Class, "len(ints)")
+	filterIntsNotNil := filterNil(false, class.Class, "ints")
+	filterIntsNil := filterNil(true, class.Class, "ints")
+
+	filterBoolsEqTrue := filterEqual[bool](true, schema.DataTypeBoolean, class.Class, "booleans")
+	filterBoolsEqFalse := filterEqual[bool](false, schema.DataTypeBoolean, class.Class, "booleans")
+	filterBoolsLen4 := filterEqual[int](4, schema.DataTypeInt, class.Class, "len(booleans)")
+	filterBoolsLen0 := filterEqual[int](0, schema.DataTypeInt, class.Class, "len(booleans)")
+	filterBoolsNotNil := filterNil(false, class.Class, "booleans")
+	filterBoolsNil := filterNil(true, class.Class, "booleans")
+
+	filterDatesEq2001 := filterEqual[string]("2001-06-01T12:00:00.000000Z", schema.DataTypeDate, class.Class, "dates")
+	filterDatesLen2 := filterEqual[int](2, schema.DataTypeInt, class.Class, "len(dates)")
+	filterDatesLen0 := filterEqual[int](0, schema.DataTypeInt, class.Class, "len(dates)")
+	filterDatesNotNil := filterNil(false, class.Class, "dates")
+	filterDatesNil := filterNil(true, class.Class, "dates")
+
+	filterUuidsEqD726 := filterEqual[string]("d726c960-aede-411c-85d3-2c77e9290a6e", schema.DataTypeText, class.Class, "uuids")
+	filterUuidsLen1 := filterEqual[int](1, schema.DataTypeInt, class.Class, "len(uuids)")
+	filterUuidsLen0 := filterEqual[int](0, schema.DataTypeInt, class.Class, "len(uuids)")
+	filterUuidsNotNil := filterNil(false, class.Class, "uuids")
+	filterUuidsNil := filterNil(true, class.Class, "uuids")
+
+	filterTextEqDDD := filterEqual[string]("ddd", schema.DataTypeText, class.Class, "text")
+	filterTextLen3 := filterEqual[int](3, schema.DataTypeInt, class.Class, "len(text)")
+	filterTextLen0 := filterEqual[int](0, schema.DataTypeInt, class.Class, "len(text)")
+	filterTextNotNil := filterNil(false, class.Class, "text")
+	filterTextNil := filterNil(true, class.Class, "text")
+
+	filterNumberEq123 := filterEqual[float64](1.23, schema.DataTypeNumber, class.Class, "number")
+	filterNumberNotNil := filterNil(false, class.Class, "number")
+	filterNumberNil := filterNil(true, class.Class, "number")
+
+	filterIntEq201 := filterEqual[int](201, schema.DataTypeInt, class.Class, "int")
+	filterIntEq202 := filterEqual[int](202, schema.DataTypeInt, class.Class, "int")
+	filterIntNotNil := filterNil(false, class.Class, "int")
+	filterIntNil := filterNil(true, class.Class, "int")
+
+	filterBoolEqFalse := filterEqual[bool](false, schema.DataTypeBoolean, class.Class, "boolean")
+	filterBoolEqTrue := filterEqual[bool](true, schema.DataTypeBoolean, class.Class, "boolean")
+	filterBoolNotNil := filterNil(false, class.Class, "boolean")
+	filterBoolNil := filterNil(true, class.Class, "boolean")
+
+	filterDateEq2003 := filterEqual[string]("2003-06-01T12:00:00.000000Z", schema.DataTypeDate, class.Class, "date")
+	filterDateNotNil := filterNil(false, class.Class, "date")
+	filterDateNil := filterNil(true, class.Class, "date")
+
+	filterUuidEq7FAB := filterEqual[string]("7fabaf01-9e10-458a-acea-cc627376c506", schema.DataTypeText, class.Class, "uuid")
+	filterUuidNotNil := filterNil(false, class.Class, "uuid")
+	filterUuidNil := filterNil(true, class.Class, "uuid")
+
+	verifySearchAfterAdd := func(shard ShardLike) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Run("to be found", func(t *testing.T) {
+				for name, filter := range map[string]*filters.LocalFilter{
+					"textsEqAAA":  filterTextsEqAAA,
+					"textsLen3":   filterTextsLen3,
+					"textsNotNil": filterTextsNotNil,
+
+					"numbersLen0": filterNumbersLen0,
+					"numbersNil":  filterNumbersNil,
+
+					"intsEq102":  filterIntsEq102,
+					"intsLen9":   filterIntsLen9,
+					"intsNotNil": filterIntsNotNil,
+
+					"boolsEqTrue":  filterBoolsEqTrue,
+					"boolsEqFalse": filterBoolsEqFalse,
+					"boolsLen4":    filterBoolsLen4,
+					"boolsNotNil":  filterBoolsNotNil,
+
+					"datesEq2001": filterDatesEq2001,
+					"datesLen2":   filterDatesLen2,
+					"datesNotNil": filterDatesNotNil,
+
+					"uuidsLen0": filterUuidsLen0,
+					"uuidsNil":  filterUuidsNil,
+
+					"textEqDDD":  filterTextEqDDD,
+					"textLen3":   filterTextLen3,
+					"textNotNil": filterTextNotNil,
+
+					"numberNil": filterNumberNil,
+
+					"intEq201":  filterIntEq201,
+					"intNotNil": filterIntNotNil,
+
+					"boolEqFalse": filterBoolEqFalse,
+					"boolNotNil":  filterBoolNotNil,
+
+					"dateEq2003": filterDateEq2003,
+					"dateNotNil": filterDateNotNil,
+
+					"uuidNil": filterUuidNil,
+				} {
+					t.Run(name, func(t *testing.T) {
+						found, _, err := shard.ObjectSearch(ctx, searchLimit, filter,
+							nil, nil, nil, additional.Properties{})
+						require.NoError(t, err)
+						require.Len(t, found, 1)
+						require.Equal(t, uuid, found[0].Object.ID)
+					})
+				}
+			})
+
+			t.Run("not to be found", func(t *testing.T) {
+				for name, filter := range map[string]*filters.LocalFilter{
+					"textsLen0": filterTextsLen0,
+					"textsNil":  filterTextsNil,
+
+					"numbersEq123":  filterNumbersEq123,
+					"numbersLen1":   filterNumbersLen1,
+					"numbersNotNil": filterNumbersNotNil,
+
+					"intsEq105": filterIntsEq105,
+					"intsLen7":  filterIntsLen7,
+					"intsNil":   filterIntsNil,
+
+					"boolsLen0": filterBoolsLen0,
+					"boolsNil":  filterBoolsNil,
+
+					"datesLen0": filterDatesLen0,
+					"datesNil":  filterDatesNil,
+
+					"uuidsEqD726": filterUuidsEqD726,
+					"uuidsLen1":   filterUuidsLen1,
+					"uuidsNotNil": filterUuidsNotNil,
+
+					"textLen0": filterTextLen0,
+					"textNil":  filterTextNil,
+
+					"numberEq123":  filterNumberEq123,
+					"numberNotNil": filterNumberNotNil,
+
+					"intEq202": filterIntEq202,
+					"intNil":   filterIntNil,
+
+					"boolEqTrue": filterBoolEqTrue,
+					"boolNil":    filterBoolNil,
+
+					"dateNil": filterDateNil,
+
+					"uuidEq7FAB": filterUuidEq7FAB,
+					"uuidNotNil": filterUuidNotNil,
+				} {
+					t.Run(name, func(t *testing.T) {
+						found, _, err := shard.ObjectSearch(ctx, searchLimit, filter,
+							nil, nil, nil, additional.Properties{})
+						require.NoError(t, err)
+						require.Len(t, found, 0)
+					})
+				}
+			})
+		}
+	}
+
+	verifySearchAfterUpdate := func(shard ShardLike) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Run("to be found", func(t *testing.T) {
+				for name, filter := range map[string]*filters.LocalFilter{
+					"textsLen0": filterTextsLen0,
+					"textsNil":  filterTextsNil,
+
+					"numbersLen0": filterNumbersLen0,
+					"numbersNil":  filterNumbersNil,
+
+					"intsEq105":  filterIntsEq105,
+					"intsLen7":   filterIntsLen7,
+					"intsNotNil": filterIntsNotNil,
+
+					"boolsEqTrue":  filterBoolsEqTrue,
+					"boolsEqFalse": filterBoolsEqFalse,
+					"boolsLen4":    filterBoolsLen4,
+					"boolsNotNil":  filterBoolsNotNil,
+
+					"datesLen0": filterDatesLen0,
+					"datesNil":  filterDatesNil,
+
+					"uuidsEqD726": filterUuidsEqD726,
+					"uuidsLen1":   filterUuidsLen1,
+					"uuidsNotNil": filterUuidsNotNil,
+
+					"textLen0": filterTextLen0,
+					"textNil":  filterTextNil,
+
+					"numberNil": filterNumberNil,
+
+					"intEq202":  filterIntEq202,
+					"intNotNil": filterIntNotNil,
+
+					"boolEqTrue": filterBoolEqTrue,
+					"boolNotNil": filterBoolNotNil,
+
+					"dateNil": filterDateNil,
+
+					"uuidEq7FAB": filterUuidEq7FAB,
+					"uuidNotNil": filterUuidNotNil,
+				} {
+					t.Run(name, func(t *testing.T) {
+						found, _, err := shard.ObjectSearch(ctx, searchLimit, filter,
+							nil, nil, nil, additional.Properties{})
+						require.NoError(t, err)
+						require.Len(t, found, 1)
+						require.Equal(t, uuid, found[0].Object.ID)
+					})
+				}
+			})
+
+			t.Run("not to be found", func(t *testing.T) {
+				for name, filter := range map[string]*filters.LocalFilter{
+					"textsEqAAA":  filterTextsEqAAA,
+					"textsLen3":   filterTextsLen3,
+					"textsNotNil": filterTextsNotNil,
+
+					"numbersEq123":  filterNumbersEq123,
+					"numbersLen1":   filterNumbersLen1,
+					"numbersNotNil": filterNumbersNotNil,
+
+					"intsEq102": filterIntsEq102,
+					"intsLen9":  filterIntsLen9,
+					"intsNil":   filterIntsNil,
+
+					"boolsLen0": filterBoolsLen0,
+					"boolsNil":  filterBoolsNil,
+
+					"datesEq2001": filterDatesEq2001,
+					"datesLen2":   filterDatesLen2,
+					"datesNotNil": filterDatesNotNil,
+
+					"uuidsLen0": filterUuidsLen0,
+					"uuidsNil":  filterUuidsNil,
+
+					"textEqDDD":  filterTextEqDDD,
+					"textLen3":   filterTextLen3,
+					"textNotNil": filterTextNotNil,
+
+					"numberEq123":  filterNumberEq123,
+					"numberNotNil": filterNumberNotNil,
+
+					"intEq201": filterIntEq201,
+					"intNil":   filterIntNil,
+
+					"boolEqFalse": filterBoolEqFalse,
+					"boolNil":     filterBoolNil,
+
+					"dateEq2003": filterDateEq2003,
+					"dateNotNil": filterDateNotNil,
+
+					"uuidNil": filterUuidNil,
+				} {
+					t.Run(name, func(t *testing.T) {
+						found, _, err := shard.ObjectSearch(ctx, searchLimit, filter,
+							nil, nil, nil, additional.Properties{})
+						require.NoError(t, err)
+						require.Len(t, found, 0)
+					})
+				}
+			})
+		}
+	}
+
+	verifyVectorSearch := func(shard ShardLike, vectorToBeFound, vectorNotToBeFound []float32) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Run("to be found", func(t *testing.T) {
+				found, _, err := shard.ObjectVectorSearch(ctx, vectorToBeFound,
+					vectorSearchDist, vectorSearchLimit, nil, nil, nil, additional.Properties{})
+				require.NoError(t, err)
+				require.Len(t, found, 1)
+				require.Equal(t, uuid, found[0].Object.ID)
+			})
+
+			t.Run("not to be found", func(t *testing.T) {
+				found, _, err := shard.ObjectVectorSearch(ctx, vectorNotToBeFound,
+					vectorSearchDist, vectorSearchLimit, nil, nil, nil, additional.Properties{})
+				require.NoError(t, err)
+				require.Len(t, found, 0)
+			})
+		}
+	}
+
+	createShard := func(t *testing.T) ShardLike {
+		shard, _ := testShardWithSettings(t, ctx, class, vectorIndexConfig, true, true)
+		return shard
+	}
+
+	t.Run("single object", func(t *testing.T) {
+		t.Run("sanity check - search after add", func(t *testing.T) {
+			shard := createShard(t)
+
+			t.Run("add object", func(t *testing.T) {
+				expectedNextDocID := uint64(1)
+
+				err := shard.PutObject(ctx, origObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("verify search after add", verifySearchAfterAdd(shard))
+			t.Run("verify vector search after add", verifyVectorSearch(shard, vector, altVector))
+		})
+
+		t.Run("replaces object, same vector", func(t *testing.T) {
+			shard := createShard(t)
+
+			t.Run("add object", func(t *testing.T) {
+				expectedNextDocID := uint64(1)
+
+				err := shard.PutObject(ctx, origObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("put object", func(t *testing.T) {
+				expectedNextDocID := uint64(1) // has not changed
+
+				err := shard.PutObject(ctx, updObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("verify search after put", verifySearchAfterUpdate(shard))
+			t.Run("verify vector search after put", verifyVectorSearch(shard, vector, altVector))
+		})
+
+		t.Run("replaces object, different vector", func(t *testing.T) {
+			shard := createShard(t)
+
+			t.Run("add object", func(t *testing.T) {
+				expectedNextDocID := uint64(1)
+
+				err := shard.PutObject(ctx, origObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("put object", func(t *testing.T) {
+				altUpdObj := &storobj.Object{
+					MarshallerVersion: updObj.MarshallerVersion,
+					Object:            updObj.Object,
+					Vector:            altVector,
+				}
+				expectedNextDocID := uint64(2) // has changed
+
+				err := shard.PutObject(ctx, altUpdObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("verify search after put", verifySearchAfterUpdate(shard))
+			t.Run("verify vector search after put", verifyVectorSearch(shard, altVector, vector))
+		})
+
+		t.Run("merges object, same vector", func(t *testing.T) {
+			shard := createShard(t)
+
+			t.Run("add object", func(t *testing.T) {
+				expectedNextDocID := uint64(1)
+
+				err := shard.PutObject(ctx, origObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("merge object", func(t *testing.T) {
+				expectedNextDocID := uint64(1) // has not changed
+
+				err := shard.MergeObject(ctx, mergeDoc)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("verify search after merge", verifySearchAfterUpdate(shard))
+			t.Run("verify vector search after merge", verifyVectorSearch(shard, vector, altVector))
+		})
+
+		t.Run("merges object, different vector", func(t *testing.T) {
+			shard := createShard(t)
+
+			t.Run("add object", func(t *testing.T) {
+				expectedNextDocID := uint64(1)
+
+				err := shard.PutObject(ctx, origObj)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("merge object", func(t *testing.T) {
+				altMergeDoc := objects.MergeDocument{
+					ID:                 mergeDoc.ID,
+					Class:              mergeDoc.Class,
+					PrimitiveSchema:    mergeDoc.PrimitiveSchema,
+					PropertiesToDelete: mergeDoc.PropertiesToDelete,
+					Vector:             altVector,
+				}
+				expectedNextDocID := uint64(2) // has changed
+
+				err := shard.MergeObject(ctx, altMergeDoc)
+				require.NoError(t, err)
+				require.Equal(t, expectedNextDocID, shard.Counter().Get())
+			})
+
+			t.Run("verify search after merge", verifySearchAfterUpdate(shard))
+			t.Run("verify vector search after merge", verifyVectorSearch(shard, altVector, vector))
+		})
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		runBatch := func(t *testing.T) {
+			t.Run("sanity check - search after add", func(t *testing.T) {
+				shard := createShard(t)
+
+				t.Run("add batch", func(t *testing.T) {
+					expectedNextDocID := uint64(1)
+
+					errs := shard.PutObjectBatch(ctx, []*storobj.Object{origObj})
+					for i := range errs {
+						require.NoError(t, errs[i])
+					}
+					require.Equal(t, expectedNextDocID, shard.Counter().Get())
+				})
+
+				t.Run("verify search after batch", verifySearchAfterAdd(shard))
+				t.Run("verify vector search after batch", verifyVectorSearch(shard, vector, altVector))
+			})
+
+			t.Run("replaces object, same vector", func(t *testing.T) {
+				shard := createShard(t)
+
+				t.Run("add batch", func(t *testing.T) {
+					expectedNextDocID := uint64(1)
+
+					errs := shard.PutObjectBatch(ctx, []*storobj.Object{origObj})
+					for i := range errs {
+						require.NoError(t, errs[i])
+					}
+					require.Equal(t, expectedNextDocID, shard.Counter().Get())
+				})
+
+				t.Run("add 2nd batch", func(t *testing.T) {
+					expectedNextDocID := uint64(1) // has not changed
+
+					errs := shard.PutObjectBatch(ctx, []*storobj.Object{updObj})
+					for i := range errs {
+						require.NoError(t, errs[i])
+					}
+					require.Equal(t, expectedNextDocID, shard.Counter().Get())
+				})
+
+				t.Run("verify search after 2nd batch", verifySearchAfterUpdate(shard))
+				t.Run("verify vector search after 2nd batch", verifyVectorSearch(shard, vector, altVector))
+			})
+
+			t.Run("replaces object, different vector", func(t *testing.T) {
+				shard := createShard(t)
+
+				t.Run("add batch", func(t *testing.T) {
+					expectedNextDocID := uint64(1)
+
+					errs := shard.PutObjectBatch(ctx, []*storobj.Object{origObj})
+					for i := range errs {
+						require.NoError(t, errs[i])
+					}
+					require.Equal(t, expectedNextDocID, shard.Counter().Get())
+				})
+
+				t.Run("add 2nd batch", func(t *testing.T) {
+					altUpdObj := &storobj.Object{
+						MarshallerVersion: updObj.MarshallerVersion,
+						Object:            updObj.Object,
+						Vector:            altVector,
+					}
+					expectedNextDocID := uint64(2) // has changed
+
+					errs := shard.PutObjectBatch(ctx, []*storobj.Object{altUpdObj})
+					for i := range errs {
+						require.NoError(t, errs[i])
+					}
+					require.Equal(t, expectedNextDocID, shard.Counter().Get())
+				})
+
+				t.Run("verify search after 2nd batch", verifySearchAfterUpdate(shard))
+				t.Run("verify vector search after 2nd batch", verifyVectorSearch(shard, altVector, vector))
+			})
+		}
+
+		t.Run("sync", func(t *testing.T) {
+			currentIndexing := os.Getenv("ASYNC_INDEXING")
+			t.Setenv("ASYNC_INDEXING", "")
+			defer t.Setenv("ASYNC_INDEXING", currentIndexing)
+
+			runBatch(t)
+		})
+
+		// t.Run("async", func(t *testing.T) {
+		// 	asyncIndexing := os.Getenv("ASYNC_INDEXING")
+		// 	t.Setenv("ASYNC_INDEXING", "true")
+		// 	defer t.Setenv("ASYNC_INDEXING", asyncIndexing)
+
+		// 	runBatch(t)
+		// })
+	})
+}
+
+func filterEqual[T any](value T, dataType schema.DataType, className, propName string) *filters.LocalFilter {
+	return &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value: &filters.Value{
+				Value: value,
+				Type:  dataType,
+			},
+			On: &filters.Path{
+				Class:    schema.ClassName(className),
+				Property: schema.PropertyName(propName),
+			},
+		},
+	}
+}
+
+func filterNil(value bool, className, propName string) *filters.LocalFilter {
+	return &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value: &filters.Value{
+				Value: value,
+				Type:  schema.DataTypeBoolean,
+			},
+			On: &filters.Path{
+				Class:    schema.ClassName(className),
+				Property: schema.PropertyName(propName),
+			},
+		},
+	}
+}
+
+func asJsonNumber(input int) json.Number {
+	return json.Number(fmt.Sprint(input))
+}
+
+func asTime(input string) time.Time {
+	asTime, err := time.Parse(time.RFC3339Nano, input)
+	if err != nil {
+		panic(err)
+	}
+	return asTime
+}
+
+func asUuid(input string) uuid.UUID {
+	asUuid, err := uuid.Parse(input)
+	if err != nil {
+		panic(err)
+	}
+	return asUuid
+}
+
+// "textsEqAAA":  filterTextsEqAAA,
+// "textsLen3":   filterTextsLen3,
+// "textsNotNil": filterTextsNotNil,
+// "textsLen0":   filterTextsLen0,
+// "textsNil":    filterTextsNil,
+
+// "numbersLen0":   filterNumbersLen0,
+// "numbersNil":    filterNumbersNil,
+// "numbersEq123":  filterNumbersEq123,
+// "numbersLen1":   filterNumbersLen1,
+// "numbersNotNil": filterNumbersNotNil,
+
+// "intsEq102":  filterIntsEq102,
+// "intsLen9":   filterIntsLen9,
+// "intsNotNil": filterIntsNotNil,
+// "intsEq105":  filterIntsEq105,
+// "intsLen7":   filterIntsLen7,
+// "intsNil":    filterIntsNil,
+
+// "boolsEqTrue":  filterBoolsEqTrue,
+// "boolsEqFalse": filterBoolsEqFalse,
+// "boolsLen4":    filterBoolsLen4,
+// "boolsNotNil":  filterBoolsNotNil,
+// "boolsLen0":    filterBoolsLen0,
+// "boolsNil":     filterBoolsNil,
+
+// "datesEq2001": filterDatesEq2001,
+// "datesLen2":   filterDatesLen2,
+// "datesNotNil": filterDatesNotNil,
+// "datesLen0":   filterDatesLen0,
+// "datesNil":    filterDatesNil,
+
+// "uuidsLen0":   filterUuidsLen0,
+// "uuidsNil":    filterUuidsNil,
+// "uuidsEqD726": filterUuidsEqD726,
+// "uuidsLen1":   filterUuidsLen1,
+// "uuidsNotNil": filterUuidsNotNil,
+
+// "textEqDDD":  filterTextEqDDD,
+// "textLen3":   filterTextLen3,
+// "textNotNil": filterTextNotNil,
+// "textLen0":   filterTextLen0,
+// "textNil":    filterTextNil,
+
+// "numberNil":    filterNumberNil,
+// "numberEq123":  filterNumberEq123,
+// "numberNotNil": filterNumberNotNil,
+
+// "intEq201":  filterIntEq201,
+// "intNotNil": filterIntNotNil,
+// "intEq202":  filterIntEq202,
+// "intNil":    filterIntNil,
+
+// "boolEqFalse": filterBoolEqFalse,
+// "boolNotNil":  filterBoolNotNil,
+// "boolEqTrue":  filterBoolEqTrue,
+// "boolNil":     filterBoolNil,
+
+// "dateEq2003": filterDateEq2003,
+// "dateNotNil": filterDateNotNil,
+// "dateNil":    filterDateNil,
+
+// "uuidNil":    filterUuidNil,
+// "uuidEq7FAB": filterUuidEq7FAB,
+// "uuidNotNil": filterUuidNotNil,

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -224,6 +224,7 @@ func (ob *objectsBatcher) markDeletedInVectorStorage(ctx context.Context) {
 	var positions []int
 	for pos, object := range ob.objects {
 		status := ob.statuses[object.ID()]
+		// TODO AL_skip_vector_reindex: delete on muteate without docID change?
 		if status.docIDChanged {
 			docIDsToDelete = append(docIDsToDelete, status.oldDocID)
 			positions = append(positions, pos)

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -224,7 +224,6 @@ func (ob *objectsBatcher) markDeletedInVectorStorage(ctx context.Context) {
 	var positions []int
 	for pos, object := range ob.objects {
 		status := ob.statuses[object.ID()]
-		// TODO AL_skip_vector_reindex: delete on mutate without docID change?
 		if status.docIDChanged {
 			docIDsToDelete = append(docIDsToDelete, status.oldDocID)
 			positions = append(positions, pos)

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -296,6 +296,10 @@ func (ob *objectsBatcher) storeAdditionalStorageWithAsyncQueue(ctx context.Conte
 			}
 		}
 
+		if status.docIDPreserved {
+			continue
+		}
+
 		if len(object.Vector) == 0 {
 			continue
 		}

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -224,7 +224,7 @@ func (ob *objectsBatcher) markDeletedInVectorStorage(ctx context.Context) {
 	var positions []int
 	for pos, object := range ob.objects {
 		status := ob.statuses[object.ID()]
-		// TODO AL_skip_vector_reindex: delete on muteate without docID change?
+		// TODO AL_skip_vector_reindex: delete on mutate without docID change?
 		if status.docIDChanged {
 			docIDsToDelete = append(docIDsToDelete, status.oldDocID)
 			positions = append(positions, pos)

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -211,8 +211,7 @@ func (b *referencesBatcher) writeInvertedDeletions(in []inverted.MergeProperty) 
 
 			for _, item := range prop.MergeItems {
 				for _, id := range item.DocIDs {
-					err := b.shard.deleteInvertedIndexItemLSM(bucket,
-						inverted.Countable{Data: item.Data}, id.DocID)
+					err := b.shard.deleteFromPropertySetBucket(bucket, id.DocID, item.Data)
 					if err != nil {
 						return err
 					}

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -140,18 +140,16 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 		return fmt.Errorf("unmarshal previous object: %w", err)
 	}
 
-	// TODO text_rbm_inverted_index null props cleanup?
-	previousInvertProps, _, err := s.AnalyzeObject(previousObject)
+	previousProps, previousNilProps, err := s.AnalyzeObject(previousObject)
 	if err != nil {
 		return fmt.Errorf("analyze previous object: %w", err)
 	}
 
-	if err = s.subtractPropLengths(previousInvertProps); err != nil {
+	if err = s.subtractPropLengths(previousProps); err != nil {
 		return fmt.Errorf("subtract prop lengths: %w", err)
 	}
 
-	// TODO AL_skip_vector_reindex: pass nil props?
-	err = s.deleteFromInvertedIndicesLSM(previousInvertProps, nil, docID)
+	err = s.deleteFromInvertedIndicesLSM(previousProps, previousNilProps, docID)
 	if err != nil {
 		return fmt.Errorf("put inverted indices props: %w", err)
 	}

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -150,7 +150,8 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 		return fmt.Errorf("subtract prop lengths: %w", err)
 	}
 
-	err = s.deleteFromInvertedIndicesLSM(previousInvertProps, docID)
+	// TODO AL_skip_vector_reindex: pass nil props?
+	err = s.deleteFromInvertedIndicesLSM(previousInvertProps, nil, docID)
 	if err != nil {
 		return fmt.Errorf("put inverted indices props: %w", err)
 	}

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -20,11 +20,6 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-type nilProp struct {
-	Name                string
-	AddToPropertyLength bool
-}
-
 func isPropertyForLength(dt schema.DataType) bool {
 	switch dt {
 	case schema.DataTypeInt, schema.DataTypeNumber, schema.DataTypeBoolean, schema.DataTypeDate:
@@ -34,7 +29,7 @@ func isPropertyForLength(dt schema.DataType) bool {
 	}
 }
 
-func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []nilProp, error) {
+func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) {
 	schemaModel := s.index.getSchema.GetSchemaSkipAuth().Objects
 	c, err := schema.GetClassByName(schemaModel, object.Class().String())
 	if err != nil {
@@ -55,7 +50,7 @@ func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []ni
 
 	// add nil for all properties that are not part of the object so that they can be added to the inverted index for
 	// the null state (if enabled)
-	var nilProps []nilProp
+	var nilProps []inverted.NilProperty
 	if s.index.invertedIndexConfig.IndexNullState {
 		for _, prop := range c.Properties {
 			dt := schema.DataType(prop.DataType[0])
@@ -69,7 +64,7 @@ func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []ni
 			// 2. Their inverted index is enabled
 			_, ok := schemaMap[prop.Name]
 			if !ok && inverted.HasInvertedIndex(prop) {
-				nilProps = append(nilProps, nilProp{
+				nilProps = append(nilProps, inverted.NilProperty{
 					Name:                prop.Name,
 					AddToPropertyLength: isPropertyForLength(dt),
 				})

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -23,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
-func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []nilProp,
+func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
 	docID uint64,
 ) error {
 	for _, prop := range props {

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -15,8 +15,6 @@ import (
 	"encoding/binary"
 	"math"
 
-	"github.com/weaviate/weaviate/entities/filters"
-
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -108,7 +106,7 @@ func (s *Shard) addToPropertyLengthIndex(propName string, docID uint64, length i
 		return errors.Errorf("no bucket for prop '%s' length found", propName)
 	}
 
-	key, err := s.keyPropertyLength(length)
+	key, err := bucketKeyPropertyLength(length)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating key for prop '%s' length", propName)
 	}
@@ -124,7 +122,7 @@ func (s *Shard) addToPropertyNullIndex(propName string, docID uint64, isNull boo
 		return errors.Errorf("no bucket for prop '%s' null found", propName)
 	}
 
-	key, err := s.keyPropertyNull(isNull)
+	key, err := bucketKeyPropertyNull(isNull)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating key for prop '%s' null", propName)
 	}
@@ -152,17 +150,6 @@ func (s *Shard) pairPropertyWithFrequency(docID uint64, freq, propLen float32) l
 		Key:   buf[:8],
 		Value: buf[8:],
 	}
-}
-
-func (s *Shard) keyPropertyLength(length int) ([]byte, error) {
-	return inverted.LexicographicallySortableInt64(int64(length))
-}
-
-func (s *Shard) keyPropertyNull(isNull bool) ([]byte, error) {
-	if isNull {
-		return []byte{uint8(filters.InternalNullState)}, nil
-	}
-	return []byte{uint8(filters.InternalNotNullState)}, nil
 }
 
 func (s *Shard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -114,7 +114,7 @@ func (s *Shard) deleteFromPropertyLengthIndex(propName string, docID uint64, len
 		return errors.Errorf("no bucket for prop '%s' length found", propName)
 	}
 
-	key, err := s.keyPropertyLength(length)
+	key, err := bucketKeyPropertyLength(length)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating key for prop '%s' length", propName)
 	}
@@ -130,7 +130,7 @@ func (s *Shard) deleteFromPropertyNullIndex(propName string, docID uint64, isNul
 		return errors.Errorf("no bucket for prop '%s' null found", propName)
 	}
 
-	key, err := s.keyPropertyNull(isNull)
+	key, err := bucketKeyPropertyNull(isNull)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating key for prop '%s' null", propName)
 	}

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -21,7 +21,8 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
-func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property,
+// TODO AL_skip_vector_reindex: handle nil props
+func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []nilProp,
 	docID uint64,
 ) error {
 	for _, prop := range props {

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TODO AL_skip_vector_reindex: handle nil props
-func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []nilProp,
+func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
 	docID uint64,
 ) error {
 	for _, prop := range props {

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -21,7 +21,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
-// TODO AL_skip_vector_reindex: handle nil props
 func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
 	docID uint64,
 ) error {
@@ -33,8 +32,7 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 			}
 
 			for _, item := range prop.Items {
-				if err := s.deleteInvertedIndexItemLSM(bucket, item,
-					docID); err != nil {
+				if err := s.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {
 					return errors.Wrapf(err, "delete item '%s' from index",
 						string(item.Data))
 				}
@@ -53,6 +51,39 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 					return errors.Wrapf(err, "delete item '%s' from index",
 						string(item.Data))
 				}
+			}
+		}
+
+		// add non-nil properties to the null-state inverted index, but skip internal properties (__meta_count, _id etc)
+		if isMetaCountProperty(prop) || isInternalProperty(prop) {
+			continue
+		}
+
+		// properties where defining a length does not make sense (floats etc.) have a negative entry as length
+		if s.index.invertedIndexConfig.IndexPropertyLength && prop.Length >= 0 {
+			if err := s.deleteFromPropertyLengthIndex(prop.Name, docID, prop.Length); err != nil {
+				return errors.Wrap(err, "add indexed property length")
+			}
+		}
+
+		if s.index.invertedIndexConfig.IndexNullState {
+			if err := s.deleteFromPropertyNullIndex(prop.Name, docID, prop.Length == 0); err != nil {
+				return errors.Wrap(err, "add indexed null state")
+			}
+		}
+	}
+
+	// remove nil properties from the nullstate and property length inverted index
+	for _, nilProperty := range nilProps {
+		if s.index.invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
+			if err := s.deleteFromPropertyLengthIndex(nilProperty.Name, docID, 0); err != nil {
+				return errors.Wrap(err, "add indexed property length")
+			}
+		}
+
+		if s.index.invertedIndexConfig.IndexNullState {
+			if err := s.deleteFromPropertyNullIndex(nilProperty.Name, docID, true); err != nil {
+				return errors.Wrap(err, "add indexed null state")
 			}
 		}
 	}
@@ -77,17 +108,47 @@ func (s *Shard) deleteInvertedIndexItemWithFrequencyLSM(bucket *lsmkv.Bucket,
 	return bucket.MapDeleteKey(item.Data, docIDBytes)
 }
 
-func (s *Shard) deleteInvertedIndexItemLSM(bucket *lsmkv.Bucket,
-	item inverted.Countable, docID uint64,
-) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
-
-	if bucket.Strategy() == lsmkv.StrategyRoaringSet {
-		return bucket.RoaringSetRemoveOne(item.Data, docID)
+func (s *Shard) deleteFromPropertyLengthIndex(propName string, docID uint64, length int) error {
+	bucketLength := s.store.Bucket(helpers.BucketFromPropNameLengthLSM(propName))
+	if bucketLength == nil {
+		return errors.Errorf("no bucket for prop '%s' length found", propName)
 	}
 
-	docIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(docIDBytes, docID)
+	key, err := s.keyPropertyLength(length)
+	if err != nil {
+		return errors.Wrapf(err, "failed creating key for prop '%s' length", propName)
+	}
+	if err := s.deleteFromPropertySetBucket(bucketLength, docID, key); err != nil {
+		return errors.Wrapf(err, "failed adding to prop '%s' length bucket", propName)
+	}
+	return nil
+}
 
-	return bucket.SetDeleteSingle(item.Data, docIDBytes)
+func (s *Shard) deleteFromPropertyNullIndex(propName string, docID uint64, isNull bool) error {
+	bucketNull := s.store.Bucket(helpers.BucketFromPropNameNullLSM(propName))
+	if bucketNull == nil {
+		return errors.Errorf("no bucket for prop '%s' null found", propName)
+	}
+
+	key, err := s.keyPropertyNull(isNull)
+	if err != nil {
+		return errors.Wrapf(err, "failed creating key for prop '%s' null", propName)
+	}
+	if err := s.deleteFromPropertySetBucket(bucketNull, docID, key); err != nil {
+		return errors.Wrapf(err, "failed adding to prop '%s' null bucket", propName)
+	}
+	return nil
+}
+
+func (s *Shard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
+	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
+
+	if bucket.Strategy() == lsmkv.StrategySetCollection {
+		docIDBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(docIDBytes, docID)
+
+		return bucket.SetDeleteSingle(key, docIDBytes)
+	}
+
+	return bucket.RoaringSetRemoveOne(key, docID)
 }

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -62,10 +62,6 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 		return errors.Wrap(err, "flush all buffered WALs")
 	}
 
-	if err := s.VectorIndex().Flush(); err != nil {
-		return errors.Wrap(err, "flush all vector index buffered WALs")
-	}
-
 	return nil
 }
 

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -24,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -70,10 +69,6 @@ func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object)
 		return errors.Wrap(err, "flush prop length tracker to disk")
 	}
 
-	if err := s.VectorIndex().Flush(); err != nil {
-		return errors.Wrap(err, "flush all vector index buffered WALs")
-	}
-
 	return nil
 }
 
@@ -83,6 +78,12 @@ func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object)
 func (s *Shard) updateVectorIndexIgnoreDelete(vector []float32,
 	status objectInsertStatus,
 ) error {
+	// vector was not changed, object was updated without changing docID
+	// https://github.com/weaviate/weaviate/issues/3948
+	if status.docIDPreserved {
+		return nil
+	}
+
 	// vector is now optional as of
 	// https://github.com/weaviate/weaviate/issues/1800
 	if len(vector) == 0 {
@@ -109,6 +110,12 @@ func (s *Shard) updateVectorIndex(vector []float32,
 		}
 	}
 
+	// vector was not changed, object was updated without changing docID
+	// https://github.com/weaviate/weaviate/issues/3948
+	if status.docIDPreserved {
+		return nil
+	}
+
 	// vector is now optional as of
 	// https://github.com/weaviate/weaviate/issues/1800
 	if len(vector) == 0 {
@@ -119,9 +126,14 @@ func (s *Shard) updateVectorIndex(vector []float32,
 		return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
 	}
 
+	if err := s.VectorIndex().Flush(); err != nil {
+		return errors.Wrap(err, "flush all vector index buffered WALs")
+	}
+
 	return nil
 }
 
+// TODO AL_skip_vector_reindex: adjust to batch
 func (s *Shard) putObjectLSM(object *storobj.Object, idBytes []byte,
 ) (objectInsertStatus, error) {
 	before := time.Now()
@@ -172,9 +184,10 @@ func (s *Shard) putObjectLSM(object *storobj.Object, idBytes []byte,
 }
 
 type objectInsertStatus struct {
-	docID        uint64
-	docIDChanged bool
-	oldDocID     uint64
+	docID          uint64
+	docIDChanged   bool
+	oldDocID       uint64
+	docIDPreserved bool // docID preserved (docID was not changed, although object did change)
 }
 
 // to be called with the current contents of a row, if the row is empty (i.e.
@@ -199,6 +212,30 @@ func (s *Shard) determineInsertStatus(previous []byte,
 		return out, errors.Wrap(err, "get previous doc id from object binary")
 	}
 	out.oldDocID = docID
+
+	// if vector was not changed, replace object and update indexed properties
+	// without changing docID
+	// https://github.com/weaviate/weaviate/issues/3948
+	//
+	// Due to geo index does not support delete+insert of geo value for the same docID
+	// (as tombstones are used for hnsw geo index),
+	// preserving docID will not be supported for classes with geo properties for now.
+	// Feature can be improved in the future, by preserving docIDs for objects
+	// not updating values of geo properties.
+	if !s.hasGeoIndex() {
+		if l := len(next.Vector); l > 0 {
+			buffer := make([]float32, l)
+			prevVector, err := storobj.VectorFromBinary(previous, buffer)
+			if err != nil {
+				return out, fmt.Errorf("get previous vector from object binary: %w", err)
+			}
+			if common.VectorsEqual(prevVector, next.Vector) {
+				out.docID = docID
+				out.docIDPreserved = true
+				return out, nil
+			}
+		}
+	}
 
 	// with docIDs now being immutable (see
 	// https://github.com/weaviate/weaviate/issues/1282) there is no
@@ -260,19 +297,26 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "analyze next object")
 	}
 
-	if status.docIDChanged {
-		oldObject, err := storobj.FromBinary(previous)
-		if err == nil {
+	var prevObject *storobj.Object
+	var prevProps []inverted.Property
+	var prevNilprops []nilProp
 
-			oldProps, _, err := s.AnalyzeObject(oldObject)
-			if err != nil {
-				s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not analyse prop lengths")
-			}
+	if previous != nil {
+		prevObject, err = storobj.FromBinary(previous)
+		if err != nil {
+			return fmt.Errorf("unmarshal previous object: %w", err)
+		}
 
-			if err := s.subtractPropLengths(oldProps); err != nil {
-				s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
-			}
+		prevProps, prevNilprops, err = s.AnalyzeObject(prevObject)
+		if err != nil {
+			return fmt.Errorf("analyze previous object: %w", err)
+		}
+	}
 
+	// if object updated (with or without docID changed)
+	if status.docIDChanged || status.docIDPreserved {
+		if err := s.subtractPropLengths(prevProps); err != nil {
+			s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
 		}
 	} else {
 		if err := s.ChangeObjectCountBy(1); err != nil {
@@ -280,105 +324,130 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		}
 	}
 
-	// TODO: metrics
-	if err := s.updateInvertedIndexCleanupOldLSM(status, previous); err != nil {
-		return errors.Wrap(err, "analyze and cleanup previous")
-	}
-
-	if s.index.invertedIndexConfig.IndexTimestamps {
-		// update the inverted timestamp indices as well
-		err = s.addIndexedTimestampsToProps(object, &props)
-		if err != nil {
-			return errors.Wrap(err, "add indexed timestamps to props")
-		}
-	}
-
-	before := time.Now()
-
-	err = s.extendInvertedIndicesLSM(props, nilprops, status.docID)
-	if err != nil {
-		return errors.Wrap(err, "put inverted indices props")
-	}
-	s.metrics.InvertedExtend(before, len(props))
-
 	if err := s.SetPropertyLengths(props); err != nil {
 		return errors.Wrap(err, "store field length values for props")
 	}
 
+	// if s.index.invertedIndexConfig.IndexTimestamps {
+	// 	// update the inverted timestamp indices as well
+	// 	err = s.addIndexedTimestampsToProps(object, &props)
+	// 	if err != nil {
+	// 		return errors.Wrap(err, "add indexed timestamps to props")
+	// 	}
+	// }
+
+	var propsToAdd []inverted.Property
+	var nilpropsToAdd []nilProp
+	var propsToDel []inverted.Property
+	var nilpropsToDel []nilProp
+
+	// determine only changed properties to avoid unnecessary updates of inverted indexes
+	if status.docIDPreserved {
+		delta := inverted.Delta(prevProps, props)
+		propsToAdd = delta.ToAdd
+		propsToDel = delta.ToDelete
+
+		// TODO delta for nil props
+		nilpropsToAdd = nilprops
+		nilpropsToDel = prevNilprops
+	} else {
+		propsToAdd = inverted.DedupItems(props)
+		nilpropsToAdd = nilprops
+		propsToDel = inverted.DedupItems(prevProps)
+		nilpropsToDel = prevNilprops
+	}
+
+	if previous != nil {
+		// TODO: metrics
+		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID); err != nil {
+			return fmt.Errorf("delete inverted indices props: %w", err)
+		}
+		if s.index.Config.TrackVectorDimensions {
+			if err := s.removeDimensionsLSM(len(prevObject.Vector), status.oldDocID); err != nil {
+				return fmt.Errorf("track dimensions (delete): %w", err)
+			}
+		}
+	}
+
+	before := time.Now()
+	if err := s.extendInvertedIndicesLSM(propsToAdd, nilpropsToAdd, status.docID); err != nil {
+		return fmt.Errorf("put inverted indices props: %w", err)
+	}
+	s.metrics.InvertedExtend(before, len(propsToAdd))
+
 	if s.index.Config.TrackVectorDimensions {
-		err = s.extendDimensionTrackerLSM(len(object.Vector), status.docID)
-		if err != nil {
-			return errors.Wrap(err, "track dimensions")
+		if err := s.extendDimensionTrackerLSM(len(object.Vector), status.docID); err != nil {
+			return fmt.Errorf("track dimensions: %w", err)
 		}
 	}
 
 	return nil
 }
 
-// addIndexedTimestampsToProps ensures that writes are indexed
-// by internal timestamps
-func (s *Shard) addIndexedTimestampsToProps(object *storobj.Object, props *[]inverted.Property) error {
-	createTime, err := json.Marshal(object.CreationTimeUnix())
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal _creationTimeUnix")
-	}
+// // addIndexedTimestampsToProps ensures that writes are indexed
+// // by internal timestamps
+// func (s *Shard) addIndexedTimestampsToProps(object *storobj.Object, props *[]inverted.Property) error {
+// 	createTime, err := json.Marshal(object.CreationTimeUnix())
+// 	if err != nil {
+// 		return errors.Wrap(err, "failed to marshal _creationTimeUnix")
+// 	}
 
-	updateTime, err := json.Marshal(object.LastUpdateTimeUnix())
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal _lastUpdateTimeUnix")
-	}
+// 	updateTime, err := json.Marshal(object.LastUpdateTimeUnix())
+// 	if err != nil {
+// 		return errors.Wrap(err, "failed to marshal _lastUpdateTimeUnix")
+// 	}
 
-	*props = append(*props,
-		inverted.Property{
-			Name:  filters.InternalPropCreationTimeUnix,
-			Items: []inverted.Countable{{Data: createTime}},
-		},
-		inverted.Property{
-			Name:  filters.InternalPropLastUpdateTimeUnix,
-			Items: []inverted.Countable{{Data: updateTime}},
-		},
-	)
+// 	*props = append(*props,
+// 		inverted.Property{
+// 			Name:  filters.InternalPropCreationTimeUnix,
+// 			Items: []inverted.Countable{{Data: createTime}},
+// 		},
+// 		inverted.Property{
+// 			Name:  filters.InternalPropLastUpdateTimeUnix,
+// 			Items: []inverted.Countable{{Data: updateTime}},
+// 		},
+// 	)
 
-	return nil
-}
+// 	return nil
+// }
 
-func (s *Shard) updateInvertedIndexCleanupOldLSM(status objectInsertStatus,
-	previous []byte,
-) error {
-	if !status.docIDChanged {
-		// nothing to do
-		return nil
-	}
+// func (s *Shard) updateInvertedIndexCleanupOldLSM(status objectInsertStatus,
+// 	previous []byte,
+// ) error {
+// 	if !status.docIDChanged {
+// 		// nothing to do
+// 		return nil
+// 	}
 
-	// The doc id changed, so we need to analyze the previous and delete all
-	// entries (immediately - since the async part is now handled inside the
-	// LSMKV store, as part of merging/compaction)
-	//
-	// NOTE: Since Doc IDs are immutable, there is no need to use a
-	// DeltaAnalyzer. docIDChanged==true, therefore the old docID is
-	// "worthless" and can be cleaned up in the inverted index fully.
-	previousObject, err := storobj.FromBinary(previous)
-	if err != nil {
-		return errors.Wrap(err, "unmarshal previous object")
-	}
+// 	// The doc id changed, so we need to analyze the previous and delete all
+// 	// entries (immediately - since the async part is now handled inside the
+// 	// LSMKV store, as part of merging/compaction)
+// 	//
+// 	// NOTE: Since Doc IDs are immutable, there is no need to use a
+// 	// DeltaAnalyzer. docIDChanged==true, therefore the old docID is
+// 	// "worthless" and can be cleaned up in the inverted index fully.
+// 	previousObject, err := storobj.FromBinary(previous)
+// 	if err != nil {
+// 		return errors.Wrap(err, "unmarshal previous object")
+// 	}
 
-	// TODO text_rbm_inverted_index null props cleanup?
-	previousInvertProps, _, err := s.AnalyzeObject(previousObject)
-	if err != nil {
-		return errors.Wrap(err, "analyze previous object")
-	}
+// 	// TODO text_rbm_inverted_index null props cleanup?
+// 	previousInvertProps, _, err := s.AnalyzeObject(previousObject)
+// 	if err != nil {
+// 		return errors.Wrap(err, "analyze previous object")
+// 	}
 
-	err = s.deleteFromInvertedIndicesLSM(previousInvertProps, status.oldDocID)
-	if err != nil {
-		return errors.Wrap(err, "put inverted indices props")
-	}
+// 	err = s.deleteFromInvertedIndicesLSM(previousInvertProps, status.oldDocID)
+// 	if err != nil {
+// 		return errors.Wrap(err, "put inverted indices props")
+// 	}
 
-	if s.index.Config.TrackVectorDimensions {
-		err = s.removeDimensionsLSM(len(previousObject.Vector), status.oldDocID)
-		if err != nil {
-			return errors.Wrap(err, "track dimensions (delete)")
-		}
-	}
+// 	if s.index.Config.TrackVectorDimensions {
+// 		err = s.removeDimensionsLSM(len(previousObject.Vector), status.oldDocID)
+// 		if err != nil {
+// 			return errors.Wrap(err, "track dimensions (delete)")
+// 		}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -133,7 +133,7 @@ func (s *Shard) updateVectorIndex(vector []float32,
 	return nil
 }
 
-// TODO AL_skip_vector_reindex: adjust to batch
+// TODO AL_skip_vector_reindex: adjust to batch?
 func (s *Shard) putObjectLSM(object *storobj.Object, idBytes []byte,
 ) (objectInsertStatus, error) {
 	before := time.Now()
@@ -328,14 +328,6 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "store field length values for props")
 	}
 
-	// if s.index.invertedIndexConfig.IndexTimestamps {
-	// 	// update the inverted timestamp indices as well
-	// 	err = s.addIndexedTimestampsToProps(object, &props)
-	// 	if err != nil {
-	// 		return errors.Wrap(err, "add indexed timestamps to props")
-	// 	}
-	// }
-
 	var propsToAdd []inverted.Property
 	var propsToDel []inverted.Property
 	var nilpropsToAdd []inverted.NilProperty
@@ -382,71 +374,3 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 
 	return nil
 }
-
-// // addIndexedTimestampsToProps ensures that writes are indexed
-// // by internal timestamps
-// func (s *Shard) addIndexedTimestampsToProps(object *storobj.Object, props *[]inverted.Property) error {
-// 	createTime, err := json.Marshal(object.CreationTimeUnix())
-// 	if err != nil {
-// 		return errors.Wrap(err, "failed to marshal _creationTimeUnix")
-// 	}
-
-// 	updateTime, err := json.Marshal(object.LastUpdateTimeUnix())
-// 	if err != nil {
-// 		return errors.Wrap(err, "failed to marshal _lastUpdateTimeUnix")
-// 	}
-
-// 	*props = append(*props,
-// 		inverted.Property{
-// 			Name:  filters.InternalPropCreationTimeUnix,
-// 			Items: []inverted.Countable{{Data: createTime}},
-// 		},
-// 		inverted.Property{
-// 			Name:  filters.InternalPropLastUpdateTimeUnix,
-// 			Items: []inverted.Countable{{Data: updateTime}},
-// 		},
-// 	)
-
-// 	return nil
-// }
-
-// func (s *Shard) updateInvertedIndexCleanupOldLSM(status objectInsertStatus,
-// 	previous []byte,
-// ) error {
-// 	if !status.docIDChanged {
-// 		// nothing to do
-// 		return nil
-// 	}
-
-// 	// The doc id changed, so we need to analyze the previous and delete all
-// 	// entries (immediately - since the async part is now handled inside the
-// 	// LSMKV store, as part of merging/compaction)
-// 	//
-// 	// NOTE: Since Doc IDs are immutable, there is no need to use a
-// 	// DeltaAnalyzer. docIDChanged==true, therefore the old docID is
-// 	// "worthless" and can be cleaned up in the inverted index fully.
-// 	previousObject, err := storobj.FromBinary(previous)
-// 	if err != nil {
-// 		return errors.Wrap(err, "unmarshal previous object")
-// 	}
-
-// 	// TODO text_rbm_inverted_index null props cleanup?
-// 	previousInvertProps, _, err := s.AnalyzeObject(previousObject)
-// 	if err != nil {
-// 		return errors.Wrap(err, "analyze previous object")
-// 	}
-
-// 	err = s.deleteFromInvertedIndicesLSM(previousInvertProps, status.oldDocID)
-// 	if err != nil {
-// 		return errors.Wrap(err, "put inverted indices props")
-// 	}
-
-// 	if s.index.Config.TrackVectorDimensions {
-// 		err = s.removeDimensionsLSM(len(previousObject.Vector), status.oldDocID)
-// 		if err != nil {
-// 			return errors.Wrap(err, "track dimensions (delete)")
-// 		}
-// 	}
-
-// 	return nil
-// }

--- a/adapters/repos/db/vector/common/vector_util.go
+++ b/adapters/repos/db/vector/common/vector_util.go
@@ -4,7 +4,7 @@
 //  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
 //   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
 //
-//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
 //

--- a/adapters/repos/db/vector/common/vector_util.go
+++ b/adapters/repos/db/vector/common/vector_util.go
@@ -1,0 +1,30 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+func VectorsEqual(vecA, vecB []float32) bool {
+	if len(vecA) != len(vecB) {
+		return false
+	}
+	if vecA == nil && vecB != nil {
+		return false
+	}
+	if vecA != nil && vecB == nil {
+		return false
+	}
+	for i := range vecA {
+		if vecA[i] != vecB[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/adapters/repos/db/vector/common/vector_util_test.go
+++ b/adapters/repos/db/vector/common/vector_util_test.go
@@ -4,7 +4,7 @@
 //  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
 //   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
 //
-//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
 //

--- a/adapters/repos/db/vector/common/vector_util_test.go
+++ b/adapters/repos/db/vector/common/vector_util_test.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2023 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVectorUtil_Equal(t *testing.T) {
+	type testCase struct {
+		vecA          []float32
+		vecB          []float32
+		expectedEqual bool
+	}
+
+	testCases := []testCase{
+		{
+			vecA:          nil,
+			vecB:          nil,
+			expectedEqual: true,
+		},
+		{
+			vecA:          nil,
+			vecB:          []float32{},
+			expectedEqual: false,
+		},
+		{
+			vecA:          []float32{},
+			vecB:          nil,
+			expectedEqual: false,
+		},
+		{
+			vecA:          []float32{},
+			vecB:          []float32{},
+			expectedEqual: true,
+		},
+		{
+			vecA:          []float32{1, 2, 3},
+			vecB:          []float32{1., 2., 3.},
+			expectedEqual: true,
+		},
+		{
+			vecA:          []float32{1, 2, 3, 4},
+			vecB:          []float32{1., 2., 3.},
+			expectedEqual: false,
+		},
+		{
+			vecA:          []float32{1, 2, 3},
+			vecB:          []float32{1., 2., 3., 4.},
+			expectedEqual: false,
+		},
+		{
+			vecA:          []float32{},
+			vecB:          []float32{1., 2., 3.},
+			expectedEqual: false,
+		},
+		{
+			vecA:          []float32{1, 2, 3},
+			vecB:          []float32{},
+			expectedEqual: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("#%d", i+1), func(t *testing.T) {
+			assert.Equal(t, tc.expectedEqual, VectorsEqual(tc.vecA, tc.vecB))
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:
Addresses https://github.com/weaviate/weaviate/issues/3948

So far every object update (either replace/put or merge/patch) resulted in new docID being assigned to new object. That resulted in vector index being updated even if object's vector was not changed (due to same vector provided or only non-vectorizable properties changed). Now if vector is not changed, docID is preserved and vector index is not updated.

Currently chaos pipelines fail with lower recall results https://github.com/weaviate/weaviate-chaos-engineering/pull/163, but the same issue currently occurs on master https://github.com/weaviate/weaviate-chaos-engineering/pull/164, so it seems unrelated to this PR's changes.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/163
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
