### PR TITLE
Lock-free vertex::maintenance flag

### DIFF
--- a/adapters/repos/db/vector/hnsw/vertex.go
+++ b/adapters/repos/db/vector/hnsw/vertex.go
@@ -13,6 +13,7 @@ package hnsw
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 type vertex struct {
@@ -20,26 +21,19 @@ type vertex struct {
 	sync.Mutex
 	level       int
 	connections [][]uint64
-	maintenance bool
+	maintenance atomic.Bool
 }
 
 func (v *vertex) markAsMaintenance() {
-	v.Lock()
-	v.maintenance = true
-	v.Unlock()
+	v.maintenance.Store(true)
 }
 
 func (v *vertex) unmarkAsMaintenance() {
-	v.Lock()
-	v.maintenance = false
-	v.Unlock()
+	v.maintenance.Store(false)
 }
 
 func (v *vertex) isUnderMaintenance() bool {
-	v.Lock()
-	m := v.maintenance
-	v.Unlock()
-	return m
+	return v.maintenance.Load()
 }
 
 func (v *vertex) connectionsAtLevelNoLock(level int) []uint64 {


### PR DESCRIPTION
### What's being changed:
Using `atomic.Bool` instead of `sync.Mutex` to protect `vertex::maintenance`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
