### PR TITLE
Fix #3588 let the baseURL for Azure OpenAI be configurable.

### DIFF
--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	vectorizer2 "github.com/weaviate/weaviate/modules/text2vec-openai/vectorizer"
 	"io"
 	"net/http"
 	"net/url"
@@ -55,7 +56,7 @@ type openAIApiError struct {
 func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 	if isAzure {
 		host := baseURL
-		if host == "" {
+		if host == "" || host == vectorizer2.DefaultBaseURL {
 			// Fall back to old assumption
 			host = "https://" + resourceName + ".openai.azure.com"
 		}

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -21,8 +21,6 @@ import (
 	"net/url"
 	"time"
 
-	vectorizer2 "github.com/weaviate/weaviate/modules/text2vec-openai/vectorizer"
-
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 
 	"github.com/pkg/errors"
@@ -57,7 +55,7 @@ type openAIApiError struct {
 func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 	if isAzure {
 		host := baseURL
-		if host == "" || host == vectorizer2.DefaultBaseURL {
+		if host == "" || host == "https://api.openai.com" {
 			// Fall back to old assumption
 			host = "https://" + resourceName + ".openai.azure.com"
 		}

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -16,11 +16,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	vectorizer2 "github.com/weaviate/weaviate/modules/text2vec-openai/vectorizer"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
+
+	vectorizer2 "github.com/weaviate/weaviate/modules/text2vec-openai/vectorizer"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -54,7 +54,12 @@ type openAIApiError struct {
 
 func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
 	if isAzure {
-		host := "https://" + resourceName + ".openai.azure.com"
+		host := baseURL
+		if host == "" {
+			// Fall back to old assumption
+			host = "https://" + resourceName + ".openai.azure.com"
+		}
+
 		path := "openai/deployments/" + deploymentID + "/embeddings"
 		queryParam := "api-version=2022-12-01"
 		return fmt.Sprintf("%s/%s?%s", host, path, queryParam), nil

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -58,6 +58,21 @@ func TestBuildUrlFn(t *testing.T) {
 		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/embeddings?api-version=2022-12-01", url)
 	})
 
+	t.Run("buildUrlFn returns Azure client with BaseUrl set", func(t *testing.T) {
+		config := ent.VectorizationConfig{
+			Type:         "",
+			Model:        "",
+			ModelVersion: "",
+			ResourceName: "resourceID",
+			DeploymentID: "deploymentID",
+			BaseURL:      "https://foobar.some.proxy",
+			IsAzure:      true,
+		}
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.IsAzure)
+		assert.Nil(t, err)
+		assert.Equal(t, "https://foobar.some.proxy/openai/deployments/deploymentID/embeddings?api-version=2022-12-01", url)
+	})
+
 	t.Run("buildUrlFn loads from BaseURL", func(t *testing.T) {
 		config := ent.VectorizationConfig{
 			Type:         "",


### PR DESCRIPTION
### What's being changed:

Fix #3588 - Let the text2vec-openai module be configured properly for AzureOpenAI.

As #3588 indicates the code https://github.com/weaviate/weaviate/blob/b10d399760f69d6b0a7ae00051c8f2f07f016b28/modules/text2vec-openai/clients/vectorizer.go#L56

 currently assumes that all Azure deployments use the base URL

```
"https://" + resourceName + ".openai.azure.com"
```

But this is no longer the case. My baseURL ends up being `https://eastus.api.cognitive.microsoft.com`

The [Azure docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=cli#get-the-endpoint-url) say the endpoint can be obtained by running this command

```
az cognitiveservices account show \
--name <myResourceName> \
--resource-group  <myResourceGroupName> \
| jq -r .properties.endpoint
```

The proposed fix allows the `baseURL` parameter to be used to set the baseURL in the case of Azure deployments

If the baseURL isn't set in the case of Azure then we fall back to the current code path. So this should preserve backwards compatibility

I've added a unittest to cover the case where baseURL is set in the case AzureOpenAI

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
