### PR TITLE
Add workflow to trigger Chaos Pipeline

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -235,12 +235,34 @@ jobs:
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Push container
-        id: push-container
-        run: ./ci/push_docker.sh
+      - name: Create tag
+        id: create-tag
+        run: ./ci/create_docker_tag.sh
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
+      - name: Push container
+        run: ./ci/push_docker.sh
+        env:
+          PREVIEW_TAG: "${{ steps.create-tag.outputs.PREVIEW_TAG }}"
       - name: Generate Report
         env:
-          PREVIEW_TAG: "${{ steps.push-container.outputs.PREVIEW_TAG }}"
+          PREVIEW_TAG: "${{ steps.create-tag.outputs.PREVIEW_TAG }}"
         run: ./ci/generate_docker_report.sh
+    # TO REMOVE: Used for testing
+      - name: Trigger chaos-pipeline for image
+        env:
+          WEAVIATE_VERSION: ${{ steps.create-tag.outputs.PREVIEW_TAG }}
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: jfrancoa
+          repo: weaviate-chaos-engineering
+          github_token: ${{ secrets.CHAOS_ENGINEERING_TOKEN }}
+          workflow_file_name: tests.yaml
+          ref: main
+          wait_interval: 30
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+          comment_downstream_url: true
+          comment_github_token: ${{ secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -260,9 +260,9 @@ jobs:
           workflow_file_name: tests.yaml
           ref: main
           wait_interval: 30
-          propagate_failure: true
+          client_payload: '{ "weaviate_version" : "${{ env.WEAVIATE_VERSION }}" }'
           trigger_workflow: true
-          wait_workflow: true
+          wait_workflow: false
           comment_downstream_url: true
           comment_github_token: ${{ secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -257,7 +257,7 @@ jobs:
           owner: jfrancoa
           repo: weaviate-chaos-engineering
           github_token: ${{ secrets.CHAOS_ENGINEERING_TOKEN }}
-          workflow_file_name: tests.yaml
+          workflow_file_name: matrix.yaml
           ref: main
           wait_interval: 30
           client_payload: '{ "weaviate_version" : "${{ env.WEAVIATE_VERSION }}" }'

--- a/.github/workflows/trigger_chaos.yaml
+++ b/.github/workflows/trigger_chaos.yaml
@@ -1,0 +1,58 @@
+name: "Trigger Chaos Pipeline"
+
+on:
+    issue_comment:
+        types: [created]
+
+jobs:
+    Trigger-Chaos:
+        name: trigger-chaos
+        runs-on: ubuntu-latest
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '/run-chaos')
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                username: ${{secrets.DOCKER_USERNAME}}
+                password: ${{secrets.DOCKER_PASSWORD}}
+            - name: Create tag
+              id: create-tag
+              run: ./ci/create_docker_tag.sh
+              env:
+                PR_TITLE: "${{ github.event.pull_request.title }}"
+            - name: Check if image exists
+              id: check-image
+              run: |
+                if ! docker image inspect semitechnologies/weaviate:${{ steps.create-tag.outputs.PREVIEW_TAG }} >/dev/null 2>&1; then
+                    echo "::set-output name=image_exists::false"
+                else
+                    echo "::set-output name=image_exists::true"
+                fi
+            - name: Push container
+              run: |
+                if [[ "${{ steps.check-image.outputs.image_exists }}" == "false" ]]; then
+                    ./ci/push_docker.sh
+                else
+                    echo "Docker image semitechnologies/weaviate:${{ steps.create-tag.outputs.PREVIEW_TAG }} already exists. Skipping push."
+                fi
+              env:
+                PREVIEW_TAG: "${{ steps.create-tag.outputs.PREVIEW_TAG }}"
+            - name: Trigger chaos-pipeline for image
+              env:
+                WEAVIATE_VERSION: ${{ steps.create-tag.outputs.PREVIEW_TAG }}
+              uses: convictional/trigger-workflow-and-wait@v1.6.5
+              with:
+                owner: weaviate
+                repo: weaviate-chaos-engineering
+                github_token: ${{ secrets.CHAOS_ENGINEERING_TOKEN }}
+                workflow_file_name: tests.yaml
+                ref: main
+                wait_interval: 30
+                propagate_failure: true
+                trigger_workflow: true
+                wait_workflow: true
+                comment_downstream_url: true
+                comment_github_token: ${{ secrets.GITHUB_TOKEN}}
+

--- a/ci/create_docker_tag.sh
+++ b/ci/create_docker_tag.sh
@@ -1,0 +1,21 @@
+DOCKER_REPO="semitechnologies/weaviate"
+
+tag=""
+git_hash=$(echo "$GITHUB_SHA" | cut -c1-7)
+
+weaviate_version="$(jq -r '.info.version' < openapi-specs/schema.json)"
+if [ "$GITHUB_REF_NAME" = "master" ]; then
+    tag="${DOCKER_REPO}:${weaviate_version}-${git_hash}"
+elif [  "$GITHUB_REF_TYPE" == "tag" ]; then
+    if [ "$GITHUB_REF_NAME" != "v$weaviate_version" ]; then
+        echo "The release tag ($GITHUB_REF_NAME) and Weaviate version (v$weaviate_version) are not equal! Can't release."
+        return 1
+    fi
+    tag="${DOCKER_REPO}:${weaviate_version}"
+else
+    pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
+    tag="${DOCKER_REPO}:preview-${pr_title}-${git_hash}"
+fi
+
+echo "PREVIEW_TAG=$tag" >> "$GITHUB_OUTPUT"
+

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -7,43 +7,14 @@ function release() {
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   docker buildx create --use
 
-  tag_latest="${DOCKER_REPO}:latest"
-  tag_exact=
-  tag_preview=
-
   git_hash=$(echo "$GITHUB_SHA" | cut -c1-7)
 
   weaviate_version="$(jq -r '.info.version' < openapi-specs/schema.json)"
-  if [ "$GITHUB_REF_NAME" = "master" ]; then
-    tag_exact="${DOCKER_REPO}:${weaviate_version}-${git_hash}"
-  elif [  "$GITHUB_REF_TYPE" == "tag" ]; then
-        if [ "$GITHUB_REF_NAME" != "v$weaviate_version" ]; then
-            echo "The release tag ($GITHUB_REF_NAME) and Weaviate version (v$weaviate_version) are not equal! Can't release."
-            return 1
-        fi
-        tag_exact="${DOCKER_REPO}:${weaviate_version}"
-  else
-    pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
-    tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_hash}"
-  fi
 
-  args=("--build-arg=GITHASH=$git_hash" "--platform=linux/amd64,linux/arm64" "--target=weaviate" "-t=$tag_latest" "--push")
-  if [ -n "$tag_exact" ]; then
-    # exact tag on master
-    args+=("-t=$tag_exact")
-  fi
-  if [ -n "$tag_preview" ]; then
-    # preview tag on PR builds
-    args+=("-t=$tag_preview")
-  fi
+  args=("--build-arg=GITHASH=$git_hash" "--platform=linux/amd64,linux/arm64" "--target=weaviate" "-t=${PREVIEW_TAG}" "--push")
 
   docker buildx build "${args[@]}" .
 
-  if [ -n "$tag_preview" ]; then
-    echo "PREVIEW_TAG=$tag_preview" >> "$GITHUB_OUTPUT"
-  elif [ -n "$tag_exact" ]; then
-    echo "PREVIEW_TAG=$tag_exact" >> "$GITHUB_OUTPUT"
-  fi
 }
 
 release


### PR DESCRIPTION
### What's being changed:
This PR refactors a little bit the push-docker job (to also make it more reusable) as well as adds a new GH Actions workflow that triggers the Chaos Pipeline upon commenting the following text in a PR:

```
/run-chaos
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
