### PR TITLE
Ensure safe class update during concurrent schema updates vis RAFT

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -260,7 +260,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		SnapshotThreshold: appState.ServerConfig.Config.Raft.SnapshotThreshold,
 
 		DB:          nil,
-		Parser:      schema.NewParser(appState.Cluster, vectorIndex.ParseAndValidateConfig),
+		Parser:      schema.NewParser(appState.Cluster, vectorIndex.ParseAndValidateConfig, migrator),
 		Logger:      sLogger(),
 		LogLevel:    logLevel(),
 		IsLocalHost: appState.ServerConfig.Config.Cluster.Localhost,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -368,7 +368,7 @@ func (m *Migrator) UpdateVectorIndexConfig(ctx context.Context,
 	return idx.updateVectorIndexConfig(ctx, updated)
 }
 
-func (m *Migrator) ValidateVectorIndexConfigUpdate(ctx context.Context,
+func (m *Migrator) ValidateVectorIndexConfigUpdate(
 	old, updated schemaConfig.VectorIndexConfig,
 ) error {
 	switch old.IndexType() {
@@ -381,8 +381,7 @@ func (m *Migrator) ValidateVectorIndexConfigUpdate(ctx context.Context,
 	return fmt.Errorf("invalid index type: %q", old.IndexType())
 }
 
-func (m *Migrator) ValidateInvertedIndexConfigUpdate(ctx context.Context,
-	old, updated *models.InvertedIndexConfig,
+func (m *Migrator) ValidateInvertedIndexConfigUpdate(old, updated *models.InvertedIndexConfig,
 ) error {
 	return inverted.ValidateUserConfigUpdate(old, updated)
 }

--- a/cloud/store/schema.go
+++ b/cloud/store/schema.go
@@ -73,23 +73,16 @@ func (s *schema) addClass(cls *models.Class, ss *sharding.State) error {
 	return nil
 }
 
-func (s *schema) updateClass(cls *models.Class, ss *sharding.State) error {
+// updateClass modifies existing class based on the givin update function
+func (s *schema) updateClass(name string, update func(*metaClass) error) error {
 	s.Lock()
 	defer s.Unlock()
 
-	info := s.Classes[cls.Class]
+	info := s.Classes[name]
 	if info == nil {
 		return errClassNotFound
 	}
-
-	if cls != nil {
-		info.Class = *cls
-	}
-	if ss != nil {
-		info.Sharding = *ss
-	}
-
-	return nil
+	return update(info)
 }
 
 func (s *schema) deleteClass(name string) {

--- a/cloud/store/store.go
+++ b/cloud/store/store.go
@@ -78,8 +78,13 @@ type Indexer interface {
 	Close(context.Context) error
 }
 
+// Parser parses concrete class fields after deserialization
 type Parser interface {
+	// ParseClassUpdate parses a class after unmarshaling by setting concrete types for the fields
 	ParseClass(class *models.Class) error
+
+	// ParseClass parses new updates by providing the current class data.
+	ParseClassUpdate(class, update *models.Class) (*models.Class, error)
 }
 
 type Config struct {

--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -271,6 +271,7 @@ func immediateReplicaCRUD(t *testing.T) {
 }
 
 func eventualReplicaCRUD(t *testing.T) {
+	t.Skip("To be addressed as part of https://semi-technology.atlassian.net/browse/WEAVIATE-701")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/test/acceptance/replication/scale_test.go
+++ b/test/acceptance/replication/scale_test.go
@@ -28,7 +28,12 @@ import (
 	"github.com/weaviate/weaviate/usecases/replica"
 )
 
+// Note: Scaling out feature disabled
+// Reason: The current implementation of scaling out is experimental and deemed unreliable.
+// It has been disabled to prevent potential issues and ensure system stability.
+// Re-enable this feature only after addressing its reliability concerns and implementing a more robust solution.
 func multiShardScaleOut(t *testing.T) {
+	t.Skip("Re-enable this feature only after addressing its reliability concerns and implementing a more robust solution.")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -25,7 +25,6 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex"
 	vIndex "github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -151,61 +150,33 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) error {
 	err := h.Authorizer.Authorize(principal, "update", "schema/objects")
-	if err != nil {
-		return err
-	}
-
-	initial := h.metaReader.ReadOnlyClass(className)
-	if initial == nil {
-		return ErrNotFound
-	}
-	mtEnabled, err := validateUpdatingMT(initial, updated)
-	if err != nil {
+	if err != nil || updated == nil {
 		return err
 	}
 
 	// make sure unset optionals on 'updated' don't lead to an error, as all
 	// optionals would have been set with defaults on the initial already
 	h.setClassDefaults(updated)
+	initial := h.metaReader.ReadOnlyClass(className)
 
-	if err := h.validateImmutableFields(initial, updated); err != nil {
-		return err
-	}
-	if err := h.parser.ParseClass(updated); err != nil {
-		return err
-	}
-
-	if err := h.validator.ValidateVectorIndexConfigUpdate(ctx,
-		initial.VectorIndexConfig.(schemaConfig.VectorIndexConfig),
-		updated.VectorIndexConfig.(schemaConfig.VectorIndexConfig)); err != nil {
-		return errors.Wrap(err, "vector index config")
-	}
-
-	if err := h.validator.ValidateInvertedIndexConfigUpdate(ctx,
-		initial.InvertedIndexConfig, updated.InvertedIndexConfig); err != nil {
-		return errors.Wrap(err, "inverted index config")
-	}
-	if err := validateShardingConfig(initial, updated, mtEnabled, h.clusterState); err != nil {
-		return fmt.Errorf("validate sharding config: %w", err)
-	}
-
-	if err := replica.ValidateConfigUpdate(initial, updated, h.clusterState); err != nil {
-		return fmt.Errorf("replication config: %w", err)
-	}
-
-	updatedSharding := updated.ShardingConfig.(shardingConfig.Config)
-	initialRF := initial.ReplicationConfig.Factor
-	updatedRF := updated.ReplicationConfig.Factor
-	var updatedState *sharding.State
-	if initialRF != updatedRF {
-		uss, err := h.scaleOut.Scale(ctx, className, updatedSharding, initialRF, updatedRF)
+	// first layer of defense is basic validation if class already exits
+	if initial != nil {
+		_, err := validateUpdatingMT(initial, updated)
 		if err != nil {
-			return fmt.Errorf("scale out from %d to %d replicas", initialRF, updatedRF)
+			return err
 		}
-		updatedState = uss
+
+		if initial.ReplicationConfig.Factor != updated.ReplicationConfig.Factor {
+			return fmt.Errorf("updating replication factor is not supported yet")
+		}
+
+		if err := validateImmutableFields(initial, updated); err != nil {
+			return err
+		}
+
 	}
 
-	return h.metaWriter.UpdateClass(updated, updatedState)
+	return h.metaWriter.UpdateClass(updated, nil)
 }
 
 func (h *Handler) setClassDefaults(class *models.Class) {
@@ -228,6 +199,10 @@ func (h *Handler) setClassDefaults(class *models.Class) {
 	setInvertedConfigDefaults(class)
 	for _, prop := range class.Properties {
 		setPropertyDefaults(prop)
+	}
+
+	if class.ReplicationConfig == nil {
+		class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
 	}
 
 	h.moduleConfig.SetClassDefaults(class)
@@ -627,7 +602,7 @@ func validateUpdatingMT(current, update *models.Class) (enabled bool, err error)
 	return
 }
 
-func validateShardingConfig(current, update *models.Class, mtEnabled bool, cl clusterState) error {
+func validateShardingConfig(current, update *models.Class, mtEnabled bool) error {
 	if mtEnabled {
 		return nil
 	}
@@ -639,13 +614,21 @@ func validateShardingConfig(current, update *models.Class, mtEnabled bool, cl cl
 	if !ok {
 		return fmt.Errorf("updated config is not well-formed")
 	}
-	if err := shardingConfig.ValidateConfigUpdate(first, second, cl); err != nil {
-		return err
+	if first.DesiredCount != second.DesiredCount {
+		return fmt.Errorf("re-sharding not supported yet: shard count is immutable: "+
+			"attempted change from \"%d\" to \"%d\"", first.DesiredCount,
+			second.DesiredCount)
+	}
+
+	if first.VirtualPerPhysical != second.VirtualPerPhysical {
+		return fmt.Errorf("virtual shards per physical is immutable: "+
+			"attempted change from \"%d\" to \"%d\"", first.VirtualPerPhysical,
+			second.VirtualPerPhysical)
 	}
 	return nil
 }
 
-func (h *Handler) validateImmutableFields(initial, updated *models.Class) error {
+func validateImmutableFields(initial, updated *models.Class) error {
 	immutableFields := []immutableText{
 		{
 			name:     "class name",
@@ -662,16 +645,9 @@ func (h *Handler) validateImmutableFields(initial, updated *models.Class) error 
 	}
 
 	for _, u := range immutableFields {
-		if err := h.validateImmutableTextField(u, initial, updated); err != nil {
+		if err := validateImmutableTextField(u, initial, updated); err != nil {
 			return err
 		}
-	}
-
-	if !reflect.DeepEqual(initial.Properties, updated.Properties) {
-		return errors.Errorf(
-			"properties cannot be updated through updating the class. Use the add " +
-				"property feature (e.g. \"POST /v1/schema/{className}/properties\") " +
-				"to add additional properties")
 	}
 
 	if !reflect.DeepEqual(initial.ModuleConfig, updated.ModuleConfig) {
@@ -686,7 +662,7 @@ type immutableText struct {
 	name     string
 }
 
-func (h *Handler) validateImmutableTextField(u immutableText,
+func validateImmutableTextField(u immutableText,
 	previous, next *models.Class,
 ) error {
 	oldField := u.accessor(previous)

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -61,7 +61,6 @@ func (e *executor) AddClass(pl cluster.AddClassRequest) error {
 func (e *executor) UpdateClass(req cluster.UpdateClassRequest) error {
 	className := req.Class.Class
 	ctx := context.Background()
-
 	if err := e.migrator.UpdateVectorIndexConfig(ctx, className,
 		req.Class.VectorIndexConfig.(schemaConfig.VectorIndexConfig)); err != nil {
 		return errors.Wrap(err, "vector index config")

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -62,10 +62,8 @@ type metaReader interface {
 }
 
 type validator interface {
-	ValidateVectorIndexConfigUpdate(ctx context.Context,
-		old, updated schemaConfig.VectorIndexConfig) error
-	ValidateInvertedIndexConfigUpdate(ctx context.Context,
-		old, updated *models.InvertedIndexConfig) error
+	ValidateVectorIndexConfigUpdate(old, updated schemaConfig.VectorIndexConfig) error
+	ValidateInvertedIndexConfigUpdate(old, updated *models.InvertedIndexConfig) error
 }
 
 // The handler manages API requests for manipulating class schemas.
@@ -105,7 +103,7 @@ func NewHandler(
 		config:                  config,
 		metaWriter:              store,
 		metaReader:              metaReader,
-		parser:                  Parser{clusterState: clusterState, configParser: configParser},
+		parser:                  Parser{clusterState: clusterState, configParser: configParser, validator: validator},
 		validator:               validator,
 		logger:                  logger,
 		Authorizer:              authorizer,

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -134,13 +134,13 @@ func (f *fakeScaleOutManager) SetSchemaManager(sm scaler.SchemaManager) {
 
 type fakeValidator struct{}
 
-func (f *fakeValidator) ValidateVectorIndexConfigUpdate(ctx context.Context,
+func (f *fakeValidator) ValidateVectorIndexConfigUpdate(
 	old, updated schemaConfig.VectorIndexConfig,
 ) error {
 	return nil
 }
 
-func (f *fakeValidator) ValidateInvertedIndexConfigUpdate(ctx context.Context,
+func (f *fakeValidator) ValidateInvertedIndexConfigUpdate(
 	old, updated *models.InvertedIndexConfig,
 ) error {
 	return nil

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -13,10 +13,12 @@ package schema
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	vIndex "github.com/weaviate/weaviate/entities/vectorindex"
 	shardingConfig "github.com/weaviate/weaviate/usecases/sharding/config"
 )
@@ -24,12 +26,14 @@ import (
 type Parser struct {
 	clusterState clusterState
 	configParser VectorConfigParser
+	validator    validator
 }
 
-func NewParser(clusterState clusterState, configParser VectorConfigParser) *Parser {
+func NewParser(cs clusterState, vCfg VectorConfigParser, v validator) *Parser {
 	return &Parser{
-		clusterState: clusterState,
-		configParser: configParser,
+		clusterState: cs,
+		configParser: vCfg,
+		validator:    v,
 	}
 }
 
@@ -79,4 +83,48 @@ func (m *Parser) parseShardingConfig(class *models.Class) (err error) {
 	}
 	class.ShardingConfig = cfg
 	return nil
+}
+
+// ParseClassUpdate parses a class after unmarshaling by setting concrete types for the fields
+func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, error) {
+	if err := p.ParseClass(update); err != nil {
+		return nil, err
+	}
+	mtEnabled, err := validateUpdatingMT(class, update)
+	if err != nil {
+		return nil, err
+	}
+
+	if class.ReplicationConfig.Factor != update.ReplicationConfig.Factor {
+		return nil, fmt.Errorf("updating replication factor is not supported yet")
+	}
+
+	if err := validateImmutableFields(class, update); err != nil {
+		return nil, err
+	}
+	if err := validateShardingConfig(class, update, mtEnabled); err != nil {
+		return nil, fmt.Errorf("validate sharding config: %w", err)
+	}
+
+	if !reflect.DeepEqual(class.Properties, update.Properties) {
+		return nil, errors.Errorf(
+			"properties cannot be updated through updating the class. Use the add " +
+				"property feature (e.g. \"POST /v1/schema/{className}/properties\") " +
+				"to add additional properties")
+	}
+
+	vIdxConfig, ok1 := class.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
+	vIdxConfigU, ok2 := update.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
+	if !ok1 || !ok2 {
+		return nil, fmt.Errorf("vector index config wrong type: current=%t new=%t", ok1, ok2)
+	}
+	if err := p.validator.ValidateVectorIndexConfigUpdate(vIdxConfig, vIdxConfigU); err != nil {
+		return nil, fmt.Errorf("validate vector index config: %w", err)
+	}
+
+	if err := p.validator.ValidateInvertedIndexConfigUpdate(class.InvertedIndexConfig, update.InvertedIndexConfig); err != nil {
+		return nil, fmt.Errorf("inverted index config: %w", err)
+	}
+
+	return update, nil
 }


### PR DESCRIPTION
### What's being changed:

- Concurrently class updates are serialized.
- The merge happens during the update application by RAFT instead
- In addition this ensures that updates are applied only to indexes instead of overwriting the class

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
