### PR TITLE
Make minimal nodes status truly minimal

### DIFF
--- a/test/acceptance/nodes/nodes_api_test.go
+++ b/test/acceptance/nodes/nodes_api_test.go
@@ -43,9 +43,7 @@ func Test_NodesAPI(t *testing.T) {
 			assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
 			assert.Equal(t, meta.Payload.Version, nodeStatus.Version)
 			assert.Empty(t, nodeStatus.Shards)
-			require.NotNil(t, nodeStatus.Stats)
-			assert.Equal(t, int64(0), nodeStatus.Stats.ObjectCount)
-			assert.Equal(t, int64(0), nodeStatus.Stats.ShardCount)
+			require.Nil(t, nodeStatus.Stats)
 		}
 
 		testStatusResponse(t, assertions, nil, "")
@@ -66,9 +64,6 @@ func Test_NodesAPI(t *testing.T) {
 			assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 			assert.True(t, len(nodeStatus.Name) > 0)
 			assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
-			require.NotNil(t, nodeStatus.Stats)
-			assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
-			assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 		}
 
 		verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
@@ -77,6 +72,9 @@ func Test_NodesAPI(t *testing.T) {
 			assert.True(t, len(shard.Name) > 0)
 			assert.Equal(t, booksClass.Class, shard.Class)
 			assert.Equal(t, int64(3), shard.ObjectCount)
+			require.NotNil(t, nodeStatus.Stats)
+			assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
+			assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 		}
 
 		testStatusResponse(t, minimalAssertions, verboseAssertions, "")
@@ -97,9 +95,6 @@ func Test_NodesAPI(t *testing.T) {
 			assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 			assert.True(t, len(nodeStatus.Name) > 0)
 			assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
-			require.NotNil(t, nodeStatus.Stats)
-			assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
-			assert.Equal(t, int64(2), nodeStatus.Stats.ShardCount)
 		}
 
 		verboseAsssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
@@ -108,6 +103,9 @@ func Test_NodesAPI(t *testing.T) {
 				assert.True(t, len(shard.Name) > 0)
 				assert.Equal(t, multiShardClass.Class, shard.Class)
 				assert.GreaterOrEqual(t, shard.ObjectCount, int64(0))
+				require.NotNil(t, nodeStatus.Stats)
+				assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
+				assert.Equal(t, int64(2), nodeStatus.Stats.ShardCount)
 			}
 		}
 
@@ -125,13 +123,14 @@ func Test_NodesAPI(t *testing.T) {
 				helper.AssertGetObjectEventually(t, book.Class, book.ID)
 			}
 
-			assertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+			minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {}
+			verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
 				require.NotNil(t, nodeStatus.Stats)
 				assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
 				assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 			}
 
-			testStatusResponse(t, assertions, nil, "")
+			testStatusResponse(t, minimalAssertions, verboseAssertions, "")
 		})
 
 		t.Run("insert and check documents", func(t *testing.T) {
@@ -152,12 +151,12 @@ func Test_NodesAPI(t *testing.T) {
 				assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 				assert.True(t, len(nodeStatus.Name) > 0)
 				assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
-				require.NotNil(t, nodeStatus.Stats)
-				assert.Equal(t, int64(2), nodeStatus.Stats.ObjectCount)
-				assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 			}
 
 			verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+				require.NotNil(t, nodeStatus.Stats)
+				assert.Equal(t, int64(2), nodeStatus.Stats.ObjectCount)
+				assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 				assert.Len(t, nodeStatus.Shards, 1)
 				shard := nodeStatus.Shards[0]
 				assert.True(t, len(shard.Name) > 0)
@@ -207,12 +206,13 @@ func Test_NodesAPI(t *testing.T) {
 			}), nil)
 		require.Nil(t, err)
 
-		assertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {}
+		verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
 			require.NotNil(t, nodeStatus.Stats)
 			assert.Equal(t, int64(1), nodeStatus.Stats.ObjectCount)
 		}
 
-		testStatusResponse(t, assertions, nil, "")
+		testStatusResponse(t, minimalAssertions, verboseAssertions, "")
 	})
 
 	t.Run("validate flat compression status", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

The previous nodes API simplification [PR](https://github.com/weaviate/weaviate/pull/3864) introduced a verbosity option to enable a more efficient response to a nodes API query on a large cluster.

However, as issue #4112 describes, we are still experiencing high latency under these circumstance.

This PR makes the `minimal` response truly minimal, meaning that no individual shards are accessed for stat updates. This should significantly decrease response latency in large clusters with many 1000s of shards, allowing for a more efficient cluster health update.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
