### PR TITLE
validates legacy vector index config when target vectors configured

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2083,6 +2083,10 @@ func convertToVectorIndexConfig(config interface{}) schema.VectorIndexConfig {
 	if config == nil {
 		return nil
 	}
+	// in case legacy vector config was set as an empty map/object instead of nil
+	if empty, ok := config.(map[string]interface{}); ok && len(empty) == 0 {
+		return nil
+	}
 	return config.(schema.VectorIndexConfig)
 }
 

--- a/test/acceptance_with_go_client/named_vectors_tests/legacy_vector_misc_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/legacy_vector_misc_test.go
@@ -1,0 +1,469 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package named_vectors_tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func allLegacyTests(endpoint string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Run("[legacy vector] schema validation", testLegacySchemaValidation(endpoint))
+		t.Run("[legacy vector] create schema", testLegacyCreateSchema(endpoint))
+	}
+}
+
+func testLegacySchemaValidation(host string) func(t *testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+		require.Nil(t, err)
+
+		cleanup := func() {
+			err := client.Schema().AllDeleter().Do(context.Background())
+			require.Nil(t, err)
+		}
+
+		t.Run("fails with multiple vectorizers in class's module config on create class", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				ModuleConfig: map[string]interface{}{
+					text2vecOpenAI: map[string]interface{}{
+						"vectorizeClassName": true,
+					},
+					text2vecCohere: map[string]interface{}{
+						"vectorizeClassName": true,
+					},
+				},
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "multiple vectorizers configured in class's moduleConfig")
+			assert.ErrorContains(t, err, text2vecOpenAI)
+			assert.ErrorContains(t, err, text2vecCohere)
+			assert.ErrorContains(t, err, "class.vectorizer is set to \\\"text2vec-cohere\\\"")
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.Error(t, err)
+			assert.Nil(t, classCreated)
+		})
+
+		t.Run("fails with different vectorizer set in class's module config on create class", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				ModuleConfig: map[string]interface{}{
+					text2vecOpenAI: map[string]interface{}{
+						"vectorizeClassName": true,
+					},
+				},
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "multiple vectorizers configured in class's moduleConfig")
+			assert.ErrorContains(t, err, text2vecOpenAI)
+			assert.ErrorContains(t, err, text2vecCohere)
+			assert.ErrorContains(t, err, "class.vectorizer is set to \\\"text2vec-cohere\\\"")
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.Error(t, err)
+			assert.Nil(t, classCreated)
+		})
+
+		t.Run("succeeds with correct vectorizer set in class's module config on create class", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				ModuleConfig: map[string]interface{}{
+					text2vecCohere: map[string]interface{}{
+						"vectorizeClassName": true,
+					},
+				},
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			assert.NotNil(t, classCreated)
+		})
+
+		t.Run("fails with multiple vectorizers in prop's module config on create class", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+						ModuleConfig: map[string]interface{}{
+							text2vecOpenAI: map[string]interface{}{
+								"vectorizePropertyName": true,
+							},
+							text2vecCohere: map[string]interface{}{
+								"vectorizePropertyName": true,
+							},
+						},
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "multiple vectorizers configured in property's \\\"text\\\" moduleConfig")
+			assert.ErrorContains(t, err, text2vecOpenAI)
+			assert.ErrorContains(t, err, text2vecCohere)
+			assert.ErrorContains(t, err, "class.vectorizer is set to \\\"text2vec-cohere\\\"")
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.Error(t, err)
+			assert.Nil(t, classCreated)
+		})
+
+		t.Run("fails with different vectorizer set in prop's module config on create class", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+						ModuleConfig: map[string]interface{}{
+							text2vecOpenAI: map[string]interface{}{
+								"vectorizePropertyName": true,
+							},
+						},
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "multiple vectorizers configured in property's \\\"text\\\" moduleConfig")
+			assert.ErrorContains(t, err, text2vecOpenAI)
+			assert.ErrorContains(t, err, text2vecCohere)
+			assert.ErrorContains(t, err, "class.vectorizer is set to \\\"text2vec-cohere\\\"")
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.Error(t, err)
+			assert.Nil(t, classCreated)
+		})
+
+		t.Run("succeeds with correct vectorizer set in prop's module config on create class", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+						ModuleConfig: map[string]interface{}{
+							text2vecCohere: map[string]interface{}{
+								"vectorizePropertyName": true,
+							},
+						},
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			assert.NotNil(t, classCreated)
+		})
+
+		t.Run("fails with multiple vectorizers in prop's module config on add property", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+			property := &models.Property{
+				Name:     "otherText",
+				DataType: schema.DataTypeText.PropString(),
+				ModuleConfig: map[string]interface{}{
+					text2vecOpenAI: map[string]interface{}{
+						"vectorizePropertyName": true,
+					},
+					text2vecCohere: map[string]interface{}{
+						"vectorizePropertyName": true,
+					},
+				},
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			err = client.Schema().PropertyCreator().WithClassName(className).WithProperty(property).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "multiple vectorizers configured in property's \\\"otherText\\\" moduleConfig")
+			assert.ErrorContains(t, err, text2vecOpenAI)
+			assert.ErrorContains(t, err, text2vecCohere)
+			assert.ErrorContains(t, err, "class.vectorizer is set to \\\"text2vec-cohere\\\"")
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			require.Len(t, classCreated.Properties, 1)
+			require.NotNil(t, classCreated.Properties[0])
+			assert.Equal(t, classCreated.Properties[0].Name, "text")
+		})
+
+		t.Run("fails with different vectorizer set in prop's module config on add property", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+			property := &models.Property{
+				Name:     "otherText",
+				DataType: schema.DataTypeText.PropString(),
+				ModuleConfig: map[string]interface{}{
+					text2vecOpenAI: map[string]interface{}{
+						"vectorizePropertyName": true,
+					},
+				},
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			err = client.Schema().PropertyCreator().WithClassName(className).WithProperty(property).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "multiple vectorizers configured in property's \\\"otherText\\\" moduleConfig")
+			assert.ErrorContains(t, err, text2vecOpenAI)
+			assert.ErrorContains(t, err, text2vecCohere)
+			assert.ErrorContains(t, err, "class.vectorizer is set to \\\"text2vec-cohere\\\"")
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			require.Len(t, classCreated.Properties, 1)
+			require.NotNil(t, classCreated.Properties[0])
+			assert.Equal(t, classCreated.Properties[0].Name, "text")
+		})
+
+		t.Run("succeeds with correct vectorizer set in prop's module config on add property", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVector"
+			text2vecCohere := "text2vec-cohere"
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+			property := &models.Property{
+				Name:     "otherText",
+				DataType: schema.DataTypeText.PropString(),
+				ModuleConfig: map[string]interface{}{
+					text2vecCohere: map[string]interface{}{
+						"vectorizePropertyName": true,
+					},
+				},
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			err = client.Schema().PropertyCreator().WithClassName(className).WithProperty(property).Do(ctx)
+			require.NoError(t, err)
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			require.Len(t, classCreated.Properties, 2)
+			require.NotNil(t, classCreated.Properties[0])
+			assert.Equal(t, classCreated.Properties[0].Name, "text")
+			require.NotNil(t, classCreated.Properties[1])
+			assert.Equal(t, classCreated.Properties[1].Name, "otherText")
+		})
+
+	}
+}
+
+func testLegacyCreateSchema(host string) func(t *testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+		require.Nil(t, err)
+
+		cleanup := func() {
+			err := client.Schema().AllDeleter().Do(context.Background())
+			require.Nil(t, err)
+		}
+
+		t.Run("defaults for vectorizer configs", func(t *testing.T) {
+			defer cleanup()
+
+			className := "LegacyVectorDefaults"
+			text2vecCohere := "text2vec-cohere"
+			classOptions := []string{"vectorizeClassName"}
+			propOptions := []string{"vectorizePropertyName", "skip"}
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				Vectorizer:      text2vecCohere,
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, class.Class, classCreated.Class)
+
+			// class defaults
+			assert.Equal(t, class.Vectorizer, classCreated.Vectorizer)
+			assert.Equal(t, class.VectorIndexType, classCreated.VectorIndexType)
+			assert.NotEmpty(t, classCreated.VectorIndexConfig)
+
+			require.NotNil(t, classCreated.ModuleConfig)
+			vectorizers, ok := classCreated.ModuleConfig.(map[string]interface{})
+			require.True(t, ok)
+			require.Len(t, vectorizers, 1)
+			require.Contains(t, vectorizers, text2vecCohere)
+			require.NotNil(t, vectorizers[text2vecCohere])
+
+			vectorizerConfig, ok := vectorizers[text2vecCohere].(map[string]interface{})
+			require.True(t, ok)
+			require.Len(t, vectorizerConfig, len(classOptions))
+			for _, classOption := range classOptions {
+				assert.Contains(t, vectorizerConfig, classOption)
+			}
+			assert.Nil(t, classCreated.VectorConfig)
+
+			// props defaults
+			for _, prop := range classCreated.Properties {
+				require.NotNil(t, prop.ModuleConfig)
+				vectorizers, ok := prop.ModuleConfig.(map[string]interface{})
+				require.True(t, ok)
+				require.Len(t, vectorizers, 1)
+				require.Contains(t, vectorizers, text2vecCohere)
+				require.NotNil(t, vectorizers[text2vecCohere])
+
+				vectorizerConfig, ok := vectorizers[text2vecCohere].(map[string]interface{})
+				require.True(t, ok)
+				require.Len(t, vectorizerConfig, len(propOptions))
+				for _, propOption := range propOptions {
+					assert.Contains(t, vectorizerConfig, propOption)
+				}
+			}
+		})
+	}
+}

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_objects_properties_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_objects_properties_test.go
@@ -106,7 +106,6 @@ func testCreateWithModulePropertiesObject(t *testing.T, host string) func(t *tes
 							VectorIndexConfig: bqFlatIndexConfig(),
 						},
 					},
