### PR TITLE
Use Async Queue(s) and VectorIndex(es) only relevant for configured legacy vector or target vectors

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -433,11 +433,14 @@ func (m *Migrator) RecalculateVectorDimensions(ctx context.Context) error {
 		// Iterate over all shards
 		if err := index.IterateObjects(ctx, func(index *Index, shard ShardLike, object *storobj.Object) error {
 			count = count + 1
-			if err := shard.extendDimensionTrackerLSM(len(object.Vector), object.DocID); err != nil {
-				return err
-			}
-			for vecName, vec := range object.Vectors {
-				if err := shard.extendDimensionTrackerForVecLSM(len(vec), object.DocID, vecName); err != nil {
+			if shard.hasTargetVectors() {
+				for vecName, vec := range object.Vectors {
+					if err := shard.extendDimensionTrackerForVecLSM(len(vec), object.DocID, vecName); err != nil {
+						return err
+					}
+				}
+			} else {
+				if err := shard.extendDimensionTrackerLSM(len(object.Vector), object.DocID); err != nil {
 					return err
 				}
 			}

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -290,16 +290,14 @@ func (s *Shard) reinit(ctx context.Context) error {
 		return fmt.Errorf("reinit non-vector: %w", err)
 	}
 
-	if err := s.initVector(ctx); err != nil {
-		return fmt.Errorf("reinit vector: %w", err)
-	}
-
-	for targetVector, vectorIndexConfig := range s.index.vectorIndexUserConfigs {
-		vectorIndex, err := s.initVectorIndex(ctx, targetVector, vectorIndexConfig)
-		if err != nil {
-			return fmt.Errorf("reinit vector for target vector %s: %w", targetVector, err)
+	if s.hasTargetVectors() {
+		if err := s.initTargetVectors(ctx); err != nil {
+			return fmt.Errorf("reinit vector: %w", err)
 		}
-		s.vectorIndexes[targetVector] = vectorIndex
+	} else {
+		if err := s.initLegacyVector(ctx); err != nil {
+			return fmt.Errorf("reinit vector: %w", err)
+		}
 	}
 
 	s.initCycleCallbacks()

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -91,21 +91,23 @@ type ShardLike interface {
 	addTimestampProperties(ctx context.Context) error
 	createPropertyIndex(ctx context.Context, prop *models.Property, eg *errgroup.Group)
 	BeginBackup(ctx context.Context) error
-	ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor) error //
+	ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor) error
 	resumeMaintenanceCycles(ctx context.Context) error
 	SetPropertyLengths(props []inverted.Property) error
-	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) //
+	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error)
 
-	Aggregate(ctx context.Context, params aggregation.Params) (*aggregation.Result, error) //
-	MergeObject(ctx context.Context, object objects.MergeDocument) error                   //
+	Aggregate(ctx context.Context, params aggregation.Params) (*aggregation.Result, error)
+	MergeObject(ctx context.Context, object objects.MergeDocument) error
 	Queue() *IndexQueue
 	Queues() map[string]*IndexQueue
 	Shutdown(context.Context) error // Shutdown the shard
 	// TODO tests only
-	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) // Search and return objects
-	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, error)                                                                                                                    // Check if an object was deleted
-	VectorIndex() VectorIndex                                                                                                                                                        // Get the vector index
-	VectorIndexes() map[string]VectorIndex                                                                                                                                           // Get the vector indexes
+	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor,
+		additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) // Search and return objects
+	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, error) // Check if an object was deleted
+	VectorIndex() VectorIndex                                     // Get the vector index
+	VectorIndexes() map[string]VectorIndex                        // Get the vector indexes
+	hasTargetVectors() bool
 	// TODO tests only
 	Versioner() *shardVersioner // Get the shard versioner
 
@@ -233,17 +235,20 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, errors.Wrapf(err, "init shard %q", s.ID())
 	}
 
