### PR TITLE
Handle internal errors in BM25/WAND logic more gracefully

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -202,7 +202,11 @@ func (b *BM25Searcher) wand(
 					defer func() {
 						p := recover()
 						if p != nil {
-							b.logger.Errorf("panic: %v", p)
+							b.logger.
+								WithField("query_term", queryTerms[j]).
+								WithField("prop_names", propNames).
+								WithField("has_filter", filterDocIds != nil).
+								Errorf("panic: %v", p)
 							debug.PrintStack()
 							err = fmt.Errorf("an internal error occurred during BM25 search")
 						}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
@@ -188,9 +189,10 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 
 		className := s.index.Config.ClassName
 		bm25Config := s.index.getInvertedIndexConfig().BM25
+		logger := s.index.logger.WithFields(logrus.Fields{"class": s.index.Config.ClassName, "shard": s.name})
 		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store,
 			s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices, s.index.classSearcher,
-			s.GetPropertyLengthTracker(), s.index.logger, s.versioner.Version())
+			s.GetPropertyLengthTracker(), logger, s.versioner.Version())
 		bm25objs, bm25count, err = bm25searcher.BM25F(ctx, filterDocIds, className, limit, *keywordRanking)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
### What's being changed:

* catches panic
* returns generic error to the user
* prints original panic annotated with shard/class name in logs

<img width="1917" alt="Screenshot 2024-01-30 at 9 33 34 AM" src="https://github.com/weaviate/weaviate/assets/8974479/8241f192-479a-4c21-a1f6-d45d611a4b0a">

<img width="1264" alt="Screenshot 2024-01-30 at 9 35 32 AM" src="https://github.com/weaviate/weaviate/assets/8974479/43169180-9b33-482a-9cf4-1c6a8ff674e5">

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
