### PR TITLE
Write Tombstones to LSM properly and handle badly formed records  

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -308,6 +308,10 @@ func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[any],
 			for j, result := range results {
 				if termIndice, ok := indices[j][res.ID]; ok {
 					queryTerm := result.queryTerm
+					if len(result.data) <= termIndice {
+						b.logger.Warnf("Skipping object explanation in BM25: termIndice %v is out of range for queryTerm %v, len() %d, res.ID %v", termIndice, queryTerm, len(result.data), res.ID)
+						continue
+					}
 					obj.Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.data[termIndice].frequency
 					obj.Object.Additional["BM25F_"+queryTerm+"_propLength"] = result.data[termIndice].propLength
 				}
@@ -443,6 +447,16 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 				freqBits := binary.LittleEndian.Uint32(val.Value[0:4])
 				propLenBits := binary.LittleEndian.Uint32(val.Value[4:8])
 				if ok {
+					if ind >= len(docMapPairs) {
+						// the index is not valid anymore, but the key is still in the map
+						b.logger.Warnf("Skipping pair in BM25: Index %d is out of range for key %d, len() %d.", ind, key, len(docMapPairs))
+						continue
+					}
+					if ind < len(docMapPairs) && docMapPairs[ind].id != key {
+						b.logger.Warnf("docMapPairs[%d].id %d != key %d", ind, docMapPairs[ind].id, key)
+						continue
+					}
+
 					docMapPairs[ind].propLength += math.Float32frombits(propLenBits)
 					docMapPairs[ind].frequency += math.Float32frombits(freqBits) * propertyBoosts[propName]
 				} else {
@@ -470,6 +484,15 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 		n += float64(filteredDocIDs.GetCardinality())
 	}
 	termResult.idf = math.Log(float64(1)+(N-n+0.5)/(n+0.5)) * float64(duplicateTextBoost)
+
+	// catch special case where there are no results and would panic termResult.data[0].id
+	// related to #4125
+	if len(termResult.data) == 0 {
+		termResult.posPointer = 0
+		termResult.idPointer = 0
+		termResult.exhausted = true
+		return termResult, docMapPairsIndices, nil
+	}
 
 	termResult.posPointer = 0
 	termResult.idPointer = termResult.data[0].id

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -309,7 +309,7 @@ func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[any],
 				if termIndice, ok := indices[j][res.ID]; ok {
 					queryTerm := result.queryTerm
 					if len(result.data) <= termIndice {
-						b.logger.Warnf("Skipping object explanation in BM25: termIndice %v is out of range for queryTerm %v, len() %d, res.ID %v", termIndice, queryTerm, len(result.data), res.ID)
+						b.logger.Warnf("Skipping object explanation in BM25: term indice %v is out of range for query term %v, len() %d, res.ID %v", termIndice, queryTerm, len(result.data), res.ID)
 						continue
 					}
 					obj.Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.data[termIndice].frequency

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -309,7 +309,7 @@ func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[any],
 				if termIndice, ok := indices[j][res.ID]; ok {
 					queryTerm := result.queryTerm
 					if len(result.data) <= termIndice {
-						b.logger.Warnf("Skipping object explanation in BM25: term indice %v is out of range for query term %v, len() %d, res.ID %v", termIndice, queryTerm, len(result.data), res.ID)
+						b.logger.Warnf("Skipping object explanation in BM25: term indice %v is out of range for query term %v, length %d, id %v", termIndice, queryTerm, len(result.data), res.ID)
 						continue
 					}
 					obj.Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.data[termIndice].frequency
@@ -449,11 +449,11 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 				if ok {
 					if ind >= len(docMapPairs) {
 						// the index is not valid anymore, but the key is still in the map
-						b.logger.Warnf("Skipping pair in BM25: Index %d is out of range for key %d, len() %d.", ind, key, len(docMapPairs))
+						b.logger.Warnf("Skipping pair in BM25: Index %d is out of range for key %d, length %d.", ind, key, len(docMapPairs))
 						continue
 					}
 					if ind < len(docMapPairs) && docMapPairs[ind].id != key {
-						b.logger.Warnf("docMapPairs[%d].id %d != key %d", ind, docMapPairs[ind].id, key)
+						b.logger.Warnf("Skipping pair in BM25: id at %d in doc map pairs, %d, differs from current key, %d", ind, docMapPairs[ind].id, key)
 						continue
 					}
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -632,7 +632,10 @@ func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 			if err := segmentDecoded[j].FromBytes(v.value, false); err != nil {
 				return nil, err
 			}
-			segmentDecoded[j].Tombstone = v.tombstone
+			// Read "broken" tombstones with length 12 but a non-tombstone value
+			// Related to Issue #4125
+			// TODO: Remove the extra check, as it may interfere future in-disk format changes
+			segmentDecoded[j].Tombstone = v.tombstone || len(v.value) == 12
 		}
 		segments = append(segments, segmentDecoded)
 	}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -294,7 +294,8 @@ func (m *Memtable) appendMapSorted(key []byte, pair MapPair) error {
 		primaryKey: key,
 		values: []value{
 			{
-				value: valuesForCommitLog,
+				value:     valuesForCommitLog,
+				tombstone: pair.Tombstone,
 			},
 		},
 	}); err != nil {


### PR DESCRIPTION
### What's being changed:

Write tombstones to WAL properly and recover from badly formed tombstones.
Better bound checks on BM25 searcher for badly formed tombstones.
Partially addresses #4125. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
