### PR TITLE
Improve resilience of nodes API

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4069,7 +4069,8 @@ func init() {
           "enum": [
             "HEALTHY",
             "UNHEALTHY",
-            "UNAVAILABLE"
+            "UNAVAILABLE",
+            "TIMEOUT"
           ]
         },
         "version": {
@@ -9259,7 +9260,8 @@ func init() {
           "enum": [
             "HEALTHY",
             "UNHEALTHY",
-            "UNAVAILABLE"
+            "UNAVAILABLE",
+            "TIMEOUT"
           ]
         },
         "version": {

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -16,25 +16,38 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/pkg/errors"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/verbosity"
+	"golang.org/x/sync/errgroup"
 )
 
 // GetNodeStatus returns the status of all Weaviate nodes.
 func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity string) ([]*models.NodeStatus, error) {
 	nodeStatuses := make([]*models.NodeStatus, len(db.schemaGetter.Nodes()))
+	eg := errgroup.Group{}
+	eg.SetLimit(_NUMCPU)
 	for i, nodeName := range db.schemaGetter.Nodes() {
-		status, err := db.getNodeStatus(ctx, nodeName, className, verbosity)
-		if err != nil {
-			return nil, fmt.Errorf("node: %v: %w", nodeName, err)
-		}
-		if status.Status == nil {
-			return nil, enterrors.NewErrNotFound(
-				fmt.Errorf("class %q not found", className))
-		}
-		nodeStatuses[i] = status
+		i, nodeName := i, nodeName
+		eg.Go(func() error {
+			status, err := db.getNodeStatus(ctx, nodeName, className, verbosity)
+			if err != nil {
+				return fmt.Errorf("node: %v: %w", nodeName, err)
+			}
+			if status.Status == nil {
+				return enterrors.NewErrNotFound(
+					fmt.Errorf("class %q not found", className))
+			}
+			nodeStatuses[i] = status
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
 	sort.Slice(nodeStatuses, func(i, j int) bool {
@@ -45,12 +58,20 @@ func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity str
 
 func (db *DB) getNodeStatus(ctx context.Context, nodeName string, className, output string) (*models.NodeStatus, error) {
 	if db.schemaGetter.NodeName() == nodeName {
-		return db.localNodeStatus(className, output), nil
+		return db.localNodeStatus(ctx, className, output), nil
 	}
 	status, err := db.remoteNode.GetNodeStatus(ctx, nodeName, className, output)
 	if err != nil {
-		switch err.(type) {
-		case enterrors.ErrOpenHttpRequest, enterrors.ErrSendHttpRequest:
+		switch typed := err.(type) {
+		case enterrors.ErrSendHttpRequest:
+			if errors.Is(typed.Unwrap(), context.DeadlineExceeded) {
+				nodeTimeout := models.NodeStatusStatusTIMEOUT
+				return &models.NodeStatus{Name: nodeName, Status: &nodeTimeout}, nil
+			}
+
+			nodeUnavailable := models.NodeStatusStatusUNAVAILABLE
+			return &models.NodeStatus{Name: nodeName, Status: &nodeUnavailable}, nil
+		case enterrors.ErrOpenHttpRequest:
 			nodeUnavailable := models.NodeStatusStatusUNAVAILABLE
 			return &models.NodeStatus{Name: nodeName, Status: &nodeUnavailable}, nil
 		default:
@@ -62,10 +83,10 @@ func (db *DB) getNodeStatus(ctx context.Context, nodeName string, className, out
 
 // IncomingGetNodeStatus returns the index if it exists or nil if it doesn't
 func (db *DB) IncomingGetNodeStatus(ctx context.Context, className, verbosity string) (*models.NodeStatus, error) {
-	return db.localNodeStatus(className, verbosity), nil
+	return db.localNodeStatus(ctx, className, verbosity), nil
 }
 
-func (db *DB) localNodeStatus(className, output string) *models.NodeStatus {
+func (db *DB) localNodeStatus(ctx context.Context, className, output string) *models.NodeStatus {
 	var (
 		objectCount int64
 		shardCount  int64
@@ -78,9 +99,9 @@ func (db *DB) localNodeStatus(className, output string) *models.NodeStatus {
 	}
 
 	if className == "" {
-		objectCount, shardCount = db.localNodeStatusAll(&shards, output)
+		objectCount, shardCount = db.localNodeStatusAll(ctx, &shards, output)
 	} else {
-		objectCount, shardCount = db.localNodeStatusForClass(&shards, className, output)
+		objectCount, shardCount = db.localNodeStatusForClass(ctx, &shards, className, output)
 	}
 
 	clusterHealthStatus := models.NodeStatusStatusHEALTHY
@@ -114,7 +135,9 @@ func (db *DB) localNodeStatus(className, output string) *models.NodeStatus {
 	return &status
 }
 
-func (db *DB) localNodeStatusAll(status *[]*models.NodeShardStatus, output string) (totalCount, shardCount int64) {
+func (db *DB) localNodeStatusAll(ctx context.Context, status *[]*models.NodeShardStatus,
+	output string,
+) (totalCount, shardCount int64) {
 	db.indexLock.RLock()
 	defer db.indexLock.RUnlock()
 	for name, idx := range db.indices {
@@ -123,13 +146,13 @@ func (db *DB) localNodeStatusAll(status *[]*models.NodeShardStatus, output strin
 				Warningf("no resource found for index %q", name)
 			continue
 		}
-		total, shard := idx.getShardsNodeStatus(status, output)
+		total, shard := idx.getShardsNodeStatus(ctx, status, output)
 		totalCount, shardCount = totalCount+total, shardCount+shard
 	}
 	return
 }
 
-func (db *DB) localNodeStatusForClass(status *[]*models.NodeShardStatus,
+func (db *DB) localNodeStatusForClass(ctx context.Context, status *[]*models.NodeShardStatus,
 	className, output string,
 ) (totalCount, shardCount int64) {
 	idx := db.GetIndex(schema.ClassName(className))
@@ -138,11 +161,16 @@ func (db *DB) localNodeStatusForClass(status *[]*models.NodeShardStatus,
 			Warningf("no index found for class %q", className)
 		return 0, 0
 	}
-	return idx.getShardsNodeStatus(status, output)
+	return idx.getShardsNodeStatus(ctx, status, output)
 }
 
-func (i *Index) getShardsNodeStatus(status *[]*models.NodeShardStatus, output string) (totalCount, shardCount int64) {
+func (i *Index) getShardsNodeStatus(ctx context.Context,
+	status *[]*models.NodeShardStatus, output string,
+) (totalCount, shardCount int64) {
 	i.ForEachShard(func(name string, shard ShardLike) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		objectCount := int64(shard.ObjectCount())
 		totalCount += objectCount
 		if output == verbosity.OutputVerbose {

--- a/entities/errors/errors_remote_client.go
+++ b/entities/errors/errors_remote_client.go
@@ -11,7 +11,9 @@
 
 package errors
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type ErrOpenHttpRequest struct {
 	err error
@@ -31,6 +33,12 @@ type ErrSendHttpRequest struct {
 
 func (e ErrSendHttpRequest) Error() string {
 	return e.err.Error()
+}
+
+// Unwrap returns the original inner error, so it can be
+// used with errors.Is and errors.As
+func (e ErrSendHttpRequest) Unwrap() error {
+	return e.err
 }
 
 func NewErrSendHttpRequest(err error) ErrSendHttpRequest {

--- a/entities/models/node_status.go
+++ b/entities/models/node_status.go
@@ -48,7 +48,7 @@ type NodeStatus struct {
 	Stats *NodeStats `json:"stats,omitempty"`
 
 	// Node's status.
-	// Enum: [HEALTHY UNHEALTHY UNAVAILABLE]
+	// Enum: [HEALTHY UNHEALTHY UNAVAILABLE TIMEOUT]
 	Status *string `json:"status,omitempty"`
 
 	// The version of Weaviate.
@@ -149,7 +149,7 @@ var nodeStatusTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["HEALTHY","UNHEALTHY","UNAVAILABLE"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["HEALTHY","UNHEALTHY","UNAVAILABLE","TIMEOUT"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -167,6 +167,9 @@ const (
 
 	// NodeStatusStatusUNAVAILABLE captures enum value "UNAVAILABLE"
 	NodeStatusStatusUNAVAILABLE string = "UNAVAILABLE"
+
+	// NodeStatusStatusTIMEOUT captures enum value "TIMEOUT"
+	NodeStatusStatusTIMEOUT string = "TIMEOUT"
 )
 
 // prop value enum

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1087,7 +1087,8 @@
           "enum": [
             "HEALTHY",
             "UNHEALTHY",
-            "UNAVAILABLE"
+            "UNAVAILABLE",
+            "TIMEOUT"
           ]
         },
         "version": {

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -20,6 +20,8 @@ import (
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
+const GetNodeStatusTimeout = 30 * time.Second
+
 type authorizer interface {
 	Authorize(principal *models.Principal, verb, resource string) error
 }
@@ -42,11 +44,11 @@ func NewManager(logger logrus.FieldLogger, authorizer authorizer,
 }
 
 // GetNodeStatus aggregates the status across all nodes. It will try for a
-// maximum of 60 seconds, then timeout
+// maximum of the configured timeout, then mark nodes as timed out.
 func (m *Manager) GetNodeStatus(ctx context.Context,
 	principal *models.Principal, className string, verbosity string,
 ) ([]*models.NodeStatus, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
 	if err := m.authorizer.Authorize(principal, "list", "nodes"); err != nil {


### PR DESCRIPTION
### What's being changed:
* Requests that are relayed to other nodes now happen concurrently. 
* A total timeout of ~~60s~~ 30s was added, if any node exceed this time, the request will be aborted.
* A remote node now honors the request context. When iterating through shards, it stops iterating as soon as the context i s no longer valid
  * Previously it would keep going forever, even if a `SIGTERM` signal came in 
  * I have verified locally that the remote node honors this. The cancelled context is reflected correctly. Both nodes stop. The coordinator node marks the remote node as timed out, the remote node aborts the execution when the context expires
* A new status `TIMEOUT` was added. This status will be shown for any node that 
   * has a successful DNS resolution
   * accepts opening the request
   * timeouts before being able to send a response

<img width="851" alt="Screenshot 2024-02-01 at 10 22 23 AM" src="https://github.com/weaviate/weaviate/assets/8974479/87e454c8-eabb-4e4d-8ba4-5d26a8d88ebc">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
