### PR TITLE
support specified ef #3730

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/ef.go
+++ b/adapters/handlers/graphql/local/common_filters/ef.go
@@ -1,0 +1,31 @@
+package common_filters
+
+import "github.com/weaviate/weaviate/entities/searchparams"
+
+// ExtractEF arguments, such as "DynamicMin" and "DynamicMax"
+func ExtractEF(source map[string]interface{}) (searchparams.EF, error) {
+	var args searchparams.EF
+
+	DynamicMin, minOk := source["dynamicMin"]
+	if minOk {
+		args.DynamicMin = DynamicMin.(int)
+	}
+
+	dynamicMin, maxOk := source["dynamicMax"]
+	if maxOk {
+		args.DynamicMax = dynamicMin.(int)
+	}
+
+	factor, factorOk := source["dynamicFactor"]
+	if factorOk {
+		args.DynamicFactor = factor.(int)
+	}
+
+	if !minOk && !maxOk && !factorOk {
+		return args, nil
+	}
+
+	args.Enable = true
+
+	return args, nil
+}

--- a/adapters/handlers/graphql/local/get/ef_argument.go
+++ b/adapters/handlers/graphql/local/get/ef_argument.go
@@ -1,0 +1,34 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/tailor-inc/graphql"
+)
+
+func efArgument(className string) *graphql.ArgumentConfig {
+	prefix := fmt.Sprintf("GetObjects%s", className)
+	return &graphql.ArgumentConfig{
+		Type: graphql.NewInputObject(
+			graphql.InputObjectConfig{
+				Name:        fmt.Sprintf("%sEFInpObj", prefix),
+				Fields:      efFields(prefix),
+				Description: "size of the ANN list",
+			},
+		),
+	}
+}
+
+func efFields(_ string) graphql.InputObjectConfigFieldMap {
+	return graphql.InputObjectConfigFieldMap{
+		"dynamicFactor": &graphql.InputObjectFieldConfig{
+			Type: graphql.NewNonNull(graphql.Int),
+		},
+		"dynamicMin": &graphql.InputObjectFieldConfig{
+			Type: graphql.NewNonNull(graphql.Int),
+		},
+		"dynamicMax": &graphql.InputObjectFieldConfig{
+			Type: graphql.NewNonNull(graphql.Int),
+		},
+	}
+}

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
@@ -24,13 +25,14 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/searchparams"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 type vectorIndex interface {
 	SearchByVectorDistance(vector []float32, targetDistance float32, maxLimit int64,
-		allowList helpers.AllowList) ([]uint64, []float32, error)
-	SearchByVector(vector []float32, k int, allowList helpers.AllowList) ([]uint64, []float32, error)
+		allowList helpers.AllowList, ef *searchparams.EF) ([]uint64, []float32, error)
+	SearchByVector(vector []float32, k int, allowList helpers.AllowList, ef *searchparams.EF) ([]uint64, []float32, error)
 }
 
 type Aggregator struct {

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -30,7 +30,7 @@ func (a *Aggregator) vectorSearch(allow helpers.AllowList, vec []float32) ([]uin
 }
 
 func (a *Aggregator) searchByVector(searchVector []float32, limit *int, ids helpers.AllowList) ([]uint64, []float32, error) {
-	idsFound, dists, err := a.vectorIndex.SearchByVector(searchVector, *limit, ids)
+	idsFound, dists, err := a.vectorIndex.SearchByVector(searchVector, *limit, ids, nil)
 	if err != nil {
 		return idsFound, nil, err
 	}
@@ -58,7 +58,7 @@ func (a *Aggregator) searchByVectorDistance(searchVector []float32, ids helpers.
 	}
 
 	targetDist := float32(1-a.params.Certainty) * 2
-	idsFound, dists, err := a.vectorIndex.SearchByVectorDistance(searchVector, targetDist, -1, ids)
+	idsFound, dists, err := a.vectorIndex.SearchByVectorDistance(searchVector, targetDist, -1, ids, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("aggregate search by vector: %w", err)
 	}

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -423,7 +424,7 @@ func TestCRUD(t *testing.T) {
 		// somewhat far from the thing. So it should match the action closer
 		searchVector := []float32{2.9, 1.1, 0.5, 8.01}
 
-		res, err := repo.CrossClassVectorSearch(context.Background(), searchVector, "", 0, 10, nil)
+		res, err := repo.CrossClassVectorSearch(context.Background(), searchVector, "", 0, 10, nil, nil)
 
 		require.Nil(t, err)
 		require.Equal(t, true, len(res) >= 2)

--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -243,7 +244,7 @@ func TestIndexQueue(t *testing.T) {
 		<-called
 
 		time.Sleep(500 * time.Millisecond)
-		res, _, err := q.SearchByVector([]float32{1, 2, 3}, 2, nil)
+		res, _, err := q.SearchByVector([]float32{1, 2, 3}, 2, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, []uint64{1, 4}, res)
 	})
@@ -261,7 +262,7 @@ func TestIndexQueue(t *testing.T) {
 			pushVector(t, ctx, q, uint64(i+1), []float32{float32(i) + 1, float32(i) + 2, float32(i) + 3})
 		}
 
-		res, _, err := q.SearchByVector([]float32{1, 2, 3}, 2, nil)
+		res, _, err := q.SearchByVector([]float32{1, 2, 3}, 2, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, []uint64{1, 2}, res)
 	})
