### PR TITLE
add docker image pull cache in GHA

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -63,7 +63,7 @@ jobs:
           name: coverage-report-unit
           path: coverage-unit.txt
   Integration-Tests:
-    name: integration-tests  
+    name: integration-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
           path: coverage-integration.txt
   Modules-Acceptance-Tests:
     name: modules-acceptance-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     strategy:
       fail-fast: false
       matrix:
@@ -93,10 +93,18 @@ jobs:
         with:
           go-version: '1.21'
           cache: true
+      # Most of the time is spent downloading module docker images.
+      # Cache them in GHA cache to speed up subsequent runs
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.3.7
+        with:
+          # We don't have a Dockerfile or docker-compose.yml file where we specify these images, instead they are specified
+          # in a go file where we use test containers. Use this file as hash for the cache.
+          key: docker-${{ runner.os }}-${{ matrix.test }}-${{ hashFiles('test/docker/compose.go') }}
       - name: Acceptance tests (modules)
         run: ./test/run.sh ${{ matrix.test }}
   Acceptance-Tests:
-    name: acceptance-tests  
+    name: acceptance-tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1>Weaviate <img alt='Weaviate logo' src='https://weaviate.io/img/site/weaviate-logo-light.png' width='148' align='right' /></h1>
 
+
+
 [![Build Status](https://github.com/weaviate/weaviate/actions/workflows/.github/workflows/pull_requests.yaml/badge.svg?branch=master)](https://github.com/weaviate/weaviate/actions/workflows/.github/workflows/pull_requests.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/weaviate/weaviate)](https://goreportcard.com/report/github.com/weaviate/weaviate)
 [![Coverage Status](https://codecov.io/gh/weaviate/weaviate/branch/master/graph/badge.svg)](https://codecov.io/gh/weaviate/weaviate)


### PR DESCRIPTION
### What's being changed:

* Add a CI step to cache pulled image in GHA cache for modules tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
