### PR TITLE
Point to jinja file located under docker-compose-raft directory

### DIFF
--- a/docker-compose-raft/raft_cluster.sh
+++ b/docker-compose-raft/raft_cluster.sh
@@ -23,6 +23,8 @@ esac
 # Set default value for VOTERS
 VOTERS=${1:-2}
 FILE_NAME="docker-compose-raft.yml"
+# Get the directory of the script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Check if jinja2 is installed
 if ! command -v jinja2 &> /dev/null; then
@@ -38,7 +40,7 @@ if ! command -v jinja2 &> /dev/null; then
 fi
 
 # Generate docker-compose-raft.yml using jinja2
-jinja2 docker-compose-raft.yml.j2 -D NUMBER_VOTERS=${VOTERS} -o ${FILE_NAME}
+jinja2 ${SCRIPT_DIR}/docker-compose-raft.yml.j2 -D NUMBER_VOTERS=${VOTERS} -o ${FILE_NAME}
 
 echo -e "You can now start your multinode Weaviate compose! To do so, run the following command:\n\
     docker-compose -f ${FILE_NAME} up -d\n\


### PR DESCRIPTION
### What's being changed:
Depending on where the script was being executed, it was not able to locate the docker-compose-raft.yml.j2 jinja2 template file.
This change retrieves the directory from which the script is running and uses it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
