### PR TITLE
Move aggregate named vectors tests to named vectors test suite

### DIFF
--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -215,7 +215,8 @@ func (db *DB) CrossClassVectorSearch(ctx context.Context, vector []float32, targ
 			if i != 0 {
 				msg.WriteString(", ")
 			}
-			msg.WriteString(err.Error())
+			errorMessage := fmt.Sprintf("%v", err)
+			msg.WriteString(errorMessage)
 		}
 		return nil, errors.New(msg.String())
 	}

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_aggregate_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_aggregate_test.go
@@ -27,81 +27,83 @@ const (
 	UUID2 = "f47ac10b-58cc-0372-8567-0e02b2c3d480"
 )
 
-func TestAggregate(t *testing.T) {
-	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: "localhost:8080"})
-	require.Nil(t, err)
-	ctx := context.Background()
+func testAggregate(host string) func(t *testing.T) {
+	return func(t *testing.T) {
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+		require.Nil(t, err)
+		ctx := context.Background()
 
-	classAggregate := "NamedAggregateTest"
+		classAggregate := "NamedAggregateTest"
 
-	// delete class if exists and cleanup after test
-	err = client.Schema().ClassDeleter().WithClassName(classAggregate).Do(ctx)
-	require.Nil(t, err)
+		// delete class if exists and cleanup after test
+		err = client.Schema().ClassDeleter().WithClassName(classAggregate).Do(ctx)
+		require.Nil(t, err)
 
-	defer client.Schema().ClassDeleter().WithClassName(classAggregate).Do(ctx)
+		defer client.Schema().ClassDeleter().WithClassName(classAggregate).Do(ctx)
 
-	// create class and objects
-	class := &models.Class{
-		Class: classAggregate,
-		Properties: []*models.Property{
-			{
-				Name: "first", DataType: []string{schema.DataTypeText.String()},
-			},
-			{
-				Name: "second", DataType: []string{schema.DataTypeText.String()},
-			},
-			{
-				Name: "number", DataType: []string{schema.DataTypeInt.String()},
-			},
-		},
-		VectorConfig: map[string]models.VectorConfig{
-			"first": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-contextionary": map[string]interface{}{
-						"vectorizeClassName": false,
-						"properties":         []string{"first"},
-					},
+		// create class and objects
+		class := &models.Class{
+			Class: classAggregate,
+			Properties: []*models.Property{
+				{
+					Name: "first", DataType: []string{schema.DataTypeText.String()},
 				},
-				VectorIndexType: "hnsw",
-			},
-			"second": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-contextionary": map[string]interface{}{
-						"vectorizeClassName": false,
-						"properties":         []string{"second"},
-					},
+				{
+					Name: "second", DataType: []string{schema.DataTypeText.String()},
 				},
-				VectorIndexType: "hnsw",
+				{
+					Name: "number", DataType: []string{schema.DataTypeInt.String()},
+				},
 			},
-		},
+			VectorConfig: map[string]models.VectorConfig{
+				"first": {
+					Vectorizer: map[string]interface{}{
+						"text2vec-contextionary": map[string]interface{}{
+							"vectorizeClassName": false,
+							"properties":         []string{"first"},
+						},
+					},
+					VectorIndexType: "hnsw",
+				},
+				"second": {
+					Vectorizer: map[string]interface{}{
+						"text2vec-contextionary": map[string]interface{}{
+							"vectorizeClassName": false,
+							"properties":         []string{"second"},
+						},
+					},
+					VectorIndexType: "hnsw",
+				},
+			},
+		}
+		require.Nil(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		creator := client.Data().Creator()
+		_, err = creator.WithClassName(classAggregate).WithProperties(
+			map[string]interface{}{"first": "Hello", "second": "World", "number": 1}).WithID(UUID1).Do(ctx)
+		require.Nil(t, err)
+		_, err = creator.WithClassName(classAggregate).WithProperties(
+			map[string]interface{}{"first": "World", "second": "Hello", "number": 2}).WithID(UUID2).Do(ctx)
+		require.Nil(t, err)
+
+		// aggregate
+		no := &graphql.NearObjectArgumentBuilder{}
+		no.WithTargetVectors("first").WithID(UUID1).WithCertainty(0.9)
+		agg, err := client.GraphQL().Aggregate().WithClassName(classAggregate).WithNearObject(no).WithFields(graphql.Field{Name: "number", Fields: []graphql.Field{{Name: "maximum"}}}).Do(ctx)
+		require.Nil(t, err)
+
+		require.NotNil(t, agg)
+		require.Nil(t, agg.Errors)
+		require.NotNil(t, agg.Data)
+
+		require.Equal(t, agg.Data["Aggregate"].(map[string]interface{})[classAggregate].([]interface{})[0].(map[string]interface{})["number"].(map[string]interface{})["maximum"], float64(1))
+
+		// aggregate without needed a target vector
+		agg, err = client.GraphQL().Aggregate().WithClassName(classAggregate).WithFields(graphql.Field{Name: "meta", Fields: []graphql.Field{{Name: "count"}}}).Do(ctx)
+		require.Nil(t, err)
+		require.NotNil(t, agg)
+		require.Nil(t, agg.Errors)
+		require.NotNil(t, agg.Data)
+		require.Equal(t, agg.Data["Aggregate"].(map[string]interface{})[classAggregate].([]interface{})[0].(map[string]interface{})["meta"].(map[string]interface{})["count"], float64(2))
 	}
