### PR TITLE
Release resources when backup process is interrupted

### DIFF
--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -166,11 +166,13 @@ func (b *backupper) backup(ctx context.Context,
 		ctx := b.withCancellation(context.Background(), id, done)
 		defer close(done)
 
+		logFields := logrus.Fields{"action": "create_backup", "backup_id": req.ID}
 		if err := provider.all(ctx, req.Classes, &result); err != nil {
-			b.logger.WithField("action", "create_backup").
-				Error(err)
+			b.logger.WithFields(logFields).Error(err)
 			b.lastAsyncError = err
 
+		} else {
+			b.logger.WithFields(logFields).Info("backup completed successfully")
 		}
 		result.CompletedAt = time.Now().UTC()
 	}()

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -170,9 +170,14 @@ func (c *coordinator) Backup(ctx context.Context, store coordStore, req *Request
 		defer c.lastOp.reset()
 		ctx := context.Background()
 		c.commit(ctx, &statusReq, nodes, false)
+		logFields := logrus.Fields{"action": OpCreate, "backup_id": req.ID}
 		if err := store.PutMeta(ctx, GlobalBackupFile, c.descriptor); err != nil {
-			c.log.WithField("action", OpCreate).
-				WithField("backup_id", req.ID).Errorf("put_meta: %v", err)
+			c.log.WithFields(logFields).Errorf("coordinator: put_meta: %v", err)
+		}
+		if c.descriptor.Status == backup.Success {
+			c.log.WithFields(logFields).Info("coordinator: backup completed successfully")
+		} else {
+			c.log.WithFields(logFields).Errorf("coordinator: %s", c.descriptor.Error)
 		}
 	}()
 
@@ -216,8 +221,14 @@ func (c *coordinator) Restore(
 		defer c.lastOp.reset()
 		ctx := context.Background()
 		c.commit(ctx, &statusReq, nodes, true)
+		logFields := logrus.Fields{"action": OpRestore, "backup_id": req.ID}
 		if err := store.PutMeta(ctx, GlobalRestoreFile, c.descriptor); err != nil {
-			c.log.WithField("action", OpRestore).WithField("backup_id", desc.ID).Errorf("put_meta: %v", err)
+			c.log.WithFields(logFields).Errorf("coordinator: put_meta: %v", err)
+		}
+		if c.descriptor.Status == backup.Success {
+			c.log.WithFields(logFields).Info("coordinator: backup restored successfully")
+		} else {
+			c.log.WithFields(logFields).Errorf("coordinator: %v", c.descriptor.Error)
 		}
 	}()
 
@@ -410,7 +421,7 @@ func (c *coordinator) queryAll(ctx context.Context, req *StatusRequest, nodes ma
 		} else if now.Sub(st.LastTime) > c.timeoutNodeDown {
 			n++
 			st.Status = backup.Failed
-			st.Reason = "might be down:" + r.err.Error()
+			st.Reason = fmt.Sprintf("node %q might be down: %v", r.node, r.err.Error())
 			delete(nodes, r.node)
 		}
 		c.Participants[r.node] = st

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -106,8 +106,11 @@ func (r *restorer) restore(ctx context.Context,
 		}
 
 		err = r.restoreAll(context.Background(), desc, req.CPUPercentage, store, req.NodeMapping)
+		logFields := logrus.Fields{"action": "restore", "backup_id": req.ID}
 		if err != nil {
-			r.logger.WithField("action", "restore").WithField("backup_id", desc.ID).Error(err)
+			r.logger.WithFields(logFields).Error(err)
+		} else {
+			r.logger.WithFields(logFields).Info("backup restored successfully")
 		}
 	}()
 


### PR DESCRIPTION
Release resources when the backup process is interrupted, enabling the cycle manager to be activated again. 
This PR also includes additional log messages to display the final backup result from both the coordinator node and other nodes

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
