### PR TITLE
locks: write-only sharded locks

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -24,7 +24,7 @@ import (
 )
 
 type shardedLockCache[T float32 | byte | uint64] struct {
-	shardedLocks     *common.ShardedLocks
+	shardedLocks     *common.ShardedRWLocks
 	cache            [][]T
 	vectorForID      common.VectorForID[T]
 	normalizeOnRead  bool
@@ -65,7 +65,7 @@ func NewShardedFloat32LockCache(vecForID common.VectorForID[float32], maxSize in
 		maxSize:          int64(maxSize),
 		cancel:           make(chan bool),
 		logger:           logger,
-		shardedLocks:     common.NewDefaultShardedLocks(),
+		shardedLocks:     common.NewDefaultShardedRWLocks(),
 		maintenanceLock:  sync.RWMutex{},
 		deletionInterval: deletionInterval,
 	}
@@ -85,7 +85,7 @@ func NewShardedByteLockCache(vecForID common.VectorForID[byte], maxSize int,
 		maxSize:          int64(maxSize),
 		cancel:           make(chan bool),
 		logger:           logger,
-		shardedLocks:     common.NewDefaultShardedLocks(),
+		shardedLocks:     common.NewDefaultShardedRWLocks(),
 		maintenanceLock:  sync.RWMutex{},
 		deletionInterval: deletionInterval,
 	}
@@ -105,7 +105,7 @@ func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int,
 		maxSize:          int64(maxSize),
 		cancel:           make(chan bool),
 		logger:           logger,
-		shardedLocks:     common.NewDefaultShardedLocks(),
+		shardedLocks:     common.NewDefaultShardedRWLocks(),
 		maintenanceLock:  sync.RWMutex{},
 		deletionInterval: deletionInterval,
 	}

--- a/adapters/repos/db/vector/common/sharded_locks.go
+++ b/adapters/repos/db/vector/common/sharded_locks.go
@@ -15,90 +15,90 @@ import "sync"
 
 const DefaultShardedLocksCount = 512
 
