### PR TITLE
Delegate Class Existence Checking to Leader on Class Addition

### DIFF
--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -78,6 +78,7 @@ func (s *Service) AddClass(cls *models.Class, ss *sharding.State) error {
 	if cls == nil || cls.Class == "" {
 		return fmt.Errorf("nil class or empty class name : %w", errBadRequest)
 	}
+
 	req := cmd.AddClassRequest{Class: cls, State: ss}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -107,6 +107,12 @@ func TestServiceEndpoints(t *testing.T) {
 	assert.Nil(t, srv.AddClass(cls, ss))
 	assert.Equal(t, schema.ClassEqual("C"), "C")
 
+	// Add same class again
+	assert.ErrorIs(t, srv.AddClass(cls, ss), errClassExists)
+
+	// Add similar class
+	assert.ErrorIs(t, srv.AddClass(&models.Class{Class: "c"}, ss), errClassExists)
+
 	// QueryReadOnlyClass
 	readOnlyClass, err := srv.QueryReadOnlyClass(cls.Class)
 	assert.NoError(t, err)

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -481,7 +481,7 @@ func (h *Handler) validateCanAddClass(
 	ctx context.Context, class *models.Class,
 	relaxCrossRefValidation bool,
 ) error {
-	if err := h.validateClassName(class.Class); err != nil {
+	if _, err := schema.ValidateClassName(class.Class); err != nil {
 		return err
 	}
 
@@ -507,22 +507,6 @@ func (h *Handler) validateCanAddClass(
 
 	// all is fine!
 	return nil
-}
-
-func (h *Handler) validateClassName(name string) error {
-	if _, err := schema.ValidateClassName(name); err != nil {
-		return err
-	}
-	existingName := h.metaReader.ClassEqual(name)
-	if existingName == "" {
-		return nil
-	}
-	if name != existingName {
-		return fmt.Errorf(
-			"class name %q already exists as a permutation of: %q. class names must be unique when lowercased",
-			name, existingName)
-	}
-	return fmt.Errorf("class name %q already exists", name)
 }
 
 func (h *Handler) validatePropertyTokenization(tokenization string, propertyDataType schema.PropertyDataType) error {

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -73,28 +73,6 @@ func Test_AddClass(t *testing.T) {
 		assert.EqualError(t, err, "'' is not a valid class name")
 	})
 
-	t.Run("with permuted-casing class names", func(t *testing.T) {
-		handler, fakeMetaHandler := newTestHandler(t, &fakeDB{})
-		fakeMetaHandler.countClassEqual = true
-
-		fakeMetaHandler.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		unset := fakeMetaHandler.On("ClassEqual", mock.Anything).Return("")
-		class1 := models.Class{Class: "NewClass", Vectorizer: "none"}
-		err := handler.AddClass(ctx, nil, &class1)
-		require.Nil(t, err)
-		assert.Nil(t, err)
-
-		unset.Unset()
-
-		fakeMetaHandler.On("ClassEqual", mock.Anything).Return("NewClass")
-		class2 := models.Class{Class: "NewCLASS", Vectorizer: "none"}
-		err = handler.AddClass(ctx, nil, &class2)
-		assert.EqualError(t, err,
-			`class name "NewCLASS" already exists as a permutation of: "NewClass". `+
-				`class names must be unique when lowercased`)
-		fakeMetaHandler.AssertExpectations(t)
-	})
-
 	t.Run("with default params", func(t *testing.T) {
 		handler, fakeMetaHandler := newTestHandler(t, &fakeDB{})
 		class := models.Class{


### PR DESCRIPTION
…classes to the leader when adding new classes

This resolves the issue of returning an error when attempting to immediately recreate a class after it has been deleted

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
