### PR TITLE
Migrate to hierarchical file structure when restoring a backup from a pre-v1.23 releases

### DIFF
--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
@@ -23,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/replica"
+	ucs "github.com/weaviate/weaviate/usecases/schema"
 )
 
 // init gets the current schema and creates one index object per class.
@@ -103,4 +106,43 @@ func (db *DB) init(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (db *DB) migrateFileStructureIfNecessary() error {
+	fsMigrationPath := path.Join(db.config.RootPath, "migration1.22.fs.hierarchy")
+	exists, err := fileExists(fsMigrationPath)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err = db.migrateToHierarchicalFS(); err != nil {
+			return fmt.Errorf("migrate to hierarchical fs: %w", err)
+		}
+		if _, err = os.Create(fsMigrationPath); err != nil {
+			return fmt.Errorf("create hierarchical fs indicator: %w", err)
+		}
+	}
+	return nil
+}
+
+func (db *DB) migrateToHierarchicalFS() error {
+	before := time.Now()
+
+	if err := ucs.MigrateToHierarchicalFS(db.config.RootPath, db.schemaGetter); err != nil {
+		return err
+	}
+	db.logger.WithField("action", "hierarchical_fs_migration").
+		Debugf("fs migration took %s\n", time.Since(before))
+	return nil
+}
+
+func fileExists(file string) (bool, error) {
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -34,7 +34,7 @@ func init() {
 	}
 
 	chunks = map[string][]byte{
-		chunkKey("DemoClass", 1): data,
+		chunkKey("Article", 1): data,
 	}
 }
 

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -13,6 +13,7 @@ package backup
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -22,7 +23,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/monitoring"
+	ucs "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 type restorer struct {
@@ -124,7 +129,7 @@ func (r *restorer) restoreAll(ctx context.Context,
 	compressed := desc.Version > version1
 	r.lastOp.set(backup.Transferring)
 	for _, cdesc := range desc.Classes {
-		if err := r.restoreOne(ctx, desc.ID, &cdesc, compressed, cpuPercentage, store, nodeMapping); err != nil {
+		if err := r.restoreOne(ctx, &cdesc, desc.ServerVersion, compressed, cpuPercentage, store, nodeMapping); err != nil {
 			return fmt.Errorf("restore class %s: %w", cdesc.Name, err)
 		}
 		r.logger.WithField("action", "restore").
@@ -143,7 +148,7 @@ func getType(myvar interface{}) string {
 }
 
 func (r *restorer) restoreOne(ctx context.Context,
-	backupID string, desc *backup.ClassDescriptor,
+	desc *backup.ClassDescriptor, serverVersion string,
 	compressed bool, cpuPercentage int, store nodeStore, nodeMapping map[string]string,
 ) (err error) {
 	classLabel := desc.Name
@@ -159,8 +164,18 @@ func (r *restorer) restoreOne(ctx context.Context,
 	if r.sourcer.ClassExists(desc.Name) {
 		return fmt.Errorf("already exists")
 	}
-	fw := newFileWriter(r.sourcer, store, backupID, compressed).
+
+	fw := newFileWriter(r.sourcer, store, compressed).
 		WithPoolPercentage(cpuPercentage)
+
+	// Pre-v1.23 versions store files in a flat format
+	if serverVersion < "1.23" {
+		f, err := hfsMigrator(desc, r.node, serverVersion)
+		if err != nil {
+			return fmt.Errorf("migrate to pre 1.23: %w", err)
+		}
+		fw.setMigrator(f)
+	}
 
 	rollback, err := fw.Write(ctx, desc)
 	if err != nil {
@@ -224,4 +239,48 @@ func (r *restorer) validate(ctx context.Context, store *nodeStore, req *Request)
 		meta.Include(req.Classes)
 	}
 	return meta, cs, nil
+}
+
+// oneClassSchema allows for creating schema with one class
+// This is required when migrating to hierarchical file structure from pre-v1.23
+type oneClassSchema struct {
+	cls *models.Class
+	ss  *sharding.State
+}
+
+func (s oneClassSchema) CopyShardingState(class string) *sharding.State {
+	return s.ss
+}
+
+func (s oneClassSchema) GetSchemaSkipAuth() schema.Schema {
+	return schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{s.cls},
+		},
+	}
+}
+
+// hfsMigrator builds and return a class migrator ready for use
+func hfsMigrator(desc *backup.ClassDescriptor, nodeName string, serverVersion string) (func(classDir string) error, error) {
+	if serverVersion >= "1.23" {
+		return func(string) error { return nil }, nil
+	}
+	var ss sharding.State
+	if desc.ShardingState != nil {
+		err := json.Unmarshal(desc.ShardingState, &ss)
+		if err != nil {
+			return nil, fmt.Errorf("marshal sharding state: %w", err)
+		}
+	}
+	ss.SetLocalName(nodeName)
+
+	// get schema and sharding state
+	class := &models.Class{}
+	if err := json.Unmarshal(desc.Schema, &class); err != nil {
+		return nil, fmt.Errorf("marshal class schema: %w", err)
+	}
+
+	return func(classDir string) error {
+		return ucs.MigrateToHierarchicalFS(classDir, oneClassSchema{class, &ss})
+	}, nil
 }

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 // ErrAny represent a random error
@@ -274,15 +275,26 @@ func TestRestoreRequestValidation(t *testing.T) {
 
 func TestManagerRestoreBackup(t *testing.T) {
 	var (
-		cls         = "DemoClass"
+		cls         = "Article"
+		rawbytes    = []byte("hello")
 		backendName = "gcs"
 		backupID    = "1"
-		rawbytes    = []byte("hello")
 		timept      = time.Now().UTC()
 		ctx         = context.Background()
 		nodeHome    = backupID + "/" + nodeName
 		path        = "bucket/backups/" + nodeHome
 	)
+
+	rawShardingStateBytes, _ := json.Marshal(&sharding.State{
+		IndexID: cls,
+		Physical: map[string]sharding.Physical{"cT9eTErXgmTX": {
+			Name:           "cT9eTErXgmTX",
+			BelongsToNodes: []string{nodeName},
+		}},
+	})
+	rawClassBytes, _ := json.Marshal(&models.Class{
+		Class: cls,
+	})
 	meta2 := backup.BackupDescriptor{
 		ID:            backupID,
 		StartedAt:     timept,
@@ -291,8 +303,10 @@ func TestManagerRestoreBackup(t *testing.T) {
 		Status:        string(backup.Success),
 
 		Classes: []backup.ClassDescriptor{{
-			Name: cls, Schema: rawbytes, ShardingState: rawbytes,
-			Chunks: map[int32][]string{1: {"Shard1"}},
+			Name:          cls,
+			Schema:        rawClassBytes,
+			ShardingState: rawShardingStateBytes,
+			Chunks:        map[int32][]string{1: {"Shard1"}},
 			Shards: []*backup.ShardDescriptor{
 				{
 					Name: "Shard1", Node: "Node-1",
@@ -309,8 +323,10 @@ func TestManagerRestoreBackup(t *testing.T) {
 		Status:        string(backup.Success),
 
 		Classes: []backup.ClassDescriptor{{
-			Name: cls, Schema: rawbytes, ShardingState: rawbytes,
-			Chunks: map[int32][]string{1: {"Shard1"}},
+			Name:          cls,
+			Schema:        rawClassBytes,
+			ShardingState: rawShardingStateBytes,
+			Chunks:        map[int32][]string{1: {"Shard1"}},
 			Shards: []*backup.ShardDescriptor{
 				{
 					Name: "Shard1", Node: "Node-1",
@@ -428,7 +444,7 @@ func TestManagerRestoreBackup(t *testing.T) {
 		}
 		assert.Equal(t, resp1, want1)
 		assert.Nil(t, err)
-		lastStatus := m.restorer.waitForCompletion(req1.Backend, req1.ID, 10, 50)
+		lastStatus := m.restorer.waitForCompletion(req1.Backend, req1.ID, 12, 50)
 		assert.Equal(t, backup.Success, lastStatus.Status)
 	})
 
@@ -530,6 +546,16 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 			Duration: time.Millisecond * 20,
 		}
 	)
+	rawShardingStateBytes, _ := json.Marshal(&sharding.State{
+		IndexID: cls,
+		Physical: map[string]sharding.Physical{"cT9eTErXgmTX": {
+			Name:           "cT9eTErXgmTX",
+			BelongsToNodes: []string{nodeName},
+		}},
+	})
+	rawClassBytes, _ := json.Marshal(&models.Class{
+		Class: cls,
+	})
 
 	metadata := backup.BackupDescriptor{
 		ID:            backupID,
@@ -538,7 +564,9 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		ServerVersion: "1",
 		Status:        string(backup.Success),
 		Classes: []backup.ClassDescriptor{{
-			Name: cls, Schema: rawbytes, ShardingState: rawbytes,
+			Name:          cls,
+			Schema:        rawClassBytes,
+			ShardingState: rawShardingStateBytes,
 			Shards: []*backup.ShardDescriptor{
 				{
 					Name: "Shard1", Node: "Node-1",
@@ -603,7 +631,7 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		assert.Equal(t, want1, resp1)
 		err := m.OnCommit(ctx, &StatusRequest{Method: OpRestore, ID: req.ID, Backend: req.Backend})
 		assert.Nil(t, err)
-		lastStatus := m.restorer.waitForCompletion(req.Backend, req.ID, 10, 50)
+		lastStatus := m.restorer.waitForCompletion(req.Backend, req.ID, 12, 50)
 		assert.Nil(t, err)
 		assert.Equal(t, lastStatus.Status, backup.Success)
 	})

--- a/usecases/schema/file_structure_migration.go
+++ b/usecases/schema/file_structure_migration.go
@@ -9,7 +9,7 @@
 //  CONTACT: hello@weaviate.io
 //
 
-package db
+package schema
 
 import (
 	"fmt"
@@ -17,41 +17,21 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	entschema "github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 const vectorIndexCommitLog = `hnsw.commitlog.d`
 
-func (db *DB) migrateFileStructureIfNecessary() error {
-	fsMigrationPath := path.Join(db.config.RootPath, "migration1.22.fs.hierarchy")
-	exists, err := fileExists(fsMigrationPath)
+func MigrateToHierarchicalFS(rootPath string, s schemaGetter) error {
+	root, err := os.ReadDir(rootPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("read source path %q: %w", rootPath, err)
 	}
-	if !exists {
-		if err = db.migrateToHierarchicalFS(); err != nil {
-			return fmt.Errorf("migrate to hierarchical fs: %w", err)
-		}
-		if _, err = os.Create(fsMigrationPath); err != nil {
-			return fmt.Errorf("create hierarchical fs indicator: %w", err)
-		}
-	}
-	return nil
-}
-
-func (db *DB) migrateToHierarchicalFS() error {
-	before := time.Now()
-
-	root, err := os.ReadDir(db.config.RootPath)
-	if err != nil {
-		return fmt.Errorf("read db root: %w", err)
-	}
-
-	plan, err := db.assembleFSMigrationPlan(root)
+	fm := newFileMatcher(s, rootPath)
+	plan, err := assembleFSMigrationPlan(root, rootPath, fm)
 	if err != nil {
 		return err
 	}
@@ -68,9 +48,6 @@ func (db *DB) migrateToHierarchicalFS() error {
 			}
 		}
 	}
-
-	db.logger.WithField("action", "hierarchical_fs_migration").
-		Debugf("fs migration took %s\n", time.Since(before))
 
 	return nil
 }
@@ -107,9 +84,8 @@ func (p *migrationPlan) prepend(class, shard, oldRootRelPath, newShardRelPath st
 	}}, p.partsByShard[shardRoot]...)
 }
 
-func (db *DB) assembleFSMigrationPlan(entries []os.DirEntry) (*migrationPlan, error) {
-	fm := newFileMatcher(db.schemaGetter, db.config.RootPath)
-	plan := newMigrationPlan(db.config.RootPath)
+func assembleFSMigrationPlan(entries []os.DirEntry, rootPath string, fm *fileMatcher) (*migrationPlan, error) {
+	plan := newMigrationPlan(rootPath)
 
 	for _, entry := range entries {
 		if ok, cs := fm.isShardLsmDir(entry); ok {
@@ -139,8 +115,8 @@ func (db *DB) assembleFSMigrationPlan(entries []os.DirEntry) (*migrationPlan, er
 
 			// explicitly rename Class directory starting with uppercase to lowercase
 			// as MkdirAll will not create lowercased dir if uppercased one exists
-			oldClassRoot := path.Join(db.config.RootPath, entry.Name())
-			newClassRoot := path.Join(db.config.RootPath, strings.ToLower(entry.Name()))
+			oldClassRoot := path.Join(rootPath, entry.Name())
+			newClassRoot := path.Join(rootPath, strings.ToLower(entry.Name()))
 			if err := os.Rename(oldClassRoot, newClassRoot); err != nil {
 				return nil, fmt.Errorf(
 					"rename pq index dir to avoid collision, old: %q, new: %q, err: %w",
@@ -170,7 +146,12 @@ type fileMatcher struct {
 	classes             map[string][]*classShard
 }
 
-func newFileMatcher(schemaGetter schema.SchemaGetter, rootPath string) *fileMatcher {
+type schemaGetter interface {
+	CopyShardingState(class string) *sharding.State
+	GetSchemaSkipAuth() entschema.Schema
+}
+
+func newFileMatcher(schemaGetter schemaGetter, rootPath string) *fileMatcher {
 	shardLsmDirs := make(map[string]*classShard)
 	shardFilePrefixes := make(map[string]*classShard)
 	shardGeoDirPrefixes := make(map[string]*classShardGeoProp)
@@ -296,15 +277,4 @@ func (fm *fileMatcher) isPqDir(entry os.DirEntry) (bool, []*classShard) {
 		return true, resultcss
 	}
 	return false, nil
-}
-
-func fileExists(file string) (bool, error) {
-	_, err := os.Stat(file)
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
 }


### PR DESCRIPTION
 With the introduction of hierarchical file structure in v1.23, db files are migrated to this new structure during app start. However, backups created prior to v1.23, still use the flat file structure. The restoration process has not updated to migrate to the new structure. As a result, when restoring these backups, the files are being handled according to the old flat format.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
