### PR TITLE
ensure tenant is passed to cref validation logic

### DIFF
--- a/test/acceptance_with_go_client/fixtures/food.go
+++ b/test/acceptance_with_go_client/fixtures/food.go
@@ -13,6 +13,7 @@ package fixtures
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,7 @@ const (
 	PIZZA_DOENER_ID           = "5b6a08ba-1d46-43aa-89cc-8b070790c6f2"
 	SOUP_CHICKENSOUP_ID       = "8c156d37-81aa-4ce9-a811-621e2702b825"
 	SOUP_BEAUTIFUL_ID         = "27351361-2898-4d1a-aad7-1ca48253eb0b"
+	SOUP_TRIPE_ID             = "a0b0c0d0-2898-4d1a-aad7-1ca48253eb0b"
 	RISOTTO_RISI_E_BISI_ID    = "da751a25-f573-4715-a893-e607b2de0ba4"
 	RISOTTO_ALLA_PILOTA_ID    = "10c2ee44-7d58-42be-9d64-5766883ca8cb"
 	RISOTTO_AL_NERO_DI_SEPPIA = "696bf381-7f98-40a4-bcad-841780e00e0e"
@@ -51,6 +53,24 @@ var IdsByClass = map[string][]string{
 	},
 }
 
+var BeaconsByClass = map[string][]map[string]string{
+	"Pizza": {
+		{"beacon": makeBeacon("Pizza", PIZZA_QUATTRO_FORMAGGI_ID)},
+		{"beacon": makeBeacon("Pizza", PIZZA_FRUTTI_DI_MARE_ID)},
+		{"beacon": makeBeacon("Pizza", PIZZA_HAWAII_ID)},
+		{"beacon": makeBeacon("Pizza", PIZZA_DOENER_ID)},
+	},
+	"Soup": {
+		{"beacon": makeBeacon("Soup", SOUP_CHICKENSOUP_ID)},
+		{"beacon": makeBeacon("Soup", SOUP_BEAUTIFUL_ID)},
+	},
+	"Risotto": {
+		{"beacon": makeBeacon("Risotto", RISOTTO_RISI_E_BISI_ID)},
+		{"beacon": makeBeacon("Risotto", RISOTTO_ALLA_PILOTA_ID)},
+		{"beacon": makeBeacon("Risotto", RISOTTO_AL_NERO_DI_SEPPIA)},
+	},
+}
+
 var AllIds = []string{
 	PIZZA_QUATTRO_FORMAGGI_ID,
 	PIZZA_FRUTTI_DI_MARE_ID,
@@ -63,6 +83,10 @@ var AllIds = []string{
 	RISOTTO_RISI_E_BISI_ID,
 	RISOTTO_ALLA_PILOTA_ID,
 	RISOTTO_AL_NERO_DI_SEPPIA,
+}
+
+func makeBeacon(class, id string) string {
+	return fmt.Sprintf("weaviate://localhost/%s/%s", class, id)
 }
 
 // ##### SCHEMA #####

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -46,6 +46,11 @@ func (v *Validator) properties(ctx context.Context, class *models.Class,
 	className := incomingObject.Class
 	isp := incomingObject.Properties
 	vectorWeights := incomingObject.VectorWeights
+	tenant := incomingObject.Tenant
+
+	if existingObject != nil && tenant != existingObject.Tenant {
+		return fmt.Errorf("tenant mismatch, expected %s but got %s", existingObject.Tenant, tenant)
+	}
 
 	if vectorWeights != nil {
 		res, err := v.validateVectorWeights(vectorWeights)
@@ -124,7 +129,7 @@ func (v *Validator) properties(ctx context.Context, class *models.Class,
 			data, err = v.extractAndValidateNestedProperty(ctx, propertyKeyLowerCase, propertyValue, className,
 				dataType, property.NestedProperties)
 		} else {
-			data, err = v.extractAndValidateProperty(ctx, propertyKeyLowerCase, propertyValue, className, dataType)
+			data, err = v.extractAndValidateProperty(ctx, propertyKeyLowerCase, propertyValue, className, dataType, tenant)
 		}
 		if err != nil {
 			return err
@@ -199,7 +204,7 @@ func objectVal(ctx context.Context, v *Validator, val interface{}, propertyPrefi
 				className, nestedDataType, nestedProperty.NestedProperties)
 		} else {
 			data, err = v.extractAndValidateProperty(ctx, propertyName, nestedValue,
-				className, nestedDataType)
+				className, nestedDataType, "")
 		}
 		if err != nil {
 			return nil, fmt.Errorf("property '%s': %w", propertyName, err)
@@ -230,7 +235,7 @@ func objectArrayVal(ctx context.Context, v *Validator, val interface{}, property
 }
 
 func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName string, pv interface{},
-	className string, dataType *schema.DataType,
+	className string, dataType *schema.DataType, tenant string,
 ) (interface{}, error) {
 	var (
 		data interface{}
@@ -239,7 +244,7 @@ func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName
 
 	switch *dataType {
 	case schema.DataTypeCRef:
-		data, err = v.cRef(ctx, propertyName, pv, className)
+		data, err = v.cRef(ctx, propertyName, pv, className, tenant)
 		if err != nil {
 			return nil, fmt.Errorf("invalid cref: %s", err)
 		}
@@ -344,7 +349,7 @@ func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName
 }
 
 func (v *Validator) cRef(ctx context.Context, propertyName string, pv interface{},
-	className string,
+	className, tenant string,
 ) (interface{}, error) {
 	switch refValue := pv.(type) {
 	case map[string]interface{}:
@@ -358,7 +363,7 @@ func (v *Validator) cRef(ctx context.Context, propertyName string, pv interface{
 					className, propertyName, ref)
 			}
 
-			cref, err := v.parseAndValidateSingleRef(ctx, propertyName, refTyped, className)
+			cref, err := v.parseAndValidateSingleRef(ctx, propertyName, refTyped, className, tenant)
 			if err != nil {
 				return nil, err
 			}
@@ -564,7 +569,7 @@ func blobVal(val interface{}) (string, error) {
 }
 
 func (v *Validator) parseAndValidateSingleRef(ctx context.Context, propertyName string,
-	pvcr map[string]interface{}, className string,
+	pvcr map[string]interface{}, className, tenant string,
 ) (*models.SingleRef, error) {
 	delete(pvcr, "href")
 
@@ -596,7 +601,7 @@ func (v *Validator) parseAndValidateSingleRef(ctx context.Context, propertyName 
 		return nil, err
 	}
 
-	if err = v.ValidateExistence(ctx, ref, errVal, ""); err != nil {
+	if err = v.ValidateExistence(ctx, ref, errVal, tenant); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -205,6 +205,7 @@ func objectVal(ctx context.Context, v *Validator, val interface{}, propertyPrefi
 		} else {
 			data, err = v.extractAndValidateProperty(ctx, propertyName, nestedValue,
 				className, nestedDataType, "")
+			// tenant isn't relevant for nested properties since crossrefs are not allowed
 		}
 		if err != nil {
 			return nil, fmt.Errorf("property '%s': %w", propertyName, err)

--- a/usecases/objects/validation/properties_validation_test.go
+++ b/usecases/objects/validation/properties_validation_test.go
@@ -130,7 +130,7 @@ func TestValidator_extractAndValidateProperty(t *testing.T) {
 				exists: tt.fields.exists,
 				config: tt.fields.config,
 			}
-			got, err := v.extractAndValidateProperty(tt.args.ctx, tt.args.propertyName, tt.args.pv, tt.args.className, tt.args.dataType)
+			got, err := v.extractAndValidateProperty(tt.args.ctx, tt.args.propertyName, tt.args.pv, tt.args.className, tt.args.dataType, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validator.extractAndValidateProperty() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug where inserting an object with a reference fails when the reference is in a multi-tenancy class

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