-	if err := s.initVector(ctx); err != nil {
-		return nil, err
-	}
-
-	s.queue, err = NewIndexQueue(s.ID(), "", s, s.VectorIndex(), s.centralJobQueue, s.indexCheckpoints, IndexQueueOptions{Logger: s.index.logger})
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.initTargetVectors(ctx, class); err != nil {
-		return nil, err
+	if s.hasTargetVectors() {
+		if err := s.initTargetVectors(ctx); err != nil {
+			return nil, err
+		}
+		if err := s.initTargetQueues(); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := s.initLegacyVector(ctx); err != nil {
+			return nil, err
+		}
+		if err := s.initLegacyQueue(); err != nil {
+			return nil, err
+		}
 	}
 
 	s.initDimensionTracking()
@@ -251,14 +256,17 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	if asyncEnabled() {
 		go func() {
 			// preload unindexed objects in the background
-			err = s.queue.PreloadShard(s)
-			if err != nil {
-				s.queue.Logger.WithError(err).Error("preload shard")
-			}
-			for targetVector, queue := range s.queues {
-				err = queue.PreloadShard(s)
+			if s.hasTargetVectors() {
+				for targetVector, queue := range s.queues {
+					err := queue.PreloadShard(s)
+					if err != nil {
+						queue.Logger.WithError(err).Errorf("preload shard for target vector: %s", targetVector)
+					}
+				}
+			} else {
+				err := s.queue.PreloadShard(s)
 				if err != nil {
-					queue.Logger.WithError(err).Errorf("preload shard for target vector: %s", targetVector)
+					s.queue.Logger.WithError(err).Error("preload shard")
 				}
 			}
 		}()
@@ -273,41 +281,57 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	return s, nil
 }
 
+func (s *Shard) hasTargetVectors() bool {
+	return hasTargetVectors(s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs)
+}
+
 // target vectors and legacy vector are (supposed to be) exclusive
 // method allows to distinguish which of them is configured for the class
 func hasTargetVectors(cfg schema.VectorIndexConfig, targetCfgs map[string]schema.VectorIndexConfig) bool {
 	return len(targetCfgs) != 0
 }
 
-func (s *Shard) initTargetVectors(ctx context.Context, class *models.Class) error {
-	if hasTargetVectors(s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs) {
-		s.vectorIndexes = make(map[string]VectorIndex)
-		s.queues = make(map[string]*IndexQueue)
-
-		for targetVector, vectorIndexConfig := range s.index.vectorIndexUserConfigs {
-			vectorIndex, err := s.initVectorIndex(ctx, targetVector, vectorIndexConfig)
-			if err != nil {
-				return fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)
-			}
-			s.vectorIndexes[targetVector] = vectorIndex
-
-			queue, err := NewIndexQueue(s.ID(), targetVector, s, vectorIndex,
-				s.centralJobQueue, s.indexCheckpoints, IndexQueueOptions{Logger: s.index.logger})
-			if err != nil {
-				return fmt.Errorf("cannot create index queue for %q: %w", targetVector, err)
-			}
-			s.queues[targetVector] = queue
+func (s *Shard) initTargetVectors(ctx context.Context) error {
+	s.vectorIndexes = make(map[string]VectorIndex)
+	for targetVector, vectorIndexConfig := range s.index.vectorIndexUserConfigs {
+		vectorIndex, err := s.initVectorIndex(ctx, targetVector, vectorIndexConfig)
+		if err != nil {
+			return fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)
 		}
+		s.vectorIndexes[targetVector] = vectorIndex
 	}
 	return nil
 }
 
-func (s *Shard) initVector(ctx context.Context) error {
+func (s *Shard) initTargetQueues() error {
+	s.queues = make(map[string]*IndexQueue)
+	for targetVector, vectorIndex := range s.vectorIndexes {
+		queue, err := NewIndexQueue(s.ID(), targetVector, s, vectorIndex, s.centralJobQueue,
+			s.indexCheckpoints, IndexQueueOptions{Logger: s.index.logger})
+		if err != nil {
+			return fmt.Errorf("cannot create index queue for %q: %w", targetVector, err)
+		}
+		s.queues[targetVector] = queue
+	}
+	return nil
+}
+
+func (s *Shard) initLegacyVector(ctx context.Context) error {
 	vectorindex, err := s.initVectorIndex(ctx, "", s.index.vectorIndexUserConfig)
 	if err != nil {
 		return err
 	}
 	s.vectorIndex = vectorindex
+	return nil
+}
+
+func (s *Shard) initLegacyQueue() error {
+	queue, err := NewIndexQueue(s.ID(), "", s, s.vectorIndex, s.centralJobQueue,
+		s.indexCheckpoints, IndexQueueOptions{Logger: s.index.logger})
+	if err != nil {
+		return err
+	}
+	s.queue = queue
 	return nil
 }
 
@@ -564,15 +588,27 @@ func (s *Shard) drop() error {
 		return errors.Wrapf(err, "remove version at %s", s.path())
 	}
 
-	// delete queue cursor
-	err = s.queue.Drop()
-	if err != nil {
-		return errors.Wrapf(err, "close queue at %s", s.path())
-	}
-	// remove vector index
-	err = s.VectorIndex().Drop(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "remove vector index at %s", s.path())
+	if s.hasTargetVectors() {
+		// TODO run in parallel?
+		for targetVector, queue := range s.queues {
+			if err = queue.Drop(); err != nil {
+				return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), err)
+			}
+		}
+		for targetVector, vectorIndex := range s.vectorIndexes {
+			if err = vectorIndex.Drop(ctx); err != nil {
+				return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), err)
+			}
+		}
+	} else {
+		// delete queue cursor
+		if err = s.queue.Drop(); err != nil {
+			return errors.Wrapf(err, "close queue at %s", s.path())
+		}
+		// remove vector index
+		if err = s.vectorIndex.Drop(ctx); err != nil {
+			return errors.Wrapf(err, "remove vector index at %s", s.path())
+		}
 	}
 
 	// delete property length tracker
@@ -820,29 +856,45 @@ func (s *Shard) Shutdown(ctx context.Context) error {
 		s.stopMetrics <- struct{}{}
 	}
 
