### PR TITLE
Python acceptance tests

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,4 +34,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          version: "23.9.1"
+          version: "24.2.0"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,3 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: yoheimuta/action-protolint@v1
+  python:
+    name: python checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+        with:
+          version: "23.9.1"

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--acceptance-only-fast", "--acceptance-only-graphql", "--acceptance-only-replication"]
+        test: ["--acceptance-only-fast", "--acceptance-only-graphql", "--acceptance-only-replication", "--acceptance-only-python"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,7 @@ creds.json
 # VSCode
 cmd/weaviate-server/__debug_bin*
 
-# python virtual env
+# python test
 .venv
+**/__pycache__
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ creds.json
 
 # VSCode
 cmd/weaviate-server/__debug_bin*
+
+# python virtual env
+.venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
         entry: ./tools/gen-code-from-swagger.sh
         language: system
         types: [ go ]
+  -   repo: https://github.com/psf/black
+      rev: 24.2.0
+      hooks:
+        -   id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 100
+include = 'test/acceptance_with_python/.*\\.py$'

--- a/test/acceptance_with_python/conftest.py
+++ b/test/acceptance_with_python/conftest.py
@@ -27,24 +27,24 @@ class CollectionFactory(Protocol):
     """Typing for fixture."""
 
     def __call__(
-            self,
-            name: str = "",
-            properties: Optional[List[Property]] = None,
-            references: Optional[List[_ReferencePropertyBase]] = None,
-            vectorizer_config: Optional[
-                Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
-            ] = None,
-            inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
-            multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
-            generative_config: Optional[_GenerativeConfigCreate] = None,
-            headers: Optional[Dict[str, str]] = None,
-            ports: Tuple[int, int] = (8080, 50051),
-            data_model_properties: Optional[Type[Properties]] = None,
-            data_model_refs: Optional[Type[Properties]] = None,
-            replication_config: Optional[_ReplicationConfigCreate] = None,
-            vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-            description: Optional[str] = None,
-            reranker_config: Optional[_RerankerConfigCreate] = None,
+        self,
+        name: str = "",
+        properties: Optional[List[Property]] = None,
+        references: Optional[List[_ReferencePropertyBase]] = None,
+        vectorizer_config: Optional[
+            Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
+        ] = None,
+        inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
+        multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
+        generative_config: Optional[_GenerativeConfigCreate] = None,
+        headers: Optional[Dict[str, str]] = None,
+        ports: Tuple[int, int] = (8080, 50051),
+        data_model_properties: Optional[Type[Properties]] = None,
+        data_model_refs: Optional[Type[Properties]] = None,
+        replication_config: Optional[_ReplicationConfigCreate] = None,
+        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+        description: Optional[str] = None,
+        reranker_config: Optional[_RerankerConfigCreate] = None,
     ) -> Collection[Any, Any]:
         """Typing for fixture."""
         ...
@@ -56,23 +56,23 @@ def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None
     client_fixture: Optional[weaviate.WeaviateClient] = None
 
     def _factory(
-            name: str = "",
-            properties: Optional[List[Property]] = None,
-            references: Optional[List[_ReferencePropertyBase]] = None,
-            vectorizer_config: Optional[
-                Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
-            ] = None,
-            inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
-            multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
-            generative_config: Optional[_GenerativeConfigCreate] = None,
-            headers: Optional[Dict[str, str]] = None,
-            ports: Tuple[int, int] = (8080, 50051),
-            data_model_properties: Optional[Type[Properties]] = None,
-            data_model_refs: Optional[Type[Properties]] = None,
-            replication_config: Optional[_ReplicationConfigCreate] = None,
-            vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-            description: Optional[str] = None,
-            reranker_config: Optional[_RerankerConfigCreate] = None,
+        name: str = "",
+        properties: Optional[List[Property]] = None,
+        references: Optional[List[_ReferencePropertyBase]] = None,
+        vectorizer_config: Optional[
+            Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
+        ] = None,
+        inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
+        multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
+        generative_config: Optional[_GenerativeConfigCreate] = None,
+        headers: Optional[Dict[str, str]] = None,
+        ports: Tuple[int, int] = (8080, 50051),
+        data_model_properties: Optional[Type[Properties]] = None,
+        data_model_refs: Optional[Type[Properties]] = None,
+        replication_config: Optional[_ReplicationConfigCreate] = None,
+        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+        description: Optional[str] = None,
+        reranker_config: Optional[_RerankerConfigCreate] = None,
     ) -> Collection[Any, Any]:
         nonlocal client_fixture, name_fixture
         name_fixture = _sanitize_collection_name(request.node.name) + name

--- a/test/acceptance_with_python/conftest.py
+++ b/test/acceptance_with_python/conftest.py
@@ -1,0 +1,114 @@
+import os
+from typing import Any, Optional, List, Generator, Protocol, Type, Dict, Tuple, Union
+
+import pytest
+from _pytest.fixtures import SubRequest
+
+import weaviate
+from weaviate.collections import Collection
+from weaviate.collections.classes.config import (
+    Property,
+    _VectorizerConfigCreate,
+    _InvertedIndexConfigCreate,
+    _ReferencePropertyBase,
+    _GenerativeConfigCreate,
+    _ReplicationConfigCreate,
+    _MultiTenancyConfigCreate,
+    _VectorIndexConfigCreate,
+    _RerankerConfigCreate,
+)
+from weaviate.collections.classes.types import Properties
+from weaviate.config import AdditionalConfig
+
+from weaviate.collections.classes.config_named_vectors import _NamedVectorConfigCreate
+
+
+class CollectionFactory(Protocol):
+    """Typing for fixture."""
+
+    def __call__(
+            self,
+            name: str = "",
+            properties: Optional[List[Property]] = None,
+            references: Optional[List[_ReferencePropertyBase]] = None,
+            vectorizer_config: Optional[
+                Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
+            ] = None,
+            inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
+            multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
+            generative_config: Optional[_GenerativeConfigCreate] = None,
+            headers: Optional[Dict[str, str]] = None,
+            ports: Tuple[int, int] = (8080, 50051),
+            data_model_properties: Optional[Type[Properties]] = None,
+            data_model_refs: Optional[Type[Properties]] = None,
+            replication_config: Optional[_ReplicationConfigCreate] = None,
+            vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+            description: Optional[str] = None,
+            reranker_config: Optional[_RerankerConfigCreate] = None,
+    ) -> Collection[Any, Any]:
+        """Typing for fixture."""
+        ...
+
+
+@pytest.fixture
+def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None, None]:
+    name_fixture: Optional[str] = None
+    client_fixture: Optional[weaviate.WeaviateClient] = None
+
+    def _factory(
+            name: str = "",
+            properties: Optional[List[Property]] = None,
+            references: Optional[List[_ReferencePropertyBase]] = None,
+            vectorizer_config: Optional[
+                Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
+            ] = None,
+            inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
+            multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
+            generative_config: Optional[_GenerativeConfigCreate] = None,
+            headers: Optional[Dict[str, str]] = None,
+            ports: Tuple[int, int] = (8080, 50051),
+            data_model_properties: Optional[Type[Properties]] = None,
+            data_model_refs: Optional[Type[Properties]] = None,
+            replication_config: Optional[_ReplicationConfigCreate] = None,
+            vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+            description: Optional[str] = None,
+            reranker_config: Optional[_RerankerConfigCreate] = None,
+    ) -> Collection[Any, Any]:
+        nonlocal client_fixture, name_fixture
+        name_fixture = _sanitize_collection_name(request.node.name) + name
+        client_fixture = weaviate.connect_to_local(
+            headers=headers,
+            grpc_port=ports[1],
+            port=ports[0],
+            additional_config=AdditionalConfig(timeout=(60, 120)),  # for image tests
+        )
+        client_fixture.collections.delete(name_fixture)
+
+        collection: Collection[Any, Any] = client_fixture.collections.create(
+            name=name_fixture,
+            description=description,
+            vectorizer_config=vectorizer_config,
+            properties=properties,
+            references=references,
+            inverted_index_config=inverted_index_config,
+            multi_tenancy_config=multi_tenancy_config,
+            generative_config=generative_config,
+            data_model_properties=data_model_properties,
+            data_model_references=data_model_refs,
+            replication_config=replication_config,
+            vector_index_config=vector_index_config,
+            reranker_config=reranker_config,
+        )
+        return collection
+
+    try:
+        yield _factory
+    finally:
+        if client_fixture is not None and name_fixture is not None:
+            client_fixture.collections.delete(name_fixture)
+            client_fixture.close()
+
+
+def _sanitize_collection_name(name: str) -> str:
+    name = name.replace("[", "").replace("]", "").replace("-", "").replace(" ", "").replace(".", "")
+    return name[0].upper() + name[1:]

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,0 +1,6 @@
+weaviate-client==4.5.1
+
+pytest>=8.0.1,<9.0.0
+pytest-xdist==3.5.0
+
+black>=24.2.0,<25.0.0

