### PR TITLE
Refine shard and replica selection to distribute replicas across more nodes

### DIFF
--- a/usecases/sharding/state_test.go
+++ b/usecases/sharding/state_test.go
@@ -141,6 +141,12 @@ func TestInitState(t *testing.T) {
 			shards:            4,
 			ok:                false,
 		},
+		{
+			nodes:             []string{"node1", "node2", "node3", "node4", "node5", "node6", "node7", "node8", "node9", "node10", "node11", "node12"},
+			replicationFactor: 3,
+			shards:            4,
+			ok:                true,
+		},
 	}
 
 	for _, test := range tests {
@@ -168,6 +174,8 @@ func TestInitState(t *testing.T) {
 						actual++
 					}
 				}
+
+				assert.Equal(t, len(nodeCounter), len(test.nodes))
 
 				// assert that total no of associations is correct
 				desired := test.shards * test.replicationFactor


### PR DESCRIPTION

### What's being changed:
Previously, the same node could be selected more than once, even when other nodes were available

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
