### PR TITLE
Change GetSchemaSkipAuth usage to avoid querying the whole schema when not needed

### DIFF
--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -118,11 +118,12 @@ func (fa *filteredAggregator) filtered(ctx context.Context) (*aggregation.Result
 }
 
 func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
-	var (
-		s     = fa.getSchema.GetSchemaSkipAuth()
-		class = s.GetClass(fa.params.ClassName.String())
-		cfg   = inverted.ConfigFromModel(class.InvertedIndexConfig)
-	)
+	s := fa.getSchema.GetSchemaSkipAuth()
+	class := s.GetClass(fa.params.ClassName.String())
+	if class == nil {
+		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", fa.params.ClassName)
+	}
+	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
 	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, s,
 		propertyspecific.Indices{}, fa.classSearcher,
 		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -28,11 +27,9 @@ func (a *Aggregator) buildHybridKeywordRanking() (*searchparams.KeywordRanking, 
 		Query: a.params.Hybrid.Query,
 	}
 
-	cl, err := schema.GetClassByName(
-		a.getSchema.GetSchemaSkipAuth().Objects,
-		a.params.ClassName.String())
-	if err != nil {
-		return nil, err
+	cl := a.getSchema.ReadOnlyClass(a.params.ClassName.String())
+	if cl == nil {
+		return nil, fmt.Errorf("could not find class %s in schema", a.params.ClassName)
 	}
 
 	for _, v := range cl.Properties {
@@ -45,11 +42,12 @@ func (a *Aggregator) buildHybridKeywordRanking() (*searchparams.KeywordRanking, 
 }
 
 func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
-	var (
-		s     = a.getSchema.GetSchemaSkipAuth()
-		class = s.GetClass(a.params.ClassName.String())
-		cfg   = inverted.ConfigFromModel(class.InvertedIndexConfig)
-	)
+	s := a.getSchema.GetSchemaSkipAuth()
+	class := s.GetClass(a.params.ClassName.String())
+	if class == nil {
+		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", a.params.ClassName)
+	}
+	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
 
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, s,
 		propertyspecific.Indices{}, a.classSearcher,

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -296,9 +296,7 @@ func (i *Index) marshalShardingState() ([]byte, error) {
 }
 
 func (i *Index) marshalSchema() ([]byte, error) {
-	schema := i.getSchema.GetSchemaSkipAuth()
-
-	b, err := schema.GetClass(i.Config.ClassName.String()).MarshalBinary()
+	b, err := i.getSchema.ReadOnlyClass(i.Config.ClassName.String()).MarshalBinary()
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal schema")
 	}

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -139,6 +139,10 @@ func (f *fakeSchemaManager) GetSchemaSkipAuth() schema.Schema {
 	return f.schema
 }
 
+func (f *fakeSchemaManager) ReadOnlyClass(class string) *models.Class {
+	return f.schema.GetClass(class)
+}
+
 func (f *fakeSchemaManager) CopyShardingState(class string) *sharding.State {
 	return f.shardState
 }

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -44,6 +44,10 @@ func (f *fakeSchemaGetter) GetSchemaSkipAuth() schema.Schema {
 	return f.schema
 }
 
+func (f *fakeSchemaGetter) ReadOnlyClass(class string) *models.Class {
+	return f.schema.GetClass(class)
+}
+
 func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	return f.shardState
 }

--- a/adapters/repos/db/file_structure_migration_test.go
+++ b/adapters/repos/db/file_structure_migration_test.go
@@ -268,6 +268,10 @@ func (sg *fakeMigrationSchemaGetter) GetSchemaSkipAuth() schema.Schema {
 	return sg.sch
 }
 
+func (sg *fakeMigrationSchemaGetter) ReadOnlyClass(class string) *models.Class {
+	return sg.sch.GetClass(class)
+}
+
 func (sg *fakeMigrationSchemaGetter) Nodes() []string {
 	return nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -624,10 +624,9 @@ func (i *Index) parseDateFieldsInProps(props interface{}) error {
 		return nil
 	}
 
-	schemaModel := i.getSchema.GetSchemaSkipAuth().Objects
-	c, err := schema.GetClassByName(schemaModel, i.Config.ClassName.String())
-	if err != nil {
-		return err
+	c := i.getSchema.ReadOnlyClass(i.Config.ClassName.String())
+	if c == nil {
+		return fmt.Errorf("class %s not found in schema", i.Config.ClassName)
 	}
 
 	for _, prop := range c.Properties {
@@ -1086,11 +1085,9 @@ func (i *Index) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 	// If the request is a BM25F with no properties selected, use all possible properties
 	if keywordRanking != nil && keywordRanking.Type == "bm25" && len(keywordRanking.Properties) == 0 {
 
-		cl, err := schema.GetClassByName(
-			i.getSchema.GetSchemaSkipAuth().Objects,
-			i.Config.ClassName.String())
-		if err != nil {
-			return nil, nil, err
+		cl := i.getSchema.ReadOnlyClass(i.Config.ClassName.String())
+		if cl == nil {
+			return nil, nil, fmt.Errorf("class %s not found in schema", i.Config.ClassName)
 		}
 
 		propHash := cl.Properties

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -622,6 +622,7 @@ func (m AllMapPairsAndPropName) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }
 
+// TODO: Refactor this function to receive the class directly to avoid sending the whole schema
 func PropertyHasSearchableIndex(schemaDefinition *models.Schema, className, tentativePropertyName string) bool {
 	propertyName := strings.Split(tentativePropertyName, "^")[0]
 	c, err := schema.GetClassByName(schemaDefinition, string(className))

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -52,8 +51,10 @@ type ShardInvertedReindexer struct {
 }
 
 func NewShardInvertedReindexer(shard ShardLike, logger logrus.FieldLogger) *ShardInvertedReindexer {
-	class, _ := schema.GetClassByName(shard.Index().getSchema.GetSchemaSkipAuth().Objects,
-		shard.Index().Config.ClassName.String())
+	class := shard.Index().getSchema.ReadOnlyClass(shard.Index().Config.ClassName.String())
+	if class == nil {
+		return nil
+	}
 
 	return &ShardInvertedReindexer{
 		logger: logger,

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -245,8 +245,7 @@ func (i *Index) IncomingFilePutter(ctx context.Context, shardName,
 }
 
 func (i *Index) IncomingCreateShard(ctx context.Context, className string, shardName string) error {
-	sch := i.getSchema.GetSchemaSkipAuth()
-	class := sch.GetClass(schema.ClassName(className).String())
+	class := i.getSchema.ReadOnlyClass(className)
 	if err := i.addNewShard(ctx, class, shardName); err != nil {
 		return fmt.Errorf("incoming create shard: %w", err)
 	}

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
@@ -333,10 +332,9 @@ func (b *referencesBatcher) flushWALs(ctx context.Context) {
 
 func (b *referencesBatcher) getSchemaPropsByName() (map[string]*models.Property, error) {
 	idx := b.shard.Index()
-	sch := idx.getSchema.GetSchemaSkipAuth().Objects
-	class, err := schema.GetClassByName(sch, idx.Config.ClassName.String())
-	if err != nil {
-		return nil, err
+	class := idx.getSchema.ReadOnlyClass(idx.Config.ClassName.String())
+	if class == nil {
+		return nil, fmt.Errorf("could not find class %s in schema", idx.Config.ClassName)
 	}
 
 	propsByName := map[string]*models.Property{}

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -30,10 +30,9 @@ func isPropertyForLength(dt schema.DataType) bool {
 }
 
 func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) {
-	schemaModel := s.index.getSchema.GetSchemaSkipAuth().Objects
-	c, err := schema.GetClassByName(schemaModel, object.Class().String())
-	if err != nil {
-		return nil, nil, err
+	c := s.index.getSchema.ReadOnlyClass(object.Class().String())
+	if c == nil {
+		return nil, nil, fmt.Errorf("could not find class %s in schema", object.Class().String())
 	}
 
 	var schemaMap map[string]interface{}

--- a/adapters/repos/db/sorter/objects_sorter.go
+++ b/adapters/repos/db/sorter/objects_sorter.go
@@ -22,6 +22,7 @@ type Sorter interface {
 		limit int, sort []filters.Sort) ([]*storobj.Object, []float32, error)
 }
 
+// TODO: Refactor objectSorter to get an interface for schemaGetter instead of the schema itself
 type objectsSorter struct {
 	schema schema.Schema
 }

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -39,6 +39,10 @@ func (f *fakeSchemaGetter) GetSchemaSkipAuth() schema.Schema {
 	return f.schema
 }
 
+func (f *fakeSchemaGetter) ReadOnlyClass(class string) *models.Class {
+	return f.schema.GetClass(class)
+}
+
 func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	panic("not implemented")
 }

--- a/usecases/classification/classifier_run.go
+++ b/usecases/classification/classifier_run.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 )
 
@@ -37,7 +36,7 @@ func (c *Classifier) run(params models.Classification,
 	ctx, cancel := contextWithTimeout(30 * time.Minute)
 	defer cancel()
 
-	go c.monitorClassification(ctx, cancel, schema.ClassName(params.Class))
+	go c.monitorClassification(ctx, cancel, params.Class)
 
 	c.logBegin(params, filters)
 	unclassifiedItems, err := c.vectorRepo.GetUnclassified(ctx,
@@ -69,9 +68,7 @@ func (c *Classifier) run(params models.Classification,
 	c.succeedRun(params)
 }
 
-func (c *Classifier) monitorClassification(ctx context.Context, cancelFn context.CancelFunc,
-	className schema.ClassName,
-) {
+func (c *Classifier) monitorClassification(ctx context.Context, cancelFn context.CancelFunc, className string) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -79,8 +76,7 @@ func (c *Classifier) monitorClassification(ctx context.Context, cancelFn context
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			schema := c.schemaGetter.GetSchemaSkipAuth()
-			class := schema.FindClassByName(className)
+			class := c.schemaGetter.ReadOnlyClass(className)
 			if class == nil {
 				cancelFn()
 				return

--- a/usecases/classification/classifier_run_zeroshot.go
+++ b/usecases/classification/classifier_run_zeroshot.go
@@ -12,6 +12,7 @@
 package classification
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -28,8 +29,10 @@ func (c *Classifier) classifyItemUsingZeroShot(item search.Result, itemIndex int
 
 	properties := params.ClassifyProperties
 
-	s := c.schemaGetter.GetSchemaSkipAuth()
-	class := s.GetClass(item.ClassName)
+	class := c.schemaGetter.ReadOnlyClass(item.ClassName)
+	if class == nil {
+		return fmt.Errorf("zeroshot: search: could not find class %s in schema", item.ClassName)
+	}
 
 	classifyProp := []string{}
 	for _, prop := range properties {

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -40,6 +40,10 @@ func (f *fakeSchemaGetter) GetSchemaSkipAuth() schema.Schema {
 	return f.schema
 }
 
+func (f *fakeSchemaGetter) ReadOnlyClass(class string) *models.Class {
+	return f.schema.GetClass(class)
+}
+
 func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	panic("not implemented")
 }

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -47,6 +47,10 @@ func (f *fakeSchemaGetter) GetSchemaSkipAuth() schema.Schema {
 	return f.schema
 }
 
+func (f *fakeSchemaGetter) ReadOnlyClass(className string) *models.Class {
+	return f.schema.GetClass(className)
+}
+
 func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	return f.shardState
 }

--- a/usecases/modules/fakes_for_test.go
+++ b/usecases/modules/fakes_for_test.go
@@ -135,8 +135,8 @@ func (m dummyNonVectorizerModule) Type() modulecapabilities.ModuleType {
 
 type fakeSchemaGetter struct{ schema schema.Schema }
 
-func (f *fakeSchemaGetter) GetSchemaSkipAuth() schema.Schema {
-	return f.schema
+func (f *fakeSchemaGetter) ReadOnlyClass(name string) *models.Class {
+	return f.schema.GetClass(name)
 }
 
 type fakeObjectsRepo struct {

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 )
 
@@ -42,7 +41,7 @@ type Provider struct {
 }
 
 type schemaGetter interface {
-	GetSchemaSkipAuth() schema.Schema
+	ReadOnlyClass(name string) *models.Class
 }
 
 func NewProvider() *Provider {
@@ -748,8 +747,7 @@ func (p *Provider) GetMeta() (map[string]interface{}, error) {
 }
 
 func (p *Provider) getClass(className string) (*models.Class, error) {
-	sch := p.schemaGetter.GetSchemaSkipAuth()
-	class := sch.FindClassByName(schema.ClassName(className))
+	class := p.schemaGetter.ReadOnlyClass(className)
 	if class == nil {
 		return nil, errors.Errorf("class %q not found in schema", className)
 	}

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -20,7 +20,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -151,9 +150,7 @@ func (p *Provider) VectorizerName(className string) (string, error) {
 }
 
 func (p *Provider) getClassVectorizer(className string) (string, interface{}, error) {
-	sch := p.schemaGetter.GetSchemaSkipAuth()
-
-	class := sch.FindClassByName(schema.ClassName(className))
+	class := p.schemaGetter.ReadOnlyClass(className)
 	if class == nil {
 		// this should be impossible by the time this method gets called, but let's
 		// be 100% certain

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -54,6 +54,7 @@ type InvertedConfigValidator func(in *models.InvertedIndexConfig) error
 type SchemaGetter interface {
 	// TODO: GetSchemaSkipAuth shall return Schema pointer
 	GetSchemaSkipAuth() schema.Schema
+	ReadOnlyClass(string) *models.Class
 	Nodes() []string
 	NodeName() string
 	ClusterHealthScore() int

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -748,11 +748,7 @@ func (e *Explorer) crossClassVectorFromModules(ctx context.Context,
 }
 
 func (e *Explorer) checkCertaintyCompatibility(className string) error {
-	s := e.schemaGetter.GetSchemaSkipAuth()
-	if s.Objects == nil {
-		return errors.Errorf("failed to get schema")
-	}
-	class := s.GetClass(className)
+	class := e.schemaGetter.ReadOnlyClass(className)
 	if class == nil {
 		return errors.Errorf("failed to get class: %s", className)
 	}
@@ -771,13 +767,13 @@ func (e *Explorer) replicationEnabled(params dto.GetParams) (bool, error) {
 	if e.schemaGetter == nil {
 		return false, fmt.Errorf("schemaGetter not set")
 	}
-	sch := e.schemaGetter.GetSchemaSkipAuth()
-	cls := sch.GetClass(params.ClassName)
-	if cls == nil {
+
+	class := e.schemaGetter.ReadOnlyClass(params.ClassName)
+	if class == nil {
 		return false, fmt.Errorf("class not found in schema: %q", params.ClassName)
 	}
 
-	return cls.ReplicationConfig != nil && cls.ReplicationConfig.Factor > 1, nil
+	return class.ReplicationConfig != nil && class.ReplicationConfig.Factor > 1, nil
 }
 
 func ExtractDistanceFromParams(params dto.GetParams) (distance float64, withDistance bool) {

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -227,6 +227,10 @@ func (f *fakeSchemaGetter) GetSchemaSkipAuth() schema.Schema {
 	return f.schema
 }
 
+func (f *fakeSchemaGetter) ReadOnlyClass(className string) *models.Class {
+	return f.schema.GetClass(className)
+}
+
 func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 	panic("not implemented")
 }

--- a/usecases/traverser/traverser_validate_distance_metrics.go
+++ b/usecases/traverser/traverser_validate_distance_metrics.go
@@ -96,8 +96,7 @@ func (t *Traverser) validateExploreDistanceParams(params ExploreParams, distType
 }
 
 func (t *Traverser) validateGetDistanceParams(params dto.GetParams) error {
-	sch := t.schemaGetter.GetSchemaSkipAuth()
-	class := sch.GetClass(params.ClassName)
+	class := t.schemaGetter.ReadOnlyClass(params.ClassName)
 	if class == nil {
 		return fmt.Errorf("failed to find class '%s' in schema", params.ClassName)
 	}


### PR DESCRIPTION
### What's being changed:

* Change all occurence of `GetSchemaSkipAuth` where we only then read a single class with a call to `ReadOnlyClass`
* Update a few `GetClass` that would not check if the returned pointer was nil

This is just the first PR where I address the easy part and I can just replace with a call to ReadOnlyClass . There are still some code using the whole schema but that would need bigger refactor that I'm currently working on.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
