### PR TITLE
Prevent Schema Deadlock: Split IncomingCommit into locked/unlocked parts [backport]

### DIFF
--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -466,32 +466,69 @@ func (c *TxManager) IncomingCommitTransaction(ctx context.Context,
 	c.ongoingCommits.Add(1)
 	defer c.ongoingCommits.Done()
 
+	// requires locking because it accesses c.currentTransaction
+	txCopy, err := c.incomingCommitTxValidate(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	// cannot use locking because of risk of deadlock, see comment inside method
+	if err := c.incomingTxCommitApplyCommitFn(ctx, txCopy); err != nil {
+		return err
+	}
+
+	// requires locking because it accesses c.currentTransaction
+	return c.incomingTxCommitCleanup(ctx, tx)
+}
+
+func (c *TxManager) incomingCommitTxValidate(
+	ctx context.Context, tx *Transaction,
+) (*Transaction, error) {
 	c.Lock()
 	defer c.Unlock()
 
 	if !c.acceptIncoming {
-		return ErrNotReady
+		return nil, ErrNotReady
 	}
 
 	if c.currentTransaction == nil || c.currentTransaction.ID != tx.ID {
 		expired := c.expired(tx.ID)
 		if expired {
-			return ErrExpiredTransaction
+			return nil, ErrExpiredTransaction
 		}
-		return ErrInvalidTransaction
+		return nil, ErrInvalidTransaction
 	}
 
+	txCopy := *c.currentTransaction
+	return &txCopy, nil
+}
+
+func (c *TxManager) incomingTxCommitApplyCommitFn(
+	ctx context.Context, tx *Transaction,
+) error {
+	// Important: Do not hold the c.Lock() while applying the commitFn. The
+	// c.Lock() is only meant to make access to c.currentTransaction thread-safe.
+	// If we would hold it during apply, there is a risk for a deadlock because
+	// apply will likely lock the schema Manager. The schema Manager itself
+	// however, might be waiting for the TxManager in case of concurrent
+	// requests.
+	// See https://github.com/weaviate/weaviate/issues/4312 for steps on how to
+	// reproduce
+	//
 	// use transaction from cache, not passed in for two reason: a. protect
 	// against the transaction being manipulated after being created, b. allow
 	// an "empty" transaction that only contains the id for less network overhead
 	// (we don't need to pass the payload around anymore, after it's successfully
 	// opened - every node has a copy of the payload now)
-	err := c.commitFn(ctx, c.currentTransaction)
-	if err != nil {
-		return err
-	}
+	return c.commitFn(ctx, tx)
+}
 
+func (c *TxManager) incomingTxCommitCleanup(
+	ctx context.Context, tx *Transaction,
+) error {
 	// TODO: only clean up on success - does this make sense?
+	c.Lock()
+	defer c.Unlock()
 	c.currentTransaction = nil
 
 	if err := c.persistence.DeleteTx(ctx, tx.ID); err != nil {


### PR DESCRIPTION
### What's being changed:

Backport of #4313

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
