### PR TITLE
Batch vectorization with custom rate limits

### DIFF
--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -181,7 +181,7 @@ func (v *vectorizer) getCohereUrl(ctx context.Context, baseURL string) string {
 func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
 	rpm := DefaultRPM
 
-	if rpmS, ok := ctx.Value("X-Cohere-Ratelimit-RequestPM-Embedding").(string); ok && rpmS != "" {
+	if rpmS := v.getValueFromContext(ctx, "X-Cohere-Ratelimit-RequestPM-Embedding"); rpmS != "" {
 		s, err := strconv.Atoi(rpmS)
 		if err == nil {
 			rpm = s

--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/moduletools"
@@ -27,6 +28,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/modules/text2vec-cohere/ent"
+)
+
+const (
+	DefaultRPM = 10000    // from https://docs.cohere.com/docs/going-live#production-key-specifications default for production keys
+	DefaultTPM = 10000000 // no token limit used by cohere
 )
 
 type embeddingsRequest struct {
@@ -170,6 +176,38 @@ func (v *vectorizer) getCohereUrl(ctx context.Context, baseURL string) string {
 		passedBaseURL = headerBaseURL
 	}
 	return v.urlBuilder.url(passedBaseURL)
+}
+
+func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+	rpm := DefaultRPM
+	if rpmParsed := v.getValueFromContext(ctx, "X-Cohere-Ratelimit-Embedding-RequestPM"); rpmParsed != "" {
+		s, err := strconv.Atoi(rpmParsed)
+		if err == nil {
+			rpm = s
+		}
+	}
+	execAfterRequestFunction := func(limits *modulecomponents.RateLimits) {
+		// refresh is after 60 seconds but leave a bit of room for errors. Otherwise, we only deduct the request that just happened
+		if limits.LastOverwrite.Add(61 * time.Second).After(time.Now()) {
+			limits.RemainingRequests -= 1
+			return
+		}
+
+		limits.RemainingRequests = rpm
+		limits.ResetRequests = 61
+		limits.LimitRequests = rpm
+		limits.LastOverwrite = time.Now()
+
+		// high dummy values
+		limits.RemainingTokens = DefaultTPM
+		limits.LimitTokens = DefaultTPM
+		limits.ResetTokens = 1
+	}
+
+	initialRL := &modulecomponents.RateLimits{AfterRequestFunction: execAfterRequestFunction, LastOverwrite: time.Now().Add(-61 * time.Minute)}
+	initialRL.ResetAfterRequestFunction() // set initial values
+
+	return initialRL
 }
 
 func getErrorMessage(statusCode int, resBodyError string, errorTemplate string) string {

--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -180,12 +180,14 @@ func (v *vectorizer) getCohereUrl(ctx context.Context, baseURL string) string {
 
 func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
 	rpm := DefaultRPM
-	if rpmParsed := v.getValueFromContext(ctx, "X-Cohere-Ratelimit-Embedding-RequestPM"); rpmParsed != "" {
-		s, err := strconv.Atoi(rpmParsed)
+
+	if rpmS, ok := ctx.Value("X-Cohere-Ratelimit-RequestPM-Embedding").(string); ok && rpmS != "" {
+		s, err := strconv.Atoi(rpmS)
 		if err == nil {
 			rpm = s
 		}
 	}
+
 	execAfterRequestFunction := func(limits *modulecomponents.RateLimits) {
 		// refresh is after 60 seconds but leave a bit of room for errors. Otherwise, we only deduct the request that just happened
 		if limits.LastOverwrite.Add(61 * time.Second).After(time.Now()) {

--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -14,6 +14,7 @@ package clients
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -176,6 +177,14 @@ func (v *vectorizer) getCohereUrl(ctx context.Context, baseURL string) string {
 		passedBaseURL = headerBaseURL
 	}
 	return v.urlBuilder.url(passedBaseURL)
+}
+
+func (v *vectorizer) GetApiKeyHash(ctx context.Context, config moduletools.ClassConfig) [32]byte {
+	key, err := v.getApiKey(ctx)
+	if err != nil {
+		return [32]byte{}
+	}
+	return sha256.Sum256([]byte(key))
 }
 
 func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {

--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -196,14 +196,14 @@ func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponen
 		}
 
 		limits.RemainingRequests = rpm
-		limits.ResetRequests = 61
+		limits.ResetRequests = time.Now().Add(time.Duration(61) * time.Second)
 		limits.LimitRequests = rpm
 		limits.LastOverwrite = time.Now()
 
 		// high dummy values
 		limits.RemainingTokens = DefaultTPM
 		limits.LimitTokens = DefaultTPM
-		limits.ResetTokens = 1
+		limits.ResetTokens = time.Now().Add(time.Duration(1) * time.Second)
 	}
 
 	initialRL := &modulecomponents.RateLimits{AfterRequestFunction: execAfterRequestFunction, LastOverwrite: time.Now().Add(-61 * time.Minute)}

--- a/modules/text2vec-cohere/clients/cohere_test.go
+++ b/modules/text2vec-cohere/clients/cohere_test.go
@@ -190,6 +190,27 @@ func TestClient(t *testing.T) {
 		buildURL = c.getCohereUrl(context.TODO(), baseURL)
 		assert.Equal(t, "http://default-url.com/v1/embed", buildURL)
 	})
+
+	t.Run("pass rate limit headers requests", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := &vectorizer{
+			apiKey:     "",
+			httpClient: &http.Client{},
+			urlBuilder: &cohereUrlBuilder{
+				origin:   server.URL,
+				pathMask: "/v1/embed",
+			},
+			logger: nullLogger(),
+		}
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Cohere-Ratelimit-RequestPM-Embedding", "50")
+
+		rl := c.GetVectorizerRateLimit(ctxWithValue)
+		assert.Equal(t, 50, rl.LimitRequests)
+		assert.Equal(t, 50, rl.RemainingRequests)
+	})
 }
 
 type fakeHandler struct {

--- a/modules/text2vec-cohere/clients/cohere_test.go
+++ b/modules/text2vec-cohere/clients/cohere_test.go
@@ -205,7 +205,7 @@ func TestClient(t *testing.T) {
 		}
 
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-Cohere-Ratelimit-RequestPM-Embedding", "50")
+			"X-Cohere-Ratelimit-RequestPM-Embedding", []string{"50"})
 
 		rl := c.GetVectorizerRateLimit(ctxWithValue)
 		assert.Equal(t, 50, rl.LimitRequests)

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -79,6 +79,10 @@ func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecom
 	return &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
+func (c *fakeBatchClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
+}
+
 type fakeClient struct {
 	lastInput  []string
 	lastConfig moduletools.ClassConfig
@@ -110,6 +114,10 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 
 func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
+}
+
+func (c *fakeClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
 }
 
 type fakeClassConfig struct {

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -36,7 +36,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 
 	vectors := make([][]float32, len(text))
 	errors := make([]error, len(text))
-	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: c.defaultResetRate, ResetRequests: 1}
+	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
 			errors[i] = fmt.Errorf(text[i][6:])
@@ -76,7 +76,7 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 }
 
 func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
-	return &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: c.defaultResetRate, ResetRequests: 1}
+	return &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
 type fakeClient struct {

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -75,6 +75,10 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 	}, nil, nil
 }
 