-	if err := s.GetPropertyLengthTracker().Close(); err != nil {
+	var err error
+	if err = s.GetPropertyLengthTracker().Close(); err != nil {
 		return errors.Wrap(err, "close prop length tracker")
 	}
 
-	if err := s.queue.Close(); err != nil {
-		return errors.Wrap(err, "shut down vector index queue")
-	}
-
-	// to ensure that all commitlog entries are written to disk.
-	// otherwise in some cases the tombstone cleanup process'
-	// 'RemoveTombstone' entry is not picked up on restarts
-	// resulting in perpetually attempting to remove a tombstone
-	// which doesn't actually exist anymore
-	if err := s.VectorIndex().Flush(); err != nil {
-		return errors.Wrap(err, "flush vector index commitlog")
-	}
-
-	if err := s.VectorIndex().Shutdown(ctx); err != nil {
-		return errors.Wrap(err, "shut down vector index")
+	if s.hasTargetVectors() {
+		// TODO run in parallel?
+		for targetVector, queue := range s.queues {
+			if err = queue.Close(); err != nil {
+				return fmt.Errorf("shut down vector index queue of vector %q: %w", targetVector, err)
+			}
+		}
+		for targetVector, vectorIndex := range s.vectorIndexes {
+			if err = vectorIndex.Flush(); err != nil {
+				return fmt.Errorf("flush vector index commitlog of vector %q: %w", targetVector, err)
+			}
+			if err = vectorIndex.Shutdown(ctx); err != nil {
+				return fmt.Errorf("shut down vector index of vector %q: %w", targetVector, err)
+			}
+		}
+	} else {
+		if err = s.queue.Close(); err != nil {
+			return errors.Wrap(err, "shut down vector index queue")
+		}
+		// to ensure that all commitlog entries are written to disk.
+		// otherwise in some cases the tombstone cleanup process'
+		// 'RemoveTombstone' entry is not picked up on restarts
+		// resulting in perpetually attempting to remove a tombstone
+		// which doesn't actually exist anymore
+		if err = s.vectorIndex.Flush(); err != nil {
+			return errors.Wrap(err, "flush vector index commitlog")
+		}
+		if err = s.vectorIndex.Shutdown(ctx); err != nil {
+			return errors.Wrap(err, "shut down vector index")
+		}
 	}
 
 	// unregister all callbacks at once, in parallel
-	if err := cyclemanager.NewCombinedCallbackCtrl(0,
+	if err = cyclemanager.NewCombinedCallbackCtrl(0,
 		s.cycleCallbacks.compactionCallbacksCtrl,
 		s.cycleCallbacks.flushCallbacksCtrl,
 		s.cycleCallbacks.vectorCombinedCallbacksCtrl,
@@ -851,7 +903,7 @@ func (s *Shard) Shutdown(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.store.Shutdown(ctx); err != nil {
+	if err = s.store.Shutdown(ctx); err != nil {
 		return errors.Wrap(err, "stop lsmkv store")
 	}
 

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -18,19 +18,12 @@ import (
 	"github.com/weaviate/weaviate/entities/aggregation"
 )
 
-func (s *Shard) Aggregate(ctx context.Context,
-	params aggregation.Params,
-) (*aggregation.Result, error) {
-	var queue *IndexQueue
-	if params.TargetVector != "" {
-		var err error
-		queue, err = s.getIndexQueue(params.TargetVector)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		queue = s.queue
+func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params) (*aggregation.Result, error) {
+	queue, err := s.getIndexQueue(params.TargetVector)
+	if err != nil {
+		return nil, err
 	}
+
 	return aggregator.New(s.store, params, s.index.getSchema, s.index.classSearcher,
 		s.index.stopwords, s.versioner.Version(), queue, s.index.logger, s.GetPropertyLengthTracker(),
 		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -136,7 +136,7 @@ func (s *Shard) publishDimensionMetrics() {
 	if s.promMetrics != nil {
 		className := s.index.Config.ClassName.String()
 
-		if !hasTargetVectors(s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs) {
+		if !s.hasTargetVectors() {
 			// send stats for legacy vector only
 			switch category, segments := getDimensionCategory(s.index.vectorIndexUserConfig); category {
 			case DimensionCategoryPQ:

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -426,6 +426,11 @@ func (l *LazyLoadShard) VectorIndexes() map[string]VectorIndex {
 	return l.shard.VectorIndexes()
 }
 
+func (l *LazyLoadShard) hasTargetVectors() bool {
+	l.mustLoad()
+	return l.shard.hasTargetVectors()
+}
+
 func (l *LazyLoadShard) Versioner() *shardVersioner {
 	l.mustLoad()
 	return l.shard.Versioner()


### PR DESCRIPTION
### What's being changed:

Inits and uses exclusively `Shard::queue` and `Shard::vectorIndex` OR `Shard::queues` and `Shard::vectorIndexes` depending in vectors configuration (1st for legacy vector, 2nd for target vectors).

Adds handling for queues and vector indexes that was missing previously (e.g. backup)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
