### PR TITLE
populating the cache after restart

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -401,8 +401,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 				return nil, errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
 			}
 			vectorIndex = vi
-
-			defer vectorIndex.PostStartup()
 		}
 	case vectorindex.VectorIndexTypeFLAT:
 		flatUserConfig, ok := vectorIndexUserConfig.(flatent.UserConfig)
@@ -433,7 +431,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		return nil, fmt.Errorf("Unknown vector index type: %q. Choose one from [\"%s\", \"%s\"]",
 			vectorIndexUserConfig.IndexType(), vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT)
 	}
-
+	defer vectorIndex.PostStartup()
 	return vectorIndex, nil
 }
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -641,6 +641,7 @@ func (index *flat) PostStartup() {
 
 	for key, v := cursor.First(); key != nil; key, v = cursor.Next() {
 		id := binary.BigEndian.Uint64(key)
+		index.bqCache.Grow(id)
 		index.bqCache.Preload(id, uint64SliceFromByteSlice(v, make([]uint64, len(v)/8)))
 	}
 }


### PR DESCRIPTION
### What's being changed:
After server restart, only hnsw was invoking the PostStartup logic. Here is a fix for it so also the Flat index resumes correctly if using BQ.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
