### PR TITLE
async: indexing from disk

### DIFF
--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -113,11 +113,11 @@ func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Ha
 func makeAddLogging(logger logrus.FieldLogger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// logger.
-			// 	WithField("action", "restapi_request").
-			// 	WithField("method", r.Method).
-			// 	WithField("url", r.URL).
-			// 	Debug("received HTTP request")
+			logger.
+				WithField("action", "restapi_request").
+				WithField("method", r.Method).
+				WithField("url", r.URL).
+				Debug("received HTTP request")
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -113,11 +113,11 @@ func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Ha
 func makeAddLogging(logger logrus.FieldLogger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger.
-				WithField("action", "restapi_request").
-				WithField("method", r.Method).
-				WithField("url", r.URL).
-				Debug("received HTTP request")
+			// logger.
+			// 	WithField("action", "restapi_request").
+			// 	WithField("method", r.Method).
+			// 	WithField("url", r.URL).
+			// 	Debug("received HTTP request")
 			next.ServeHTTP(w, r)
 		})
 	}


### PR DESCRIPTION
### What's being changed:


### Benchmarks

**On SSDs (M1 macbook)**

In-memory queue:
Import: 0:02:57.825880
Indexing: 13m35.915612542s

Indexing from disk:
Import: 0:03:04.710558 (+7s)
Indexing: 13m45.336531417s (+10s)

**On HDDs (gcp e2, 16GB ram, 4vcpus)**

In-memory queue:
Import: 0:05:55.609922
Indexing: 24m6.298858503s

Indexing from disk:
Import: 0:04:43.939849 (-1m12s)
Indexing: 25m1.233011265s (+43s)

Performance seems to be relatively similar, modulo disk caching probably.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
