### PR TITLE
[Multiple Vectors]  Fix validation of none vectorizer modules when multiple vectorizer configuration is present

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
@@ -112,6 +112,8 @@ func composeModules() (composeModules *docker.Compose) {
 		WithText2VecContextionary().
 		WithText2VecTransformers().
 		WithText2VecOpenAI().
-		WithText2VecCohere()
+		WithText2VecCohere().
+		WithGenerativeOpenAI().
+		WithGenerativeCohere()
 	return
 }


### PR DESCRIPTION
### What's being changed:

This PR re-adds none vectorizer module configuration validation when multiple vectors configuration is present.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
