### PR TITLE
Avoid panic at tombstones cleanup when the entryPoint was deleted

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -46,7 +46,7 @@ type VectorCompressor interface {
 	DistanceBetweenCompressedVectorsFromIDs(ctx context.Context, x, y uint64) (float32, error)
 	DistanceBetweenCompressedAndUncompressedVectorsFromID(ctx context.Context, x uint64, y []float32) (float32, error)
 	NewDistancer(vector []float32) (CompressorDistancer, ReturnDistancerFn)
-	NewDistancerFromID(id uint64) CompressorDistancer
+	NewDistancerFromID(id uint64) (CompressorDistancer, error)
 	NewBag() CompressionDistanceBag
 
 	ExposeFields() PQData
@@ -163,13 +163,21 @@ func (compressor *quantizedVectorsCompressor[T]) NewDistancer(vector []float32) 
 	}
 }
 
-func (compressor *quantizedVectorsCompressor[T]) NewDistancerFromID(id uint64) CompressorDistancer {
-	compressedVector, _ := compressor.compressedVectorFromID(context.Background(), id)
+func (compressor *quantizedVectorsCompressor[T]) NewDistancerFromID(id uint64) (CompressorDistancer, error) {
+	compressedVector, err := compressor.compressedVectorFromID(context.Background(), id)
+	if err != nil {
+		return nil, err
+	}
+	if compressedVector == nil {
+		return nil, storobj.ErrNotFound{
+			DocID: id,
+		}
+	}
 	d := &quantizedCompressorDistancer[T]{
 		compressor: compressor,
 		distancer:  compressor.quantizer.NewCompressedQuantizerDistancer(compressedVector),
 	}
-	return d
+	return d, nil
 }
 
 func (compressor *quantizedVectorsCompressor[T]) returnDistancer(distancer CompressorDistancer) {

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -284,6 +284,10 @@ func (distancer *quantizedCompressorDistancer[T]) DistanceToNode(id uint64) (flo
 	if err != nil {
 		return 0, false, err
 	}
+	if len(compressedVector) == 0 {
+		return 0, false, fmt.Errorf(
+			"got a nil or zero-length vector at docID %d", id)
+	}
 	return distancer.distancer.Distance(compressedVector)
 }
 

--- a/adapters/repos/db/vector/compressionhelpers/compression_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_test.go
@@ -92,7 +92,9 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 		compressor.Preload(1, []float32{-0.5, 0.5})
 		compressor.Preload(2, []float32{0.25, 0.7})
 		compressor.Preload(3, []float32{0.5, 0.5})
-		distancer := compressor.NewDistancerFromID(1)
+		distancer, err := compressor.NewDistancerFromID(1)
+
+		assert.Nil(t, err)
 
 		d, _, err := distancer.DistanceToNode(1)
 		assert.Nil(t, err)

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -291,6 +291,10 @@ func (pq *ProductQuantizer) ExposeFields() PQData {
 }
 
 func (pq *ProductQuantizer) DistanceBetweenCompressedVectors(x, y []byte) (float32, error) {
+	if len(x) != pq.m || len(y) != pq.m {
+		return 0, fmt.Errorf("inconsistent compressed vectors lengths")
+	}
+
 	dist := float32(0)
 
 	for i := 0; i < pq.m; i++ {
@@ -345,6 +349,9 @@ func (d *PQDistancer) Distance(x []byte) (float32, bool, error) {
 	if d.lut == nil {
 		dist, err := d.pq.DistanceBetweenCompressedVectors(d.compressed, x)
 		return dist, err == nil, err
+	}
+	if len(x) != d.pq.m {
+		return 0, false, fmt.Errorf("inconsistent compressed vector length")
 	}
 	return d.pq.Distance(x, d.lut), true, nil
 }

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -379,7 +379,7 @@ func (h *hnsw) reassignNeighbor(
 	var neighborVec []float32
 	var compressorDistancer compressionhelpers.CompressorDistancer
 	if h.compressed.Load() {
-		compressorDistancer = h.compressor.NewDistancerFromID(neighbor)
+		compressorDistancer, err = h.compressor.NewDistancerFromID(neighbor)
 	} else {
 		neighborVec, err = h.cache.Get(context.Background(), neighbor)
 	}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -412,6 +412,10 @@ func (h *hnsw) findBestEntrypointForNode(currentMaxLevel, targetLevel int,
 		var err error
 		if h.compressed.Load() {
 			dist, ok, err = distancer.DistanceToNode(entryPointID)
+			var e storobj.ErrNotFound
+			if errors.As(err, &e) {
+				h.handleDeletedNode(e.DocID)
+			}
 		} else {
 			dist, ok, err = h.distBetweenNodeAndVec(entryPointID, nodeVec)
 		}


### PR DESCRIPTION
### What's being changed:
Making sure we do the same error handling in case there is compression during the tombstones cleanup

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
