### PR TITLE
Fix sharded locks lock contention

### DIFF
--- a/adapters/repos/db/vector/sharded_locks.go
+++ b/adapters/repos/db/vector/sharded_locks.go
@@ -16,55 +16,50 @@ import "sync"
 const DefaultShardedLocksCount = 512
 
 type ShardedLocks struct {
-	// number of locks
-	count int
-	// ensures single LockAll and multiple RLockAll, Lock and RLock
-	// LockAll is exclusive to RLockAll, Lock, RLock
-	writeAll *sync.RWMutex
-	// indicates whether write of any single shard is ongoing, exclusive with readAll
-	writeAny *sync.RWMutex
-	// indicates whether read of all shards is ongoing, exclusive with writeAny
-	readAll *sync.RWMutex
-	// allows safe transition between writeAny and readAll
-	change *sync.RWMutex
 	// sharded locks
-	shards []*sync.RWMutex
+	shards []Shard
+	// number of locks
+	count uint64
+}
+
+type Shard struct {
+	// shared lock for shard
+	shardLock sync.RWMutex
+	// Each read must acquire a read rlock.
+	// Locking it for writing (Lock()) prevents any reads from happening.
+	readLock sync.RWMutex
+	// Each write must acquire a write rlock.
+	// Locking it for writing (Lock()) prevents any writes from happening.
+	writeLock sync.RWMutex
 }
 
 func NewDefaultShardedLocks() *ShardedLocks {
 	return NewShardedLocks(DefaultShardedLocksCount)
 }
 
