### PR TITLE
migration part 3 put cluster under read only mode

### DIFF
--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -220,7 +220,7 @@ func TestServiceStoreInit(t *testing.T) {
 
 	// Already Open
 	store.open.Store(true)
-	assert.Nil(t, store.Open(ctx))
+	assert.Nil(t, store.Open(ctx, make(chan uint)))
 
 	// notify non voter
 	store.bootstrapExpect = 0

--- a/usecases/auth/authorization/errors/errors.go
+++ b/usecases/auth/authorization/errors/errors.go
@@ -35,7 +35,18 @@ func NewForbidden(principal *models.Principal, verb, resource string) Forbidden 
 	}
 }
 
+func NewWriteForbidden() Forbidden {
+	return Forbidden{
+		verb:     "Write",
+		resource: "*",
+	}
+}
+
 func (f Forbidden) Error() string {
+	if f.principal == nil {
+		return "forbidden: the node is under READONLY mode"
+	}
+
 	optionalGroups := ""
 	if len(f.principal.Groups) == 1 {
 		optionalGroups = fmt.Sprintf(" (of group '%s')", f.principal.Groups[0])


### PR DESCRIPTION
### What's being changed:
During the migration process, implement functionality to transition the cluster into a read-only mode to prevent unintended modifications. This ensures data integrity and consistency while the migration is in progress
This PR put the cluster under READONLY mode and return FORBIDDEN in case of any write requests during migration 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
