### PR TITLE
async: fix double close of chunk channel

### DIFF
--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -782,7 +782,13 @@ func (q *vectorQueue) borrowChunks(max int) []*chunk {
 }
 
 func (q *vectorQueue) releaseChunk(c *chunk) {
-	close(c.indexed)
+	if c == nil {
+		return
+	}
+
+	if c.indexed != nil {
+		close(c.indexed)
+	}
 
 	q.fullChunks.Lock()
 	if c.elem != nil {
@@ -801,7 +807,9 @@ func (q *vectorQueue) releaseChunk(c *chunk) {
 
 	q.fullChunks.Unlock()
 
-	q.pool.Put(&data)
+	if len(data) == q.IndexQueue.BatchSize {
+		q.pool.Put(&data)
+	}
 }
 
 // persistCheckpoint update the on-disk checkpoint that tracks the last indexed id


### PR DESCRIPTION
### What's being changed:

This makes sure the chunk releasing is idempotent, as workers can potentially release chunks twice because of retries.

Fixes https://github.com/weaviate/weaviate/issues/3823

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
