### PR TITLE
fix: eventual consistency on tenant creation and refactor recovery

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -29,6 +29,7 @@ services:
       RAFT_JOIN: "weaviate-test"
       RAFT_BOOTSTRAP_EXPECT: "1"
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
+      DISABLE_TELEMETRY: true
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in

--- a/test/acceptance/recovery/recovery_test.go
+++ b/test/acceptance/recovery/recovery_test.go
@@ -18,11 +18,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestRecovery(t *testing.T) {
-	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -42,17 +41,32 @@ func TestRecovery(t *testing.T) {
 	container2Ip := compose.ContainerURI(2)
 	container3Ip := compose.ContainerURI(3)
 
-	<-time.After(2 * time.Second) // wait for memberlist
+	<-time.After(3 * time.Second) // wait for memberlist
 
 	// restart cluster with different IPs
+	eg := errgroup.Group{}
+
 	require.Nil(t, compose.StopAt(ctx, 1, nil))
+	eg.Go(func() error {
+		require.Nil(t, compose.StartAt(ctx, 1))
+		return nil
+	})
+
 	require.Nil(t, compose.StopAt(ctx, 2, nil))
+	eg.Go(func() error {
+		time.Sleep(4 * time.Second)
+		require.Nil(t, compose.StartAt(ctx, 2))
+		return nil
+	})
+
 	require.Nil(t, compose.StopAt(ctx, 3, nil))
+	eg.Go(func() error {
+		time.Sleep(4 * time.Second)
+		require.Nil(t, compose.StartAt(ctx, 3))
+		return nil
+	})
 
-	require.Nil(t, compose.StartAt(ctx, 1))
-	require.Nil(t, compose.StartAt(ctx, 2))
-	require.Nil(t, compose.StartAt(ctx, 3))
-
+	eg.Wait()
 	// ips shouldn't be equal
 	require.NotEqual(t, container1Ip, compose.ContainerURI(1))
 	require.NotEqual(t, container2Ip, compose.ContainerURI(2))

--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -436,7 +436,7 @@ func restartNode1(ctx context.Context, t *testing.T, compose *docker.DockerCompo
 		return nil
 	})
 	eg.Go(func() error { // restart node 2
-		time.Sleep(2 * time.Second) // wait for member list initialization
+		time.Sleep(3 * time.Second) // wait for member list initialization
 		stopNodeAt(ctx, t, compose, 2)
 		require.Nil(t, compose.StartAt(ctx, 2))
 		return nil

--- a/test/acceptance_with_go_client/filters_tests/regex_test.go
+++ b/test/acceptance_with_go_client/filters_tests/regex_test.go
@@ -12,9 +12,10 @@
 package filters_tests
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"testing"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"

--- a/test/acceptance_with_go_client/multi_tenancy_tests/batch_reference_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/batch_reference_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestBatchReferenceCreate_MultiTenancy(t *testing.T) {
-	t.Skip("to be adjusted to work with eventual consistency on follower node")
 	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: "localhost:8080"})
 	require.Nil(t, err)
 

--- a/test/acceptance_with_go_client/multi_tenancy_tests/batch_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/batch_test.go
@@ -12,9 +12,10 @@
 package multi_tenancy_tests
 
 import (
-	"acceptance_tests_with_client/fixtures"
 	"context"
 	"testing"
+
+	"acceptance_tests_with_client/fixtures"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,6 @@ import (
 )
 
 func TestBatchCreate_MultiTenancy(t *testing.T) {
-	t.Skip("to be adjusted to work with eventual consistency on follower node")
 	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: "localhost:8080"})
 	require.Nil(t, err)
 

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -301,6 +301,7 @@ func (d *Compose) WithWeaviateEnv(name, value string) *Compose {
 }
 
 func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
+	d.weaviateEnvs["DISABLE_TELEMETRY"] = "true"
 	network, err := tescontainersnetwork.New(
 		ctx,
 		tescontainersnetwork.WithCheckDuplicate(),
@@ -312,6 +313,7 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 	}
 	envSettings := make(map[string]string)
 	envSettings["network"] = networkName
+	envSettings["DISABLE_TELEMETRY"] = "true"
 	containers := []*DockerContainer{}
 	if d.withMinIO {
 		container, err := startMinIO(ctx, networkName)
@@ -503,6 +505,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	cs := make([]*DockerContainer, size)
 	image := os.Getenv(envTestWeaviateImage)
 	networkName := settings["network"]
+	settings["DISABLE_TELEMETRY"] = "true"
 	if d.withWeaviateBasicAuth {
 		settings["CLUSTER_BASIC_AUTH_USERNAME"] = d.withWeaviateBasicAuthUsername
 		settings["CLUSTER_BASIC_AUTH_PASSWORD"] = d.withWeaviateBasicAuthPassword
@@ -521,7 +524,6 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	settings["RAFT_INTERNAL_RPC_PORT"] = "8301"
 	settings["RAFT_JOIN"] = raft_join
 	settings["RAFT_BOOTSTRAP_EXPECT"] = strconv.Itoa(d.size)
-	settings["RAFT_RECOVERY_TIMEOUT"] = "2"
 
 	// first node
 	config1 := copySettings(settings)

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -117,7 +117,7 @@ func startWeaviate(ctx context.Context,
 				PostStarts: []testcontainers.ContainerHook{
 					func(ctx context.Context, container testcontainers.Container) error {
 						for _, waitStrategy := range waitStrategies {
-							ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+							ctx, cancel := context.WithTimeout(ctx, 180*time.Second)
 							defer cancel()
 
 							if err := waitStrategy.WaitUntilReady(ctx, container); err != nil {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -40,6 +40,11 @@ func CreateClass(t *testing.T, class *models.Class) {
 	t.Helper()
 	params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
 	resp, err := Client(t).Schema.SchemaObjectsCreate(params, nil)
+	// TODO shall be removed with the DB is idempotent
+	// delete class before trying to create in case it was existing.
+	if err != nil && strings.Contains(err.Error(), "exists") {
+		return
+	}
 	AssertRequestOk(t, resp, err, nil)
 }
 

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -17,6 +17,7 @@ export QUERY_DEFAULTS_LIMIT=${QUERY_DEFAULTS_LIMIT:-"20"}
 export QUERY_MAXIMUM_RESULTS=${QUERY_MAXIMUM_RESULTS:-"10000"}
 export TRACK_VECTOR_DIMENSIONS=true
 export CLUSTER_HOSTNAME=${CLUSTER_HOSTNAME:-"node1"}
+export DISABLE_TELEMETRY=true # disable telemetry for local development
 
 function go_run() {
   GIT_HASH=$(git rev-parse --short HEAD)

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -136,6 +136,7 @@ func (e *executor) UpdateTenants(class string, req *cluster.UpdateTenantsRequest
 	if err != nil {
 		e.logger.WithField("action", "update_tenants").
 			WithField("class", class).Error(err)
+		return err
 	}
 
 	commit(true) // commit update of tenants

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -155,7 +155,7 @@ func TestExecutor(t *testing.T) {
 		req := &cluster.UpdateTenantsRequest{Tenants: tenants}
 		migrator.On("UpdateTenants", Anything, cls, Anything).Return(commit, ErrAny)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.UpdateTenants("A", req))
+		assert.ErrorIs(t, x.UpdateTenants("A", req), ErrAny)
 	})
 
 	t.Run("AddTenants", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
after rebasing master, some tests were failing and turns out we have a compact func which does fail and has to be retried
this PR 
 - bring back tests were skipped on 
https://github.com/weaviate/weaviate/commit/77ce216dde1b252f02a7c193302cc9fe02c4a5e1 
 - adds `DISABLE_TELEMETRY`to not push  telemetry, it should be added later after rebase though.   
 - clear some logs which can be misleading. 
 - make recovery conditional if there is more than 1 node 
 - update the recovery test because `container.Start()` is blocking op and calling it in routine to allow recovery and unblock nodes from waiting on each other
 - update FSM passed to `RecoverCluster()`, it has to be temporary, because it will be left in state shouldn't be used by the application. 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
