### PR TITLE
change GetSchemaSkipAuth usage to query only the necessary information

### DIFF
--- a/adapters/handlers/grpc/v1/batch_delete.go
+++ b/adapters/handlers/grpc/v1/batch_delete.go
@@ -17,18 +17,19 @@ import (
 	"strings"
 
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, scheme schema.Schema) (objects.BatchDeleteParams, error) {
+func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, getClass func(string) *models.Class) (objects.BatchDeleteParams, error) {
 	params := objects.BatchDeleteParams{}
 
 	// make sure collection exists
-	_, err := schema.GetClassByName(scheme.Objects, req.Collection)
-	if err != nil {
-		return objects.BatchDeleteParams{}, err
+	class := getClass(req.Collection)
+	if class == nil {
+		return objects.BatchDeleteParams{}, fmt.Errorf("could not find class %s in schema", req.Collection)
 	}
 
 	params.ClassName = schema.ClassName(req.Collection)
@@ -45,12 +46,12 @@ func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, scheme schema.Schema
 		return objects.BatchDeleteParams{}, fmt.Errorf("no filters in batch delete request")
 	}
 
-	clause, err := extractFilters(req.Filters, scheme, req.Collection)
+	clause, err := extractFilters(req.Filters, getClass, req.Collection)
 	if err != nil {
 		return objects.BatchDeleteParams{}, err
 	}
 	filter := &filters.LocalFilter{Root: &clause}
-	if err := filters.ValidateFilters(scheme.GetClass, filter); err != nil {
+	if err := filters.ValidateFilters(getClass, filter); err != nil {
 		return objects.BatchDeleteParams{}, err
 	}
 	params.Filters = filter

--- a/adapters/handlers/grpc/v1/batch_delete_test.go
+++ b/adapters/handlers/grpc/v1/batch_delete_test.go
@@ -71,7 +71,7 @@ func TestBatchDeleteRequest(t *testing.T) {
 		{
 			name:  "collection does not exist",
 			req:   &pb.BatchDeleteRequest{Collection: "does not exist"},
-			error: errors.New("no such class with name 'does not exist' found in the schema. Check your schema files for which classes are available"),
+			error: errors.New("could not find class does not exist in schema"),
 		},
 		{
 			name:  "no filter",
@@ -113,7 +113,7 @@ func TestBatchDeleteRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := batchDeleteParamsFromProto(tt.req, scheme)
+			out, err := batchDeleteParamsFromProto(tt.req, scheme.GetClass)
 			require.Equal(t, tt.error, err)
 
 			if tt.error == nil {

--- a/adapters/handlers/grpc/v1/batch_parse_request.go
+++ b/adapters/handlers/grpc/v1/batch_parse_request.go
@@ -33,7 +33,7 @@ func sliceToInterface[T any](values []T) []interface{} {
 	return tmpArray
 }
 
-func batchFromProto(req *pb.BatchObjectsRequest, scheme schema.Schema) ([]*models.Object, map[int]int, map[int]error) {
+func batchFromProto(req *pb.BatchObjectsRequest, getClass func(string) *models.Class) ([]*models.Object, map[int]int, map[int]error) {
 	objectsBatch := req.Objects
 	objs := make([]*models.Object, 0, len(objectsBatch))
 	objOriginalIndex := make(map[int]int)
@@ -41,7 +41,6 @@ func batchFromProto(req *pb.BatchObjectsRequest, scheme schema.Schema) ([]*model
 
 	insertCounter := 0
 	for i, obj := range objectsBatch {
-		class := scheme.GetClass(obj.Collection)
 		var props map[string]interface{}
 		if obj.Properties != nil {
 			props = extractPrimitiveProperties(&pb.ObjectPropertiesValue{
@@ -54,13 +53,17 @@ func batchFromProto(req *pb.BatchObjectsRequest, scheme schema.Schema) ([]*model
 				ObjectArrayProperties:  obj.Properties.ObjectArrayProperties,
 				EmptyListProps:         obj.Properties.EmptyListProps,
 			})
-			if err := extractSingleRefTarget(class, obj.Properties.SingleTargetRefProps, props); err != nil {
-				objectErrors[i] = err
-				continue
-			}
-			if err := extractMultiRefTarget(class, obj.Properties.MultiTargetRefProps, props); err != nil {
-				objectErrors[i] = err
-				continue
+			// If class is not in schema, continue as there is no ref to extract
+			class := getClass(obj.Collection)
+			if class != nil {
+				if err := extractSingleRefTarget(class, obj.Properties.SingleTargetRefProps, props); err != nil {
+					objectErrors[i] = err
+					continue
+				}
+				if err := extractMultiRefTarget(class, obj.Properties.MultiTargetRefProps, props); err != nil {
+					objectErrors[i] = err
+					continue
+				}
 			}
 		}
 

--- a/adapters/handlers/grpc/v1/batch_parse_request_test.go
+++ b/adapters/handlers/grpc/v1/batch_parse_request_test.go
@@ -279,7 +279,7 @@ func TestGRPCBatchRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, origIndex, batchErrors := batchFromProto(&pb.BatchObjectsRequest{Objects: tt.req}, scheme)
+			out, origIndex, batchErrors := batchFromProto(&pb.BatchObjectsRequest{Objects: tt.req}, scheme.GetClass)
 			if len(tt.outError) > 0 {
 				require.NotNil(t, batchErrors)
 				if len(tt.out) > 0 {

--- a/adapters/handlers/grpc/v1/filters.go
+++ b/adapters/handlers/grpc/v1/filters.go
@@ -20,7 +20,7 @@ import (
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
-func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string) (filters.Clause, error) {
+func extractFilters(filterIn *pb.Filters, getClass func(string) *models.Class, className string) (filters.Clause, error) {
 	returnFilter := filters.Clause{}
 	if filterIn.Operator == pb.Filters_OPERATOR_AND || filterIn.Operator == pb.Filters_OPERATOR_OR {
 		if filterIn.Operator == pb.Filters_OPERATOR_AND {
@@ -31,7 +31,7 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 
 		clauses := make([]filters.Clause, len(filterIn.Filters))
 		for i, clause := range filterIn.Filters {
-			retClause, err := extractFilters(clause, scheme, className)
+			retClause, err := extractFilters(clause, getClass, className)
 			if err != nil {
 				return filters.Clause{}, err
 			}
@@ -76,18 +76,18 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 
 		var dataType schema.DataType
 		if filterIn.Target == nil {
-			path, err := extractPath(scheme, className, filterIn.On)
+			path, err := extractPath(className, filterIn.On)
 			if err != nil {
 				return filters.Clause{}, err
 			}
 			returnFilter.On = path
 
-			dataType, err = extractDataType(scheme, returnFilter.Operator, className, filterIn.On)
+			dataType, err = extractDataType(getClass, returnFilter.Operator, className, filterIn.On)
 			if err != nil {
 				return filters.Clause{}, err
 			}
 		} else {
-			path, dataType2, err := extractPathNew(scheme, className, filterIn.Target, returnFilter.Operator)
+			path, dataType2, err := extractPathNew(getClass, className, filterIn.Target, returnFilter.Operator)
 			if err != nil {
 				return filters.Clause{}, err
 			}
@@ -182,7 +182,7 @@ func extractFilters(filterIn *pb.Filters, scheme schema.Schema, className string
 	return returnFilter, nil
 }
 
-func extractDataTypeProperty(scheme schema.Schema, operator filters.Operator, classname string, on []string) (schema.DataType, error) {
+func extractDataTypeProperty(getClass func(string) *models.Class, operator filters.Operator, className string, on []string) (schema.DataType, error) {
 	var dataType schema.DataType
 	if operator == filters.OperatorIsNull {
 		dataType = schema.DataTypeBoolean
@@ -194,7 +194,11 @@ func extractDataTypeProperty(scheme schema.Schema, operator filters.Operator, cl
 		}
 
 		classOfProp := on[len(on)-2]
-		prop, err := scheme.GetProperty(schema.ClassName(classOfProp), schema.PropertyName(propToCheck))
+		class := getClass(classOfProp)
+		if class == nil {
+			return dataType, fmt.Errorf("could not find class %s in schema", classOfProp)
+		}
+		prop, err := schema.GetPropertyByName(class, propToCheck)
 		if err != nil {
 			return dataType, err
 		}
@@ -206,7 +210,11 @@ func extractDataTypeProperty(scheme schema.Schema, operator filters.Operator, cl
 			return schema.DataTypeInt, nil
 		}
 
-		prop, err := scheme.GetProperty(schema.ClassName(classname), schema.PropertyName(propToCheck))
+		class := getClass(className)
+		if class == nil {
+			return dataType, fmt.Errorf("could not find class %s in schema", className)
+		}
+		prop, err := schema.GetPropertyByName(class, propToCheck)
 		if err != nil {
 			return dataType, err
 		}
@@ -225,21 +233,21 @@ func extractDataTypeProperty(scheme schema.Schema, operator filters.Operator, cl
 	return dataType, nil
 }
 
-func extractDataType(scheme schema.Schema, operator filters.Operator, classname string, on []string) (schema.DataType, error) {
+func extractDataType(getClass func(string) *models.Class, operator filters.Operator, classname string, on []string) (schema.DataType, error) {
 	propToFilterOn := on[len(on)-1]
 	if propToFilterOn == filters.InternalPropID {
 		return schema.DataTypeText, nil
 	} else if propToFilterOn == filters.InternalPropCreationTimeUnix || propToFilterOn == filters.InternalPropLastUpdateTimeUnix {
 		return schema.DataTypeDate, nil
 	} else {
-		return extractDataTypeProperty(scheme, operator, classname, on)
+		return extractDataTypeProperty(getClass, operator, classname, on)
 	}
 }
 
-func extractPath(scheme schema.Schema, className string, on []string) (*filters.Path, error) {
+func extractPath(className string, on []string) (*filters.Path, error) {
 	if len(on) > 1 {
 		var err error
-		child, err := extractPath(scheme, on[1], on[2:])
+		child, err := extractPath(on[1], on[2:])
 		if err != nil {
 			return nil, err
 		}
@@ -249,11 +257,14 @@ func extractPath(scheme schema.Schema, className string, on []string) (*filters.
 	return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(on[0]), Child: nil}, nil
 }
 
-func extractPathNew(scheme schema.Schema, className string, target *pb.FilterTarget, operator filters.Operator) (*filters.Path, schema.DataType, error) {
-	class := scheme.GetClass(className)
+func extractPathNew(getClass func(string) *models.Class, className string, target *pb.FilterTarget, operator filters.Operator) (*filters.Path, schema.DataType, error) {
+	class := getClass(className)
+	if class == nil {
+		return nil, "", fmt.Errorf("could not find class %s in schema", className)
+	}
 	switch target.Target.(type) {
 	case *pb.FilterTarget_Property:
-		dt, err := extractDataType(scheme, operator, className, []string{target.GetProperty()})
+		dt, err := extractDataType(getClass, operator, className, []string{target.GetProperty()})
 		if err != nil {
 			return nil, "", err
 		}
@@ -268,14 +279,14 @@ func extractPathNew(scheme schema.Schema, className string, target *pb.FilterTar
 		if len(refProp.DataType) != 1 {
 			return nil, "", fmt.Errorf("expected reference property with a single target, got %v for %v ", refProp.DataType, refProp.Name)
 		}
-		child, property, err := extractPathNew(scheme, refProp.DataType[0], singleTarget.Target, operator)
+		child, property, err := extractPathNew(getClass, refProp.DataType[0], singleTarget.Target, operator)
 		if err != nil {
 			return nil, "", err
 		}
 		return &filters.Path{Class: schema.ClassName(className), Property: schema.PropertyName(normalizedRefPropName), Child: child}, property, nil
 	case *pb.FilterTarget_MultiTarget:
 		multiTarget := target.GetMultiTarget()
-		child, property, err := extractPathNew(scheme, multiTarget.TargetCollection, multiTarget.Target, operator)
+		child, property, err := extractPathNew(getClass, multiTarget.TargetCollection, multiTarget.Target, operator)
 		if err != nil {
 			return nil, "", err
 		}

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -1297,7 +1297,7 @@ func TestGRPCRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := searchParamsFromProto(tt.req, scheme)
+			out, err := searchParamsFromProto(tt.req, scheme.GetClass)
 			if tt.error {
 				require.NotNil(t, err)
 			} else {

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -19,9 +19,10 @@ import (
 
 	"github.com/weaviate/weaviate/usecases/byteops"
 
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	generative "github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate"
-	"github.com/weaviate/weaviate/usecases/modulecomponents/additional/models"
+	moduleModels "github.com/weaviate/weaviate/usecases/modulecomponents/additional/models"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func searchResultsToProto(res []interface{}, start time.Time, searchParams dto.GetParams, scheme schema.Schema, usesPropertiesMessage bool) (*pb.SearchReply, error) {
+func searchResultsToProto(res []interface{}, start time.Time, searchParams dto.GetParams, getClass func(string) *models.Class, usesPropertiesMessage bool) (*pb.SearchReply, error) {
 	tookSeconds := float64(time.Since(start)) / float64(time.Second)
 	out := &pb.SearchReply{
 		Took:                    float32(tookSeconds),
@@ -42,7 +43,7 @@ func searchResultsToProto(res []interface{}, start time.Time, searchParams dto.G
 	if searchParams.GroupBy != nil {
 		out.GroupByResults = make([]*pb.GroupByResult, len(res))
 		for i, raw := range res {
-			group, generativeGroupResponse, err := extractGroup(raw, searchParams, scheme, usesPropertiesMessage)
+			group, generativeGroupResponse, err := extractGroup(raw, searchParams, getClass, usesPropertiesMessage)
 			if err != nil {
 				return nil, err
 			}
@@ -52,7 +53,7 @@ func searchResultsToProto(res []interface{}, start time.Time, searchParams dto.G
 			out.GroupByResults[i] = group
 		}
 	} else {
-		objects, generativeGroupResponse, err := extractObjectsToResults(res, searchParams, scheme, false, usesPropertiesMessage)
+		objects, generativeGroupResponse, err := extractObjectsToResults(res, searchParams, getClass, false, usesPropertiesMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -62,7 +63,7 @@ func searchResultsToProto(res []interface{}, start time.Time, searchParams dto.G
 	return out, nil
 }
 
-func extractObjectsToResults(res []interface{}, searchParams dto.GetParams, scheme schema.Schema, fromGroup, usesPropertiesMessage bool) ([]*pb.SearchResult, string, error) {
+func extractObjectsToResults(res []interface{}, searchParams dto.GetParams, getClass func(string) *models.Class, fromGroup, usesPropertiesMessage bool) ([]*pb.SearchResult, string, error) {
 	results := make([]*pb.SearchResult, len(res))
 	generativeGroupResultsReturn := ""
 	for i, raw := range res {
@@ -76,9 +77,9 @@ func extractObjectsToResults(res []interface{}, searchParams dto.GetParams, sche
 		var err error
 
 		if usesPropertiesMessage {
-			props, err = extractPropertiesAnswer(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.AdditionalProperties)
+			props, err = extractPropertiesAnswer(getClass, asMap, searchParams.Properties, searchParams.ClassName, searchParams.AdditionalProperties)
 		} else {
-			props, err = extractPropertiesAnswerDeprecated(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.AdditionalProperties)
+			props, err = extractPropertiesAnswerDeprecated(getClass, asMap, searchParams.Properties, searchParams.ClassName, searchParams.AdditionalProperties)
 		}
 		if err != nil {
 			return nil, "", err
@@ -166,13 +167,13 @@ func extractAdditionalProps(asMap map[string]any, additionalPropsParams addition
 	}
 
 	if generativeSearchEnabled {
-		var generateFmt *models.GenerateResult
+		var generateFmt *moduleModels.GenerateResult
 
 		generate, ok := additionalPropertiesMap["generate"]
 		if !ok {
-			generateFmt = &models.GenerateResult{}
+			generateFmt = &moduleModels.GenerateResult{}
 		} else {
-			generateFmt, ok = generate.(*models.GenerateResult)
+			generateFmt, ok = generate.(*moduleModels.GenerateResult)
 			if !ok {
 				return nil, "", errors.New("could not cast generative result additional prop")
 			}
@@ -208,7 +209,7 @@ func extractAdditionalProps(asMap map[string]any, additionalPropsParams addition
 		if !ok {
 			return nil, "", errors.New("No results for rerank despite a search request. Is a the rerank module enabled?")
 		}
-		rerankFmt, ok := rerank.([]*models.RankResult)
+		rerankFmt, ok := rerank.([]*moduleModels.RankResult)
 		if !ok {
 			return nil, "", errors.New("could not cast rerank result additional prop")
 		}
@@ -314,7 +315,7 @@ func extractAdditionalProps(asMap map[string]any, additionalPropsParams addition
 	return metadata, generativeGroupResults, nil
 }
 
-func extractGroup(raw any, searchParams dto.GetParams, scheme schema.Schema, usesMarshalling bool) (*pb.GroupByResult, string, error) {
+func extractGroup(raw any, searchParams dto.GetParams, getClass func(string) *models.Class, usesMarshalling bool) (*pb.GroupByResult, string, error) {
 	generativeSearchRaw, generativeSearchEnabled := searchParams.AdditionalProperties.ModuleParams["generate"]
 	_, rerankEnabled := searchParams.AdditionalProperties.ModuleParams["rerank"]
 	asMap, ok := raw.(map[string]interface{})
@@ -347,13 +348,13 @@ func extractGroup(raw any, searchParams dto.GetParams, scheme schema.Schema, use
 
 	groupedGenerativeResults := ""
 	if generativeSearchEnabled {
-		var generateFmt *models.GenerateResult
+		var generateFmt *moduleModels.GenerateResult
 
 		generate, ok := addAsMap["generate"]
 		if !ok {
-			generateFmt = &models.GenerateResult{}
+			generateFmt = &moduleModels.GenerateResult{}
 		} else {
-			generateFmt, ok = generate.(*models.GenerateResult)
+			generateFmt, ok = generate.(*moduleModels.GenerateResult)
 			if !ok {
 				return nil, "", errors.New("could not cast generative result additional prop")
 			}
@@ -388,7 +389,7 @@ func extractGroup(raw any, searchParams dto.GetParams, scheme schema.Schema, use
 		if !ok {
 			return nil, "", fmt.Errorf("rerank is not present %v", addAsMap)
 		}
-		rerank, ok := rerankRaw.([]*models.RankResult)
+		rerank, ok := rerankRaw.([]*moduleModels.RankResult)
 		if !ok {
 			return nil, "", fmt.Errorf("cannot parse rerank %v", rerankRaw)
 		}
@@ -413,7 +414,7 @@ func extractGroup(raw any, searchParams dto.GetParams, scheme schema.Schema, use
 		returnObjectsUntyped[i] = group.Hits[i]
 	}
 
-	objects, _, err := extractObjectsToResults(returnObjectsUntyped, searchParams, scheme, true, usesMarshalling)
+	objects, _, err := extractObjectsToResults(returnObjectsUntyped, searchParams, getClass, true, usesMarshalling)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "extracting hits from group")
 	}
@@ -423,7 +424,7 @@ func extractGroup(raw any, searchParams dto.GetParams, scheme schema.Schema, use
 	return ret, groupedGenerativeResults, nil
 }
 
-func extractPropertiesAnswerDeprecated(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+func extractPropertiesAnswerDeprecated(getClass func(string) *models.Class, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
 	nonRefProps := make(map[string]interface{}, 0)
 	refProps := make([]*pb.RefPropertiesResult, 0)
 	objProps := make([]*pb.ObjectProperties, 0)
@@ -438,13 +439,17 @@ func extractPropertiesAnswerDeprecated(scheme schema.Schema, results map[string]
 			continue
 		}
 		if prop.IsObject {
-			nested, err := scheme.GetProperty(schema.ClassName(className), schema.PropertyName(prop.Name))
+			class := getClass(className)
+			if class == nil {
+				return nil, fmt.Errorf("could not find class %s in schema", className)
+			}
+			nested, err := schema.GetPropertyByName(class, prop.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "getting property")
 			}
 			singleObj, ok := propRaw.(map[string]interface{})
 			if ok {
-				extractedNestedProp, err := extractPropertiesNested(scheme, singleObj, prop, className, &Property{Property: nested})
+				extractedNestedProp, err := extractPropertiesNested(getClass, singleObj, prop, className, &Property{Property: nested})
 				if err != nil {
 					return nil, errors.Wrap(err, "extracting nested properties")
 				}
@@ -462,7 +467,7 @@ func extractPropertiesAnswerDeprecated(scheme schema.Schema, results map[string]
 					if !ok {
 						continue
 					}
-					extractedNestedProp, err := extractPropertiesNested(scheme, singleObj, prop, className, &Property{Property: nested})
+					extractedNestedProp, err := extractPropertiesNested(getClass, singleObj, prop, className, &Property{Property: nested})
 					if err != nil {
 						return nil, err
 					}
@@ -487,7 +492,7 @@ func extractPropertiesAnswerDeprecated(scheme schema.Schema, results map[string]
 			if !ok {
 				continue
 			}
-			extractedRefProp, err := extractPropertiesAnswerDeprecated(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, additionalPropsParams)
+			extractedRefProp, err := extractPropertiesAnswerDeprecated(getClass, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, additionalPropsParams)
 			if err != nil {
 				continue
 			}
@@ -505,7 +510,7 @@ func extractPropertiesAnswerDeprecated(scheme schema.Schema, results map[string]
 	props := pb.PropertiesResult{}
 	if len(nonRefProps) > 0 {
 		outProps := pb.ObjectPropertiesValue{}
-		if err := extractArrayTypesRoot(scheme, className, nonRefProps, &outProps); err != nil {
+		if err := extractArrayTypesRoot(getClass, className, nonRefProps, &outProps); err != nil {
 			return nil, errors.Wrap(err, "extracting non-primitive types")
 		}
 		newStruct, err := structpb.NewStruct(nonRefProps)
@@ -534,12 +539,11 @@ func extractPropertiesAnswerDeprecated(scheme schema.Schema, results map[string]
 	return &props, nil
 }
 
-func extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+func extractPropertiesAnswer(getClass func(string) *models.Class, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
 	nonRefProps := &pb.Properties{
 		Fields: make(map[string]*pb.Value, 0),
 	}
 	refProps := make([]*pb.RefPropertiesResult, 0)
-	class := scheme.GetClass(className)
 	for _, prop := range properties {
 		propRaw, ok := results[prop.Name]
 
@@ -550,6 +554,10 @@ func extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{
 			continue
 		}
 		if prop.IsPrimitive {
+			class := getClass(className)
+			if class == nil {
+				return nil, fmt.Errorf("could not find class %s in schema", className)
+			}
 			dataType, err := schema.GetPropertyDataType(class, prop.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "getting primitive property datatype")
@@ -562,7 +570,11 @@ func extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{
 			continue
 		}
 		if prop.IsObject {
-			nested, err := scheme.GetProperty(schema.ClassName(className), schema.PropertyName(prop.Name))
+			class := getClass(className)
+			if class == nil {
+				return nil, fmt.Errorf("could not find class %s in schema", className)
+			}
+			nested, err := schema.GetPropertyByName(class, prop.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "getting nested property")
 			}
@@ -583,7 +595,7 @@ func extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{
 			if !ok {
 				continue
 			}
-			extractedRefProp, err := extractPropertiesAnswer(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, additionalPropsParams)
+			extractedRefProp, err := extractPropertiesAnswer(getClass, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, additionalPropsParams)
 			if err != nil {
 				continue
 			}
@@ -610,7 +622,7 @@ func extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{
 	return &props, nil
 }
 
-func extractPropertiesNested[P schema.PropertyInterface](scheme schema.Schema, results map[string]interface{}, property search.SelectProperty, className string, parent P) (*pb.ObjectPropertiesValue, error) {
+func extractPropertiesNested[P schema.PropertyInterface](getClass func(string) *models.Class, results map[string]interface{}, property search.SelectProperty, className string, parent P) (*pb.ObjectPropertiesValue, error) {
 	primitiveProps := make(map[string]interface{}, 0)
 	objProps := make([]*pb.ObjectProperties, 0)
 	objArrayProps := make([]*pb.ObjectArrayProperties, 0)
@@ -625,7 +637,7 @@ func extractPropertiesNested[P schema.PropertyInterface](scheme schema.Schema, r
 		}
 		if prop.IsObject {
 			var err error
-			objProps, objArrayProps, err = extractObjectProperties(scheme, propRaw, prop, className, parent, objProps, objArrayProps)
+			objProps, objArrayProps, err = extractObjectProperties(getClass, propRaw, prop, className, parent, objProps, objArrayProps)
 			if err != nil {
 				return nil, err
 			}
@@ -633,7 +645,7 @@ func extractPropertiesNested[P schema.PropertyInterface](scheme schema.Schema, r
 	}
 	props := pb.ObjectPropertiesValue{}
 	if len(primitiveProps) > 0 {
-		if err := extractArrayTypesNested(scheme, className, primitiveProps, &props, parent); err != nil {
+		if err := extractArrayTypesNested(className, primitiveProps, &props, parent); err != nil {
 			return nil, errors.Wrap(err, "extracting non-primitive types")
 		}
 		newStruct, err := structpb.NewStruct(primitiveProps)
@@ -651,10 +663,10 @@ func extractPropertiesNested[P schema.PropertyInterface](scheme schema.Schema, r
 	return &props, nil
 }
 
-func extractObjectProperties[P schema.PropertyInterface](scheme schema.Schema, propRaw interface{}, property search.SelectProperty, className string, parent P, objProps []*pb.ObjectProperties, objArrayProps []*pb.ObjectArrayProperties) ([]*pb.ObjectProperties, []*pb.ObjectArrayProperties, error) {
+func extractObjectProperties[P schema.PropertyInterface](getClass func(string) *models.Class, propRaw interface{}, property search.SelectProperty, className string, parent P, objProps []*pb.ObjectProperties, objArrayProps []*pb.ObjectArrayProperties) ([]*pb.ObjectProperties, []*pb.ObjectArrayProperties, error) {
 	prop, ok := propRaw.(map[string]interface{})
 	if ok {
-		objProp, err := extractObjectSingleProperties(scheme, prop, property, className, parent)
+		objProp, err := extractObjectSingleProperties(getClass, prop, property, className, parent)
 		if err != nil {
 			return objProps, objArrayProps, err
 		}
@@ -662,7 +674,7 @@ func extractObjectProperties[P schema.PropertyInterface](scheme schema.Schema, p
 	}
 	propArray, ok := propRaw.([]interface{})
 	if ok {
-		objArrayProp, err := extractObjectArrayProperties(scheme, propArray, property, className, parent)
+		objArrayProp, err := extractObjectArrayProperties(getClass, propArray, property, className, parent)
 		if err != nil {
 			return objProps, objArrayProps, err
 		}
@@ -671,12 +683,12 @@ func extractObjectProperties[P schema.PropertyInterface](scheme schema.Schema, p
 	return objProps, objArrayProps, nil
 }
 
-func extractObjectSingleProperties[P schema.PropertyInterface](scheme schema.Schema, prop map[string]interface{}, property search.SelectProperty, className string, parent P) (*pb.ObjectProperties, error) {
+func extractObjectSingleProperties[P schema.PropertyInterface](getClass func(string) *models.Class, prop map[string]interface{}, property search.SelectProperty, className string, parent P) (*pb.ObjectProperties, error) {
 	nested, err := schema.GetNestedPropertyByName(parent, property.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting property")
 	}
-	extractedNestedProp, err := extractPropertiesNested(scheme, prop, property, className, &NestedProperty{NestedProperty: nested})
+	extractedNestedProp, err := extractPropertiesNested(getClass, prop, property, className, &NestedProperty{NestedProperty: nested})
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("extracting nested properties from %v", nested))
 	}
@@ -686,7 +698,7 @@ func extractObjectSingleProperties[P schema.PropertyInterface](scheme schema.Sch
 	}, nil
 }
 
-func extractObjectArrayProperties[P schema.PropertyInterface](scheme schema.Schema, propObjs []interface{}, property search.SelectProperty, className string, parent P) (*pb.ObjectArrayProperties, error) {
+func extractObjectArrayProperties[P schema.PropertyInterface](getClass func(string) *models.Class, propObjs []interface{}, property search.SelectProperty, className string, parent P) (*pb.ObjectArrayProperties, error) {
 	extractedNestedProps := make([]*pb.ObjectPropertiesValue, 0, len(propObjs))
 	for _, objRaw := range propObjs {
 		nested, err := schema.GetNestedPropertyByName(parent, property.Name)
@@ -697,7 +709,7 @@ func extractObjectArrayProperties[P schema.PropertyInterface](scheme schema.Sche
 		if !ok {
 			continue
 		}
-		extractedNestedProp, err := extractPropertiesNested(scheme, obj, property, className, &NestedProperty{NestedProperty: nested})
+		extractedNestedProp, err := extractPropertiesNested(getClass, obj, property, className, &NestedProperty{NestedProperty: nested})
 		if err != nil {
 			return nil, errors.Wrap(err, "extracting nested properties")
 		}
@@ -709,19 +721,23 @@ func extractObjectArrayProperties[P schema.PropertyInterface](scheme schema.Sche
 	}, nil
 }
 
-func extractArrayTypesRoot(scheme schema.Schema, className string, rawProps map[string]interface{}, props *pb.ObjectPropertiesValue) error {
+func extractArrayTypesRoot(getClass func(string) *models.Class, className string, rawProps map[string]interface{}, props *pb.ObjectPropertiesValue) error {
 	dataTypes := make(map[string]*schema.DataType, 0)
+	class := getClass(className)
+	if class == nil {
+		return fmt.Errorf("could not find class %s in schema", className)
+	}
 	for propName := range rawProps {
-		dataType, err := schema.GetPropertyDataType(scheme.GetClass(className), propName)
+		dataType, err := schema.GetPropertyDataType(class, propName)
 		if err != nil {
 			return err
 		}
 		dataTypes[propName] = dataType
 	}
-	return extractArrayTypes(scheme, rawProps, props, dataTypes)
+	return extractArrayTypes(rawProps, props, dataTypes)
 }
 
-func extractArrayTypesNested[P schema.PropertyInterface](scheme schema.Schema, className string, rawProps map[string]interface{}, props *pb.ObjectPropertiesValue, parent P) error {
+func extractArrayTypesNested[P schema.PropertyInterface](className string, rawProps map[string]interface{}, props *pb.ObjectPropertiesValue, parent P) error {
 	dataTypes := make(map[string]*schema.DataType, 0)
 	for propName := range rawProps {
 		dataType, err := schema.GetNestedPropertyDataType(parent, propName)
@@ -730,11 +746,11 @@ func extractArrayTypesNested[P schema.PropertyInterface](scheme schema.Schema, c
 		}
 		dataTypes[propName] = dataType
 	}
-	return extractArrayTypes(scheme, rawProps, props, dataTypes)
+	return extractArrayTypes(rawProps, props, dataTypes)
 }
 
 // slices cannot be part of a grpc struct, so we need to handle each of them separately
-func extractArrayTypes(scheme schema.Schema, rawProps map[string]interface{}, props *pb.ObjectPropertiesValue, dataTypes map[string]*schema.DataType) error {
+func extractArrayTypes(rawProps map[string]interface{}, props *pb.ObjectPropertiesValue, dataTypes map[string]*schema.DataType) error {
 	for propName, prop := range rawProps {
 		dataType := dataTypes[propName]
 		switch *dataType {

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -1495,7 +1495,7 @@ func TestGRPCReply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := searchResultsToProto(tt.res, time.Now(), tt.searchParams, scheme, tt.usesWeaviateStruct)
+			out, err := searchResultsToProto(tt.res, time.Now(), tt.searchParams, scheme.GetClass, tt.usesWeaviateStruct)
 			require.Nil(t, err)
 			for i := range tt.outSearch {
 				require.Equal(t, tt.outSearch[i].Properties.String(), out.Results[i].Properties.String())

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -56,9 +56,8 @@ func (s *Service) BatchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
 	replicationProperties := extractReplicationProperties(req.ConsistencyLevel)
-	scheme := s.schemaManager.GetSchemaSkipAuth()
 
-	params, err := batchDeleteParamsFromProto(req, scheme)
+	params, err := batchDeleteParamsFromProto(req, s.schemaManager.ReadOnlyClass)
 	if err != nil {
 		return nil, fmt.Errorf("batch delete params: %w", err)
 	}
@@ -88,9 +87,7 @@ func (s *Service) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
-	scheme := s.schemaManager.GetSchemaSkipAuth()
-
-	objs, objOriginalIndex, objectParsingErrors := batchFromProto(req, scheme)
+	objs, objOriginalIndex, objectParsingErrors := batchFromProto(req, s.schemaManager.ReadOnlyClass)
 
 	replicationProperties := extractReplicationProperties(req.ConsistencyLevel)
 
@@ -126,8 +123,6 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
 
-	scheme := s.schemaManager.GetSchemaSkipAuth()
-
 	type reply struct {
 		Result *pb.SearchReply
 		Error  error
@@ -144,7 +139,7 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 			}
 		}()
 
-		searchParams, err := searchParamsFromProto(req, scheme)
+		searchParams, err := searchParamsFromProto(req, s.schemaManager.ReadOnlyClass)
 		if err != nil {
 			c <- reply{
 				Result: nil,
@@ -167,7 +162,7 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 			}
 		}
 
-		proto, err := searchResultsToProto(res, before, searchParams, scheme, req.Uses_123Api)
+		proto, err := searchResultsToProto(res, before, searchParams, s.schemaManager.ReadOnlyClass, req.Uses_123Api)
 		c <- reply{
 			Result: proto,
 			Error:  err,
@@ -178,10 +173,9 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 }
 
 func (s *Service) validateClassAndProperty(searchParams dto.GetParams) error {
-	scheme := s.schemaManager.GetSchemaSkipAuth()
-	class, err := schema.GetClassByName(scheme.Objects, searchParams.ClassName)
-	if err != nil {
-		return err
+	class := s.schemaManager.ReadOnlyClass(searchParams.ClassName)
+	if class == nil {
+		return fmt.Errorf("could not find class %s in schema", searchParams.ClassName)
 	}
 
 	for _, prop := range searchParams.Properties {

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -90,8 +90,11 @@ func (a *Aggregator) Do(ctx context.Context) (*aggregation.Result, error) {
 func (a *Aggregator) aggTypeOfProperty(
 	name schema.PropertyName,
 ) (aggregation.PropertyType, schema.DataType, error) {
-	s := a.getSchema.GetSchemaSkipAuth()
-	schemaProp, err := s.GetProperty(a.params.ClassName, name)
+	class := a.getSchema.ReadOnlyClass(a.params.ClassName.String())
+	if class == nil {
+		return "", "", fmt.Errorf("could not find class %s in schema", a.params.ClassName)
+	}
+	schemaProp, err := schema.GetPropertyByName(class, name.String())
 	if err != nil {
 		return "", "", errors.Wrapf(err, "property %s", name)
 	}

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -118,13 +118,12 @@ func (fa *filteredAggregator) filtered(ctx context.Context) (*aggregation.Result
 }
 
 func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
-	s := fa.getSchema.GetSchemaSkipAuth()
-	class := s.GetClass(fa.params.ClassName.String())
+	class := fa.getSchema.ReadOnlyClass(fa.params.ClassName.String())
 	if class == nil {
 		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", fa.params.ClassName)
 	}
 	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
-	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, s,
+	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, fa.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, fa.classSearcher,
 		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,
 	).BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw)

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -42,14 +42,13 @@ func (a *Aggregator) buildHybridKeywordRanking() (*searchparams.KeywordRanking, 
 }
 
 func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
-	s := a.getSchema.GetSchemaSkipAuth()
-	class := s.GetClass(a.params.ClassName.String())
+	class := a.getSchema.ReadOnlyClass(a.params.ClassName.String())
 	if class == nil {
 		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", a.params.ClassName)
 	}
 	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
 
-	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, s,
+	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, a.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, a.classSearcher,
 		a.GetPropertyLengthTracker(), a.logger, a.shardVersion,
 	).BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw)

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -89,8 +89,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 	)
 
 	if a.params.Filters != nil {
-		s := a.getSchema.GetSchemaSkipAuth()
-		allow, err = inverted.NewSearcher(a.logger, a.store, s, nil,
+		allow, err = inverted.NewSearcher(a.logger, a.store, a.getSchema.ReadOnlyClass, nil,
 			a.classSearcher, a.stopwords, a.shardVersion, a.isFallbackToSearchable,
 			a.tenant, a.nestedCrossRefLimit).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -787,23 +787,20 @@ func Test_propertyHasSearchableIndex(t *testing.T) {
 		},
 	}
 
-	ClassSchema := &models.Schema{
-		Classes: []*models.Class{class},
-	}
 	t.Run("Property index", func(t *testing.T) {
-		if got := inverted.PropertyHasSearchableIndex(ClassSchema, "MyClass", "description"); got != true {
+		if got := inverted.PropertyHasSearchableIndex(class, "description"); got != true {
 			t.Errorf("PropertyHasSearchableIndex() = %v, want %v", got, true)
 		}
 
-		if got := inverted.PropertyHasSearchableIndex(ClassSchema, "MyClass", "description^2"); got != true {
+		if got := inverted.PropertyHasSearchableIndex(class, "description^2"); got != true {
 			t.Errorf("PropertyHasSearchableIndex() = %v, want %v", got, true)
 		}
 
-		if got := inverted.PropertyHasSearchableIndex(ClassSchema, "MyClass", "textField"); got != false {
+		if got := inverted.PropertyHasSearchableIndex(class, "textField"); got != false {
 			t.Errorf("PropertyHasSearchableIndex() = %v, want %v", got, false)
 		}
 
-		if got := inverted.PropertyHasSearchableIndex(ClassSchema, "MyClass", "title"); got != true {
+		if got := inverted.PropertyHasSearchableIndex(class, "title"); got != true {
 			t.Errorf("PropertyHasSearchableIndex() = %v, want %v", got, true)
 		}
 	})

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1093,9 +1093,7 @@ func (i *Index) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 		propHash := cl.Properties
 		// Get keys of hash
 		for _, v := range propHash {
-			if inverted.PropertyHasSearchableIndex(i.getSchema.GetSchemaSkipAuth().Objects,
-				i.Config.ClassName.String(), v.Name) {
-
+			if inverted.PropertyHasSearchableIndex(i.getSchema.ReadOnlyClass(i.Config.ClassName.String()), v.Name) {
 				keywordRanking.Properties = append(keywordRanking.Properties, v.Name)
 			}
 		}
@@ -1299,7 +1297,7 @@ func (i *Index) sortKeywordRanking(objects []*storobj.Object,
 func (i *Index) sort(objects []*storobj.Object, scores []float32,
 	sort []filters.Sort, limit int,
 ) ([]*storobj.Object, []float32, error) {
-	return sorter.NewObjectsSorter(i.getSchema.GetSchemaSkipAuth()).
+	return sorter.NewObjectsSorter(i.getSchema.ReadOnlyClass).
 		Sort(objects, scores, limit, sort)
 }
 

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -51,55 +51,57 @@ func (db *DB) init(ctx context.Context) error {
 	}
 
 	objects := db.schemaGetter.GetSchemaSkipAuth().Objects
-	if objects != nil {
-		for _, class := range objects.Classes {
-			invertedConfig := class.InvertedIndexConfig
-			if invertedConfig == nil {
-				// for backward compatibility, this field was introduced in v1.0.4,
-				// prior schemas will not yet have the field. Init with the defaults
-				// which were previously hard-coded.
-				// In this method we are essentially reading the schema from disk, so
-				// it could have been created before v1.0.4
-				invertedConfig = &models.InvertedIndexConfig{
-					CleanupIntervalSeconds: config.DefaultCleanupIntervalSeconds,
-					Bm25: &models.BM25Config{
-						K1: config.DefaultBM25k1,
-						B:  config.DefaultBM25b,
-					},
-				}
-			}
-			if err := replica.ValidateConfig(class, db.config.Replication); err != nil {
-				return fmt.Errorf("replication config: %w", err)
-			}
+	if objects == nil {
+		return nil
+	}
 
-			idx, err := NewIndex(ctx, IndexConfig{
-				ClassName:                 schema.ClassName(class.Class),
-				RootPath:                  db.config.RootPath,
-				ResourceUsage:             db.config.ResourceUsage,
-				QueryMaximumResults:       db.config.QueryMaximumResults,
-				QueryNestedRefLimit:       db.config.QueryNestedRefLimit,
-				MemtablesFlushIdleAfter:   db.config.MemtablesFlushIdleAfter,
-				MemtablesInitialSizeMB:    db.config.MemtablesInitialSizeMB,
-				MemtablesMaxSizeMB:        db.config.MemtablesMaxSizeMB,
-				MemtablesMinActiveSeconds: db.config.MemtablesMinActiveSeconds,
-				MemtablesMaxActiveSeconds: db.config.MemtablesMaxActiveSeconds,
-				TrackVectorDimensions:     db.config.TrackVectorDimensions,
-				AvoidMMap:                 db.config.AvoidMMap,
-				DisableLazyLoadShards:     db.config.DisableLazyLoadShards,
-				ReplicationFactor:         class.ReplicationConfig.Factor,
-			}, db.schemaGetter.CopyShardingState(class.Class),
-				inverted.ConfigFromModel(invertedConfig),
-				class.VectorIndexConfig.(schemaConfig.VectorIndexConfig),
-				db.schemaGetter, db, db.logger, db.nodeResolver, db.remoteIndex,
-				db.replicaClient, db.promMetrics, class, db.jobQueueCh, db.indexCheckpoints)
-			if err != nil {
-				return errors.Wrap(err, "create index")
+	for _, class := range objects.Classes {
+		invertedConfig := class.InvertedIndexConfig
+		if invertedConfig == nil {
+			// for backward compatibility, this field was introduced in v1.0.4,
+			// prior schemas will not yet have the field. Init with the defaults
+			// which were previously hard-coded.
+			// In this method we are essentially reading the schema from disk, so
+			// it could have been created before v1.0.4
+			invertedConfig = &models.InvertedIndexConfig{
+				CleanupIntervalSeconds: config.DefaultCleanupIntervalSeconds,
+				Bm25: &models.BM25Config{
+					K1: config.DefaultBM25k1,
+					B:  config.DefaultBM25b,
+				},
 			}
-
-			db.indexLock.Lock()
-			db.indices[idx.ID()] = idx
-			db.indexLock.Unlock()
 		}
+		if err := replica.ValidateConfig(class, db.config.Replication); err != nil {
+			return fmt.Errorf("replication config: %w", err)
+		}
+
+		idx, err := NewIndex(ctx, IndexConfig{
+			ClassName:                 schema.ClassName(class.Class),
+			RootPath:                  db.config.RootPath,
+			ResourceUsage:             db.config.ResourceUsage,
+			QueryMaximumResults:       db.config.QueryMaximumResults,
+			QueryNestedRefLimit:       db.config.QueryNestedRefLimit,
+			MemtablesFlushIdleAfter:   db.config.MemtablesFlushIdleAfter,
+			MemtablesInitialSizeMB:    db.config.MemtablesInitialSizeMB,
+			MemtablesMaxSizeMB:        db.config.MemtablesMaxSizeMB,
+			MemtablesMinActiveSeconds: db.config.MemtablesMinActiveSeconds,
+			MemtablesMaxActiveSeconds: db.config.MemtablesMaxActiveSeconds,
+			TrackVectorDimensions:     db.config.TrackVectorDimensions,
+			AvoidMMap:                 db.config.AvoidMMap,
+			DisableLazyLoadShards:     db.config.DisableLazyLoadShards,
+			ReplicationFactor:         class.ReplicationConfig.Factor,
+		}, db.schemaGetter.CopyShardingState(class.Class),
+			inverted.ConfigFromModel(invertedConfig),
+			class.VectorIndexConfig.(schemaConfig.VectorIndexConfig),
+			db.schemaGetter, db, db.logger, db.nodeResolver, db.remoteIndex,
+			db.replicaClient, db.promMetrics, class, db.jobQueueCh, db.indexCheckpoints)
+		if err != nil {
+			return errors.Wrap(err, "create index")
+		}
+
+		db.indexLock.Lock()
+		db.indices[idx.ID()] = idx
+		db.indexLock.Unlock()
 	}
 
 	return nil

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -44,7 +44,7 @@ import (
 type BM25Searcher struct {
 	config         schema.BM25Config
 	store          *lsmkv.Store
-	schema         schema.Schema
+	getClass       func(string) *models.Class
 	classSearcher  ClassSearcher // to allow recursive searches on ref-props
 	propIndices    propertyspecific.Indices
 	propLenTracker propLengthRetriever
@@ -57,14 +57,14 @@ type propLengthRetriever interface {
 }
 
 func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store,
-	schema schema.Schema, propIndices propertyspecific.Indices,
+	getClass func(string) *models.Class, propIndices propertyspecific.Indices,
 	classSearcher ClassSearcher, propLenTracker propLengthRetriever,
 	logger logrus.FieldLogger, shardVersion uint16,
 ) *BM25Searcher {
 	return &BM25Searcher{
 		config:         config,
 		store:          store,
-		schema:         schema,
+		getClass:       getClass,
 		propIndices:    propIndices,
 		classSearcher:  classSearcher,
 		propLenTracker: propLenTracker,
@@ -76,13 +76,13 @@ func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store,
 func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList, className schema.ClassName, limit int, keywordRanking searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
 	// WEAVIATE-471 - If a property is not searchable, return an error
 	for _, property := range keywordRanking.Properties {
-		if !PropertyHasSearchableIndex(b.schema.Objects, string(className), property) {
+		if !PropertyHasSearchableIndex(b.getClass(className.String()), property) {
 			return nil, nil, inverted.NewMissingSearchableIndexError(property)
 		}
 	}
-	class, err := schema.GetClassByName(b.schema.Objects, string(className))
-	if err != nil {
-		return nil, nil, err
+	class := b.getClass(className.String())
+	if class == nil {
+		return nil, nil, fmt.Errorf("could not find class %s in schema", className)
 	}
 
 	objs, scores, err := b.wand(ctx, filterDocIds, class, keywordRanking, limit)
@@ -622,14 +622,13 @@ func (m AllMapPairsAndPropName) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }
 
-// TODO: Refactor this function to receive the class directly to avoid sending the whole schema
-func PropertyHasSearchableIndex(schemaDefinition *models.Schema, className, tentativePropertyName string) bool {
-	propertyName := strings.Split(tentativePropertyName, "^")[0]
-	c, err := schema.GetClassByName(schemaDefinition, string(className))
-	if err != nil {
+func PropertyHasSearchableIndex(class *models.Class, tentativePropertyName string) bool {
+	if class == nil {
 		return false
 	}
-	p, err := schema.GetPropertyByName(c, propertyName)
+
+	propertyName := strings.Split(tentativePropertyName, "^")[0]
+	p, err := schema.GetPropertyByName(class, propertyName)
 	if err != nil {
 		return false
 	}

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -81,7 +81,7 @@ func Test_Filters_String(t *testing.T) {
 		require.Nil(t, bWithFrequency.FlushAndSwitch())
 	})
 
-	searcher := NewSearcher(logger, store, createSchema(), nil, nil,
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "", config.DefaultQueryNestedCrossReferenceLimit)
 
 	type test struct {
@@ -346,7 +346,7 @@ func Test_Filters_Int(t *testing.T) {
 		require.Nil(t, bucket.FlushAndSwitch())
 	})
 
-	searcher := NewSearcher(logger, store, createSchema(), nil, nil,
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "", config.DefaultQueryNestedCrossReferenceLimit)
 
 	type test struct {
@@ -528,7 +528,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 		require.Nil(t, bWithFrequency.FlushAndSwitch())
 	})
 
-	searcher := NewSearcher(logger, store, createSchema(), nil, nil,
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "", config.DefaultQueryNestedCrossReferenceLimit)
 
 	type test struct {
@@ -641,11 +641,11 @@ func idsToBinaryMapValues(ids []uint64) []lsmkv.MapPair {
 	return out
 }
 
-func createSchema() schema.Schema {
+func createSchema() *schema.Schema {
 	vFalse := false
 	vTrue := true
 
-	return schema.Schema{
+	return &schema.Schema{
 		Objects: &models.Schema{
 			Classes: []*models.Class{
 				{

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -39,7 +39,7 @@ import (
 type Searcher struct {
 	logger                 logrus.FieldLogger
 	store                  *lsmkv.Store
-	schema                 schema.Schema
+	getClass               func(string) *models.Class
 	classSearcher          ClassSearcher // to allow recursive searches on ref-props
 	propIndices            propertyspecific.Indices
 	stopwords              stopwords.StopwordDetector
@@ -51,7 +51,7 @@ type Searcher struct {
 }
 
 func NewSearcher(logger logrus.FieldLogger, store *lsmkv.Store,
-	schema schema.Schema, propIndices propertyspecific.Indices,
+	getClass func(string) *models.Class, propIndices propertyspecific.Indices,
 	classSearcher ClassSearcher, stopwords stopwords.StopwordDetector,
 	shardVersion uint16, isFallbackToSearchable IsFallbackToSearchable,
 	tenant string, nestedCrossRefLimit int64,
@@ -59,7 +59,7 @@ func NewSearcher(logger logrus.FieldLogger, store *lsmkv.Store,
 	return &Searcher{
 		logger:                 logger,
 		store:                  store,
-		schema:                 schema,
+		getClass:               getClass,
 		propIndices:            propIndices,
 		classSearcher:          classSearcher,
 		stopwords:              stopwords,
@@ -97,7 +97,7 @@ func (s *Searcher) Objects(ctx context.Context, limit int,
 func (s *Searcher) sort(ctx context.Context, limit int, sort []filters.Sort, docIDs helpers.AllowList,
 	additional additional.Properties, className schema.ClassName,
 ) ([]uint64, error) {
-	lsmSorter, err := sorter.NewLSMSorter(s.store, s.schema, className)
+	lsmSorter, err := sorter.NewLSMSorter(s.store, s.getClass, className)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 	className schema.ClassName,
 ) (*propValuePair, error) {
-	class := s.schema.FindClassByName(schema.ClassName(className))
+	class := s.getClass(className.String())
 	if class == nil {
 		return nil, fmt.Errorf("class %q not found", className)
 	}
@@ -216,14 +216,22 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 	}
 
 	if extractedPropName, ok := schema.IsPropertyLength(propName, 0); ok {
-		property, err := s.schema.GetProperty(className, schema.PropertyName(extractedPropName))
+		class := s.getClass(schema.ClassName(className).String())
+		if class == nil {
+			return nil, fmt.Errorf("could not find class %s in schema", className)
+		}
+
+		property, err := schema.GetPropertyByName(class, extractedPropName)
 		if err != nil {
 			return nil, err
 		}
 		return s.extractPropertyLength(property, filter.Value.Type, filter.Value.Value, filter.Operator, class)
 	}
 
-	property, err := s.schema.GetProperty(className, schema.PropertyName(propName))
+	property, err := schema.GetPropertyByName(class, propName)
+	if err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -231,8 +231,7 @@ func (db *DB) Query(ctx context.Context, q *objects.QueryInput) (search.Results,
 		return nil, nil
 	}
 	if len(q.Sort) > 0 {
-		scheme := db.schemaGetter.GetSchemaSkipAuth()
-		if err := filters.ValidateSort(scheme, schema.ClassName(q.Class), q.Sort); err != nil {
+		if err := filters.ValidateSort(db.schemaGetter.ReadOnlyClass, schema.ClassName(q.Class), q.Sort); err != nil {
 			return nil, &objects.Error{Msg: "sorting", Code: objects.StatusBadRequest, Err: err}
 		}
 	}
@@ -356,12 +355,9 @@ func (db *DB) ResolveReferences(ctx context.Context, objs search.Results,
 func (db *DB) validateSort(sort []filters.Sort) error {
 	if len(sort) > 0 {
 		var errorMsgs []string
-		// needs to happen before the index lock as they might deadlock each other
-		schema := db.schemaGetter.GetSchemaSkipAuth()
 		db.indexLock.RLock()
 		for _, index := range db.indices {
-			err := filters.ValidateSort(schema,
-				index.Config.ClassName, sort)
+			err := filters.ValidateSort(db.schemaGetter.ReadOnlyClass, index.Config.ClassName, sort)
 			if err != nil {
 				errorMsg := errors.Wrapf(err, "search index %s", index.ID()).Error()
 				errorMsgs = append(errorMsgs, errorMsg)

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -176,7 +176,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 
 		if filters != nil {
 			objs, err = inverted.NewSearcher(s.index.logger, s.store,
-				s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices,
+				s.index.getSchema.ReadOnlyClass, s.propertyIndices,
 				s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
 				s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
@@ -191,7 +191,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		bm25Config := s.index.getInvertedIndexConfig().BM25
 		logger := s.index.logger.WithFields(logrus.Fields{"class": s.index.Config.ClassName, "shard": s.name})
 		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store,
-			s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices, s.index.classSearcher,
+			s.index.getSchema.ReadOnlyClass, s.propertyIndices, s.index.classSearcher,
 			s.GetPropertyLengthTracker(), logger, s.versioner.Version())
 		bm25objs, bm25count, err = bm25searcher.BM25F(ctx, filterDocIds, className, limit, *keywordRanking)
 		if err != nil {
@@ -206,7 +206,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 			cursor, additional, s.index.Config.ClassName)
 		return objs, nil, err
 	}
-	objs, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.GetSchemaSkipAuth(),
+	objs, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		s.propertyIndices, s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
 		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName)
@@ -338,7 +338,7 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor,
 }
 
 func (s *Shard) sortedObjectList(ctx context.Context, limit int, sort []filters.Sort, className schema.ClassName) ([]uint64, error) {
-	lsmSorter, err := sorter.NewLSMSorter(s.store, s.index.getSchema.GetSchemaSkipAuth(), className)
+	lsmSorter, err := sorter.NewLSMSorter(s.store, s.index.getSchema.ReadOnlyClass, className)
 	if err != nil {
 		return nil, errors.Wrap(err, "sort object list")
 	}
@@ -350,7 +350,7 @@ func (s *Shard) sortedObjectList(ctx context.Context, limit int, sort []filters.
 }
 
 func (s *Shard) sortDocIDsAndDists(ctx context.Context, limit int, sort []filters.Sort, className schema.ClassName, docIDs []uint64, dists []float32) ([]uint64, []float32, error) {
-	lsmSorter, err := sorter.NewLSMSorter(s.store, s.index.getSchema.GetSchemaSkipAuth(), className)
+	lsmSorter, err := sorter.NewLSMSorter(s.store, s.index.getSchema.ReadOnlyClass, className)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "sort objects with distances")
 	}
@@ -362,7 +362,7 @@ func (s *Shard) sortDocIDsAndDists(ctx context.Context, limit int, sort []filter
 }
 
 func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter, addl additional.Properties) (helpers.AllowList, error) {
-	list, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.GetSchemaSkipAuth(),
+	list, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		s.propertyIndices, s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
 		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -129,7 +129,7 @@ func (b *deleteObjectsBatcher) setErrorAtIndex(err error, index int) {
 }
 
 func (s *Shard) findDocIDs(ctx context.Context, filters *filters.LocalFilter) ([]uint64, error) {
-	allowList, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.GetSchemaSkipAuth(),
+	allowList, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		nil, s.index.classSearcher, s.index.stopwords, s.versioner.version, s.isFallbackToSearchable,
 		s.tenant(), s.index.Config.QueryNestedRefLimit).
 		DocIDs(ctx, filters, additional.Properties{}, s.index.Config.ClassName)

--- a/adapters/repos/db/sorter/fakes_for_test.go
+++ b/adapters/repos/db/sorter/fakes_for_test.go
@@ -142,8 +142,8 @@ func createMyFavoriteClassObject() *storobj.Object {
 	)
 }
 
-func sorterCitySchema() schema.Schema {
-	return schema.Schema{
+func sorterCitySchema() *schema.Schema {
+	return &schema.Schema{
 		Objects: &models.Schema{
 			Classes: []*models.Class{
 				{

--- a/adapters/repos/db/sorter/lsm_sorter.go
+++ b/adapters/repos/db/sorter/lsm_sorter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -37,12 +38,12 @@ type lsmSorter struct {
 	valueExtractor  *comparableValueExtractor
 }
 
-func NewLSMSorter(store *lsmkv.Store, sch schema.Schema, className schema.ClassName) (LSMSorter, error) {
+func NewLSMSorter(store *lsmkv.Store, fn func(string) *models.Class, className schema.ClassName) (LSMSorter, error) {
 	bucket := store.Bucket(helpers.ObjectsBucketLSM)
 	if bucket == nil {
 		return nil, fmt.Errorf("lsm sorter - bucket %s for class %s not found", helpers.ObjectsBucketLSM, className)
 	}
-	class := sch.GetClass(schema.ClassName(className).String())
+	class := fn(className.String())
 	if class == nil {
 		return nil, fmt.Errorf("lsm sorter - class %s not found", className)
 	}

--- a/adapters/repos/db/sorter/objects_sorter.go
+++ b/adapters/repos/db/sorter/objects_sorter.go
@@ -13,7 +13,7 @@ package sorter
 
 import (
 	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
@@ -22,13 +22,12 @@ type Sorter interface {
 		limit int, sort []filters.Sort) ([]*storobj.Object, []float32, error)
 }
 
-// TODO: Refactor objectSorter to get an interface for schemaGetter instead of the schema itself
 type objectsSorter struct {
-	schema schema.Schema
+	readOnlyClass func(string) *models.Class
 }
 
-func NewObjectsSorter(schema schema.Schema) *objectsSorter {
-	return &objectsSorter{schema}
+func NewObjectsSorter(fn func(string) *models.Class) *objectsSorter {
+	return &objectsSorter{readOnlyClass: fn}
 }
 
 func (s objectsSorter) Sort(objects []*storobj.Object,
@@ -45,7 +44,7 @@ func (s objectsSorter) Sort(objects []*storobj.Object,
 		return nil, nil, err
 	}
 
-	class := s.schema.GetClass(objects[0].Class().String())
+	class := s.readOnlyClass(objects[0].Class().String())
 	dataTypesHelper := newDataTypesHelper(class)
 	valueExtractor := newComparableValueExtractor(dataTypesHelper)
 	comparator := newComparator(dataTypesHelper, propNames, orders)

--- a/adapters/repos/db/sorter/objects_sorter_test.go
+++ b/adapters/repos/db/sorter/objects_sorter_test.go
@@ -327,7 +327,7 @@ func TestObjectsSorter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run("with distance", func(t *testing.T) {
-				sorter := NewObjectsSorter(sorterCitySchema())
+				sorter := NewObjectsSorter(sorterCitySchema().GetClass)
 				gotObjs, gotDists, err := sorter.Sort(sorterCitySchemaObjects(), sorterCitySchemaDistances(), 0, tt.sort)
 
 				require.Nil(t, err)
@@ -343,7 +343,7 @@ func TestObjectsSorter(t *testing.T) {
 			})
 
 			t.Run("without distance", func(t *testing.T) {
-				sorter := NewObjectsSorter(sorterCitySchema())
+				sorter := NewObjectsSorter(sorterCitySchema().GetClass)
 				gotObjs, gotDists, err := sorter.Sort(sorterCitySchemaObjects(), nil, 0, tt.sort)
 
 				require.Nil(t, err)
@@ -359,7 +359,7 @@ func TestObjectsSorter(t *testing.T) {
 			})
 
 			t.Run("with limit", func(t *testing.T) {
-				sorter := NewObjectsSorter(sorterCitySchema())
+				sorter := NewObjectsSorter(sorterCitySchema().GetClass)
 				gotObjs, gotDists, err := sorter.Sort(sorterCitySchemaObjects(), sorterCitySchemaDistances(), tt.limit, tt.sort)
 
 				require.Nil(t, err)

--- a/entities/filters/sort_validator_test.go
+++ b/entities/filters/sort_validator_test.go
@@ -54,7 +54,7 @@ func TestSortValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sch := schema.Schema{Objects: &models.Schema{
+			sch := &schema.Schema{Objects: &models.Schema{
 				Classes: []*models.Class{
 					{
 						Class: "Car",
@@ -74,7 +74,7 @@ func TestSortValidation(t *testing.T) {
 				Order: "asc",
 			}}
 
-			err := ValidateSort(sch, schema.ClassName("Car"), sort)
+			err := ValidateSort(sch.GetClass, schema.ClassName("Car"), sort)
 			if tt.valid {
 				require.Nil(t, err)
 			} else {

--- a/entities/modulecapabilities/classification.go
+++ b/entities/modulecapabilities/classification.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 )
 
@@ -32,7 +31,7 @@ type VectorClassSearchRepo interface {
 }
 
 type ClassifyParams struct {
-	Schema            schema.Schema
+	GetClass          func(string) *models.Class
 	Params            models.Classification
 	Filters           Filters
 	UnclassifiedItems []search.Result

--- a/modules/text2vec-contextionary/classification/classifier.go
+++ b/modules/text2vec-contextionary/classification/classifier.go
@@ -46,14 +46,14 @@ func (c *Classifier) ClassifyFn(params modulecapabilities.ClassifyParams) (modul
 	}
 
 	// 1. do preparation here once
-	preparedContext, err := c.prepareContextualClassification(params.Schema, params.VectorRepo,
+	preparedContext, err := c.prepareContextualClassification(params.GetClass, params.VectorRepo,
 		params.Params, params.Filters, params.UnclassifiedItems)
 	if err != nil {
 		return nil, errors.Wrap(err, "prepare context for text2vec-contextionary-contextual classification")
 	}
 
 	// 2. use higher order function to inject preparation data so it is then present for each single run
-	return c.makeClassifyItemContextual(params.Schema, preparedContext), nil
+	return c.makeClassifyItemContextual(preparedContext), nil
 }
 
 func (c *Classifier) ParseClassifierSettings(params *models.Classification) error {

--- a/modules/text2vec-contextionary/classification/classifier_run_contextual.go
+++ b/modules/text2vec-contextionary/classification/classifier_run_contextual.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 )
@@ -35,7 +34,6 @@ type contextualItemClassifier struct {
 	settings    *ParamsContextual
 	classifier  *Classifier
 	writer      modulecapabilities.Writer
-	schema      schema.Schema
 	filters     modulecapabilities.Filters
 	context     contextualPreparationContext
 	vectorizer  vectorizer
@@ -62,7 +60,7 @@ func (c *Classifier) extendItemWithObjectMeta(item *search.Result,
 // makeClassifyItemContextual is a higher-order function to produce the actual
 // classify function, but additionally allows us to inject data which is valid
 // for the entire run, such as tf-idf data and target vectors
-func (c *Classifier) makeClassifyItemContextual(schema schema.Schema, preparedContext contextualPreparationContext) func(search.Result,
+func (c *Classifier) makeClassifyItemContextual(preparedContext contextualPreparationContext) func(search.Result,
 	int, models.Classification, modulecapabilities.Filters, modulecapabilities.Writer) error {
 	return func(item search.Result, itemIndex int, params models.Classification,
 		filters modulecapabilities.Filters, writer modulecapabilities.Writer,
@@ -75,7 +73,6 @@ func (c *Classifier) makeClassifyItemContextual(schema schema.Schema, preparedCo
 			settings:    params.Settings.(*ParamsContextual), // safe assertion after parsing
 			classifier:  c,
 			writer:      writer,
-			schema:      schema,
 			filters:     filters,
 			context:     preparedContext,
 			vectorizer:  vectorizer,

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -142,7 +142,7 @@ func (c *Classifier) Schedule(ctx context.Context, principal *models.Principal, 
 		return nil, err
 	}
 
-	err = NewValidator(c.schemaGetter, params).Do()
+	err = NewValidator(c.schemaGetter.ReadOnlyClass, params).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -230,8 +230,7 @@ func (c *Classifier) validateFilter(filter *libfilters.LocalFilter) error {
 	if filter == nil {
 		return nil
 	}
-	sch := c.schemaGetter.GetSchemaSkipAuth()
-	return libfilters.ValidateFilters(sch.GetClass, filter)
+	return libfilters.ValidateFilters(c.schemaGetter.ReadOnlyClass, filter)
 }
 
 func (c *Classifier) assignNewID(params *models.Classification) error {

--- a/usecases/classification/classifier_run.go
+++ b/usecases/classification/classifier_run.go
@@ -119,7 +119,7 @@ func (c *Classifier) getClassifyParams(params models.Classification,
 	filters Filters, unclassifiedItems []search.Result,
 ) modulecapabilities.ClassifyParams {
 	return modulecapabilities.ClassifyParams{
-		Schema:            c.schemaGetter.GetSchemaSkipAuth(),
+		GetClass:          c.schemaGetter.ReadOnlyClass,
 		Params:            params,
 		Filters:           filters,
 		UnclassifiedItems: unclassifiedItems,

--- a/usecases/classification/validation_test.go
+++ b/usecases/classification/validation_test.go
@@ -177,7 +177,8 @@ func Test_ValidateUserInput(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			validator := NewValidator(&fakeSchemaGetter{testSchema()}, test.input)
+			fsg := &fakeSchemaGetter{testSchema()}
+			validator := NewValidator(fsg.ReadOnlyClass, test.input)
 			err := validator.Do()
 			assert.Equal(t, test.expectedError, err)
 		})

--- a/usecases/traverser/explorer_validate_filters.go
+++ b/usecases/traverser/explorer_validate_filters.go
@@ -19,6 +19,5 @@ func (e *Explorer) validateFilters(filter *filters.LocalFilter) error {
 	if filter == nil {
 		return nil
 	}
-	sch := e.schemaGetter.GetSchemaSkipAuth()
-	return filters.ValidateFilters(sch.GetClass, filter)
+	return filters.ValidateFilters(e.schemaGetter.ReadOnlyClass, filter)
 }

--- a/usecases/traverser/explorer_validate_sort.go
+++ b/usecases/traverser/explorer_validate_sort.go
@@ -20,5 +20,5 @@ func (e *Explorer) validateSort(className string, sort []filters.Sort) error {
 	if len(sort) == 0 {
 		return nil
 	}
-	return filters.ValidateSort(e.schemaGetter.GetSchemaSkipAuth(), schema.ClassName(className), sort)
+	return filters.ValidateSort(e.schemaGetter.ReadOnlyClass, schema.ClassName(className), sort)
 }

--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -40,7 +40,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 	}
 	defer unlock()
 
-	inspector := newTypeInspector(t.schemaGetter)
+	inspector := newTypeInspector(t.schemaGetter.ReadOnlyClass)
 
 	if params.NearVector != nil || params.NearObject != nil || len(params.ModuleParams) > 0 {
 		className := params.ClassName.String()
@@ -74,8 +74,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 	}
 
 	if params.Filters != nil {
-		sch := t.schemaGetter.GetSchemaSkipAuth()
-		if err := filters.ValidateFilters(sch.GetClass, params.Filters); err != nil {
+		if err := filters.ValidateFilters(t.schemaGetter.ReadOnlyClass, params.Filters); err != nil {
 			return nil, errors.Wrap(err, "invalid 'where' filter")
 		}
 	}


### PR DESCRIPTION
### What's being changed:

* Replace all usage of `GetSchemaSkipAuth` where only a single class was retrieve with `getClass` parameter (using `ReadOnlyClass` from the previous PR https://github.com/weaviate/weaviate/pull/4016
* Refactor many sub structure using `schema.Schema` with a `getClass` instead when possible. Most of the time a single class was retrieve and then reading it's properties.
* Removed unused `schema.Schema` parameters from some functions.
* Remove `schema.Schema` struct parameters when unused

The only usage of `GetSchemaSkipAuth` left in the code are when we are actually using the whole schema to iterate on all the classes (for example during backup or to validate distance).

Before changes
```
$> grep -r 'GetSchemaSkipAuth' |grep -v '.git' | wc -l
$> 68
```

After changes (most are implementation for fakes during tests)
```
$> grep -r 'GetSchemaSkipAuth' |grep -v '.git' | wc -l
$> 24
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
