### PR TITLE
Compress action does not panic if not enough data

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -244,7 +244,10 @@ func NewHNSWPQCompressor(
 	pqVectorsCompressor.initCompressedStore()
 	pqVectorsCompressor.cache = cache.NewShardedByteLockCache(pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger, 0)
 	pqVectorsCompressor.cache.Grow(uint64(len(data)))
-	quantizer.Fit(data)
+	err = quantizer.Fit(data)
+	if err != nil {
+		return nil, err
+	}
 	return pqVectorsCompressor, nil
 }
 

--- a/adapters/repos/db/vector/hnsw/compress_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_test.go
@@ -12,9 +12,17 @@
 package hnsw
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 func TestCompression_CalculateOptimalSegments(t *testing.T) {
@@ -70,4 +78,65 @@ func TestCompression_CalculateOptimalSegments(t *testing.T) {
 		segments := h.calculateOptimalSegments(tc.dimensions)
 		assert.Equal(t, tc.expectedSegments, segments)
 	}
+}
+
+func Test_NoRaceCompressReturnsErrorWhenNotEnoughData(t *testing.T) {
+	efConstruction := 64
+	ef := 32
+	maxNeighbors := 32
+	dimensions := 200
+	vectors_size := 10
+	vectors, _ := testinghelpers.RandomVecs(vectors_size, 0, dimensions)
+	distancer := distancer.NewL2SquaredProvider()
+
+	uc := ent.UserConfig{}
+	uc.MaxConnections = maxNeighbors
+	uc.EFConstruction = efConstruction
+	uc.EF = ef
+	uc.VectorCacheMaxObjects = 10e12
+	uc.PQ = ent.PQConfig{
+		Enabled: false,
+		Encoder: ent.PQEncoder{
+			Type:         ent.PQEncoderTypeKMeans,
+			Distribution: ent.PQEncoderDistributionLogNormal,
+		},
+		TrainingLimit: 5,
+		Segments:      dimensions,
+		Centroids:     256,
+	}
+
+	index, _ := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "recallbenchmark",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[int(id)], nil
+		},
+		TempVectorForIDThunk: func(ctx context.Context, id uint64, container *common.VectorSlice) ([]float32, error) {
+			copy(container.Slice, vectors[int(id)])
+			return container.Slice, nil
+		},
+	}, uc, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	defer index.Shutdown(context.Background())
+	compressionhelpers.Concurrently(uint64(len(vectors)), func(id uint64) {
+		index.Add(uint64(id), vectors[id])
+	})
+
+	cfg := ent.PQConfig{
+		Enabled: true,
+		Encoder: ent.PQEncoder{
+			Type:         ent.PQEncoderTypeKMeans,
+			Distribution: ent.PQEncoderDistributionLogNormal,
+		},
+		Segments:  dimensions,
+		Centroids: 256,
+	}
+	uc.PQ = cfg
+	err := index.compress(uc)
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
### What's being changed:
We are explicitly panicking if the compress is hit without enough data using sync mode. This PR changes this and instead writes an error log.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
