### PR TITLE
Use remainder to ensure last batch is indexed

### DIFF
--- a/test/benchmark_bm25/cmd/import.go
+++ b/test/benchmark_bm25/cmd/import.go
@@ -103,7 +103,7 @@ var importCmd = &cobra.Command{
 			}
 		}
 
-		if len(c)&BatchSize != 0 {
+		if len(c)%BatchSize != 0 {
 			// we need to send one final batch
 			br, err := batch.Do(context.Background())
 			if err != nil {


### PR DESCRIPTION
### What's being changed:

Fix typo that made last batch not indexed for datasets when DOC_COUNT % BATCH_SIZE != 0

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.