@@ -371,7 +372,7 @@ func TestIndexQueue(t *testing.T) {
 		pushVector(t, ctx, q, 3, []float32{7, 8, 9})
 		pushVector(t, ctx, q, 4, []float32{1, 2, 3})
 
-		res, _, err := q.SearchByVector([]float32{7, 8, 9}, 2, nil)
+		res, _, err := q.SearchByVector([]float32{7, 8, 9}, 2, nil, nil)
 		require.NoError(t, err)
 		// despite having 4 vectors in the queue
 		// only the first two are used for brute force search
@@ -544,7 +545,7 @@ func TestIndexQueue(t *testing.T) {
 
 		q.pushToWorkers(-1, false)
 
-		_, distances, err := q.SearchByVector(randVector(1536), 10, nil)
+		_, distances, err := q.SearchByVector(randVector(1536), 10, nil, nil)
 		require.NoError(t, err)
 
 		// all distances should be between 0 and 1
@@ -820,7 +821,7 @@ func (m *mockBatchIndexer) AddBatch(ctx context.Context, ids []uint64, vector []
 	return
 }
 
-func (m *mockBatchIndexer) SearchByVector(vector []float32, k int, allowList helpers.AllowList) ([]uint64, []float32, error) {
+func (m *mockBatchIndexer) SearchByVector(vector []float32, k int, allowList helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -867,7 +868,7 @@ func (m *mockBatchIndexer) SearchByVector(vector []float32, k int, allowList hel
 	return ids, distances, nil
 }
 
-func (m *mockBatchIndexer) SearchByVectorDistance(vector []float32, maxDistance float32, maxLimit int64, allowList helpers.AllowList) ([]uint64, []float32, error) {
+func (m *mockBatchIndexer) SearchByVectorDistance(vector []float32, maxDistance float32, maxLimit int64, allowList helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error) {
 	m.Lock()
 	defer m.Unlock()
 

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
@@ -434,7 +435,7 @@ func makeTestRetrievingBaseClass(repo *DB, data []*models.Object,
 
 		t.Run("retrieve through inter-class vector search", func(t *testing.T) {
 			do := func(t *testing.T, limit, expected int) {
-				res, err := repo.CrossClassVectorSearch(context.Background(), queryVec, "", 0, limit, nil)
+				res, err := repo.CrossClassVectorSearch(context.Background(), queryVec, "", 0, limit, nil, nil)
 				assert.Nil(t, err)
 				assert.Len(t, res, expected)
 				for i, obj := range res {

--- a/adapters/repos/db/ranked_fusion_test.go
+++ b/adapters/repos/db/ranked_fusion_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -829,7 +830,7 @@ func (f *fakeObjectSearcher) VectorSearch(context.Context, dto.GetParams) ([]sea
 	return nil, nil
 }
 
-func (f *fakeObjectSearcher) CrossClassVectorSearch(context.Context, []float32, string, int, int, *filters.LocalFilter) ([]search.Result, error) {
+func (f *fakeObjectSearcher) CrossClassVectorSearch(context.Context, []float32, string, int, int, *filters.LocalFilter, *searchparams.EF) ([]search.Result, error) {
 	return nil, nil
 }
 
@@ -865,7 +866,7 @@ func (f *fakeObjectSearcher) SparseObjectSearch(ctx context.Context, params dto.
 	return out[:lim], []float32{0.008, 0.001}[:lim], nil
 }
 
-func (f *fakeObjectSearcher) DenseObjectSearch(ctx context.Context, class string, vector []float32, targetVector string, offset int, limit int, filters *filters.LocalFilter, additinal additional.Properties, tenant string) ([]*storobj.Object, []float32, error) {
+func (f *fakeObjectSearcher) DenseObjectSearch(ctx context.Context, class string, vector []float32, targetVector string, offset int, limit int, filters *filters.LocalFilter, additinal additional.Properties, ef *searchparams.EF, tenant string) ([]*storobj.Object, []float32, error) {
 	out := []*storobj.Object{
 		{
 			Object: models.Object{

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -23,6 +23,8 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
@@ -53,7 +55,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	"golang.org/x/sync/errgroup"
 )
 
 const IdLockPoolSize = 128
@@ -77,7 +78,7 @@ type ShardLike interface {
 	ObjectByID(ctx context.Context, id strfmt.UUID, props search.SelectProperties, additional additional.Properties) (*storobj.Object, error)
 	Exists(ctx context.Context, id strfmt.UUID) (bool, error)
 	ObjectSearch(ctx context.Context, limit int, filters *filters.LocalFilter, keywordRanking *searchparams.KeywordRanking, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties) ([]*storobj.Object, []float32, error)
-	ObjectVectorSearch(ctx context.Context, searchVector []float32, targetVector string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties) ([]*storobj.Object, []float32, error)
+	ObjectVectorSearch(ctx context.Context, searchVector []float32, targetVector string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, ef *searchparams.EF, additional additional.Properties) ([]*storobj.Object, []float32, error)
 	UpdateVectorIndexConfig(ctx context.Context, updated schema.VectorIndexConfig) error
 	UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schema.VectorIndexConfig) error
 	AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"github.com/go-openapi/strfmt"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -38,7 +40,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	"golang.org/x/sync/errgroup"
 )
 
 type LazyLoadShard struct {
@@ -209,11 +210,11 @@ func (l *LazyLoadShard) ObjectSearch(ctx context.Context, limit int, filters *fi
 	return l.shard.ObjectSearch(ctx, limit, filters, keywordRanking, sort, cursor, additional)
 }
 
-func (l *LazyLoadShard) ObjectVectorSearch(ctx context.Context, searchVector []float32, targetVector string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties) ([]*storobj.Object, []float32, error) {
+func (l *LazyLoadShard) ObjectVectorSearch(ctx context.Context, searchVector []float32, targetVector string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, ef *searchparams.EF, additional additional.Properties) ([]*storobj.Object, []float32, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, nil, err
 	}
-	return l.shard.ObjectVectorSearch(ctx, searchVector, targetVector, targetDist, limit, filters, sort, groupBy, additional)
+	return l.shard.ObjectVectorSearch(ctx, searchVector, targetVector, targetDist, limit, filters, sort, groupBy, ef, additional)
 }
 
 func (l *LazyLoadShard) UpdateVectorIndexConfig(ctx context.Context, updated schema.VectorIndexConfig) error {

--- a/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -508,7 +509,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		return func(t *testing.T) {
 			t.Run("to be found", func(t *testing.T) {
 				found, _, err := shard.ObjectVectorSearch(ctx, vectorToBeFound, targetVector,
-					vectorSearchDist, vectorSearchLimit, nil, nil, nil, additional.Properties{})
+					vectorSearchDist, vectorSearchLimit, nil, nil, nil, nil, additional.Properties{})
 				require.NoError(t, err)
 				require.Len(t, found, 1)
 				require.Equal(t, uuid_, found[0].Object.ID)
@@ -516,7 +517,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 
 			t.Run("not to be found", func(t *testing.T) {
 				found, _, err := shard.ObjectVectorSearch(ctx, vectorNotToBeFound, targetVector,
-					vectorSearchDist, vectorSearchLimit, nil, nil, nil, additional.Properties{})
+					vectorSearchDist, vectorSearchLimit, nil, nil, nil, nil, additional.Properties{})
 				require.NoError(t, err)
 				require.Len(t, found, 0)
 			})

--- a/adapters/repos/db/vector/common/search_with_ef_option.go
+++ b/adapters/repos/db/vector/common/search_with_ef_option.go
@@ -1,0 +1,17 @@
+package common
+
+type SearchWithEFOptions struct {
+	DynamicMin    int
+	DynamicMax    int
+	DynamicFactor int
+}
+
+type SearchWithEFOption func(*SearchWithEFOptions)
+
+func WithEFOptions(dynamicMin, dynamicMax, dynamicFactor int) SearchWithEFOption {
+	return func(opts *SearchWithEFOptions) {
+		opts.DynamicMin = dynamicMin
+		opts.DynamicMax = dynamicMax
+		opts.DynamicFactor = dynamicFactor
+	}
+}

--- a/adapters/repos/db/vector/common/search_with_ef_option_test.go
+++ b/adapters/repos/db/vector/common/search_with_ef_option_test.go
@@ -1,0 +1,39 @@
+package common
+
+import "testing"
+
+func TestWithEFOptions(t *testing.T) {
+	tests := []struct {
+		name           string
+		dynamicMin     int
+		dynamicMax     int
+		dynamicFactor  int
+		expectedResult SearchWithEFOptions
+	}{
+		{
+			name:          "The specified parameters can be assigned to options.",
+			dynamicMin:    1,
+			dynamicMax:    10,
+			dynamicFactor: 2,
+			expectedResult: SearchWithEFOptions{
+				DynamicMin:    1,
+				DynamicMax:    10,
+				DynamicFactor: 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualResult := SearchWithEFOptions{}
+			option := WithEFOptions(tt.dynamicMin, tt.dynamicMax, tt.dynamicFactor)
+			option(&actualResult)
+
+			if actualResult.DynamicMin != tt.expectedResult.DynamicMin ||
+				actualResult.DynamicMax != tt.expectedResult.DynamicMax ||
+				actualResult.DynamicFactor != tt.expectedResult.DynamicFactor {
+				t.Errorf("WithEFOptions() = %v, want %v", actualResult, tt.expectedResult)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
@@ -299,7 +300,7 @@ func (index *flat) searchTimeRescore(k int) int {
 	return k
 }
 
-func (index *flat) SearchByVector(vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
+func (index *flat) SearchByVector(vector []float32, k int, allow helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error) {
 	switch index.compression {
 	case compressionBQ:
 		return index.searchByVectorBQ(vector, k, allow)
@@ -523,7 +524,7 @@ func (index *flat) normalized(vector []float32) []float32 {
 	return vector
 }
 
-func (index *flat) SearchByVectorDistance(vector []float32, targetDistance float32, maxLimit int64, allow helpers.AllowList) ([]uint64, []float32, error) {
+func (index *flat) SearchByVectorDistance(vector []float32, targetDistance float32, maxLimit int64, allow helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error) {
 	var (
 		searchParams = newSearchByDistParams(maxLimit)
 

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -81,6 +83,12 @@ func TestNilCheckOnPartiallyCleanedNode(t *testing.T) {
 
 	t.Run("run a search that would typically find the new ep", func(t *testing.T) {
 		res, _, err := vectorIndex.SearchByVector([]float32{1.7, 1.7}, 20, nil)
+		require.Nil(t, err)
+		assert.Equal(t, []uint64{2, 0}, res, "right results are found")
+	})
+
+	t.Run("run a search with specified ef", func(t *testing.T) {
+		res, _, err := vectorIndex.SearchByVector([]float32{1.7, 1.7}, 3, nil, common.WithEFOptions(3, 5, 2))
 		require.Nil(t, err)
 		assert.Equal(t, []uint64{2, 0}, res, "right results are found")
 	})

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -16,7 +16,9 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -43,11 +45,11 @@ func (i *Index) Delete(id ...uint64) error {
 	return nil
 }
 
-func (i *Index) SearchByVector(vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
+func (i *Index) SearchByVector(vector []float32, k int, allow helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error) {
 	return nil, nil, errors.Errorf("cannot vector-search on a class not vector-indexed")
 }
 
-func (i *Index) SearchByVectorDistance(vector []float32, dist float32, maxLimit int64, allow helpers.AllowList) ([]uint64, []float32, error) {
+func (i *Index) SearchByVectorDistance(vector []float32, dist float32, maxLimit int64, allow helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error) {
 	return nil, nil, errors.Errorf("cannot vector-search on a class not vector-indexed")
 }
 

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -26,9 +27,8 @@ type VectorIndex interface {
 	Add(id uint64, vector []float32) error
 	AddBatch(ctx context.Context, id []uint64, vector [][]float32) error
 	Delete(id ...uint64) error
-	SearchByVector(vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error)
-	SearchByVectorDistance(vector []float32, dist float32,
-		maxLimit int64, allow helpers.AllowList) ([]uint64, []float32, error)
+	SearchByVector(vector []float32, k int, allowList helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error)
+	SearchByVectorDistance(vector []float32, dist float32, maxLimit int64, allow helpers.AllowList, opts ...common.SearchWithEFOption) ([]uint64, []float32, error)
 	UpdateUserConfig(updated schema.VectorIndexConfig, callback func()) error
 	Drop(ctx context.Context) error
 	Shutdown(ctx context.Context) error

--- a/entities/dto/dto.go
+++ b/entities/dto/dto.go
@@ -43,4 +43,5 @@ type GetParams struct {
 	ReplicationProperties *additional.ReplicationProperties
 	Tenant                string
 	IsRefOrigin           bool // is created by ref filter
+	EF                    *searchparams.EF
 }

--- a/entities/searchparams/retrieval.go
+++ b/entities/searchparams/retrieval.go
@@ -64,6 +64,13 @@ type ExploreMove struct {
 	Objects []ObjectMove
 }
 
+type EF struct {
+	Enable        bool
+	DynamicMin    int
+	DynamicMax    int
+	DynamicFactor int
+}
+
 type NearTextParams struct {
 	Values       []string
 	Limit        int

--- a/usecases/traverser/explorer_validate_ef.go
+++ b/usecases/traverser/explorer_validate_ef.go
@@ -1,0 +1,19 @@
+package traverser
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/searchparams"
+)
+
+func (e *Explorer) validateEF(ef *searchparams.EF) error {
+	if ef == nil {
+		return nil
+	}
+
+	if ef.DynamicMax == 0 || ef.DynamicMin == 0 || ef.DynamicFactor == 0 {
+		return fmt.Errorf("if specify ef, you need to specify three parameters at the same time")
+	}
+
+	return nil
+}

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/tailor-inc/graphql"
 	"github.com/tailor-inc/graphql/language/ast"
+
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/descriptions"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -88,7 +89,7 @@ type fakeVectorSearcher struct {
 }
 
 func (f *fakeVectorSearcher) CrossClassVectorSearch(ctx context.Context,
-	vector []float32, targetVector string, offset, limit int, filters *filters.LocalFilter,
+	vector []float32, targetVector string, offset, limit int, filters *filters.LocalFilter, ef *searchparams.EF,
 ) ([]search.Result, error) {
 	f.calledWithVector = vector
 	f.calledWithLimit = limit
@@ -140,7 +141,7 @@ func (f *fakeVectorSearcher) SparseObjectSearch(ctx context.Context,
 }
 
 func (f *fakeVectorSearcher) DenseObjectSearch(context.Context, string,
-	[]float32, string, int, int, *filters.LocalFilter, additional.Properties, string,
+	[]float32, string, int, int, *filters.LocalFilter, additional.Properties, *searchparams.EF, string,
 ) ([]*storobj.Object, []float32, error) {
 	return nil, nil, nil
 }

--- a/usecases/traverser/traverser_explore_concepts.go
+++ b/usecases/traverser/traverser_explore_concepts.go
@@ -48,6 +48,7 @@ func (t *Traverser) Explore(ctx context.Context,
 type ExploreParams struct {
 	NearVector        *searchparams.NearVector
 	NearObject        *searchparams.NearObject
+	EF                *searchparams.EF
 	Offset            int
 	Limit             int
 	ModuleParams      map[string]interface{}


### PR DESCRIPTION
### What's being changed:
Context: #3730 

Scope:
* User can specify `ef` which is specific to `hnsw` at search time.
* The `ef` specified at search time takes precedence over the configured `ef`.

TODOs:
* Update client sdk to enable req to configure `ef`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
