### PR TITLE
fix: qna-transformer acceptance test runners by adding larger runners

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -95,6 +95,22 @@ jobs:
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh ${{ matrix.test }}
+  Modules-Acceptance-Tests-large:
+    name: modules-acceptance-tests-large
+    runs-on: ubuntu-latest-4-cores
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ["--only-module-qna-transformers"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+      - name: Acceptance tests Large (modules)
+        run: ./test/run.sh ${{ matrix.test }}
   Acceptance-Tests:
     name: acceptance-tests  
     runs-on: ubuntu-latest
@@ -208,7 +224,7 @@ jobs:
         run: go test -count 1 -race test/acceptance/actions/*.go  # tests that don't need a Vectorizer
 
   Push-Docker:
-    needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]
+    needs: [Acceptance-Tests, Modules-Acceptance-Tests, Modules-Acceptance-Tests-large, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]
     name: push-docker
     runs-on: ubuntu-latest-8-cores
     if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork


### PR DESCRIPTION
### What's being changed:
this PR uses a bigger runner for `qna-transformer` acceptance test to be able to pull big images without running out of cache. by adding acceptance tests with bigger runners step


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
