### PR TITLE
fix: backup assign defaults on paritals config

### DIFF
--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -31,6 +31,19 @@ type backupHandlers struct {
 // compressionFromCfg transforms model backup config to a backup compression config
 func compressionFromCfg(cfg *models.BackupConfig) ubak.Compression {
 	if cfg != nil {
+		if cfg.CPUPercentage == 0 {
+			cfg.CPUPercentage = ubak.DefaultCPUPercentage
+		}
+
+		if cfg.ChunkSize == 0 {
+			cfg.ChunkSize = ubak.DefaultChunkSize
+		}
+
+		if cfg.CompressionLevel == nil {
+			dc := models.BackupConfigCompressionLevelDefaultCompression
+			cfg.CompressionLevel = &dc
+		}
+
 		return ubak.Compression{
 			CPUPercentage: int(cfg.CPUPercentage),
 			ChunkSize:     int(cfg.ChunkSize),

--- a/adapters/handlers/rest/handlers_backup_test.go
+++ b/adapters/handlers/rest/handlers_backup_test.go
@@ -43,6 +43,30 @@ func TestCompressionCfg(t *testing.T) {
 			expectedCPU:         25,
 			expectedChunkSize:   512,
 		},
+		"with partial config [CPU]": {
+			cfg: &models.BackupConfig{
+				CPUPercentage: 25,
+			},
+			expectedCompression: ubak.DefaultCompression,
+			expectedCPU:         25,
+			expectedChunkSize:   ubak.DefaultChunkSize,
+		},
+		"with partial config [ChunkSize]": {
+			cfg: &models.BackupConfig{
+				ChunkSize: 125,
+			},
+			expectedCompression: ubak.DefaultCompression,
+			expectedCPU:         ubak.DefaultCPUPercentage,
+			expectedChunkSize:   125,
+		},
+		"with partial config [Compression]": {
+			cfg: &models.BackupConfig{
+				CompressionLevel: &l,
+			},
+			expectedCompression: ubak.BestSpeed,
+			expectedCPU:         ubak.DefaultCPUPercentage,
+			expectedChunkSize:   ubak.DefaultChunkSize,
+		},
 	}
 
 	for n, tc := range tcs {


### PR DESCRIPTION
### What's being changed:
if config is passed `{}` as an empty object , atm  it passes the validation, however to make sure we gonna assign the defaults for partial config passed 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
