### PR TITLE
keep using LittleEndian if hnsw+pq for backwards compatibility

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -80,7 +80,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		}
 
 		var err error
-		h.compressor, err = compressionhelpers.NewPQCompressor(cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store)
+		h.compressor, err = compressionhelpers.NewPQCompressor(cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store, false)
 		if err != nil {
 			return fmt.Errorf("Compressing vectors: %w", err)
 		}

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -80,7 +80,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		}
 
 		var err error
-		h.compressor, err = compressionhelpers.NewPQCompressor(cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store, false)
+		h.compressor, err = compressionhelpers.NewHNSWPQCompressor(cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store)
 		if err != nil {
 			return fmt.Errorf("Compressing vectors: %w", err)
 		}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -137,7 +137,7 @@ func (h *hnsw) restoreFromDisk() error {
 			if h.pqConfig.Segments == 0 {
 				h.pqConfig.Segments = int(state.PQData.Dimensions)
 			}
-			h.compressor, err = compressionhelpers.RestorePQCompressor(
+			h.compressor, err = compressionhelpers.RestoreHNSWPQCompressor(
 				h.pqConfig,
 				h.distancerProvider,
 				int(state.PQData.Dimensions),
@@ -146,7 +146,6 @@ func (h *hnsw) restoreFromDisk() error {
 				h.logger,
 				state.PQData.Encoders,
 				h.store,
-				false,
 			)
 			if err != nil {
 				return errors.Wrap(err, "Restoring compressed data.")

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -146,6 +146,7 @@ func (h *hnsw) restoreFromDisk() error {
 				h.logger,
 				state.PQData.Encoders,
 				h.store,
+				false,
 			)
 			if err != nil {
 				return errors.Wrap(err, "Restoring compressed data.")


### PR DESCRIPTION
### What's being changed:
Reverting the use of BigEndian in case of HNSW+PQ for backwards compatibility.

Originally, we used LittleEndian everywhere. Then in 1.23 we introduced flat and flat+bq and we changed how the Ids are stored and used BigEndian instead, so we could seek in the files using the Ids correctly. This was necessary for the filter logic. Later, when we unified, we introduced the bug since hnsw+pq was originally using LittleEndian for the Ids. Now, for backward compatibility, we cannot use BigEndian for the Ids in the hnsw+pq case, but the rest should be fine.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
