### PR TITLE
Fix references endless recursion

### DIFF
--- a/adapters/repos/db/refcache/cacher.go
+++ b/adapters/repos/db/refcache/cacher.go
@@ -296,6 +296,7 @@ func (c *Cacher) dedupJobList() {
 		// nothing to do
 		return
 	}
+
 	c.logger.
 		WithFields(logrus.Fields{
 			"action": "request_cacher_dedup_joblist_start",
@@ -304,6 +305,11 @@ func (c *Cacher) dedupJobList() {
 		Debug("starting job list deduplication")
 	deduped := make([]cacherJob, len(incompleteJobs))
 	found := map[multi.Identifier]struct{}{}
+
+	// don't look up refs that are already completed - this can for example happen with cyclic refs
+	for _, job := range c.completeJobs() {
+		found[job.si] = struct{}{}
+	}
 
 	n := 0
 	for _, job := range incompleteJobs {

--- a/adapters/repos/db/refcache/cacher_test.go
+++ b/adapters/repos/db/refcache/cacher_test.go
@@ -600,7 +600,7 @@ func TestCacher(t *testing.T) {
 		res, ok = cr.Get(multi.Identifier{ID: idNestedInNestedID, ClassName: "SomeNestedClassNested2"})
 		require.True(t, ok)
 		assert.Equal(t, expectedInnerInner, res)
-		assert.Equal(t, 4, repo.counter, "required the expected amount of lookups")
+		assert.Equal(t, 3, repo.counter, "required the expected amount of lookups")
 	})
 
 	t.Run("with group and with a additional group lookup", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Takes the fix commit from https://github.com/weaviate/weaviate/pull/4539 but does not include the tests as we do not have the python acceptance tests in 1.23

