### PR TITLE
Improve locking of shared pool

### DIFF
--- a/adapters/repos/db/vector/hnsw/hnsw_stress_test.go
+++ b/adapters/repos/db/vector/hnsw/hnsw_stress_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	vectorSize          = 128
-	vectorsPerGoroutine = 100
-	parallelGoroutines  = 100
+	vectorSize               = 128
+	vectorsPerGoroutine      = 100
+	parallelGoroutines       = 100
+	parallelSearchGoroutines = 8
 )
 
 func idVector(ctx context.Context, id uint64) ([]float32, error) {
@@ -65,7 +66,9 @@ func int32FromBytes(bytes []byte) int {
 
 func TestHnswStress(t *testing.T) {
 	siftFile := "datasets/ann-benchmarks/siftsmall/siftsmall_base.fvecs"
-	if _, err := os.Stat(siftFile); err != nil {
+	siftFileQuery := "datasets/ann-benchmarks/siftsmall/sift_query.fvecs"
+	_, err2 := os.Stat(siftFileQuery)
+	if _, err := os.Stat(siftFile); err != nil || err2 != nil {
 		if !*download {
 			t.Skip(`Sift data needs to be present.
 Run test with -download to automatically download the dataset.
@@ -75,6 +78,7 @@ Ex: go test -v -run TestHnswStress . -download
 		downloadDatasetFile(t, siftFile)
 	}
 	vectors := readSiftFloat(siftFile, parallelGoroutines*vectorsPerGoroutine)
+	vectorsQuery := readSiftFloat(siftFile, parallelGoroutines*vectorsPerGoroutine)
 
 	t.Run("Insert and search and maybe delete", func(t *testing.T) {
 		for n := 0; n < 1; n++ { // increase if you don't want to reread SIFT for every run
@@ -137,6 +141,35 @@ Ex: go test -v -run TestHnswStress . -download
 			wg.Wait()
 
 		}
+	})
+
+	t.Run("Concurrent search", func(t *testing.T) {
+		index := createEmptyHnswIndexForTests(t, idVector)
+		// add elements
+		for k, vec := range vectors {
+			err := index.Add(uint64(k), vec)
+			require.Nil(t, err)
+		}
+
+		vectorsPerGoroutineSearch := len(vectorsQuery) / parallelSearchGoroutines
+		wg := sync.WaitGroup{}
+
+		for i := 0; i < 10; i++ { // increase if you don't want to reread SIFT for every run
+			for k := 0; k < parallelSearchGoroutines; k++ {
+				wg.Add(1)
+				k := k
+				go func() {
+					goroutineIndex := k * vectorsPerGoroutineSearch
+					for j := 0; j < vectorsPerGoroutineSearch; j++ {
+						_, _, err := index.SearchByVector(vectors[goroutineIndex+j], 0, nil)
+						require.Nil(t, err)
+
+					}
+					wg.Done()
+				}()
+			}
+		}
+		wg.Wait()
 	})
 
 	t.Run("Concurrent deletes", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -170,9 +170,9 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 	if n.tombstoneCleanupNodes {
 		results = n.graph.pools.pqResults.GetMax(n.graph.efConstruction)
 
-		n.graph.pools.visitedListsLock.Lock()
+		n.graph.pools.visitedListsLock.RLock()
 		visited := n.graph.pools.visitedLists.Borrow()
-		n.graph.pools.visitedListsLock.Unlock()
+		n.graph.pools.visitedListsLock.RUnlock()
 		n.node.Lock()
 		connections := make([]uint64, len(n.node.connections[level]))
 		copy(connections, n.node.connections[level])
@@ -198,9 +198,9 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 				return err
 			}
 		}
-		n.graph.pools.visitedListsLock.Lock()
+		n.graph.pools.visitedListsLock.RLock()
 		n.graph.pools.visitedLists.Return(visited)
-		n.graph.pools.visitedListsLock.Unlock()
+		n.graph.pools.visitedListsLock.RUnlock()
 		if err := n.pickEntrypoint(); err != nil {
 			return errors.Wrap(err, "pick entrypoint at level beginning")
 		}

--- a/adapters/repos/db/vector/hnsw/pools.go
+++ b/adapters/repos/db/vector/hnsw/pools.go
@@ -22,7 +22,7 @@ import (
 
 type pools struct {
 	visitedLists     *visited.Pool
-	visitedListsLock *sync.Mutex
+	visitedListsLock *sync.RWMutex
 
 	pqItemSlice  *sync.Pool
 	pqHeuristic  *pqMinWithIndexPool
@@ -35,7 +35,7 @@ type pools struct {
 func newPools(maxConnectionsLayerZero int) *pools {
 	return &pools{
 		visitedLists:     visited.NewPool(1, cache.InitialSize+500),
-		visitedListsLock: &sync.Mutex{},
+		visitedListsLock: &sync.RWMutex{},
 		pqItemSlice: &sync.Pool{
 			New: func() interface{} {
 				return make([]priorityqueue.Item[uint64], 0, maxConnectionsLayerZero)

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -174,9 +174,9 @@ func (h *hnsw) searchLayerByVectorWithDistancer(queryVector []float32,
 	entrypoints *priorityqueue.Queue[any], ef int, level int,
 	allowList helpers.AllowList, compressorDistancer compressionhelpers.CompressorDistancer) (*priorityqueue.Queue[any], error,
 ) {
-	h.pools.visitedListsLock.Lock()
+	h.pools.visitedListsLock.RLock()
 	visited := h.pools.visitedLists.Borrow()
-	h.pools.visitedListsLock.Unlock()
+	h.pools.visitedListsLock.RUnlock()
 
 	candidates := h.pools.pqCandidates.GetMin(ef)
 	results := h.pools.pqResults.GetMax(ef)
@@ -327,9 +327,9 @@ func (h *hnsw) searchLayerByVectorWithDistancer(queryVector []float32,
 
 	h.pools.pqCandidates.Put(candidates)
 
-	h.pools.visitedListsLock.Lock()
+	h.pools.visitedListsLock.RLock()
 	h.pools.visitedLists.Return(visited)
-	h.pools.visitedListsLock.Unlock()
+	h.pools.visitedListsLock.RUnlock()
 
 	return results, nil
 }


### PR DESCRIPTION
### What's being changed:

- adds a hnsw test with parallel search
- visistedpool has it is own internal locking, so read locks guarding against a growing index is sufficient
- reduce amount of locking in  visistedpool

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
