### PR TITLE
autoSchema: remove retry and some tests sleeps

### DIFF
--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -333,9 +333,6 @@ func eventualReplicaCRUD(t *testing.T) {
 		helper.UpdateClass(t, pc)
 	})
 
-	// Ensure consistency on follower nodes by sleeping BEFORE shutting down the leader node
-	time.Sleep(3 * time.Second)
-
 	t.Run("stop node 1", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 1)
 	})

--- a/test/acceptance/replication/graphql_test.go
+++ b/test/acceptance/replication/graphql_test.go
@@ -81,7 +81,6 @@ func graphqlSearch(t *testing.T) {
 
 	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
-		time.Sleep(5 * time.Second)
 	})
 
 	t.Run("get consistent search results with ONE (1/2 nodes up)", func(t *testing.T) {

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -81,6 +81,7 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
+		time.Sleep(5 * time.Second)
 	})
 
 	repairObj := models.Object{
@@ -106,6 +107,7 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 1", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 1)
+		time.Sleep(10 * time.Second)
 	})
 
 	t.Run("assert new object read repair was made", func(t *testing.T) {

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -81,7 +81,6 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
-		time.Sleep(5 * time.Second)
 	})
 
 	repairObj := models.Object{
@@ -107,7 +106,6 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 1", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 1)
-		time.Sleep(10 * time.Second)
 	})
 
 	t.Run("assert new object read repair was made", func(t *testing.T) {
@@ -142,7 +140,6 @@ func readRepair(t *testing.T) {
 
 	t.Run("assert updated object read repair was made", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
-		time.Sleep(10 * time.Second)
 
 		exists, err := objectExistsCL(t, compose.GetWeaviate().URI(),
 			replaceObj.Class, replaceObj.ID, replica.One)

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -14,7 +14,6 @@ package helper
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +74,7 @@ func CreateObject(t *testing.T, object *models.Object) {
 func CreateObjectCL(t *testing.T, object *models.Object, cl replica.ConsistencyLevel) {
 	t.Helper()
 	cls := string(cl)
-	params := objects.NewObjectsCreateParamsWithTimeout(60 * time.Second).WithBody(object).WithConsistencyLevel(&cls)
+	params := objects.NewObjectsCreateParams().WithBody(object).WithConsistencyLevel(&cls)
 	resp, err := Client(t).Objects.ObjectsCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
 }
@@ -112,7 +111,7 @@ func UpdateObject(t *testing.T, object *models.Object) {
 func UpdateObjectCL(t *testing.T, object *models.Object, cl replica.ConsistencyLevel) {
 	t.Helper()
 	cls := string(cl)
-	params := objects.NewObjectsClassPutParamsWithTimeout(60 * time.Second).WithClassName(object.Class).
+	params := objects.NewObjectsClassPutParams().WithClassName(object.Class).
 		WithID(object.ID).WithBody(object).WithConsistencyLevel(&cls)
 	resp, err := Client(t).Objects.ObjectsClassPut(params, nil)
 	AssertRequestOk(t, resp, err, nil)

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -14,6 +14,7 @@ package helper
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,7 @@ func CreateObject(t *testing.T, object *models.Object) {
 func CreateObjectCL(t *testing.T, object *models.Object, cl replica.ConsistencyLevel) {
 	t.Helper()
 	cls := string(cl)
-	params := objects.NewObjectsCreateParams().WithBody(object).WithConsistencyLevel(&cls)
+	params := objects.NewObjectsCreateParamsWithTimeout(60 * time.Second).WithBody(object).WithConsistencyLevel(&cls)
 	resp, err := Client(t).Objects.ObjectsCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
 }
@@ -111,7 +112,7 @@ func UpdateObject(t *testing.T, object *models.Object) {
 func UpdateObjectCL(t *testing.T, object *models.Object, cl replica.ConsistencyLevel) {
 	t.Helper()
 	cls := string(cl)
-	params := objects.NewObjectsClassPutParams().WithClassName(object.Class).
+	params := objects.NewObjectsClassPutParamsWithTimeout(60 * time.Second).WithClassName(object.Class).
 		WithID(object.ID).WithBody(object).WithConsistencyLevel(&cls)
 	resp, err := Client(t).Objects.ObjectsClassPut(params, nil)
 	AssertRequestOk(t, resp, err, nil)

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -76,7 +76,7 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 		// Batch together the GetClass and subsequent createClass or updateClass to ensure we will retry if the schema changes
 		// have not yet propagated back to the follower node.
 		err := backoff.Retry(func() error {
-			schemaClass, err := m.schemaManager.GetConsistentClass(ctx, principal, object.Class, true)
+			schemaClass, err := m.schemaManager.GetClass(ctx, principal, object.Class)
 			if err != nil {
 				return err
 			}

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -76,7 +76,7 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 		// Batch together the GetClass and subsequent createClass or updateClass to ensure we will retry if the schema changes
 		// have not yet propagated back to the follower node.
 		err := backoff.Retry(func() error {
-			schemaClass, err := m.schemaManager.GetClass(ctx, principal, object.Class)
+			schemaClass, err := m.schemaManager.GetConsistentClass(ctx, principal, object.Class, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What's being changed:
remove `autoSchema` retry and remove some of the time.Sleep in acceptance tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
