### PR TITLE
Prevent deadlock when goroutine panics (HNSW delete cleanup deadlock)

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -346,6 +346,9 @@ LOOP:
 		select {
 		case ch <- uint64(i):
 		case <-ctx.Done():
+			// before https://github.com/weaviate/weaviate/issues/4615 the context
+			// would not be canceled if a routine panicked. However, with the fix, it is
+			// now valid to wait for a cancelation – even if a panic occurs.
 			break LOOP
 		}
 	}


### PR DESCRIPTION
### What's being changed:

The previous logic would assume that either routines can't exit and there is always a routine to listen to the channel or that they exited because a context was canceled. Since the errgroup was already using a WithContext-wrapper, we could easily make sure that a panic cancels the returned context. Now the logic works again and the select statement can make progress – even when a routine in the error group panicked.

fixes #4615

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
