### PR TITLE
Make object count in nodes API "async" / approximate / eventually consistent

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -802,6 +802,14 @@ func (b *Bucket) Count() int {
 	return memtableCount + diskCount
 }
 
+// CountAsync ignores the current memtable, that makes it async because it only
+// reflects what has been already flushed. This in turn makes it very cheap to
+// call, so it can be used for observability purposes where eventual
+// consistency on the count is fine, but a large cost is not.
+func (b *Bucket) CountAsync() int {
+	return b.disk.count()
+}
+
 func (b *Bucket) memtableNetCount(stats *countStats, previousMemtable *countStats) int {
 	netCount := 0
 

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -87,6 +87,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 			require.Nil(t, err)
 
 			assert.Equal(t, 3, b.Count())
+			assert.Equal(t, 0, b.CountAsync())
 
 			res, err := b.Get(key1)
 			require.Nil(t, err)
@@ -113,6 +114,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 			require.Nil(t, err)
 
 			assert.Equal(t, 3, b.Count())
+			assert.Equal(t, 0, b.CountAsync())
 
 			res, err := b.Get(key1)
 			require.Nil(t, err)
@@ -166,6 +168,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 		t.Run("count only objects on disk segment", func(t *testing.T) {
 			assert.Equal(t, 3, b.Count())
+			assert.Equal(t, 3, b.CountAsync())
 		})
 
 		t.Run("replace some, keep one", func(t *testing.T) {
@@ -183,6 +186,10 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 			// make sure that the updates aren't counted as additions
 			assert.Equal(t, 3, b.Count())
+
+			// happens to be the same value, but that's just a coincidence, async
+			// ignores the memtable
+			assert.Equal(t, 3, b.CountAsync())
 
 			res, err := b.Get(key1)
 			require.Nil(t, err)
@@ -263,6 +270,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 		t.Run("count objects over several segments", func(t *testing.T) {
 			assert.Equal(t, 3, b.Count())
+			assert.Equal(t, 3, b.CountAsync())
 		})
 	})
 
@@ -342,6 +350,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 			// count objects over several segments after disk read
 			assert.Equal(t, 3, b2.Count())
+			assert.Equal(t, 3, b2.CountAsync())
 		})
 	})
 }
@@ -691,6 +700,9 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 
 		t.Run("count objects", func(t *testing.T) {
 			assert.Equal(t, 1, b.Count())
+			// all happenin in the memtable so far, async does not know of any
+			// objects yet
+			assert.Equal(t, 0, b.CountAsync())
 		})
 	})
 
@@ -746,6 +758,9 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 
 		t.Run("count objects", func(t *testing.T) {
 			assert.Equal(t, 1, b.Count())
+			// async still looks at the objects in the segment, ignores deletes in
+			// the memtable
+			assert.Equal(t, 3, b.CountAsync())
 		})
 	})
 
@@ -804,6 +819,7 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 
 		t.Run("count objects", func(t *testing.T) {
 			assert.Equal(t, 1, b.Count())
+			assert.Equal(t, 1, b.CountAsync())
 		})
 	})
 }

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -669,10 +669,11 @@ func testNodesAPI(repo *DB) func(t *testing.T) {
 			}
 		}
 		assert.Equal(t, int64(3), testClassShardsCount)
-		assert.Equal(t, int64(20), testClassObjectsCount)
+		// a previous version of this test made assertions on object counts,
+		// however with object count becoming async, we can no longer make exact
+		// assertions here. See https://github.com/weaviate/weaviate/issues/4193
+		// for details.
 		assert.Equal(t, int64(3), testRefClassShardsCount)
