### PR TITLE
Fix concurrent read/write of object's named vectors on merge

### DIFF
--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -169,7 +169,11 @@ func (m *Manager) mergeObjectSchemaAndVectorize(ctx context.Context, className s
 			vector = prevVec
 		}
 		if len(vectors) == 0 && len(class.VectorConfig) > 0 {
-			vectors = prevVecs
+			// copy target vectors map to avoid concurrent read/write on assigning new vectors to object
+			vectors := make(models.Vectors)
+			for name, vec := range prevVecs {
+				vectors[name] = vec
+			}
 		}
 
 		mergedProps = map[string]interface{}{}


### PR DESCRIPTION
### What's being changed:
Prevents concurrent read/write of object's `Vectors` map that could occur during vectorization on merge operation.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
