### PR TITLE
refact: thread saftey on runJobOnBuckets()

### DIFF
--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -210,7 +210,6 @@ func (s *Store) runJobOnBuckets(ctx context.Context,
 	jobFunc jobFunc, rollbackFunc rollbackFunc,
 ) ([]interface{}, error) {
 	s.bucketAccessLock.Lock()
-	defer s.bucketAccessLock.Unlock()
 	var (
 		status      = newBucketJobStatus()
 		resultQueue = make(chan interface{}, len(s.bucketsByName))
@@ -229,7 +228,7 @@ func (s *Store) runJobOnBuckets(ctx context.Context,
 			wg.Done()
 		}()
 	}
-
+	s.bucketAccessLock.Unlock()
 	wg.Wait()
 	close(resultQueue)
 

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -209,6 +209,8 @@ func (s *Store) ListFiles(ctx context.Context, basePath string) ([]string, error
 func (s *Store) runJobOnBuckets(ctx context.Context,
 	jobFunc jobFunc, rollbackFunc rollbackFunc,
 ) ([]interface{}, error) {
+	s.bucketAccessLock.Lock()
+	defer s.bucketAccessLock.Unlock()
 	var (
 		status      = newBucketJobStatus()
 		resultQueue = make(chan interface{}, len(s.bucketsByName))


### PR DESCRIPTION
### What's being changed:
realized that it wasn't thread safe, just un/lock the lock for thread safety 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
