### PR TITLE
Fix getting a default target vector in hybrid when only 1 vectorizer is defined

### DIFF
--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -84,7 +84,7 @@ func (fa *filteredAggregator) hybrid(ctx context.Context) (*aggregation.Result, 
 	res, err := hybrid.Search(ctx, &hybrid.Params{
 		HybridSearch: fa.params.Hybrid,
 		Class:        fa.params.ClassName.String(),
-	}, fa.logger, sparseSearch, denseSearch, nil, nil)
+	}, fa.logger, sparseSearch, denseSearch, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -139,7 +139,7 @@ func (g *grouper) hybrid(ctx context.Context, allowList helpers.AllowList) ([]ui
 		HybridSearch: g.params.Hybrid,
 		Keyword:      nil,
 		Class:        g.params.ClassName.String(),
-	}, g.logger, sparseSearch, denseSearch, nil, nil)
+	}, g.logger, sparseSearch, denseSearch, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/ranked_fusion_test.go
+++ b/adapters/repos/db/ranked_fusion_test.go
@@ -430,6 +430,7 @@ func TestRFJourney(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 		require.Nil(t, err)
 
@@ -462,6 +463,7 @@ func TestRFJourney(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 
 		fmt.Println("--- Start results for hybrid with negative limit ---")
@@ -495,6 +497,7 @@ func TestRFJourney(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 
 		fmt.Println("--- Start results for hybrid with offset 2 ---")
@@ -530,6 +533,7 @@ func TestRFJourney(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 
 		fmt.Println("--- Start results for hybrid with offset 4 ---")
@@ -649,6 +653,7 @@ func TestRFJourneyWithFilters(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 		require.Nil(t, err)
 		require.Equal(t, 0, len(hybridResults))
@@ -674,6 +679,7 @@ func TestRFJourneyWithFilters(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 		require.Nil(t, err)
 		require.Equal(t, 3, len(hybridResults))
@@ -709,6 +715,7 @@ func TestRFJourneyWithFilters(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(repo, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 		require.Nil(t, err)
 		require.Equal(t, 1, len(hybridResults))
@@ -960,6 +967,7 @@ func TestHybridOverSearch(t *testing.T) {
 		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
 		explorer := traverser.NewExplorer(fos, log, prov, metrics, defaultConfig)
+		explorer.SetSchemaGetter(schemaGetter)
 		hybridResults, err := explorer.Hybrid(context.TODO(), params)
 		require.Nil(t, err)
 		require.Equal(t, 1, len(hybridResults))

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_hybrid_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_hybrid_test.go
@@ -1,0 +1,95 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package named_vectors_tests
+
+import (
+	acceptance_with_go_client "acceptance_tests_with_client"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func testHybrid(host string) func(t *testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+		require.Nil(t, err)
+
+		cleanup := func() {
+			err := client.Schema().AllDeleter().Do(context.Background())
+			require.Nil(t, err)
+		}
+
+		cleanup()
+
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name: "text", DataType: []string{schema.DataTypeText.String()},
+				},
+			},
+			VectorConfig: map[string]models.VectorConfig{
+				transformers: {
+					Vectorizer: map[string]interface{}{
+						text2vecTransformers: map[string]interface{}{
+							"vectorizeClassName": false,
+						},
+					},
+					VectorIndexType: "flat",
+				},
+			},
+		}
+		t.Run("hybrid with 1 vectorizer", func(t *testing.T) {
+			id := "1aa6fbff-461b-4ca5-9ff7-47ccd6d07519"
+			// create class
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+			// insert object
+			objWrapper, err := client.Data().Creator().
+				WithClassName(class.Class).
+				WithID(id).
+				WithProperties(map[string]interface{}{
+					"text": "Some text goes here",
+				}).
+				Do(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, objWrapper)
+			assert.Len(t, objWrapper.Object.Vectors, 1)
+
+			field := graphql.Field{
+				Name: "_additional",
+				Fields: []graphql.Field{
+					{Name: "id"},
+				},
+			}
+
+			resp, err := client.GraphQL().Get().
+				WithClassName(class.Class).
+				WithHybrid(client.GraphQL().
+					HybridArgumentBuilder().
+					WithQuery("Some text goes here").
+					WithAlpha(0.5)).
+				WithFields(field).
+				Do(ctx)
+			require.NoError(t, err)
+			ids := acceptance_with_go_client.GetIds(t, resp, class.Class)
+			require.ElementsMatch(t, ids, []string{id})
+		})
+	}
+}

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
@@ -79,6 +79,7 @@ func allTests(endpoint string) func(t *testing.T) {
 		t.Run("validation", testSchemaValidation(endpoint))
 		t.Run("cross references", testReferenceProperties(endpoint))
 		t.Run("objects with vectorizer and objects", testCreateSchemaWithVectorizerAndBYOV(endpoint))
+		t.Run("hybrid", testHybrid(endpoint))
 	}
 }
 

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -47,7 +47,7 @@ type Explorer struct {
 	modulesProvider   ModulesProvider
 	schemaGetter      uc.SchemaGetter
 	nearParamsVector  *nearParamsVector
-	targetParamHelper *targetVectorParamHelper
+	targetParamHelper *TargetVectorParamHelper
 	metrics           explorerMetrics
 	config            config.Config
 }
@@ -107,7 +107,7 @@ func NewExplorer(searcher objectsSearcher, logger logrus.FieldLogger, modulesPro
 		metrics:           metrics,
 		schemaGetter:      nil, // schemaGetter is set later
 		nearParamsVector:  newNearParamsVector(modulesProvider, searcher),
-		targetParamHelper: newTargetParamHelper(),
+		targetParamHelper: NewTargetParamHelper(),
 		config:            conf,
 	}
 }
@@ -203,7 +203,7 @@ func (e *Explorer) getClassVectorSearch(ctx context.Context,
 		return nil, errors.Errorf("explorer: get class: vectorize params: %v", err)
 	}
 
-	targetVector, err = e.targetParamHelper.getTargetVectorOrDefault(e.schemaGetter.GetSchemaSkipAuth(),
+	targetVector, err = e.targetParamHelper.GetTargetVectorOrDefault(e.schemaGetter.GetSchemaSkipAuth(),
 		params.ClassName, targetVector)
 	if err != nil {
 		return nil, errors.Errorf("explorer: get class: validate target vector: %v", err)
@@ -328,13 +328,18 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		} else {
 			hybridSearchLimit = baseSearchLimit
 		}
-		targetVec := ""
+		targetVector := ""
 		if len(params.HybridSearch.TargetVectors) > 0 {
-			targetVec = params.HybridSearch.TargetVectors[0]
+			targetVector = params.HybridSearch.TargetVectors[0]
+		}
+		targetVector, err := e.targetParamHelper.GetTargetVectorOrDefault(e.schemaGetter.GetSchemaSkipAuth(),
+			params.ClassName, targetVector)
+		if err != nil {
+			return nil, nil, err
 		}
 
 		res, dists, err := e.searcher.DenseObjectSearch(ctx,
-			params.ClassName, vec, targetVec, 0, hybridSearchLimit, params.Filters,
+			params.ClassName, vec, targetVector, 0, hybridSearchLimit, params.Filters,
 			params.AdditionalProperties, params.Tenant)
 		if err != nil {
 			return nil, nil, err
@@ -370,7 +375,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		Keyword:      params.KeywordRanking,
 		Class:        params.ClassName,
 		Autocut:      params.Pagination.Autocut,
-	}, e.logger, sparseSearch, denseSearch, postProcess, e.modulesProvider)
+	}, e.logger, sparseSearch, denseSearch, postProcess, e.modulesProvider, e.schemaGetter, e.targetParamHelper)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/hybrid/fakes_for_test.go
+++ b/usecases/traverser/hybrid/fakes_for_test.go
@@ -1,0 +1,86 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hybrid
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func newFakeTargetVectorParamHelper() *fakeTargetVectorParamHelper {
+	return &fakeTargetVectorParamHelper{}
+}
+
+func newFakeSchemaManager() *fakeSchemaManager {
+	return &fakeSchemaManager{
+		schema: schema.Schema{Objects: &models.Schema{}},
+	}
+}
+
+type fakeTargetVectorParamHelper struct{}
+
+func (*fakeTargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, className, targetVector string) (string, error) {
+	return targetVector, nil
+}
+
+type fakeSchemaManager struct {
+	schema schema.Schema
+}
+
+func (f *fakeSchemaManager) GetSchemaSkipAuth() schema.Schema {
+	return f.schema
+}
+
+func (f *fakeSchemaManager) CopyShardingState(class string) *sharding.State {
+	return nil
+}
+
+func (f *fakeSchemaManager) ShardOwner(class, shard string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeSchemaManager) ShardReplicas(class, shard string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (f *fakeSchemaManager) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, nodeMapping map[string]string) error {
+	return nil
+}
+
+func (f *fakeSchemaManager) Nodes() []string {
+	return []string{"NOT SET"}
+}
+
+func (f *fakeSchemaManager) NodeName() string {
+	return ""
+}
+
+func (f *fakeSchemaManager) ClusterHealthScore() int {
+	return 0
+}
+
+func (f *fakeSchemaManager) ResolveParentNodes(_ string, shard string,
+) (map[string]string, error) {
+	return nil, nil
+}
+
+func (f *fakeSchemaManager) ShardFromUUID(class string, uuid []byte) string {
+	return ""
+}
+
+func (f *fakeSchemaManager) TenantShard(class, tenant string) (string, string) {
+	return "", ""
+}

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -19,9 +19,11 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/autocut"
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
+	uc "github.com/weaviate/weaviate/usecases/schema"
 )
 
 const DefaultLimit = 100
@@ -64,10 +66,14 @@ type modulesProvider interface {
 		className, input, targetVector string) ([]float32, error)
 }
 
