### PR TITLE
RAFT acceptance test add cluster prefix parameter to allow starting a second cluster

### DIFF
--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -217,7 +217,7 @@ func immediateReplicaCRUD(t *testing.T) {
 		})
 
 		t.Run("assert object is patched on node 1", func(t *testing.T) {
-			after, err := getObjectFromNode(t, compose.ContainerURI(1), "Article", articleIDs[0], "node1")
+			after, err := getObjectFromNode(t, compose.ContainerURI(1), "Article", articleIDs[0], "1-node1")
 			require.Nil(t, err)
 
 			newVal, ok := after.Properties.(map[string]interface{})["title"]
@@ -240,7 +240,7 @@ func immediateReplicaCRUD(t *testing.T) {
 		})
 
 		t.Run("assert object removed from node 2", func(t *testing.T) {
-			_, err := getObjectFromNode(t, compose.ContainerURI(2), "Article", articleIDs[0], "node2")
+			_, err := getObjectFromNode(t, compose.ContainerURI(2), "Article", articleIDs[0], "1-node2")
 			assert.Equal(t, &objects.ObjectsClassGetNotFound{}, err)
 		})
 
@@ -367,7 +367,7 @@ func eventualReplicaCRUD(t *testing.T) {
 			})
 
 			t.Run("assert object is patched on node 1", func(t *testing.T) {
-				after, err := getObjectFromNode(t, compose.GetWeaviate().URI(), "Article", articleIDs[0], "node1")
+				after, err := getObjectFromNode(t, compose.GetWeaviate().URI(), "Article", articleIDs[0], "1-node1")
 				require.Nil(t, err)
 
 				newVal, ok := after.Properties.(map[string]interface{})["title"]
@@ -391,7 +391,7 @@ func eventualReplicaCRUD(t *testing.T) {
 			})
 
 			t.Run("assert object removed from node 2", func(t *testing.T) {
-				_, err := getObjectFromNode(t, compose.GetWeaviateNode2().URI(), "Article", articleIDs[0], "node2")
+				_, err := getObjectFromNode(t, compose.GetWeaviateNode2().URI(), "Article", articleIDs[0], "1-node2")
 				assert.Equal(t, &objects.ObjectsClassGetNotFound{}, err)
 			})
 
@@ -424,8 +424,8 @@ func eventualReplicaCRUD(t *testing.T) {
 }
 
 func restartNode1(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-	// since node1 is the gossip "leader", node 2 must be stopped and restarted
-	// after node1 to re-facilitate internode communication
+	// since 1-node1 is the gossip "leader", 1-node2 must be stopped and restarted
+	// after 1-node1 to re-facilitate internode communication
 	eg := errgroup.Group{}
 	eg.Go(func() error {
 		require.Nil(t, compose.StartAt(ctx, 1))

--- a/test/acceptance/replication/multi_tenancy_test.go
+++ b/test/acceptance/replication/multi_tenancy_test.go
@@ -210,7 +210,7 @@ func multiTenancyEnabled(t *testing.T) {
 
 		t.Run("assert object is patched on node 1", func(t *testing.T) {
 			after, err := getTenantObjectFromNode(t, compose.ContainerURI(1),
-				"Article", articleIDs[0], "node1", tenantID.String())
+				"Article", articleIDs[0], "1-node1", tenantID.String())
 			require.Nil(t, err)
 
 			newVal, ok := after.Properties.(map[string]interface{})["title"]
@@ -234,7 +234,7 @@ func multiTenancyEnabled(t *testing.T) {
 
 		t.Run("assert object removed from node 2", func(t *testing.T) {
 			_, err := getTenantObjectFromNode(t, compose.ContainerURI(2),
-				"Article", articleIDs[0], "node2", tenantID.String())
+				"Article", articleIDs[0], "1-node2", tenantID.String())
 			assert.Equal(t, &objects.ObjectsClassGetNotFound{}, err)
 		})
 

--- a/test/docker/contextionary.go
+++ b/test/docker/contextionary.go
@@ -39,7 +39,7 @@ func startT2VContextionary(ctx context.Context, networkName, contextionaryImage 
 			Env: map[string]string{
 				"OCCURRENCE_WEIGHT_LINEAR_FACTOR": "0.75",
 				"EXTENSIONS_STORAGE_MODE":         "weaviate",
-				"EXTENSIONS_STORAGE_ORIGIN":       fmt.Sprintf("http://%s:8080", Weaviate1),
+				"EXTENSIONS_STORAGE_ORIGIN":       fmt.Sprintf("http://1-%s:8080", Weaviate1),
 			},
 			ExposedPorts: []string{"9999/tcp"},
 			AutoRemove:   true,

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -123,15 +123,15 @@ func (d *DockerCompose) GetAzurite() *DockerContainer {
 }
 
 func (d *DockerCompose) GetWeaviate() *DockerContainer {
-	return d.getContainerByName(Weaviate1)
+	return d.getContainerByName("1-" + Weaviate1)
 }
 
 func (d *DockerCompose) GetSecondWeaviate() *DockerContainer {
-	return d.getContainerByName(SecondWeaviate)
+	return d.getContainerByName("2-" + Weaviate1)
 }
 
 func (d *DockerCompose) GetWeaviateNode2() *DockerContainer {
-	return d.getContainerByName(Weaviate2)
+	return d.getContainerByName("1-" + Weaviate2)
 }
 
 func (d *DockerCompose) GetText2VecTransformers() *DockerContainer {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -25,10 +25,9 @@ import (
 )
 
 const (
-	Weaviate1      = "weaviate"
-	Weaviate2      = "weaviate2"
-	Weaviate3      = "weaviate3"
-	SecondWeaviate = "second-weaviate"
+	Weaviate1 = "weaviate"
+	Weaviate2 = "weaviate2"
+	Weaviate3 = "weaviate3"
 )
 
 func startWeaviate(ctx context.Context,

--- a/test/modules/backup-azure/node_mapping_backup_journey_test.go
+++ b/test/modules/backup-azure/node_mapping_backup_journey_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func Test_NodeMappingBackupJourney(t *testing.T) {
-	t.Skip("TODO-RAFT: need to start a second 1 node cluster to work")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
@@ -57,7 +56,7 @@ func Test_NodeMappingBackupJourney(t *testing.T) {
 		t.Run("restore-azure", func(t *testing.T) {
 			journey.NodeMappingBackupJourneyTests_SingleNode_Restore(t, compose.GetSecondWeaviate().URI(),
 				"azure", azureBackupJourneyClassName, azureBackupJourneyBackupIDSingleNode, nil, map[string]string{
-					docker.Weaviate1: docker.SecondWeaviate,
+					"1-node1": "2-node1",
 				})
 		})
 

--- a/test/modules/backup-gcs/node_mapping_backup_journey_test.go
+++ b/test/modules/backup-gcs/node_mapping_backup_journey_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func Test_NodeMappingBackupJourney(t *testing.T) {
-	t.Skip("TODO-RAFT: need to start a second 1 node cluster to work")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
@@ -64,7 +63,7 @@ func Test_NodeMappingBackupJourney(t *testing.T) {
 		t.Run("restore-gcs", func(t *testing.T) {
 			journey.NodeMappingBackupJourneyTests_SingleNode_Restore(t, compose.GetSecondWeaviate().URI(),
 				"gcs", gcsBackupJourneyClassName, gcsBackupJourneyBackupIDSingleNode, nil, map[string]string{
-					docker.Weaviate1: docker.SecondWeaviate,
+					"1-node1": "2-node1",
 				})
 		})
 	})

--- a/test/modules/backup-s3/node_mapping_backup_journey_test.go
+++ b/test/modules/backup-s3/node_mapping_backup_journey_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func Test_NodeMappingBackupJourney(t *testing.T) {
-	t.Skip("TODO-RAFT: need to start a second 1 node cluster to work")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
@@ -62,7 +61,7 @@ func Test_NodeMappingBackupJourney(t *testing.T) {
 		t.Run("restore-s3", func(t *testing.T) {
 			journey.NodeMappingBackupJourneyTests_SingleNode_Restore(t, compose.GetSecondWeaviate().URI(),
 				"s3", s3BackupJourneyClassName, s3BackupJourneyBackupIDSingleNode, nil, map[string]string{
-					docker.Weaviate1: docker.SecondWeaviate,
+					"1-node1": "2-node1",
 				})
 		})
 	})

--- a/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
+++ b/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
@@ -61,16 +61,16 @@ func Test_WeaviateCluster_NodesAPI(t *testing.T) {
 				require.NotNil(t, nodes)
 				require.Len(t, nodes, 2)
 
-				assert.Equal(t, "node1", nodes[0].Name)
-				assert.Equal(t, "node2", nodes[1].Name)
+				assert.Equal(t, "1-node1", nodes[0].Name)
+				assert.Equal(t, "1-node2", nodes[1].Name)
 
 				for i, nodeStatus := range nodes {
 					require.NotNil(t, nodeStatus)
 					assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 					if i == 0 {
-						assert.Equal(t, "node1", nodeStatus.Name)
+						assert.Equal(t, "1-node1", nodeStatus.Name)
 					} else {
-						assert.Equal(t, "node2", nodeStatus.Name)
+						assert.Equal(t, "1-node2", nodeStatus.Name)
 					}
 					assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
 					assert.Len(t, nodeStatus.Shards, 2)


### PR DESCRIPTION
### What's being changed:

* Add a new clusterPrefix parameter when starting a weaviate cluster in acceptance
* use new clusterPrefix parameter to logically separate group of weaviate node into cluster


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
