### PR TITLE
Setting default values for weaviate server 

### DIFF
--- a/usecases/config/authentication.go
+++ b/usecases/config/authentication.go
@@ -20,18 +20,25 @@ type Authentication struct {
 	APIKey          APIKey
 }
 
+// DefaultAuthentication is the default authentication scheme when no authentication is provided
+var DefaultAuthentication = Authentication{
+	AnonymousAccess: AnonymousAccess{
+		Enabled: true,
+	},
+}
+
 // Validate the Authentication configuration. This only validates at a general
 // level. Validation specific to the individual auth methods should happen
 // inside their respective packages
 func (a Authentication) Validate() error {
-	if !a.anyAuthMethodSelected() {
+	if !a.AnyAuthMethodSelected() {
 		return fmt.Errorf("no authentication scheme configured, you must select at least one")
 	}
 
 	return nil
 }
 
-func (a Authentication) anyAuthMethodSelected() bool {
+func (a Authentication) AnyAuthMethodSelected() bool {
 	return a.AnonymousAccess.Enabled || a.OIDC.Enabled || a.APIKey.Enabled
 }
 

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -169,6 +169,9 @@ type QueryDefaults struct {
 	Limit int64 `json:"limit" yaml:"limit"`
 }
 
+// DefaultQueryDefaultsLimit is the default query limit when no limit is provided
+const DefaultQueryDefaultsLimit int64 = 10
+
 type Contextionary struct {
 	URL string `json:"url" yaml:"url"`
 }
@@ -199,6 +202,9 @@ type Persistence struct {
 	MemtablesMinActiveDurationSeconds int    `json:"memtablesMinActiveDurationSeconds" yaml:"memtablesMinActiveDurationSeconds"`
 	MemtablesMaxActiveDurationSeconds int    `json:"memtablesMaxActiveDurationSeconds" yaml:"memtablesMaxActiveDurationSeconds"`
 }
+
+// DefaultPersistenceDataPath is the default location for data directory when no location is provided
+const DefaultPersistenceDataPath string = "./data"
 
 func (p Persistence) Validate() error {
 	if p.DataPath == "" {
@@ -298,7 +304,6 @@ func (f *WeaviateConfig) GetHostAddress() string {
 func (f *WeaviateConfig) LoadConfig(flags *swag.CommandLineOptionsGroup, logger logrus.FieldLogger) error {
 	// Get command line flags
 	configFileName := flags.Options.(*Flags).ConfigFile
-
 	// Set default if not given
 	if configFileName == "" {
 		configFileName = DefaultConfigFile

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -151,6 +151,10 @@ func FromEnv(config *Config) error {
 		}
 	}
 
+	if !config.Authentication.AnyAuthMethodSelected() {
+		config.Authentication = DefaultAuthentication
+	}
+
 	if os.Getenv("PERSISTENCE_LSM_ACCESS_STRATEGY") == "pread" {
 		config.AvoidMmap = true
 	}
@@ -163,6 +167,10 @@ func FromEnv(config *Config) error {
 
 	if v := os.Getenv("PERSISTENCE_DATA_PATH"); v != "" {
 		config.Persistence.DataPath = v
+	} else {
+		if config.Persistence.DataPath == "" {
+			config.Persistence.DataPath = DefaultPersistenceDataPath
+		}
 	}
 
 	if err := config.parseMemtableConfig(); err != nil {
@@ -188,6 +196,10 @@ func FromEnv(config *Config) error {
 		}
 
 		config.QueryDefaults.Limit = int64(asInt)
+	} else {
+		if config.QueryDefaults.Limit == 0 {
+			config.QueryDefaults.Limit = DefaultQueryDefaultsLimit
+		}
 	}
 
 	if v := os.Getenv("QUERY_MAXIMUM_RESULTS"); v != "" {


### PR DESCRIPTION
partly fixes #2656 

### Changes
1. Setting default value for `PERSISTENCE_DATA_PATH` to `./data` if not set in config and as env var.
2. Setting default value for `AUTHENTICATION` to `Anonymous access enabled = true` if not set in config and as env var.
3. Setting default value for `QUERY_DEFAULTS_LIMIT` to `10` if not set in config and as env var.
4. Add unit tests for these^.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
