### PR TITLE
Implements `ContainsNone` Operator

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/filters.go
+++ b/adapters/handlers/graphql/local/common_filters/filters.go
@@ -40,6 +40,7 @@ func BuildNew(path string) graphql.InputObjectConfigFieldMap {
 					"IsNull":           &graphql.EnumValueConfig{},
 					"ContainsAny":      &graphql.EnumValueConfig{},
 					"ContainsAll":      &graphql.EnumValueConfig{},
+					"ContainsNone":     &graphql.EnumValueConfig{},
 				},
 				Description: descriptions.WhereOperatorEnum,
 			}),

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4819,7 +4819,8 @@ func init() {
             "WithinGeoRange",
             "IsNull",
             "ContainsAny",
-            "ContainsAll"
+            "ContainsAll",
+            "ContainsNone"
           ],
           "example": "GreaterThanEqual"
         },
@@ -10178,7 +10179,8 @@ func init() {
             "WithinGeoRange",
             "IsNull",
             "ContainsAny",
-            "ContainsAll"
+            "ContainsAll",
+            "ContainsNone"
           ],
           "example": "GreaterThanEqual"
         },

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -145,6 +145,8 @@ func parseOperator(in string) (filters.Operator, error) {
 		return filters.ContainsAny, nil
 	case models.WhereFilterOperatorContainsAll:
 		return filters.ContainsAll, nil
+	case models.WhereFilterOperatorContainsNone:
+		return filters.ContainsNone, nil
 	default:
 		return -1, fmt.Errorf("unrecognized operator: %s", in)
 	}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -225,7 +225,7 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 		return out, nil
 	}
 
-	if filter.Operator == filters.ContainsAny || filter.Operator == filters.ContainsAll {
+	if filter.Operator == filters.ContainsAny || filter.Operator == filters.ContainsAll || filter.Operator == filters.ContainsNone {
 		return s.extractContains(filter.On, filter.Value.Type, filter.Value.Value, filter.Operator, class)
 	}
 

--- a/entities/filters/filters.go
+++ b/entities/filters/filters.go
@@ -34,6 +34,7 @@ const (
 	OperatorIsNull
 	ContainsAny
 	ContainsAll
+	ContainsNone
 )
 
 func (o Operator) OnValue() bool {

--- a/entities/filters/filters.go
+++ b/entities/filters/filters.go
@@ -49,7 +49,8 @@ func (o Operator) OnValue() bool {
 		OperatorLike,
 		OperatorIsNull,
 		ContainsAny,
-		ContainsAll:
+		ContainsAll,
+		ContainsNone:
 		return true
 	default:
 		return false
@@ -84,6 +85,8 @@ func (o Operator) Name() string {
 		return "ContainsAny"
 	case ContainsAll:
 		return "ContainsAll"
+	case ContainsNone:
+		return "ContainsNone"
 	default:
 		panic("Unknown operator")
 	}

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -205,7 +205,7 @@ func validateUUIDOperators(propName schema.PropertyName, cw *clauseWrapper) erro
 
 	switch op {
 	case OperatorEqual, OperatorNotEqual, OperatorLessThan, OperatorLessThanEqual,
-		OperatorGreaterThan, OperatorGreaterThanEqual, ContainsAll, ContainsAny:
+		OperatorGreaterThan, OperatorGreaterThanEqual, ContainsAll, ContainsAny, ContainsNone:
 		return nil
 	default:
 		return fmt.Errorf("operator %q cannot be used on uuid/uuid[] props", op.Name())

--- a/entities/models/where_filter.go
+++ b/entities/models/where_filter.go
@@ -37,7 +37,7 @@ type WhereFilter struct {
 
 	// operator to use
 	// Example: GreaterThanEqual
-	// Enum: [And Or Equal Like NotEqual GreaterThan GreaterThanEqual LessThan LessThanEqual WithinGeoRange IsNull ContainsAny ContainsAll]
+	// Enum: [And Or Equal Like NotEqual GreaterThan GreaterThanEqual LessThan LessThanEqual WithinGeoRange IsNull ContainsAny ContainsAll ContainsNone]
 	Operator string `json:"operator,omitempty"`
 
 	// path to the property currently being filtered
@@ -148,7 +148,7 @@ var whereFilterTypeOperatorPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["And","Or","Equal","Like","NotEqual","GreaterThan","GreaterThanEqual","LessThan","LessThanEqual","WithinGeoRange","IsNull","ContainsAny","ContainsAll"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["And","Or","Equal","Like","NotEqual","GreaterThan","GreaterThanEqual","LessThan","LessThanEqual","WithinGeoRange","IsNull","ContainsAny","ContainsAll","ContainsNone"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -196,6 +196,9 @@ const (
 
 	// WhereFilterOperatorContainsAll captures enum value "ContainsAll"
 	WhereFilterOperatorContainsAll string = "ContainsAll"
+
+	// WhereFilterOperatorContainsNone captures enum value "ContainsNone"
+	WhereFilterOperatorContainsNone string = "ContainsNone"
 )
 
 // prop value enum

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1790,7 +1790,8 @@
             "WithinGeoRange",
             "IsNull",
             "ContainsAny",
-            "ContainsAll"
+            "ContainsAll",
+            "ContainsNone"
           ],
           "example": "GreaterThanEqual"
         },


### PR DESCRIPTION
### What's being changed:

Added a ContainsNone operator which is internally implemented by `AND`s of multiple `NotEquals` Operations.

Fixes #3513

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. 
