### PR TITLE
Improve cluster stability: transfer leadership and remove Non-Voters before shutdown

### DIFF
--- a/cloud/store/store_test.go
+++ b/cloud/store/store_test.go
@@ -695,11 +695,11 @@ func NewMockStore(t *testing.T, nodeID string, raftPort int) MockStore {
 		logger:  logger,
 
 		cfg: Config{
-			WorkDir:  t.TempDir(),
-			NodeID:   nodeID,
-			Host:     "localhost",
-			RaftPort: raftPort,
-			// RPCPort:           9092,
+			WorkDir:           t.TempDir(),
+			NodeID:            nodeID,
+			Host:              "localhost",
+			RaftPort:          raftPort,
+			Voter:             true,
 			BootstrapExpect:   1,
 			HeartbeatTimeout:  1 * time.Second,
 			ElectionTimeout:   1 * time.Second,


### PR DESCRIPTION
### What's being changed:
This PR enhances the stability of leader election by transferring leadership to another server instead of waiting for a new election term. Additionally it ensures that non voters are promptly removed upon leaving the cluster. This opt saves network traffic by eliminating the need for the the leader to contact offline non-voters

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