-func NewShardedLocks(count int) *ShardedLocks {
+func NewShardedLocks(count uint64) *ShardedLocks {
 	if count < 2 {
 		count = 2
 	}
 
-	writeAll := new(sync.RWMutex)
-	writeAny := new(sync.RWMutex)
-	readAll := new(sync.RWMutex)
-	change := new(sync.RWMutex)
-	shards := make([]*sync.RWMutex, count)
-	for i := 0; i < count; i++ {
-		shards[i] = new(sync.RWMutex)
-	}
-
 	return &ShardedLocks{
-		count:    count,
-		writeAll: writeAll,
-		readAll:  readAll,
-		writeAny: writeAny,
-		change:   change,
-		shards:   shards,
+		shards: make([]Shard, count),
+		count:  count,
 	}
 }
 
 func (sl *ShardedLocks) LockAll() {
-	sl.writeAll.Lock()
+	for i := uint64(0); i < sl.count; i++ {
+		sl.shards[i].writeLock.Lock()
+		sl.shards[i].readLock.Lock()
+	}
 }
 
 func (sl *ShardedLocks) UnlockAll() {
-	sl.writeAll.Unlock()
+	for i := int(sl.count) - 1; i >= 0; i-- {
+		sl.shards[i].readLock.Unlock()
+		sl.shards[i].writeLock.Unlock()
+	}
 }
 
 func (sl *ShardedLocks) LockedAll(callback func()) {
@@ -75,15 +70,15 @@ func (sl *ShardedLocks) LockedAll(callback func()) {
 }
 
 func (sl *ShardedLocks) Lock(id uint64) {
-	sl.writeAll.RLock()
-	sl.markOngoingWriteAny()
-	sl.shards[sl.mid(id)].Lock()
+	shard := &sl.shards[id%sl.count]
+	shard.writeLock.RLock()
+	shard.shardLock.Lock()
 }
 
 func (sl *ShardedLocks) Unlock(id uint64) {
-	sl.shards[sl.mid(id)].Unlock()
-	sl.writeAny.RUnlock()
-	sl.writeAll.RUnlock()
+	shard := &sl.shards[id%sl.count]
+	shard.shardLock.Unlock()
+	shard.writeLock.RUnlock()
 }
 
 func (sl *ShardedLocks) Locked(id uint64, callback func()) {
@@ -94,13 +89,15 @@ func (sl *ShardedLocks) Locked(id uint64, callback func()) {
 }
 
 func (sl *ShardedLocks) RLockAll() {
-	sl.writeAll.RLock()
-	sl.markOngoingReadAll()
+	for i := uint64(0); i < sl.count; i++ {
+		sl.shards[i].writeLock.Lock()
+	}
 }
 
 func (sl *ShardedLocks) RUnlockAll() {
-	sl.readAll.RUnlock()
-	sl.writeAll.RUnlock()
+	for i := int(sl.count) - 1; i >= 0; i-- {
+		sl.shards[i].writeLock.Unlock()
+	}
 }
 
 func (sl *ShardedLocks) RLockedAll(callback func()) {
@@ -111,13 +108,15 @@ func (sl *ShardedLocks) RLockedAll(callback func()) {
 }
 
 func (sl *ShardedLocks) RLock(id uint64) {
-	sl.writeAll.RLock()
-	sl.shards[sl.mid(id)].RLock()
+	shard := &sl.shards[id%sl.count]
+	shard.readLock.RLock()
+	shard.shardLock.RLock()
 }
 
 func (sl *ShardedLocks) RUnlock(id uint64) {
-	sl.shards[sl.mid(id)].RUnlock()
-	sl.writeAll.RUnlock()
+	group := &sl.shards[id%sl.count]
+	group.shardLock.RUnlock()
+	group.readLock.RUnlock()
 }
 
 func (sl *ShardedLocks) RLocked(id uint64, callback func()) {
@@ -125,30 +124,4 @@ func (sl *ShardedLocks) RLocked(id uint64, callback func()) {
 	defer sl.RUnlock(id)
 
 	callback()
-}
-
-func (sl *ShardedLocks) mid(id uint64) uint64 {
-	return id % uint64(sl.count)
-}
-
-func (sl *ShardedLocks) markOngoingWriteAny() {
-	sl.change.RLock()
-	defer sl.change.RUnlock()
-
-	// wait until no ongoing readAll
-	sl.readAll.Lock()
-	// mark ongoing writeAny
-	sl.writeAny.RLock()
-	sl.readAll.Unlock()
-}
-
-func (sl *ShardedLocks) markOngoingReadAll() {
-	sl.change.Lock()
-	defer sl.change.Unlock()
-
-	// wait until no ongoing writeAny
-	sl.writeAny.Lock()
-	// mark ongoing readAll
-	sl.readAll.RLock()
-	sl.writeAny.Unlock()
 }

--- a/adapters/repos/db/vector/sharded_locks_test.go
+++ b/adapters/repos/db/vector/sharded_locks_test.go
@@ -14,6 +14,9 @@ package vector
 import (
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestShardedLocks_ParallelLocksAll(t *testing.T) {
@@ -107,4 +110,324 @@ func TestShardedLocks_MixedLocks(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestShardedLocks(t *testing.T) {
+	t.Run("RLock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.RLock(1)
+		m.RLock(1)
+
+		m.RUnlock(1)
+		m.RUnlock(1)
+	})
+
+	t.Run("Lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.Lock(1)
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(time.Millisecond)
+			m.Unlock(1)
+
+			close(ch)
+		}()
+
+		m.Lock(1)
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.Unlock(1)
+	})
+
+	t.Run("RLock blocks Lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.RLock(1)
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.RUnlock(1)
+
+			close(ch)
+		}()
+
+		m.Lock(1)
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.Unlock(1)
+	})
+
+	t.Run("Lock blocks RLock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.Lock(1)
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			m.Unlock(1)
+
+			close(ch)
+		}()
+
+		m.RLock(1)
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.RUnlock(1)
+	})
+
+	t.Run("Lock blocks LockAll", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.Lock(1)
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.Unlock(1)
+
+			close(ch)
+		}()
+
+		m.LockAll()
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.UnlockAll()
+	})
+
+	t.Run("LockAll blocks Lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.UnlockAll()
+
+			close(ch)
+		}()
+
+		m.Lock(1)
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.Unlock(1)
+	})
+
+	t.Run("LockAll blocks RLock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.UnlockAll()
+
+			close(ch)
+		}()
+
+		m.RLock(1)
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.RUnlock(1)
+	})
+
+	t.Run("LockAll blocks LockAll", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.UnlockAll()
+
+			close(ch)
+		}()
+
+		m.LockAll()
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.UnlockAll()
+	})
+
+	t.Run("UnlockAll releases all locks", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+		m.UnlockAll()
+
+		m.Lock(1)
+		m.Unlock(1)
+
+		m.RLock(1)
+		m.RUnlock(1)
+	})
+
+	t.Run("RLockAll blocks Lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.RLockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.RUnlockAll()
+
+			close(ch)
+		}()
+
+		m.Lock(1)
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.Unlock(1)
+	})
+
+	t.Run("RLockAll doesn't block/unblock RLock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.RLockAll()
+		m.RLock(1)
+
+		m.RUnlockAll()
+		m.RUnlock(1)
+	})
+
+	t.Run("RLockAll blocks LockAll", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.RLockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.RUnlockAll()
+
+			close(ch)
+		}()
+
+		m.LockAll()
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.UnlockAll()
+	})
+
+	t.Run("RLockAll doesn't block RLockAll", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.RLockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			m.RUnlockAll()
+
+			close(ch)
+		}()
+
+		m.RLockAll()
+
+		select {
+		case <-ch:
+		default:
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.RUnlockAll()
+	})
+
+	t.Run("unlock should wake up next waiting lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(2)
+
+		m.RLock(1)
+
+		ch1 := make(chan struct{})
+		ch2 := make(chan struct{})
+
+		go func() {
+			defer close(ch1)
+
+			m.Lock(1)
+		}()
+
+		go func() {
+			defer close(ch2)
+
+			time.Sleep(100 * time.Millisecond)
+			m.Lock(1)
+		}()
+
+		time.Sleep(10 * time.Millisecond)
+		m.RUnlock(1)
+
+		<-ch1
+
+		m.Unlock(1)
+
+		<-ch2
+	})
 }