-	require.Nil(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
-
-	creator := client.Data().Creator()
-	_, err = creator.WithClassName(classAggregate).WithProperties(
-		map[string]interface{}{"first": "Hello", "second": "World", "number": 1}).WithID(UUID1).Do(ctx)
-	require.Nil(t, err)
-	_, err = creator.WithClassName(classAggregate).WithProperties(
-		map[string]interface{}{"first": "World", "second": "Hello", "number": 2}).WithID(UUID2).Do(ctx)
-	require.Nil(t, err)
-
-	// aggregate
-	no := &graphql.NearObjectArgumentBuilder{}
-	no.WithTargetVectors("first").WithID(UUID1).WithCertainty(0.9)
-	agg, err := client.GraphQL().Aggregate().WithClassName(classAggregate).WithNearObject(no).WithFields(graphql.Field{Name: "number", Fields: []graphql.Field{{Name: "maximum"}}}).Do(ctx)
-	require.Nil(t, err)
-
-	require.NotNil(t, agg)
-	require.Nil(t, agg.Errors)
-	require.NotNil(t, agg.Data)
-
-	require.Equal(t, agg.Data["Aggregate"].(map[string]interface{})[classAggregate].([]interface{})[0].(map[string]interface{})["number"].(map[string]interface{})["maximum"], float64(1))
-
-	// aggregate without needed a target vector
-	agg, err = client.GraphQL().Aggregate().WithClassName(classAggregate).WithFields(graphql.Field{Name: "meta", Fields: []graphql.Field{{Name: "count"}}}).Do(ctx)
-	require.Nil(t, err)
-	require.NotNil(t, agg)
-	require.Nil(t, agg.Errors)
-	require.NotNil(t, agg.Data)
-	require.Equal(t, agg.Data["Aggregate"].(map[string]interface{})[classAggregate].([]interface{})[0].(map[string]interface{})["meta"].(map[string]interface{})["count"], float64(2))
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_test.go
@@ -81,6 +81,7 @@ func allTests(endpoint string) func(t *testing.T) {
 		t.Run("objects with vectorizer and objects", testCreateSchemaWithVectorizerAndBYOV(endpoint))
 		t.Run("hybrid", testHybrid(endpoint))
 		t.Run("generative modules", testNamedVectorsWithGenerativeModules(endpoint))
+		t.Run("aggregate", testAggregate(endpoint))
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

Move aggregate named vectors tests to named vectors test suite.

Before this change Aggregate tests for named vectors were not a part of the test suite, which tests all 4 possible configurations of Weaviate. Now does tests are included in each run.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
