### PR TITLE
allow pushing to docker on remote branch without PR

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -30,4 +30,25 @@ jobs:
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
+  Push-Docker:
+    needs: [Unit-Tests] # TODO-RAFT could be removed
+    name: push-docker
+    runs-on: ubuntu-latest-8-cores
+    if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Push container
+        id: push-container
+        run: ./ci/push_docker.sh
+        env:
+          PR_TITLE: "${{ github.event.pull_request.title }}"
+      - name: Generate Report
+        env:
+          PREVIEW_TAG: "${{ steps.push-container.outputs.PREVIEW_TAG }}"
+        run: ./ci/generate_docker_report.sh
 


### PR DESCRIPTION
### What's being changed:
many times  we just need to generate docker image to be used and shared with other pipelines in order to debug changes. 

this change make that by pushing without the need to open PRs and then close them especially for debugging purposes 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
