### PR TITLE
protecting the cleanup from concurrent use with the compression

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -213,6 +213,8 @@ func (h *hnsw) CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 }
 
 func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (bool, error) {
+	h.compressActionLock.RLock()
+	defer h.compressActionLock.RUnlock()
 	defer func() {
 		err := recover()
 		if err != nil {


### PR DESCRIPTION
### What's being changed:
Compression and tombstone cleanup should not happen concurrently. This PR protects the code from concurrent use. It also fixes #4427 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
