### PR TITLE
Release resources when backup process is interrupted

### DIFF
--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -166,11 +166,13 @@ func (b *backupper) backup(ctx context.Context,
 		ctx := b.withCancellation(context.Background(), id, done)
 		defer close(done)
 
+		logFields := logrus.Fields{"action": "create_backup", "backup_id": req.ID}
 		if err := provider.all(ctx, req.Classes, &result); err != nil {
-			b.logger.WithField("action", "create_backup").
-				Error(err)
+			b.logger.WithFields(logFields).Error(err)
 			b.lastAsyncError = err
 
+		} else {
+			b.logger.WithFields(logFields).Info("backup completed successfully")
 		}
 		result.CompletedAt = time.Now().UTC()
 	}()

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -106,8 +106,11 @@ func (r *restorer) restore(ctx context.Context,
 		}
 
 		err = r.restoreAll(context.Background(), desc, req.CPUPercentage, store, req.NodeMapping)
+		logFields := logrus.Fields{"action": "restore", "backup_id": req.ID}
 		if err != nil {
-			r.logger.WithField("action", "restore").WithField("backup_id", desc.ID).Error(err)
+			r.logger.WithFields(logFields).Error(err)
+		} else {
+			r.logger.WithFields(logFields).Info("backup restored successfully")
 		}
 	}()
 


### PR DESCRIPTION
Release resources when the backup process is interrupted, enabling the cycle manager to be activated again. 
This PR also includes additional log messages to display the final backup result from both the coordinator node and other nodes

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