+type targetVectorParamHelper interface {
+	GetTargetVectorOrDefault(sch schema.Schema, className, targetVector string) (string, error)
+}
+
 // Search executes sparse and dense searches and combines the result sets using Reciprocal Rank Fusion
 func Search(ctx context.Context, params *Params, logger logrus.FieldLogger, sparseSearch sparseSearchFunc,
-	denseSearch denseSearchFunc, postProc postProcFunc,
-	modules modulesProvider,
+	denseSearch denseSearchFunc, postProc postProcFunc, modules modulesProvider,
+	schemaGetter uc.SchemaGetter, targetVectorParamHelper targetVectorParamHelper,
 ) ([]*search.Result, error) {
 	var (
 		found   [][]*search.Result
@@ -90,7 +96,7 @@ func Search(ctx context.Context, params *Params, logger logrus.FieldLogger, spar
 		}
 
 		if alpha > 0 {
-			res, err := processDenseSearch(ctx, denseSearch, params, modules)
+			res, err := processDenseSearch(ctx, denseSearch, params, modules, schemaGetter, targetVectorParamHelper)
 			if err != nil {
 				return nil, err
 			}
@@ -101,7 +107,7 @@ func Search(ctx context.Context, params *Params, logger logrus.FieldLogger, spar
 		}
 	} else if params.Vector != nil {
 		// Perform a plain vector search, no keyword query provided
-		res, err := processDenseSearch(ctx, denseSearch, params, modules)
+		res, err := processDenseSearch(ctx, denseSearch, params, modules, schemaGetter, targetVectorParamHelper)
 		if err != nil {
 			return nil, err
 		}
@@ -114,13 +120,13 @@ func Search(ctx context.Context, params *Params, logger logrus.FieldLogger, spar
 		ss := params.SubSearches
 
 		// To catch error if ss is empty
-		_, err := decideSearchVector(ctx, params, modules)
+		_, err := decideSearchVector(ctx, params, modules, schemaGetter, targetVectorParamHelper)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, subsearch := range ss.([]searchparams.WeightedSearchResult) {
-			res, name, weight, err := handleSubSearch(ctx, &subsearch, denseSearch, sparseSearch, params, modules)
+			res, name, weight, err := handleSubSearch(ctx, &subsearch, denseSearch, sparseSearch, params, modules, schemaGetter, targetVectorParamHelper)
 			if err != nil {
 				return nil, err
 			}
@@ -190,8 +196,11 @@ func processSparseSearch(results []*storobj.Object, scores []float32, err error)
 	return out, nil
 }
 
-func processDenseSearch(ctx context.Context, denseSearch denseSearchFunc, params *Params, modules modulesProvider) ([]*search.Result, error) {
-	vector, err := decideSearchVector(ctx, params, modules)
+func processDenseSearch(ctx context.Context,
+	denseSearch denseSearchFunc, params *Params, modules modulesProvider,
+	schemaGetter uc.SchemaGetter, targetVectorParamHelper targetVectorParamHelper,
+) ([]*search.Result, error) {
+	vector, err := decideSearchVector(ctx, params, modules, schemaGetter, targetVectorParamHelper)
 	if err != nil {
 		return nil, err
 	}
@@ -210,14 +219,18 @@ func processDenseSearch(ctx context.Context, denseSearch denseSearchFunc, params
 	return out, nil
 }
 
-func handleSubSearch(ctx context.Context, subsearch *searchparams.WeightedSearchResult, denseSearch denseSearchFunc, sparseSearch sparseSearchFunc, params *Params, modules modulesProvider) ([]*search.Result, string, float64, error) {
+func handleSubSearch(ctx context.Context,
+	subsearch *searchparams.WeightedSearchResult, denseSearch denseSearchFunc, sparseSearch sparseSearchFunc,
+	params *Params, modules modulesProvider,
+	schemaGetter uc.SchemaGetter, targetVectorParamHelper targetVectorParamHelper,
+) ([]*search.Result, string, float64, error) {
 	switch subsearch.Type {
 	case "bm25":
 		fallthrough
 	case "sparseSearch":
 		return sparseSubSearch(subsearch, params, sparseSearch)
 	case "nearText":
-		return nearTextSubSearch(ctx, subsearch, denseSearch, params, modules)
+		return nearTextSubSearch(ctx, subsearch, denseSearch, params, modules, schemaGetter, targetVectorParamHelper)
 	case "nearVector":
 		return nearVectorSubSearch(subsearch, denseSearch)
 	default:
@@ -244,13 +257,21 @@ func sparseSubSearch(subsearch *searchparams.WeightedSearchResult, params *Param
 	return out, "bm25f", subsearch.Weight, nil
 }
 
-func nearTextSubSearch(ctx context.Context, subsearch *searchparams.WeightedSearchResult, denseSearch denseSearchFunc, params *Params, modules modulesProvider) ([]*search.Result, string, float64, error) {
+func nearTextSubSearch(ctx context.Context, subsearch *searchparams.WeightedSearchResult, denseSearch denseSearchFunc,
+	params *Params, modules modulesProvider,
+	schemaGetter uc.SchemaGetter, targetVectorParamHelper targetVectorParamHelper,
+) ([]*search.Result, string, float64, error) {
 	sp := subsearch.SearchParams.(searchparams.NearTextParams)
-	if modules == nil {
+	if modules == nil || schemaGetter == nil || targetVectorParamHelper == nil {
 		return nil, "", 0, nil
 	}
 
 	targetVector := getTargetVector(params.TargetVectors)
+	targetVector, err := targetVectorParamHelper.GetTargetVectorOrDefault(schemaGetter.GetSchemaSkipAuth(),
+		params.Class, targetVector)
+	if err != nil {
+		return nil, "", 0, err
+	}
 
 	vector, err := vectorFromModuleInput(ctx, params.Class, sp.Values[0], targetVector, modules)
 	if err != nil {
@@ -290,7 +311,10 @@ func nearVectorSubSearch(subsearch *searchparams.WeightedSearchResult, denseSear
 	return out, "vector,nearVector", subsearch.Weight, nil
 }
 
-func decideSearchVector(ctx context.Context, params *Params, modules modulesProvider) ([]float32, error) {
+func decideSearchVector(ctx context.Context,
+	params *Params, modules modulesProvider,
+	schemaGetter uc.SchemaGetter, targetVectorParamHelper targetVectorParamHelper,
+) ([]float32, error) {
 	var (
 		vector []float32
 		err    error
@@ -299,8 +323,13 @@ func decideSearchVector(ctx context.Context, params *Params, modules modulesProv
 	if params.Vector != nil && len(params.Vector) != 0 {
 		vector = params.Vector
 	} else {
-		if modules != nil {
+		if modules != nil && schemaGetter != nil && targetVectorParamHelper != nil {
 			targetVector := getTargetVector(params.TargetVectors)
+			targetVector, err = targetVectorParamHelper.GetTargetVectorOrDefault(schemaGetter.GetSchemaSkipAuth(),
+				params.Class, targetVector)
+			if err != nil {
+				return nil, err
+			}
 			vector, err = vectorFromModuleInput(ctx, params.Class, params.Query, targetVector, modules)
 			if err != nil {
 				return nil, err

--- a/usecases/traverser/hybrid/searcher_score_fusion_test.go
+++ b/usecases/traverser/hybrid/searcher_score_fusion_test.go
@@ -83,7 +83,7 @@ func TestScoreFusionSearchWithoutModuleProvider(t *testing.T) {
 		return inputs[0].documents, inputs[0].inputScores[1], nil
 	}
 
-	res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+	res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 	require.Nil(t, err)
 	fmt.Printf("res: %v\n", res)
 }
@@ -105,7 +105,9 @@ func TestScoreFusionSearchWithModuleProvider(t *testing.T) {
 	sparse := func() ([]*storobj.Object, []float32, error) { return nil, nil, nil }
 	dense := func([]float32) ([]*storobj.Object, []float32, error) { return nil, nil, nil }
 	provider := &fakeModuleProvider{}
-	_, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+	schemaGetter := newFakeSchemaManager()
+	targetVectorParamHelper := newFakeTargetVectorParamHelper()
+	_, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 	require.Nil(t, err)
 }
 
@@ -138,7 +140,7 @@ func TestScoreFusionSearchWithSparseSearchOnly(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 	dense := func([]float32) ([]*storobj.Object, []float32, error) { return nil, nil, nil }
-	res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+	res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 	require.Nil(t, err)
 	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0])
@@ -180,7 +182,7 @@ func TestScoreFusionSearchWithDenseSearchOnly(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 
-	res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+	res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 	require.Nil(t, err)
 	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0])
@@ -235,7 +237,7 @@ func TestScoreFusionCombinedHybridSearch(t *testing.T) {
 			},
 		}, []float32{0.008}, nil
 	}
-	res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+	res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 	require.Nil(t, err)
 	assert.Len(t, res, 2)
 	assert.NotNil(t, res[0])
@@ -288,7 +290,7 @@ func TestScoreFusionWithSparseSubsearchFilter(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 	dense := func([]float32) ([]*storobj.Object, []float32, error) { return nil, nil, nil }
-	res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+	res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 	require.Nil(t, err)
 	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0])
@@ -335,7 +337,9 @@ func TestScoreFusionWithNearTextSubsearchFilter(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 	provider := &fakeModuleProvider{}
-	res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+	schemaGetter := newFakeSchemaManager()
+	targetVectorParamHelper := newFakeTargetVectorParamHelper()
+	res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 	require.Nil(t, err)
 	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0])
@@ -382,8 +386,9 @@ func TestScoreFusionWithNearVectorSubsearchFilter(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 	provider := &fakeModuleProvider{}
-
-	res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+	schemaGetter := newFakeSchemaManager()
+	targetVectorParamHelper := newFakeTargetVectorParamHelper()
+	res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 	require.Nil(t, err)
 	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0])
@@ -461,7 +466,9 @@ func TestScoreFusionWithAllSubsearchFilters(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 	provider := &fakeModuleProvider{}
-	res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+	schemaGetter := newFakeSchemaManager()
+	targetVectorParamHelper := newFakeTargetVectorParamHelper()
+	res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 	require.Nil(t, err)
 	assert.Len(t, res, 2)
 	assert.NotNil(t, res[0])

--- a/usecases/traverser/hybrid/searcher_test.go
+++ b/usecases/traverser/hybrid/searcher_test.go
@@ -48,7 +48,9 @@ func TestSearcher(t *testing.T) {
 				sparse := func() ([]*storobj.Object, []float32, error) { return nil, nil, nil }
 				dense := func([]float32) ([]*storobj.Object, []float32, error) { return nil, nil, nil }
 				provider := &fakeModuleProvider{}
-				_, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+				schemaGetter := newFakeSchemaManager()
+				targetVectorParamHelper := newFakeTargetVectorParamHelper()
+				_, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 				require.Nil(t, err)
 			},
 		},
@@ -66,7 +68,7 @@ func TestSearcher(t *testing.T) {
 				sparse := func() ([]*storobj.Object, []float32, error) { return nil, nil, nil }
 				dense := func([]float32) ([]*storobj.Object, []float32, error) { return nil, nil, nil }
 
-				_, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+				_, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 				require.Nil(t, err)
 			},
 		},
@@ -95,7 +97,7 @@ func TestSearcher(t *testing.T) {
 					}, []float32{0.008}, nil
 				}
 				dense := func([]float32) ([]*storobj.Object, []float32, error) { return nil, nil, nil }
-				res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+				res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 				require.Nil(t, err)
 				assert.Len(t, res, 1)
 				assert.NotNil(t, res[0])
@@ -132,7 +134,7 @@ func TestSearcher(t *testing.T) {
 					}, []float32{0.008}, nil
 				}
 
-				res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+				res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 				require.Nil(t, err)
 				assert.Len(t, res, 1)
 				assert.NotNil(t, res[0])
@@ -180,7 +182,7 @@ func TestSearcher(t *testing.T) {
 						},
 					}, []float32{0.008}, nil
 				}
-				res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+				res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 				require.Nil(t, err)
 				assert.Len(t, res, 2)
 				assert.NotNil(t, res[0])
@@ -232,7 +234,7 @@ func TestSearcher(t *testing.T) {
 				dense := func([]float32) ([]*storobj.Object, []float32, error) {
 					return nil, nil, nil
 				}
-				res, err := Search(ctx, params, logger, sparse, dense, nil, nil)
+				res, err := Search(ctx, params, logger, sparse, dense, nil, nil, nil, nil)
 				require.Nil(t, err)
 				assert.Len(t, res, 1)
 				assert.NotNil(t, res[0])
@@ -279,7 +281,9 @@ func TestSearcher(t *testing.T) {
 					}, []float32{0.008}, nil
 				}
 				provider := &fakeModuleProvider{}
-				res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+				schemaGetter := newFakeSchemaManager()
+				targetVectorParamHelper := newFakeTargetVectorParamHelper()
+				res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 				require.Nil(t, err)
 				assert.Len(t, res, 1)
 				assert.NotNil(t, res[0])
@@ -326,8 +330,9 @@ func TestSearcher(t *testing.T) {
 					}, []float32{0.008}, nil
 				}
 				provider := &fakeModuleProvider{}
-
-				res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+				schemaGetter := newFakeSchemaManager()
+				targetVectorParamHelper := newFakeTargetVectorParamHelper()
+				res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 				require.Nil(t, err)
 				assert.Len(t, res, 1)
 				assert.NotNil(t, res[0])
@@ -403,7 +408,9 @@ func TestSearcher(t *testing.T) {
 					}, []float32{0.008}, nil
 				}
 				provider := &fakeModuleProvider{}
-				res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+				schemaGetter := newFakeSchemaManager()
+				targetVectorParamHelper := newFakeTargetVectorParamHelper()
+				res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 				require.Nil(t, err)
 				assert.Len(t, res, 2)
 				assert.NotNil(t, res[0])
@@ -504,7 +511,9 @@ func TestNullScores(t *testing.T) {
 		}, []float32{0.008}, nil
 	}
 	provider := &fakeModuleProvider{}
-	res, err := Search(ctx, params, logger, sparse, dense, nil, provider)
+	schemaGetter := newFakeSchemaManager()
+	targetVectorParamHelper := newFakeTargetVectorParamHelper()
+	res, err := Search(ctx, params, logger, sparse, dense, nil, provider, schemaGetter, targetVectorParamHelper)
 	require.Nil(t, err)
 	assert.Len(t, res, 2)
 	assert.NotNil(t, res[0])

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -19,13 +19,13 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-type targetVectorParamHelper struct{}
+type TargetVectorParamHelper struct{}
 
-func newTargetParamHelper() *targetVectorParamHelper {
-	return &targetVectorParamHelper{}
+func NewTargetParamHelper() *TargetVectorParamHelper {
+	return &TargetVectorParamHelper{}
 }
 
-func (t *targetVectorParamHelper) getTargetVectorOrDefault(sch schema.Schema, className, targetVector string) (string, error) {
+func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, className, targetVector string) (string, error) {
 	if targetVector == "" {
 		class := sch.FindClassByName(schema.ClassName(className))
 
@@ -42,7 +42,7 @@ func (t *targetVectorParamHelper) getTargetVectorOrDefault(sch schema.Schema, cl
 	return targetVector, nil
 }
 
-func (t *targetVectorParamHelper) getTargetVectorFromParams(params dto.GetParams) string {
+func (t *TargetVectorParamHelper) GetTargetVectorFromParams(params dto.GetParams) string {
 	if params.NearObject != nil && len(params.NearObject.TargetVectors) == 1 {
 		return params.NearObject.TargetVectors[0]
 	}

--- a/usecases/traverser/traverser.go
+++ b/usecases/traverser/traverser.go
@@ -45,7 +45,7 @@ type Traverser struct {
 	explorer                explorer
 	schemaGetter            schema.SchemaGetter
 	nearParamsVector        *nearParamsVector
-	targetVectorParamHelper *targetVectorParamHelper
+	targetVectorParamHelper *TargetVectorParamHelper
 	metrics                 *Metrics
 	ratelimiter             *ratelimiter.Limiter
 }
@@ -81,7 +81,7 @@ func NewTraverser(config *config.WeaviateConfig, locks locks,
 		explorer:                explorer,
 		schemaGetter:            schemaGetter,
 		nearParamsVector:        newNearParamsVector(modulesProvider, vectorSearcher),
-		targetVectorParamHelper: newTargetParamHelper(),
+		targetVectorParamHelper: NewTargetParamHelper(),
 		metrics:                 metrics,
 		ratelimiter:             ratelimiter.New(maxGetRequests),
 	}

--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -55,7 +55,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 			return nil, err
 		}
 
-		targetVector, err = t.targetVectorParamHelper.getTargetVectorOrDefault(t.schemaGetter.GetSchemaSkipAuth(),
+		targetVector, err = t.targetVectorParamHelper.GetTargetVectorOrDefault(t.schemaGetter.GetSchemaSkipAuth(),
 			className, targetVector)
 		if err != nil {
 			return nil, err
@@ -77,7 +77,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 		if len(params.Hybrid.TargetVectors) == 1 {
 			targetVector = params.Hybrid.TargetVectors[0]
 		}
-		targetVector, err = t.targetVectorParamHelper.getTargetVectorOrDefault(t.schemaGetter.GetSchemaSkipAuth(),
+		targetVector, err = t.targetVectorParamHelper.GetTargetVectorOrDefault(t.schemaGetter.GetSchemaSkipAuth(),
 			params.ClassName.String(), targetVector)
 		if err != nil {
 			return nil, err

--- a/usecases/traverser/traverser_validate_distance_metrics.go
+++ b/usecases/traverser/traverser_validate_distance_metrics.go
@@ -103,7 +103,7 @@ func (t *Traverser) validateGetDistanceParams(params dto.GetParams) error {
 		return fmt.Errorf("failed to find class '%s' in schema", params.ClassName)
 	}
 
-	targetVector := t.targetVectorParamHelper.getTargetVectorFromParams(params)
+	targetVector := t.targetVectorParamHelper.GetTargetVectorFromParams(params)
 	vectorConfig, err := schema.TypeAssertVectorIndex(class, []string{targetVector})
 	if err != nil {
 		return err


### PR DESCRIPTION
### What's being changed:

This PR fixes a situation where 1 named vector is defined and hybrid returns an error when somebody performs search without providing a `targetVector`. 

In that case (where's only 1 vectorizer defined) Weaviate is able to deduce the `targetVector` bc it's the only 1 defined, this PR adds this capability.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
