### PR TITLE
No force shard loading for nodes status API

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4034,6 +4034,11 @@ func init() {
           "format": "boolean",
           "x-omitempty": false
         },
+        "loaded": {
+          "description": "The load status of the shard.",
+          "type": "boolean",
+          "x-omitempty": false
+        },
         "name": {
           "description": "The name of the shard.",
           "type": "string",
@@ -9316,6 +9321,11 @@ func init() {
         "compressed": {
           "description": "The status of vector compression/quantization.",
           "format": "boolean",
+          "x-omitempty": false
+        },
+        "loaded": {
+          "description": "The load status of the shard.",
+          "type": "boolean",
           "x-omitempty": false
         },
         "name": {

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -175,6 +175,14 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 		// Don't force load a lazy shard to get nodes status
 		if lazy, ok := shard.(*LazyLoadShard); ok {
 			if !lazy.isLoaded() {
+				shardStatus := &models.NodeShardStatus{
+					Name:                 name,
+					Class:                shard.Index().Config.ClassName.String(),
+					VectorIndexingStatus: shard.GetStatus().String(),
+					Loaded:               false,
+				}
+				*status = append(*status, shardStatus)
+				shardCount++
 				return nil
 			}
 		}
@@ -207,6 +215,7 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 			VectorIndexingStatus: shard.GetStatus().String(),
 			VectorQueueLength:    queueLen,
 			Compressed:           compressed,
+			Loaded:               true,
 		}
 		*status = append(*status, shardStatus)
 		shardCount++

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -171,6 +171,14 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+
+		// Don't force load a lazy shard to get nodes status
+		if lazy, ok := shard.(*LazyLoadShard); ok {
+			if !lazy.isLoaded() {
+				return nil
+			}
+		}
+
 		objectCount := int64(shard.ObjectCountAsync())
 		totalCount += objectCount
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -55,8 +55,7 @@ func NewLazyLoadShard(ctx context.Context, promMetrics *monitoring.PrometheusMet
 	promMetrics.NewUnloadedshard(class.Class)
 	return &LazyLoadShard{
 		shardOpts: &deferredShardOpts{
-			promMetrics: promMetrics,
-
+			promMetrics:      promMetrics,
 			name:             shardName,
 			index:            index,
 			class:            class,

--- a/entities/models/node_shard_status.go
+++ b/entities/models/node_shard_status.go
@@ -34,6 +34,9 @@ type NodeShardStatus struct {
 	// The status of vector compression/quantization.
 	Compressed bool `json:"compressed"`
 
+	// The load status of the shard.
+	Loaded bool `json:"loaded"`
+
 	// The name of the shard.
 	Name string `json:"name"`
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1159,6 +1159,11 @@
           "format": "int64",
           "type": "number",
           "x-omitempty": false
+        },
+        "loaded": {
+          "description": "The load status of the shard.",
+          "type": "boolean",
+          "x-omitempty": false
         }
       }
     },

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -6,7 +6,7 @@ replace github.com/weaviate/weaviate => ../..
 
 require (
 	github.com/go-openapi/strfmt v0.21.7
-	github.com/google/uuid v1.4.0
+	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.7.0
 	github.com/weaviate/weaviate v1.23.0
 	github.com/weaviate/weaviate-go-client/v4 v4.12.1
@@ -31,12 +31,12 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.12.1 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/oauth2 v0.13.0 // indirect
+	golang.org/x/net v0.21.0 // indirect
+	golang.org/x/oauth2 v0.17.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
-	google.golang.org/grpc v1.59.0 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9 // indirect
+	google.golang.org/grpc v1.61.1 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -75,6 +75,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -165,9 +166,11 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/oauth2 v0.12.0 h1:smVPGxink+n1ZI5pkQa8y6fZT0RW0MgCO5bFpepy4B4=
 golang.org/x/oauth2 v0.12.0/go.mod h1:A74bZ3aGXgCY0qaIC9Ahg6Lglin4AMAco8cIv9baba4=
 golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
+golang.org/x/oauth2 v0.17.0/go.mod h1:OzPDGQiuQMguemayvdylqddI7qcD9lnSDb+1FiwQ5HA=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -217,12 +220,15 @@ google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d h1:uvYuEyMHKNt+lT4K3bN6fGswmK8qSvcreM3BwjDh+y4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d/go.mod h1:+Bk1OCOj40wS2hwAMA+aCW9ypzm63QTBBHp6lQ3p+9M=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240213162025-012b6fc9bca9/go.mod h1:YUWgXUFRPfoYK1IHMuxH5K6nPEXSCzIMljnQ59lLRCk=
 google.golang.org/grpc v1.59.0 h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=
 google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
+google.golang.org/grpc v1.61.1/go.mod h1:VUbo7IFqmF1QtCAstipjG0GIoq49KvMe9+h1jFLBNJs=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### What's being changed:

Due to the unpredictable number of methods added to `LazyLoadShard`'s and their usage in the nodes status API, we should never attempt to fulfill a full shard status for an unloaded shard. The background here is that the nodes status API will range over all shards in each index, force loading them all in parallel, totally defeating the purpose of the lazy load feature.

Instead, the shard name, class, and queue status can still be returned without loading, alongside a new boolean `Loaded` field in the nodes status response, indicating that the shard is not yet loaded.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
