### PR TITLE
Fix: Truncate buffered doc IDs from Searcher

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -1335,7 +1335,7 @@ func TestGRPCRequest(t *testing.T) {
 				require.NotNil(t, err)
 			} else {
 				require.Nil(t, err)
-				require.Equal(t, tt.out, out)
+				require.EqualValues(t, tt.out, out)
 			}
 		})
 	}

--- a/adapters/repos/db/helpers/allow_list.go
+++ b/adapters/repos/db/helpers/allow_list.go
@@ -27,6 +27,7 @@ type AllowList interface {
 	Min() uint64
 	Max() uint64
 	Size() uint64
+	Truncate(uint64) AllowList
 
 	Iterator() AllowListIterator
 	LimitedIterator(limit int) AllowListIterator
@@ -88,6 +89,14 @@ func (al *bitmapAllowList) Max() uint64 {
 func (al *bitmapAllowList) Size() uint64 {
 	// TODO provide better size estimation
 	return uint64(1.5 * float64(len(al.bm.ToBuffer())))
+}
+
+func (al *bitmapAllowList) Truncate(upTo uint64) AllowList {
+	card := al.bm.GetCardinality()
+	if upTo < uint64(card) {
+		al.bm.RemoveRange(upTo, uint64(al.bm.GetCardinality()+1))
+	}
+	return al
 }
 
 func (al *bitmapAllowList) Iterator() AllowListIterator {

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -688,7 +688,7 @@ func newFakeMaxIDGetter(maxID uint64) func() uint64 {
 }
 
 func notEqualsExpectedResults(maxID uint64, skip int) helpers.AllowList {
-	allow := make([]uint64, maxID+roaringset.DefaultBufferIncrement+1)
+	allow := make([]uint64, maxID)
 	p := 0
 	for i := 0; i < len(allow); i++ {
 		if i != skip {

--- a/adapters/repos/db/inverted/searcher_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_integration_test.go
@@ -147,6 +147,105 @@ func TestObjects(t *testing.T) {
 	})
 }
 
+func TestDocIDs(t *testing.T) {
+	var (
+		dirName      = t.TempDir()
+		logger, _    = test.NewNullLogger()
+		propName     = "inverted-with-frequency"
+		charSet      = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		charRepeat   = 3
+		multiplier   = 100
+		numObjects   = len(charSet) * multiplier
+		docIDCounter = uint64(0)
+	)
+	store, err := lsmkv.New(dirName, dirName, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+	defer func() { assert.Nil(t, err) }()
+
+	t.Run("create buckets", func(t *testing.T) {
+		require.Nil(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
+			lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1)))
+		require.NotNil(t, store.Bucket(helpers.ObjectsBucketLSM))
+
+		require.Nil(t, store.CreateOrLoadBucket(context.Background(),
+			helpers.BucketSearchableFromPropNameLSM(propName),
+			lsmkv.WithStrategy(lsmkv.StrategyMapCollection)))
+		require.NotNil(t, store.Bucket(helpers.BucketSearchableFromPropNameLSM(propName)))
+	})
+
+	t.Run("put objects", func(t *testing.T) {
+		for i := 0; i < numObjects; i++ {
+			targetChar := charSet[i%len(charSet)]
+			prop := repeatString(string(targetChar), charRepeat)
+			obj := storobj.Object{
+				MarshallerVersion: 1,
+				Object: models.Object{
+					ID:    strfmt.UUID(uuid.NewString()),
+					Class: className,
+					Properties: map[string]interface{}{
+						propName: prop,
+					},
+				},
+				DocID: docIDCounter,
+			}
+			docIDCounter++
+			putObject(t, store, &obj, propName, []byte(prop))
+		}
+	})
+
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter))
+
+	searcher := NewSearcher(logger, store, createSchema(), nil, nil,
+		fakeStopwordDetector{}, 2, func() bool { return false }, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	type testCase struct {
+		expectedMatches int
+		filter          filters.LocalFilter
+	}
+	tests := []testCase{
+		{
+			filter: filters.LocalFilter{
+				Root: &filters.Clause{
+					Operator: filters.OperatorNotEqual,
+					On: &filters.Path{
+						Class:    className,
+						Property: schema.PropertyName(propName),
+					},
+					Value: &filters.Value{
+						Value: "[[[",
+						Type:  schema.DataTypeText,
+					},
+				},
+			},
+			expectedMatches: numObjects,
+		},
+		{
+			filter: filters.LocalFilter{
+				Root: &filters.Clause{
+					Operator: filters.OperatorNotEqual,
+					On: &filters.Path{
+						Class:    className,
+						Property: schema.PropertyName(propName),
+					},
+					Value: &filters.Value{
+						Value: "AAA",
+						Type:  schema.DataTypeText,
+					},
+				},
+			},
+			expectedMatches: len(charSet)*multiplier - 1,
+		},
+	}
+
+	for _, tc := range tests {
+		allow, err := searcher.DocIDs(context.Background(), &tc.filter, additional.Properties{}, className)
+		require.Nil(t, err)
+		assert.Equal(t, tc.expectedMatches, allow.Len())
+	}
+}
+
 // lifted from Shard::pairPropertyWithFrequency to emulate Bucket::MapSet functionality
 func pairPropWithFreq(docID uint64, freq, propLen float32) lsmkv.MapPair {
 	buf := make([]byte, 16)

--- a/adapters/repos/db/roaringset/helpers.go
+++ b/adapters/repos/db/roaringset/helpers.go
@@ -203,3 +203,10 @@ func (bmf *BitmapFactory) GetBitmap() *sroar.Bitmap {
 
 	return bmf.bitmap.Clone()
 }
+
+// ActualMaxVal returns the highest value in the bitmap not including the buffer
+func (bmf *BitmapFactory) ActualMaxVal() uint64 {
+	bmf.lock.RLock()
+	defer bmf.lock.RUnlock()
+	return bmf.maxValGetter()
+}

--- a/adapters/repos/db/roaringset/helpers_test.go
+++ b/adapters/repos/db/roaringset/helpers_test.go
@@ -238,6 +238,7 @@ func TestBitmapFactory(t *testing.T) {
 		assert.NotNil(t, bmf.GetBitmap())
 		assert.Equal(t, currMax, bmf.currentMaxVal)
 		assert.Equal(t, currMax+1, uint64(bmf.bitmap.GetCardinality()))
+		assert.Equal(t, maxVal, bmf.ActualMaxVal())
 	})
 
 	t.Run("max val surpasses threshold, cardinality increased", func(t *testing.T) {
@@ -246,6 +247,7 @@ func TestBitmapFactory(t *testing.T) {
 		currMax += 1 + DefaultBufferIncrement
 		assert.Equal(t, currMax, bmf.currentMaxVal)
 		assert.Equal(t, currMax+1, uint64(bmf.bitmap.GetCardinality()))
+		assert.Equal(t, maxVal, bmf.ActualMaxVal())
 	})
 }
 


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
