### PR TITLE
Return all named vectors if vectors is true

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -615,6 +615,15 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 		Vectors:            prop.Vectors,
 	}
 
+	// return all named vectors if vector is true
+	if prop.Vector && len(class.VectorConfig) > 0 {
+		props.Vectors = make([]string, 0, len(class.VectorConfig))
+		for vectorName := range class.VectorConfig {
+			props.Vectors = append(props.Vectors, vectorName)
+		}
+
+	}
+
 	vectorIndex, err := schema.TypeAssertVectorIndex(class)
 	if err != nil {
 		return props, err

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -44,6 +44,7 @@ func TestGRPCRequest(t *testing.T) {
 	refClass2 := "AnotherClass"
 	dotClass := "DotClass"
 	objClass := "ObjClass"
+	multiVecClass := "MultiVecClass"
 
 	defaultTestClassProps := search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "number", IsPrimitive: true}, {Name: "floats", IsPrimitive: true}, {Name: "uuid", IsPrimitive: true}}
 
@@ -120,6 +121,23 @@ func TestGRPCRequest(t *testing.T) {
 						},
 					},
 					VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DefaultDistanceMetric},
+				},
+				{
+					Class: multiVecClass,
+					Properties: []*models.Property{
+						{Name: "first", DataType: schema.DataTypeText.PropString()},
+					},
+					VectorIndexConfig: hnsw.UserConfig{},
+					VectorConfig: map[string]models.VectorConfig{
+						"custom": {
+							VectorIndexType: "hnsw",
+							Vectorizer:      map[string]interface{}{"none": map[string]interface{}{}},
+						},
+						"first": {
+							VectorIndexType: "flat",
+							Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+						},
+					},
 				},
 			},
 		},
@@ -222,6 +240,14 @@ func TestGRPCRequest(t *testing.T) {
 			req:  &pb.SearchRequest{Collection: classname},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: defaultTestClassProps,
+			},
+			error: false,
+		},
+		{
+			name: "Vectors returns all named vectors",
+			req:  &pb.SearchRequest{Collection: multiVecClass, Metadata: &pb.MetadataRequest{Vector: true}, Properties: &pb.PropertiesRequest{}},
+			out: dto.GetParams{
+				ClassName: multiVecClass, Pagination: defaultPagination, Properties: search.SelectProperties{}, AdditionalProperties: additional.Properties{Vectors: []string{"custom", "first"}, Vector: true, NoProps: true},
 			},
 			error: false,
 		},


### PR DESCRIPTION
### What's being changed:

When a user requests `vector=true` through the GRPC API it now returns all named vectors.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
