### PR TITLE
Add support for baseURL in generative-openai azure config

### DIFF
--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -35,7 +35,7 @@ import (
 
 var compile, _ = regexp.Compile(`{([\w\s]*?)}`)
 
-func buildUrlFn(isLegacy bool, resourceName, deploymentID, baseURL string) (string, error) {
+func buildUrlFn(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
 	if resourceName != "" && deploymentID != "" {
 		host := baseURL
 		if host == "" || host == "https://api.openai.com" {
@@ -43,7 +43,7 @@ func buildUrlFn(isLegacy bool, resourceName, deploymentID, baseURL string) (stri
 			host = "https://" + resourceName + ".openai.azure.com"
 		}
 		path := "openai/deployments/" + deploymentID + "/chat/completions"
-		queryParam := "api-version=2023-05-15"
+		queryParam := fmt.Sprintf("api-version=%s", apiVersion)
 		return fmt.Sprintf("%s/%s?%s", host, path, queryParam), nil
 	}
 	path := "/v1/chat/completions"
@@ -57,7 +57,7 @@ type openai struct {
 	openAIApiKey       string
 	openAIOrganization string
 	azureApiKey        string
-	buildUrl           func(isLegacy bool, resourceName, deploymentID, baseURL string) (string, error)
+	buildUrl           func(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error)
 	httpClient         *http.Client
 	logger             logrus.FieldLogger
 }
@@ -171,7 +171,7 @@ func (v *openai) buildOpenAIUrl(ctx context.Context, settings config.ClassSettin
 	if headerBaseURL := v.getValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		baseURL = headerBaseURL
 	}
-	return v.buildUrl(settings.IsLegacy(), settings.ResourceName(), settings.DeploymentID(), baseURL)
+	return v.buildUrl(settings.IsLegacy(), settings.ResourceName(), settings.DeploymentID(), baseURL, settings.ApiVersion())
 }
 
 func (v *openai) generateInput(prompt string, settings config.ClassSettings) (generateInput, error) {

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -37,7 +37,11 @@ var compile, _ = regexp.Compile(`{([\w\s]*?)}`)
 
 func buildUrlFn(isLegacy bool, resourceName, deploymentID, baseURL string) (string, error) {
 	if resourceName != "" && deploymentID != "" {
-		host := "https://" + resourceName + ".openai.azure.com"
+		host := baseURL
+		if host == "" || host == "https://api.openai.com" {
+			// Fall back to old assumption
+			host = "https://" + resourceName + ".openai.azure.com"
+		}
 		path := "openai/deployments/" + deploymentID + "/chat/completions"
 		queryParam := "api-version=2023-03-15-preview"
 		return fmt.Sprintf("%s/%s?%s", host, path, queryParam), nil

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -43,7 +43,7 @@ func buildUrlFn(isLegacy bool, resourceName, deploymentID, baseURL string) (stri
 			host = "https://" + resourceName + ".openai.azure.com"
 		}
 		path := "openai/deployments/" + deploymentID + "/chat/completions"
-		queryParam := "api-version=2023-03-15-preview"
+		queryParam := "api-version=2023-05-15"
 		return fmt.Sprintf("%s/%s?%s", host, path, queryParam), nil
 	}
 	path := "/v1/chat/completions"

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -53,7 +53,7 @@ func TestBuildUrlFn(t *testing.T) {
 	t.Run("buildUrlFn returns Azure Client", func(t *testing.T) {
 		url, err := buildUrlFn(false, "resourceID", "deploymentID", "")
 		assert.Nil(t, err)
-		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/chat/completions?api-version=2023-03-15-preview", url)
+		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/chat/completions?api-version=2023-05-15", url)
 	})
 	t.Run("buildUrlFn loads from environment variable", func(t *testing.T) {
 		url, err := buildUrlFn(false, "", "", "https://foobar.some.proxy")
@@ -64,7 +64,7 @@ func TestBuildUrlFn(t *testing.T) {
 	t.Run("buildUrlFn returns Azure Client with custom baseURL", func(t *testing.T) {
 		url, err := buildUrlFn(false, "resourceID", "deploymentID", "customBaseURL")
 		assert.Nil(t, err)
-		assert.Equal(t, "customBaseURL/openai/deployments/deploymentID/chat/completions?api-version=2023-03-15-preview", url)
+		assert.Equal(t, "customBaseURL/openai/deployments/deploymentID/chat/completions?api-version=2023-05-15", url)
 	})
 }
 

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -55,12 +55,16 @@ func TestBuildUrlFn(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/chat/completions?api-version=2023-03-15-preview", url)
 	})
-
 	t.Run("buildUrlFn loads from environment variable", func(t *testing.T) {
 		url, err := buildUrlFn(false, "", "", "https://foobar.some.proxy")
 		assert.Nil(t, err)
 		assert.Equal(t, "https://foobar.some.proxy/v1/chat/completions", url)
 		os.Unsetenv("OPENAI_BASE_URL")
+	})
+	t.Run("buildUrlFn returns Azure Client with custom baseURL", func(t *testing.T) {
+		url, err := buildUrlFn(false, "resourceID", "deploymentID", "customBaseURL")
+		assert.Nil(t, err)
+		assert.Equal(t, "customBaseURL/openai/deployments/deploymentID/chat/completions?api-version=2023-03-15-preview", url)
 	})
 }
 

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -139,6 +139,32 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantBaseURL:          "https://api.openai.com",
 		},
 		{
+			name: "Azure OpenAI config with baseURL",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"baseURL":          "some-base-url",
+					"resourceName":     "weaviate",
+					"deploymentId":     "gpt-3.5-turbo",
+					"maxTokens":        4097,
+					"temperature":      0.5,
+					"topP":             3,
+					"frequencyPenalty": 0.1,
+					"presencePenalty":  0.9,
+				},
+			},
+			wantResourceName:     "weaviate",
+			wantDeploymentID:     "gpt-3.5-turbo",
+			wantIsAzure:          true,
+			wantModel:            "gpt-3.5-turbo",
+			wantMaxTokens:        4097,
+			wantTemperature:      0.5,
+			wantTopP:             3,
+			wantFrequencyPenalty: 0.1,
+			wantPresencePenalty:  0.9,
+			wantErr:              nil,
+			wantBaseURL:          "some-base-url",
+		},
+		{
 			name: "With gpt-3.5-turbo-16k model",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -34,6 +34,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantIsAzure          bool
 		wantErr              error
 		wantBaseURL          string
+		wantApiVersion       string
 	}{
 		{
 			name: "Happy flow",
@@ -48,6 +49,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.0,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
+			wantApiVersion:       "2023-05-15",
 		},
 		{
 			name: "Everything non default configured",
@@ -69,6 +71,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
+			wantApiVersion:       "2023-05-15",
 		},
 		{
 			name: "OpenAI Proxy",
@@ -84,6 +87,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantBaseURL:          "https://proxy.weaviate.dev/",
+			wantApiVersion:       "2023-05-15",
 			wantModel:            "gpt-3.5-turbo",
 			wantMaxTokens:        4097,
 			wantTemperature:      0.5,
@@ -112,6 +116,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
+			wantApiVersion:       "2023-05-15",
 		},
 		{
 			name: "Azure OpenAI config",
@@ -137,6 +142,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
+			wantApiVersion:       "2023-05-15",
 		},
 		{
 			name: "Azure OpenAI config with baseURL",
@@ -163,6 +169,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "some-base-url",
+			wantApiVersion:       "2023-05-15",
 		},
 		{
 			name: "With gpt-3.5-turbo-16k model",
@@ -184,6 +191,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
+			wantApiVersion:       "2023-05-15",
 		},
 		{
 			name: "Wrong maxTokens configured",
@@ -248,6 +256,17 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 			wantErr: errors.Errorf("both resourceName and deploymentId must be provided"),
 		},
+		{
+			name: "Wrong Azure config - wrong api version",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"apiVersion": "wrong-api-version",
+				},
+			},
+			wantErr: errors.Errorf("wrong Azure OpenAI apiVersion, available api versions are: " +
+				"[2022-12-01 2023-03-15-preview 2023-05-15 2023-06-01-preview 2023-07-01-preview " +
+				"2023-08-01-preview 2023-09-01-preview 2023-12-01-preview]"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -265,6 +284,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				assert.Equal(t, tt.wantDeploymentID, ic.DeploymentID())
 				assert.Equal(t, tt.wantIsAzure, ic.IsAzure())
 				assert.Equal(t, tt.wantBaseURL, ic.BaseURL())
+				assert.Equal(t, tt.wantApiVersion, ic.ApiVersion())
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:

This PR adds the ability to define `baseURL` when user uses Azure (closes #4092).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
