### PR TITLE
Class and Property name max length validation

### DIFF
--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -24,9 +24,23 @@ var (
 )
 
 const (
-	ClassNameRegexCore      = `[A-Z][_0-9A-Za-z]*`
-	ShardNameRegexCore      = `[A-Za-z0-9\-\_]{1,64}`
-	PropertyNameRegex       = `[_A-Za-z][_0-9A-Za-z]*`
+	// Restricted by max length allowed for dir name (255 chars)
+	// As dir containing class data is named after class, 255 chars are allowed
+	classNameMaxLength = 255
+	ClassNameRegexCore = `[A-Z][_0-9A-Za-z]{0,254}`
+	ShardNameRegexCore = `[A-Za-z0-9\-\_]{1,64}`
+	// Restricted by max length allowed for dir name (255 chars)
+	// Property name is used to build dir names of various purposes containing property
+	// related data. Among them might be (depending on the settings):
+	// - geo.{property_name}.hnsw.commitlog.d
+	// - property_{property_name}__meta_count
+	// - property_{property_name}_propertyLength
+	// Last one seems to add the most additional characters (24) to property name,
+	// therefore poperty max lentgh should not exceed 255 - 24 = 231 chars.
+	propertyNameMaxLength = 231
+	PropertyNameRegex     = `[_A-Za-z][_0-9A-Za-z]{0,230}`
+	// Nested properties names are not used to build directory names (yet),
+	// no max length restriction is imposed
 	NestedPropertyNameRegex = `[_A-Za-z][_0-9A-Za-z]*`
 )
 
@@ -39,14 +53,22 @@ func init() {
 
 // ValidateClassName validates that this string is a valid class name (format wise)
 func ValidateClassName(name string) (ClassName, error) {
-	if validateClassNameRegex.MatchString(name) {
-		return ClassName(name), nil
+	if len(name) > classNameMaxLength {
+		return "", fmt.Errorf("'%s' is not a valid class name. Name should not be longer than %d characters.",
+			name, classNameMaxLength)
 	}
-	return "", fmt.Errorf("'%s' is not a valid class name", name)
+	if !validateClassNameRegex.MatchString(name) {
+		return "", fmt.Errorf("'%s' is not a valid class name", name)
+	}
+	return ClassName(name), nil
 }
 
 // ValidatePropertyName validates that this string is a valid property name
 func ValidatePropertyName(name string) (PropertyName, error) {
+	if len(name) > propertyNameMaxLength {
+		return "", fmt.Errorf("'%s' is not a valid property name. Name should not be longer than %d characters.",
+			name, propertyNameMaxLength)
+	}
 	if !validatePropertyNameRegex.MatchString(name) {
 		return "", fmt.Errorf("'%s' is not a valid property name. "+
 			"Property names in Weaviate are restricted to valid GraphQL names, "+

--- a/entities/schema/validation_test.go
+++ b/entities/schema/validation_test.go
@@ -13,139 +13,78 @@ package schema
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateOKClassName(t *testing.T) {
-	_, err := ValidateClassName("FooBar")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("FooBar2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("Foo_______bar__with_numbers___1234567890_and_2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("C_123456___foo_bar_2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("NormalClassNameWithNumber1")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("Normal__Class__Name__With__Number__1")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("CClassName")
-	if err != nil {
-		t.Fail()
+	for _, name := range []string{
+		"A",
+		"FooBar",
+		"FooBar2",
+		"Foo_______bar__with_numbers___1234567890_and_2",
+		"C_123456___foo_bar_2",
+		"NormalClassNameWithNumber1",
+		"Normal__Class__Name__With__Number__1",
+		"CClassName",
+		"ThisClassNameHasExactly255Characters_MaximumAllowed____________________qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ValidateClassName(name)
+			assert.NoError(t, err)
+		})
 	}
 }
 
 func TestFailValidateBadClassName(t *testing.T) {
-	_, err := ValidateClassName("Foo Bar")
-	if err == nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("foo")
-	if err == nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("fooBar")
-	if err == nil {
-		t.Fail()
-	}
-
-	_, err = ValidateClassName("_foo")
-	if err == nil {
-		t.Fail()
+	for _, name := range []string{
+		"",
+		"Foo Bar",
+		"foo",
+		"fooBar",
+		"_foo",
+		"ThisClassNameHasMoreThan255Characters_MaximumAllowed____________________qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ValidateClassName(name)
+			assert.Error(t, err)
+		})
 	}
 }
 
 func TestValidateOKPropertyName(t *testing.T) {
-	// valid proper names
-	_, err := ValidatePropertyName("fooBar")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("fooBar2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("_fooBar2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("intField")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("hasAction")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("_foo_bar_2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("______foo_bar_2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("___123456___foo_bar_2")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("a_very_Long_property_Name__22_with_numbers_9")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("a_very_Long_property_Name__22_with_numbers_9880888800888800008")
-	if err != nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("FooBar")
-	if err != nil {
-		t.Fail()
+	for _, name := range []string{
+		"fooBar",
+		"fooBar2",
+		"_fooBar2",
+		"intField",
+		"hasAction",
+		"_foo_bar_2",
+		"______foo_bar_2",
+		"___123456___foo_bar_2",
+		"a_very_Long_property_Name__22_with_numbers_9",
+		"a_very_Long_property_Name__22_with_numbers_9880888800888800008",
+		"FooBar",
+		"ThisPropertyNameHasExactly231Characters_MaximumAllowed______________________________qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ValidatePropertyName(name)
+			assert.NoError(t, err)
+		})
 	}
 }
 
 func TestFailValidateBadPropertyName(t *testing.T) {
-	_, err := ValidatePropertyName("foo Bar")
-	if err == nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("a_very_Long_property_Name__22_with-dash_9")
-	if err == nil {
-		t.Fail()
-	}
-
-	_, err = ValidatePropertyName("1_FooBar")
-	if err == nil {
-		t.Fail()
+	for _, name := range []string{
+		"foo Bar",
+		"a_very_Long_property_Name__22_with-dash_9",
+		"1_FooBar",
+		"ThisPropertyNameHasMoreThan231Characters_MaximumAllowed______________________________qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ValidatePropertyName(name)
+			assert.Error(t, err)
+		})
 	}
 }
 

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -82,7 +82,7 @@ func TestInvalidPropertyName(t *testing.T) {
 			parsed, ok := err.(*clschema.SchemaObjectsCreateUnprocessableEntity)
 			require.True(t, ok, "error should be unprocessable entity")
 			assert.Equal(t, "'some-property' is not a valid property name. Property names in Weaviate "+
-				"are restricted to valid GraphQL names, which must be “/[_A-Za-z][_0-9A-Za-z]*/”.",
+				"are restricted to valid GraphQL names, which must be “/[_A-Za-z][_0-9A-Za-z]{0,230}/”.",
 				parsed.Payload.Error[0].Message)
 		})
 	})


### PR DESCRIPTION
### What's being changed:
Adds validation for max length of class name (255 chars) and property name (231 chars)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
