### PR TITLE
fix: overwrite tmp bloom filter during precalculation

### DIFF
--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -144,7 +144,10 @@ func (s *segment) precomputeBloomFilter() error {
 	}
 
 	if ok {
-		return fmt.Errorf("a bloom filter already exists with path %s", path)
+		err := os.Remove(path)
+		if err != nil {
+			return fmt.Errorf("delete existing bloom filter %s: %w", path, err)
+		}
 	}
 
 	if err := s.computeAndStoreBloomFilter(path); err != nil {


### PR DESCRIPTION
#4469 backport 

if compaction fails after pre-calculating the bloom filter, then compaction of those segments won't proceed because bloom filter pre-calculation was returning an error if a temporary bloom filter was present in the filesystem.

### What's being changed:
bloom filter pre-calculation can safely remove the existent temporary bloom filter

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