-		assert.Equal(t, int64(0), testRefClassObjectsCount)
-		assert.Equal(t, int64(20), nodeStatus.Stats.ObjectCount)
 		assert.Equal(t, int64(6), nodeStatus.Stats.ShardCount)
 	}
 }

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -171,7 +171,7 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		objectCount := int64(shard.ObjectCount())
+		objectCount := int64(shard.ObjectCountAsync())
 		totalCount += objectCount
 		shardStatus := &models.NodeShardStatus{
 			Name:                 name,

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -134,9 +134,11 @@ func TestNodesAPI_Journey(t *testing.T) {
 	assert.Len(t, nodeStatus.Shards, 1)
 	assert.Equal(t, "ClassNodesAPI", nodeStatus.Shards[0].Class)
 	assert.True(t, len(nodeStatus.Shards[0].Name) > 0)
-	assert.Equal(t, int64(2), nodeStatus.Shards[0].ObjectCount)
+	// a previous version of this test made assertions on object counts,
+	// however with object count becoming async, we can no longer make exact
+	// assertions here. See https://github.com/weaviate/weaviate/issues/4193
+	// for details.
 	assert.Equal(t, "READY", nodeStatus.Shards[0].VectorIndexingStatus)
 	assert.Equal(t, int64(0), nodeStatus.Shards[0].VectorQueueLength)
-	assert.Equal(t, int64(2), nodeStatus.Stats.ObjectCount)
 	assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -68,6 +68,7 @@ type ShardLike interface {
 
 	Counter() *indexcounter.Counter
 	ObjectCount() int
+	ObjectCountAsync() int
 	GetPropertyLengthTracker() *inverted.JsonPropertyLengthTracker
 
 	PutObject(context.Context, *storobj.Object) error
@@ -780,6 +781,7 @@ func (s *Shard) NotifyReady() {
 		Debugf("shard=%s is ready", s.name)
 }
 
+// ObjectCount returns the exact count at any moment
 func (s *Shard) ObjectCount() int {
 	b := s.store.Bucket(helpers.ObjectsBucketLSM)
 	if b == nil {
@@ -787,6 +789,17 @@ func (s *Shard) ObjectCount() int {
 	}
 
 	return b.Count()
+}
+
+// ObjectCountAsync returns the eventually consistent "async" count which is
+// much cheaper to obtain
+func (s *Shard) ObjectCountAsync() int {
+	b := s.store.Bucket(helpers.ObjectsBucketLSM)
+	if b == nil {
+		return 0
+	}
+
+	return b.CountAsync()
 }
 
 func (s *Shard) isFallbackToSearchable() bool {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -159,6 +159,11 @@ func (l *LazyLoadShard) ObjectCount() int {
 	return l.shard.ObjectCount()
 }
 
+func (l *LazyLoadShard) ObjectCountAsync() int {
+	l.mustLoad()
+	return l.shard.ObjectCountAsync()
+}
+
 func (l *LazyLoadShard) GetPropertyLengthTracker() *inverted.JsonPropertyLengthTracker {
 	l.mustLoad()
 	return l.shard.GetPropertyLengthTracker()

--- a/test/acceptance/nodes/nodes_api_test.go
+++ b/test/acceptance/nodes/nodes_api_test.go
@@ -36,7 +36,7 @@ func Test_NodesAPI(t *testing.T) {
 		require.Nil(t, err)
 		assert.NotNil(t, meta.GetPayload())
 
-		assertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		assertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 			require.NotNil(t, nodeStatus)
 			assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 			assert.True(t, len(nodeStatus.Name) > 0)
@@ -59,14 +59,14 @@ func Test_NodesAPI(t *testing.T) {
 			helper.AssertGetObjectEventually(t, book.Class, book.ID)
 		}
 
-		minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		minimalAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 			require.NotNil(t, nodeStatus)
 			assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 			assert.True(t, len(nodeStatus.Name) > 0)
 			assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
 		}
 
-		verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		verboseAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 			require.Len(t, nodeStatus.Shards, 1)
 			shard := nodeStatus.Shards[0]
 			assert.True(t, len(shard.Name) > 0)
@@ -90,14 +90,14 @@ func Test_NodesAPI(t *testing.T) {
 			helper.AssertGetObjectEventually(t, multiShard.Class, multiShard.ID)
 		}
 
-		minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		minimalAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 			require.NotNil(t, nodeStatus)
 			assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 			assert.True(t, len(nodeStatus.Name) > 0)
 			assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
 		}
 
-		verboseAsssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		verboseAsssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 			assert.Len(t, nodeStatus.Shards, 2)
 			for _, shard := range nodeStatus.Shards {
 				assert.True(t, len(shard.Name) > 0)
@@ -123,8 +123,8 @@ func Test_NodesAPI(t *testing.T) {
 				helper.AssertGetObjectEventually(t, book.Class, book.ID)
 			}
 
-			minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {}
-			verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+			minimalAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {}
+			verboseAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 				require.NotNil(t, nodeStatus.Stats)
 				assert.Equal(t, int64(3), nodeStatus.Stats.ObjectCount)
 				assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
@@ -147,13 +147,13 @@ func Test_NodesAPI(t *testing.T) {
 
 			docsClass := docsClasses[0]
 
-			minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+			minimalAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 				assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 				assert.True(t, len(nodeStatus.Name) > 0)
 				assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
 			}
 
-			verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+			verboseAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 				require.NotNil(t, nodeStatus.Stats)
 				assert.Equal(t, int64(2), nodeStatus.Stats.ObjectCount)
 				assert.Equal(t, int64(1), nodeStatus.Stats.ShardCount)
@@ -206,8 +206,8 @@ func Test_NodesAPI(t *testing.T) {
 			}), nil)
 		require.Nil(t, err)
 
-		minimalAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {}
-		verboseAssertions := func(t *testing.T, nodeStatus *models.NodeStatus) {
+		minimalAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {}
+		verboseAssertions := func(t require.TestingT, nodeStatus *models.NodeStatus) {
 			require.NotNil(t, nodeStatus.Stats)
 			assert.Equal(t, int64(1), nodeStatus.Stats.ObjectCount)
 		}
@@ -322,7 +322,7 @@ func Test_NodesAPI(t *testing.T) {
 	})
 }
 
-func testStatusResponse(t *testing.T, minimalAssertions, verboseAssertions func(*testing.T, *models.NodeStatus),
+func testStatusResponse(t *testing.T, minimalAssertions, verboseAssertions func(require.TestingT, *models.NodeStatus),
 	class string,
 ) {
 	minimal, verbose := verbosity.OutputMinimal, verbosity.OutputVerbose
@@ -343,11 +343,16 @@ func testStatusResponse(t *testing.T, minimalAssertions, verboseAssertions func(
 
 	if verboseAssertions != nil {
 		t.Run("verbose", func(t *testing.T) {
-			payload, err := getNodesStatus(t, verbose, class)
-			require.Nil(t, err)
-			commonTests(&nodes.NodesGetOK{Payload: payload})
-			// If commonTests pass, resp.Nodes[0] != nil
-			verboseAssertions(t, payload.Nodes[0])
+			getNodes := func() (*models.NodesStatusResponse, error) {
+				return getNodesStatus(t, verbose, class)
+			}
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
+				payload, err := getNodes()
+				require.Nil(t, err)
+				commonTests(&nodes.NodesGetOK{Payload: payload})
+				// If commonTests pass, resp.Nodes[0] != nil
+				verboseAssertions(t, payload.Nodes[0])
+			}, 15*time.Second, 500*time.Millisecond)
 		})
 	}
 }

--- a/test/helper/logger.go
+++ b/test/helper/logger.go
@@ -11,9 +11,9 @@
 
 package helper
 
-// Internal struct to link the HTTP client logging of the Weaviate API client to the test's logging output.
-
 import "testing"
+
+// Internal struct to link the HTTP client logging of the Weaviate API client to the test's logging output.
 
 type testLogger struct {
 	t *testing.T


### PR DESCRIPTION
## What's being changed:

- implements #4193
- See #4193 for details, the tl;dr is that only in the Nodes API object count will become approximate because it's too expensive to get the exact number in a massive cluster under heavy write load
- By approximate, we mean that we only count objects that have been flushed to disk and no longer include objects that were only in the memtable.
- In practice, this means it can take up to 60s for changes to be reflected
- We justify this change in the following ways
   - It is orders of magnitudes cheaper (see below)
   - The `/v1/nodes` API is an observability endpoint, not an "application-logic" endpoint
   - If you need an exact count for a collection or tenant you can still use `len(collection)` which uses `{ Aggregate { meta { count } } }`. This endpoint is not changed, it is not made approximate. It still returns the exact count even with a dirty memtable.
   
## Performance 

The test scenario pauses imports every 10 cycles to allow all segments to flush. Every cycle we call the `/v1/nodes` API with `output=verbose`.

### Before / Control / Sync

Using the sync object count in `v1.23.8` we can see spikes to over 1 second:

<img width="978" alt="Screenshot 2024-02-13 at 12 17 20 PM" src="https://github.com/weaviate/weaviate/assets/8974479/d99cfcbc-41e1-4aec-8535-9cb9fab91107">

### After / This branch / Async

Using this branch, the worst time observed was around `9ms`.

<img width="948" alt="Screenshot 2024-02-13 at 2 26 06 PM" src="https://github.com/weaviate/weaviate/assets/8974479/93120991-65d2-4197-ac04-08a542ab4945">

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: No, but if we decide to merge this, this is something that we clearly have to document.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not yet, will do.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
