### PR TITLE
Fix api version support in text2vec-openai module

### DIFF
--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -53,7 +53,7 @@ func TestBuildUrlFn(t *testing.T) {
 	t.Run("buildUrlFn returns Azure Client", func(t *testing.T) {
 		url, err := buildUrlFn(false, "resourceID", "deploymentID", "", config.DefaultApiVersion)
 		assert.Nil(t, err)
-		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/chat/completions?api-version=2023-05-15", url)
+		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/chat/completions?api-version=2024-02-01", url)
 	})
 	t.Run("buildUrlFn loads from environment variable", func(t *testing.T) {
 		url, err := buildUrlFn(false, "", "", "https://foobar.some.proxy", config.DefaultApiVersion)
@@ -64,7 +64,7 @@ func TestBuildUrlFn(t *testing.T) {
 	t.Run("buildUrlFn returns Azure Client with custom baseURL", func(t *testing.T) {
 		url, err := buildUrlFn(false, "resourceID", "deploymentID", "customBaseURL", config.DefaultApiVersion)
 		assert.Nil(t, err)
-		assert.Equal(t, "customBaseURL/openai/deployments/deploymentID/chat/completions?api-version=2023-05-15", url)
+		assert.Equal(t, "customBaseURL/openai/deployments/deploymentID/chat/completions?api-version=2024-02-01", url)
 	})
 }
 

--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -53,7 +53,7 @@ var (
 	DefaultOpenAIPresencePenalty  = 0.0
 	DefaultOpenAITopP             = 1.0
 	DefaultOpenAIBaseURL          = "https://api.openai.com"
-	DefaultApiVersion             = "2023-05-15"
+	DefaultApiVersion             = "2024-02-01"
 )
 
 // todo Need to parse the tokenLimits in a smarter way, as the prompt defines the max length
@@ -77,6 +77,9 @@ var availableApiVersions = []string{
 	"2023-08-01-preview",
 	"2023-09-01-preview",
 	"2023-12-01-preview",
+	"2024-02-15-preview",
+	"2024-03-01-preview",
+	"2024-02-01",
 }
 
 type ClassSettings interface {

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -49,7 +49,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.0,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 		},
 		{
 			name: "Everything non default configured",
@@ -71,7 +71,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 		},
 		{
 			name: "OpenAI Proxy",
@@ -87,7 +87,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantBaseURL:          "https://proxy.weaviate.dev/",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 			wantModel:            "gpt-3.5-turbo",
 			wantMaxTokens:        4097,
 			wantTemperature:      0.5,
@@ -116,7 +116,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 		},
 		{
 			name: "Azure OpenAI config",
@@ -142,7 +142,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 		},
 		{
 			name: "Azure OpenAI config with baseURL",
@@ -169,7 +169,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "some-base-url",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 		},
 		{
 			name: "With gpt-3.5-turbo-16k model",
@@ -191,7 +191,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantPresencePenalty:  0.9,
 			wantErr:              nil,
 			wantBaseURL:          "https://api.openai.com",
-			wantApiVersion:       "2023-05-15",
+			wantApiVersion:       "2024-02-01",
 		},
 		{
 			name: "Wrong maxTokens configured",
@@ -265,7 +265,8 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 			wantErr: errors.Errorf("wrong Azure OpenAI apiVersion, available api versions are: " +
 				"[2022-12-01 2023-03-15-preview 2023-05-15 2023-06-01-preview 2023-07-01-preview " +
-				"2023-08-01-preview 2023-09-01-preview 2023-12-01-preview]"),
+				"2023-08-01-preview 2023-09-01-preview 2023-12-01-preview 2024-02-15-preview " +
+				"2024-03-01-preview 2024-02-01]"),
 		},
 	}
 	for _, tt := range tests {

--- a/modules/text2vec-openai/ent/vectorization_config.go
+++ b/modules/text2vec-openai/ent/vectorization_config.go
@@ -15,6 +15,7 @@ type VectorizationConfig struct {
 	Type, Model, ModelVersion, ResourceName string
 	BaseURL                                 string
 	DeploymentID                            string `json:"deploymentId"`
+	ApiVersion                              string
 	IsAzure                                 bool
 	Dimensions                              *int64
 }

--- a/modules/text2vec-openai/vectorizer/class_settings.go
+++ b/modules/text2vec-openai/vectorizer/class_settings.go
@@ -29,6 +29,7 @@ const (
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	DefaultBaseURL               = "https://api.openai.com"
+	DefaultApiVersion            = "2024-02-01"
 )
 
 const (
@@ -59,6 +60,20 @@ var availableOpenAIModels = []string{
 	"babbage", // only supports 001
 	"curie",   // only supports 001
 	"davinci", // only supports 001
+}
+
+var availableApiVersions = []string{
+	"2022-12-01",
+	"2023-03-15-preview",
+	"2023-05-15",
+	"2023-06-01-preview",
+	"2023-07-01-preview",
+	"2023-08-01-preview",
+	"2023-09-01-preview",
+	"2023-12-01-preview",
+	"2024-02-15-preview",
+	"2024-03-01-preview",
+	"2024-02-01",
 }
 
 type classSettings struct {
@@ -93,6 +108,10 @@ func (cs *classSettings) BaseURL() string {
 
 func (cs *classSettings) DeploymentID() string {
 	return cs.getProperty("deploymentId", "")
+}
+
+func (cs *classSettings) ApiVersion() string {
+	return cs.getProperty("apiVersion", DefaultApiVersion)
 }
 
 func (cs *classSettings) IsAzure() bool {
@@ -141,7 +160,7 @@ func (cs *classSettings) Validate(class *models.Class) error {
 		return err
 	}
 
-	err := cs.validateAzureConfig(cs.ResourceName(), cs.DeploymentID())
+	err := cs.validateAzureConfig(cs.ResourceName(), cs.DeploymentID(), cs.ApiVersion())
 	if err != nil {
 		return err
 	}
@@ -234,9 +253,12 @@ func (cs *classSettings) validateIndexState(class *models.Class, settings ClassS
 		"indexing.")
 }
 
-func (cs *classSettings) validateAzureConfig(resourceName string, deploymentId string) error {
+func (cs *classSettings) validateAzureConfig(resourceName, deploymentId, apiVersion string) error {
 	if (resourceName == "" && deploymentId != "") || (resourceName != "" && deploymentId == "") {
 		return fmt.Errorf("both resourceName and deploymentId must be provided")
+	}
+	if !validateOpenAISetting[string](apiVersion, availableApiVersions) {
+		return errors.Errorf("wrong Azure OpenAI apiVersion setting, available api versions are: %v", availableApiVersions)
 	}
 	return nil
 }

--- a/modules/text2vec-openai/vectorizer/class_settings_test.go
+++ b/modules/text2vec-openai/vectorizer/class_settings_test.go
@@ -139,6 +139,19 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 			wantErr: errors.New("properties field needs to be of array type, got: string"),
 		},
+		{
+			name: "wrong apiVersion",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"resourceName": "resource",
+					"deploymentId": "deploymentId",
+					"apiVersion":   "wrong-api-version",
+				},
+			},
+			wantErr: errors.New("wrong Azure OpenAI apiVersion setting, available api versions are: " +
+				"[2022-12-01 2023-03-15-preview 2023-05-15 2023-06-01-preview 2023-07-01-preview 2023-08-01-preview " +
+				"2023-09-01-preview 2023-12-01-preview 2024-02-15-preview 2024-03-01-preview 2024-02-01]"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -51,6 +51,7 @@ type ClassSettings interface {
 	ResourceName() string
 	DeploymentID() string
 	BaseURL() string
+	ApiVersion() string
 	IsAzure() bool
 }
 
@@ -89,6 +90,7 @@ func (v *Vectorizer) getVectorizationConfig(cfg moduletools.ClassConfig) ent.Vec
 		ModelVersion: settings.ModelVersion(),
 		ResourceName: settings.ResourceName(),
 		DeploymentID: settings.DeploymentID(),
+		ApiVersion:   settings.ApiVersion(),
 		BaseURL:      settings.BaseURL(),
 		IsAzure:      settings.IsAzure(),
 		Dimensions:   settings.Dimensions(),


### PR DESCRIPTION
### What's being changed:

This PR adds `apiVersion` support to `text2vec-openai` module.

It sets the default `apiVersion` to `2024-02-01` both in `text2vec-openai` and `generative-openai` modules.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