--- a/test/acceptance_with_python/run.sh
+++ b/test/acceptance_with_python/run.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/test/acceptance_with_python/run.sh
+++ b/test/acceptance_with_python/run.sh
@@ -19,6 +19,7 @@ source .venv/bin/activate
 
 cd "$SCRIPT_DIR" || return
 
+pip install --upgrade pip --quiet
 pip install -r requirements.txt --quiet
 
 # run python tests in parallel

--- a/test/acceptance_with_python/run.sh
+++ b/test/acceptance_with_python/run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Check if Python is installed
+if ! command -v python3 &>/dev/null; then
+    echo "Python is not installed. Please install Python and try again."
+    exit 1
+fi
+
+# Check if a virtual environment (venv) exists
+if [ ! -d "venv" ]; then
+    echo "Creating a new virtual environment (venv)..."
+    python3 -m venv .venv
+fi
+
+# Activate the virtual environment
+source .venv/bin/activate
+
+cd "$SCRIPT_DIR" || return
+
+pip install -r requirements.txt --quiet
+
+# run python tests in parallel
+pytest -n auto .

--- a/test/acceptance_with_python/test_filter.py
+++ b/test/acceptance_with_python/test_filter.py
@@ -6,16 +6,31 @@ from weaviate.collections.classes.filters import Filter, _FilterValue
 
 from conftest import CollectionFactory
 
