### PR TITLE
Allow user setting AdvertiseAddr

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -35,6 +35,7 @@ type Config struct {
 	IgnoreStartupSchemaSync bool       `json:"ignoreStartupSchemaSync" yaml:"ignoreStartupSchemaSync"`
 	SkipSchemaSyncRepair    bool       `json:"skipSchemaSyncRepair" yaml:"skipSchemaSyncRepair"`
 	AuthConfig              AuthConfig `json:"auth" yaml:"auth"`
+	AdvertiseAddr			string     `json:"AdvertiseAddr" yaml:"AdvertiseAddr"`
 }
 
 type AuthConfig struct {
@@ -71,6 +72,10 @@ func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *Sta
 	cfg.Events = events{&state.delegate}
 	if userConfig.GossipBindPort != 0 {
 		cfg.BindPort = userConfig.GossipBindPort
+	}
+
+	if userConfig.AdvertiseAddr != "" {
+		cfg.AdvertiseAddr = userConfig.AdvertiseAddr
 	}
 
 	if state.list, err = memberlist.Create(cfg); err != nil {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -36,6 +36,7 @@ type Config struct {
 	SkipSchemaSyncRepair    bool       `json:"skipSchemaSyncRepair" yaml:"skipSchemaSyncRepair"`
 	AuthConfig              AuthConfig `json:"auth" yaml:"auth"`
 	AdvertiseAddr           string     `json:"advertiseAddr" yaml:"advertiseAddr"`
+	AdvertisePort           int        `json:"advertisePort" yaml:"advertisePort"`
 }
 
 type AuthConfig struct {
@@ -76,6 +77,10 @@ func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *Sta
 
 	if userConfig.AdvertiseAddr != "" {
 		cfg.AdvertiseAddr = userConfig.AdvertiseAddr
+	}
+
+	if userConfig.AdvertisePort != 0 {
+		cfg.AdvertisePort = userConfig.AdvertisePort
 	}
 
 	if state.list, err = memberlist.Create(cfg); err != nil {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -35,7 +35,7 @@ type Config struct {
 	IgnoreStartupSchemaSync bool       `json:"ignoreStartupSchemaSync" yaml:"ignoreStartupSchemaSync"`
 	SkipSchemaSyncRepair    bool       `json:"skipSchemaSyncRepair" yaml:"skipSchemaSyncRepair"`
 	AuthConfig              AuthConfig `json:"auth" yaml:"auth"`
-	AdvertiseAddr			string     `json:"AdvertiseAddr" yaml:"AdvertiseAddr"`
+	AdvertiseAddr           string     `json:"advertiseAddr" yaml:"advertiseAddr"`
 }
 
 type AuthConfig struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -521,8 +521,13 @@ func parseClusterConfig() (cluster.Config, error) {
 	cfg.Hostname = os.Getenv("CLUSTER_HOSTNAME")
 	cfg.Join = os.Getenv("CLUSTER_JOIN")
 
+	advertiseAddr, advertiseAddrSet := os.LookupEnv("ADVERTISE_ADDR")
 	gossipBind, gossipBindSet := os.LookupEnv("CLUSTER_GOSSIP_BIND_PORT")
 	dataBind, dataBindSet := os.LookupEnv("CLUSTER_DATA_BIND_PORT")
+
+	if advertiseAddrSet {
+		cfg.AdvertiseAddr = advertiseAddr
+	}
 
 	if gossipBindSet {
 		asInt, err := strconv.Atoi(gossipBind)

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -462,13 +462,9 @@ const (
 
 const VectorizerModuleNone = "none"
 
-// DefaultGossipBindPort and DefaultGossipAdvertisePort uses the
-// hashicorp/memberlist default port value assigned with the use of
-// DefaultLocalConfig
-const (
-	DefaultGossipBindPort = 7946
-	DefaultAdvertisePort  = 7946
-)
+// DefaultGossipBindPort uses the hashicorp/memberlist default port value
+// assigned with the use of DefaultLocalConfig
+const DefaultGossipBindPort = 7946
 
 // TODO: This should be retrieved dynamically from all installed modules
 const VectorizerModuleText2VecContextionary = "text2vec-contextionary"
@@ -541,8 +537,6 @@ func parseClusterConfig() (cluster.Config, error) {
 			return cfg, fmt.Errorf("parse CLUSTER_ADVERTISE_PORT as int: %w", err)
 		}
 		cfg.AdvertisePort = asInt
-	} else {
-		cfg.AdvertisePort = DefaultAdvertisePort
 	}
 
 	if gossipBindSet {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -462,11 +462,13 @@ const (
 
 const VectorizerModuleNone = "none"
 
-// DefaultGossipBindPort and DefaultGossipAdvertisePort uses the 
-// hashicorp/memberlist default port value assigned with the use of 
+// DefaultGossipBindPort and DefaultGossipAdvertisePort uses the
+// hashicorp/memberlist default port value assigned with the use of
 // DefaultLocalConfig
-const DefaultGossipBindPort = 7946
-const DefaultAdvertisePort = 7946
+const (
+	DefaultGossipBindPort = 7946
+	DefaultAdvertisePort  = 7946
+)
 
 // TODO: This should be retrieved dynamically from all installed modules
 const VectorizerModuleText2VecContextionary = "text2vec-contextionary"

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -521,7 +521,7 @@ func parseClusterConfig() (cluster.Config, error) {
 	cfg.Hostname = os.Getenv("CLUSTER_HOSTNAME")
 	cfg.Join = os.Getenv("CLUSTER_JOIN")
 
-	advertiseAddr, advertiseAddrSet := os.LookupEnv("ADVERTISE_ADDR")
+	advertiseAddr, advertiseAddrSet := os.LookupEnv("CLUSTER_ADVERTISE_ADDR")
 	gossipBind, gossipBindSet := os.LookupEnv("CLUSTER_GOSSIP_BIND_PORT")
 	dataBind, dataBindSet := os.LookupEnv("CLUSTER_DATA_BIND_PORT")
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -462,8 +462,8 @@ const (
 
 const VectorizerModuleNone = "none"
 
-// DefaultGossipBindPort uses the hashicorp/memberlist default port value
-// assigned with the use of DefaultLocalConfig
+// DefaultGossipBindPort uses the hashicorp/memberlist default
+// port value assigned with the use of DefaultLocalConfig
 const DefaultGossipBindPort = 7946
 
 // TODO: This should be retrieved dynamically from all installed modules

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -462,9 +462,11 @@ const (
 
 const VectorizerModuleNone = "none"
 
-// DefaultGossipBindPort uses the hashicorp/memberlist default
-// port value assigned with the use of DefaultLocalConfig
+// DefaultGossipBindPort and DefaultGossipAdvertisePort uses the 
+// hashicorp/memberlist default port value assigned with the use of 
+// DefaultLocalConfig
 const DefaultGossipBindPort = 7946
+const DefaultAdvertisePort = 7946
 
 // TODO: This should be retrieved dynamically from all installed modules
 const VectorizerModuleText2VecContextionary = "text2vec-contextionary"
@@ -522,11 +524,23 @@ func parseClusterConfig() (cluster.Config, error) {
 	cfg.Join = os.Getenv("CLUSTER_JOIN")
 
 	advertiseAddr, advertiseAddrSet := os.LookupEnv("CLUSTER_ADVERTISE_ADDR")
+	advertisePort, advertisePortSet := os.LookupEnv("CLUSTER_ADVERTISE_PORT")
+
 	gossipBind, gossipBindSet := os.LookupEnv("CLUSTER_GOSSIP_BIND_PORT")
 	dataBind, dataBindSet := os.LookupEnv("CLUSTER_DATA_BIND_PORT")
 
 	if advertiseAddrSet {
 		cfg.AdvertiseAddr = advertiseAddr
+	}
+
+	if advertisePortSet {
+		asInt, err := strconv.Atoi(advertisePort)
+		if err != nil {
+			return cfg, fmt.Errorf("parse CLUSTER_ADVERTISE_PORT as int: %w", err)
+		}
+		cfg.AdvertisePort = asInt
+	} else {
+		cfg.AdvertisePort = DefaultAdvertisePort
 	}
 
 	if gossipBindSet {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -267,7 +267,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				"CLUSTER_GOSSIP_BIND_PORT": "7100",
 				"CLUSTER_DATA_BIND_PORT":   "7101",
 				"CLUSTER_ADVERTISE_ADDR":   "193.0.0.1",
-				"CLUSTER_ADVERTISE_PORT":   9999,
+				"CLUSTER_ADVERTISE_PORT":   "9999",
 			},
 			expectedResult: cluster.Config{
 				GossipBindPort: 7100,
@@ -293,6 +293,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 			expectedResult: cluster.Config{
 				GossipBindPort: 7777,
 				DataBindPort:   7778,
+				AdvertisePort:  7946,
 			},
 		},
 		{
@@ -321,6 +322,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				GossipBindPort:          7946,
 				DataBindPort:            7947,
 				IgnoreStartupSchemaSync: true,
+				AdvertisePort:           7946,
 			},
 		},
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -281,7 +281,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 			expectedResult: cluster.Config{
 				GossipBindPort: DefaultGossipBindPort,
 				DataBindPort:   DefaultGossipBindPort + 1,
-				AdvertiseAddr: "",
+				AdvertiseAddr:  "",
 				AdvertisePort:  7946,
 			},
 		},

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -262,21 +262,25 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 		expectedErr    error
 	}{
 		{
-			name: "valid cluster config - both ports provided",
+			name: "valid cluster config - both ports and advertiseaddr " + 
+					"provided",
 			envVars: map[string]string{
 				"CLUSTER_GOSSIP_BIND_PORT": "7100",
 				"CLUSTER_DATA_BIND_PORT":   "7101",
+				"CLUSTER_ADVERTISE_ADDR":   "193.0.0.1",
 			},
 			expectedResult: cluster.Config{
 				GossipBindPort: 7100,
 				DataBindPort:   7101,
+				AdvertiseAddr:  "193.0.0.1",
 			},
 		},
 		{
-			name: "valid cluster config - no ports provided",
+			name: "valid cluster config - no ports and advertiseaddr provided",
 			expectedResult: cluster.Config{
 				GossipBindPort: DefaultGossipBindPort,
 				DataBindPort:   DefaultGossipBindPort + 1,
+				AdvertiseAddr: "",
 			},
 		},
 		{

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -282,7 +282,6 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				GossipBindPort: DefaultGossipBindPort,
 				DataBindPort:   DefaultGossipBindPort + 1,
 				AdvertiseAddr:  "",
-				AdvertisePort:  7946,
 			},
 		},
 		{
@@ -293,7 +292,6 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 			expectedResult: cluster.Config{
 				GossipBindPort: 7777,
 				DataBindPort:   7778,
-				AdvertisePort:  7946,
 			},
 		},
 		{
@@ -322,7 +320,6 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				GossipBindPort:          7946,
 				DataBindPort:            7947,
 				IgnoreStartupSchemaSync: true,
-				AdvertisePort:           7946,
 			},
 		},
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -262,17 +262,18 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 		expectedErr    error
 	}{
 		{
-			name: "valid cluster config - both ports and advertiseaddr " + 
-					"provided",
+			name: "valid cluster config - ports and advertiseaddr provided",
 			envVars: map[string]string{
 				"CLUSTER_GOSSIP_BIND_PORT": "7100",
 				"CLUSTER_DATA_BIND_PORT":   "7101",
 				"CLUSTER_ADVERTISE_ADDR":   "193.0.0.1",
+				"CLUSTER_ADVERTISE_PORT":   9999,
 			},
 			expectedResult: cluster.Config{
 				GossipBindPort: 7100,
 				DataBindPort:   7101,
 				AdvertiseAddr:  "193.0.0.1",
+				AdvertisePort:  9999,
 			},
 		},
 		{
@@ -281,6 +282,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				GossipBindPort: DefaultGossipBindPort,
 				DataBindPort:   DefaultGossipBindPort + 1,
 				AdvertiseAddr: "",
+				AdvertisePort:  7946,
 			},
 		},
 		{


### PR DESCRIPTION
### What's being changed:
Allow users setting AdvertiseAddr. This way Embedded Weaviate will run normaly on subnets outside of RFC6890 CIDRs (such as in Sagemaker Studio Kernel Apps) and the error "Failed to get final asvertise address: no private addresses found, and explicit IP not provided" won't be raised anymore.

The code was compiled and tested in a Docker environment with a virtual subnet outside of RFC6890 CIDRs.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
