### PR TITLE
HNSW BQ dimension tracking

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -123,6 +123,7 @@ type ShardLike interface {
 	filePutter(context.Context, string) (io.WriteCloser, error)
 
 	extendDimensionTrackerLSM(int, uint64) error
+	publishDimensionMetrics()
 
 	addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -351,6 +351,11 @@ func (l *LazyLoadShard) QuantizedDimensions(segments int) int {
 	return l.shard.QuantizedDimensions(segments)
 }
 
+func (l *LazyLoadShard) publishDimensionMetrics() {
+	l.mustLoad()
+	l.shard.publishDimensionMetrics()
+}
+
 func (l *LazyLoadShard) Aggregate(ctx context.Context, params aggregation.Params) (*aggregation.Result, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
### What's being changed:

With the newly introduced HNSW BQ feature we also need metrics which are used for billing / sizing to reflect this.

- HNSW BQ will cause an 8x reduction to `vector_segments_dimensions`
- DimensionCategory type created for easier extension in the future
- Additional tests were added that directly inspect prometheus metrics
- Typo fixed for resetting PQ `vector_segments_dimensions` when a class is deleted

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
