### PR TITLE
Refine tenants selection to distribute tenants an their replicas across more nodes

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -461,6 +461,12 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 		logger.WithField("action", "startup").WithError(err).Error("could not load config")
 		logger.Exit(1)
 	}
+	dataPath := serverConfig.Config.Persistence.DataPath
+	if err := os.MkdirAll(dataPath, 0o777); err != nil {
+		logger.WithField("action", "startup").
+			WithField("path", dataPath).Error("cannot create data directory")
+		logger.Exit(1)
+	}
 
 	monitoring.InitConfig(serverConfig.Config.Monitoring)
 
@@ -501,7 +507,7 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 	logger.WithField("action", "startup").WithField("startup_time_left", timeTillDeadline(ctx)).
 		Debug("initialized schema")
 
-	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Persistence.DataPath, logger)
+	clusterState, err := cluster.Init(serverConfig.Config.Cluster, dataPath, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).
 			Error("could not init cluster state")

--- a/usecases/cluster/delegate_test.go
+++ b/usecases/cluster/delegate_test.go
@@ -202,7 +202,7 @@ func TestDelegateSort(t *testing.T) {
 	delegate.set("N2", NodeInfo{DiskUsage{Available: GB + 128}, now})
 	delegate.set("N3", NodeInfo{DiskUsage{Available: GB + 512}, now})
 	// one block more
-	delegate.set("N4", NodeInfo{DiskUsage{Available: GB + 4096}, now})
+	delegate.set("N4", NodeInfo{DiskUsage{Available: GB + 1<<25}, now})
 	got = delegate.sortCandidates([]string{"N1", "N0", "N2", "N3", "N4"})
 	if got[1] == "N2" {
 		assert.Equal(t, []string{"N4", "N2", "N3", "N1", "N0"}, got)

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -251,29 +251,30 @@ func (s *State) IsLocalShard(name string) bool {
 // Shard 1: Node7, Node8, Node9, Node10, Node 11
 // Shard 2: Node8, Node9, Node10, Node 11, Node 12
 // Shard 3: Node9, Node10, Node11, Node 12, Node 1
-func (s *State) initPhysical(names []string, replFactor int64) error {
-	it, err := cluster.NewNodeIterator(names, cluster.StartAfter)
+func (s *State) initPhysical(nodes []string, replFactor int64) error {
+	it, err := cluster.NewNodeIterator(nodes, cluster.StartAfter)
 	if err != nil {
 		return err
 	}
-	it.SetStartNode(names[len(names)-1])
+	it.SetStartNode(nodes[len(nodes)-1])
 
 	s.Physical = map[string]Physical{}
 
-	shards := make(map[string]bool)
+	nodeSet := make(map[string]bool)
 	for i := 0; i < s.Config.DesiredCount; i++ {
 		name := generateShardName()
 		shard := Physical{Name: name}
+		shard.BelongsToNodes = make([]string, 0, replFactor)
 		for { // select shard
 			node := it.Next()
-			if len(shards) == len(names) { // this is a new round
-				for k := range shards {
-					delete(shards, k)
+			if len(nodeSet) == len(nodes) { // this is a new round
+				for k := range nodeSet {
+					delete(nodeSet, k)
 				}
 			}
-			if !shards[node] {
-				shards[node] = true
-				shard.BelongsToNodes = []string{node}
+			if !nodeSet[node] {
+				nodeSet[node] = true
+				shard.BelongsToNodes = append(shard.BelongsToNodes, node)
 				break
 			}
 		}
@@ -290,42 +291,42 @@ func (s *State) initPhysical(names []string, replFactor int64) error {
 
 // GetPartitions based on the specified shards, available nodes, and replFactor
 // It doesn't change the internal state
-func (s *State) GetPartitions(nodes nodes, shards []string, replFactor int64) (map[string][]string, error) {
-	names := nodes.Candidates()
-	if len(names) == 0 {
+func (s *State) GetPartitions(lookUp nodes, shards []string, replFactor int64) (map[string][]string, error) {
+	nodes := lookUp.Candidates()
+	if len(nodes) == 0 {
 		return nil, fmt.Errorf("list of node candidates is empty")
 	}
-	if f, n := replFactor, len(names); f > int64(n) {
+	if f, n := replFactor, len(nodes); f > int64(n) {
 		return nil, fmt.Errorf("not enough replicas: found %d want %d", n, f)
 	}
-	it, err := cluster.NewNodeIterator(names, cluster.StartAfter)
+	it, err := cluster.NewNodeIterator(nodes, cluster.StartAfter)
 	if err != nil {
 		return nil, err
 	}
-	it.SetStartNode(names[len(names)-1])
+	it.SetStartNode(nodes[len(nodes)-1])
 	partitions := make(map[string][]string, len(shards))
+	nodeSet := make(map[string]bool)
 	for _, name := range shards {
 		if _, alreadyExists := s.Physical[name]; alreadyExists {
 			continue
 		}
-		owners := make([]string, 1, replFactor)
-		node := it.Next()
-		owners[0] = node
-		if replFactor > 1 {
-			// create a second node iterator and start after the already assigned
-			// one, this way we can identify our next n right neighbors without
-			// affecting the root iterator which will determine the next shard
-			replicationIter, err := cluster.NewNodeIterator(names, cluster.StartAfter)
-			if err != nil {
-				return nil, fmt.Errorf("assign replication nodes: %w", err)
+		owners := make([]string, 0, replFactor)
+		for { // select shard
+			node := it.Next()
+			if len(nodeSet) == len(nodes) { // this is a new round
+				for k := range nodeSet {
+					delete(nodeSet, k)
+				}
 			}
+			if !nodeSet[node] {
+				nodeSet[node] = true
+				owners = append(owners, node)
+				break
+			}
+		}
 
-			replicationIter.SetStartNode(node)
-			// the first node is already assigned, we only need to assign the
-			// additional nodes
-			for i := replFactor; i > 1; i-- {
-				owners = append(owners, replicationIter.Next())
-			}
+		for i := replFactor; i > 1; i-- {
+			owners = append(owners, it.Next())
 		}
 
 		partitions[name] = owners

--- a/usecases/sharding/state_test.go
+++ b/usecases/sharding/state_test.go
@@ -254,9 +254,9 @@ func TestGetPartitions(t *testing.T) {
 		require.Nil(t, partitions)
 		require.ErrorContains(t, err, "not enough replicas")
 	})
-	t.Run("Success", func(t *testing.T) {
+	t.Run("Success/RF3", func(t *testing.T) {
 		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3"}}
-		shards := []string{"H1", "H2", "H3"}
+		shards := []string{"H1", "H2", "H3", "H4", "H5"}
 		state := State{}
 		got, err := state.GetPartitions(nodes, shards, 3)
 		require.Nil(t, err)
@@ -264,6 +264,24 @@ func TestGetPartitions(t *testing.T) {
 			"H1": {"N1", "N2", "N3"},
 			"H2": {"N2", "N3", "N1"},
 			"H3": {"N3", "N1", "N2"},
+			"H4": {"N3", "N1", "N2"},
+			"H5": {"N1", "N2", "N3"},
+		}
+		require.Equal(t, want, got)
+	})
+
+	t.Run("Success/RF2", func(t *testing.T) {
+		nodes := fakeNodes{nodes: []string{"N1", "N2", "N3", "N4", "N5", "N6", "N7"}}
+		shards := []string{"H1", "H2", "H3", "H4", "H5"}
+		state := State{}
+		got, err := state.GetPartitions(nodes, shards, 2)
+		require.Nil(t, err)
+		want := map[string][]string{
+			"H1": {"N1", "N2"},
+			"H2": {"N3", "N4"},
+			"H3": {"N5", "N6"},
+			"H4": {"N7", "N1"},
+			"H5": {"N2", "N3"},
 		}
 		require.Equal(t, want, got)
 	})


### PR DESCRIPTION
### What's being changed:

- This PR enhances the distribution of tenants and replicas across all available nodes. It follows a similar approach to a previous [PR](https://github.com/weaviate/weaviate/pull/4077) aimed at improving shard distribution for a shared class
- Fix member list delegate for new nodes with no data directory

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
