### PR TITLE
Add minimal schema metrics

### DIFF
--- a/tools/dev/grafana/dashboards/schema.json
+++ b/tools/dev/grafana/dashboards/schema.json
@@ -1,0 +1,264 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 10,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Closed"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(schema_tx_opened_total[$__rate_interval]))",
+          "legendFormat": "Opened",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(schema_tx_closed_total[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "Closed",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Transactions Opened/Closed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(schema_tx_duration_seconds_sum[$__rate_interval])/rate(schema_tx_duration_seconds_count[$__rate_interval])",
+          "legendFormat": "{{ownership}}-{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction duration by status",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Schema Transactions",
+  "uid": "J4aHTlxIz",
+  "version": 2,
+  "weekStart": ""
+}

--- a/usecases/cluster/transactions_read.go
+++ b/usecases/cluster/transactions_read.go
@@ -31,6 +31,7 @@ func (c *TxManager) CloseReadTransaction(ctx context.Context,
 	}
 
 	c.Unlock()
+	c.slowLog.Update("close_read_started")
 
 	// now that we know we are dealing with a valid transaction: no  matter the
 	// outcome, after this call, we should not have a local transaction anymore
@@ -46,6 +47,7 @@ func (c *TxManager) CloseReadTransaction(ctx context.Context,
 			"ownership": "coordinator",
 			"status":    "close_read",
 		}).Observe(took.Seconds())
+		c.slowLog.Close("closed_read")
 		c.Unlock()
 	}()
 

--- a/usecases/cluster/transactions_read.go
+++ b/usecases/cluster/transactions_read.go
@@ -13,9 +13,12 @@ package cluster
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func (c *TxManager) CloseReadTransaction(ctx context.Context,
@@ -34,6 +37,15 @@ func (c *TxManager) CloseReadTransaction(ctx context.Context,
 	defer func() {
 		c.Lock()
 		c.currentTransaction = nil
+		monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
+			"ownership": "coordinator",
+			"status":    "close_read",
+		}).Inc()
+		took := time.Since(c.currentTransactionBegin)
+		monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
+			"ownership": "coordinator",
+			"status":    "close_read",
+		}).Observe(took.Seconds())
 		c.Unlock()
 	}()
 
@@ -43,12 +55,12 @@ func (c *TxManager) CloseReadTransaction(ctx context.Context,
 
 		if err := c.remote.BroadcastAbortTransaction(ctx, tx); err != nil {
 			c.logger.WithFields(logrus.Fields{
-				"action": "broadcast_abort_transaction",
+				"action": "broadcast_abort_read_transaction",
 				"id":     tx.ID,
-			}).WithError(err).Errorf("broadcast tx abort failed")
+			}).WithError(err).Errorf("broadcast tx (read-only) abort failed")
 		}
 
-		return errors.Wrap(err, "broadcast commit transaction")
+		return errors.Wrap(err, "broadcast commit read transaction")
 	}
 
 	return nil