--- a/adapters/repos/db/vector/sharded_locks_test.go
+++ b/adapters/repos/db/vector/sharded_locks_test.go
@@ -415,5 +415,7 @@ func TestShardedLocks(t *testing.T) {
 		m.Unlock(1)
 
 		<-ch2
+
+		m.Unlock(1)
 	})
 }

--- a/adapters/repos/db/vector/sharded_locks_test.go
+++ b/adapters/repos/db/vector/sharded_locks_test.go
@@ -379,23 +379,9 @@ func TestShardedLocks(t *testing.T) {
 		m := NewShardedLocks(5)
 
 		m.RLockAll()
-
-		ch := make(chan struct{})
-		go func() {
-			time.Sleep(500 * time.Millisecond)
-			m.RUnlockAll()
-
-			close(ch)
-		}()
-
 		m.RLockAll()
 
-		select {
-		case <-ch:
-		default:
-			require.Fail(t, "should be unlocked")
-		}
-
+		m.RUnlockAll()
 		m.RUnlockAll()
 	})
 


### PR DESCRIPTION
### What's being changed:

This is a small redesign of the sharded locks type that focuses on Lock and RLock latency.

## Performance improvements

### Apple Silicon

| Version      | GraphQL benchmark | gRPC |
| ------------ | ----------------- | ---- |
| v1.22.4      | 2m58              | 1m39 |
| stable/v1.22 | 13m53             | 10m17     |
| New version  | 2m51              | 1m32 |

### Intel x86

| Version      | GraphQL benchmark | gRPC |
| ------------ | ----------------- | ---- |
| v1.22.4      | 5m36              | 3m28 |
| stable/v1.22 | 7m51             | 5m5     |
| New version  | 5m41              | 3m29 |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/7569356062
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
