### PR TITLE
Prevent segment inconsistencies

### DIFF
--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -278,7 +278,7 @@ func (t *JsonPropertyLengthTracker) Flush(flushBackup bool) error {
 	// Do a write+rename to avoid corrupting the file if we crash while writing
 	tempfile := filename + ".tmp"
 
-	err = os.WriteFile(tempfile, bytes, 0o666)
+	err = WriteAndSyncFile(tempfile, bytes, 0o666)
 	if err != nil {
 		return err
 	}
@@ -289,6 +289,21 @@ func (t *JsonPropertyLengthTracker) Flush(flushBackup bool) error {
 	}
 
 	return nil
+}
+
+func WriteAndSyncFile(name string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
 }
 
 // Closes the tracker and removes the backup file

--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -278,7 +278,7 @@ func (t *JsonPropertyLengthTracker) Flush(flushBackup bool) error {
 	// Do a write+rename to avoid corrupting the file if we crash while writing
 	tempfile := filename + ".tmp"
 
-	err = WriteAndSyncFile(tempfile, bytes, 0o666)
+	err = WriteFile(tempfile, bytes, 0o666)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func (t *JsonPropertyLengthTracker) Flush(flushBackup bool) error {
 	return nil
 }
 
-func WriteAndSyncFile(name string, data []byte, perm os.FileMode) error {
+func WriteFile(name string, data []byte, perm os.FileMode) error {
 	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return err
@@ -303,7 +303,10 @@ func WriteAndSyncFile(name string, data []byte, perm os.FileMode) error {
 		return err
 	}
 
-	return f.Sync()
+	// TODO: f.Sync() is introducing performance penalization at this point
+	// it will be addressed as part of another PR
+
+	return nil
 }
 
 // Closes the tracker and removes the backup file

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -12,16 +12,19 @@
 package lsmkv
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 )
 
-func (b *Bucket) recoverFromCommitLogs(ctx context.Context) error {
+func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 	beforeAll := time.Now()
 	defer b.metrics.TrackStartupBucketRecovery(beforeAll)
 
@@ -47,27 +50,78 @@ func (b *Bucket) recoverFromCommitLogs(ctx context.Context) error {
 			continue
 		}
 
-		if filepath.Join(b.dir, fileInfo.Name()) == b.active.path+".wal" {
-			// this is the new one which was just created
+		segmentFileName := strings.TrimSuffix(fileInfo.Name(), ".wal") + ".db"
+		ok, err := fileExists(filepath.Join(b.dir, segmentFileName))
+		if err != nil {
+			return fmt.Errorf("check for presence of segment file for wal %s: %w", fileInfo.Name(), err)
+		}
+
+		if !ok {
+			// Note (jeroiraz): deletion may not be needed when integrity checking of wal files is incorporated
+			if err := os.Remove(filepath.Join(b.dir, fileInfo.Name())); err != nil {
+				return fmt.Errorf("delete potentially corrupt wal file %s: %w", fileInfo.Name(), err)
+			}
+
+			b.logger.WithField("action", "lsm_recover_from_active_wal").
+				WithField("path", filepath.Join(b.dir, fileInfo.Name())).
+				WithField("segment_path", segmentFileName).
+				Info("Discarded (potentially corrupted) WAL file, because no segment file for " +
+					"the same WAL file was found.")
+
 			continue
 		}
 
 		walFileNames = append(walFileNames, fileInfo.Name())
 	}
 
-	if len(walFileNames) == 0 {
-		// nothing to recover from
-		return nil
-	}
-
 	// recover from each log
 	for _, fname := range walFileNames {
+		path := filepath.Join(b.dir, strings.TrimSuffix(fname, ".wal"))
+
+		cl, err := newCommitLogger(path)
+		if err != nil {
+			return errors.Wrap(err, "init commit logger")
+		}
+		defer cl.close()
+
+		cl.pause()
+
+		mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics)
+		if err != nil {
+			return err
+		}
+
 		b.logger.WithField("action", "lsm_recover_from_active_wal").
-			WithField("path", filepath.Join(b.dir, fname)).
+			WithField("path", path).
 			Warning("active write-ahead-log found. Did weaviate crash prior to this? Trying to recover...")
 
-		if err := b.parseWALIntoMemtable(filepath.Join(b.dir, fname)); err != nil {
+		err = newCommitLoggerParser(bufio.NewReader(cl.file), mt, b.strategy, b.metrics).Do()
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			// we need to check for both EOF or UnexpectedEOF, as we don't know where
+			// the commit log got corrupted, a field ending that weset a longer
+			// encoding for would return EOF, whereas a field read with binary.Read
+			// with a fixed size would return UnexpectedEOF. From our perspective both
+			// are unexpected.
+
+			b.logger.WithField("action", "lsm_recover_from_active_wal_corruption").
+				WithField("path", filepath.Join(b.dir, fname)).
+				Error("write-ahead-log ended abruptly, some elements may not have been recovered")
+		} else if err != nil {
 			return errors.Wrapf(err, "ingest wal %q", fname)
+		}
+
+		if err := mt.flush(); err != nil {
+			return errors.Wrap(err, "flush memtable after WAL recovery")
+		}
+
+		if err := b.disk.add(path + ".db"); err != nil {
+			return err
+		}
+
+		if b.strategy == StrategyReplace && b.monitorCount {
+			// having just flushed the memtable we now have the most up2date count which
+			// is a good place to update the metric
+			b.metrics.ObjectCount(b.disk.count())
 		}
 
 		b.logger.WithField("action", "lsm_recover_from_active_wal_success").
@@ -75,43 +129,5 @@ func (b *Bucket) recoverFromCommitLogs(ctx context.Context) error {
 			Info("successfully recovered from write-ahead-log")
 	}
 
-	if b.active.size > 0 {
-		if err := b.FlushAndSwitch(); err != nil {
-			return errors.Wrap(err, "flush memtable after WAL recovery")
-		}
-	}
-
-	// delete the commit logs as we can now be sure that they are part of a disk
-	// segment
-	for _, fname := range walFileNames {
-		if err := os.RemoveAll(filepath.Join(b.dir, fname)); err != nil {
-			return errors.Wrap(err, "clean up commit log")
-		}
-	}
-
 	return nil
-}
-
-func (b *Bucket) parseWALIntoMemtable(fname string) error {
-	// pause commit logging while reading the old log to avoid creating a
-	// duplicate of the log
-	b.active.commitlog.pause()
-	defer b.active.commitlog.unpause()
-
-	err := newCommitLoggerParser(fname, b.active, b.strategy, b.metrics).Do()
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		// we need to check for both EOF or UnexpectedEOF, as we don't know where
-		// the commit log got corrupted, a field ending that weset a longer
-		// encoding for would return EOF, whereas a field read with binary.Read
-		// with a fixed size would return UnexpectedEOF. From our perspective both
-		// are unexpected.
-
-		b.logger.WithField("action", "lsm_recover_from_active_wal_corruption").
-			WithField("path", filepath.Join(b.dir, fname)).
-			Error("write-ahead-log ended abruptly, some elements may not have been recovered")
-
-		return nil
-	}
-
-	return err
 }

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -63,6 +63,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		defer cl.close()
 
 		cl.pause()
