### PR TITLE
map correct dtype when filtering references by count

### DIFF
--- a/adapters/handlers/grpc/v1/filters.go
+++ b/adapters/handlers/grpc/v1/filters.go
@@ -268,7 +268,10 @@ func extractPathNew(scheme schema.Schema, className string, target *pb.FilterTar
 		if len(refProp.DataType) != 1 {
 			return nil, "", fmt.Errorf("expected reference property with a single target, got %v for %v ", refProp.DataType, refProp.Name)
 		}
-
+		if singleTarget.Target == nil {
+			// This is a reference count filter request
+			return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(normalizedRefPropName), Child: nil}, schema.DataTypeInt, nil
+		}
 		child, property, err := extractPathNew(scheme, refProp.DataType[0], singleTarget.Target, operator)
 		if err != nil {
 			return nil, "", err
@@ -276,11 +279,16 @@ func extractPathNew(scheme schema.Schema, className string, target *pb.FilterTar
 		return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(normalizedRefPropName), Child: child}, property, nil
 	case *pb.FilterTarget_MultiTarget:
 		multiTarget := target.GetMultiTarget()
+		normalizedRefPropName := schema.LowercaseFirstLetter(multiTarget.On)
+		if multiTarget.Target == nil {
+			// This is a reference count filter request
+			return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(normalizedRefPropName), Child: nil}, schema.DataTypeInt, nil
+		}
 		child, property, err := extractPathNew(scheme, multiTarget.TargetCollection, multiTarget.Target, operator)
 		if err != nil {
 			return nil, "", err
 		}
-		return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(schema.LowercaseFirstLetter(multiTarget.On)), Child: child}, property, nil
+		return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(normalizedRefPropName), Child: child}, property, nil
 	default:
 		return nil, "", fmt.Errorf("unknown target type %v", target)
 	}

--- a/adapters/handlers/grpc/v1/filters.go
+++ b/adapters/handlers/grpc/v1/filters.go
@@ -179,7 +179,6 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 		returnFilter.Value = &value
 
 	}
-
 	return returnFilter, nil
 }
 
@@ -210,6 +209,11 @@ func extractDataTypeProperty(scheme schema.Schema, operator filters.Operator, cl
 		prop, err := scheme.GetProperty(schema.ClassName(classname), schema.PropertyName(propToCheck))
 		if err != nil {
 			return dataType, err
+		}
+		if schema.IsRefDataType(prop.DataType) {
+			// This is a filter on a reference property without a path so is counting
+			// the number of references. Needs schema.DataTypeInt: entities/filters/filters_validator.go#L116-L127
+			return schema.DataTypeInt, nil
 		}
 		dataType = schema.DataType(prop.DataType[0])
 	}

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -678,6 +678,33 @@ func TestGRPCRequest(t *testing.T) {
 			error: false,
 		},
 		{
+			name: "count filter ref",
+			req: &pb.SearchRequest{
+				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_LESS_THAN,
+					TestValue: &pb.Filters_ValueInt{ValueInt: 3},
+					On:        []string{"ref"},
+				},
+			},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultTestClassProps,
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
+				Filters: &filters.LocalFilter{
+					Root: &filters.Clause{
+						On: &filters.Path{
+							Class:    schema.ClassName(classname),
+							Property: "ref",
+						},
+						Operator: filters.OperatorLessThan,
+						Value:    &filters.Value{Value: 3, Type: schema.DataTypeInt},
+					},
+				},
+			},
+			error: false,
+		},
+		{
 			name: "length filter",
 			req: &pb.SearchRequest{
 				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -678,7 +678,7 @@ func TestGRPCRequest(t *testing.T) {
 			error: false,
 		},
 		{
-			name: "count filter ref",
+			name: "count filter single target ref old",
 			req: &pb.SearchRequest{
 				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
 				Filters: &pb.Filters{
@@ -696,6 +696,90 @@ func TestGRPCRequest(t *testing.T) {
 						On: &filters.Path{
 							Class:    schema.ClassName(classname),
 							Property: "ref",
+						},
+						Operator: filters.OperatorLessThan,
+						Value:    &filters.Value{Value: 3, Type: schema.DataTypeInt},
+					},
+				},
+			},
+			error: false,
+		},
+		{
+			name: "count filter single target ref new",
+			req: &pb.SearchRequest{
+				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_LESS_THAN,
+					TestValue: &pb.Filters_ValueInt{ValueInt: 3},
+					Target:    &pb.FilterTarget{Target: &pb.FilterTarget_SingleTarget{SingleTarget: &pb.FilterReferenceSingleTarget{On: "ref"}}},
+				},
+			},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultTestClassProps,
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
+				Filters: &filters.LocalFilter{
+					Root: &filters.Clause{
+						On: &filters.Path{
+							Class:    schema.ClassName(classname),
+							Property: "ref",
+						},
+						Operator: filters.OperatorLessThan,
+						Value:    &filters.Value{Value: 3, Type: schema.DataTypeInt},
+					},
+				},
+			},
+			error: false,
+		},
+		{
+			name: "count filter multi target ref old",
+			req: &pb.SearchRequest{
+				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_LESS_THAN,
+					TestValue: &pb.Filters_ValueInt{ValueInt: 3},
+					On:        []string{"multiRef"},
+				},
+			},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultTestClassProps,
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
+				Filters: &filters.LocalFilter{
+					Root: &filters.Clause{
+						On: &filters.Path{
+							Class:    schema.ClassName(classname),
+							Property: "multiRef",
+						},
+						Operator: filters.OperatorLessThan,
+						Value:    &filters.Value{Value: 3, Type: schema.DataTypeInt},
+					},
+				},
+			},
+			error: false,
+		},
+		{
+			name: "count filter multi target ref new",
+			req: &pb.SearchRequest{
+				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_LESS_THAN,
+					TestValue: &pb.Filters_ValueInt{ValueInt: 3},
+					Target: &pb.FilterTarget{Target: &pb.FilterTarget_MultiTarget{MultiTarget: &pb.FilterReferenceMultiTarget{
+						On:               "multiRef",
+						TargetCollection: refClass1,
+					}}},
+				},
+			},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination,
+				Properties:           defaultTestClassProps,
+				AdditionalProperties: additional.Properties{Vector: true, NoProps: false},
+				Filters: &filters.LocalFilter{
+					Root: &filters.Clause{
+						On: &filters.Path{
+							Class:    schema.ClassName(classname),
+							Property: "multiRef",
 						},
 						Operator: filters.OperatorLessThan,
 						Value:    &filters.Value{Value: 3, Type: schema.DataTypeInt},


### PR DESCRIPTION
### What's being changed:

This PR fixes [a bug](https://github.com/weaviate/weaviate/issues/4027) when filtering through the gRPC API by the number of references within an object

Thanks @savvasmohito for reporting it!

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
