### PR TITLE
Refactor to reload local db using the new UpdateIndex()

### DIFF
--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -779,6 +779,11 @@ func (m *MockIndexer) UpdateClass(req cmd.UpdateClassRequest) error {
 	return args.Error(0)
 }
 
+func (m *MockIndexer) UpdateIndex(req cmd.UpdateClassRequest) error {
+	args := m.Called(req)
+	return args.Error(0)
+}
+
 func (m *MockIndexer) DeleteClass(name string) error {
 	args := m.Called(name)
 	return args.Error(0)

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -28,7 +28,7 @@ import (
 const (
 	DefaultRaftPort             = 8300
 	DefaultRaftInternalPort     = 8301
-	DefaultRaftBootstrapTimeout = 10
+	DefaultRaftBootstrapTimeout = 90
 	DefaultRaftBootstrapExpect  = 1
 )
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -81,6 +81,15 @@ func (e *executor) UpdateClass(req cluster.UpdateClassRequest) error {
 	return nil
 }
 
+func (e *executor) UpdateIndex(req cluster.UpdateClassRequest) error {
+	ctx := context.Background()
+	if err := e.migrator.UpdateIndex(ctx, req.Class, req.State); err != nil {
+		return err
+	}
+	e.triggerSchemaUpdateCallbacks()
+	return nil
+}
+
 func (e *executor) DeleteClass(cls string) error {
 	ctx := context.Background()
 	if err := e.migrator.DropClass(ctx, cls); err != nil {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -85,6 +85,10 @@ func (f *fakeDB) UpdateClass(cmd command.UpdateClassRequest) error {
 	return nil
 }
 
+func (f *fakeDB) UpdateIndex(cmd command.UpdateClassRequest) error {
+	return nil
+}
+
 func (f *fakeDB) DeleteClass(class string) error {
 	return nil
 }


### PR DESCRIPTION
This change works around leaking resouces caused by improper implemenation of db.Close()

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