+
+# bug in client + not supported in weaviate for filter by empty list
 @pytest.mark.parametrize(
     "weaviate_filter,results,skip",
     [
-        (Filter.by_property("textArray").equal([]), [1], True),  # bug in client + not supported in weaviate
+        (
+            Filter.by_property("textArray").equal([]),
+            [1],
+            True,
+        ),
         (Filter.by_property("textArray", length=True).equal(0), [1], False),
-        (Filter.by_property("textArray").not_equal([]), [0], True),  # bug in client + not supported in weaviate
+        (
+            Filter.by_property("textArray").not_equal([]),
+            [0],
+            True,
+        ),
         (Filter.by_property("textArray", length=True).not_equal(0), [0], False),
     ],
 )
-def test_empty_list_filter(collection_factory: CollectionFactory, weaviate_filter: _FilterValue,results: List[int],skip: bool) -> None:
+def test_empty_list_filter(
+    collection_factory: CollectionFactory,
+    weaviate_filter: _FilterValue,
+    results: List[int],
+    skip: bool,
+) -> None:
     if skip:
         pytest.skip("Not supported in this version")
     collection = collection_factory(

--- a/test/acceptance_with_python/test_filter.py
+++ b/test/acceptance_with_python/test_filter.py
@@ -1,0 +1,36 @@
+from typing import List
+
+import pytest
+from weaviate.collections.classes.config import Configure, Property, DataType
+from weaviate.collections.classes.filters import Filter, _FilterValue
+
+from conftest import CollectionFactory
+
+@pytest.mark.parametrize(
+    "weaviate_filter,results,skip",
+    [
+        (Filter.by_property("textArray").equal([]), [1], True),  # bug in client + not supported in weaviate
+        (Filter.by_property("textArray", length=True).equal(0), [1], False),
+        (Filter.by_property("textArray").not_equal([]), [0], True),  # bug in client + not supported in weaviate
+        (Filter.by_property("textArray", length=True).not_equal(0), [0], False),
+    ],
+)
+def test_empty_list_filter(collection_factory: CollectionFactory, weaviate_filter: _FilterValue,results: List[int],skip: bool) -> None:
+    if skip:
+        pytest.skip("Not supported in this version")
+    collection = collection_factory(
+        vectorizer_config=Configure.Vectorizer.none(),
+        properties=[Property(name="textArray", data_type=DataType.TEXT_ARRAY)],
+        inverted_index_config=Configure.inverted_index(index_property_length=True),
+    )
+
+    uuids = [
+        collection.data.insert({"textArray": ["one", "two"]}),
+        collection.data.insert({"textArray": []}),
+    ]
+
+    objects = collection.query.fetch_objects(filters=weaviate_filter).objects
+    assert len(objects) == len(results)
+
+    uuids = [uuids[result] for result in results]
+    assert all(obj.uuid in uuids for obj in objects)

--- a/test/run.sh
+++ b/test/run.sh
@@ -114,7 +114,7 @@ function main() {
     fi
   fi
 
-  if $run_acceptance_only_python|| $run_all_tests
+  if $run_acceptance_only_python || $run_all_tests
   then
     echo_green "Run python acceptance tests..."
     ./test/acceptance_with_python/run.sh

--- a/test/run.sh
+++ b/test/run.sh
@@ -85,14 +85,7 @@ function main() {
     echo_green "Integration tests successful"
   fi
 
-    if $run_acceptance_only_python|| $run_all_tests
-    then
-      echo_green "Run python acceptance tests..."
-      ./test/acceptance_with_python/run.sh
-      echo_green "Python tests successful"
-    fi
-
-  if $run_acceptance_tests  || $run_acceptance_only_fast || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_all_tests || $run_benchmark
+  if $run_acceptance_tests  || $run_acceptance_only_fast || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark
   then
     echo "Start docker container needed for acceptance and/or benchmark test"
     echo_green "Stop any running docker-compose containers..."
@@ -119,6 +112,13 @@ function main() {
       echo_green "Run acceptance tests..."
       run_acceptance_tests "$@"
     fi
+  fi
+
+  if $run_acceptance_only_python|| $run_all_tests
+  then
+    echo_green "Run python acceptance tests..."
+    ./test/acceptance_with_python/run.sh
+    echo_green "Python tests successful"
   fi
 
   if $only_module; then

--- a/test/run.sh
+++ b/test/run.sh
@@ -7,6 +7,7 @@ function main() {
   run_all_tests=true
   run_acceptance_tests=false
   run_acceptance_only_fast=false
+  run_acceptance_only_python=false
   run_acceptance_graphql_tests=false
   run_acceptance_replication_tests=false
   run_module_tests=false
@@ -27,6 +28,7 @@ function main() {
           --acceptance-only|--e2e-only|-a) run_all_tests=false; run_acceptance_tests=true ;;
           
           --acceptance-only-fast|-aof) run_all_tests=false; run_acceptance_only_fast=true;;
+          --acceptance-only-python|-aop) run_all_tests=false; run_acceptance_only_python=true;;
           --acceptance-only-graphql|-aog) run_all_tests=false; run_acceptance_graphql_tests=true ;;
           --acceptance-only-replication|-aor) run_all_tests=false; run_acceptance_replication_tests=true ;;
           --only-module-*|-om)run_all_tests=false; only_module=true;only_module_value=$1;;
@@ -41,6 +43,7 @@ function main() {
               "--integration-only | -i"\
               "--acceptance-only | -a"\
               "--acceptance-only-fast | -aof"\
+              "--acceptance-only-python | -aop"\
               "--acceptance-only-graphql | -aog"\
               "--acceptance-only-replication| -aor"\
               "--acceptance-module-tests-only | --modules-only | -m"\
@@ -80,7 +83,14 @@ function main() {
     echo_green "Run integration tests..."
     run_integration_tests "$@"
     echo_green "Integration tests successful"
-  fi 
+  fi
+
+    if $run_acceptance_only_python|| $run_all_tests
+    then
+      echo_green "Run python acceptance tests..."
+      ./test/acceptance_with_python/run.sh
+      echo_green "Python tests successful"
+    fi
 
   if $run_acceptance_tests  || $run_acceptance_only_fast || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_all_tests || $run_benchmark
   then


### PR DESCRIPTION
### What's being changed:

Adds framework for python acceptance test

This:
- allows to run python tests from the standard run.sh script
  - can also be used directly using `pytest -n auto *path*`
- Adds an extra CI job
- automatically creates a venv with the correct dependencies and activates it

All tests are run in parallel by default and clean up before and after their execution

