### PR TITLE
feat: idempotence on class DB ops

### DIFF
--- a/adapters/repos/schema/store.go
+++ b/adapters/repos/schema/store.go
@@ -224,11 +224,10 @@ func (r *store) loadSchemaV1() (*ucs.State, error) {
 // UpdateClass if it exists, otherwise it will create the class.
 func (r *store) UpdateClass(_ context.Context, data ucs.ClassPayload) error {
 	classKey := encodeClassName(data.Name)
-	var err error
 	f := func(tx *bolt.Tx) error {
 		b := tx.Bucket(schemaBucket).Bucket(classKey)
 		if b == nil {
-			b, err = tx.Bucket(schemaBucket).CreateBucket(classKey)
+			b, err := tx.Bucket(schemaBucket).CreateBucket(classKey)
 			if err != nil {
 				return err
 			}

--- a/adapters/repos/schema/store.go
+++ b/adapters/repos/schema/store.go
@@ -222,7 +222,7 @@ func (r *store) loadSchemaV1() (*ucs.State, error) {
 }
 
 // UpdateClass if it exists, otherwise it will create the class.
-func (r *store) UpdateClass(ctx context.Context, data ucs.ClassPayload) error {
+func (r *store) UpdateClass(_ context.Context, data ucs.ClassPayload) error {
 	classKey := encodeClassName(data.Name)
 	var err error
 	f := func(tx *bolt.Tx) error {

--- a/adapters/repos/schema/store_test.go
+++ b/adapters/repos/schema/store_test.go
@@ -203,7 +203,7 @@ func TestRepositoryUpdateClass(t *testing.T) {
 	assert.Nil(t, err)
 	payload.Name = "C3"
 
-	// should be handled and created updating non-exiting class
+	// should be handled and created on updating non-exiting class
 	err = repo.UpdateClass(ctx, payload)
 	assert.Nil(t, err)
 	err = repo.DeleteClass(ctx, "C3")

--- a/adapters/repos/schema/store_test.go
+++ b/adapters/repos/schema/store_test.go
@@ -127,6 +127,7 @@ func TestRepositorySaveLoad(t *testing.T) {
 	}
 	repo.asserEqualSchema(t, schema, "delete class")
 }
+
 func TestRepositoryCRUDIdempotence(t *testing.T) {
 	var (
 		ctx       = context.Background()
@@ -171,6 +172,7 @@ func TestRepositoryCRUDIdempotence(t *testing.T) {
 	assert.Nil(t, err)
 	repo.asserEqualSchema(t, schema, "update class")
 }
+
 func TestRepositoryUpdateClass(t *testing.T) {
 	var (
 		ctx       = context.Background()

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -367,14 +367,19 @@ func TestUpdateDistanceSettings(t *testing.T) {
 }
 
 func TestAddClassIdempotence(t *testing.T) {
-	randomObjectClassName := "RedCars"
-
+	className := "RedCars"
+	defer func() {
+		t.Log("Remove the class")
+		delParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		delResp, err := helper.Client(t).Schema.SchemaObjectsDelete(delParams, nil)
+		helper.AssertRequestOk(t, delResp, err, nil)
+	}()
 	// Ensure that this name is not in the schema yet.
 	t.Log("Asserting that this class does not exist yet")
-	assert.NotContains(t, GetObjectClassNames(t), randomObjectClassName)
+	assert.NotContains(t, GetObjectClassNames(t), className)
 
 	tc := &models.Class{
-		Class: randomObjectClassName,
+		Class: className,
 		ModuleConfig: map[string]interface{}{
 			"text2vec-contextionary": map[string]interface{}{
 				"vectorizeClassName": true,
@@ -388,9 +393,7 @@ func TestAddClassIdempotence(t *testing.T) {
 	helper.AssertRequestOk(t, resp, err, nil)
 
 	t.Log("Asserting that this class is now created")
-	assert.Contains(t, GetObjectClassNames(t), randomObjectClassName)
-
-	t.Run("pure http - without the auto-generated client", testGetSchemaWithoutClient)
+	assert.Contains(t, GetObjectClassNames(t), className)
 
 	t.Log("Creating class again")
 	resp, err = helper.Client(t).Schema.SchemaObjectsCreate(params, nil)

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -367,7 +367,7 @@ func TestUpdateDistanceSettings(t *testing.T) {
 }
 
 func TestAddClassIdempotence(t *testing.T) {
-	randomObjectClassName := "YellowCars"
+	randomObjectClassName := "RedCars"
 
 	// Ensure that this name is not in the schema yet.
 	t.Log("Asserting that this class does not exist yet")
@@ -396,8 +396,6 @@ func TestAddClassIdempotence(t *testing.T) {
 	resp, err = helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
 	helper.AssertRequestOk(t, resp, err, nil)
 
-	t.Log("Asserting that this class is now created")
-	assert.Contains(t, GetObjectClassNames(t), randomObjectClassName)
 	t.Log("Verify schema cluster status")
 	statusResp, err := helper.Client(t).Schema.SchemaClusterStatus(
 		clschema.NewSchemaClusterStatusParams(), nil,

--- a/test/acceptance_with_go_client/filters_tests/regex_test.go
+++ b/test/acceptance_with_go_client/filters_tests/regex_test.go
@@ -12,9 +12,10 @@
 package filters_tests
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"testing"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"

--- a/test/acceptance_with_go_client/schema_test.go
+++ b/test/acceptance_with_go_client/schema_test.go
@@ -91,6 +91,7 @@ func TestSchemaCasingClass(t *testing.T) {
 }
 
 func checkDuplicateClassErrors(t *testing.T, err error, tt testCase) {
+	// should be ok because of idempotence.
 	if tt.className1 == tt.className2 {
 		return
 	}

--- a/test/acceptance_with_go_client/schema_test.go
+++ b/test/acceptance_with_go_client/schema_test.go
@@ -91,19 +91,19 @@ func TestSchemaCasingClass(t *testing.T) {
 }
 
 func checkDuplicateClassErrors(t *testing.T, err error, tt testCase) {
+	if tt.className1 == tt.className2 {
+		return
+	}
 	require.NotNil(t, err)
 	rawError, ok := err.(*fault.WeaviateClientError)
 	if ok {
 		var clientErr clientError
 		require.Nil(t, json.Unmarshal([]byte(rawError.Msg), &clientErr))
 		require.Len(t, clientErr.Error, 1)
-		if tt.className1 == tt.className2 {
-			require.Equal(t, clientErr.Error[0].Message, fmt.Sprintf("class name %q already exists", tt.className2))
-		} else {
-			require.Equal(t, clientErr.Error[0].Message,
-				fmt.Sprintf("class name %q already exists as a permutation of: %q. class names must be unique when lowercased",
-					tt.className2, tt.className1))
-		}
+		require.Equal(t, clientErr.Error[0].Message,
+			fmt.Sprintf("class name %q already exists as a permutation of: %q. class names must be unique when lowercased",
+				tt.className2, tt.className1))
+
 	} else {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -41,16 +41,6 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 }
 
 func ValidateConfigUpdate(old, updated *models.Class, nodeCounter nodeCounter) error {
-	// This is not possible if schema is being updated via by a client.
-	// But for a test object that wasn't created by a client, it is.
-	if old.ReplicationConfig == nil {
-		old.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
-	}
-
-	if updated.ReplicationConfig == nil {
-		updated.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
-	}
-
 	if old.ReplicationConfig.Factor != updated.ReplicationConfig.Factor {
 		nc := nodeCounter.NodeCount()
 		if int(updated.ReplicationConfig.Factor) > nc {

--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -41,6 +41,13 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 }
 
 func ValidateConfigUpdate(old, updated *models.Class, nodeCounter nodeCounter) error {
+	if old.ReplicationConfig == nil {
+		return fmt.Errorf("replication can not be empty for class %s", old.Class)
+	}
+	if updated.ReplicationConfig == nil {
+		return fmt.Errorf("replication can not be empty for class %s", updated.Class)
+	}
+
 	if old.ReplicationConfig.Factor != updated.ReplicationConfig.Factor {
 		nc := nodeCounter.NodeCount()
 		if int(updated.ReplicationConfig.Factor) > nc {

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -158,7 +158,7 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 		if reflect.DeepEqual(existedClass, class) {
 			return m.ShardingState[class.Class], nil
 		}
-		return nil, fmt.Errorf("class name %q already exists with different properties", class.Class)
+		return nil, errDuplicateClass(class.Class)
 	}
 
 	// migrate only after validation in completed
@@ -619,4 +619,8 @@ func CreateClassPayload(class *models.Class,
 		}
 	}
 	return pl, nil
+}
+
+func errDuplicateClass(name string) error {
+	return fmt.Errorf("class name %q already exists with different properties", name)
 }

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -155,6 +155,8 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 		m.parseVectorIndexConfig(ctx, class)
 		m.parseReplicationConfig(class)
 
+		m.parseReplicationConfig(existedClass)
+
 		if reflect.DeepEqual(existedClass, class) {
 			return m.ShardingState[class.Class], nil
 		}
@@ -550,7 +552,7 @@ func (m *Manager) parseVectorIndexConfig(ctx context.Context,
 func (m *Manager) parseReplicationConfig(class *models.Class) (err error) {
 	// This is not possible if schema is being updated via by a client.
 	// But for a test object that wasn't created by a client, it is.
-	if class.ReplicationConfig == nil {
+	if class.ReplicationConfig == nil || class.ReplicationConfig.Factor == 0 {
 		class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
 	}
 

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -144,9 +144,13 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 
 	m.setClassDefaults(class)
 	err := m.validateCanAddClass(ctx, class, false)
-	if err != nil {
+	if err != nil && !errors.Is(err, errClassNameExists) {
 		return nil, err
 	}
+	if err != nil && errors.Is(err, errClassNameExists) {
+		return m.ShardingState[class.Class], nil
+	}
+
 	// migrate only after validation in completed
 	m.migrateClassSettings(class)
 

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -176,6 +176,11 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 		return nil, err
 	}
 
+	err = m.parseReplicationConfig(class)
+	if err != nil {
+		return nil, err
+	}
+
 	err = m.invertedConfigValidator(class.InvertedIndexConfig)
 	if err != nil {
 		return nil, err
@@ -549,6 +554,7 @@ func (m *Manager) parseVectorIndexConfig(ctx context.Context,
 	return nil
 }
 
+// parseReplicationConfig normalize the replication config and assign the default to be factorized by 1.
 func (m *Manager) parseReplicationConfig(class *models.Class) (err error) {
 	// This is not possible if schema is being updated via by a client.
 	// But for a test object that wasn't created by a client, it is.

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -548,9 +548,10 @@ func (m *Manager) parseVectorIndexConfig(ctx context.Context,
 }
 
 func (m *Manager) parseReplicationConfig(class *models.Class) (err error) {
-	// assign default
+	// This is not possible if schema is being updated via by a client.
+	// But for a test object that wasn't created by a client, it is.
 	if class.ReplicationConfig == nil {
-		class.ReplicationConfig = &models.ReplicationConfig{}
+		class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
 	}
 
 	return nil

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -69,6 +69,24 @@ func TestAddClass(t *testing.T) {
 		require.NotNil(t, cls)
 	})
 
+	t.Run("add multiple times with different prop.", func(t *testing.T) {
+		mgr := newSchemaManager()
+		className := "NewClass"
+
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: className})
+		require.Nil(t, err)
+		cls, err := mgr.GetClass(context.Background(),
+			nil, className)
+		require.Nil(t, err)
+		require.NotNil(t, cls)
+
+		err = mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: className, Vectorizer: "someVectorizer"})
+		require.NotNil(t, err)
+		require.Equal(t, err, errDuplicateClass(className))
+	})
+
 	t.Run("with default BM25 params", func(t *testing.T) {
 		mgr := newSchemaManager()
 

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -49,20 +49,22 @@ func TestAddClass(t *testing.T) {
 
 	t.Run("add multiple times", func(t *testing.T) {
 		mgr := newSchemaManager()
+		className := "NewClass"
+
 		err := mgr.AddClass(context.Background(),
-			nil, &models.Class{Class: "NewClass"})
+			nil, &models.Class{Class: className})
 		require.Nil(t, err)
 		cls, err := mgr.GetClass(context.Background(),
-			nil, "NewClass")
+			nil, className)
 		require.Nil(t, err)
 		require.NotNil(t, cls)
 
 		err = mgr.AddClass(context.Background(),
-			nil, &models.Class{Class: "NewClass"})
+			nil, &models.Class{Class: className})
 		require.Nil(t, err)
 
 		cls, err = mgr.GetClass(context.Background(),
-			nil, "NewClass")
+			nil, className)
 		require.Nil(t, err)
 		require.NotNil(t, cls)
 	})

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -47,6 +47,26 @@ func TestAddClass(t *testing.T) {
 				"class names must be unique when lowercased", err.Error())
 	})
 
+	t.Run("add multiple times", func(t *testing.T) {
+		mgr := newSchemaManager()
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: "NewClass"})
+		require.Nil(t, err)
+		cls, err := mgr.GetClass(context.Background(),
+			nil, "NewClass")
+		require.Nil(t, err)
+		require.NotNil(t, cls)
+
+		err = mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: "NewClass"})
+		require.Nil(t, err)
+
+		cls, err = mgr.GetClass(context.Background(),
+			nil, "NewClass")
+		require.Nil(t, err)
+		require.NotNil(t, cls)
+	})
+
 	t.Run("with default BM25 params", func(t *testing.T) {
 		mgr := newSchemaManager()
 

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -990,3 +990,43 @@ func Test_Defaults_NestedProperties(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepEqual(t *testing.T) {
+	sm := newSchemaManager()
+	ctx := context.Background()
+	tcs := []struct {
+		name  string
+		c1    *models.Class
+		c2    *models.Class
+		equal bool
+	}{
+		{
+			name:  "one is nil",
+			c1:    nil,
+			c2:    &models.Class{Class: "C2"},
+			equal: false,
+		},
+		{
+			name:  "different names",
+			c1:    &models.Class{Class: "C1"},
+			c2:    &models.Class{Class: "C2"},
+			equal: false,
+		},
+		{
+			name:  "different config",
+			c1:    &models.Class{Class: "C1", Vectorizer: "v1"},
+			c2:    &models.Class{Class: "C1", Vectorizer: "v2"},
+			equal: false,
+		},
+		{
+			name:  "they are equal",
+			c1:    &models.Class{Class: "C1"},
+			c2:    &models.Class{Class: "C1"},
+			equal: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		require.Equal(t, tc.equal, sm.deepEqual(ctx, tc.c1, tc.c2))
+	}
+}

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -67,20 +67,8 @@ func TestAddClass(t *testing.T) {
 			nil, className)
 		require.Nil(t, err)
 		require.NotNil(t, cls)
-	})
 
-	t.Run("add multiple times with different prop.", func(t *testing.T) {
-		mgr := newSchemaManager()
-		className := "NewClass"
-
-		err := mgr.AddClass(context.Background(),
-			nil, &models.Class{Class: className})
-		require.Nil(t, err)
-		cls, err := mgr.GetClass(context.Background(),
-			nil, className)
-		require.Nil(t, err)
-		require.NotNil(t, cls)
-
+		// add multiple times with different prop.
 		err = mgr.AddClass(context.Background(),
 			nil, &models.Class{Class: className, Vectorizer: "someVectorizer"})
 		require.NotNil(t, err)

--- a/usecases/schema/cache.go
+++ b/usecases/schema/cache.go
@@ -214,7 +214,7 @@ func (s *schemaCache) unsafeAddClass(c *models.Class, ss *sharding.State) {
 	s.ObjectSchema.Classes = append(s.ObjectSchema.Classes, c)
 }
 
-func (s *schemaCache) updateClass(u *models.Class, ss *sharding.State) error {
+func (s *schemaCache) updateClass(u *models.Class, ss *sharding.State) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -222,12 +222,11 @@ func (s *schemaCache) updateClass(u *models.Class, ss *sharding.State) error {
 		*c = *u
 	} else {
 		s.unsafeAddClass(u, ss)
-		return nil
+		return
 	}
 	if ss != nil {
 		s.ShardingState[u.Class] = ss
 	}
-	return nil
 }
 
 func (s *schemaCache) addProperty(class string, p *models.Property) (models.Class, error) {

--- a/usecases/schema/cache.go
+++ b/usecases/schema/cache.go
@@ -25,6 +25,7 @@ var (
 	errPropertyNotFound = errors.New("property not found")
 	errClassNotFound    = errors.New("class not found")
 	errShardNotFound    = errors.New("shard not found")
+	errClassNameExists  = errors.New("class name already exists")
 )
 
 // State is a cached copy of the schema that can also be saved into a remote

--- a/usecases/schema/cache_test.go
+++ b/usecases/schema/cache_test.go
@@ -59,9 +59,9 @@ func TestUpdateClass(t *testing.T) {
 		},
 	}
 
-	if err := cache.updateClass(&models.Class{}, nil); !errors.Is(err, errClassNotFound) {
-		t.Fatalf("update_class: want %v got %v", errClassNotFound, err)
-	}
+	err := cache.updateClass(&models.Class{Class: "C1"}, nil)
+	assert.Nil(t, err)
+
 	if _, err := cache.addProperty("?", nil); !errors.Is(err, errClassNotFound) {
 		t.Fatalf("add_property: want %v got %v", errClassNotFound, err)
 	}

--- a/usecases/schema/cache_test.go
+++ b/usecases/schema/cache_test.go
@@ -59,8 +59,7 @@ func TestUpdateClass(t *testing.T) {
 		},
 	}
 
-	err := cache.updateClass(&models.Class{Class: "C1"}, nil)
-	assert.Nil(t, err)
+	cache.updateClass(&models.Class{Class: "C1"}, nil)
 
 	if _, err := cache.addProperty("?", nil); !errors.Is(err, errClassNotFound) {
 		t.Fatalf("add_property: want %v got %v", errClassNotFound, err)

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -95,13 +95,13 @@ type SchemaStore interface {
 	// Load loads the complete schema from the persistent storage
 	Load(context.Context) (State, error)
 
-	// NewClass creates a new class if it doesn't exists, otherwise return an error
+	// NewClass creates a new class if it doesn't exists, and bailout if the class exists.
 	NewClass(context.Context, ClassPayload) error
 
-	// UpdateClass if it exists, otherwise return an error
+	// UpdateClass if it exists, otherwise it will create the class.
 	UpdateClass(context.Context, ClassPayload) error
 
-	// DeleteClass deletes class
+	// DeleteClass is idempotent and won't fail if class doesn't exists.
 	DeleteClass(ctx context.Context, class string) error
 
 	// NewShards creates new shards of an existing class

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -320,7 +320,7 @@ func testCantAddSameClassTwice(t *testing.T, lsm *Manager) {
 		},
 	})
 
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 }
 
 func testCantAddSameClassTwiceDifferentKinds(t *testing.T, lsm *Manager) {
@@ -340,16 +340,17 @@ func testCantAddSameClassTwiceDifferentKinds(t *testing.T, lsm *Manager) {
 
 	// Add it again, but with a different kind.
 	err = lsm.AddClass(context.Background(), nil, &models.Class{
+		Class:      "Car",
+		Vectorizer: "another-text2vec-contextionary",
 		ModuleConfig: map[string]interface{}{
-			"text2vec-contextionary": map[string]interface{}{
-				"vectorizeClassName": true,
+			"another-text2vec-contextionary": map[string]interface{}{
+				"vectorizePropertyName": false,
 			},
 		},
-		Class:      "Car",
-		Vectorizer: "text2vec-contextionary",
 	})
 
 	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "class name \"Car\" already exists with different properties")
 }
 
 // TODO: parts of this test contain text2vec-contextionary logic, but parts are

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -68,6 +68,14 @@ func (m *Manager) UpdateClass(ctx context.Context, principal *models.Principal,
 		return err
 	}
 
+	// backward compatible normalize replication factor for existing classes
+	if err := m.parseReplicationConfig(initial); err != nil {
+		return err
+	}
+	if err := m.parseReplicationConfig(updated); err != nil {
+		return err
+	}
+
 	if err := m.migrator.ValidateVectorIndexConfigUpdate(ctx,
 		initial.VectorIndexConfig.(schema.VectorIndexConfig),
 		updated.VectorIndexConfig.(schema.VectorIndexConfig)); err != nil {

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -26,9 +26,12 @@ import (
 func (m *Manager) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) (err error) {
+	// this defer so that we don't end up in deadlock situation given update
+	// and create locking the mutex, it's deferred to release the lock from
+	// update before starting create.
 	defer func() {
 		if err == ErrNotFound {
-			_, err = m.addClass(ctx, updated)
+			err = m.AddClass(ctx, principal, updated)
 			return
 		}
 	}()

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -26,7 +26,6 @@ import (
 func (m *Manager) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) (err error) {
-
 	defer func() {
 		if err == ErrNotFound {
 			_, err = m.addClass(ctx, updated)

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -187,7 +187,7 @@ func (m *Manager) updateClassApplyChanges(ctx context.Context, className string,
 	m.logger.
 		WithField("action", "schema.update_class").
 		Debug("saving updated schema to configuration store")
-	// payload.Shards
+
 	if err := m.repo.UpdateClass(ctx, payload); err != nil {
 		return err
 	}

--- a/usecases/schema/update_test.go
+++ b/usecases/schema/update_test.go
@@ -28,9 +28,29 @@ import (
 // specific updates, such as the vector index config
 func TestClassUpdates(t *testing.T) {
 	t.Run("a class which doesn't exist will be created", func(t *testing.T) {
-		err := newSchemaManager().UpdateClass(context.Background(),
-			nil, "someClass", &models.Class{Class: "someClass"})
+		className := "SomeClass"
+		sm := newSchemaManager()
+		err := sm.UpdateClass(context.Background(),
+			nil, className, &models.Class{Class: className})
 		require.Nil(t, err)
+		require.NotNil(t, sm.getClassByName(className))
+	})
+
+	t.Run("call update non existing and multiple times", func(t *testing.T) {
+		className := "SomeClass"
+		sm := newSchemaManager()
+		err := sm.UpdateClass(context.Background(),
+			nil, className, &models.Class{Class: className})
+		require.Nil(t, err)
+		require.NotNil(t, sm.getClassByName(className))
+
+		err = sm.UpdateClass(context.Background(),
+			nil, className, &models.Class{Class: className})
+		require.Nil(t, err)
+
+		cls, err := sm.GetClass(context.Background(), nil, className)
+		require.Nil(t, err)
+		require.NotNil(t, cls)
 	})
 
 	t.Run("various immutable and mutable fields", func(t *testing.T) {

--- a/usecases/schema/update_test.go
+++ b/usecases/schema/update_test.go
@@ -27,11 +27,10 @@ import (
 // As of now, most class settings are immutable, but we need to allow some
 // specific updates, such as the vector index config
 func TestClassUpdates(t *testing.T) {
-	t.Run("a class which doesn't exist", func(t *testing.T) {
+	t.Run("a class which doesn't exist will be created", func(t *testing.T) {
 		err := newSchemaManager().UpdateClass(context.Background(),
-			nil, "WrongClass", &models.Class{})
-		require.NotNil(t, err)
-		assert.Equal(t, ErrNotFound, err)
+			nil, "someClass", &models.Class{Class: "someClass"})
+		require.Nil(t, err)
 	})
 
 	t.Run("various immutable and mutable fields", func(t *testing.T) {

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -43,7 +43,7 @@ func (m *Manager) validateClassNameUniqueness(name string) error {
 			"class name %q already exists as a permutation of: %q. class names must be unique when lowercased",
 			name, existingName)
 	}
-	return fmt.Errorf("class name %q already exists", name)
+	return errClassNameExists
 }
 
 // Check that the format of the name is correct


### PR DESCRIPTION
### What's being changed:
this PR taking care of the class CRUD ops in both memory and persistent storage 
- Eliminates returning `ErrClassExists` and bailout if the class exists. 
- Introduces automatic class creation during updates if the class is not found.
- add default `replicationConfig` on adding a class.
- enhances handling for comparing two class properties, particularly useful when adding the same class multiple times with identical configurations.


 
### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
