### PR TITLE
Allow for the go profiler to be hosted on ports other than 6060

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -902,11 +902,11 @@ func reasonableHttpClient(authConfig cluster.AuthConfig) *http.Client {
 
 func setupGoProfiling(config config.Config) {
 	go func() {
-		portNumber, present := os.LookupEnv("PORT_NUMBER")
-		if present {
-			fmt.Println(http.ListenAndServe(":"+portNumber, nil))
-		} else {
+		portNumber := config.Profiling.Port
+		if portNumber == 0 {
 			fmt.Println(http.ListenAndServe(":6060", nil))
+		} else {
+			http.ListenAndServe(fmt.Sprintf(":%d", portNumber), nil)
 		}
 	}()
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -902,7 +902,12 @@ func reasonableHttpClient(authConfig cluster.AuthConfig) *http.Client {
 
 func setupGoProfiling(config config.Config) {
 	go func() {
-		fmt.Println(http.ListenAndServe(":6060", nil))
+		portNumber, present := os.LookupEnv("PORT_NUMBER")
+		if present {
+			fmt.Println(http.ListenAndServe(":"+portNumber, nil))
+		} else {
+			fmt.Println(http.ListenAndServe(":6060", nil))
+		}
 	}()
 
 	if config.Profiling.BlockProfileRate > 0 {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -194,6 +194,7 @@ type GRPC struct {
 type Profiling struct {
 	BlockProfileRate     int `json:"blockProfileRate" yaml:"blockProfileRate"`
 	MutexProfileFraction int `json:"mutexProfileFraction" yaml:"mutexProfileFraction"`
+	Port                 int `json:"port" yaml:"port"`
 }
 
 type Persistence struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -81,6 +81,15 @@ func FromEnv(config *Config) error {
 		config.Monitoring.Port = asInt
 	}
 
+	if v := os.Getenv("PROFILING_PORT"); v != "" {
+		asInt, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("parse PROFILING_PORT as int: %w", err)
+		}
+
+		config.Profiling.Port = asInt
+	}
+
 	if Enabled(os.Getenv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED")) {
 		config.Authentication.AnonymousAccess.Enabled = true
 	}


### PR DESCRIPTION
Mentioned in #4235  

### What's being changed:

Optional environment variable PORT_NUMBER added for go profiler in the rest client handler

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