+func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+	return &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: c.defaultResetRate, ResetRequests: 1}
+}
+
 type fakeClient struct {
 	lastInput  []string
 	lastConfig moduletools.ClassConfig
@@ -102,6 +106,10 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 		Dimensions: 4,
 		Text:       text,
 	}, nil, nil
+}
+
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+	return &modulecomponents.RateLimits{}
 }
 
 type fakeClassConfig struct {

--- a/modules/text2vec-cohere/vectorizer/objects.go
+++ b/modules/text2vec-cohere/vectorizer/objects.go
@@ -47,11 +47,9 @@ func New(client Client, logger logrus.FieldLogger) *Vectorizer {
 }
 
 type Client interface {
-	Vectorize(ctx context.Context, input []string,
-		cfg moduletools.ClassConfig) (*modulecomponents.VectorizationResult, *modulecomponents.RateLimits, error)
+	batch.BatchClient
 	VectorizeQuery(ctx context.Context, input []string,
 		cfg moduletools.ClassConfig) (*modulecomponents.VectorizationResult, *modulecomponents.RateLimits, error)
-	GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -14,6 +14,7 @@ package clients
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -260,6 +261,16 @@ func (v *client) getRateLimit(ctx context.Context) (int, int) {
 	}
 
 	return returnRPM, returnTPM
+}
+
+func (v *client) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	config := v.getVectorizationConfig(cfg)
+
+	key, err := v.getApiKey(ctx, config.IsAzure)
+	if err != nil {
+		return [32]byte{}
+	}
+	return sha256.Sum256([]byte(key))
 }
 
 func (v *client) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -267,10 +267,10 @@ func (v *client) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.R
 	return &modulecomponents.RateLimits{
 		RemainingTokens:   tpm,
 		LimitTokens:       tpm,
-		ResetTokens:       61,
+		ResetTokens:       time.Now().Add(61 * time.Second),
 		RemainingRequests: rpm,
 		LimitRequests:     rpm,
-		ResetRequests:     61,
+		ResetRequests:     time.Now().Add(61 * time.Second),
 	}
 }
 

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -246,15 +246,13 @@ func (v *client) getOpenAIOrganization(ctx context.Context) string {
 func (v *client) getRateLimit(ctx context.Context) (int, int) {
 	returnRPM := 0
 	returnTPM := 0
-	rpm := ctx.Value("X-Openai-Ratelimit-RequestPM-Embedding")
-	if rpmS, ok := rpm.(string); ok && rpmS != "" {
+	if rpmS := v.getValueFromContext(ctx, "X-Openai-Ratelimit-RequestPM-Embedding"); rpmS != "" {
 		s, err := strconv.Atoi(rpmS)
 		if err == nil {
 			returnRPM = s
 		}
 	}
-	tpm := ctx.Value("X-Openai-Ratelimit-TokenPM-Embedding")
-	if tpmS, ok := tpm.(string); ok && tpmS != "" {
+	if tpmS := v.getValueFromContext(ctx, "X-Openai-Ratelimit-TokenPM-Embedding"); tpmS != "" {
 		s, err := strconv.Atoi(tpmS)
 		if err == nil {
 			returnTPM = s

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -243,6 +243,37 @@ func (v *client) getOpenAIOrganization(ctx context.Context) string {
 	return v.openAIOrganization
 }
 
+func (v *client) getRateLimit(ctx context.Context) (int, int) {
+	returnRPM := 0
+	returnTPM := 0
+	if rpm := v.getValueFromContext(ctx, "X-Openai-Ratelimit-RequestPM-Embedding"); rpm != "" {
+		s, err := strconv.Atoi(rpm)
+		if err == nil {
+			returnRPM = s
+		}
+	}
+	if rpm := v.getValueFromContext(ctx, "X-Openai-Ratelimit-TokenPM-Embedding"); rpm != "" {
+		s, err := strconv.Atoi(rpm)
+		if err == nil {
+			returnTPM = s
+		}
+	}
+
+	return returnRPM, returnTPM
+}
+
+func (v *client) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+	rpm, tpm := v.getRateLimit(ctx)
+	return &modulecomponents.RateLimits{
+		RemainingTokens:   rpm,
+		LimitTokens:       rpm,
+		ResetTokens:       61,
+		RemainingRequests: tpm,
+		LimitRequests:     tpm,
+		ResetRequests:     61,
+	}
+}
+
 func (v *client) getApiKey(ctx context.Context, isAzure bool) (string, error) {
 	var apiKey, envVar string
 

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -246,14 +246,16 @@ func (v *client) getOpenAIOrganization(ctx context.Context) string {
 func (v *client) getRateLimit(ctx context.Context) (int, int) {
 	returnRPM := 0
 	returnTPM := 0
-	if rpm := v.getValueFromContext(ctx, "X-Openai-Ratelimit-RequestPM-Embedding"); rpm != "" {
-		s, err := strconv.Atoi(rpm)
+	rpm := ctx.Value("X-Openai-Ratelimit-RequestPM-Embedding")
+	if rpmS, ok := rpm.(string); ok && rpmS != "" {
+		s, err := strconv.Atoi(rpmS)
 		if err == nil {
 			returnRPM = s
 		}
 	}
-	if rpm := v.getValueFromContext(ctx, "X-Openai-Ratelimit-TokenPM-Embedding"); rpm != "" {
-		s, err := strconv.Atoi(rpm)
+	tpm := ctx.Value("X-Openai-Ratelimit-TokenPM-Embedding")
+	if tpmS, ok := tpm.(string); ok && tpmS != "" {
+		s, err := strconv.Atoi(tpmS)
 		if err == nil {
 			returnTPM = s
 		}
@@ -265,11 +267,11 @@ func (v *client) getRateLimit(ctx context.Context) (int, int) {
 func (v *client) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
 	rpm, tpm := v.getRateLimit(ctx)
 	return &modulecomponents.RateLimits{
-		RemainingTokens:   rpm,
-		LimitTokens:       rpm,
+		RemainingTokens:   tpm,
+		LimitTokens:       tpm,
 		ResetTokens:       61,
-		RemainingRequests: tpm,
-		LimitRequests:     tpm,
+		RemainingRequests: rpm,
+		LimitRequests:     rpm,
 		ResetRequests:     61,
 	}
 }

--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -233,6 +233,31 @@ func TestClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/v1/embeddings", buildURL)
 	})
+
+	t.Run("pass rate limit headers requests", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := New("", "", "", 0, nullLogger())
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Openai-Ratelimit-RequestPM-Embedding", "50")
+
+		rl := c.GetVectorizerRateLimit(ctxWithValue)
+		assert.Equal(t, 50, rl.LimitRequests)
+		assert.Equal(t, 50, rl.RemainingRequests)
+	})
+
+	t.Run("pass rate limit headers tokens", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := New("", "", "", 0, nullLogger())
+
+		ctxWithValue := context.WithValue(context.Background(), "X-Openai-Ratelimit-TokenPM-Embedding", "60")
+
+		rl := c.GetVectorizerRateLimit(ctxWithValue)
+		assert.Equal(t, 60, rl.LimitTokens)
+		assert.Equal(t, 60, rl.RemainingTokens)
+	})
 }
 
 type fakeHandler struct {

--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -240,7 +240,7 @@ func TestClient(t *testing.T) {
 		c := New("", "", "", 0, nullLogger())
 
 		ctxWithValue := context.WithValue(context.Background(),
-			"X-Openai-Ratelimit-RequestPM-Embedding", "50")
+			"X-Openai-Ratelimit-RequestPM-Embedding", []string{"50"})
 
 		rl := c.GetVectorizerRateLimit(ctxWithValue)
 		assert.Equal(t, 50, rl.LimitRequests)
@@ -252,7 +252,7 @@ func TestClient(t *testing.T) {
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
 
-		ctxWithValue := context.WithValue(context.Background(), "X-Openai-Ratelimit-TokenPM-Embedding", "60")
+		ctxWithValue := context.WithValue(context.Background(), "X-Openai-Ratelimit-TokenPM-Embedding", []string{"60"})
 
 		rl := c.GetVectorizerRateLimit(ctxWithValue)
 		assert.Equal(t, 60, rl.LimitTokens)

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -33,8 +33,8 @@ func GetRateLimitsFromHeader(header http.Header) *modulecomponents.RateLimits {
 		LimitTokens:       getHeaderInt(header, "x-ratelimit-limit-tokens"),
 		RemainingRequests: getHeaderInt(header, "x-ratelimit-remaining-requests"),
 		RemainingTokens:   getHeaderInt(header, "x-ratelimit-remaining-tokens"),
-		ResetRequests:     int(requestsReset.Seconds()),
-		ResetTokens:       int(tokensReset.Seconds()),
+		ResetRequests:     time.Now().Add(requestsReset),
+		ResetTokens:       time.Now().Add(tokensReset),
 	}
 }
 

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -36,7 +36,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 
 	vectors := make([][]float32, len(text))
 	errors := make([]error, len(text))
-	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: c.defaultResetRate, ResetRequests: 1}
+	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
 			errors[i] = fmt.Errorf(text[i][6:])
@@ -83,7 +83,7 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 }
 
 func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
-	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: c.defaultResetRate, ResetRequests: 0}
+	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
 type fakeClient struct {

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -82,6 +82,10 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
+func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: c.defaultResetRate, ResetRequests: 0}
+}
+
 type fakeClient struct {
 	lastInput  []string
 	lastConfig moduletools.ClassConfig
@@ -109,6 +113,10 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 		Dimensions: 4,
 		Text:       text,
 	}, nil
+}
+
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+	return &modulecomponents.RateLimits{}
 }
 
 type FakeClassConfig struct {

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -86,6 +86,10 @@ func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecom
 	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
+func (c *fakeBatchClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
+}
+
 type fakeClient struct {
 	lastInput  []string
 	lastConfig moduletools.ClassConfig
@@ -117,6 +121,10 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 
 func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
+}
+
+func (c *fakeClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
 }
 
 type FakeClassConfig struct {

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -55,11 +55,9 @@ func New(client Client, maxBatchTime time.Duration, logger logrus.FieldLogger) *
 }
 
 type Client interface {
-	Vectorize(ctx context.Context, input []string,
-		cfg moduletools.ClassConfig) (*modulecomponents.VectorizationResult, *modulecomponents.RateLimits, error)
+	batch.BatchClient
 	VectorizeQuery(ctx context.Context, input []string,
 		cfg moduletools.ClassConfig) (*modulecomponents.VectorizationResult, error)
-	GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -35,7 +35,7 @@ const (
 	MaxObjectsPerBatch = 2000 // https://platform.openai.com/docs/api-reference/embeddings/create
 	// time per token goes down up to a certain batch size and then flattens - however the times vary a lot so we
 	// don't want to get too close to the maximum of 50s
-	OpenAiMaxTimePerBatch = float64(10)
+	OpenAIMaxTimePerBatch = float64(10)
 )
 
 type Vectorizer struct {
@@ -48,7 +48,7 @@ func New(client Client, maxBatchTime time.Duration, logger logrus.FieldLogger) *
 	vec := &Vectorizer{
 		client:           client,
 		objectVectorizer: objectsvectorizer.New(),
-		batchVectorizer:  batch.NewBatchVectorizer(client, maxBatchTime, MaxObjectsPerBatch, OpenAiMaxTimePerBatch, logger),
+		batchVectorizer:  batch.NewBatchVectorizer(client, maxBatchTime, MaxObjectsPerBatch, OpenAIMaxTimePerBatch, logger),
 	}
 
 	return vec

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -48,7 +48,7 @@ func New(client Client, maxBatchTime time.Duration, logger logrus.FieldLogger) *
 	vec := &Vectorizer{
 		client:           client,
 		objectVectorizer: objectsvectorizer.New(),
-		batchVectorizer:  batch.NewBatchVectorizer(client, maxBatchTime, MaxObjectsPerBatch, OpenAiMaxTimePerBatch, nil, logger, true),
+		batchVectorizer:  batch.NewBatchVectorizer(client, maxBatchTime, MaxObjectsPerBatch, OpenAiMaxTimePerBatch, logger),
 	}
 
 	return vec
@@ -59,6 +59,7 @@ type Client interface {
 		cfg moduletools.ClassConfig) (*modulecomponents.VectorizationResult, *modulecomponents.RateLimits, error)
 	VectorizeQuery(ctx context.Context, input []string,
 		cfg moduletools.ClassConfig) (*modulecomponents.VectorizationResult, error)
+	GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -162,9 +162,9 @@ func TestBatchTimeouts(t *testing.T) {
 
 	objs := []*models.Object{
 		{Class: "Car", Properties: map[string]interface{}{"test": "tokens 18"}}, // first request, set rate down so the next two items can be sent
-		{Class: "Car", Properties: map[string]interface{}{"test": "wait 90"}},   // second batch, use up batch time to trigger waiting for refresh
+		{Class: "Car", Properties: map[string]interface{}{"test": "wait 200"}},  // second batch, use up batch time to trigger waiting for refresh
 		{Class: "Car", Properties: map[string]interface{}{"test": "tokens 20"}}, // set next rate so the next object is too long. Depending on the total batch time it either sleeps or not
-		{Class: "Car", Properties: map[string]interface{}{"test": "next batch long long"}},
+		{Class: "Car", Properties: map[string]interface{}{"test": "next batch long long long long long"}},
 	}
 	skip := []bool{false, false, false, false}
 
@@ -173,7 +173,7 @@ func TestBatchTimeouts(t *testing.T) {
 		expectedErrors int
 	}{
 		{batchTime: 100 * time.Millisecond, expectedErrors: 1},
-		{batchTime: 2 * time.Second, expectedErrors: 0},
+		{batchTime: 1 * time.Second, expectedErrors: 0},
 	}
 	for _, tt := range cases {
 		t.Run("", func(t *testing.T) {

--- a/usecases/modulecomponents/batch/fakes_for_test.go
+++ b/usecases/modulecomponents/batch/fakes_for_test.go
@@ -38,7 +38,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 
 	vectors := make([][]float32, len(text))
 	errors := make([]error, len(text))
-	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: c.defaultResetRate, ResetRequests: 1}
+	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
 			errors[i] = fmt.Errorf(text[i][6:])
@@ -80,7 +80,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 }
 
 func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
-	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: c.defaultResetRate, ResetRequests: 0}
+	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
 type fakeClassConfig struct {

--- a/usecases/modulecomponents/batch/fakes_for_test.go
+++ b/usecases/modulecomponents/batch/fakes_for_test.go
@@ -83,6 +83,10 @@ func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecom
 	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
+func (c *fakeBatchClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
+}
+
 type fakeClassConfig struct {
 	classConfig           map[string]interface{}
 	vectorizePropertyName bool

--- a/usecases/modulecomponents/client_results.go
+++ b/usecases/modulecomponents/client_results.go
@@ -30,6 +30,10 @@ func (rl *RateLimits) ResetAfterRequestFunction() {
 	}
 }
 
+func (rl *RateLimits) IsInitialized() bool {
+	return rl.RemainingRequests == 0 && rl.RemainingTokens == 0
+}
+
 type VectorizationResult struct {
 	Text       []string
 	Dimensions int

--- a/usecases/modulecomponents/client_results.go
+++ b/usecases/modulecomponents/client_results.go
@@ -20,8 +20,8 @@ type RateLimits struct {
 	LimitTokens          int
 	RemainingRequests    int
 	RemainingTokens      int
-	ResetRequests        int
-	ResetTokens          int
+	ResetRequests        time.Time
+	ResetTokens          time.Time
 }
 
 func (rl *RateLimits) ResetAfterRequestFunction() {

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -204,7 +204,7 @@ func (p *Provider) batchUpdateVector(ctx context.Context, objects []*models.Obje
 			if !reVectorize {
 				skipRevectorization[i] = true
 				p.lockGuard(func() {
-					obj = p.addVectorToObject(obj, vector, addProps, cfg)
+					p.addVectorToObject(obj, vector, addProps, cfg)
 				})
 			}
 		}
@@ -220,7 +220,7 @@ func (p *Provider) batchUpdateVector(ctx context.Context, objects []*models.Obje
 			}
 
 			p.lockGuard(func() {
-				objects[i] = p.addVectorToObject(objects[i], vectors[i], addProp, cfg)
+				p.addVectorToObject(objects[i], vectors[i], addProp, cfg)
 			})
 		}
 
@@ -234,7 +234,7 @@ func (p *Provider) batchUpdateVector(ctx context.Context, objects []*models.Obje
 				errs[i] = fmt.Errorf("update reference vector: %w", err)
 			}
 			p.lockGuard(func() {
-				obj = p.addVectorToObject(obj, vector, nil, cfg)
+				p.addVectorToObject(obj, vector, nil, cfg)
 			})
 		}
 		return errs, nil
@@ -305,7 +305,7 @@ func (p *Provider) lockGuard(mutate func()) {
 
 func (p *Provider) addVectorToObject(object *models.Object,
 	vector []float32, additional models.AdditionalProperties, cfg moduletools.ClassConfig,
-) *models.Object {
+) {
 	if len(additional) > 0 {
 		if object.Additional == nil {
 			object.Additional = models.AdditionalProperties{}
@@ -316,13 +316,12 @@ func (p *Provider) addVectorToObject(object *models.Object,
 	}
 	if cfg.TargetVector() == "" {
 		object.Vector = vector
-		return object
+		return
 	}
 	if object.Vectors == nil {
 		object.Vectors = models.Vectors{}
 	}
 	object.Vectors[cfg.TargetVector()] = vector
-	return object
 }
 
 func (p *Provider) vectorizeOne(ctx context.Context, object *models.Object, class *models.Class,
@@ -374,7 +373,7 @@ func (p *Provider) vectorize(ctx context.Context, object *models.Object, class *
 			}
 
 			p.lockGuard(func() {
-				object = p.addVectorToObject(object, vector, additionalProperties, cfg)
+				p.addVectorToObject(object, vector, additionalProperties, cfg)
 			})
 			return nil
 		}
@@ -385,7 +384,7 @@ func (p *Provider) vectorize(ctx context.Context, object *models.Object, class *
 			return fmt.Errorf("update reference vector: %w", err)
 		}
 		p.lockGuard(func() {
-			object = p.addVectorToObject(object, vector, nil, cfg)
+			p.addVectorToObject(object, vector, nil, cfg)
 		})
 	}
 	return nil


### PR DESCRIPTION
### What's being changed:

- supports providing rate limits by the user through headers. The python client supports sending them: https://github.com/weaviate/weaviate-python-client/pull/981
- Better handling of low-rate api keys such as cohere trial keys
- Some bug fixes and cleanups

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
