### PR TITLE
fix: cluster recover updating nodes ip from memberlist

### DIFF
--- a/cloud/store/recover_test.go
+++ b/cloud/store/recover_test.go
@@ -14,7 +14,6 @@ package store
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/raft"
@@ -118,17 +117,17 @@ func TestRecoverable(t *testing.T) {
 				{
 					ID:       raft.ServerID("1"),
 					Suffrage: raft.Voter,
-					Address:  raft.ServerAddress("localhost:8001"),
+					Address:  raft.ServerAddress("localhost:8080"),
 				},
 				{
 					ID:       raft.ServerID("2"),
 					Suffrage: raft.Voter,
-					Address:  raft.ServerAddress("localhost:8002"),
+					Address:  raft.ServerAddress("localhost:8080"),
 				},
 				{
 					ID:       raft.ServerID("3"),
 					Suffrage: raft.Nonvoter,
-					Address:  raft.ServerAddress("localhost:8003"),
+					Address:  raft.ServerAddress("localhost:8080"),
 				},
 			},
 			recoverable: true,
@@ -170,13 +169,13 @@ func testRaftLog(lt raft.LogType, idx int, data []byte) *raft.Log {
 }
 
 type MockCluster struct {
-	list map[string]bool
+	list map[string]raft.Server
 }
 
 func NewMockCluster(servers []raft.Server) *MockCluster {
-	list := map[string]bool{}
+	list := map[string]raft.Server{}
 	for _, s := range servers {
-		list[strings.Split(string(s.ID), ":")[0]] = true
+		list[string(s.ID)] = s
 	}
 	return &MockCluster{list}
 }
@@ -189,6 +188,6 @@ func (m *MockCluster) AllHostnames() []string {
 	return ks
 }
 
-func (m *MockCluster) Alive(ip string) bool {
-	return m.list[ip]
+func (m *MockCluster) NodeHostname(nodeName string) (string, bool) {
+	return string(m.list[nodeName].Address), true
 }

--- a/cloud/store/store.go
+++ b/cloud/store/store.go
@@ -231,7 +231,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	}
 
 	if servers, recover := st.recoverable(existedConfig.Servers); recover {
-		st.log.Info("recovery: start recovery with",
+		st.log.Info("recovery: start recovery with provided",
 			"peers", servers,
 			"snapshot_index", snapshotIndex(snapshotStore),
 			"last_applied_log_index", st.initialLastAppliedIndex)
@@ -256,7 +256,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 			st.loadDatabase(ctx)
 		}
 
-		st.log.Info("recovery: succeeded from previous configuration",
+		st.log.Info("recovery: succeeded from previous configuration with new",
 			"peers", servers,
 			"snapshot_index", snapshotIndex(snapshotStore),
 			"last_applied_log_index", st.initialLastAppliedIndex)

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -23,7 +23,7 @@ import (
 
 type Reader interface {
 	AllHostnames() []string
-	Alive(ID string) bool
+	NodeHostname(nodeName string) (string, bool)
 }
 
 type State struct {
@@ -151,19 +151,6 @@ func (s *State) AllHostnames() []string {
 	}
 
 	return out
-}
-
-// Alive detects if the specified node is a member and in Alive state, including self.
-func (s *State) Alive(nodeName string) bool {
-	if s.list == nil {
-		return false
-	}
-	for _, mem := range s.list.Members() {
-		if mem.Name == nodeName {
-			return true
-		}
-	}
-	return false
 }
 
 // All node names (not their hostnames!) for live members, including self.


### PR DESCRIPTION
### What's being changed:
there was a bug in the recovery part, were we detected if the node alive or not but didn't update the node new IP addr. for raft config and that was causing node to end up in stale state because when they try to recover they were supplied the old IP address not the new one even though the node is alive.

this PR changes the logic to always update the node IP to the new IP by getting the node by it's ID from the memberlist using `NodeHostName()`

**Tested with helm** 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
