### PR TITLE
improving handling of eventual consistency in updating new indexes

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -358,8 +358,8 @@ func (i *indices) postObjectBatch(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	index := i.db.GetIndexForIncoming(entschema.ClassName(class))
-	if index == nil {
+	index, err := i.db.GetIndexForIncoming(entschema.ClassName(class))
+	if err != nil {
 		http.Error(w, "index not found", http.StatusInternalServerError)
 		return
 	}

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"runtime"
 	"runtime/debug"
@@ -20,9 +21,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
+	"github.com/weaviate/weaviate/cloud/utils"
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -196,65 +199,63 @@ type Config struct {
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't
+// by default it will retry 3 times between 0-600 ms to get the index
+// to handle the eventual consistency.
 func (db *DB) GetIndex(className schema.ClassName) *Index {
-	db.indexLock.RLock()
-	defer db.indexLock.RUnlock()
+	var (
+		index  *Index
+		exists bool
+	)
+	backoff.Retry(func() error {
+		db.indexLock.RLock()
+		defer db.indexLock.RUnlock()
 
-	id := indexID(className)
-	index, ok := db.indices[id]
-	if !ok {
+		index, exists = db.indices[indexID(className)]
+		if !exists {
+			return fmt.Errorf("index for class %v not found locally", index)
+		}
 		return nil
-	}
+	}, utils.ConstantBackoff(3, 200*time.Millisecond))
 
 	return index
 }
 
 // IndexExists returns if an index exists
 func (db *DB) IndexExists(className schema.ClassName) bool {
-	db.indexLock.RLock()
-	defer db.indexLock.RUnlock()
-
-	id := indexID(className)
-	_, ok := db.indices[id]
-	return ok
+	return db.GetIndex(className) != nil
 }
 
 // GetIndexForIncoming returns the index if it exists or nil if it doesn't
-func (db *DB) GetIndexForIncoming(className schema.ClassName) sharding.RemoteIndexIncomingRepo {
-	db.indexLock.RLock()
-	defer db.indexLock.RUnlock()
-
-	id := indexID(className)
-	index, ok := db.indices[id]
-	if !ok {
-		return nil
+// by default it will retry 3 times between 0-600 ms to get the index
+// to handle the eventual consistency.
+func (db *DB) GetIndexForIncoming(className schema.ClassName) (sharding.RemoteIndexIncomingRepo, error) {
+	index := db.GetIndex(className)
+	if index == nil {
+		return nil, fmt.Errorf("index for class %v not found locally", index)
 	}
-
-	return index
+	return index, nil
 }
 
 // DeleteIndex deletes the index
 func (db *DB) DeleteIndex(className schema.ClassName) error {
-	db.indexLock.Lock()
-	defer db.indexLock.Unlock()
-
-	// Get index
-	id := indexID(className)
-	index := db.indices[id]
+	index := db.GetIndex(className)
 	if index == nil {
 		return nil
 	}
 
-	// Drop index
+	// drop index
+	db.indexLock.Lock()
+	defer db.indexLock.Unlock()
+
 	index.dropIndex.Lock()
 	defer index.dropIndex.Unlock()
 	if err := index.drop(); err != nil {
 		db.logger.WithField("action", "delete_index").WithField("class", className).Error(err)
 	}
-	delete(db.indices, id)
 
-	db.promMetrics.DeleteClass(className.String())
-	return nil
+	delete(db.indices, indexID(className))
+
+	return db.promMetrics.DeleteClass(className.String())
 }
 
 func (db *DB) Shutdown(ctx context.Context) error {

--- a/adapters/repos/db/repo_test.go
+++ b/adapters/repos/db/repo_test.go
@@ -1,0 +1,67 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestGetIndex(t *testing.T) {
+	db := testDB(t.TempDir(), []*models.Class{}, make(map[string]*sharding.State))
+
+	// empty indices
+	db.indices = map[string]*Index{}
+	idx := db.GetIndex(schema.ClassName("test1"))
+	require.Nil(t, idx)
+
+	// after 100 ms
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		db.indexLock.Lock()
+		defer db.indexLock.Unlock()
+		db.indices = map[string]*Index{
+			"test1": {},
+		}
+	}()
+	idx = db.GetIndex(schema.ClassName("test1"))
+	require.NotNil(t, idx)
+
+	// after 200 ms
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		db.indexLock.Lock()
+		defer db.indexLock.Unlock()
+		db.indices = map[string]*Index{
+			"test2": {},
+		}
+	}()
+	idx = db.GetIndex(schema.ClassName("test2"))
+	require.NotNil(t, idx)
+
+	// after 300 ms
+	go func() {
+		time.Sleep(299 * time.Millisecond)
+		db.indexLock.Lock()
+		defer db.indexLock.Unlock()
+		db.indices = map[string]*Index{
+			"test3": {},
+		}
+	}()
+	idx = db.GetIndex(schema.ClassName("test3"))
+	require.NotNil(t, idx)
+}

--- a/cloud/utils/retry.go
+++ b/cloud/utils/retry.go
@@ -27,3 +27,9 @@ func NewBackoff() backoff.BackOff {
 	expBackoff.MaxElapsedTime = 3 * time.Second
 	return backoff.WithMaxRetries(expBackoff, 3)
 }
+
+// ConstantBackoff is a backoff configuration used to handle getters
+// retry for eventual consistency handling
+func ConstantBackoff(maxrtry int, interval time.Duration) backoff.BackOff {
+	return backoff.WithMaxRetries(backoff.NewConstantBackOff(interval), uint64(maxrtry))
+}

--- a/entities/schema/backward_compat.go
+++ b/entities/schema/backward_compat.go
@@ -15,7 +15,10 @@ import (
 	errors_ "errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
+	"github.com/weaviate/weaviate/cloud/utils"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -29,28 +32,33 @@ func GetClassByName(s *models.Schema, className string) (*models.Class, error) {
 	if s == nil {
 		return nil, fmt.Errorf(ErrorNoSuchClass, className)
 	}
-	// For each class
-	for _, class := range s.Classes {
-		// Check if the name of the class is the given name, that's the class we need
-		if class.Class == className {
-			return class, nil
-		}
-	}
+	var cls *models.Class
 
-	return nil, fmt.Errorf(ErrorNoSuchClass, className)
+	return cls, backoff.Retry(func() error {
+		for _, class := range s.Classes {
+			// Check if the name of the class is the given name, that's the class we need
+			if class.Class == className {
+				cls = class
+				return nil
+			}
+		}
+		return fmt.Errorf(ErrorNoSuchClass, className)
+	}, utils.ConstantBackoff(3, 200*time.Millisecond))
 }
 
 // GetPropertyByName returns the class by its name
 func GetPropertyByName(c *models.Class, propName string) (*models.Property, error) {
-	// For each class-property
-	for _, prop := range c.Properties {
-		// Check if the name of the property is the given name, that's the property we need
-		if prop.Name == strings.Split(propName, ".")[0] {
-			return prop, nil
+	var property *models.Property
+	return property, backoff.Retry(func() error {
+		for _, prop := range c.Properties {
+			// Check if the name of the property is the given name, that's the property we need
+			if prop.Name == strings.Split(propName, ".")[0] {
+				property = prop
+				return nil
+			}
 		}
-	}
-
-	return nil, fmt.Errorf(ErrorNoSuchProperty, propName, c.Class)
+		return fmt.Errorf(ErrorNoSuchProperty, propName, c.Class)
+	}, utils.ConstantBackoff(3, 200*time.Millisecond))
 }
 
 // GetPropertyDataType checks whether the given string is a valid data type

--- a/entities/schema/data_types_test.go
+++ b/entities/schema/data_types_test.go
@@ -207,7 +207,7 @@ func TestGetPropertyDataType(t *testing.T) {
 		{
 			propName:         "invalidProp",
 			expectedDataType: nil,
-			expectedErr:      fmt.Errorf("given value-DataType does not exist."),
+			expectedErr:      fmt.Errorf(ErrorNoSuchDatatype),
 		},
 	}
 

--- a/entities/schema/errors.go
+++ b/entities/schema/errors.go
@@ -16,7 +16,7 @@ import "errors"
 const (
 	ErrorNoSuchClass    string = "no such class with name '%s' found in the schema. Check your schema files for which classes are available"
 	ErrorNoSuchProperty string = "no such prop with name '%s' found in class '%s' in the schema. Check your schema files for which properties in this class are available"
-	ErrorNoSuchDatatype string = "given value-DataType does not exist."
+	ErrorNoSuchDatatype string = "given value-DataType does not exist"
 )
 
 var ErrRefToNonexistentClass = errors.New("reference property to nonexistent class")

--- a/test/helper/journey/backup_journey.go
+++ b/test/helper/journey/backup_journey.go
@@ -64,24 +64,28 @@ func backupJourney(t *testing.T, className, backend, backupID string,
 	t.Run("create backup", func(t *testing.T) {
 		resp, err := helper.CreateBackup(t, helper.DefaultBackupConfig(), className, backend, backupID)
 		helper.AssertRequestOk(t, resp, err, nil)
+
 		// wait for create success
-		createTime := time.Now()
+		ticker := time.NewTicker(90 * time.Second)
+
+	wait:
 		for {
-			if time.Now().After(createTime.Add(time.Minute)) {
-				break
-			}
+			select {
+			case <-ticker.C:
+				break wait
+			default:
+				resp, err := helper.CreateBackupStatus(t, backend, backupID)
+				helper.AssertRequestOk(t, resp, err, func() {
+					require.NotNil(t, resp)
+					require.NotNil(t, resp.Payload)
+					require.NotNil(t, resp.Payload.Status)
+				})
 
-			resp, err := helper.CreateBackupStatus(t, backend, backupID)
-			helper.AssertRequestOk(t, resp, err, func() {
-				require.NotNil(t, resp)
-				require.NotNil(t, resp.Payload)
-				require.NotNil(t, resp.Payload.Status)
-			})
-
-			if *resp.Payload.Status == string(backup.Success) {
-				break
+				if *resp.Payload.Status == string(backup.Success) {
+					break wait
+				}
+				time.Sleep(1 * time.Second)
 			}
-			time.Sleep(time.Second * 1)
 		}
 
 		statusResp, err := helper.CreateBackupStatus(t, backend, backupID)
@@ -105,24 +109,25 @@ func backupJourney(t *testing.T, className, backend, backupID string,
 		require.Nil(t, err, "expected nil, got: %v", err)
 
 		// wait for restore success
-		restoreTime := time.Now()
+		ticker := time.NewTicker(90 * time.Second)
+	wait:
 		for {
-			if time.Now().After(restoreTime.Add(time.Minute)) {
-				break
+			select {
+			case <-ticker.C:
+				break wait
+			default:
+				resp, err := helper.RestoreBackupStatus(t, backend, backupID)
+				helper.AssertRequestOk(t, resp, err, func() {
+					require.NotNil(t, resp)
+					require.NotNil(t, resp.Payload)
+					require.NotNil(t, resp.Payload.Status)
+				})
+
+				if *resp.Payload.Status == string(backup.Success) {
+					break wait
+				}
+				time.Sleep(1 * time.Second)
 			}
-
-			resp, err := helper.RestoreBackupStatus(t, backend, backupID)
-			helper.AssertRequestOk(t, resp, err, func() {
-				require.NotNil(t, resp)
-				require.NotNil(t, resp.Payload)
-				require.NotNil(t, resp.Payload.Status)
-			})
-
-			if *resp.Payload.Status == string(backup.Success) {
-				break
-			}
-
-			time.Sleep(time.Second)
 		}
 
 		statusResp, err := helper.RestoreBackupStatus(t, backend, backupID)
@@ -132,7 +137,7 @@ func backupJourney(t *testing.T, className, backend, backupID string,
 			require.NotNil(t, statusResp.Payload.Status)
 		})
 
-		require.Equal(t, *statusResp.Payload.Status, string(backup.Success))
+		require.Equal(t, string(backup.Success), *statusResp.Payload.Status)
 	})
 
 	// assert class exists again it its entirety
@@ -157,6 +162,10 @@ func backupJourney(t *testing.T, className, backend, backupID string,
 }
 
 func addTestClass(t *testing.T, className string, multiTenant bool) {
+	// TODO shall be removed with the DB is idempotent
+	// delete class before trying to create in case it was existing.
+	helper.DeleteClass(t, className)
+
 	class := &models.Class{
 		Class: className,
 		ModuleConfig: map[string]interface{}{
@@ -210,6 +219,5 @@ func addTestObjects(t *testing.T, className string, tenantNames []string) {
 			batch[j] = &obj
 		}
 		helper.CreateObjectsBatch(t, batch)
-
 	}
 }

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -14,7 +14,6 @@ package helper
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +41,6 @@ func CreateClass(t *testing.T, class *models.Class) {
 	params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
 	resp, err := Client(t).Schema.SchemaObjectsCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
-	time.Sleep(time.Millisecond * 500) // give some time for update to propagate because request are not retried
 }
 
 func GetClass(t *testing.T, class string) *models.Class {
@@ -59,7 +57,6 @@ func UpdateClass(t *testing.T, class *models.Class) {
 		WithObjectClass(class).WithClassName(class.Class)
 	resp, err := Client(t).Schema.SchemaObjectsUpdate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
-	time.Sleep(time.Millisecond * 500) // give some time for update to propagate because request are not retried
 }
 
 func CreateObject(t *testing.T, object *models.Object) {
@@ -127,7 +124,6 @@ func DeleteClass(t *testing.T, class string) {
 	delParams := schema.NewSchemaObjectsDeleteParams().WithClassName(class)
 	delRes, err := Client(t).Schema.SchemaObjectsDelete(delParams, nil)
 	AssertRequestOk(t, delRes, err, nil)
-	time.Sleep(time.Millisecond * 500) // give some time for update to propagate because request are not retried
 }
 
 func DeleteObject(t *testing.T, object *models.Object) {
@@ -223,14 +219,12 @@ func CreateTenants(t *testing.T, class string, tenants []*models.Tenant) {
 	params := schema.NewTenantsCreateParams().WithClassName(class).WithBody(tenants)
 	resp, err := Client(t).Schema.TenantsCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
-	time.Sleep(time.Millisecond * 500) // give some time for update to propagate because request are not retried
 }
 
 func CreateTenantsReturnError(t *testing.T, class string, tenants []*models.Tenant) error {
 	t.Helper()
 	params := schema.NewTenantsCreateParams().WithClassName(class).WithBody(tenants)
 	_, err := Client(t).Schema.TenantsCreate(params, nil)
-	time.Sleep(time.Millisecond * 500) // give some time for update to propagate because request are not retried
 	return err
 }
 
@@ -245,7 +239,6 @@ func DeleteTenants(t *testing.T, class string, tenants []string) error {
 	t.Helper()
 	params := schema.NewTenantsDeleteParams().WithClassName(class).WithTenants(tenants)
 	_, err := Client(t).Schema.TenantsDelete(params, nil)
-	time.Sleep(time.Millisecond * 500) // give some time for update to propagate because request are not retried
 	return err
 }
 

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -30,7 +30,7 @@ import (
 )
 
 type RemoteIncomingRepo interface {
-	GetIndexForIncoming(className schema.ClassName) RemoteIndexIncomingRepo
+	GetIndexForIncoming(className schema.ClassName) (RemoteIndexIncomingRepo, error)
 }
 
 type RemoteIndexIncomingRepo interface {
@@ -92,8 +92,8 @@ func NewRemoteIndexIncoming(repo RemoteIncomingRepo) *RemoteIndexIncoming {
 func (rii *RemoteIndexIncoming) PutObject(ctx context.Context, indexName,
 	shardName string, obj *storobj.Object,
 ) error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -103,8 +103,8 @@ func (rii *RemoteIndexIncoming) PutObject(ctx context.Context, indexName,
 func (rii *RemoteIndexIncoming) BatchPutObjects(ctx context.Context, indexName,
 	shardName string, objs []*storobj.Object,
 ) []error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return duplicateErr(errors.Errorf("local index %q not found", indexName),
 			len(objs))
 	}
@@ -115,8 +115,8 @@ func (rii *RemoteIndexIncoming) BatchPutObjects(ctx context.Context, indexName,
 func (rii *RemoteIndexIncoming) BatchAddReferences(ctx context.Context, indexName,
 	shardName string, refs objects.BatchReferences,
 ) []error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return duplicateErr(errors.Errorf("local index %q not found", indexName),
 			len(refs))
 	}
@@ -128,8 +128,8 @@ func (rii *RemoteIndexIncoming) GetObject(ctx context.Context, indexName,
 	shardName string, id strfmt.UUID, selectProperties search.SelectProperties,
 	additional additional.Properties,
 ) (*storobj.Object, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -139,8 +139,8 @@ func (rii *RemoteIndexIncoming) GetObject(ctx context.Context, indexName,
 func (rii *RemoteIndexIncoming) Exists(ctx context.Context, indexName,
 	shardName string, id strfmt.UUID,
 ) (bool, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return false, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -150,8 +150,8 @@ func (rii *RemoteIndexIncoming) Exists(ctx context.Context, indexName,
 func (rii *RemoteIndexIncoming) DeleteObject(ctx context.Context, indexName,
 	shardName string, id strfmt.UUID,
 ) error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -161,8 +161,8 @@ func (rii *RemoteIndexIncoming) DeleteObject(ctx context.Context, indexName,
 func (rii *RemoteIndexIncoming) MergeObject(ctx context.Context, indexName,
 	shardName string, mergeDoc objects.MergeDocument,
 ) error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -172,8 +172,8 @@ func (rii *RemoteIndexIncoming) MergeObject(ctx context.Context, indexName,
 func (rii *RemoteIndexIncoming) MultiGetObjects(ctx context.Context, indexName,
 	shardName string, ids []strfmt.UUID,
 ) ([]*storobj.Object, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -185,8 +185,8 @@ func (rii *RemoteIndexIncoming) Search(ctx context.Context, indexName, shardName
 	keywordRanking *searchparams.KeywordRanking, sort []filters.Sort, cursor *filters.Cursor,
 	groupBy *searchparams.GroupBy, additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, nil, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -197,8 +197,8 @@ func (rii *RemoteIndexIncoming) Search(ctx context.Context, indexName, shardName
 func (rii *RemoteIndexIncoming) Aggregate(ctx context.Context, indexName, shardName string,
 	params aggregation.Params,
 ) (*aggregation.Result, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -208,8 +208,8 @@ func (rii *RemoteIndexIncoming) Aggregate(ctx context.Context, indexName, shardN
 func (rii *RemoteIndexIncoming) FindUUIDs(ctx context.Context, indexName, shardName string,
 	filters *filters.LocalFilter,
 ) ([]strfmt.UUID, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -219,8 +219,8 @@ func (rii *RemoteIndexIncoming) FindUUIDs(ctx context.Context, indexName, shardN
 func (rii *RemoteIndexIncoming) DeleteObjectBatch(ctx context.Context, indexName, shardName string,
 	uuids []strfmt.UUID, dryRun bool,
 ) objects.BatchSimpleObjects {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		err := errors.Errorf("local index %q not found", indexName)
 		return objects.BatchSimpleObjects{objects.BatchSimpleObject{Err: err}}
 	}
@@ -231,8 +231,8 @@ func (rii *RemoteIndexIncoming) DeleteObjectBatch(ctx context.Context, indexName
 func (rii *RemoteIndexIncoming) GetShardQueueSize(ctx context.Context,
 	indexName, shardName string,
 ) (int64, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return 0, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -242,8 +242,8 @@ func (rii *RemoteIndexIncoming) GetShardQueueSize(ctx context.Context,
 func (rii *RemoteIndexIncoming) GetShardStatus(ctx context.Context,
 	indexName, shardName string,
 ) (string, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return "", errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -253,8 +253,8 @@ func (rii *RemoteIndexIncoming) GetShardStatus(ctx context.Context,
 func (rii *RemoteIndexIncoming) UpdateShardStatus(ctx context.Context,
 	indexName, shardName, targetStatus string,
 ) error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -264,8 +264,8 @@ func (rii *RemoteIndexIncoming) UpdateShardStatus(ctx context.Context,
 func (rii *RemoteIndexIncoming) FilePutter(ctx context.Context,
 	indexName, shardName, filePath string,
 ) (io.WriteCloser, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -275,8 +275,8 @@ func (rii *RemoteIndexIncoming) FilePutter(ctx context.Context,
 func (rii *RemoteIndexIncoming) CreateShard(ctx context.Context,
 	indexName, shardName string,
 ) error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -286,8 +286,8 @@ func (rii *RemoteIndexIncoming) CreateShard(ctx context.Context,
 func (rii *RemoteIndexIncoming) ReInitShard(ctx context.Context,
 	indexName, shardName string,
 ) error {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
@@ -297,8 +297,8 @@ func (rii *RemoteIndexIncoming) ReInitShard(ctx context.Context,
 func (rii *RemoteIndexIncoming) OverwriteObjects(ctx context.Context,
 	indexName, shardName string, vobjects []*objects.VObject,
 ) ([]replica.RepairResponse, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, fmt.Errorf("local index %q not found", indexName)
 	}
 
@@ -308,8 +308,8 @@ func (rii *RemoteIndexIncoming) OverwriteObjects(ctx context.Context,
 func (rii *RemoteIndexIncoming) DigestObjects(ctx context.Context,
 	indexName, shardName string, ids []strfmt.UUID,
 ) ([]replica.RepairResponse, error) {
-	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
-	if index == nil {
+	index, err := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if err != nil {
 		return nil, fmt.Errorf("local index %q not found", indexName)
 	}
 


### PR DESCRIPTION
### What's being changed:
this PR adds a retry for index getter so that we would have some time between 100-300 ms to make sure the index is propagated to the follower. 

the pitfall of that we could have increased latency in the followers but i think it's acceptable in order to handle the eventual consistency

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