-					Vectorizer: text2vecContextionary,
 				}
 
 				err := client.Schema().ClassCreator().WithClass(class).Do(ctx)

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_schema_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_schema_test.go
@@ -125,5 +125,116 @@ func testCreateSchema(t *testing.T, host string) func(t *testing.T) {
 				require.NotEmpty(t, vectorizerConfig[vectorizerName])
 			}
 		})
+
+		t.Run("defaults for vectorizer configs", func(t *testing.T) {
+			cleanup()
+
+			className := "NamedVectorsDefaults"
+			nameOpenAI := "openai"
+			nameCohere := "cohere"
+			text2vecOpenAI := "text2vec-openai"
+			text2vecCohere := "text2vec-cohere"
+
+			vectorizerConfigData := map[string]struct {
+				name         string
+				classOptions []string
+				propOptions  []string
+			}{
+				nameOpenAI: {
+					name:         text2vecOpenAI,
+					classOptions: []string{"vectorizeClassName", "baseURL", "model"},
+					propOptions:  []string{"vectorizePropertyName", "skip"},
+				},
+				nameCohere: {
+					name:         text2vecCohere,
+					classOptions: []string{"vectorizeClassName"},
+					propOptions:  []string{"vectorizePropertyName", "skip"},
+				},
+			}
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "text",
+						DataType: schema.DataTypeText.PropString(),
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					nameOpenAI: {
+						VectorIndexType: "hnsw",
+						Vectorizer: map[string]interface{}{
+							text2vecOpenAI: map[string]interface{}{},
+						},
+					},
+					nameCohere: {
+						VectorIndexType: "flat",
+						Vectorizer: map[string]interface{}{
+							text2vecCohere: map[string]interface{}{},
+						},
+					},
+				},
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+
+			classCreated, err := client.Schema().ClassGetter().WithClassName(className).Do(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, class.Class, classCreated.Class)
+
+			// class defaults
+			require.NotNil(t, classCreated.VectorConfig)
+			require.Len(t, classCreated.VectorConfig, len(vectorizerConfigData))
+			for vectorName, vectorizer := range vectorizerConfigData {
+				require.Contains(t, classCreated.VectorConfig, vectorName)
+
+				vectorConfig := class.VectorConfig[vectorName]
+				vectorConfigCreated := classCreated.VectorConfig[vectorName]
+
+				require.NotNil(t, vectorConfigCreated)
+				assert.Equal(t, vectorConfig.VectorIndexType, vectorConfigCreated.VectorIndexType)
+				assert.NotEmpty(t, vectorConfigCreated.VectorIndexConfig)
+
+				require.NotNil(t, vectorConfigCreated.Vectorizer)
+				vectorizers, ok := vectorConfigCreated.Vectorizer.(map[string]interface{})
+				require.True(t, ok)
+				require.Len(t, vectorizers, 1)
+				require.Contains(t, vectorizers, vectorizer.name)
+				require.NotNil(t, vectorizers[vectorizer.name])
+
+				vectorizerConfig, ok := vectorizers[vectorizer.name].(map[string]interface{})
+				require.True(t, ok)
+				require.Len(t, vectorizerConfig, len(vectorizer.classOptions))
+				for _, classOption := range vectorizer.classOptions {
+					assert.Contains(t, vectorizerConfig, classOption)
+				}
+			}
+			assert.Nil(t, class.ModuleConfig)
+			assert.Empty(t, class.Vectorizer)
+			assert.Empty(t, class.VectorIndexType)
+			assert.Nil(t, class.VectorIndexConfig)
+
+			// props defaults
+			for _, prop := range classCreated.Properties {
+				require.NotNil(t, prop.ModuleConfig)
+
+				propModuleConfig, ok := prop.ModuleConfig.(map[string]interface{})
+				require.True(t, ok)
+				require.Len(t, propModuleConfig, len(vectorizerConfigData))
+
+				for _, vectorizer := range vectorizerConfigData {
+					require.Contains(t, propModuleConfig, vectorizer.name)
+					require.NotNil(t, propModuleConfig[vectorizer.name])
+
+					vectorizerConfig, ok := propModuleConfig[vectorizer.name].(map[string]interface{})
+					require.True(t, ok)
+					require.Len(t, vectorizerConfig, len(vectorizer.propOptions))
+					for _, propOption := range vectorizer.propOptions {
+						assert.Contains(t, vectorizerConfig, propOption)
+					}
+				}
+			}
+		})
 	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_schema_validation_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_schema_validation_test.go
