### PR TITLE
autoSchema: Optimizing Property Merging

### DIFF
--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -118,7 +118,7 @@ func (s *schemaHandlers) deleteClass(params schema.SchemaObjectsDeleteParams, pr
 func (s *schemaHandlers) addClassProperty(params schema.SchemaObjectsPropertiesAddParams,
 	principal *models.Principal,
 ) middleware.Responder {
-	err := s.manager.AddClassProperty(params.HTTPRequest.Context(), principal, params.ClassName, params.Body)
+	err := s.manager.UpdateClassProperty(params.HTTPRequest.Context(), principal, s.manager.ReadOnlyClass(params.ClassName), false, params.Body)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch err.(type) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -399,16 +399,18 @@ func (i *Index) IterateShards(ctx context.Context, cb func(index *Index, shard S
 	})
 }
 
-func (i *Index) addProperty(ctx context.Context, prop *models.Property) error {
+func (i *Index) addProperty(ctx context.Context, props ...*models.Property) error {
 	eg := &errgroup.Group{}
 	eg.SetLimit(_NUMCPU)
 
-	i.ForEachShard(func(key string, shard ShardLike) error {
-		shard.createPropertyIndex(ctx, prop, eg)
-		return nil
-	})
-	if err := eg.Wait(); err != nil {
-		return errors.Wrapf(err, "extend idx '%s' with property '%s", i.ID(), prop.Name)
+	for _, prop := range props {
+		i.ForEachShard(func(key string, shard ShardLike) error {
+			shard.createPropertyIndex(ctx, prop, eg)
+			return nil
+		})
+		if err := eg.Wait(); err != nil {
+			return errors.Wrapf(err, "extend idx '%s' with property '%s", i.ID(), prop.Name)
+		}
 	}
 	return nil
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -112,13 +112,13 @@ func (m *Migrator) UpdateClass(ctx context.Context, className string, newClassNa
 	return nil
 }
 
-func (m *Migrator) AddProperty(ctx context.Context, className string, prop *models.Property) error {
+func (m *Migrator) AddProperty(ctx context.Context, className string, prop ...*models.Property) error {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		return errors.Errorf("cannot add property to a non-existing index for %s", className)
 	}
 
-	return idx.addProperty(ctx, prop)
+	return idx.addProperty(ctx, prop...)
 }
 
 // DropProperty is ignored, API compliant change

--- a/cloud/proto/cluster/request.go
+++ b/cloud/proto/cluster/request.go
@@ -27,7 +27,7 @@ type UpdateClassRequest struct {
 }
 
 type AddPropertyRequest struct {
-	*models.Property
+	Properties []*models.Property
 }
 
 type DeleteClassRequest struct {

--- a/cloud/store/db.go
+++ b/cloud/store/db.go
@@ -98,13 +98,13 @@ func (db *localDB) AddProperty(cmd *command.ApplyRequest, schemaOnly bool) error
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
 	}
-	if req.Property == nil {
-		return fmt.Errorf("%w: nil property", errBadRequest)
+	if req.Properties == nil || len(req.Properties) == 0 {
+		return fmt.Errorf("%w: empty property", errBadRequest)
 	}
 
 	return db.apply(
 		cmd.GetType().String(),
-		func() error { return db.Schema.addProperty(cmd.Class, *req.Property) },
+		func() error { return db.Schema.addProperty(cmd.Class, req.Properties...) },
 		func() error { return db.store.AddProperty(cmd.Class, req) },
 		schemaOnly)
 }

--- a/cloud/store/schema.go
+++ b/cloud/store/schema.go
@@ -91,7 +91,7 @@ func (s *schema) deleteClass(name string) {
 	delete(s.Classes, name)
 }
 
-func (s *schema) addProperty(class string, p models.Property) error {
+func (s *schema) addProperty(class string, props ...*models.Property) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -102,9 +102,8 @@ func (s *schema) addProperty(class string, p models.Property) error {
 
 	// update all at once to prevent race condition with concurrent readers
 	src := info.Class.Properties
-	dest := make([]*models.Property, len(src)+1)
-	copy(dest, src)
-	dest[len(src)] = &p
+	dest := make([]*models.Property, len(src)+len(props))
+	copy(dest, append(src, props...))
 	info.Class.Properties = dest
 	return nil
 }

--- a/cloud/store/service.go
+++ b/cloud/store/service.go
@@ -118,11 +118,13 @@ func (s *Service) RestoreClass(cls *models.Class, ss *sharding.State) error {
 	return s.Execute(command)
 }
 
-func (s *Service) AddProperty(class string, p *models.Property) error {
-	if p == nil || p.Name == "" || class == "" {
-		return fmt.Errorf("empty property or empty class name : %w", errBadRequest)
+func (s *Service) AddProperty(class string, props ...*models.Property) error {
+	for _, p := range props {
+		if p == nil || p.Name == "" || class == "" {
+			return fmt.Errorf("empty property or empty class name : %w", errBadRequest)
+		}
 	}
-	req := cmd.AddPropertyRequest{Property: p}
+	req := cmd.AddPropertyRequest{Properties: props}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)

--- a/cloud/store/store_test.go
+++ b/cloud/store/store_test.go
@@ -428,7 +428,7 @@ func TestStoreApply(t *testing.T) {
 		{
 			name: "AddProperty/ClassNotFound",
 			req: raft.Log{Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_PROPERTY,
-				cmd.AddPropertyRequest{Property: &models.Property{Name: "P1"}}, nil)},
+				cmd.AddPropertyRequest{Properties: []*models.Property{{Name: "P1"}}}, nil)},
 			resp:     Response{Error: errSchema},
 			doBefore: doFirst,
 		},
@@ -436,7 +436,7 @@ func TestStoreApply(t *testing.T) {
 			name: "AddProperty/Nil",
 			req: raft.Log{
 				Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_PROPERTY,
-					cmd.AddPropertyRequest{Property: nil}, nil),
+					cmd.AddPropertyRequest{Properties: nil}, nil),
 			},
 			resp: Response{Error: errBadRequest},
 			doBefore: func(m *MockStore) {
@@ -448,7 +448,7 @@ func TestStoreApply(t *testing.T) {
 			name: "AddProperty/Success",
 			req: raft.Log{
 				Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_PROPERTY,
-					cmd.AddPropertyRequest{Property: &models.Property{Name: "P1"}}, nil),
+					cmd.AddPropertyRequest{Properties: []*models.Property{{Name: "P1"}}}, nil),
 			},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -34,10 +34,8 @@ type schemaManager interface {
 	) (*models.Class, error)
 	// ReadOnlyClass return class model.
 	ReadOnlyClass(name string) *models.Class
-	AddClassProperty(ctx context.Context, principal *models.Principal,
-		class string, property *models.Property) error
-	MergeClassObjectProperty(ctx context.Context, principal *models.Principal,
-		class string, property *models.Property) error
+	UpdateClassProperty(ctx context.Context, principal *models.Principal,
+		class *models.Class, merge bool, prop ...*models.Property) error
 	MultiTenancy(class string) models.MultiTenancyConfig
 }
 

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
-	cloud_utils "github.com/weaviate/weaviate/cloud/utils"
+	"github.com/weaviate/weaviate/cloud/utils"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -88,8 +88,8 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 		if schemaClass == nil {
 			return m.createClass(ctx, principal, object.Class, properties)
 		}
-		return m.updateClass(ctx, principal, object.Class, properties, schemaClass.Properties)
-	}, cloud_utils.NewBackoff())
+		return m.schemaManager.UpdateClassProperty(ctx, principal, schemaClass, true, properties...)
+	}, utils.NewBackoff())
 }
 
 func (m *autoSchemaManager) createClass(ctx context.Context, principal *models.Principal,
@@ -105,50 +105,6 @@ func (m *autoSchemaManager) createClass(ctx context.Context, principal *models.P
 		WithField("auto_schema", "createClass").
 		Debugf("create class %s", className)
 	return m.schemaManager.AddClass(ctx, principal, class)
-}
-
-func (m *autoSchemaManager) updateClass(ctx context.Context, principal *models.Principal,
-	className string, properties []*models.Property, existingProperties []*models.Property,
-) error {
-	existingPropertiesIndexMap := make(map[string]int, len(existingProperties))
-	for index := range existingProperties {
-		existingPropertiesIndexMap[existingProperties[index].Name] = index
-	}
-
-	propertiesToAdd := []*models.Property{}
-	propertiesToUpdate := []*models.Property{}
-	for _, prop := range properties {
-		index, exists := existingPropertiesIndexMap[schema.LowercaseFirstLetter(prop.Name)]
-		if !exists {
-			propertiesToAdd = append(propertiesToAdd, prop)
-		} else if _, isNested := schema.AsNested(existingProperties[index].DataType); isNested {
-			mergedNestedProperties, merged := schema.MergeRecursivelyNestedProperties(existingProperties[index].NestedProperties,
-				prop.NestedProperties)
-			if merged {
-				prop.NestedProperties = mergedNestedProperties
-				propertiesToUpdate = append(propertiesToUpdate, prop)
-			}
-		}
-	}
-	for _, newProp := range propertiesToAdd {
-		m.logger.
-			WithField("auto_schema", "updateClass").
-			Debugf("update class %s add property %s", className, newProp.Name)
-		err := m.schemaManager.AddClassProperty(ctx, principal, className, newProp)
-		if err != nil {
-			return err
-		}
-	}
-	for _, updatedProp := range propertiesToUpdate {
-		m.logger.
-			WithField("auto_schema", "updateClass").
-			Debugf("update class %s merge object property %s", className, updatedProp.Name)
-		err := m.schemaManager.MergeClassObjectProperty(ctx, principal, className, updatedProp)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (m *autoSchemaManager) getProperties(object *models.Object) ([]*models.Property, error) {

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -70,14 +70,8 @@ func Test_Schema_Authorization(t *testing.T) {
 			expectedResource: "schema/objects",
 		},
 		{
-			methodName:       "AddClassProperty",
-			additionalArgs:   []interface{}{"somename", &models.Property{}},
-			expectedVerb:     "update",
-			expectedResource: "schema/objects",
-		},
-		{
-			methodName:       "MergeClassObjectProperty",
-			additionalArgs:   []interface{}{"somename", &models.Property{}},
+			methodName:       "UpdateClassProperty",
+			additionalArgs:   []interface{}{&models.Class{}, false, &models.Property{}},
 			expectedVerb:     "update",
 			expectedResource: "schema/objects",
 		},

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -212,57 +212,63 @@ func (h *Handler) setClassDefaults(class *models.Class) {
 	h.moduleConfig.SetClassDefaults(class)
 }
 
-func setPropertyDefaults(prop *models.Property) {
-	setPropertyDefaultTokenization(prop)
-	setPropertyDefaultIndexing(prop)
-	setNestedPropertiesDefaults(prop.NestedProperties)
-}
-
-func setPropertyDefaultTokenization(prop *models.Property) {
-	switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
-	case schema.DataTypeString, schema.DataTypeStringArray:
-		// deprecated as of v1.19, default tokenization was word
-		// which will be migrated to text+whitespace
-		if prop.Tokenization == "" {
-			prop.Tokenization = models.PropertyTokenizationWord
-		}
-	case schema.DataTypeText, schema.DataTypeTextArray:
-		if prop.Tokenization == "" {
-			if os.Getenv("DEFAULT_TOKENIZATION") != "" {
-				prop.Tokenization = os.Getenv("DEFAULT_TOKENIZATION")
-			} else {
-				prop.Tokenization = models.PropertyTokenizationWord
-			}
-		}
-	default:
-		// tokenization not supported for other data types
+func setPropertyDefaults(props ...*models.Property) {
+	setPropertyDefaultTokenization(props...)
+	setPropertyDefaultIndexing(props...)
+	for _, prop := range props {
+		setNestedPropertiesDefaults(prop.NestedProperties)
 	}
 }
 
-func setPropertyDefaultIndexing(prop *models.Property) {
-	// if IndexInverted is set but IndexFilterable and IndexSearchable are not
-	// migrate IndexInverted later.
-	if prop.IndexInverted != nil &&
-		prop.IndexFilterable == nil &&
-		prop.IndexSearchable == nil {
-		return
-	}
-
-	vTrue := true
-	if prop.IndexFilterable == nil {
-		prop.IndexFilterable = &vTrue
-	}
-	if prop.IndexSearchable == nil {
+func setPropertyDefaultTokenization(props ...*models.Property) {
+	for _, prop := range props {
 		switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
 		case schema.DataTypeString, schema.DataTypeStringArray:
-			// string/string[] are migrated to text/text[] later,
-			// at this point they are still valid data types, therefore should be handled here
-			prop.IndexSearchable = &vTrue
+			// deprecated as of v1.19, default tokenization was word
+			// which will be migrated to text+whitespace
+			if prop.Tokenization == "" {
+				prop.Tokenization = models.PropertyTokenizationWord
+			}
 		case schema.DataTypeText, schema.DataTypeTextArray:
-			prop.IndexSearchable = &vTrue
+			if prop.Tokenization == "" {
+				if os.Getenv("DEFAULT_TOKENIZATION") != "" {
+					prop.Tokenization = os.Getenv("DEFAULT_TOKENIZATION")
+				} else {
+					prop.Tokenization = models.PropertyTokenizationWord
+				}
+			}
 		default:
-			vFalse := false
-			prop.IndexSearchable = &vFalse
+			// tokenization not supported for other data types
+		}
+	}
+}
+
+func setPropertyDefaultIndexing(props ...*models.Property) {
+	for _, prop := range props {
+		// if IndexInverted is set but IndexFilterable and IndexSearchable are not
+		// migrate IndexInverted later.
+		if prop.IndexInverted != nil &&
+			prop.IndexFilterable == nil &&
+			prop.IndexSearchable == nil {
+			continue
+		}
+
+		vTrue := true
+		if prop.IndexFilterable == nil {
+			prop.IndexFilterable = &vTrue
+		}
+		if prop.IndexSearchable == nil {
+			switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
+			case schema.DataTypeString, schema.DataTypeStringArray:
+				// string/string[] are migrated to text/text[] later,
+				// at this point they are still valid data types, therefore should be handled here
+				prop.IndexSearchable = &vTrue
+			case schema.DataTypeText, schema.DataTypeTextArray:
+				prop.IndexSearchable = &vTrue
+			default:
+				vFalse := false
+				prop.IndexSearchable = &vFalse
+			}
 		}
 	}
 }
@@ -330,30 +336,32 @@ func (h *Handler) migrateClassSettings(class *models.Class) {
 	}
 }
 
-func migratePropertySettings(prop *models.Property) {
-	migratePropertyDataTypeAndTokenization(prop)
-	migratePropertyIndexInverted(prop)
+func migratePropertySettings(props ...*models.Property) {
+	migratePropertyDataTypeAndTokenization(props...)
+	migratePropertyIndexInverted(props...)
 }
 
 // as of v1.19 DataTypeString and DataTypeStringArray are deprecated
 // here both are changed to Text/TextArray
 // and proper, backward compatible tokenization
-func migratePropertyDataTypeAndTokenization(prop *models.Property) {
-	switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
-	case schema.DataTypeString:
-		prop.DataType = schema.DataTypeText.PropString()
-	case schema.DataTypeStringArray:
-		prop.DataType = schema.DataTypeTextArray.PropString()
-	default:
-		// other types need no migration and do not support tokenization
-		return
-	}
+func migratePropertyDataTypeAndTokenization(props ...*models.Property) {
+	for _, prop := range props {
+		switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
+		case schema.DataTypeString:
+			prop.DataType = schema.DataTypeText.PropString()
+		case schema.DataTypeStringArray:
+			prop.DataType = schema.DataTypeTextArray.PropString()
+		default:
+			// other types need no migration and do not support tokenization
+			continue
+		}
 
-	switch prop.Tokenization {
-	case models.PropertyTokenizationWord:
-		prop.Tokenization = models.PropertyTokenizationWhitespace
-	case models.PropertyTokenizationField:
-		// stays field
+		switch prop.Tokenization {
+		case models.PropertyTokenizationWord:
+			prop.Tokenization = models.PropertyTokenizationWhitespace
+		case models.PropertyTokenizationField:
+			// stays field
+		}
 	}
 }
 
@@ -361,68 +369,71 @@ func migratePropertyDataTypeAndTokenization(prop *models.Property) {
 // IndexFilterable (set inverted index)
 // and IndexSearchable (map inverted index with term frequencies;
 // therefore applicable only to text/text[] data types)
-func migratePropertyIndexInverted(prop *models.Property) {
-	// if none of new options is set, use inverted settings
-	if prop.IndexInverted != nil &&
-		prop.IndexFilterable == nil &&
-		prop.IndexSearchable == nil {
-		prop.IndexFilterable = prop.IndexInverted
-		switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
-		// string/string[] are already migrated into text/text[], can be skipped here
-		case schema.DataTypeText, schema.DataTypeTextArray:
-			prop.IndexSearchable = prop.IndexInverted
-		default:
-			vFalse := false
-			prop.IndexSearchable = &vFalse
+func migratePropertyIndexInverted(props ...*models.Property) {
+	for _, prop := range props {
+		// if none of new options is set, use inverted settings
+		if prop.IndexInverted != nil &&
+			prop.IndexFilterable == nil &&
+			prop.IndexSearchable == nil {
+			prop.IndexFilterable = prop.IndexInverted
+			switch dataType, _ := schema.AsPrimitive(prop.DataType); dataType {
+			// string/string[] are already migrated into text/text[], can be skipped here
+			case schema.DataTypeText, schema.DataTypeTextArray:
+				prop.IndexSearchable = prop.IndexInverted
+			default:
+				vFalse := false
+				prop.IndexSearchable = &vFalse
+			}
 		}
+		// new options have precedence so inverted can be reset
+		prop.IndexInverted = nil
 	}
-	// new options have precedence so inverted can be reset
-	prop.IndexInverted = nil
 }
 
 func (h *Handler) validateProperty(
-	property *models.Property, className string,
-	existingPropertyNames map[string]bool, relaxCrossRefValidation bool,
+	className string, existingPropertyNames map[string]bool,
+	relaxCrossRefValidation bool, props ...*models.Property,
 ) error {
-	if _, err := schema.ValidatePropertyName(property.Name); err != nil {
-		return err
-	}
-
-	if err := schema.ValidateReservedPropertyName(property.Name); err != nil {
-		return err
-	}
-
-	if existingPropertyNames[strings.ToLower(property.Name)] {
-		return fmt.Errorf("class %q: conflict for property %q: already in use or provided multiple times", property.Name, className)
-	}
-
-	// Validate data type of property.
-	propertyDataType, err := schema.FindPropertyDataTypeWithRefs(h.metaReader.ReadOnlyClass, property.DataType,
-		relaxCrossRefValidation, schema.ClassName(className))
-	if err != nil {
-		return fmt.Errorf("property '%s': invalid dataType: %v", property.Name, err)
-	}
-
-	if propertyDataType.IsNested() {
-		if err := validateNestedProperties(property.NestedProperties, property.Name); err != nil {
+	for _, property := range props {
+		if _, err := schema.ValidatePropertyName(property.Name); err != nil {
 			return err
 		}
-	} else {
-		if len(property.NestedProperties) > 0 {
-			return fmt.Errorf("property '%s': nestedProperties not allowed for data types other than object/object[]",
-				property.Name)
+
+		if err := schema.ValidateReservedPropertyName(property.Name); err != nil {
+			return err
+		}
+
+		if existingPropertyNames[strings.ToLower(property.Name)] {
+			return fmt.Errorf("class %q: conflict for property %q: already in use or provided multiple times", property.Name, className)
+		}
+
+		// Validate data type of property.
+		propertyDataType, err := schema.FindPropertyDataTypeWithRefs(h.metaReader.ReadOnlyClass, property.DataType,
+			relaxCrossRefValidation, schema.ClassName(className))
+		if err != nil {
+			return fmt.Errorf("property '%s': invalid dataType: %v", property.Name, err)
+		}
+
+		if propertyDataType.IsNested() {
+			if err := validateNestedProperties(property.NestedProperties, property.Name); err != nil {
+				return err
+			}
+		} else {
+			if len(property.NestedProperties) > 0 {
+				return fmt.Errorf("property '%s': nestedProperties not allowed for data types other than object/object[]",
+					property.Name)
+			}
+		}
+
+		if err := h.validatePropertyTokenization(property.Tokenization, propertyDataType); err != nil {
+			return err
+		}
+
+		if err := h.validatePropertyIndexing(property); err != nil {
+			return err
 		}
 	}
 
-	if err := h.validatePropertyTokenization(property.Tokenization, propertyDataType); err != nil {
-		return err
-	}
-
-	if err := h.validatePropertyIndexing(property); err != nil {
-		return err
-	}
-
-	// all is fine!
 	return nil
 }
 
@@ -459,7 +470,7 @@ func (h *Handler) validateCanAddClass(
 
 	existingPropertyNames := map[string]bool{}
 	for _, property := range class.Properties {
-		if err := h.validateProperty(property, class.Class, existingPropertyNames, relaxCrossRefValidation); err != nil {
+		if err := h.validateProperty(class.Class, existingPropertyNames, relaxCrossRefValidation, property); err != nil {
 			return err
 		}
 		existingPropertyNames[strings.ToLower(property.Name)] = true

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -442,7 +442,7 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 				fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
 				fakeMetaHandler.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
 				t.Run("added_"+tc.propName, func(t *testing.T) {
-					err := handler.AddClassProperty(ctx, nil, className, &models.Property{
+					err := handler.UpdateClassProperty(ctx, nil, &class, false, &models.Property{
 						Name:         "added_" + tc.propName,
 						DataType:     tc.dataType.PropString(),
 						Tokenization: tc.tokenization,
@@ -613,9 +613,8 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 						IndexFilterable: tc.indexFilterable,
 						IndexSearchable: tc.indexSearchable,
 					}
-					fakeMetaHandler.On("AddProperty", className, prop).Return(nil)
-					fakeMetaHandler.On("ReadOnlyClass", className).Return(&class)
-					err := handler.AddClassProperty(ctx, nil, className, prop)
+					fakeMetaHandler.On("AddProperty", className, []*models.Property{prop}).Return(nil)
+					err := handler.UpdateClassProperty(ctx, nil, &class, false, prop)
 
 					require.Nil(t, err)
 				})
@@ -936,13 +935,10 @@ func Test_Validation_PropertyNames(t *testing.T) {
 						DataType: schema.DataTypeText.PropString(),
 						Name:     test.input,
 					}
-					if test.input != "" {
-						fakeMetaHandler.On("ReadOnlyClass", class.Class).Return(class)
-					}
 					if test.valid {
-						fakeMetaHandler.On("AddProperty", class.Class, property).Return(nil)
+						fakeMetaHandler.On("AddProperty", class.Class, []*models.Property{property}).Return(nil)
 					}
-					err = handler.AddClassProperty(context.Background(), nil, "ValidName", property)
+					err = handler.UpdateClassProperty(context.Background(), nil, class, false, property)
 					t.Log(err)
 					require.Equal(t, test.valid, err == nil)
 					fakeMetaHandler.AssertExpectations(t)

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -97,7 +97,7 @@ func (e *executor) DeleteClass(cls string) error {
 func (e *executor) AddProperty(className string, req cluster.AddPropertyRequest) error {
 	ctx := context.Background()
 	e.triggerSchemaUpdateCallbacks()
-	return e.migrator.AddProperty(ctx, className, req.Property)
+	return e.migrator.AddProperty(ctx, className, req.Properties...)
 }
 
 func (e *executor) AddTenants(class string, req *cluster.AddTenantsRequest) error {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -109,8 +109,8 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("AddProperty", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		req := cluster.AddPropertyRequest{Property: &models.Property{}}
-		migrator.On("AddProperty", Anything, "A", req.Property).Return(nil)
+		req := cluster.AddPropertyRequest{Properties: []*models.Property{}}
+		migrator.On("AddProperty", Anything, "A", req.Properties).Return(nil)
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.AddProperty("A", req))
 	})

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -48,7 +48,7 @@ func (f *fakeMetaHandler) DeleteClass(name string) error {
 	return args.Error(0)
 }
 
-func (f *fakeMetaHandler) AddProperty(class string, p *models.Property) error {
+func (f *fakeMetaHandler) AddProperty(class string, p ...*models.Property) error {
 	args := f.Called(class, p)
 	return args.Error(0)
 }

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -34,7 +34,7 @@ type metaWriter interface {
 	RestoreClass(cls *models.Class, ss *sharding.State) error
 	UpdateClass(cls *models.Class, ss *sharding.State) error
 	DeleteClass(name string) error
-	AddProperty(class string, p *models.Property) error
+	AddProperty(class string, p ...*models.Property) error
 	UpdateShardStatus(class, shard, status string) error
 	AddTenants(class string, req *command.AddTenantsRequest) error
 	UpdateTenants(class string, req *command.UpdateTenantsRequest) error

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -308,7 +308,7 @@ func (f *fakeMigrator) DropClass(ctx context.Context, className string) error {
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) AddProperty(ctx context.Context, className string, prop *models.Property) error {
+func (f *fakeMigrator) AddProperty(ctx context.Context, className string, prop ...*models.Property) error {
 	args := f.Called(ctx, className, prop)
 	return args.Error(0)
 }

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -40,7 +40,7 @@ type Migrator interface {
 	GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error)
 
 	AddProperty(ctx context.Context, className string,
-		prop *models.Property) error
+		prop ...*models.Property) error
 	UpdateProperty(ctx context.Context, className string,
 		propName string, newName *string) error
 

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -71,6 +71,8 @@ func (h *Handler) UpdateClassProperty(ctx context.Context, principal *models.Pri
 	migratePropertySettings(newProps...)
 
 	// TODO-RAFT use UpdateProperty() for adding/merging property when index idempotence exists
+	// we don't support updating property in index atm,
+	// h.metaWriter.UpdateClass() and h.metaWriter.AddProperty() should be replaced by h.metaWriter.UpdateProperty
 	new, old := split(class.Properties, newProps)
 	if len(old) > 0 {
 		for _, p := range old {

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -23,41 +23,97 @@ import (
 
 var errPropertyNotFound = errors.New("property not found")
 
-// AddClassProperty to an existing Class
-func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Principal,
-	class string, prop *models.Property,
+func (h *Handler) UpdateClassProperty(ctx context.Context, principal *models.Principal,
+	class *models.Class, merge bool, newProps ...*models.Property,
 ) error {
 	err := h.Authorizer.Authorize(principal, "update", "schema/objects")
 	if err != nil {
 		return err
 	}
 
-	if prop.Name == "" {
-		return fmt.Errorf("property must contain name")
-	}
-	prop.Name = schema.LowercaseFirstLetter(prop.Name)
-	if prop.DataType == nil {
-		return fmt.Errorf("property must contain dataType")
-	}
-
-	cls := h.metaReader.ReadOnlyClass(class)
-	if cls == nil {
-		return fmt.Errorf("class %q: %w", class, ErrNotFound)
+	// validate new props
+	for _, prop := range newProps {
+		if prop.Name == "" {
+			return fmt.Errorf("property must contain name")
+		}
+		prop.Name = schema.LowercaseFirstLetter(prop.Name)
+		if prop.DataType == nil {
+			return fmt.Errorf("property must contain dataType")
+		}
 	}
 
-	existing := map[string]bool{}
-	for _, p := range cls.Properties {
-		existing[strings.ToLower(p.Name)] = true
+	existingNames := map[string]bool{}
+	for _, p := range class.Properties {
+		existingNames[strings.ToLower(p.Name)] = true
 	}
 
-	if err := h.setNewPropDefaults(cls, prop); err != nil {
+	// normalize the new props
+	for _, p := range newProps {
+		_, ex := existingNames[strings.ToLower(p.Name)]
+		existingNames[strings.ToLower(p.Name)] = ex
+	}
+
+	if err := h.setNewPropDefaults(class, newProps...); err != nil {
 		return err
 	}
-	if err := h.validateProperty(prop, class, existing, false); err != nil {
-		return err
+
+	if merge {
+		// clear in case if we want to merge
+		if err := h.validateProperty(class.Class, map[string]bool{}, false, newProps...); err != nil {
+			return err
+		}
+	} else {
+		if err := h.validateProperty(class.Class, existingNames, false, newProps...); err != nil {
+			return err
+		}
 	}
-	migratePropertySettings(prop)
-	return h.metaWriter.AddProperty(class, prop)
+
+	migratePropertySettings(newProps...)
+
+	// TODO-RAFT use UpdateProperty() for adding/merging property when index idempotence exists
+	new, old := split(class.Properties, newProps)
+	if len(old) > 0 {
+		for _, p := range old {
+			if existingNames[strings.ToLower(p.Name)] {
+				if err = mergeObjectProperty(class, p); err != nil {
+					return err
+				}
+			}
+		}
+		if err = h.metaWriter.UpdateClass(class, nil); err != nil {
+			return err
+		}
+	}
+
+	if len(new) == 0 {
+		return nil
+	}
+	return h.metaWriter.AddProperty(class.Class, new...)
+}
+
+// split does split the passed properties based in their existence
+// it shouldn't be needed once we have idempotence on Add/Update Property
+// it's used to mark shall the index be updated or not
+func split(old, new []*models.Property) (propertiesToAdd, propertiesToUpdate []*models.Property) {
+	exPropMap := make(map[string]int, len(old))
+	for index := range old {
+		exPropMap[old[index].Name] = index
+	}
+
+	for _, prop := range new {
+		index, exists := exPropMap[schema.LowercaseFirstLetter(prop.Name)]
+		if !exists {
+			propertiesToAdd = append(propertiesToAdd, prop)
+		} else if _, isNested := schema.AsNested(old[index].DataType); isNested {
+			mergedNestedProperties, merged := schema.MergeRecursivelyNestedProperties(old[index].NestedProperties,
+				prop.NestedProperties)
+			if merged {
+				prop.NestedProperties = mergedNestedProperties
+				propertiesToUpdate = append(propertiesToUpdate, prop)
+			}
+		}
+	}
+	return
 }
 
 // DeleteClassProperty from existing Schema
@@ -78,30 +134,35 @@ func (h *Handler) DeleteClassProperty(ctx context.Context, principal *models.Pri
 	// return h.deleteClassProperty(ctx, class, property, kind.Action)
 }
 
-func (h *Handler) setNewPropDefaults(class *models.Class, prop *models.Property) error {
-	setPropertyDefaults(prop)
-	if err := validateUserProp(class, prop); err != nil {
+func (h *Handler) setNewPropDefaults(class *models.Class, props ...*models.Property) error {
+	setPropertyDefaults(props...)
+	if err := validateUserProp(class, props...); err != nil {
 		return err
 	}
-	h.moduleConfig.SetSinglePropertyDefaults(class, prop)
+
+	for _, prop := range props {
+		h.moduleConfig.SetSinglePropertyDefaults(class, prop)
+	}
 	return nil
 }
 
-func validateUserProp(class *models.Class, prop *models.Property) error {
-	if prop.ModuleConfig == nil {
-		return nil
-	} else {
-		modconfig, ok := prop.ModuleConfig.(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("%v property config invalid", prop.Name)
-		}
-		vectorizerConfig, ok := modconfig[class.Vectorizer]
-		if !ok {
-			return fmt.Errorf("%v vectorizer module not part of the property", class.Vectorizer)
-		}
-		_, ok = vectorizerConfig.(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("vectorizer config for vectorizer %v, not of type map[string]interface{}", class.Vectorizer)
+func validateUserProp(class *models.Class, props ...*models.Property) error {
+	for _, prop := range props {
+		if prop.ModuleConfig == nil {
+			continue
+		} else {
+			modconfig, ok := prop.ModuleConfig.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("%v property config invalid", prop.Name)
+			}
+			vectorizerConfig, ok := modconfig[class.Vectorizer]
+			if !ok {
+				return fmt.Errorf("%v vectorizer module not part of the property", class.Vectorizer)
+			}
+			_, ok = vectorizerConfig.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("vectorizer config for vectorizer %v, not of type map[string]interface{}", class.Vectorizer)
+			}
 		}
 	}
 	return nil
@@ -120,51 +181,5 @@ func mergeObjectProperty(c *models.Class, p *models.Property) error {
 	}
 
 	prop.NestedProperties, _ = schema.MergeRecursivelyNestedProperties(prop.NestedProperties, p.NestedProperties)
-	return nil
-}
-
-// MergeClassObjectProperty of an existing Class
-// Merges NestedProperties of incoming object/object[] property into existing one
-func (h *Handler) MergeClassObjectProperty(
-	ctx context.Context,
-	principal *models.Principal,
-	className string,
-	prop *models.Property,
-) error {
-	err := h.Authorizer.Authorize(principal, "update", "schema/objects")
-	if err != nil {
-		return err
-	}
-
-	class := h.metaReader.ReadOnlyClass(className)
-	prop.Name = schema.LowercaseFirstLetter(prop.Name)
-
-	// reuse setDefaults/validation/migrate methods coming from add property
-	// (empty existing names map, to validate existing updated property)
-	// TODO nested - refactor / cleanup setDefaults/validation/migrate methods
-	if err := h.setNewPropDefaults(class, prop); err != nil {
-		return err
-	}
-	if err := h.validateProperty(prop, className, map[string]bool{}, false); err != nil {
-		return err
-	}
-
-	// migrate only after validation in completed
-	migratePropertySettings(prop)
-
-	err = mergeObjectProperty(class, prop)
-	if err != nil {
-		return err
-	}
-
-	h.logger.WithField("action", "schema.update_object_property").Debugf("updating class %s after property merge", className)
-	err = h.metaWriter.UpdateClass(class, nil)
-	if err != nil {
-		return err
-	}
-
-	// TODO: implement MergeObjectProperty (needed for indexing/filtering)
-	// will result in a mismatch between schema and index if function below fails
-	// return h.migrator.MergeObjectProperty(ctx, className, prop)
 	return nil
 }

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -63,9 +63,8 @@ func TestHandler_AddProperty(t *testing.T) {
 						Name:     dt.AsName(),
 						DataType: dt.PropString(),
 					}
-					fakeMetaHandler.On("AddProperty", class.Class, prop).Return(nil)
-					fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
-					err := handler.AddClassProperty(ctx, nil, class.Class, prop)
+					fakeMetaHandler.On("AddProperty", class.Class, []*models.Property{prop}).Return(nil)
+					err := handler.UpdateClassProperty(ctx, nil, &class, false, prop)
 					require.NoError(t, err)
 				})
 			}
@@ -91,7 +90,6 @@ func TestHandler_AddProperty(t *testing.T) {
 			Vectorizer: "none",
 		}
 		fakeMetaHandler.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
 		require.NoError(t, handler.AddClass(ctx, nil, &class))
 
 		existingNames := []string{
@@ -103,14 +101,13 @@ func TestHandler_AddProperty(t *testing.T) {
 		}
 
 		t.Run("adding properties", func(t *testing.T) {
-			fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
 			for _, propName := range existingNames {
 				t.Run(propName, func(t *testing.T) {
 					prop := &models.Property{
 						Name:     propName,
-						DataType: schema.DataTypeInt.PropString(),
+						DataType: schema.DataTypeText.PropString(),
 					}
-					err := handler.AddClassProperty(ctx, nil, class.Class, prop)
+					err := handler.UpdateClassProperty(ctx, nil, &class, false, prop)
 					require.ErrorContains(t, err, "conflict for property")
 					require.ErrorContains(t, err, "already in use or provided multiple times")
 				})
@@ -132,7 +129,6 @@ func TestHandler_AddProperty_Object(t *testing.T) {
 			Class:      "NewClass",
 			Vectorizer: "none",
 		}
-		fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
 		fakeMetaHandler.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 		require.NoError(t, handler.AddClass(ctx, nil, &class))
 		dataTypes := []schema.DataType{
@@ -148,9 +144,8 @@ func TestHandler_AddProperty_Object(t *testing.T) {
 						DataType:         dt.PropString(),
 						NestedProperties: []*models.NestedProperty{{Name: "test", DataType: schema.DataTypeInt.PropString()}},
 					}
-					fakeMetaHandler.On("AddProperty", class.Class, prop).Return(nil)
-					fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
-					err := handler.AddClassProperty(ctx, nil, class.Class, prop)
+					fakeMetaHandler.On("AddProperty", class.Class, []*models.Property{prop}).Return(nil)
+					err := handler.UpdateClassProperty(ctx, nil, &class, false, prop)
 					require.NoError(t, err)
 				})
 			}
@@ -203,12 +198,12 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 				// property
 				fakeMetaHandler.On("ReadOnlyClass", mock.Anything).Return(&class)
 				if len(tc.expectedErrContains) == 0 {
-					fakeMetaHandler.On("AddProperty", class.Class, prop).Return(nil)
+					fakeMetaHandler.On("AddProperty", class.Class, []*models.Property{prop}).Return(nil)
 				} else {
 					fakeMetaHandler.AssertNotCalled(t, "AddProperty", mock.Anything, mock.Anything)
 				}
 
-				err := handler.AddClassProperty(ctx, nil, class.Class, prop)
+				err := handler.UpdateClassProperty(ctx, nil, &class, false, prop)
 				if len(tc.expectedErrContains) == 0 {
 					require.NoError(t, err)
 				} else {
@@ -421,7 +416,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	for _, tokenization := range helpers.Tokenizations {
 		propName := fmt.Sprintf("ref_%s", tokenization)
 		t.Run(propName, func(t *testing.T) {
-			err := handler.AddClassProperty(ctx, nil, class.Class,
+			err := handler.UpdateClassProperty(ctx, nil, &class, false,
 				&models.Property{
 					Name:         propName,
 					DataType:     dataType,
@@ -437,7 +432,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	// non-existent tokenization
 	propName := "ref_nonExistent"
 	t.Run(propName, func(t *testing.T) {
-		err := handler.AddClassProperty(ctx, nil, class.Class,
+		err := handler.UpdateClassProperty(ctx, nil, &class, false,
 			&models.Property{
 				Name:         propName,
 				DataType:     dataType,
@@ -453,7 +448,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	propName = "ref_empty"
 	t.Run(propName, func(t *testing.T) {
 		fakeMetaHandler.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
-		err := handler.AddClassProperty(ctx, nil, class.Class,
+		err := handler.UpdateClassProperty(ctx, nil, &class, false,
 			&models.Property{
 				Name:         propName,
 				DataType:     dataType,


### PR DESCRIPTION
### What's being changed:
this PR convert adding/updating property to 1..N op (variadic func) where instead of loop over properties to add/update, they will be passed to methods and handled accordingly 

it merges the `AddClassProperty()` and `MergeClassObjectProperty()` into one method `UpdateClassProperty()`

```go
UpdateClassProperty(ctx context.Context, principal *models.Principal, class *models.Class, merge bool, prop ...*models.Property) error
```

- in case of calling it for multiple props. we don't need to query the class 
- we don't need to auth or call the manager multiple times

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
