### PR TITLE
Improved update of target vector configs

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -79,7 +79,7 @@ type ShardLike interface {
 	ObjectSearch(ctx context.Context, limit int, filters *filters.LocalFilter, keywordRanking *searchparams.KeywordRanking, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties) ([]*storobj.Object, []float32, error)
 	ObjectVectorSearch(ctx context.Context, searchVector []float32, targetVector string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties) ([]*storobj.Object, []float32, error)
 	UpdateVectorIndexConfig(ctx context.Context, updated schema.VectorIndexConfig) error
-	UpdateVectorConfigForName(ctx context.Context, updated schema.VectorIndexConfig, targetVector string) error
+	UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schema.VectorIndexConfig) error
 	AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error
 	DeleteObjectBatch(ctx context.Context, ids []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects // Delete many objects by id
 	DeleteObject(ctx context.Context, id strfmt.UUID) error                                           // Delete object by id
@@ -832,21 +832,29 @@ func (s *Shard) UpdateVectorIndexConfig(ctx context.Context, updated schema.Vect
 	})
 }
 
-func (s *Shard) UpdateVectorConfigForName(ctx context.Context, updated schema.VectorIndexConfig,
-	targetVector string,
-) error {
+func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schema.VectorIndexConfig) error {
 	if s.isReadOnly() {
 		return storagestate.ErrStatusReadOnly
 	}
-
-	err := s.UpdateStatus(storagestate.StatusReadOnly.String())
-	if err != nil {
+	if err := s.UpdateStatus(storagestate.StatusReadOnly.String()); err != nil {
 		return fmt.Errorf("attempt to mark read-only: %w", err)
 	}
 
-	return s.VectorIndexForName(targetVector).UpdateUserConfig(updated, func() {
+	wg := new(sync.WaitGroup)
+	var err error
+	for targetName, targetCfg := range updated {
+		wg.Add(1)
+		if err = s.VectorIndexForName(targetName).UpdateUserConfig(targetCfg, wg.Done); err != nil {
+			break
+		}
+	}
+
+	go func() {
+		wg.Wait()
 		s.UpdateStatus(storagestate.StatusReady.String())
-	})
+	}()
+
+	return err
 }
 
 func (s *Shard) Shutdown(ctx context.Context) error {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -223,13 +223,11 @@ func (l *LazyLoadShard) UpdateVectorIndexConfig(ctx context.Context, updated sch
 	return l.shard.UpdateVectorIndexConfig(ctx, updated)
 }
 
-func (l *LazyLoadShard) UpdateVectorConfigForName(ctx context.Context, updated schema.VectorIndexConfig,
-	targetVector string,
-) error {
+func (l *LazyLoadShard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schema.VectorIndexConfig) error {
 	if err := l.Load(ctx); err != nil {
 		return err
 	}
-	return l.shard.UpdateVectorConfigForName(ctx, updated, targetVector)
+	return l.shard.UpdateVectorIndexConfigs(ctx, updated)
 }
 
 func (l *LazyLoadShard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {

--- a/test/acceptance_with_go_client/compression/compression_test.go
+++ b/test/acceptance_with_go_client/compression/compression_test.go
@@ -27,20 +27,41 @@ import (
 )
 
 func TestCompression_AdaptSegments(t *testing.T) {
-	type testCase struct {
-		dimensions int
+	type dimensionTestCase struct {
+		vectors [][]float32
 	}
-
-	testCases := []testCase{
-		{dimensions: 768},
-		{dimensions: 125},
-		{dimensions: 4},
+	type vectorTypeTestCase struct {
+		name          string
+		createClassFn func(t *testing.T, client *wvt.Client, className string) *models.Class
+		populateFn    func(t *testing.T, client *wvt.Client, className string, vectors [][]float32)
+		compressFn    func(t *testing.T, client *wvt.Client, class *models.Class)
 	}
 
 	ctx := context.Background()
 	className := "Compressed"
+	vectorsCount := 1000
+
+	dimensionTestCases := []dimensionTestCase{
+		{vectors: randomVecs(vectorsCount, 768)},
+		{vectors: randomVecs(vectorsCount, 4)},
+	}
 
 	t.Run("async indexing", func(t *testing.T) {
+		vectorTypeTestCases := []vectorTypeTestCase{
+			{
+				name:          "legacy vector",
+				createClassFn: createClassLegacyVector,
+				populateFn:    populateLegacyVector,
+				compressFn:    compressLegacyVectorAsync,
+			},
+			{
+				name:          "target vectors",
+				createClassFn: createClassTargetVectors,
+				populateFn:    populateTargetVectors,
+				compressFn:    compressTargetVectorsAsync,
+			},
+		}
+
 		compose, err := docker.New().
 			WithWeaviate().
 			WithWeaviateEnv("ASYNC_INDEXING", "true").
@@ -57,40 +78,51 @@ func TestCompression_AdaptSegments(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		for _, tc := range testCases {
-			t.Run(fmt.Sprintf("dimensions %d", tc.dimensions), func(t *testing.T) {
-				defer cleanup()
+		for _, dtc := range dimensionTestCases {
+			t.Run(fmt.Sprintf("dimensions %d", len(dtc.vectors[0])), func(t *testing.T) {
+				for _, vttc := range vectorTypeTestCases {
+					t.Run(vttc.name, func(t *testing.T) {
+						defer cleanup()
 
-				var class *models.Class
+						var class *models.Class
 
-				t.Run("create class", func(t *testing.T) {
-					class = createClass(t, client, className)
-				})
+						t.Run("create class", func(t *testing.T) {
+							class = vttc.createClassFn(t, client, className)
+						})
 
-				t.Run("compress", func(t *testing.T) {
-					pq := class.VectorIndexConfig.(map[string]interface{})["pq"].(map[string]interface{})
-					pq["segments"] = 0
-					pq["centroids"] = 256
-					pq["trainingLimit"] = 999
+						t.Run("compress", func(t *testing.T) {
+							vttc.compressFn(t, client, class)
+						})
 
-					err = client.Schema().ClassUpdater().
-						WithClass(class).
-						Do(ctx)
-					require.NoError(t, err)
-				})
+						t.Run("populate", func(t *testing.T) {
+							vttc.populateFn(t, client, className, dtc.vectors)
+						})
 
-				t.Run("populate", func(t *testing.T) {
-					populate(t, client, className, tc.dimensions)
-				})
-
-				t.Run("check eventually compressed", func(t *testing.T) {
-					checkEventuallyCompressed(t, client, className)
-				})
+						t.Run("check eventually compressed", func(t *testing.T) {
+							checkEventuallyCompressed(t, client, className)
+						})
+					})
+				}
 			})
 		}
 	})
 
 	t.Run("sync indexing", func(t *testing.T) {
+		vectorTypeTestCases := []vectorTypeTestCase{
+			{
+				name:          "legacy vector",
+				createClassFn: createClassLegacyVector,
+				populateFn:    populateLegacyVector,
+				compressFn:    compressLegacyVectorSync,
+			},
+			{
+				name:          "target vectors",
+				createClassFn: createClassTargetVectors,
+				populateFn:    populateTargetVectors,
+				compressFn:    compressTargetVectorsSync,
+			},
+		}
+
 		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: "localhost:8080"})
 		require.NoError(t, err)
 		cleanup := func() {
@@ -98,83 +130,106 @@ func TestCompression_AdaptSegments(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		for _, tc := range testCases {
-			t.Run(fmt.Sprintf("dimensions %d", tc.dimensions), func(t *testing.T) {
-				defer cleanup()
+		for _, dtc := range dimensionTestCases {
+			t.Run(fmt.Sprintf("dimensions %d", len(dtc.vectors[0])), func(t *testing.T) {
+				for _, vttc := range vectorTypeTestCases {
+					t.Run(vttc.name, func(t *testing.T) {
+						defer cleanup()
 
-				var class *models.Class
+						var class *models.Class
 
-				t.Run("create class", func(t *testing.T) {
-					class = createClass(t, client, className)
-				})
+						t.Run("create class", func(t *testing.T) {
+							class = vttc.createClassFn(t, client, className)
+						})
 
-				t.Run("populate", func(t *testing.T) {
-					populate(t, client, className, tc.dimensions)
-				})
+						t.Run("populate", func(t *testing.T) {
+							vttc.populateFn(t, client, className, dtc.vectors)
+						})
 
-				t.Run("compress", func(t *testing.T) {
-					pq := class.VectorIndexConfig.(map[string]interface{})["pq"].(map[string]interface{})
-					pq["segments"] = 0
-					pq["centroids"] = 256
+						t.Run("compress", func(t *testing.T) {
+							vttc.compressFn(t, client, class)
+						})
 
-					err = client.Schema().ClassUpdater().
-						WithClass(class).
-						Do(ctx)
-					require.NoError(t, err)
-				})
-
-				t.Run("check eventually compressed", func(t *testing.T) {
-					checkEventuallyCompressed(t, client, className)
-				})
+						t.Run("check eventually compressed", func(t *testing.T) {
+							checkEventuallyCompressed(t, client, className)
+						})
+					})
+				}
 			})
 		}
 	})
 }
 
-func createClass(t *testing.T, client *wvt.Client, className string) *models.Class {
-	ctx := context.Background()
-	efConstruction := 64
-	ef := 32
-	maxNeighbors := 32
-	vectorCacheMaxObjects := 10e12
-
+func createClassLegacyVector(t *testing.T, client *wvt.Client, className string) *models.Class {
 	class := &models.Class{
 		Class: className,
 		Properties: []*models.Property{{
 			Name:     "int",
 			DataType: schema.DataTypeInt.PropString(),
 		}},
-		Vectorizer: "none",
-		VectorIndexConfig: map[string]interface{}{
-			"maxConnections":        maxNeighbors,
-			"efConstruction":        efConstruction,
-			"ef":                    ef,
-			"vectorCacheMaxObjects": vectorCacheMaxObjects,
-			"distance":              "l2-squared",
-			"pq": map[string]interface{}{
-				"enabled": true,
-				"encoder": map[string]interface{}{
-					"distribution": hnsw.PQEncoderDistributionNormal,
-					"type":         hnsw.PQEncoderTypeKMeans,
+		Vectorizer:        "none",
+		VectorIndexConfig: hnswCompressVectorIndexConfig(),
+	}
+
+	createClass(t, client, class)
+	return class
+}
+
+func createClassTargetVectors(t *testing.T, client *wvt.Client, className string) *models.Class {
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{{
+			Name:     "int",
+			DataType: schema.DataTypeInt.PropString(),
+		}},
+		VectorConfig: map[string]models.VectorConfig{
+			"vectorFlat": {
+				VectorIndexType: "flat",
+				Vectorizer: map[string]interface{}{
+					"none": struct{}{},
 				},
+			},
+			"vectorHnswCompress": {
+				VectorIndexType: "hnsw",
+				Vectorizer: map[string]interface{}{
+					"none": struct{}{},
+				},
+				VectorIndexConfig: hnswCompressVectorIndexConfig(),
 			},
 		},
 	}
 
-	err := client.Schema().ClassCreator().
-		WithClass(class).
-		Do(ctx)
-	require.NoError(t, err)
-
+	createClass(t, client, class)
 	return class
 }
 
-func populate(t *testing.T, client *wvt.Client, className string, dimensions int) {
-	ctx := context.Background()
-	vectorsCount := 1000
+func createClass(t *testing.T, client *wvt.Client, class *models.Class) {
+	err := client.Schema().ClassCreator().
+		WithClass(class).
+		Do(context.Background())
+	require.NoError(t, err)
+}
 
-	objects := make([]*models.Object, vectorsCount)
-	for i, vector := range randomVecs(vectorsCount, dimensions) {
+func hnswCompressVectorIndexConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"maxConnections":        32,
+		"efConstruction":        64,
+		"ef":                    32,
+		"vectorCacheMaxObjects": 10e12,
+		"distance":              "l2-squared",
+		"pq": map[string]interface{}{
+			"enabled": true,
+			"encoder": map[string]interface{}{
+				"distribution": hnsw.PQEncoderDistributionNormal,
+				"type":         hnsw.PQEncoderTypeKMeans,
+			},
+		},
+	}
+}
+
+func populateLegacyVector(t *testing.T, client *wvt.Client, className string, vectors [][]float32) {
+	objects := make([]*models.Object, len(vectors))
+	for i, vector := range vectors {
 		objects[i] = &models.Object{
 			Class: className,
 			Properties: map[string]interface{}{
@@ -183,15 +238,78 @@ func populate(t *testing.T, client *wvt.Client, className string, dimensions int
 			Vector: vector,
 		}
 	}
+
+	populate(t, client, objects)
+}
+
+func populateTargetVectors(t *testing.T, client *wvt.Client, className string, vectors [][]float32) {
+	objects := make([]*models.Object, len(vectors))
+	for i, vector := range vectors {
+		objects[i] = &models.Object{
+			Class: className,
+			Properties: map[string]interface{}{
+				"int": i,
+			},
+			Vectors: models.Vectors{
+				"vectorFlat":         vector,
+				"vectorHnswCompress": vector,
+			},
+		}
+	}
+
+	populate(t, client, objects)
+}
+
+func populate(t *testing.T, client *wvt.Client, objects []*models.Object) {
 	resps, err := client.Batch().ObjectsBatcher().
 		WithObjects(objects...).
-		Do(ctx)
+		Do(context.Background())
 	require.NoError(t, err)
-	require.Len(t, resps, vectorsCount)
+	require.Len(t, resps, len(objects))
 	for _, resp := range resps {
 		require.NotNil(t, resp.Result.Status)
 		require.Equal(t, models.ObjectsGetResponseAO2ResultStatusSUCCESS, *resp.Result.Status)
 	}
+}
+
+func compressLegacyVectorAsync(t *testing.T, client *wvt.Client, class *models.Class) {
+	updateConfigAsync(class.VectorIndexConfig.(map[string]interface{})["pq"].(map[string]interface{}))
+	compress(t, client, class)
+}
+
+func compressLegacyVectorSync(t *testing.T, client *wvt.Client, class *models.Class) {
+	updateConfigSync(class.VectorIndexConfig.(map[string]interface{})["pq"].(map[string]interface{}))
+	compress(t, client, class)
+}
+
+func compressTargetVectorsAsync(t *testing.T, client *wvt.Client, class *models.Class) {
+	updateConfigAsync(class.VectorConfig["vectorHnswCompress"].
+		VectorIndexConfig.(map[string]interface{})["pq"].(map[string]interface{}))
+	compress(t, client, class)
+}
+
+func compressTargetVectorsSync(t *testing.T, client *wvt.Client, class *models.Class) {
+	updateConfigSync(class.VectorConfig["vectorHnswCompress"].
+		VectorIndexConfig.(map[string]interface{})["pq"].(map[string]interface{}))
+	compress(t, client, class)
+}
+
+func updateConfigAsync(pq map[string]interface{}) {
+	pq["segments"] = 0
+	pq["centroids"] = 256
+	pq["trainingLimit"] = 999
+}
+
+func updateConfigSync(pq map[string]interface{}) {
+	pq["segments"] = 0
+	pq["centroids"] = 256
+}
+
+func compress(t *testing.T, client *wvt.Client, class *models.Class) {
+	err := client.Schema().ClassUpdater().
+		WithClass(class).
+		Do(context.Background())
+	require.NoError(t, err)
 }
 
 func checkEventuallyCompressed(t *testing.T, client *wvt.Client, className string) {
@@ -212,6 +330,7 @@ func checkEventuallyCompressed(t *testing.T, client *wvt.Client, className strin
 		require.Len(t, resp.Nodes[0].Shards, 1)
 
 		compressed = resp.Nodes[0].Shards[0].Compressed
+		fmt.Printf("  ==> compressed %v\n", compressed)
 		if compressed {
 			break
 		}
@@ -221,9 +340,9 @@ func checkEventuallyCompressed(t *testing.T, client *wvt.Client, className strin
 	require.True(t, compressed)
 }
 
-func randomVecs(size int, dimensions int) [][]float32 {
+func randomVecs(count int, dimensions int) [][]float32 {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	vectors := make([][]float32, size)
+	vectors := make([][]float32, count)
 	for i := range vectors {
 		vectors[i] = genVector(r, dimensions)
 	}


### PR DESCRIPTION
### What's being changed:

TLDR: fixes "shard is read-only" error while updating target vectors' configs.

Previously update of target vectors' configs on shard was performed for each target vector separately, starting with changing shard's state to `read-only`, then running update on vector index, then switching state back to `ready` mode.
As vector index update may be async it was undetermined when state will be set to `ready` again, causing update of vector index for next target vector to fail while trying to change shard's state to `read-only`.
Now single transition of shard's state is made. First state is changed to `read-only`, then updates of vector indexes of all target vectors are executed, then shard's state is changed back to `ready` when last (slowest) of updates finishes.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