@@ -62,6 +62,90 @@ func testSchemaValidation(t *testing.T, host string) func(t *testing.T) {
 			assert.ErrorContains(t, err, fmt.Sprintf("class.VectorConfig.Vectorizer module with name %s doesn't exist", nonExistenVectorizer))
 		})
 
+		t.Run("VectorConfig and Vectorizer", func(t *testing.T) {
+			cleanup()
+			className := "NamedVector"
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name: "text", DataType: []string{schema.DataTypeText.String()},
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					"named": {
+						Vectorizer: map[string]interface{}{
+							text2vecContextionary: map[string]interface{}{
+								"vectorizeClassName": false,
+							},
+						},
+						VectorIndexType: "hnsw",
+					},
+				},
+				Vectorizer: text2vecContextionary,
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, fmt.Sprintf("class.vectorizer (text2vec-contextionary) can not be set if class.vectorConfig"))
+		})
+
+		t.Run("VectorConfig and Vector index type", func(t *testing.T) {
+			cleanup()
+			className := "NamedVector"
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name: "text", DataType: []string{schema.DataTypeText.String()},
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					"wrong": {
+						Vectorizer: map[string]interface{}{
+							text2vecContextionary: map[string]interface{}{
+								"vectorizeClassName": false,
+							},
+						},
+						VectorIndexType: "hnsw",
+					},
+				},
+				VectorIndexType: "hnsw",
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, fmt.Sprintf("class.vectorIndexType (hnsw) can not be set if class.vectorConfig"))
+		})
+
+		t.Run("VectorConfig and VectorIndexConfig", func(t *testing.T) {
+			cleanup()
+			className := "NamedVector"
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name: "text", DataType: []string{schema.DataTypeText.String()},
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					"wrong": {
+						Vectorizer: map[string]interface{}{
+							text2vecContextionary: map[string]interface{}{
+								"vectorizeClassName": false,
+							},
+						},
+						VectorIndexType: "hnsw",
+					},
+				},
+				VectorIndexConfig: map[string]interface{}{},
+			}
+
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, fmt.Sprintf("class.VectorIndexConfig (map[]) can not be set if class.vectorConfig"))
+		})
+
 		t.Run("properties check", func(t *testing.T) {
 			cleanup()
 			className := "NamedVector"

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_schema_validation_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_schema_validation_test.go
@@ -37,7 +37,7 @@ func testSchemaValidation(t *testing.T, host string) func(t *testing.T) {
 		t.Run("none existent name of the vectorizer module", func(t *testing.T) {
 			cleanup()
 			className := "NamedVector"
-			nonExistenVectorizer := "none_existent_vectorizer_module"
+			nonExistenVectorizer := "non_existent_vectorizer_module"
 			class := &models.Class{
 				Class: className,
 				Properties: []*models.Property{
@@ -59,7 +59,7 @@ func testSchemaValidation(t *testing.T, host string) func(t *testing.T) {
 
 			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, fmt.Sprintf("class.VectorConfig.Vectorizer module with name %s doesn't exist", nonExistenVectorizer))
+			assert.ErrorContains(t, err, "vectorizer: no module with name \\\"non_existent_vectorizer_module\\\" present")
 		})
 
 		t.Run("VectorConfig and Vectorizer", func(t *testing.T) {
@@ -87,7 +87,7 @@ func testSchemaValidation(t *testing.T, host string) func(t *testing.T) {
 
 			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, fmt.Sprintf("class.vectorizer (text2vec-contextionary) can not be set if class.vectorConfig"))
+			assert.ErrorContains(t, err, "class.vectorizer \\\"text2vec-contextionary\\\" can not be set if class.vectorConfig")
 		})
 
 		t.Run("VectorConfig and Vector index type", func(t *testing.T) {
@@ -115,7 +115,7 @@ func testSchemaValidation(t *testing.T, host string) func(t *testing.T) {
 
 			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, fmt.Sprintf("class.vectorIndexType (hnsw) can not be set if class.vectorConfig"))
+			assert.ErrorContains(t, err, "class.vectorIndexType \\\"hnsw\\\" can not be set if class.vectorConfig")
 		})
 
 		t.Run("VectorConfig and VectorIndexConfig", func(t *testing.T) {
@@ -143,7 +143,7 @@ func testSchemaValidation(t *testing.T, host string) func(t *testing.T) {
 
 			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, fmt.Sprintf("class.VectorIndexConfig (map[]) can not be set if class.vectorConfig"))
+			assert.ErrorContains(t, err, "class.vectorIndexConfig can not be set if class.vectorConfig is configured")
 		})
 
 		t.Run("properties check", func(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
@@ -28,6 +28,7 @@ func TestNamedVectors_SingleNode(t *testing.T) {
 	}()
 	endpoint := compose.GetWeaviate().URI()
 	t.Run("tests", allTests(t, endpoint))
+	t.Run("legacy tests", allLegacyTests(endpoint))
 }
 
 func TestNamedVectors_SingleNode_AsyncIndexing(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
@@ -40,6 +40,7 @@ func TestNamedVectors_SingleNode_AsyncIndexing(t *testing.T) {
 	}()
 	endpoint := compose.GetWeaviate().URI()
 	t.Run("tests", allTests(t, endpoint))
+	t.Run("legacy tests", allLegacyTests(endpoint))
 }
 
 func TestNamedVectors_Cluster(t *testing.T) {
@@ -51,6 +52,7 @@ func TestNamedVectors_Cluster(t *testing.T) {
 	}()
 	endpoint := compose.GetWeaviate().URI()
 	t.Run("tests", allTests(t, endpoint))
+	t.Run("legacy tests", allLegacyTests(endpoint))
 }
 
 func TestNamedVectors_Cluster_AsyncIndexing(t *testing.T) {
@@ -62,6 +64,7 @@ func TestNamedVectors_Cluster_AsyncIndexing(t *testing.T) {
 	}()
 	endpoint := compose.GetWeaviate().URI()
 	t.Run("tests", allTests(t, endpoint))
+	t.Run("legacy tests", allLegacyTests(endpoint))
 }
 
 func allTests(t *testing.T, endpoint string) func(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test_data_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test_data_test.go
@@ -149,7 +149,6 @@ func createNamedVectorsClass(t *testing.T, client *wvt.Client) {
 				VectorIndexConfig: bqFlatIndexConfig(),
 			},
 		},
-		Vectorizer: text2vecContextionary,
 	}
 
 	err := client.Schema().ClassCreator().WithClass(class).Do(ctx)

--- a/test/helper/sample-schema/multishard/multishard.go
+++ b/test/helper/sample-schema/multishard/multishard.go
@@ -39,6 +39,7 @@ func class(vectorizer string) *models.Class {
 				"vectorizeClassName": false,
 			},
 		},
+		Vectorizer: vectorizer,
 		Properties: []*models.Property{
 			{
 				Name:         "name",

--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -23,46 +23,53 @@ import (
 // SetClassDefaults sets the module-specific defaults for the class itself, but
 // also for each prop
 func (p *Provider) SetClassDefaults(class *models.Class) {
-	if class.Vectorizer == "none" {
-		// the class does not use a vectorizer, nothing to do for us
+	if !hasTargetVectors(class) {
+		p.setClassDefaults(class, class.Vectorizer, "", func(vectorizerConfig map[string]interface{}) {
+			if class.ModuleConfig == nil {
+				class.ModuleConfig = map[string]interface{}{}
+			}
+			class.ModuleConfig.(map[string]interface{})[class.Vectorizer] = vectorizerConfig
+		})
 		return
 	}
 
-	mod := p.GetByName(class.Vectorizer)
-	cc, ok := mod.(modulecapabilities.ClassConfigurator)
-	if !ok {
-		// the module exists, but is not a class configurator, nothing to do for us
-		return
+	for targetVector, vectorConfig := range class.VectorConfig {
+		if moduleConfig, ok := vectorConfig.Vectorizer.(map[string]interface{}); ok && len(moduleConfig) == 1 {
+			for vectorizer := range moduleConfig {
+				p.setClassDefaults(class, vectorizer, targetVector, func(vectorizerConfig map[string]interface{}) {
+					moduleConfig[vectorizer] = vectorizerConfig
+				})
+			}
+		}
 	}
-
-	cfg := NewClassBasedModuleConfig(class, class.Vectorizer, "", "")
-
-	p.setPerClassConfigDefaults(class, cfg, cc)
-	p.setPerPropertyConfigDefaults(class, cfg, cc)
 }
 
-// SetSinglePropertyDefaults can be used when a property is added later, e.g.
-// as part of merging in a ref prop after a class has already been created
-func (p *Provider) SetSinglePropertyDefaults(class *models.Class,
-	prop *models.Property,
+func (p *Provider) setClassDefaults(class *models.Class, vectorizer string,
+	targetVector string, storeFn func(vectorizerConfig map[string]interface{}),
 ) {
-	if class.Vectorizer == "none" {
+	if vectorizer == "none" {
 		// the class does not use a vectorizer, nothing to do for us
 		return
 	}
 
-	mod := p.GetByName(class.Vectorizer)
+	mod := p.GetByName(vectorizer)
 	cc, ok := mod.(modulecapabilities.ClassConfigurator)
 	if !ok {
 		// the module exists, but is not a class configurator, nothing to do for us
 		return
 	}
 
-	p.setSinglePropertyConfigDefaults(class, prop, cc)
+	cfg := NewClassBasedModuleConfig(class, vectorizer, "", targetVector)
+
+	p.setPerClassConfigDefaults(cfg, cc, storeFn)
+	for _, prop := range class.Properties {
+		p.setSinglePropertyConfigDefaults(prop, vectorizer, cc)
+	}
 }
 
-func (p *Provider) setPerClassConfigDefaults(class *models.Class,
-	cfg *ClassBasedModuleConfig, cc modulecapabilities.ClassConfigurator,
+func (p *Provider) setPerClassConfigDefaults(cfg *ClassBasedModuleConfig,
+	cc modulecapabilities.ClassConfigurator,
+	storeFn func(vectorizerConfig map[string]interface{}),
 ) {
 	modDefaults := cc.ClassConfigDefaults()
 	userSpecified := cfg.Class()
@@ -75,31 +82,61 @@ func (p *Provider) setPerClassConfigDefaults(class *models.Class,
 		mergedConfig[key] = value
 	}
 
-	if class.ModuleConfig == nil {
-		class.ModuleConfig = map[string]interface{}{}
+	if len(mergedConfig) > 0 {
+		storeFn(mergedConfig)
 	}
-
-	class.ModuleConfig.(map[string]interface{})[class.Vectorizer] = mergedConfig
 }
 
-func (p *Provider) setPerPropertyConfigDefaults(class *models.Class,
-	cfg *ClassBasedModuleConfig, cc modulecapabilities.ClassConfigurator,
+// SetSinglePropertyDefaults can be used when a property is added later, e.g.
+// as part of merging in a ref prop after a class has already been created
+func (p *Provider) SetSinglePropertyDefaults(class *models.Class,
+	prop *models.Property,
 ) {
-	for _, prop := range class.Properties {
-		p.setSinglePropertyConfigDefaults(class, prop, cc)
+	if !hasTargetVectors(class) {
+		p.setSinglePropertyDefaults(prop, class.Vectorizer)
+		return
 	}
+
+	for _, vectorConfig := range class.VectorConfig {
+		if moduleConfig, ok := vectorConfig.Vectorizer.(map[string]interface{}); ok && len(moduleConfig) == 1 {
+			for vectorizer := range moduleConfig {
+				p.setSinglePropertyDefaults(prop, vectorizer)
+			}
+		}
+	}
+
 }
 
-func (p *Provider) setSinglePropertyConfigDefaults(class *models.Class,
-	prop *models.Property, cc modulecapabilities.ClassConfigurator,
+func (p *Provider) setSinglePropertyDefaults(prop *models.Property, vectorizer string) {
+	if vectorizer == "none" {
+		// the class does not use a vectorizer, nothing to do for us
+		return
+	}
+
+	mod := p.GetByName(vectorizer)
+	cc, ok := mod.(modulecapabilities.ClassConfigurator)
+	if !ok {
+		// the module exists, but is not a class configurator, nothing to do for us
+		return
+	}
+
+	p.setSinglePropertyConfigDefaults(prop, vectorizer, cc)
+}
+
+func (p *Provider) setSinglePropertyConfigDefaults(prop *models.Property,
+	vectorizer string, cc modulecapabilities.ClassConfigurator,
 ) {
 	dt, _ := schema.GetValueDataTypeFromString(prop.DataType[0])
 	modDefaults := cc.PropertyConfigDefaults(dt)
+	userSpecified := map[string]interface{}{}
 	mergedConfig := map[string]interface{}{}
-	userSpecified := make(map[string]interface{})
 
 	if prop.ModuleConfig != nil {
-		userSpecified = prop.ModuleConfig.(map[string]interface{})[class.Vectorizer].(map[string]interface{})
+		if vectorizerConfig, ok := prop.ModuleConfig.(map[string]interface{})[vectorizer]; ok {
+			if mcvm, ok := vectorizerConfig.(map[string]interface{}); ok {
+				userSpecified = mcvm
+			}
+		}
 	}
 
 	for key, value := range modDefaults {
@@ -109,11 +146,12 @@ func (p *Provider) setSinglePropertyConfigDefaults(class *models.Class,
 		mergedConfig[key] = value
 	}
 
-	if prop.ModuleConfig == nil {
-		prop.ModuleConfig = map[string]interface{}{}
+	if len(mergedConfig) > 0 {
+		if prop.ModuleConfig == nil {
+			prop.ModuleConfig = map[string]interface{}{}
+		}
+		prop.ModuleConfig.(map[string]interface{})[vectorizer] = mergedConfig
 	}
-
-	prop.ModuleConfig.(map[string]interface{})[class.Vectorizer] = mergedConfig
 }
 
 func (p *Provider) ValidateClass(ctx context.Context, class *models.Class) error {
@@ -218,4 +256,8 @@ func (p *Provider) validateClassModuleConfig(ctx context.Context,
 		return errors.Wrapf(err, "module '%s'", moduleName)
 	}
 	return nil
+}
+
+func hasTargetVectors(class *models.Class) bool {
+	return len(class.VectorConfig) > 0
 }

--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -104,7 +104,6 @@ func (p *Provider) SetSinglePropertyDefaults(class *models.Class,
 			}
 		}
 	}
-
 }
 
 func (p *Provider) setSinglePropertyDefaults(prop *models.Property, vectorizer string) {

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -232,8 +232,12 @@ func (p *Provider) shouldVectorizeObject(object *models.Object, cfg moduletools.
 		return object.Vector == nil
 	}
 
-	vec, ok := object.Vectors[cfg.TargetVector()]
-	return !ok || len(vec) == 0
+	targetVectorExists := false
+	p.lockGuard(func() {
+		vec, ok := object.Vectors[cfg.TargetVector()]
+		targetVectorExists = ok && len(vec) > 0
+	})
+	return !targetVectorExists
 }
 
 func (p *Provider) shouldVectorize(object *models.Object, class *models.Class,

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -514,7 +514,7 @@ func (m *Manager) validateProperty(
 		return err
 	}
 
-	if err := validatePropModuleConfig(class, property); err != nil {
+	if err := m.validatePropModuleConfig(class, property); err != nil {
 		return err
 	}
 

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -530,15 +530,14 @@ func (m *Manager) parseVectorIndexConfig(ctx context.Context,
 	}
 
 	if class.Vectorizer != "" {
-		return fmt.Errorf("class.vectorizer can not be set if class.vectorConfig is configured")
+		return fmt.Errorf("class.vectorizer (%v) can not be set if class.vectorConfig (%v) is configured", class.Vectorizer, class.VectorConfig)
 	}
 	if class.VectorIndexType != "" {
-		return fmt.Errorf("class.vectorIndexType can not be set if class.vectorConfig is configured")
+		return fmt.Errorf("class.vectorIndexType (%v) can not be set if class.vectorConfig (%v) is configured", class.VectorIndexType, class.VectorConfig)
 	}
-	if m, ok := class.VectorIndexConfig.(map[string]interface{}); ok && len(m) > 0 {
-		return fmt.Errorf("class.vectorIndexConfig can not be set if class.vectorConfig is configured")
+	if class.VectorIndexConfig != nil {
+		return fmt.Errorf("class.vectorIndexConfig (%v) can not be set if class.vectorConfig (%v) is configured", class.VectorIndexConfig, class.VectorConfig)
 	}
-	class.VectorIndexConfig = nil
 
 	if err := m.parseTargetVectorsVectorIndexConfig(class); err != nil {
 		return err

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -526,7 +526,19 @@ func (m *Manager) parseVectorIndexConfig(ctx context.Context,
 			return err
 		}
 		class.VectorIndexConfig = parsed
+		return nil
 	}
+
+	if class.Vectorizer != "" {
+		return fmt.Errorf("class.vectorizer can not be set if class.vectorConfig is configured")
+	}
+	if class.VectorIndexType != "" {
+		return fmt.Errorf("class.vectorIndexType can not be set if class.vectorConfig is configured")
+	}
+	if m, ok := class.VectorIndexConfig.(map[string]interface{}); ok && len(m) > 0 {
+		return fmt.Errorf("class.vectorIndexConfig can not be set if class.vectorConfig is configured")
+	}
+	class.VectorIndexConfig = nil
 
 	if err := m.parseTargetVectorsVectorIndexConfig(class); err != nil {
 		return err

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -57,10 +57,8 @@ func (m *Manager) addClassProperty(ctx context.Context,
 		existingPropertyNames[strings.ToLower(existingProperty.Name)] = true
 	}
 
-	if err := m.setNewPropDefaults(class, prop); err != nil {
-		return err
-	}
-	if err := m.validateProperty(prop, className, existingPropertyNames, false); err != nil {
+	m.setNewPropDefaults(class, prop)
+	if err := m.validateProperty(prop, class, existingPropertyNames, false); err != nil {
 		return err
 	}
 	// migrate only after validation in completed
@@ -95,32 +93,53 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	return m.addClassPropertyApplyChanges(ctx, className, prop)
 }
 
-func (m *Manager) setNewPropDefaults(class *models.Class, prop *models.Property) error {
+func (m *Manager) setNewPropDefaults(class *models.Class, prop *models.Property) {
 	setPropertyDefaults(prop)
-	if err := validateUserProp(class, prop); err != nil {
-		return err
-	}
 	m.moduleConfig.SetSinglePropertyDefaults(class, prop)
-	return nil
 }
 
-func validateUserProp(class *models.Class, prop *models.Property) error {
+func validatePropModuleConfig(class *models.Class, prop *models.Property) error {
 	if prop.ModuleConfig == nil {
 		return nil
-	} else {
-		modconfig, ok := prop.ModuleConfig.(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("%v property config invalid", prop.Name)
-		}
+	}
+	modconfig, ok := prop.ModuleConfig.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("%v property config invalid", prop.Name)
+	}
+
+	if !hasTargetVectors(class) {
 		vectorizerConfig, ok := modconfig[class.Vectorizer]
 		if !ok {
+			if class.Vectorizer == "none" {
+				return nil
+			}
 			return fmt.Errorf("%v vectorizer module not part of the property", class.Vectorizer)
 		}
 		_, ok = vectorizerConfig.(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("vectorizer config for vectorizer %v, not of type map[string]interface{}", class.Vectorizer)
 		}
+		return nil
 	}
+
+	// TODO reuse for multiple props?
+	vectorizersSet := map[string]struct{}{}
+	for _, cfg := range class.VectorConfig {
+		if vm, ok := cfg.Vectorizer.(map[string]interface{}); ok && len(vm) == 1 {
+			for vectorizer := range vm {
+				vectorizersSet[vectorizer] = struct{}{}
+			}
+		}
+	}
+	for vectorizer, cfg := range modconfig {
+		if _, ok := vectorizersSet[vectorizer]; !ok {
+			return fmt.Errorf("vectorizer %q not configured for any of target vectors", vectorizer)
+		}
+		if _, ok := cfg.(map[string]interface{}); !ok {
+			return fmt.Errorf("vectorizer config for vectorizer %q not of type map[string]interface{}", vectorizer)
+		}
+	}
+
 	return nil
 }
 

--- a/usecases/schema/schema_comparison.go
+++ b/usecases/schema/schema_comparison.go
@@ -205,6 +205,8 @@ func (ccc *classConfigComparison) diff() []string {
 		ccc.right.VectorIndexType, "vector index type")
 	ccc.compare(ccc.left.Vectorizer,
 		ccc.right.Vectorizer, "vectorizer")
+	ccc.compare(ccc.left.VectorConfig,
+		ccc.right.VectorConfig, "vector config")
 	return ccc.msgs
 }
 

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -60,6 +60,10 @@ func (m *Manager) UpdateClass(ctx context.Context, principal *models.Principal,
 		return err
 	}
 
+	if err := m.validateVectorSettings(updated); err != nil {
+		return err
+	}
+
 	if err := m.parseVectorIndexConfig(ctx, updated); err != nil {
 		return err
 	}

--- a/usecases/schema/update_property.go
+++ b/usecases/schema/update_property.go
@@ -49,10 +49,8 @@ func (m *Manager) mergeClassObjectProperty(ctx context.Context,
 	// reuse setDefaults/validation/migrate methods coming from add property
 	// (empty existing names map, to validate existing updated property)
 	// TODO nested - refactor / cleanup setDefaults/validation/migrate methods
-	if err := m.setNewPropDefaults(class, prop); err != nil {
-		return err
-	}
-	if err := m.validateProperty(prop, className, map[string]bool{}, false); err != nil {
+	m.setNewPropDefaults(class, prop)
+	if err := m.validateProperty(prop, class, map[string]bool{}, false); err != nil {
 		return err
 	}
 	// migrate only after validation in completed

--- a/usecases/schema/update_test.go
+++ b/usecases/schema/update_test.go
@@ -398,7 +398,7 @@ func TestClassUpdate_ValidateVectorIndexConfigs(t *testing.T) {
 	vcFlatContextionary := models.VectorConfig{
 		VectorIndexType: "flat",
 		Vectorizer: map[string]interface{}{
-			"contextionary": "some-settings",
+			"text2vec-contextionary": "some-settings",
 		},
 		VectorIndexConfig: map[string]interface{}{
 			"setting-flat": "value-flat",
@@ -407,7 +407,7 @@ func TestClassUpdate_ValidateVectorIndexConfigs(t *testing.T) {
 	vcHnswContextionary := models.VectorConfig{
 		VectorIndexType: "hnsw",
 		Vectorizer: map[string]interface{}{
-			"contextionary": "some-settings",
+			"text2vec-contextionary": "some-settings",
 		},
 		VectorIndexConfig: map[string]interface{}{
 			"setting-hnsw": "value-hnsw",
@@ -529,7 +529,7 @@ func TestClassUpdate_ValidateVectorIndexConfigs(t *testing.T) {
 					},
 				},
 			}),
-			expectedErrMsg: "vectorizer of vector \"vector1\" is immutable: attempted change from \"contextionary\" to \"not-contextionary\"",
+			expectedErrMsg: "vectorizer of vector \"vector1\" is immutable: attempted change from \"text2vec-contextionary\" to \"not-contextionary\"",
 		},
 		{
 			name: "vectorizer config not map",
@@ -553,8 +553,8 @@ func TestClassUpdate_ValidateVectorIndexConfigs(t *testing.T) {
 				"vector1": {
 					VectorIndexType: "flat",
 					Vectorizer: map[string]interface{}{
-						"contextionary":  "some-settings",
-						"additional-key": "value",
+						"text2vec-contextionary": "some-settings",
+						"additional-key":         "value",
 					},
 				},
 			}),

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -280,40 +280,59 @@ func validateNestedPropertyIndexSearchable(property *models.NestedProperty,
 	return nil
 }
 
-func (m *Manager) validateVectorSettings(ctx context.Context, class *models.Class) error {
-	// validate only when no target vectors configured
+func (m *Manager) validateVectorSettings(class *models.Class) error {
 	if !hasTargetVectors(class) {
-		if err := m.validateVectorizer(ctx, class); err != nil {
+		if err := m.validateVectorizer(class.Vectorizer); err != nil {
 			return err
 		}
-
-		if err := m.validateVectorIndex(ctx, class); err != nil {
+		if err := m.validateVectorIndexType(class.VectorIndexType); err != nil {
 			return err
+		}
+		return nil
+	}
+
+	if class.Vectorizer != "" {
+		return fmt.Errorf("class.vectorizer %q can not be set if class.vectorConfig is configured", class.Vectorizer)
+	}
+	if class.VectorIndexType != "" {
+		return fmt.Errorf("class.vectorIndexType %q can not be set if class.vectorConfig is configured", class.VectorIndexType)
+	}
+
+	for name, cfg := range class.VectorConfig {
+		// check only if vectorizer correctly configured (map with single key being vectorizer name)
+		// other cases are handled in module config validation
+		if vm, ok := cfg.Vectorizer.(map[string]interface{}); ok && len(vm) == 1 {
+			for vectorizer := range vm {
+				if err := m.validateVectorizer(vectorizer); err != nil {
+					return fmt.Errorf("target vector %q: %w", name, err)
+				}
+			}
+		}
+		if err := m.validateVectorIndexType(cfg.VectorIndexType); err != nil {
+			return fmt.Errorf("target vector %q: %w", name, err)
 		}
 	}
 	return nil
 }
 
-func (m *Manager) validateVectorizer(ctx context.Context, class *models.Class) error {
-	if class.Vectorizer == config.VectorizerModuleNone {
+func (m *Manager) validateVectorizer(vectorizer string) error {
+	if vectorizer == config.VectorizerModuleNone {
 		return nil
 	}
 
-	if err := m.vectorizerValidator.ValidateVectorizer(class.Vectorizer); err != nil {
+	if err := m.vectorizerValidator.ValidateVectorizer(vectorizer); err != nil {
 		return errors.Wrap(err, "vectorizer")
 	}
 
 	return nil
 }
 
-func (m *Manager) validateVectorIndex(ctx context.Context, class *models.Class) error {
-	switch class.VectorIndexType {
-	case "hnsw":
-		return nil
-	case "flat":
+func (m *Manager) validateVectorIndexType(vectorIndexType string) error {
+	switch vectorIndexType {
+	case "hnsw", "flat":
 		return nil
 	default:
 		return errors.Errorf("unrecognized or unsupported vectorIndexType %q",
-			class.VectorIndexType)
+			vectorIndexType)
 	}
 }


### PR DESCRIPTION
### What's being changed:

changes validation of class's schema in respect of legacy/named vectors:
- legacy vector related options (`class.vectorizer`, `class.vectorIndexType`, `class.vectorIndexType`) forbidden when named vectors are configured (`class.vectorConfig`)
- vectorizer's default options are set for class (`class.vectorConfig[_vectorName_].vectorizer[_vectorizerName_]`) and properties (`property.moduleConfig[_vectorizerName_]`) when named vectors are configured (`class.vectorConfig`)
- multiple vectorizers for legacy vector in `class.moduleConfig` or `property.moduleConfig` are forbidden
- added `property.moduleConfig` validation on add class (previously only on add property)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
