### PR TITLE
Delay telemetry object count

### DIFF
--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -173,10 +173,18 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 	if err != nil {
 		return nil, fmt.Errorf("get enabled modules: %w", err)
 	}
-	objs, err := tel.getObjectCount(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get object count: %w", err)
+
+	var objs int64
+	// The first payload should not include object count,
+	// because all the shards may not be loaded yet. We
+	// don't want to force load for telemetry alone
+	if payloadType != PayloadType.Init {
+		objs, err = tel.getObjectCount(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("get object count: %w", err)
+		}
 	}
+
 	return &Payload{
 		MachineID:  tel.machineID,
 		Type:       payloadType,

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -53,7 +53,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 			assert.Equal(t, PayloadType.Init, payload.Type)
 			assert.Equal(t, config.ServerVersion, payload.Version)
 			assert.Equal(t, "module-1,module-2", payload.Modules)
-			assert.Equal(t, int64(100), payload.NumObjects)
+			assert.Equal(t, int64(0), payload.NumObjects)
 			assert.Equal(t, runtime.GOOS, payload.OS)
 			assert.Equal(t, runtime.GOARCH, payload.Arch)
 		})
@@ -234,7 +234,11 @@ func (h *testConsumer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}, payload.Type)
 	assert.Equal(h.t, config.ServerVersion, payload.Version)
 	assert.NotEmpty(h.t, payload.Modules)
-	assert.NotZero(h.t, payload.NumObjects)
+	if payload.Type == PayloadType.Init {
+		assert.Zero(h.t, payload.NumObjects)
+	} else {
+		assert.NotZero(h.t, payload.NumObjects)
+	}
 	assert.Equal(h.t, runtime.GOOS, payload.OS)
 	assert.Equal(h.t, runtime.GOARCH, payload.Arch)
 


### PR DESCRIPTION
### What's being changed:

To avoid force loading a lazy-loaded shard for the sake of telemetry alone, the first telemetry payload (type `INIT`) will not contain the object count. Each following `UPDATE` or `TERMINATE` payload will contain the object count

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
