### PR TITLE
add debug weviate build and related script to use remote delve

### DIFF
--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,0 +1,50 @@
+# Dockerfile for development purposes.
+# Read docs/development.md for more information
+# vi: ft=dockerfile
+
+###############################################################################
+# Base build image
+FROM golang:1.21-alpine AS build_base
+RUN apk add bash ca-certificates git gcc g++ libc-dev
+WORKDIR /go/src/github.com/weaviate/weaviate
+ENV GO111MODULE=on
+# Populate the module cache based on the go.{mod,sum} files.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+###############################################################################
+# This image builds the weaviate server with debug enabled and optimization disabled
+FROM build_base AS server_builder_debug
+ARG TARGETARCH
+ENV CGO_ENABLED=0
+COPY . .
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN GOOS=linux GOARCH=$TARGETARCH go build \
+      -gcflags "all=-N -l" \
+      -o /weaviate-server ./cmd/weaviate-server
+
+###############################################################################
+# This creates an image that can be used to fake an api for telemetry acceptance test purposes
+FROM build_base AS telemetry_mock_api
+COPY . .
+ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
+
+###############################################################################
+# This image gets grpc health check probe
+FROM build_base AS grpc_health_probe_builder
+ARG TARGETARCH
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
+      wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
+      chmod +x /bin/grpc_health_probe
+
+###############################################################################
+# Weaviate with debug enabled and ready for remote debugging. Use for debugging/dev purpose only!
+FROM alpine AS weaviate_debug
+ENTRYPOINT [ "/bin/dlv" ]
+COPY --from=server_builder_debug /go/bin/dlv /bin/dlv
+COPY --from=grpc_health_probe_builder /bin/grpc_health_probe /bin/
+COPY --from=server_builder_debug /weaviate-server /bin/weaviate
+RUN apk add --no-cache --upgrade ca-certificates openssl
+RUN mkdir ./modules
+CMD ["--listen=:2345", "--headless=true", "--check-go-version=false", "--log=true", "--accept-multiclient", "--api-version=2", "exec", "/bin/weaviate", "--", "--host", "0.0.0.0", "--port", "8080", "--scheme", "http"]

--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -1,0 +1,43 @@
+version: '3.4'
+services:
+  weaviate:
+    image: weaviate/debug-server
+    build:
+      context: .
+      dockerfile: debug.Dockerfile
+      target: weaviate_debug
+    restart: on-failure:0
+    ports:
+      - "2345:2345"
+      - "8080:8080"
+      - "6060:6060"
+      - "2112:2112"
+      - "7101:7101"
+      - "50051:50051"
+    environment:
+      LOG_LEVEL: "debug"
+      CONTEXTIONARY_URL: contextionary:9999
+      QUERY_DEFAULTS_LIMIT: 20
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: "./data"
+      DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
+      ENABLE_MODULES: text2vec-contextionary
+      PROMETHEUS_MONITORING_ENABLED: 'true'
+      PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'
+      CLUSTER_GOSSIP_BIND_PORT: "7100"
+      CLUSTER_DATA_BIND_PORT: "7101"
+      ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
+
+      # necessary for the metrics tests, some metrics only exist once segments
+      # are flushed. If we wait to long the before run is completely in
+      # memtables, the after run has some flushed which leads to some metrics
+      # diffs in the before and after
+      PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS: 2
+  contextionary:
+    image: semitechnologies/contextionary:en0.16.0-v1.2.1
+    ports:
+      - "9999:9999"
+    environment:
+      OCCURRENCE_WEIGHT_LINEAR_FACTOR: 0.75
+      EXTENSIONS_STORAGE_MODE: weaviate
+      EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080

--- a/tools/dev/delve_connect.sh
+++ b/tools/dev/delve_connect.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+echo "Connecting delve to headless instance at 127.0.0.1:2345..."
+
+dlv connect 127.0.0.1:2345

--- a/tools/dev/run_debug_server.sh
+++ b/tools/dev/run_debug_server.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+function echo_green() {
+  green='\033[0;32m'
+  nc='\033[0m'
+  echo "${green}${*}${nc}"
+}
+
+echo_green "Building and starting a debug instance of weaviate locally..."
+
+if [[ ! -f docker-compose-debug.yml ]]; then
+    echo "Could not locate docker-compose-debug.yml file. Ensure your current PWD is the root the repository"
+    exit 1
+fi
+
+# Use of the --build flag ensure the latest local changes are picked up and we are debugging the current state of the repo
+docker compose -f docker-compose-debug.yml up --build -d
+
+echo_green "Debug instance of weaviate started locally"


### PR DESCRIPTION
### What's being changed:

* Add a new build target in the root Dockerfile to build a debug friendly binary of weaviate
* Add new docker-compose and debug script to start this new build and connect a remote debugger to it

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
