### PR TITLE
refact: custom linter to report all files before exit

### DIFF
--- a/tools/linter_error_groups.sh
+++ b/tools/linter_error_groups.sh
@@ -5,10 +5,16 @@ set -euo pipefail
 # Get all files with 'errgroup' in them. The only place where direct usage is allowed is in error_group_wrapper.go
 files=$(git ls-files | xargs grep -l 'errgroup')
 
+found_error=false
+
 for file in $files; do
     # Check if the file is not one of the permitted usages
     if [ "$file" != "entities/errors/error_group_wrapper.go" ] && [ "$file" != "tools/linter_error_groups.sh" ]; then
         echo "Error: $file directly uses error groups. Please use entities/errors/error_group_wrapper.go instead."
-        exit 1
+        found_error=true
     fi
 done
+
+if [ "$found_error" = true ]; then
+    exit 1
+fi


### PR DESCRIPTION
### What's being changed:
this PR make sure that the custom linter reports all the files needs to be lint-ed before exiting, to catch them all 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
