### PR TITLE
Add support for OpenAI's new V3 embedding models

### DIFF
--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
@@ -30,8 +31,9 @@ import (
 )
 
 type embeddingsRequest struct {
-	Input []string `json:"input"`
-	Model string   `json:"model,omitempty"`
+	Input      []string `json:"input"`
+	Model      string   `json:"model,omitempty"`
+	Dimensions *int64   `json:"dimensions,omitempty"`
 }
 
 type embedding struct {
@@ -130,7 +132,7 @@ func (v *vectorizer) VectorizeQuery(ctx context.Context, input []string,
 }
 
 func (v *vectorizer) vectorize(ctx context.Context, input []string, model string, config ent.VectorizationConfig) (*ent.VectorizationResult, error) {
-	body, err := json.Marshal(v.getEmbeddingsRequest(input, model, config.IsAzure))
+	body, err := json.Marshal(v.getEmbeddingsRequest(input, model, config.IsAzure, config.Dimensions))
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal body")
 	}
@@ -208,11 +210,11 @@ func (v *vectorizer) getError(statusCode int, resBodyError *openAIApiError, isAz
 	return fmt.Errorf("connection to: %s failed with status: %d", endpoint, statusCode)
 }
 
-func (v *vectorizer) getEmbeddingsRequest(input []string, model string, isAzure bool) embeddingsRequest {
+func (v *vectorizer) getEmbeddingsRequest(input []string, model string, isAzure bool, dimensions *int64) embeddingsRequest {
 	if isAzure {
 		return embeddingsRequest{Input: input}
 	}
-	return embeddingsRequest{Input: input, Model: model}
+	return embeddingsRequest{Input: input, Model: model, Dimensions: dimensions}
 }
 
 func (v *vectorizer) getApiKeyHeaderAndValue(apiKey string, isAzure bool) (string, string) {
@@ -271,10 +273,13 @@ func (v *vectorizer) getValueFromContext(ctx context.Context, key string) string
 }
 
 func (v *vectorizer) getModelString(docType, model, action, version string) string {
+	if strings.HasPrefix(model, "text-embedding-3") {
+		// indicates that we handle v3 models
+		return model
+	}
 	if version == "002" {
 		return v.getModel002String(model)
 	}
-
 	return v.getModel001String(docType, model, action)
 }
 

--- a/modules/text2vec-openai/config.go
+++ b/modules/text2vec-openai/config.go
@@ -24,11 +24,8 @@ import (
 func (m *OpenAIModule) ClassConfigDefaults() map[string]interface{} {
 	return map[string]interface{}{
 		"vectorizeClassName": vectorizer.DefaultVectorizeClassName,
-		"type":               vectorizer.DefaultOpenAIDocumentType,
-		"model":              vectorizer.DefaultOpenAIModel,
 		"baseURL":            vectorizer.DefaultBaseURL,
-		"modelVersion": vectorizer.PickDefaultModelVersion(vectorizer.DefaultOpenAIModel,
-			vectorizer.DefaultOpenAIDocumentType),
+		"model":              vectorizer.DefaultOpenAIModel,
 	}
 }
 

--- a/modules/text2vec-openai/ent/vectorization_config.go
+++ b/modules/text2vec-openai/ent/vectorization_config.go
@@ -16,4 +16,5 @@ type VectorizationConfig struct {
 	BaseURL                                 string
 	DeploymentID                            string `json:"deploymentId"`
 	IsAzure                                 bool
+	Dimensions                              *int64
 }

--- a/modules/text2vec-openai/vectorizer/class_settings_test.go
+++ b/modules/text2vec-openai/vectorizer/class_settings_test.go
@@ -1,0 +1,143 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package vectorizer
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func Test_classSettings_Validate(t *testing.T) {
+	class := &models.Class{
+		Class: "test",
+		Properties: []*models.Property{
+			{
+				DataType: []string{schema.DataTypeText.String()},
+				Name:     "test",
+			},
+		},
+	}
+	tests := []struct {
+		name    string
+		cfg     moduletools.ClassConfig
+		wantErr error
+	}{
+		{
+			name: "text-embedding-3-small",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model": "text-embedding-3-small",
+				},
+			},
+		},
+		{
+			name: "text-embedding-3-small, 512 dimensions",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":      "text-embedding-3-small",
+					"dimensions": 512,
+				},
+			},
+		},
+		{
+			name: "text-embedding-3-small, wrong dimensions",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":      "text-embedding-3-small",
+					"dimensions": 1,
+				},
+			},
+			wantErr: errors.New("wrong dimensions setting for text-embedding-3-small model, available dimensions are: [512 1536]"),
+		},
+		{
+			name: "text-embedding-3-large",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model": "text-embedding-3-large",
+				},
+			},
+		},
+		{
+			name: "text-embedding-3-large, 512 dimensions",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":      "text-embedding-3-large",
+					"dimensions": 1024,
+				},
+			},
+		},
+		{
+			name: "text-embedding-3-large, wrong dimensions",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":      "text-embedding-3-large",
+					"dimensions": 512,
+				},
+			},
+			wantErr: errors.New("wrong dimensions setting for text-embedding-3-large model, available dimensions are: [256 1024 3072]"),
+		},
+		{
+			name: "text-embedding-ada-002",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":        "ada",
+					"modelVersion": "002",
+				},
+			},
+		},
+		{
+			name: "text-embedding-ada-002 - dimensions error",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":      "ada",
+					"dimensions": 512,
+				},
+			},
+			wantErr: errors.New("dimensions setting can only be used with V3 embedding models: [text-embedding-3-small text-embedding-3-large]"),
+		},
+		{
+			name: "text-embedding-ada-002 - wrong model version",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":        "ada",
+					"modelVersion": "003",
+				},
+			},
+			wantErr: errors.New("unsupported version 003"),
+		},
+		{
+			name: "wrong model name",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model": "unknown-model",
+				},
+			},
+			wantErr: errors.New("wrong OpenAI model name, available model names are: [ada babbage curie davinci text-embedding-3-small text-embedding-3-large]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewClassSettings(tt.cfg)
+			err := cs.Validate(class)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -99,5 +99,6 @@ func (v *Vectorizer) getVectorizationConfig(cfg moduletools.ClassConfig) ent.Vec
 		DeploymentID: settings.DeploymentID(),
 		BaseURL:      settings.BaseURL(),
 		IsAzure:      settings.IsAzure(),
+		Dimensions:   settings.Dimensions(),
 	}
 }


### PR DESCRIPTION
### What's being changed:

This PR adds support for 2 new OpenAI embeddings models:
- `text-embedding-3-small`
- `text-embedding-3-large`

This PR also adds new `dimensions` setting which is only applicable for `V3 embeddings models`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
