### PR TITLE
Fix for cyclemanager not resetting `unregisterRequested` flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/text v0.13.0
-	google.golang.org/protobuf v1.31.0
+	google.golang.org/protobuf v1.33.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1137,6 +1137,8 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### What's being changed:

Addresses: https://github.com/weaviate/weaviate/issues/4418

`Callback` registered in `cyclecallbackgroup` can be unregistered or deactivated. Both of this actions used to overwrite `shouldAbort` function passed to `callback` to always return positive value, indicating that long-running `callback` should abort its execution whenever possible. Overwritten `shouldAbort` function was never restored after `callback` was activated. As a result `callback` once deactivated was never successfully activated again.

To ensure all data already sent to database are included into backup, they have to persisted in files. Therefore memtables are forced to flush. Forced flush requires deactivating and activating back again background flush process responsible for flushing dirty memtables in intervals.
Due to bug described above, background flush process was not correctly resumed, resulting in data being stored in memory and wals until db shutdown (forced flush) or db restart (wal ingestion).

This fix makes sure `shouldAbort` function is restored to its original form when `callback` is activated after being deactivated.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/pull/186
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
