### PR TITLE
populating the cache after restart

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -315,8 +315,6 @@ func (s *Shard) initVector(ctx context.Context) error {
 				return errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
 			}
 			s.vectorIndex = vi
-
-			defer s.vectorIndex.PostStartup()
 		}
 	case vectorindex.VectorIndexTypeFLAT:
 		flatUserConfig, ok := s.index.vectorIndexUserConfig.(flatent.UserConfig)
@@ -347,6 +345,7 @@ func (s *Shard) initVector(ctx context.Context) error {
 			s.index.vectorIndexUserConfig.IndexType(), vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT)
 	}
 
+	defer s.vectorIndex.PostStartup()
 	return nil
 }
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -630,6 +630,7 @@ func (index *flat) PostStartup() {
 
 	for key, v := cursor.First(); key != nil; key, v = cursor.Next() {
 		id := binary.BigEndian.Uint64(key)
+		index.bqCache.Grow(id)
 		index.bqCache.Preload(id, uint64SliceFromByteSlice(v, make([]uint64, len(v)/8)))
 	}
 }


### PR DESCRIPTION
### What's being changed:
After server restart, only hnsw was invoking the PostStartup logic. Here is a fix for it so also the Flat index resumes correctly if using BQ.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
