### PR TITLE
Fixed backup of class schema for nodes without related data

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -200,7 +200,11 @@ type nodeResolver struct {
 }
 
 func (r nodeResolver) AllNames() []string {
-	panic("node resolving not implemented yet")
+	xs := []string{}
+	for _, n := range *r.nodes {
+		xs = append(xs, n.name)
+	}
+	return xs
 }
 
 func (r nodeResolver) Candidates() []string {

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,7 +35,7 @@ const (
 )
 
 var (
-	errNoShardFound = errors.New("no shard found")
+	// errNoShardFound = errors.New("no shard found")
 	errCannotCommit = errors.New("cannot commit")
 	errMetaNotFound = errors.New("metadata not found")
 	errUnknownOp    = errors.New("unknown backup operation")
@@ -481,20 +482,10 @@ func (c *coordinator) abortAll(ctx context.Context, req *AbortRequest, nodes map
 
 // groupByShard returns classes group by nodes
 func (c *coordinator) groupByShard(ctx context.Context, classes []string) (nodeMap, error) {
-	m := make(nodeMap, 32)
-	for _, cls := range classes {
-		nodes, err := c.selector.Shards(ctx, cls)
-		if err != nil {
-			return nil, fmt.Errorf("class %q: %w", cls, errNoShardFound)
-		}
-		for _, node := range nodes {
-			nd, ok := m[node]
-			if !ok {
-				nd = &backup.NodeDescriptor{Classes: make([]string, 0, 5)}
-			}
-			nd.Classes = append(nd.Classes, cls)
-			m[node] = nd
-		}
+	nodes := c.nodeResolver.AllNames()
+	m := make(nodeMap, len(nodes))
+	for _, node := range nodes {
+		m[node] = &backup.NodeDescriptor{Classes: slices.Clone(classes)}
 	}
 	return m, nil
 }

--- a/usecases/backup/coordinator_test.go
+++ b/usecases/backup/coordinator_test.go
@@ -13,7 +13,6 @@ package backup
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -74,9 +73,6 @@ func TestCoordinatedBackup(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 		fc := newFakeCoordinator(nodeResolver)
-		fc.selector.On("Shards", ctx, classes[0]).Return(nodes, nil)
-		fc.selector.On("Shards", ctx, classes[1]).Return(nodes, nil)
-
 		fc.client.On("CanCommit", any, nodes[0], creq).Return(cresp, nil)
 		fc.client.On("CanCommit", any, nodes[1], creq).Return(cresp, nil)
 		fc.client.On("Commit", any, nodes[0], sReq).Return(nil)
@@ -126,7 +122,7 @@ func TestCoordinatedBackup(t *testing.T) {
 			Method:   OpCreate,
 			ID:       backupID,
 			Backend:  backendName,
-			Classes:  []string{classes[1]},
+			Classes:  classes[:],
 			Duration: _BookingPeriod,
 		}
 		fc.client.On("CanCommit", any, nodes[0], creqWithOneClass).Return(cresp, nil)
@@ -156,29 +152,16 @@ func TestCoordinatedBackup(t *testing.T) {
 			ServerVersion: config.ServerVersion,
 			Nodes: map[string]*backup.NodeDescriptor{
 				nodes[0]: {
-					Classes: []string{classes[1]},
+					Classes: classes[:],
 					Status:  backup.Success,
 				},
 				nodes[1]: {
-					Classes: []string{classes[1]},
+					Classes: classes[:],
 					Status:  backup.Success,
 				},
 			},
 		}
 		assert.Equal(t, want, got)
-	})
-
-	t.Run("FailOnShardWithNoNodes", func(t *testing.T) {
-		t.Parallel()
-
-		fc := newFakeCoordinator(nodeResolver)
-		fc.selector.On("Shards", ctx, classes[0]).Return([]string{}, fmt.Errorf("a shard has no nodes"))
-		fc.selector.On("Shards", ctx, classes[1]).Return(nodes, nil)
-		coordinator := *fc.coordinator()
-		store := coordStore{objStore: objStore{fc.backend, req.ID}}
-		err := coordinator.Backup(ctx, store, &req)
-		assert.ErrorIs(t, err, errNoShardFound)
-		assert.Contains(t, err.Error(), classes[0])
 	})
 
 	t.Run("CanCommit", func(t *testing.T) {
@@ -531,6 +514,14 @@ func (r *fakeNodeResolver) NodeCount() int {
 		return len(r.hosts)
 	}
 	return 1
+}
+
+func (r *fakeNodeResolver) AllNames() []string {
+	xs := make([]string, 0, len(r.hosts))
+	for k := range r.hosts {
+		xs = append(xs, k)
+	}
+	return xs
 }
 
 func newFakeNodeResolver(nodes []string) *fakeNodeResolver {

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -51,6 +51,7 @@ type schemaManger interface {
 
 type nodeResolver interface {
 	NodeHostname(nodeName string) (string, bool)
+	AllNames() []string
 	NodeCount() int
 }
 


### PR DESCRIPTION
Currently, only class schemas with associated data are included in the backup. 
However, this approach overlooks the fact that class schemas are shared across all nodes, regardless of data presence.

It’s worth noting that enabling MT may mitigate this issue, as tenants are evenly distributed across nodes.
Additionally, consider creating a backup post-fix implementation to prevent future occurrences

This PR includes the fix, which instructs all nodes to back up all classes. 

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
