### PR TITLE
Replace Generate with Chat for `generative-cohere`, Add Command R support

### DIFF
--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -73,9 +73,7 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	if err != nil {
 		return nil, errors.Wrap(err, "join Cohere API host and path")
 	}
-	emptyChatHistory := make([]message, 0)
 	input := generateInput{
-		ChatHistory:   emptyChatHistory,
 		Message:       prompt,
 		Model:         settings.Model(),
 		MaxTokens:     settings.MaxTokens(),
@@ -190,7 +188,7 @@ func (v *cohere) getApiKey(ctx context.Context) (string, error) {
 }
 
 type generateInput struct {
-	ChatHistory   []message `json:"chat_history"`
+	ChatHistory   []message `json:"chat_history,omitempty"`
 	Message       string    `json:"message"`
 	Model         string    `json:"model"`
 	MaxTokens     int       `json:"max_tokens"`

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -74,13 +74,12 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 		return nil, errors.Wrap(err, "join Cohere API host and path")
 	}
 	input := generateInput{
-		Prompt:            prompt,
-		Model:             settings.Model(),
-		MaxTokens:         settings.MaxTokens(),
-		Temperature:       settings.Temperature(),
-		K:                 settings.K(),
-		StopSequences:     settings.StopSequences(),
-		ReturnLikelihoods: settings.ReturnLikelihoods(),
+		Prompt:        prompt,
+		Model:         settings.Model(),
+		MaxTokens:     settings.MaxTokens(),
+		Temperature:   settings.Temperature(),
+		K:             settings.K(),
+		StopSequences: settings.StopSequences(),
 	}
 
 	body, err := json.Marshal(input)
@@ -189,13 +188,12 @@ func (v *cohere) getApiKey(ctx context.Context) (string, error) {
 }
 
 type generateInput struct {
-	Prompt            string   `json:"prompt"`
-	Model             string   `json:"model"`
-	MaxTokens         int      `json:"max_tokens"`
-	Temperature       int      `json:"temperature"`
-	K                 int      `json:"k"`
-	StopSequences     []string `json:"stop_sequences"`
-	ReturnLikelihoods string   `json:"return_likelihoods"`
+	Prompt        string   `json:"prompt"`
+	Model         string   `json:"model"`
+	MaxTokens     int      `json:"max_tokens"`
+	Temperature   int      `json:"temperature"`
+	K             int      `json:"k"`
+	StopSequences []string `json:"stop_sequences"`
 }
 
 type generateResponse struct {

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -116,9 +116,9 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 		return nil, errors.Wrap(err, "unmarshal response body")
 	}
 
-	if res.StatusCode != 200 || resBody.Error != nil {
-		if resBody.Error != nil {
-			return nil, errors.Errorf("connection to Cohere API failed with status: %d error: %v", res.StatusCode, resBody.Error.Message)
+	if res.StatusCode != 200 {
+		if resBody.Message != "" {
+			return nil, errors.Errorf("connection to Cohere API failed with status: %d error: %v", res.StatusCode, resBody.Message)
 		}
 		return nil, errors.Errorf("connection to Cohere API failed with status: %d", res.StatusCode)
 	}
@@ -203,12 +203,8 @@ type message struct {
 }
 
 type generateResponse struct {
-	Text  string          `json:"text"`
-	Error *cohereApiError `json:"error,omitempty"`
-}
-
-// need to check this
-// I think you just get message
-type cohereApiError struct {
+	Text string `json:"text"`
+	// When an error occurs then the error message object is being returned with an error message
+	// https://docs.cohere.com/reference/errors
 	Message string `json:"message"`
 }

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -73,8 +73,10 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	if err != nil {
 		return nil, errors.Wrap(err, "join Cohere API host and path")
 	}
+	emptyChatHistory := make([]message, 0)
 	input := generateInput{
-		Prompt:        prompt,
+		ChatHistory:   emptyChatHistory,
+		Message:       prompt,
 		Model:         settings.Model(),
 		MaxTokens:     settings.MaxTokens(),
 		Temperature:   settings.Temperature(),
@@ -188,12 +190,18 @@ func (v *cohere) getApiKey(ctx context.Context) (string, error) {
 }
 
 type generateInput struct {
-	Prompt        string   `json:"prompt"`
-	Model         string   `json:"model"`
-	MaxTokens     int      `json:"max_tokens"`
-	Temperature   int      `json:"temperature"`
-	K             int      `json:"k"`
-	StopSequences []string `json:"stop_sequences"`
+	ChatHistory   []message `json:"chat_history"`
+	Message       string    `json:"message"`
+	Model         string    `json:"model"`
+	MaxTokens     int       `json:"max_tokens"`
+	Temperature   int       `json:"temperature"`
+	K             int       `json:"k"`
+	StopSequences []string  `json:"stop_sequences"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Message string `json:"message"`
 }
 
 type generateResponse struct {

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -137,7 +137,7 @@ func (v *cohere) getCohereUrl(ctx context.Context, baseURL string) (string, erro
 	if headerBaseURL := v.getValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
 		passedBaseURL = headerBaseURL
 	}
-	return url.JoinPath(passedBaseURL, "/v1/generate")
+	return url.JoinPath(passedBaseURL, "/v1/chat")
 }
 
 func (v *cohere) generatePromptForTask(textProperties []map[string]string, task string) (string, error) {

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -123,7 +123,7 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 		return nil, errors.Errorf("connection to Cohere API failed with status: %d", res.StatusCode)
 	}
 
-	textResponse := resBody.Generations[0].Text
+	textResponse := resBody.Text
 
 	return &generativemodels.GenerateResponse{
 		Result: &textResponse,
@@ -197,12 +197,8 @@ type generateInput struct {
 }
 
 type generateResponse struct {
-	Generations []generation
-	Error       *cohereApiError `json:"error,omitempty"`
-}
-
-type generation struct {
-	Text string `json:"text"`
+	Text  string          `json:"text"`
+	Error *cohereApiError `json:"error,omitempty"`
 }
 
 // need to check this

--- a/modules/generative-cohere/clients/cohere_meta.go
+++ b/modules/generative-cohere/clients/cohere_meta.go
@@ -14,6 +14,6 @@ package clients
 func (v *cohere) MetaInfo() (map[string]interface{}, error) {
 	return map[string]interface{}{
 		"name":              "Generative Search - Cohere",
-		"documentationHref": "https://docs.cohere.com/reference/generate",
+		"documentationHref": "https://docs.cohere.com/reference/chat",
 	}, nil
 }

--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -43,22 +43,19 @@ func TestGetAnswer(t *testing.T) {
 		{
 			name: "when the server has a successful aner",
 			answer: generateResponse{
-				Text:  "John",
-				Error: nil,
+				Text: "John",
 			},
 			expectedResult: "John",
 		},
 		{
 			name: "when the server has a an error",
 			answer: generateResponse{
-				Error: &cohereApiError{
-					Message: "some error from the server",
-				},
+				Message: "some error from the server",
 			},
 		},
 		{
 			name:    "when the server does not respond in time",
-			answer:  generateResponse{Error: &cohereApiError{Message: "context deadline exceeded"}},
+			answer:  generateResponse{Message: "context deadline exceeded"},
 			timeout: time.Second,
 		},
 	}
@@ -77,8 +74,8 @@ func TestGetAnswer(t *testing.T) {
 			settings := &fakeClassConfig{baseURL: server.URL}
 			res, err := c.GenerateAllResults(context.Background(), textProperties, "What is my name?", settings)
 
-			if test.answer.Error != nil {
-				assert.Contains(t, err.Error(), test.answer.Error.Message)
+			if test.answer.Message != "" {
+				assert.Contains(t, err.Error(), test.answer.Message)
 			} else {
 				assert.Equal(t, test.expectedResult, *res.Result)
 			}
@@ -115,7 +112,7 @@ func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	time.Sleep(f.timeout)
 
-	if f.answer.Error != nil && f.answer.Error.Message != "" {
+	if f.answer.Message != "" {
 		outBytes, err := json.Marshal(f.answer)
 		require.Nil(f.t, err)
 

--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -43,8 +43,8 @@ func TestGetAnswer(t *testing.T) {
 		{
 			name: "when the server has a successful aner",
 			answer: generateResponse{
-				Generations: []generation{{Text: "John"}},
-				Error:       nil,
+				Text:  "John",
+				Error: nil,
 			},
 			expectedResult: "John",
 		},

--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -94,11 +94,11 @@ func TestGetAnswer(t *testing.T) {
 
 		buildURL, err := c.getCohereUrl(ctxWithValue, baseURL)
 		require.NoError(t, err)
-		assert.Equal(t, "http://base-url-passed-in-header.com/v1/generate", buildURL)
+		assert.Equal(t, "http://base-url-passed-in-header.com/v1/chat", buildURL)
 
 		buildURL, err = c.getCohereUrl(context.TODO(), baseURL)
 		require.NoError(t, err)
-		assert.Equal(t, "http://default-url.com/v1/generate", buildURL)
+		assert.Equal(t, "http://default-url.com/v1/chat", buildURL)
 	})
 }
 
@@ -110,7 +110,7 @@ type testAnswerHandler struct {
 }
 
 func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	assert.Equal(f.t, "/v1/generate", r.URL.String())
+	assert.Equal(f.t, "/v1/chat", r.URL.String())
 	assert.Equal(f.t, http.MethodPost, r.Method)
 
 	time.Sleep(f.timeout)

--- a/modules/generative-cohere/config/class_settings.go
+++ b/modules/generative-cohere/config/class_settings.go
@@ -19,13 +19,12 @@ import (
 )
 
 const (
-	baseURLProperty           = "baseURL"
-	modelProperty             = "model"
-	temperatureProperty       = "temperature"
-	maxTokensProperty         = "maxTokens"
-	kProperty                 = "k"
-	stopSequencesProperty     = "stopSequences"
-	returnLikelihoodsProperty = "returnLikelihoods"
+	baseURLProperty       = "baseURL"
+	modelProperty         = "model"
+	temperatureProperty   = "temperature"
+	maxTokensProperty     = "maxTokens"
+	kProperty             = "k"
+	stopSequencesProperty = "stopSequences"
 )
 
 var availableCohereModels = []string{
@@ -36,13 +35,12 @@ var availableCohereModels = []string{
 
 // note it might not like this -- might want int values for e.g. MaxTokens
 var (
-	DefaultBaseURL                 = "https://api.cohere.ai"
-	DefaultCohereModel             = "command-r"
-	DefaultCohereTemperature       = 0
-	DefaultCohereMaxTokens         = 2048
-	DefaultCohereK                 = 0
-	DefaultCohereStopSequences     = []string{}
-	DefaultCohereReturnLikelihoods = "NONE"
+	DefaultBaseURL             = "https://api.cohere.ai"
+	DefaultCohereModel         = "command-r"
+	DefaultCohereTemperature   = 0
+	DefaultCohereMaxTokens     = 2048
+	DefaultCohereK             = 0
+	DefaultCohereStopSequences = []string{}
 )
 
 type classSettings struct {
@@ -125,10 +123,6 @@ func (ic *classSettings) K() int {
 
 func (ic *classSettings) StopSequences() []string {
 	return *ic.getListOfStringsProperty(stopSequencesProperty, DefaultCohereStopSequences)
-}
-
-func (ic *classSettings) ReturnLikelihoods() string {
-	return *ic.getStringProperty(returnLikelihoodsProperty, DefaultCohereReturnLikelihoods)
 }
 
 func contains[T comparable](s []T, e T) bool {

--- a/modules/generative-cohere/config/class_settings.go
+++ b/modules/generative-cohere/config/class_settings.go
@@ -29,7 +29,7 @@ const (
 )
 
 var availableCohereModels = []string{
-	"command-xlarge-beta",
+	"command-r", "command-xlarge-beta",
 	"command-xlarge", "command-medium", "command-xlarge-nightly", "command-medium-nightly", "xlarge", "medium",
 	"command", "command-light", "command-nightly", "command-light-nightly", "base", "base-light",
 }
@@ -37,7 +37,7 @@ var availableCohereModels = []string{
 // note it might not like this -- might want int values for e.g. MaxTokens
 var (
 	DefaultBaseURL                 = "https://api.cohere.ai"
-	DefaultCohereModel             = "command-nightly"
+	DefaultCohereModel             = "command-r"
 	DefaultCohereTemperature       = 0
 	DefaultCohereMaxTokens         = 2048
 	DefaultCohereK                 = 0

--- a/modules/generative-cohere/config/class_settings_test.go
+++ b/modules/generative-cohere/config/class_settings_test.go
@@ -21,51 +21,47 @@ import (
 
 func Test_classSettings_Validate(t *testing.T) {
 	tests := []struct {
-		name                  string
-		cfg                   moduletools.ClassConfig
-		wantModel             string
-		wantMaxTokens         int
-		wantTemperature       int
-		wantK                 int
-		wantStopSequences     []string
-		wantReturnLikelihoods string
-		wantBaseURL           string
-		wantErr               error
+		name              string
+		cfg               moduletools.ClassConfig
+		wantModel         string
+		wantMaxTokens     int
+		wantTemperature   int
+		wantK             int
+		wantStopSequences []string
+		wantBaseURL       string
+		wantErr           error
 	}{
 		{
 			name: "default settings",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{},
 			},
-			wantModel:             "command-nightly",
-			wantMaxTokens:         2048,
-			wantTemperature:       0,
-			wantK:                 0,
-			wantStopSequences:     []string{},
-			wantReturnLikelihoods: "NONE",
-			wantBaseURL:           "https://api.cohere.ai",
-			wantErr:               nil,
+			wantModel:         "command-nightly",
+			wantMaxTokens:     2048,
+			wantTemperature:   0,
+			wantK:             0,
+			wantStopSequences: []string{},
+			wantBaseURL:       "https://api.cohere.ai",
+			wantErr:           nil,
 		},
 		{
 			name: "everything non default configured",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"model":             "command-xlarge",
-					"maxTokens":         2048,
-					"temperature":       1,
-					"k":                 2,
-					"stopSequences":     []string{"stop1", "stop2"},
-					"returnLikelihoods": "NONE",
+					"model":         "command-xlarge",
+					"maxTokens":     2048,
+					"temperature":   1,
+					"k":             2,
+					"stopSequences": []string{"stop1", "stop2"},
 				},
 			},
-			wantModel:             "command-xlarge",
-			wantMaxTokens:         2048,
-			wantTemperature:       1,
-			wantK:                 2,
-			wantStopSequences:     []string{"stop1", "stop2"},
-			wantReturnLikelihoods: "NONE",
-			wantBaseURL:           "https://api.cohere.ai",
-			wantErr:               nil,
+			wantModel:         "command-xlarge",
+			wantMaxTokens:     2048,
+			wantTemperature:   1,
+			wantK:             2,
+			wantStopSequences: []string{"stop1", "stop2"},
+			wantBaseURL:       "https://api.cohere.ai",
+			wantErr:           nil,
 		},
 		{
 			name: "wrong model configured",
@@ -85,14 +81,13 @@ func Test_classSettings_Validate(t *testing.T) {
 					"model": "command-light-nightly",
 				},
 			},
-			wantModel:             "command-light-nightly",
-			wantMaxTokens:         2048,
-			wantTemperature:       0,
-			wantK:                 0,
-			wantStopSequences:     []string{},
-			wantReturnLikelihoods: "NONE",
-			wantBaseURL:           "https://api.cohere.ai",
-			wantErr:               nil,
+			wantModel:         "command-light-nightly",
+			wantMaxTokens:     2048,
+			wantTemperature:   0,
+			wantK:             0,
+			wantStopSequences: []string{},
+			wantBaseURL:       "https://api.cohere.ai",
+			wantErr:           nil,
 		},
 		{
 			name: "default settings with command-light-nightly and baseURL",
@@ -102,14 +97,13 @@ func Test_classSettings_Validate(t *testing.T) {
 					"baseURL": "http://custom-url.com",
 				},
 			},
-			wantModel:             "command-light-nightly",
-			wantMaxTokens:         2048,
-			wantTemperature:       0,
-			wantK:                 0,
-			wantStopSequences:     []string{},
-			wantReturnLikelihoods: "NONE",
-			wantBaseURL:           "http://custom-url.com",
-			wantErr:               nil,
+			wantModel:         "command-light-nightly",
+			wantMaxTokens:     2048,
+			wantTemperature:   0,
+			wantK:             0,
+			wantStopSequences: []string{},
+			wantBaseURL:       "http://custom-url.com",
+			wantErr:           nil,
 		},
 	}
 	for _, tt := range tests {
@@ -123,7 +117,6 @@ func Test_classSettings_Validate(t *testing.T) {
 				assert.Equal(t, tt.wantTemperature, ic.Temperature())
 				assert.Equal(t, tt.wantK, ic.K())
 				assert.Equal(t, tt.wantStopSequences, ic.StopSequences())
-				assert.Equal(t, tt.wantReturnLikelihoods, ic.ReturnLikelihoods())
 			}
 		})
 	}

--- a/modules/generative-cohere/config/class_settings_test.go
+++ b/modules/generative-cohere/config/class_settings_test.go
@@ -36,7 +36,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{},
 			},
-			wantModel:         "command-nightly",
+			wantModel:         "command-r",
 			wantMaxTokens:     2048,
 			wantTemperature:   0,
 			wantK:             0,
@@ -71,7 +71,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantErr: errors.Errorf("wrong Cohere model name, available model names are: " +
-				"[command-xlarge-beta command-xlarge command-medium command-xlarge-nightly " +
+				"[command-r command-xlarge-beta command-xlarge command-medium command-xlarge-nightly " +
 				"command-medium-nightly xlarge medium command command-light command-nightly command-light-nightly base base-light]"),
 		},
 		{


### PR DESCRIPTION
### What's being changed:

Replace `Generate` with `Chat` and add support for `Command R`.

More info here: https://docs.cohere.com/reference/chat

Note: The `return_likelihoods` argument is deprecated.

Note: It is also maybe an idea to turn the default `max_tokens` up a bit with this model.

I have tested that this works on my machine.

### Review checklist

- [X] Documentation has been updated, if necessary. Link to changed documentation: https://github.com/weaviate/weaviate-io/pull/1863
- [X] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.
