### PR TITLE
Add support for multiple transformers and clip modules

### DIFF
--- a/modules/multi2vec-clip/clients/meta.go
+++ b/modules/multi2vec-clip/clients/meta.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (v *vectorizer) MetaInfo() (map[string]interface{}, error) {
-	req, err := http.NewRequestWithContext(context.Background(), "GET", v.url("/meta"), nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", v.url("/meta", ""), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "create GET meta request")
 	}

--- a/modules/multi2vec-clip/clients/startup.go
+++ b/modules/multi2vec-clip/clients/startup.go
@@ -49,7 +49,7 @@ func (v *vectorizer) checkReady(initCtx context.Context) error {
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet,
-		v.url("/.well-known/ready"), nil)
+		v.url("/.well-known/ready", ""), nil)
 	if err != nil {
 		return errors.Wrap(err, "create check ready request")
 	}

--- a/modules/multi2vec-clip/clients/vectorizer.go
+++ b/modules/multi2vec-clip/clients/vectorizer.go
@@ -42,7 +42,7 @@ func New(origin string, timeout time.Duration, logger logrus.FieldLogger) *vecto
 }
 
 func (v *vectorizer) Vectorize(ctx context.Context,
-	texts, images []string,
+	texts, images []string, config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
 	body, err := json.Marshal(vecRequest{
 		Texts:  texts,
@@ -52,7 +52,7 @@ func (v *vectorizer) Vectorize(ctx context.Context,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", v.url("/vectorize"),
+	req, err := http.NewRequestWithContext(ctx, "POST", v.url("/vectorize", config.InferenceURL),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "create POST request")
@@ -85,7 +85,10 @@ func (v *vectorizer) Vectorize(ctx context.Context,
 	}, nil
 }
 
-func (v *vectorizer) url(path string) string {
+func (v *vectorizer) url(path string, inferenceURL string) string {
+	if inferenceURL != "" {
+		return fmt.Sprintf("%s%s", inferenceURL, path)
+	}
 	return fmt.Sprintf("%s%s", v.origin, path)
 }
 

--- a/modules/multi2vec-clip/clients/vectorizer_test.go
+++ b/modules/multi2vec-clip/clients/vectorizer_test.go
@@ -39,7 +39,7 @@ func TestVectorize(t *testing.T) {
 		defer server.Close()
 		c := New(server.URL, 0, nullLogger())
 		res, err := c.Vectorize(context.Background(), []string{"hello"},
-			[]string{"image-encoding"})
+			[]string{"image-encoding"}, ent.VectorizationConfig{})
 
 		assert.Nil(t, err)
 		assert.Equal(t, &ent.VectorizationResult{
@@ -62,7 +62,7 @@ func TestVectorize(t *testing.T) {
 		defer server.Close()
 		c := New(server.URL, 0, nullLogger())
 		_, err := c.Vectorize(context.Background(), []string{"hello"},
-			[]string{"image-encoding"})
+			[]string{"image-encoding"}, ent.VectorizationConfig{})
 
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "some error from the server")

--- a/modules/multi2vec-clip/ent/vectorization_config.go
+++ b/modules/multi2vec-clip/ent/vectorization_config.go
@@ -12,7 +12,5 @@
 package ent
 
 type VectorizationConfig struct {
-	PoolingStrategy                        string
-	InferenceURL                           string
-	PassageInferenceURL, QueryInferenceURL string
+	InferenceURL string
 }

--- a/modules/multi2vec-clip/vectorizer/class_settings.go
+++ b/modules/multi2vec-clip/vectorizer/class_settings.go
@@ -45,6 +45,24 @@ func (ic *classSettings) TextFieldsWeights() ([]float32, error) {
 	return ic.getFieldsWeights("text")
 }
 
+func (ic *classSettings) InferenceURL() string {
+	if ic.cfg == nil {
+		return ""
+	}
+
+	url, ok := ic.cfg.Class()["inferenceUrl"]
+	if !ok {
+		return ""
+	}
+
+	asString, ok := url.(string)
+	if !ok {
+		return ""
+	}
+
+	return asString
+}
+
 func (ic *classSettings) field(name, property string) bool {
 	if ic.cfg == nil {
 		// we would receive a nil-config on cross-class requests, such as Explore{}

--- a/modules/multi2vec-clip/vectorizer/class_settings_test.go
+++ b/modules/multi2vec-clip/vectorizer/class_settings_test.go
@@ -80,6 +80,14 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "should pass with proper value in imageFields and inferenceUrl",
+			fields: fields{
+				cfg: newConfigBuilder().
+					addSetting("inferenceUrl", "http://inference.url").
+					addSetting("imageFields", []interface{}{"field"}).build(),
+			},
+		},
+		{
 			name: "should pass with proper value in imageFields and textFields",
 			fields: fields{
 				cfg: newConfigBuilder().

--- a/modules/multi2vec-clip/vectorizer/fakes_for_test.go
+++ b/modules/multi2vec-clip/vectorizer/fakes_for_test.go
@@ -77,7 +77,7 @@ func (f fakeClassConfig) TargetVector() string {
 type fakeClient struct{}
 
 func (c *fakeClient) Vectorize(ctx context.Context,
-	texts, images []string,
+	texts, images []string, config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
 	result := &ent.VectorizationResult{
 		TextVectors:  [][]float32{{1.0, 2.0, 3.0, 4.0, 5.0}},

--- a/modules/multi2vec-clip/vectorizer/texts.go
+++ b/modules/multi2vec-clip/vectorizer/texts.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/multi2vec-clip/ent"
 	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
 )
 
 func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	cfg moduletools.ClassConfig,
 ) ([]float32, error) {
-	res, err := v.client.Vectorize(ctx, inputs, []string{})
+	res, err := v.client.Vectorize(ctx, inputs, []string{}, v.getVectorizationConfig(cfg))
 	if err != nil {
 		return nil, errors.Wrap(err, "remote client vectorize")
 	}
@@ -30,4 +31,8 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 		return nil, errors.New("inputs are not equal to vectors returned")
 	}
 	return libvectorizer.CombineVectors(res.TextVectors), nil
+}
+
+func (v *Vectorizer) getVectorizationConfig(cfg moduletools.ClassConfig) ent.VectorizationConfig {
+	return ent.VectorizationConfig{InferenceURL: NewClassSettings(cfg).InferenceURL()}
 }

--- a/modules/multi2vec-clip/vectorizer/vectorizer.go
+++ b/modules/multi2vec-clip/vectorizer/vectorizer.go
@@ -38,7 +38,7 @@ func New(client Client) *Vectorizer {
 
 type Client interface {
 	Vectorize(ctx context.Context,
-		texts, images []string) (*ent.VectorizationResult, error)
+		texts, images []string, config ent.VectorizationConfig) (*ent.VectorizationResult, error)
 }
 
 type ClassSettings interface {
@@ -46,6 +46,7 @@ type ClassSettings interface {
 	ImageFieldsWeights() ([]float32, error)
 	TextField(property string) bool
 	TextFieldsWeights() ([]float32, error)
+	InferenceURL() string
 }
 
 func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
@@ -56,7 +57,7 @@ func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
 }
 
 func (v *Vectorizer) VectorizeImage(ctx context.Context, id, image string, cfg moduletools.ClassConfig) ([]float32, error) {
-	res, err := v.client.Vectorize(ctx, []string{}, []string{image})
+	res, err := v.client.Vectorize(ctx, []string{}, []string{image}, v.getVectorizationConfig(cfg))
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +116,7 @@ func (v *Vectorizer) object(ctx context.Context, id strfmt.UUID,
 
 	vectors := [][]float32{}
 	if len(texts) > 0 || len(images) > 0 {
-		res, err := v.client.Vectorize(ctx, texts, images)
+		res, err := v.client.Vectorize(ctx, texts, images, v.getVectorizationConfig(cfg))
 		if err != nil {
 			return nil, err
 		}

--- a/modules/text2vec-transformers/clients/meta.go
+++ b/modules/text2vec-transformers/clients/meta.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/modules/text2vec-transformers/ent"
 )
 
 func (v *vectorizer) MetaInfo() (map[string]interface{}, error) {
@@ -32,10 +33,10 @@ func (v *vectorizer) MetaInfo() (map[string]interface{}, error) {
 
 	endpoints := map[string]string{}
 	if v.originPassage != v.originQuery {
-		endpoints["passage"] = v.urlPassage("/meta")
-		endpoints["query"] = v.urlQuery("/meta")
+		endpoints["passage"] = v.urlPassage("/meta", ent.VectorizationConfig{})
+		endpoints["query"] = v.urlQuery("/meta", ent.VectorizationConfig{})
 	} else {
-		endpoints[""] = v.urlPassage("/meta")
+		endpoints[""] = v.urlPassage("/meta", ent.VectorizationConfig{})
 	}
 
 	var wg sync.WaitGroup

--- a/modules/text2vec-transformers/clients/startup.go
+++ b/modules/text2vec-transformers/clients/startup.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/modules/text2vec-transformers/ent"
 )
 
 func (v *vectorizer) WaitForStartup(initCtx context.Context,
@@ -26,10 +27,10 @@ func (v *vectorizer) WaitForStartup(initCtx context.Context,
 ) error {
 	endpoints := map[string]string{}
 	if v.originPassage != v.originQuery {
-		endpoints["passage"] = v.urlPassage("/.well-known/ready")
-		endpoints["query"] = v.urlQuery("/.well-known/ready")
+		endpoints["passage"] = v.urlPassage("/.well-known/ready", ent.VectorizationConfig{})
+		endpoints["query"] = v.urlQuery("/.well-known/ready", ent.VectorizationConfig{})
 	} else {
-		endpoints[""] = v.urlPassage("/.well-known/ready")
+		endpoints[""] = v.urlPassage("/.well-known/ready", ent.VectorizationConfig{})
 	}
 
 	ch := make(chan error, len(endpoints))

--- a/modules/text2vec-transformers/clients/transformers.go
+++ b/modules/text2vec-transformers/clients/transformers.go
@@ -56,7 +56,7 @@ func (v *vectorizer) VectorizeQuery(ctx context.Context, input string,
 }
 
 func (v *vectorizer) vectorize(ctx context.Context, input string,
-	config ent.VectorizationConfig, url func(string) string,
+	config ent.VectorizationConfig, url func(string, ent.VectorizationConfig) string,
 ) (*ent.VectorizationResult, error) {
 	body, err := json.Marshal(vecRequest{
 		Text: input,
@@ -68,7 +68,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input string,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url("/vectors"),
+	req, err := http.NewRequestWithContext(ctx, "POST", url("/vectors", config),
 		bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "create POST request")
@@ -102,12 +102,26 @@ func (v *vectorizer) vectorize(ctx context.Context, input string,
 	}, nil
 }
 
-func (v *vectorizer) urlPassage(path string) string {
-	return fmt.Sprintf("%s%s", v.originPassage, path)
+func (v *vectorizer) urlPassage(path string, config ent.VectorizationConfig) string {
+	baseURL := v.originPassage
+	if config.PassageInferenceURL != "" {
+		baseURL = config.PassageInferenceURL
+	}
+	if config.InferenceURL != "" {
+		baseURL = config.InferenceURL
+	}
+	return fmt.Sprintf("%s%s", baseURL, path)
 }
 
-func (v *vectorizer) urlQuery(path string) string {
-	return fmt.Sprintf("%s%s", v.originQuery, path)
+func (v *vectorizer) urlQuery(path string, config ent.VectorizationConfig) string {
+	baseURL := v.originQuery
+	if config.QueryInferenceURL != "" {
+		baseURL = config.QueryInferenceURL
+	}
+	if config.InferenceURL != "" {
+		baseURL = config.InferenceURL
+	}
+	return fmt.Sprintf("%s%s", baseURL, path)
 }
 
 type vecRequest struct {

--- a/modules/text2vec-transformers/vectorizer/class_settings.go
+++ b/modules/text2vec-transformers/vectorizer/class_settings.go
@@ -12,6 +12,8 @@
 package vectorizer
 
 import (
+	"errors"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
@@ -52,6 +54,48 @@ func (ic *classSettings) PoolingStrategy() string {
 	return asString
 }
 
+func (ic *classSettings) InferenceURL() string {
+	return ic.getSetting("inferenceUrl")
+}
+
+func (ic *classSettings) PassageInferenceURL() string {
+	return ic.getSetting("passageInferenceUrl")
+}
+
+func (ic *classSettings) QueryInferenceURL() string {
+	return ic.getSetting("queryInferenceUrl")
+}
+
+func (ic *classSettings) getSetting(property string) string {
+	if ic.cfg == nil {
+		return ""
+	}
+
+	url, ok := ic.cfg.Class()[property]
+	if !ok {
+		return ""
+	}
+
+	asString, ok := url.(string)
+	if !ok {
+		return ""
+	}
+
+	return asString
+}
+
 func (ic *classSettings) Validate(class *models.Class) error {
+	if err := ic.BaseClassSettings.Validate(); err != nil {
+		return err
+	}
+	if ic.InferenceURL() != "" && (ic.PassageInferenceURL() != "" || ic.QueryInferenceURL() != "") {
+		return errors.New("either inferenceUrl or passageInferenceUrl together with queryInferenceUrl needs to be set, not both")
+	}
+	if ic.PassageInferenceURL() == "" && ic.QueryInferenceURL() != "" {
+		return errors.New("queryInferenceUrl is set but passageInferenceUrl is empty, both needs to be set")
+	}
+	if ic.PassageInferenceURL() != "" && ic.QueryInferenceURL() == "" {
+		return errors.New("passageInferenceUrl is set but queryInferenceUrl is empty, both needs to be set")
+	}
 	return ic.BaseClassSettings.Validate()
 }

--- a/modules/text2vec-transformers/vectorizer/class_settings_test.go
+++ b/modules/text2vec-transformers/vectorizer/class_settings_test.go
@@ -12,9 +12,11 @@
 package vectorizer
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/modules"
 )
@@ -149,4 +151,171 @@ func TestClassSettings(t *testing.T) {
 		assert.False(t, ic.VectorizePropertyName("otherProp"))
 		assert.False(t, ic.VectorizeClassName())
 	})
+
+	t.Run("with inferenceUrl setting", func(t *testing.T) {
+		class := &models.Class{
+			Class: "MyClass",
+			VectorConfig: map[string]models.VectorConfig{
+				"withInferenceUrl": {
+					Vectorizer: map[string]interface{}{
+						"my-module": map[string]interface{}{
+							"vectorizeClassName": false,
+							"poolingStrategy":    "cls",
+							"inferenceUrl":       "http://inference.url",
+						},
+					},
+				},
+				"withPassageAndQueryInferenceUrl": {
+					Vectorizer: map[string]interface{}{
+						"my-module": map[string]interface{}{
+							"vectorizeClassName":  false,
+							"poolingStrategy":     "cls",
+							"passageInferenceUrl": "http://passage.inference.url",
+							"queryInferenceUrl":   "http://query.inference.url",
+						},
+					},
+				},
+			},
+
+			Properties: []*models.Property{{
+				Name: "someProp",
+				ModuleConfig: map[string]interface{}{
+					"my-module": map[string]interface{}{
+						"skip":                  true,
+						"vectorizePropertyName": true,
+					},
+				},
+			}},
+		}
+
+		cfg := modules.NewClassBasedModuleConfig(class, "my-module", "tenant", "withInferenceUrl")
+		ic := NewClassSettings(cfg)
+
+		assert.False(t, ic.PropertyIndexed("someProp"))
+		assert.True(t, ic.VectorizePropertyName("someProp"))
+		assert.False(t, ic.VectorizeClassName())
+		assert.Equal(t, ic.PoolingStrategy(), "cls")
+		assert.Equal(t, ic.InferenceURL(), "http://inference.url")
+		assert.Empty(t, ic.PassageInferenceURL())
+		assert.Empty(t, ic.QueryInferenceURL())
+
+		cfg = modules.NewClassBasedModuleConfig(class, "my-module", "tenant", "withPassageAndQueryInferenceUrl")
+		ic = NewClassSettings(cfg)
+
+		assert.False(t, ic.PropertyIndexed("someProp"))
+		assert.True(t, ic.VectorizePropertyName("someProp"))
+		assert.False(t, ic.VectorizeClassName())
+		assert.Equal(t, ic.PoolingStrategy(), "cls")
+		assert.Empty(t, ic.InferenceURL())
+		assert.Equal(t, ic.PassageInferenceURL(), "http://passage.inference.url")
+		assert.Equal(t, ic.QueryInferenceURL(), "http://query.inference.url")
+	})
+}
+
+func Test_classSettings_Validate(t *testing.T) {
+	tests := []struct {
+		name       string
+		vectorizer map[string]interface{}
+		wantErr    error
+	}{
+		{
+			name: "only inference url",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName": false,
+				"poolingStrategy":    "cls",
+				"inferenceUrl":       "http://inference.url",
+			},
+		},
+		{
+			name: "only passage and query inference urls",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName":  false,
+				"poolingStrategy":     "cls",
+				"passageInferenceUrl": "http://passage.inference.url",
+				"queryInferenceUrl":   "http://query.inference.url",
+			},
+		},
+		{
+			name: "error - all inference urls",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName":  false,
+				"poolingStrategy":     "cls",
+				"inferenceUrl":        "http://inference.url",
+				"passageInferenceUrl": "http://passage.inference.url",
+				"queryInferenceUrl":   "http://query.inference.url",
+			},
+			wantErr: errors.New("either inferenceUrl or passageInferenceUrl together with queryInferenceUrl needs to be set, not both"),
+		},
+		{
+			name: "error - all inference urls, without passage",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName": false,
+				"poolingStrategy":    "cls",
+				"inferenceUrl":       "http://inference.url",
+				"queryInferenceUrl":  "http://query.inference.url",
+			},
+			wantErr: errors.New("either inferenceUrl or passageInferenceUrl together with queryInferenceUrl needs to be set, not both"),
+		},
+		{
+			name: "error - all inference urls, without query",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName":  false,
+				"poolingStrategy":     "cls",
+				"inferenceUrl":        "http://inference.url",
+				"passageInferenceUrl": "http://passage.inference.url",
+			},
+			wantErr: errors.New("either inferenceUrl or passageInferenceUrl together with queryInferenceUrl needs to be set, not both"),
+		},
+		{
+			name: "error - passage inference url set but not query",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName":  false,
+				"poolingStrategy":     "cls",
+				"passageInferenceUrl": "http://passage.inference.url",
+			},
+			wantErr: errors.New("passageInferenceUrl is set but queryInferenceUrl is empty, both needs to be set"),
+		},
+		{
+			name: "error - query inference url set but not passage",
+			vectorizer: map[string]interface{}{
+				"vectorizeClassName": false,
+				"poolingStrategy":    "cls",
+				"queryInferenceUrl":  "http://passage.inference.url",
+			},
+			wantErr: errors.New("queryInferenceUrl is set but passageInferenceUrl is empty, both needs to be set"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class := &models.Class{
+				Class: "MyClass",
+				VectorConfig: map[string]models.VectorConfig{
+					"namedVector": {
+						Vectorizer: map[string]interface{}{
+							"my-module": tt.vectorizer,
+						},
+					},
+				},
+				Properties: []*models.Property{{
+					Name: "someProp",
+					ModuleConfig: map[string]interface{}{
+						"my-module": map[string]interface{}{
+							"skip":                  true,
+							"vectorizePropertyName": true,
+						},
+					},
+				}},
+			}
+
+			cfg := modules.NewClassBasedModuleConfig(class, "my-module", "tenant", "namedVector")
+			ic := NewClassSettings(cfg)
+			err := ic.Validate(class)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
 }

--- a/modules/text2vec-transformers/vectorizer/objects.go
+++ b/modules/text2vec-transformers/vectorizer/objects.go
@@ -63,9 +63,7 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 		return vector, nil
 	}
 	// vectorize text
-	res, err := v.client.VectorizeObject(ctx, text, ent.VectorizationConfig{
-		PoolingStrategy: NewClassSettings(cfg).PoolingStrategy(),
-	})
+	res, err := v.client.VectorizeObject(ctx, text, v.getVectorizationConfig(cfg))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/text2vec-transformers/vectorizer/texts.go
+++ b/modules/text2vec-transformers/vectorizer/texts.go
@@ -25,9 +25,7 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 ) ([]float32, error) {
 	vectors := make([][]float32, len(inputs))
 	for i := range inputs {
-		res, err := v.client.VectorizeQuery(ctx, inputs[i], ent.VectorizationConfig{
-			PoolingStrategy: NewClassSettings(cfg).PoolingStrategy(),
-		})
+		res, err := v.client.VectorizeQuery(ctx, inputs[i], v.getVectorizationConfig(cfg))
 		if err != nil {
 			return nil, errors.Wrap(err, "remote client vectorize")
 		}
@@ -35,4 +33,14 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	}
 
 	return libvectorizer.CombineVectors(vectors), nil
+}
+
+func (v *Vectorizer) getVectorizationConfig(cfg moduletools.ClassConfig) ent.VectorizationConfig {
+	settings := NewClassSettings(cfg)
+	return ent.VectorizationConfig{
+		PoolingStrategy:     settings.PoolingStrategy(),
+		InferenceURL:        settings.InferenceURL(),
+		PassageInferenceURL: settings.PassageInferenceURL(),
+		QueryInferenceURL:   settings.QueryInferenceURL(),
+	}
 }


### PR DESCRIPTION
### What's being changed:

This PR adds support for multiple transformers and clip modules. It introduces new `inferenceUrl` setting that can be applied in `transformers` and `clip` modules configuration examples:

```
"text2vec-transformers": map[string]interface{}{
    "vectorizeClassName": false,
    "inferenceUrl":       "http://custom-server-url:8080",
    "properties":         []interface{}{"prompt"},
},
```
```
"multi2vec-clip": map[string]interface{}{
    "vectorizeClassName": false,
    "inferenceUrl":       "http://192.168.0.1:9090",
    "imageFields":        []interface{}{"image"},
},
```
Additionally in `transformers` module it's also possible to configure `passage` and `query` endpoints:
```
"text2vec-transformers": map[string]interface{}{
    "vectorizeClassName":  false,
    "passageInferenceUrl": "http://passage-server-url:8080",
    "queryInferenceUrl":   "http://query-server-url:8080",
},
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
