### PR TITLE
replace map nil assignment with clear

### DIFF
--- a/adapters/repos/db/inverted/new_prop_length_tracker.go
+++ b/adapters/repos/db/inverted/new_prop_length_tracker.go
@@ -318,7 +318,7 @@ func (t *JsonPropertyLengthTracker) Close() error {
 	t.Lock()
 	defer t.Unlock()
 
-	t.data.BucketedData = nil
+	clear(t.data.BucketedData)
 
 	return nil
 }
@@ -330,7 +330,7 @@ func (t *JsonPropertyLengthTracker) Drop() error {
 	t.Lock()
 	defer t.Unlock()
 
-	t.data.BucketedData = nil
+	clear(t.data.BucketedData)
 
 	if err := os.Remove(t.path); err != nil {
 		return errors.Wrap(err, "remove prop length tracker state from disk:"+t.path)


### PR DESCRIPTION
### What's being changed:
this PR avoids explicit `nil` assignment to map and instead clears the map to avoid nil panics on trying to add something to the map. 

it starts to arise when we had some tests in the chaos-pipeline for  MT- activate-deactivate test

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
