### PR TITLE
Backport fix for clearing deleted segments metric

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -146,7 +146,7 @@ func clearDimensionMetrics(promMetrics *monitoring.PrometheusMetrics,
 ) {
 	if pqEnabled, _ := getPQSegments(cfg); pqEnabled {
 		sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
-		sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
+		sendVectorSegmentsMetric(promMetrics, className, shardName, 0)
 	} else {
 		sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
 	}


### PR DESCRIPTION
### What's being changed:

- https://github.com/weaviate/weaviate/pull/3783 introduced a typo where the segments metric would not be cleared on class deletion
- A fix was applied in https://github.com/weaviate/weaviate/pull/4209 for 1.24 / master
- Because of refactoring for BQ and multi-vector, it was easier to backport this separately

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
