### PR TITLE
Fix random skipping of named vector validation

### DIFF
--- a/test/acceptance_with_python/test_named_vectors.py
+++ b/test/acceptance_with_python/test_named_vectors.py
@@ -1,0 +1,31 @@
+import weaviate.classes as wvc
+
+from conftest import CollectionFactory
+
+
+def test_create_named_vectors_with_and_without_vectorizer(
+    collection_factory: CollectionFactory,
+) -> None:
+    collection = collection_factory(
+        properties=[
+            wvc.config.Property(name="title", data_type=wvc.config.DataType.TEXT),
+            wvc.config.Property(name="content", data_type=wvc.config.DataType.TEXT),
+        ],
+        vectorizer_config=[
+            wvc.config.Configure.NamedVectors.text2vec_contextionary(
+                name="AllExplicit",
+                source_properties=["title", "content"],
+                vectorize_collection_name=False,
+            ),
+            wvc.config.Configure.NamedVectors.none(name="bringYourOwn"),
+        ],
+    )
+
+    uuid = collection.data.insert(
+        properties={"title": "Hello", "content": "World"},
+        vector={"bringYourOwn": [0.5, 0.25, 0.75]},
+    )
+
+    obj = collection.query.fetch_object_by_id(uuid, include_vector=True)
+    assert obj.vector["AllExplicit"] is not None
+    assert obj.vector["bringYourOwn"] is not None

--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -189,7 +189,7 @@ func (p *Provider) ValidateClass(ctx context.Context, class *models.Class) error
 			for modName := range vectorizer {
 				if modName == "none" {
 					// the class does not use a vectorizer, nothing to do for us
-					return nil
+					continue
 				}
 				if mod := p.GetByName(modName); mod == nil {
 					return errors.Errorf("class.VectorConfig.Vectorizer module with name %s doesn't exist", modName)

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -282,6 +282,8 @@ func (p *Provider) getVectorizer(class *models.Class, targetVector string) strin
 }
 
 func (p *Provider) getVector(object *models.Object, targetVector string) []float32 {
+	p.vectorsLock.Lock()
+	defer p.vectorsLock.Unlock()
 	if targetVector != "" {
 		if len(object.Vectors) == 0 {
 			return nil


### PR DESCRIPTION
### What's being changed:

Fixes two bugs:
- Validation was aborted if a named vector without vectorizer (eg BYOV) was hit. Depending on the order of iteration this means that validation of other named vectors was skipped. This skipping caused a crash in current master (because only master accesses a non-validated/type-fixed field), but the bug is already present in 1.24.
- race between writing to the .Vectors field and reading if it is present

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