+		defer cl.unpause()
 
 		mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics)
 		if err != nil {

--- a/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
@@ -12,18 +12,13 @@
 package lsmkv
 
 import (
-	"bufio"
 	"encoding/binary"
 	"io"
 
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/entities/diskio"
 )
 
 func (p *commitloggerParser) doCollection() error {
-	metered := diskio.NewMeteredReader(p.r, p.metrics.TrackStartupReadWALDiskIO)
-	p.reader = bufio.NewReaderSize(metered, 1*1024*1024)
-
 	for {
 		var commitType CommitType
 
@@ -31,7 +26,6 @@ func (p *commitloggerParser) doCollection() error {
 		if errors.Is(err, io.EOF) {
 			break
 		}
-
 		if err != nil {
 			return errors.Wrap(err, "read commit type")
 		}

--- a/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
@@ -57,9 +57,6 @@ func (p *commitloggerParser) parseCollectionNodeV0() error {
 	var commitType CommitType
 
 	err := binary.Read(p.reader, binary.LittleEndian, &commitType)
-	if errors.Is(err, io.EOF) {
-		return nil
-	}
 	if err != nil {
 		return errors.Wrap(err, "read commit type")
 	}

--- a/adapters/repos/db/lsmkv/commitlogger_parser_replace.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_replace.go
@@ -79,9 +79,6 @@ func (p *commitloggerParser) doReplaceRecordV0(nodeCache map[string]segmentRepla
 	var commitType CommitType
 
 	err := binary.Read(p.reader, binary.LittleEndian, &commitType)
-	if errors.Is(err, io.EOF) {
-		return nil
-	}
 	if err != nil {
 		return errors.Wrap(err, "read commit type")
 	}

--- a/adapters/repos/db/lsmkv/commitlogger_parser_replace.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_replace.go
@@ -1,0 +1,162 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// doReplace parsers all entries into a cache for deduplication first and only
+// imports unique entries into the actual memtable as a final step.
+func (p *commitloggerParser) doReplace() error {
+	nodeCache := make(map[string]segmentReplaceNode)
+
+	var errWhileParsing error
+
+	for {
+		var version uint8
+
+		err := binary.Read(p.checksumReader, binary.LittleEndian, &version)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			errWhileParsing = errors.Wrap(err, "read commit version")
+			break
+		}
+
+		switch version {
+		case 0:
+			{
+				err = p.doReplaceRecordV0(nodeCache)
+			}
+		case 1:
+			{
+				err = p.doReplaceRecordV1(nodeCache)
+			}
+		default:
+			{
+				return fmt.Errorf("unsupported commit version %d", version)
+			}
+		}
+		if err != nil {
+			errWhileParsing = err
+			break
+		}
+	}
+
+	for _, node := range nodeCache {
+		var opts []SecondaryKeyOption
+		if p.memtable.secondaryIndices > 0 {
+			for i, secKey := range node.secondaryKeys {
+				opts = append(opts, WithSecondaryKey(i, secKey))
+			}
+		}
+		if node.tombstone {
+			p.memtable.setTombstone(node.primaryKey, opts...)
+		} else {
+			p.memtable.put(node.primaryKey, node.value, opts...)
+		}
+	}
+
+	return errWhileParsing
+}
+
+func (p *commitloggerParser) doReplaceRecordV0(nodeCache map[string]segmentReplaceNode) error {
+	var commitType CommitType
+
+	err := binary.Read(p.reader, binary.LittleEndian, &commitType)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "read commit type")
+	}
+
+	if CommitTypeReplace.Is(commitType) {
+		if err := p.parseReplaceNode(p.reader, nodeCache); err != nil {
+			return errors.Wrap(err, "read replace node")
+		}
+	} else {
+		return errors.Errorf("found a %s commit on a replace bucket", commitType.String())
+	}
+
+	return nil
+}
+
+func (p *commitloggerParser) doReplaceRecordV1(nodeCache map[string]segmentReplaceNode) error {
+	var commitType CommitType
+
+	err := binary.Read(p.checksumReader, binary.LittleEndian, &commitType)
+	if err != nil {
+		return errors.Wrap(err, "read commit type")
+	}
+	if !CommitTypeReplace.Is(commitType) {
+		return errors.Errorf("found a %s commit on a replace bucket", commitType.String())
+	}
+
+	var nodeLen uint32
+	err = binary.Read(p.checksumReader, binary.LittleEndian, &nodeLen)
+	if err != nil {
+		return errors.Wrap(err, "read commit node length")
+	}
+
+	p.bufNode.Reset()
+
+	io.CopyN(p.bufNode, p.checksumReader, int64(nodeLen))
+
+	// read checksum directly from the reader
+	var checksum [4]byte
+	_, err = io.ReadFull(p.reader, checksum[:])
+	if err != nil {
+		return errors.Wrap(err, "read commit checksum")
+	}
+
+	// validate checksum
+	if !bytes.Equal(checksum[:], p.checksumReader.Hash()) {
+		return errors.Wrap(ErrInvalidChecksum, "read commit entry")
+	}
+
+	if err := p.parseReplaceNode(p.bufNode, nodeCache); err != nil {
+		return errors.Wrap(err, "read replace node")
+	}
+
+	return nil
+}
+
+// parseReplaceNode only parses into the deduplication cache, not into the
+// final memtable yet. A second step is required to parse from the cache into
+// the actual memtable.
+func (p *commitloggerParser) parseReplaceNode(r io.Reader, nodeCache map[string]segmentReplaceNode) error {
+	n, err := ParseReplaceNode(r, p.memtable.secondaryIndices)
+	if err != nil {
+		return err
+	}
+
+	if !n.tombstone {
+		nodeCache[string(n.primaryKey)] = n
+	} else {
+		if existing, ok := nodeCache[string(n.primaryKey)]; ok {
+			existing.tombstone = true
+			nodeCache[string(n.primaryKey)] = existing
+		} else {
+			nodeCache[string(n.primaryKey)] = n
+		}
+	}
+
+	return nil
+}

--- a/adapters/repos/db/lsmkv/commitlogger_parser_roaringset.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_roaringset.go
@@ -58,9 +58,6 @@ func (p *commitloggerParser) parseRoaringSetNodeV0() error {
 	var commitType CommitType
 
 	err := binary.Read(p.reader, binary.LittleEndian, &commitType)
-	if errors.Is(err, io.EOF) {
-		return nil
-	}
 	if err != nil {
 		return errors.Wrap(err, "read commit type")
 	}

--- a/adapters/repos/db/lsmkv/commitlogger_parser_roaringset.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_roaringset.go
@@ -12,19 +12,14 @@
 package lsmkv
 
 import (
-	"bufio"
 	"encoding/binary"
 	"io"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/roaringset"
-	"github.com/weaviate/weaviate/entities/diskio"
 )
 
 func (p *commitloggerParser) doRoaringSet() error {
-	metered := diskio.NewMeteredReader(p.r, p.metrics.TrackStartupReadWALDiskIO)
-	p.reader = bufio.NewReaderSize(metered, 1*1024*1024)
-
 	for {
 		var commitType CommitType
 
@@ -32,7 +27,6 @@ func (p *commitloggerParser) doRoaringSet() error {
 		if errors.Is(err, io.EOF) {
 			break
 		}
-
 		if err != nil {
 			return errors.Wrap(err, "read commit type")
 		}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -40,13 +40,8 @@ type Memtable struct {
 }
 
 func newMemtable(path string, strategy string,
-	secondaryIndices uint16, metrics *Metrics,
+	secondaryIndices uint16, cl *commitLogger, metrics *Metrics,
 ) (*Memtable, error) {
-	cl, err := newCommitLogger(path)
-	if err != nil {
-		return nil, errors.Wrap(err, "init commit logger")
-	}
-
 	m := &Memtable{
 		key:              &binarySearchTree{},
 		keyMulti:         &binarySearchTreeMulti{},

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -47,7 +47,7 @@ func (m *Memtable) flush() error {
 		return err
 	}
 
-	w := bufio.NewWriterSize(f, int(float64(m.size)*1.3)) // calculate 30% overhead for disk representation
+	w := bufio.NewWriter(f)
 
 	var keys []segmentindex.Key
 	switch m.strategy {

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -89,6 +89,10 @@ func (m *Memtable) flush() error {
 		return err
 	}
 
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
 	if err := f.Close(); err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -42,7 +42,7 @@ func (m *Memtable) flush() error {
 		return nil
 	}
 
-	f, err := os.Create(m.path + ".db")
+	f, err := os.OpenFile(m.path+".db", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o666)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
@@ -26,7 +26,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	}
 
 	t.Run("inserting individual entries", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -55,7 +58,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("inserting lists", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -82,7 +88,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("inserting bitmaps", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -111,7 +120,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing individual entries", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -134,7 +146,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing lists", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -161,7 +176,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing bitmaps", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -188,7 +206,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("adding/removing bitmaps", func(t *testing.T) {
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, nil)
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -24,7 +24,11 @@ import (
 // https://www.youtube.com/watch?v=OS8taasZl8k
 func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	dir := t.TempDir()
-	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, nil)
+
+	cl, err := newCommitLogger(dir)
+	require.NoError(t, err)
+
+	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, cl, nil)
 	require.Nil(t, err)
 	t.Cleanup(func() {
 		require.Nil(t, m.commitlog.close())

--- a/adapters/repos/db/lsmkv/rwhasher/reader.go
+++ b/adapters/repos/db/lsmkv/rwhasher/reader.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rwhasher
+
+import (
+	"hash"
+	"hash/crc32"
+	"io"
+)
+
+type ReaderHasher interface {
+	io.Reader
+	N() int
+	Hash() []byte
+	Reset()
+}
+
+var _ ReaderHasher = (*CRC32Reader)(nil)
+
+type CRC32Reader struct {
+	r    io.Reader
+	n    int
+	hash hash.Hash32
+}
+
+func NewCRC32Reader(r io.Reader) *CRC32Reader {
+	return &CRC32Reader{
+		r:    r,
+		hash: crc32.NewIEEE(),
+	}
+}
+
+func (rc *CRC32Reader) Read(p []byte) (n int, err error) {
+	n, err = rc.r.Read(p)
+	rc.n += n
+	rc.hash.Write(p[:n])
+	return n, err
+}
+
+func (rc *CRC32Reader) N() int {
+	return rc.n
+}
+
+func (rc *CRC32Reader) Hash() []byte {
+	return rc.hash.Sum(nil)
+}
+
+func (rc *CRC32Reader) Reset() {
+	rc.n = 0
+	rc.hash.Reset()
+}

--- a/adapters/repos/db/lsmkv/rwhasher/writer.go
+++ b/adapters/repos/db/lsmkv/rwhasher/writer.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rwhasher
+
+import (
+	"hash"
+	"hash/crc32"
+	"io"
+)
+
+type WriterHasher interface {
+	io.Writer
+	N() int
+	Hash() []byte
+	Reset()
+}
+
+var _ WriterHasher = (*CRC32Writer)(nil)
+
+type CRC32Writer struct {
+	w    io.Writer
+	n    int
+	hash hash.Hash32
+}
+
+func NewCRC32Writer(w io.Writer) *CRC32Writer {
+	return &CRC32Writer{
+		w:    w,
+		hash: crc32.NewIEEE(),
+	}
+}
+
+func (wc *CRC32Writer) Write(p []byte) (n int, err error) {
+	n, err = wc.w.Write(p)
+	wc.n += n
+	wc.hash.Write(p[:n])
+	return n, err
+}
+
+func (wc *CRC32Writer) N() int {
+	return wc.n
+}
+
+func (wc *CRC32Writer) Hash() []byte {
+	return wc.hash.Sum(nil)
+}
+
+func (wc *CRC32Writer) Reset() {
+	wc.n = 0
+	wc.hash.Reset()
+}

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -72,7 +72,7 @@ type diskIndex interface {
 
 func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	existsLower existsOnLowerSegmentsFn, mmapContents bool,
-	useBloomFilter bool, calcCountNetAdditions bool,
+	useBloomFilter bool, calcCountNetAdditions bool, overwriteDerived bool,
 ) (*segment, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -147,12 +147,12 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	}
 
 	if seg.useBloomFilter {
-		if err := seg.initBloomFilters(metrics); err != nil {
+		if err := seg.initBloomFilters(metrics, overwriteDerived); err != nil {
 			return nil, err
 		}
 	}
 	if seg.calcCountNetAdditions {
-		if err := seg.initCountNetAdditions(existsLower); err != nil {
+		if err := seg.initCountNetAdditions(existsLower, overwriteDerived); err != nil {
 			return nil, err
 		}
 	}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -115,10 +115,6 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 		}
 
 		if ok {
-			if err := os.Remove(filepath.Join(sg.dir, entry.Name())); err != nil {
-				return nil, fmt.Errorf("delete corrupt segment %s: %w", entry.Name(), err)
-			}
-
 			logger.WithField("action", "lsm_segment_init").
 				WithField("path", filepath.Join(sg.dir, entry.Name())).
 				WithField("wal_path", potentialWALFileName).

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -183,7 +183,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 		walFileName := strings.TrimSuffix(entry.Name(), ".db") + ".wal"
 		ok, err := fileExists(filepath.Join(sg.dir, walFileName))
 		if err != nil {
-			return nil, fmt.Errorf("check for ¡¡ of wals for segment %s: %w",
+			return nil, fmt.Errorf("check for presence of wals for segment %s: %w",
 				entry.Name(), err)
 		}
 		if ok {

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -284,7 +284,7 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	}
 
 	seg, err := newSegment(newPath, sg.logger, sg.metrics, nil,
-		sg.mmapContents, sg.useBloomFilter, sg.calcCountNetAdditions)
+		sg.mmapContents, sg.useBloomFilter, sg.calcCountNetAdditions, false)
 	if err != nil {
 		return errors.Wrap(err, "create new segment")
 	}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -179,7 +179,7 @@ func (t *DiskTree) AllKeys() ([][]byte, error) {
 	for {
 		node, readLength, err := t.readNode(t.data[bufferPos:])
 		bufferPos += readLength
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {


### PR DESCRIPTION
- integrity checking into lsm wal files (new versioned wal file format)
- file syncing when a memtable is dumped as a segment
- crash tolerant segment-compaction

Integrity checking was added to WAL files in a backward compatible manner. The new WAL entries data format is defined as follows:

```
 |---------------------------|
 |  version == 0 (1byte)  |
 |  record (dynamic length)  |
 |---------------------------|

-------------------------------------------------------
|  version == 1 (1byte)  |
|  type (1byte)   |
|  node length (4bytes)    |
|  node (dynamic length)   |
|  checksum (crc32 4bytes non-checksum fields so far)  |
-------------------------------------------------------
```

### What's being changed:

Memtable serialization into a Segment file and Segment compaction process with stronger crash-tolerance
 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
