### PR TITLE
[HNSW] Only use dynamic max connections during tombstone cleanup

### DIFF
--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -167,6 +167,8 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 	var results *priorityqueue.Queue[any]
 	var extraIDs []uint64 = nil
 	var total int = 0
+	var maxConnections int = n.graph.maximumConnections
+
 	if n.tombstoneCleanupNodes {
 		results = n.graph.pools.pqResults.GetMax(n.graph.efConstruction)
 
@@ -204,6 +206,8 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		if err := n.pickEntrypoint(); err != nil {
 			return errors.Wrap(err, "pick entrypoint at level beginning")
 		}
+		// use dynamic max connections only during tombstone cleanup
+		maxConnections = n.maximumConnections(level)
 	} else {
 		if err := n.pickEntrypoint(); err != nil {
 			return errors.Wrap(err, "pick entrypoint at level beginning")
@@ -222,8 +226,7 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		before = time.Now()
 	}
 
-	max := n.maximumConnections(level)
-	if err := n.graph.selectNeighborsHeuristic(results, max-total, n.denyList); err != nil {
+	if err := n.graph.selectNeighborsHeuristic(results, maxConnections-total, n.denyList); err != nil {
 		return errors.Wrap(err, "heuristic")
 	}
 


### PR DESCRIPTION
### What's being changed:

- https://github.com/weaviate/weaviate/pull/4003 improved tombstone cleanup performance but had a change to the initial select neighbors heuristic for HNSW which should use M rather than the dynamic M_max (which is double at layer 0). This change reverts that change while still leaving tombstone cleanups with the larger value to improve recall.

<img width="421" alt="Screenshot 2024-02-26 at 8 47 46 pm" src="https://github.com/weaviate/weaviate/assets/2173919/3d26f972-f6b6-449e-a8ac-932847bb0d99">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
