### PR TITLE
Download SIFT dataset when not present

### DIFF
--- a/test/benchmark/run_performance_tracker.sh
+++ b/test/benchmark/run_performance_tracker.sh
@@ -3,4 +3,16 @@
 # change to script directory
 cd "${0%/*}" || exit
 
+# create benchmark/sift directory
+mkdir -p ./sift
+
+# check that the files sift_base.fvecs and sift_query.fvecs exist in the benchmark/sift directory.
+# download them otherwise.
+if [ ! -f "./sift/sift_base.fvecs" ] || [ ! -f "./sift/sift_query.fvecs" ]; then
+  echo "Downloading SIFT dataset"
+  wget ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz -P /tmp/
+  tar -xvf /tmp/sift.tar.gz -C /tmp
+  mv /tmp/sift/sift_base.fvecs  /tmp/sift/sift_query.fvecs ./sift/
+fi
+
 go run . -name "SIFT" -numberEntries 100000 -fail "-1" -numBatches "1"


### PR DESCRIPTION
### What's being changed:
The test/benchmark test case was relying on the fact that the user would create a /sift folder under the test/benchmark directory, in which the SIFT dataset would be downloaded (only the files sift_query.fvecs. and sift_base.fvecs). However, this point isn't being documented anywhere in the code. And even if you dig into the code, it isn't clear which SIFT dataset is expected to be downloaded.

This PR adds a block which takes care of the creation of the sift folder, as well as the downloading of the SIFT dataset in case it doesn't exist, if it does exist it will just go directly to running the benchmark test.

```
Weaviate is up and running!
Run performance tracker...
Downloading SIFT dataset
--2024-01-15 09:36:45--  ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz
           => ‘/tmp/sift.tar.gz’
Resolving ftp.irisa.fr (ftp.irisa.fr)... 131.254.254.45
Connecting to ftp.irisa.fr (ftp.irisa.fr)|131.254.254.45|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /local/texmex/corpus ... done.
==> SIZE sift.tar.gz ... 168280445
==> PASV ... done.    ==> RETR sift.tar.gz ... done.
Length: 168280445 (160M) (unauthoritative)

sift.tar.gz                       100%[============================================================>] 160.48M  22.9MB/s    in 7.7s

2024-01-15 09:36:54 (20.9 MB/s) - ‘/tmp/sift.tar.gz’ saved [168280445]

x sift/
x sift/sift_base.fvecs
x sift/sift_groundtruth.ivecs
x sift/sift_learn.fvecs
x sift/sift_query.fvecs
Weaviate instance already running.
Runtime for benchmark SIFT-100000_Entries-1_Batch(es): old total runtime: 166188ms, new total runtime:166895ms.
```  

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.
