### PR TITLE
refact: split go client test to save time and allow push docker in parallel with the tests

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--acceptance-only-fast", "--acceptance-only-graphql", "--acceptance-only-replication"]
+        test: ["--acceptance-only-fast", "--acceptance-go-client" ,"--acceptance-only-graphql", "--acceptance-only-replication"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -227,7 +227,7 @@ jobs:
         run: go test -count 1 -race test/acceptance/actions/*.go  # tests that don't need a Vectorizer
 
   Push-Docker:
-    needs: [Acceptance-Tests, Modules-Acceptance-Tests, Modules-Acceptance-Tests-large, Unit-Tests, Integration-Tests, Vulnerability-Scanning, Run-Swagger]
+    needs: [Unit-Tests,  Vulnerability-Scanning, Run-Swagger] # TODO-RAFT to be added on release Acceptance-Tests, Modules-Acceptance-Tests, Modules-Acceptance-Tests-large, Integration-Tests 
     name: push-docker
     runs-on: ubuntu-latest-8-cores
     if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork


### PR DESCRIPTION
### What's being changed:

- allow push docker image in parallel of the tests
- split the go clients tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