-type ShardedLocks struct {
+type ShardedRWLocks struct {
 	// sharded locks
 	shards []sync.RWMutex
 	// number of locks
 	count uint64
 }
 
-func NewDefaultShardedLocks() *ShardedLocks {
-	return NewShardedLocks(DefaultShardedLocksCount)
+func NewDefaultShardedRWLocks() *ShardedRWLocks {
+	return NewShardedRWLocks(DefaultShardedLocksCount)
 }
 
-func NewShardedLocks(count uint64) *ShardedLocks {
+func NewShardedRWLocks(count uint64) *ShardedRWLocks {
 	if count < 2 {
 		count = 2
 	}
 
-	return &ShardedLocks{
+	return &ShardedRWLocks{
 		shards: make([]sync.RWMutex, count),
 		count:  count,
 	}
 }
 
-func (sl *ShardedLocks) LockAll() {
+func (sl *ShardedRWLocks) LockAll() {
 	for i := uint64(0); i < sl.count; i++ {
 		sl.shards[i].Lock()
 	}
 }
 
-func (sl *ShardedLocks) UnlockAll() {
+func (sl *ShardedRWLocks) UnlockAll() {
 	for i := int(sl.count) - 1; i >= 0; i-- {
 		sl.shards[i].Unlock()
 	}
 }
 
-func (sl *ShardedLocks) LockedAll(callback func()) {
+func (sl *ShardedRWLocks) LockedAll(callback func()) {
 	sl.LockAll()
 	defer sl.UnlockAll()
 
 	callback()
 }
 
-func (sl *ShardedLocks) Lock(id uint64) {
+func (sl *ShardedRWLocks) Lock(id uint64) {
 	sl.shards[id%sl.count].Lock()
 }
 
-func (sl *ShardedLocks) Unlock(id uint64) {
+func (sl *ShardedRWLocks) Unlock(id uint64) {
 	sl.shards[id%sl.count].Unlock()
 }
 
-func (sl *ShardedLocks) Locked(id uint64, callback func()) {
+func (sl *ShardedRWLocks) Locked(id uint64, callback func()) {
 	sl.Lock(id)
 	defer sl.Unlock(id)
 
 	callback()
 }
 
-func (sl *ShardedLocks) RLockAll() {
+func (sl *ShardedRWLocks) RLockAll() {
 	for i := uint64(0); i < sl.count; i++ {
 		sl.shards[i].RLock()
 	}
 }
 
-func (sl *ShardedLocks) RUnlockAll() {
+func (sl *ShardedRWLocks) RUnlockAll() {
 	for i := int(sl.count) - 1; i >= 0; i-- {
 		sl.shards[i].RUnlock()
 	}
 }
 
-func (sl *ShardedLocks) RLockedAll(callback func()) {
+func (sl *ShardedRWLocks) RLockedAll(callback func()) {
 	sl.RLockAll()
 	defer sl.RUnlockAll()
 
 	callback()
 }
 
-func (sl *ShardedLocks) RLock(id uint64) {
+func (sl *ShardedRWLocks) RLock(id uint64) {
 	sl.shards[id%sl.count].RLock()
 }
 
-func (sl *ShardedLocks) RUnlock(id uint64) {
+func (sl *ShardedRWLocks) RUnlock(id uint64) {
 	sl.shards[id%sl.count].RUnlock()
 }
 
-func (sl *ShardedLocks) RLocked(id uint64, callback func()) {
+func (sl *ShardedRWLocks) RLocked(id uint64, callback func()) {
 	sl.RLock(id)
 	defer sl.RUnlock(id)
 

--- a/adapters/repos/db/vector/common/sharded_locks_test.go
+++ b/adapters/repos/db/vector/common/sharded_locks_test.go
@@ -23,7 +23,7 @@ func TestShardedLocks_ParallelLocksAll(t *testing.T) {
 	// no asserts
 	// ensures parallel LockAll does not fall into deadlock
 	count := 10
-	sl := NewDefaultShardedLocks()
+	sl := NewDefaultShardedRWLocks()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(count)
@@ -41,7 +41,7 @@ func TestShardedLocks_ParallelRLocksAll(t *testing.T) {
 	// no asserts
 	// ensures parallel RLockAll does not fall into deadlock
 	count := 10
-	sl := NewDefaultShardedLocks()
+	sl := NewDefaultShardedRWLocks()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(count)
@@ -59,7 +59,7 @@ func TestShardedLocks_ParallelLocksAllAndRLocksAll(t *testing.T) {
 	// no asserts
 	// ensures parallel LockAll + RLockAll does not fall into deadlock
 	count := 50
-	sl := NewDefaultShardedLocks()
+	sl := NewDefaultShardedRWLocks()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(count)
@@ -82,7 +82,7 @@ func TestShardedLocks_MixedLocks(t *testing.T) {
 	// no asserts
 	// ensures parallel LockAll + RLockAll + Lock + RLock does not fall into deadlock
 	count := 1000
-	sl := NewShardedLocks(10)
+	sl := NewShardedRWLocks(10)
 
 	wg := new(sync.WaitGroup)
 	wg.Add(count)
@@ -115,7 +115,7 @@ func TestShardedLocks_MixedLocks(t *testing.T) {
 func TestShardedLocks(t *testing.T) {
 	t.Run("RLock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.RLock(1)
 		m.RLock(1)
@@ -126,7 +126,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("Lock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.Lock(1)
 
@@ -151,7 +151,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("RLock blocks Lock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.RLock(1)
 
@@ -176,7 +176,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("Lock blocks RLock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.Lock(1)
 
@@ -201,7 +201,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("Lock blocks LockAll", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.Lock(1)
 
@@ -226,7 +226,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("LockAll blocks Lock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.LockAll()
 
@@ -251,7 +251,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("LockAll blocks RLock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.LockAll()
 
@@ -276,7 +276,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("LockAll blocks LockAll", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.LockAll()
 
@@ -301,7 +301,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("UnlockAll releases all locks", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.LockAll()
 		m.UnlockAll()
@@ -315,7 +315,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("RLockAll blocks Lock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.RLockAll()
 
@@ -340,7 +340,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("RLockAll doesn't block/unblock RLock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.RLockAll()
 		m.RLock(1)
@@ -351,7 +351,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("RLockAll blocks LockAll", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.RLockAll()
 
@@ -376,7 +376,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("RLockAll doesn't block RLockAll", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(5)
+		m := NewShardedRWLocks(5)
 
 		m.RLockAll()
 		m.RLockAll()
@@ -387,7 +387,7 @@ func TestShardedLocks(t *testing.T) {
 
 	t.Run("unlock should wake up next waiting lock", func(t *testing.T) {
 		t.Parallel()
-		m := NewShardedLocks(2)
+		m := NewShardedRWLocks(2)
 
 		m.RLock(1)
 

--- a/adapters/repos/db/vector/common/sharded_locks_test.go
+++ b/adapters/repos/db/vector/common/sharded_locks_test.go
@@ -23,6 +23,196 @@ func TestShardedLocks_ParallelLocksAll(t *testing.T) {
 	// no asserts
 	// ensures parallel LockAll does not fall into deadlock
 	count := 10
+	sl := NewDefaultShardedLocks()
+
+	wg := new(sync.WaitGroup)
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func() {
+			defer wg.Done()
+			sl.LockAll()
+			sl.UnlockAll()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestShardedLocks_MixedLocks(t *testing.T) {
+	// no asserts
+	// ensures parallel LockAll + RLockAll + Lock + RLock does not fall into deadlock
+	count := 1000
+	sl := NewShardedLocks(10)
+
+	wg := new(sync.WaitGroup)
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := uint64(i)
+			if i%5 == 0 {
+				sl.LockAll()
+				sl.UnlockAll()
+			} else {
+				sl.Lock(id)
+				sl.Unlock(id)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestShardedLocks(t *testing.T) {
+
+	t.Run("Lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.Lock(1)
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			m.Unlock(1)
+
+			close(ch)
+		}()
+
+		m.Lock(1)
+
+		select {
+		case <-ch:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.Unlock(1)
+	})
+
+	t.Run("Lock blocks LockAll", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.Lock(1)
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			m.Unlock(1)
+
+			close(ch)
+		}()
+
+		m.LockAll()
+
+		select {
+		case <-ch:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.UnlockAll()
+	})
+
+	t.Run("LockAll blocks Lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			m.UnlockAll()
+
+			close(ch)
+		}()
+
+		m.Lock(1)
+
+		select {
+		case <-ch:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.Unlock(1)
+	})
+
+	t.Run("LockAll blocks LockAll", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+
+		ch := make(chan struct{})
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			m.UnlockAll()
+
+			close(ch)
+		}()
+
+		m.LockAll()
+
+		select {
+		case <-ch:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "should be unlocked")
+		}
+
+		m.UnlockAll()
+	})
+
+	t.Run("UnlockAll releases all locks", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(5)
+
+		m.LockAll()
+		m.UnlockAll()
+
+		m.Lock(1)
+		m.Unlock(1)
+	})
+
+	t.Run("unlock should wake up next waiting lock", func(t *testing.T) {
+		t.Parallel()
+		m := NewShardedLocks(2)
+
+		m.Lock(1)
+
+		ch1 := make(chan struct{})
+		ch2 := make(chan struct{})
+
+		go func() {
+			defer close(ch1)
+
+			m.Lock(1)
+		}()
+
+		go func() {
+			defer close(ch2)
+
+			time.Sleep(100 * time.Millisecond)
+			m.Lock(1)
+		}()
+
+		time.Sleep(10 * time.Millisecond)
+		m.Unlock(1)
+
+		<-ch1
+
+		m.Unlock(1)
+
+		<-ch2
+
+		m.Unlock(1)
+	})
+}
+
+func TestShardedRWLocks_ParallelLocksAll(t *testing.T) {
+	// no asserts
+	// ensures parallel LockAll does not fall into deadlock
+	count := 10
 	sl := NewDefaultShardedRWLocks()
 
 	wg := new(sync.WaitGroup)
@@ -37,7 +227,7 @@ func TestShardedLocks_ParallelLocksAll(t *testing.T) {
 	wg.Wait()
 }
 
-func TestShardedLocks_ParallelRLocksAll(t *testing.T) {
+func TestShardedRWLocks_ParallelRLocksAll(t *testing.T) {
 	// no asserts
 	// ensures parallel RLockAll does not fall into deadlock
 	count := 10
@@ -55,7 +245,7 @@ func TestShardedLocks_ParallelRLocksAll(t *testing.T) {
 	wg.Wait()
 }
 
-func TestShardedLocks_ParallelLocksAllAndRLocksAll(t *testing.T) {
+func TestShardedRWLocks_ParallelLocksAllAndRLocksAll(t *testing.T) {
 	// no asserts
 	// ensures parallel LockAll + RLockAll does not fall into deadlock
 	count := 50
@@ -78,7 +268,7 @@ func TestShardedLocks_ParallelLocksAllAndRLocksAll(t *testing.T) {
 	wg.Wait()
 }
 
-func TestShardedLocks_MixedLocks(t *testing.T) {
+func TestShardedRWLocks_MixedLocks(t *testing.T) {
 	// no asserts
 	// ensures parallel LockAll + RLockAll + Lock + RLock does not fall into deadlock
 	count := 1000
@@ -112,7 +302,7 @@ func TestShardedLocks_MixedLocks(t *testing.T) {
 	wg.Wait()
 }
 
-func TestShardedLocks(t *testing.T) {
+func TestShardedRWLocks(t *testing.T) {
 	t.Run("RLock", func(t *testing.T) {
 		t.Parallel()
 		m := NewShardedRWLocks(5)

--- a/adapters/repos/db/vector/common/sharded_locks_test.go
+++ b/adapters/repos/db/vector/common/sharded_locks_test.go
@@ -62,7 +62,6 @@ func TestShardedLocks_MixedLocks(t *testing.T) {
 }
 
 func TestShardedLocks(t *testing.T) {
-
 	t.Run("Lock", func(t *testing.T) {
 		t.Parallel()
 		m := NewShardedLocks(5)

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -161,7 +161,7 @@ type hnsw struct {
 	className          string
 	shardName          string
 	VectorForIDThunk   common.VectorForID[float32]
-	shardedNodeLocks   *common.ShardedLocks
+	shardedNodeLocks   *common.ShardedRWLocks
 	store              *lsmkv.Store
 }
 
@@ -261,7 +261,7 @@ func New(cfg Config, uc ent.UserConfig, tombstoneCallbacks, shardCompactionCallb
 		VectorForIDThunk:     cfg.VectorForIDThunk,
 		TempVectorForIDThunk: cfg.TempVectorForIDThunk,
 		pqConfig:             uc.PQ,
-		shardedNodeLocks:     common.NewDefaultShardedLocks(),
+		shardedNodeLocks:     common.NewDefaultShardedRWLocks(),
 
 		shardCompactionCallbacks: shardCompactionCallbacks,
 		shardFlushCallbacks:      shardFlushCallbacks,

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -25,7 +25,7 @@ func TestVectorCachePrefilling(t *testing.T) {
 	index := &hnsw{
 		nodes:               generateDummyVertices(100),
 		currentMaximumLayer: 3,
-		shardedNodeLocks:    common.NewDefaultShardedLocks(),
+		shardedNodeLocks:    common.NewDefaultShardedRWLocks(),
 	}
 
 	logger, _ := test.NewNullLogger()


### PR DESCRIPTION
### What's being changed:

This adds a write-only (sync.Mutex) variant of the sharded locks for scenarios where only Lock/Unlock is needed and the lock performance is important.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
