### PR TITLE
Fix parsing of OpenAI's error response

### DIFF
--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -341,8 +342,32 @@ type choice struct {
 }
 
 type openAIApiError struct {
-	Message string      `json:"message"`
-	Type    string      `json:"type"`
-	Param   string      `json:"param"`
-	Code    json.Number `json:"code"`
+	Message string     `json:"message"`
+	Type    string     `json:"type"`
+	Param   string     `json:"param"`
+	Code    openAICode `json:"code"`
+}
+
+type openAICode string
+
+func (c *openAICode) String() string {
+	if c == nil {
+		return ""
+	}
+	return string(*c)
+}
+
+func (c *openAICode) UnmarshalJSON(data []byte) (err error) {
+	if number, err := strconv.Atoi(string(data)); err == nil {
+		str := strconv.Itoa(number)
+		*c = openAICode(str)
+		return nil
+	}
+	var str string
+	err = json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	*c = openAICode(str)
+	return nil
 }

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -195,11 +195,18 @@ func TestOpenAIApiErrorDecode(t *testing.T) {
 				want: "500",
 			},
 			{
-				name: "Error code as string",
+				name: "Error code as string number",
 				args: args{
 					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "500"}`),
 				},
 				want: "500",
+			},
+			{
+				name: "Error code as string text",
+				args: args{
+					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "invalid_api_key"}`),
+				},
+				want: "invalid_api_key",
 			},
 		}
 		for _, tt := range tests {

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -244,8 +245,32 @@ type choice struct {
 }
 
 type openAIApiError struct {
-	Message string      `json:"message"`
-	Type    string      `json:"type"`
-	Param   string      `json:"param"`
-	Code    json.Number `json:"code"`
+	Message string     `json:"message"`
+	Type    string     `json:"type"`
+	Param   string     `json:"param"`
+	Code    openAICode `json:"code"`
+}
+
+type openAICode string
+
+func (c *openAICode) String() string {
+	if c == nil {
+		return ""
+	}
+	return string(*c)
+}
+
+func (c *openAICode) UnmarshalJSON(data []byte) (err error) {
+	if number, err := strconv.Atoi(string(data)); err == nil {
+		str := strconv.Itoa(number)
+		*c = openAICode(str)
+		return nil
+	}
+	var str string
+	err = json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	*c = openAICode(str)
+	return nil
 }

--- a/modules/qna-openai/clients/qna_test.go
+++ b/modules/qna-openai/clients/qna_test.go
@@ -160,11 +160,18 @@ func TestOpenAIApiErrorDecode(t *testing.T) {
 				want: "500",
 			},
 			{
-				name: "Error code as string",
+				name: "Error code as string number",
 				args: args{
 					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "500"}`),
 				},
 				want: "500",
+			},
+			{
+				name: "Error code as string text",
+				args: args{
+					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "invalid_api_key"}`),
+				},
+				want: "invalid_api_key",
 			},
 		}
 		for _, tt := range tests {

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
@@ -46,10 +47,34 @@ type embeddingData struct {
 }
 
 type openAIApiError struct {
-	Message string      `json:"message"`
-	Type    string      `json:"type"`
-	Param   string      `json:"param"`
-	Code    json.Number `json:"code"`
+	Message string     `json:"message"`
+	Type    string     `json:"type"`
+	Param   string     `json:"param"`
+	Code    openAICode `json:"code"`
+}
+
+type openAICode string
+
+func (c *openAICode) String() string {
+	if c == nil {
+		return ""
+	}
+	return string(*c)
+}
+
+func (c *openAICode) UnmarshalJSON(data []byte) (err error) {
+	if number, err := strconv.Atoi(string(data)); err == nil {
+		str := strconv.Itoa(number)
+		*c = openAICode(str)
+		return nil
+	}
+	var str string
+	err = json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+	*c = openAICode(str)
+	return nil
 }
 
 func buildUrl(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {

--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -473,11 +473,18 @@ func TestOpenAIApiErrorDecode(t *testing.T) {
 				want: "500",
 			},
 			{
-				name: "Error code as string",
+				name: "Error code as string number",
 				args: args{
 					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "500"}`),
 				},
 				want: "500",
+			},
+			{
+				name: "Error code as string text",
+				args: args{
+					response: []byte(`{"message": "failed", "type": "error", "param": "arg...", "code": "invalid_api_key"}`),
+				},
+				want: "invalid_api_key",
 			},
 		}
 		for _, tt := range tests {


### PR DESCRIPTION
### What's being changed:

Example response:
```
{
    "error": {
        "message": "Incorrect API key provided: shouldntwork. You can find your API key at https://platform.openai.com/account/api-keys.",
        "type": "invalid_request_error",
        "param": null,
        "code": "invalid_api_key"
    }
}
```

OpenAI's error message, field `code` can be:
- a number: `"code": 500`
- a number string: `"code": "500"`
- a string text: `"code": "invalid_api_key"`

In order to cover of 3 possible scenarios for field `code` we had to introduce a custom `openAIError` struct.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
