### PR TITLE
Return error if autoschema tries to create a prop by guessing the type

### DIFF
--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -732,14 +732,25 @@ func addTestDataCompanies(t *testing.T) {
 				})
 		}
 
-		createObject(t, &models.Object{
-			Class: "Company",
-			ID:    company.id,
-			Properties: map[string]interface{}{
-				"inCity": inCity,
-				"name":   company.name,
-			},
-		})
+		if len(inCity) > 0 {
+			createObject(t, &models.Object{
+				Class: "Company",
+				ID:    company.id,
+				Properties: map[string]interface{}{
+					"inCity": inCity,
+					"name":   company.name,
+				},
+			})
+		} else {
+			createObject(t, &models.Object{
+				Class: "Company",
+				ID:    company.id,
+				Properties: map[string]interface{}{
+					"name": company.name,
+				},
+			})
+		}
+
 	}
 
 	assertGetObjectEventually(t, companies[len(companies)-1].id)
@@ -790,15 +801,20 @@ func addTestDataPersons(t *testing.T) {
 				})
 		}
 
+		props := map[string]interface{}{
+			"name":       person.name,
+			"profession": person.profession,
+			"about":      person.about,
+		}
+
+		if len(person.livesIn) > 0 {
+			props["livesIn"] = livesIn
+		}
+
 		createObject(t, &models.Object{
-			Class: "Person",
-			ID:    person.id,
-			Properties: map[string]interface{}{
-				"livesIn":    livesIn,
-				"name":       person.name,
-				"profession": person.profession,
-				"about":      person.about,
-			},
+			Class:      "Person",
+			ID:         person.id,
+			Properties: props,
 		})
 	}
 

--- a/test/acceptance_with_go_client/autoschema_test.go
+++ b/test/acceptance_with_go_client/autoschema_test.go
@@ -197,24 +197,6 @@ func TestAutoschemaPanicOnUnregonizedDataType(t *testing.T) {
 			containsErrMessage: "property 'nilPropertyArray' on class 'BeautifulWeather': element [0]: unrecognized data type of value '<nil>'",
 		},
 		{
-			name: "empty string array property",
-			properties: map[string]interface{}{
-				"emptyPropertyArray": []string{},
-			},
-		},
-		{
-			name: "empty interface array property",
-			properties: map[string]interface{}{
-				"emptyPropertyArray": []interface{}{},
-			},
-		},
-		{
-			name: "empty int array property",
-			properties: map[string]interface{}{
-				"emptyPropertyArray": []int{},
-			},
-		},
-		{
 			name: "array property with empty string",
 			properties: map[string]interface{}{
 				"emptyPropertyArray": []string{""},
@@ -285,7 +267,7 @@ func TestAutoschemaPanicOnUnregonizedDataTypeWithBatch(t *testing.T) {
 				"stringProperty": "value",
 			},
 		}
-		resp, err := c.Batch().ObjectsBatcher().WithObject(obj).Do(ctx)
+		resp, err := c.Batch().ObjectsBatcher().WithObjects(obj).Do(ctx)
 		require.Nil(t, err)
 		require.Len(t, resp, 1)
 		require.NotNil(t, resp[0].Result)
@@ -299,5 +281,17 @@ func TestAutoschemaPanicOnUnregonizedDataTypeWithBatch(t *testing.T) {
 
 		err = c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 		require.Nil(t, err)
+	})
+
+	t.Run("should return an error if datatype cannot be determined", func(t *testing.T) {
+		obj := &models.Object{
+			Class: className,
+			Properties: map[string]interface{}{
+				"emptyArrayProp": []interface{}{},
+			},
+		}
+		resp, err := c.Batch().ObjectsBatcher().WithObjects(obj).Do(ctx)
+		require.Nil(t, err)
+		require.Contains(t, resp[0].Result.Errors.Error[0].Message, "AS001")
 	})
 }

--- a/usecases/objects/errors.go
+++ b/usecases/objects/errors.go
@@ -15,6 +15,9 @@ import (
 	"fmt"
 )
 
+// Errors with codes that the clients can evaluate - keep these stable
+var ErrAutoSchemaCannotDetermineObject = fmt.Errorf("AS001: cannot determine datatype of empty list")
+
 // objects status code
 const (
 	StatusForbidden           = 403


### PR DESCRIPTION
### What's being changed:

Autoschema tries to guess the type of emtpy lists as `text[]`, but it could be any other array datatype or empty references. 

Instead return an error with a detectable constant that the clients can use to resend the object. In batches there is a high probability that another object contains the property with a detectable type and the resend would succeed. Otherwise surface it to the user.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
