### PR TITLE
Prevent Schema Deadlock: Split IncomingCommit into locked/unlocked parts

### DIFF
--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -466,32 +466,69 @@ func (c *TxManager) IncomingCommitTransaction(ctx context.Context,
 	c.ongoingCommits.Add(1)
 	defer c.ongoingCommits.Done()
 
+	// requires locking because it accesses c.currentTransaction
+	txCopy, err := c.incomingCommitTxValidate(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	// cannot use locking because of risk of deadlock, see comment inside method
+	if err := c.incomingTxCommitApplyCommitFn(ctx, txCopy); err != nil {
+		return err
+	}
+
+	// requires locking because it accesses c.currentTransaction
+	return c.incomingTxCommitCleanup(ctx, tx)
+}
+
+func (c *TxManager) incomingCommitTxValidate(
+	ctx context.Context, tx *Transaction,
+) (*Transaction, error) {
 	c.Lock()
 	defer c.Unlock()
 
 	if !c.acceptIncoming {
-		return ErrNotReady
+		return nil, ErrNotReady
 	}
 
 	if c.currentTransaction == nil || c.currentTransaction.ID != tx.ID {
 		expired := c.expired(tx.ID)
 		if expired {
-			return ErrExpiredTransaction
+			return nil, ErrExpiredTransaction
 		}
-		return ErrInvalidTransaction
+		return nil, ErrInvalidTransaction
 	}
 
+	txCopy := *c.currentTransaction
+	return &txCopy, nil
+}
+
+func (c *TxManager) incomingTxCommitApplyCommitFn(
+	ctx context.Context, tx *Transaction,
+) error {
+	// Important: Do not hold the c.Lock() while applying the commitFn. The
+	// c.Lock() is only meant to make access to c.currentTransaction thread-safe.
+	// If we would hold it during apply, there is a risk for a deadlock because
+	// apply will likely lock the schema Manager. The schema Manager itself
+	// however, might be waiting for the TxManager in case of concurrent
+	// requests.
+	// See https://github.com/weaviate/weaviate/issues/4312 for steps on how to
+	// reproduce
+	//
 	// use transaction from cache, not passed in for two reason: a. protect
 	// against the transaction being manipulated after being created, b. allow
 	// an "empty" transaction that only contains the id for less network overhead
 	// (we don't need to pass the payload around anymore, after it's successfully
 	// opened - every node has a copy of the payload now)
-	err := c.commitFn(ctx, c.currentTransaction)
-	if err != nil {
-		return err
-	}
+	return c.commitFn(ctx, tx)
+}
 
+func (c *TxManager) incomingTxCommitCleanup(
+	ctx context.Context, tx *Transaction,
+) error {
 	// TODO: only clean up on success - does this make sense?
+	c.Lock()
+	defer c.Unlock()
 	c.currentTransaction = nil
 
 	if err := c.persistence.DeleteTx(ctx, tx.ID); err != nil {


### PR DESCRIPTION
### What's being changed:
- Split `TxManager.IncomingCommitTransaction` into three parts
- Previously, it would hold the `TxManager.Lock()` for the entire duration
- However, that lock is only designed to protect against accessing `.currentTransaction`
- It is not needed for mutual exclusion of running Commit operations. They are already mutually exclusive because there can only be one Tx at a time
- This lead to a circular kind of deadlock as described in #4312 because the TxManager might be waiting for the SchemaManager which is in turn waiting for the TxManager under concurrent load
- The fix now only holds the lock while accessing variables that need to be protected, but no longer holds the lock while running the `commitFn` which in turn locks the SchemaManager
- fixes #4312 

### Notes
The entire tx logic (and therefore both the bug and this fix) will go away with #4280 (to be released in `v1.25`), however, we cannot predict what update journeys are going to be like, so a fix for old versions will still come in very handy.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not yet - will do
- [x] All new code is covered by tests where it is reasonable: Tested through the [multi-tenancy-loadtest](https://github.com/weaviate/multi-tenancy-load-test/issues/3) where it was first discovered. Another manual way to validate this is outlined in #4312.
- [ ] Performance tests have been run or not necessary.
