### PR TITLE
Fix cardinality issues for backup-related metrics (v1.24.x)

### DIFF
--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -35,7 +35,11 @@ func (s *Store) PauseCompaction(ctx context.Context) error {
 
 	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
 	for _, b := range s.bucketsByName {
-		if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(b.dir); err == nil {
+		label := b.dir
+		if monitoring.GetMetrics().Group {
+			label = "n/a"
+		}
+		if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label); err == nil {
 			b.pauseTimer = prometheus.NewTimer(metric)
 		}
 	}

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,7 +20,8 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: "./data"
       DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
-      ENABLE_MODULES: text2vec-contextionary
+      ENABLE_MODULES: text2vec-contextionary,backup-filesystem
+      BACKUP_FILESYSTEM_PATH: "/var/lib/backups" 
       PROMETHEUS_MONITORING_ENABLED: 'true'
       PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'
       CLUSTER_GOSSIP_BIND_PORT: "7100"

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -238,5 +238,5 @@ func waitForBackupToFinish(t *testing.T, id string) {
 		res := getStatus()
 		require.NotNil(t, res.Payload.Status)
 		assert.Equal(t, "SUCCESS", *res.Payload.Status)
-	}, 1*time.Minute, 1*time.Second)
+	}, 10*time.Minute, 1*time.Second)
 }

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/backups"
 	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -36,8 +37,12 @@ const metricClassPrefix = "MetricsClassPrefix"
 func metricsCount(t *testing.T) {
 	defer cleanupMetricsClasses(t, 0, 20)
 	createImportQueryMetricsClasses(t, 0, 10)
+	backupID := startBackup(t, 0, 10)
+	waitForBackupToFinish(t, backupID)
 	metricsLinesBefore := countMetricsLines(t)
 	createImportQueryMetricsClasses(t, 10, 20)
+	backupID = startBackup(t, 0, 20)
+	waitForBackupToFinish(t, backupID)
 	metricsLinesAfter := countMetricsLines(t)
 	assert.Equal(t, metricsLinesBefore, metricsLinesAfter, "number of metrics should not have changed")
 }
@@ -198,4 +203,40 @@ func countMetricsLines(t *testing.T) int {
 
 func metricsClassName(classIndex int) string {
 	return fmt.Sprintf("%s_%d", metricClassPrefix, classIndex)
+}
+
+func startBackup(t *testing.T, start, end int) string {
+	var includeClasses []string
+	for i := start; i < end; i++ {
+		includeClasses = append(includeClasses, metricsClassName(i))
+	}
+
+	backupID := fmt.Sprintf("metrics-test-backup-%d", rand.Intn(100000000))
+
+	_, err := helper.Client(t).Backups.BackupsCreate(
+		backups.NewBackupsCreateParams().
+			WithBackend("filesystem").
+			WithBody(&models.BackupCreateRequest{
+				ID:      backupID,
+				Include: includeClasses,
+			}),
+		nil)
+	require.Nil(t, err)
+
+	return backupID
+}
+
+func waitForBackupToFinish(t *testing.T, id string) {
+	getStatus := func() *backups.BackupsCreateStatusOK {
+		res, err := helper.Client(t).Backups.BackupsCreateStatus(
+			backups.NewBackupsCreateStatusParams().WithBackend("filesystem").WithID(id),
+			nil)
+		require.Nil(t, err)
+		return res
+	}
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res := getStatus()
+		require.NotNil(t, res.Payload.Status)
+		assert.Equal(t, "SUCCESS", *res.Payload.Status)
+	}, 1*time.Minute, 1*time.Second)
 }

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -34,6 +34,7 @@ func TestGraphQL_AsyncIndexing(t *testing.T) {
 	compose, err := docker.New().
 		WithWeaviate().
 		WithText2VecContextionary().
+		WithBackendFilesystem().
 		WithWeaviateEnv("ASYNC_INDEXING", "true").
 		Start(ctx)
 	require.NoError(t, err)

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -248,7 +248,11 @@ Loop:
 
 // class uploads one class
 func (u *uploader) class(ctx context.Context, id string, desc *backup.ClassDescriptor) (err error) {
-	metric, err := monitoring.GetMetrics().BackupStoreDurations.GetMetricWithLabelValues(getType(u.backend.b), desc.Name)
+	classLabel := desc.Name
+	if monitoring.GetMetrics().Group {
+		classLabel = "n/a"
+	}
+	metric, err := monitoring.GetMetrics().BackupStoreDurations.GetMetricWithLabelValues(getType(u.backend.b), classLabel)
 	if err == nil {
 		timer := prometheus.NewTimer(metric)
 		defer timer.ObserveDuration()

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -146,7 +146,11 @@ func (r *restorer) restoreOne(ctx context.Context,
 	backupID string, desc *backup.ClassDescriptor,
 	compressed bool, cpuPercentage int, store nodeStore, nodeMapping map[string]string,
 ) (err error) {
-	metric, err := monitoring.GetMetrics().BackupRestoreDurations.GetMetricWithLabelValues(getType(store.b), desc.Name)
+	classLabel := desc.Name
+	if monitoring.GetMetrics().Group {
+		classLabel = "n/a"
+	}
+	metric, err := monitoring.GetMetrics().BackupRestoreDurations.GetMetricWithLabelValues(getType(store.b), classLabel)
 	if err != nil {
 		timer := prometheus.NewTimer(metric)
 		defer timer.ObserveDuration()


### PR DESCRIPTION
### What's being changed:

- add backups to metrics cardinality tests
- test is now red
- fix cardinality issues for bucket pause, backup store and backup restore metrics
- test is now green

fixes #4442

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