--- a/usecases/cluster/transactions_slowlog.go
+++ b/usecases/cluster/transactions_slowlog.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package cluster
 
 import (

--- a/usecases/cluster/transactions_slowlog.go
+++ b/usecases/cluster/transactions_slowlog.go
@@ -1,0 +1,149 @@
+package cluster
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func newTxSlowLog(logger logrus.FieldLogger) *txSlowLog {
+	ageThreshold := 5 * time.Second
+	changeThreshold := 1 * time.Second
+
+	if age := os.Getenv("TX_SLOW_LOG_AGE_THRESHOLD_SECONDS"); age != "" {
+		ageParsed, err := strconv.Atoi(age)
+		if err == nil {
+			ageThreshold = time.Duration(ageParsed) * time.Second
+		}
+	}
+
+	if change := os.Getenv("TX_SLOW_LOG_CHANGE_THRESHOLD_SECONDS"); change != "" {
+		changeParsed, err := strconv.Atoi(change)
+		if err == nil {
+			changeThreshold = time.Duration(changeParsed) * time.Second
+		}
+	}
+
+	return &txSlowLog{
+		logger:          logger,
+		ageThreshold:    ageThreshold,
+		changeThreshold: changeThreshold,
+	}
+}
+
+// txSlowLog is meant as a temporary debugging tool for the v1 schema. When the
+// v2 schema is ready, this can be thrown away.
+type txSlowLog struct {
+	sync.Mutex
+	logger logrus.FieldLogger
+
+	// tx-specific
+	id           string
+	status       string
+	begin        time.Time
+	lastChange   time.Time
+	writable     bool
+	coordinating bool
+	txPresent    bool
+	logged       bool
+
+	// config
+	ageThreshold    time.Duration
+	changeThreshold time.Duration
+}
+
+func (txsl *txSlowLog) Start(id string, coordinating bool,
+	writable bool,
+) {
+	txsl.Lock()
+	defer txsl.Unlock()
+
+	txsl.id = id
+	txsl.status = "opened"
+	now := time.Now()
+	txsl.begin = now
+	txsl.lastChange = now
+	txsl.coordinating = coordinating
+	txsl.writable = writable
+	txsl.txPresent = true
+	txsl.logged = false
+}
+
+func (txsl *txSlowLog) Update(status string) {
+	txsl.Lock()
+	defer txsl.Unlock()
+
+	txsl.status = status
+	txsl.lastChange = time.Now()
+}
+
+func (txsl *txSlowLog) Close(status string) {
+	txsl.Lock()
+	defer txsl.Unlock()
+
+	txsl.status = "status"
+	txsl.lastChange = time.Now()
+
+	// there are two situations where we need to log the end of the transaction:
+	//
+	// 1. if it is slower than the age threshold
+	//
+	// 2. if we have logged it before (e.g. because it was in a specific state
+	// longer than expected)
+
+	if txsl.lastChange.Sub(txsl.begin) >= txsl.ageThreshold || txsl.logged {
+		txsl.logger.WithFields(logrus.Fields{
+			"action":         "transaction_slow_log",
+			"event":          "tx_closed",
+			"status":         txsl.status,
+			"total_duration": txsl.lastChange.Sub(txsl.begin),
+			"tx_id":          txsl.id,
+			"coordinating":   txsl.coordinating,
+			"writable":       txsl.writable,
+		}).Infof("slow transaction completed")
+	}
+
+	// reset for next usage
+	txsl.txPresent = false
+}
+
+func (txsl *txSlowLog) StartWatching() {
+	t := time.Tick(250 * time.Millisecond)
+	go func() {
+		for {
+			<-t
+			txsl.observe()
+		}
+	}()
+}
+
+func (txsl *txSlowLog) observe() {
+	txsl.Lock()
+	defer txsl.Unlock()
+
+	if !txsl.txPresent {
+		return
+	}
+
+	now := time.Now()
+	age := now.Sub(txsl.begin)
+	changed := now.Sub(txsl.lastChange)
+
+	if age >= txsl.ageThreshold || changed >= txsl.changeThreshold {
+		txsl.logger.WithFields(logrus.Fields{
+			"action":            "transaction_slow_log",
+			"event":             "tx_in_progress",
+			"status":            txsl.status,
+			"total_duration":    age,
+			"since_last_change": changed,
+			"tx_id":             txsl.id,
+			"coordinating":      txsl.coordinating,
+			"writable":          txsl.writable,
+		}).Infof("slow transaction in progress")
+
+		txsl.logged = true
+	}
+}

--- a/usecases/cluster/transactions_slowlog.go
+++ b/usecases/cluster/transactions_slowlog.go
@@ -84,7 +84,7 @@ func (txsl *txSlowLog) Close(status string) {
 	txsl.Lock()
 	defer txsl.Unlock()
 
-	txsl.status = "status"
+	txsl.status = status
 	txsl.lastChange = time.Now()
 
 	// there are two situations where we need to log the end of the transaction:
@@ -111,16 +111,16 @@ func (txsl *txSlowLog) Close(status string) {
 }
 
 func (txsl *txSlowLog) StartWatching() {
-	t := time.Tick(250 * time.Millisecond)
+	t := time.Tick(500 * time.Millisecond)
 	go func() {
 		for {
 			<-t
-			txsl.observe()
+			txsl.log()
 		}
 	}()
 }
 
-func (txsl *txSlowLog) observe() {
+func (txsl *txSlowLog) log() {
 	txsl.Lock()
 	defer txsl.Unlock()
 

--- a/usecases/cluster/transactions_slowlog.go
+++ b/usecases/cluster/transactions_slowlog.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/errors"
 )
 
 func newTxSlowLog(logger logrus.FieldLogger) *txSlowLog {
@@ -112,12 +113,12 @@ func (txsl *txSlowLog) Close(status string) {
 
 func (txsl *txSlowLog) StartWatching() {
 	t := time.Tick(500 * time.Millisecond)
-	go func() {
+	errors.GoWrapper(func() {
 		for {
 			<-t
 			txsl.log()
 		}
-	}()
+	}, txsl.logger)
 }
 
 func (txsl *txSlowLog) log() {

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -264,6 +264,7 @@ func (c *TxManager) resetTxExpiry(ttl time.Duration, id string) {
 				"ownership": "n/a",
 				"status":    "expire",
 			}).Observe(took.Seconds())
+			c.slowLog.Close("expired")
 		}
 	}
 	enterrors.GoWrapper(f, c.logger)

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -85,7 +85,6 @@ type TxManager struct {
 
 	persistence Persistence
 
-	metrics monitoring.PrometheusMetrics
 	slowLog *txSlowLog
 }
 

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"gopkg.in/yaml.v2"
 )
 
@@ -88,7 +89,7 @@ type Config struct {
 	AutoSchema                          AutoSchema               `json:"auto_schema" yaml:"auto_schema"`
 	Cluster                             cluster.Config           `json:"cluster" yaml:"cluster"`
 	Replication                         replication.GlobalConfig `json:"replication" yaml:"replication"`
-	Monitoring                          Monitoring               `json:"monitoring" yaml:"monitoring"`
+	Monitoring                          monitoring.Config        `json:"monitoring" yaml:"monitoring"`
 	GRPC                                GRPC                     `json:"grpc" yaml:"grpc"`
 	Profiling                           Profiling                `json:"profiling" yaml:"profiling"`
 	ResourceUsage                       ResourceUsage            `json:"resource_usage" yaml:"resource_usage"`
@@ -175,13 +176,6 @@ const DefaultQueryDefaultsLimit int64 = 10
 
 type Contextionary struct {
 	URL string `json:"url" yaml:"url"`
-}
-
-type Monitoring struct {
-	Enabled bool   `json:"enabled" yaml:"enabled"`
-	Tool    string `json:"tool" yaml:"tool"`
-	Port    int    `json:"port" yaml:"port"`
-	Group   bool   `json:"group_classes" yaml:"group_classes"`
 }
 
 // Support independent TLS credentials for gRPC

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -16,8 +16,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/weaviate/weaviate/usecases/config"
 )
+
+type Config struct {
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Tool    string `json:"tool" yaml:"tool"`
+	Port    int    `json:"port" yaml:"port"`
+	Group   bool   `json:"group_classes" yaml:"group_classes"`
+}
 
 type PrometheusMetrics struct {
 	BatchTime                         *prometheus.HistogramVec
@@ -68,6 +74,10 @@ type PrometheusMetrics struct {
 	ShardsUnloaded  *prometheus.GaugeVec
 	ShardsLoading   *prometheus.GaugeVec
 	ShardsUnloading *prometheus.GaugeVec
+
+	SchemaTxOpened   *prometheus.CounterVec
+	SchemaTxClosed   *prometheus.CounterVec
+	SchemaTxDuration *prometheus.SummaryVec
 
 	Group bool
 }
@@ -149,7 +159,7 @@ func init() {
 	metrics = newPrometheusMetrics()
 }
 
-func InitConfig(cfg config.Monitoring) {
+func InitConfig(cfg Config) {
 	metrics.Group = cfg.Group
 }
 
@@ -358,6 +368,20 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "shards_unloading",
 			Help: "Number of shards in process of unloading",
 		}, []string{"class_name"}),
+
+		// Schema TX-metrics. Can be removed when RAFT is ready
+		SchemaTxOpened: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "schema_tx_opened_total",
+			Help: "Total number of opened schema transactions",
+		}, []string{"ownership"}),
+		SchemaTxClosed: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "schema_tx_closed_total",
+			Help: "Total number of closed schema transactions. A close must be either successful or failed",
+		}, []string{"ownership", "status"}),
+		SchemaTxDuration: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "schema_tx_duration_seconds",
+			Help: "Mean duration of a tx by status",
+		}, []string{"ownership", "status"}),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

* closes #4602
* adds basic metrics to indicated opening and closing schema transactions
* adds a slowlog that logs any transaction that is either stuck in a specific state for a while or taking long in general
* does not add a schema_age metric as described in #4602 for simplicity's sake. We can add that later if necessary.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
