### PR TITLE
Add env var to disable error recovery in errorgroupwrapper

### DIFF
--- a/entities/errors/error_group_wrapper.go
+++ b/entities/errors/error_group_wrapper.go
@@ -14,7 +14,9 @@ package errors
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime/debug"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 
@@ -24,42 +26,50 @@ import (
 // ErrorGroupWrapper is a custom type that embeds errgroup.Group.
 type ErrorGroupWrapper struct {
 	*errgroup.Group
-	ReturnError error
-	Variables   []interface{}
-	Logger      logrus.FieldLogger
+	returnError error
+	variables   []interface{}
+	logger      logrus.FieldLogger
 }
 
 // NewErrorGroupWrapper creates a new ErrorGroupWrapper.
 func NewErrorGroupWrapper(logger logrus.FieldLogger, vars ...interface{}) *ErrorGroupWrapper {
 	return &ErrorGroupWrapper{
 		Group:       new(errgroup.Group),
-		ReturnError: nil,
-		Variables:   vars,
-		Logger:      logger,
+		returnError: nil,
+		variables:   vars,
+		logger:      logger,
 	}
 }
 
-// NewErrorGroupWrapper creates a new ErrorGroupWrapper.
+// NewErrorGroupWithContextWrapper creates a new ErrorGroupWrapper
 func NewErrorGroupWithContextWrapper(logger logrus.FieldLogger, ctx context.Context, vars ...interface{}) (*ErrorGroupWrapper, context.Context) {
 	eg, ctx := errgroup.WithContext(ctx)
 	return &ErrorGroupWrapper{
 		Group:       eg,
-		ReturnError: nil,
-		Variables:   vars,
-		Logger:      logger,
+		returnError: nil,
+		variables:   vars,
+		logger:      logger,
 	}, ctx
 }
 
 // Go overrides the Go method to add panic recovery logic.
 func (egw *ErrorGroupWrapper) Go(f func() error, localVars ...interface{}) {
-	egw.Group.Go(func() error {
-		defer func() {
+	disable, err := strconv.ParseBool(os.Getenv("DISABLE_RECOVERY_ON_PANIC"))
+	var deferFunc func()
+	if err != nil || !disable {
+		deferFunc = func() {
 			if r := recover(); r != nil {
-				egw.Logger.WithField("panic", r).Errorf("Recovered from panic: %v, local variables %v, additional localVars %v\n", r, localVars, egw.Variables)
+				egw.logger.WithField("panic", r).Errorf("Recovered from panic: %v, local variables %v, additional localVars %v\n", r, localVars, egw.variables)
 				debug.PrintStack()
-				egw.ReturnError = fmt.Errorf("panic occurred: %v", r)
+				egw.returnError = fmt.Errorf("panic occurred: %v", r)
 			}
-		}()
+		}
+	} else {
+		deferFunc = func() {}
+	}
+
+	egw.Group.Go(func() error {
+		defer deferFunc()
 		return f()
 	})
 }
@@ -69,5 +79,5 @@ func (egw *ErrorGroupWrapper) Wait() error {
 	if err := egw.Group.Wait(); err != nil {
 		return err
 	}
-	return egw.ReturnError
+	return egw.returnError
 }

--- a/entities/errors/error_group_wrapper_test.go
+++ b/entities/errors/error_group_wrapper_test.go
@@ -1,0 +1,56 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package errors
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName(t *testing.T) {
+	cases := []struct {
+		env string
+		set bool
+	}{
+		{env: "something", set: true},
+		{env: "something", set: false},
+		{env: "", set: true},
+		{env: "false", set: true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.env, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := logrus.New()
+			log.SetOutput(&buf)
+			defer func() {
+				log.SetOutput(os.Stderr)
+			}()
+
+			eg := NewErrorGroupWrapper(log)
+			if tt.set {
+				t.Setenv("DISABLE_RECOVERY_ON_PANIC", tt.env)
+			}
+			eg.Go(func() error {
+				slice := make([]string, 0)
+				slice[0] = "test"
+				return nil
+			})
+			err := eg.Wait()
+			assert.Contains(t, buf.String(), "Recovered from panic")
+			assert.Contains(t, err.Error(), "index out of range")
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Adds an env var to disable recovery on case of panics

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
