### PR TITLE
Enhanced backup functionality for Raft, implementing two-phase restoration process and centralized schema restoration for improved consistency

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -261,9 +261,10 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	nodeName := appState.Cluster.LocalName()
 	nodeAddr, _ := appState.Cluster.NodeHostname(nodeName)
 	addrs := strings.Split(nodeAddr, ":")
+	dataPath := appState.ServerConfig.Config.Persistence.DataPath
 
 	rConfig := rStore.Config{
-		WorkDir:            filepath.Join(appState.ServerConfig.Config.Persistence.DataPath, "raft"),
+		WorkDir:            filepath.Join(dataPath, "raft"),
 		NodeID:             nodeName,
 		Host:               addrs[0],
 		RaftPort:           appState.ServerConfig.Config.Raft.Port,
@@ -292,8 +293,10 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	}
 
 	appState.CloudService = rCluster.New(rConfig)
-	executor := schema.NewExecutor(migrator, appState.CloudService.SchemaReader(), appState.Logger)
-
+	executor := schema.NewExecutor(migrator,
+		appState.CloudService.SchemaReader(),
+		appState.Logger, backup.RestoreClassDir(dataPath),
+	)
 	schemaManager, err := schemaUC.NewManager(migrator,
 		appState.CloudService.Service,
 		appState.CloudService.SchemaReader(),
@@ -475,7 +478,8 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.Authorizer,
 		clients.NewClusterBackups(appState.ClusterHttpClient),
 		appState.DB, appState.Modules,
-		appState.Cluster,
+		membership{appState.Cluster, appState.CloudService},
+		appState.SchemaManager,
 		appState.Logger)
 	setupBackupHandlers(api, backupScheduler, appState.Metrics, appState.Logger)
 	setupNodesHandlers(api, appState.SchemaManager, appState.DB, appState)
@@ -1098,4 +1102,14 @@ func limitResources(appState *state.State) {
 
 func telemetryEnabled(state *state.State) bool {
 	return !state.ServerConfig.Config.DisableTelemetry
+}
+
+type membership struct {
+	*cluster.State
+	raft *rCluster.Service
+}
+
+func (m membership) LeaderID() string {
+	_, id := m.raft.LeaderWithID()
+	return id
 }

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -95,7 +95,7 @@ func (n *node) init(dirName string, shardStateRaw []byte,
 
 	backupClient := clients.NewClusterBackups(&http.Client{})
 	n.scheduler = ubak.NewScheduler(
-		&fakeAuthorizer{}, backupClient, n.repo, backendProvider, nodeResolver, logger)
+		&fakeAuthorizer{}, backupClient, n.repo, backendProvider, nodeResolver, n.schemaManager, logger)
 
 	n.migrator = db.NewMigrator(n.repo, logger)
 
@@ -231,6 +231,13 @@ func (r nodeResolver) NodeHostname(nodeName string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func (r nodeResolver) LeaderID() string {
+	if r.nodes != nil && len(*r.nodes) > 0 {
+		return (*r.nodes)[0].name
+	}
+	return ""
 }
 
 func newFakeBackupBackendProvider(backupsPath string) *fakeBackupBackendProvider {

--- a/adapters/repos/schema/store_test.go
+++ b/adapters/repos/schema/store_test.go
@@ -148,7 +148,7 @@ func TestRepositoryUpdateClass(t *testing.T) {
 		t.Fatalf("create new class: %v", err)
 	}
 	if err := repo.NewClass(ctx, payload); err == nil {
-		t.Fatal("create new class: must fail since class already exits")
+		t.Fatal("create new class: must fail since class already exists")
 	}
 	repo.asserEqualSchema(t, schema, "create class")
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -94,3 +94,9 @@ func (c *Service) Close(ctx context.Context) (err error) {
 func (c *Service) Ready() bool {
 	return c.Service.Ready()
 }
+
+// LeaderWithID is used to return the current leader address and ID of the cluster.
+// It may return empty strings if there is no current leader or the leader is unknown.
+func (c *Service) LeaderWithID() (string, string) {
+	return c.Service.LeaderWithID()
+}

--- a/cluster/store/schema.go
+++ b/cluster/store/schema.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	errClassNotFound = errors.New("class not found")
-	errClassExists   = errors.New("class already exits")
+	errClassExists   = errors.New("class already exists")
 	errShardNotFound = errors.New("shard not found")
 )
 

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -267,6 +267,13 @@ func (s *Service) Stats() map[string]string {
 	return s.store.Stats()
 }
 
+// LeaderWithID is used to return the current leader address and ID of the cluster.
+// It may return empty strings if there is no current leader or the leader is unknown.
+func (s *Service) LeaderWithID() (string, string) {
+	addr, id := s.store.LeaderWithID()
+	return string(addr), string(id)
+}
+
 func (s *Service) WaitUntilDBRestored(ctx context.Context, period time.Duration) error {
 	return s.store.WaitToRestoreDB(ctx, period)
 }

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -46,6 +46,7 @@ func TestServiceEndpoints(t *testing.T) {
 	m.indexer.On("Open", Anything).Return(nil)
 	m.indexer.On("Close", Anything).Return(nil)
 	m.indexer.On("AddClass", Anything).Return(nil)
+	m.indexer.On("RestoreClassDir", Anything).Return(nil)
 	m.indexer.On("UpdateClass", Anything).Return(nil)
 	m.indexer.On("DeleteClass", Anything).Return(nil)
 	m.indexer.On("AddProperty", Anything, Anything).Return(nil)
@@ -376,7 +377,7 @@ func TestStoreApply(t *testing.T) {
 			doBefore: func(m *MockStore) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
-				m.store.db.Schema.addClass(cls, ss)
+				m.indexer.On("RestoreClassDir", cls.Class).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				_, ok := ms.store.db.Schema.Classes["C1"]
@@ -785,6 +786,11 @@ type MockIndexer struct {
 
 func (m *MockIndexer) AddClass(req cmd.AddClassRequest) error {
 	args := m.Called(req)
+	return args.Error(0)
+}
+
+func (m *MockIndexer) RestoreClassDir(class string) error {
+	args := m.Called(class)
 	return args.Error(0)
 }
 

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -33,6 +33,7 @@ type DistributedBackupDescriptor struct {
 	Status        Status                     `json:"status"`  //
 	Version       string                     `json:"version"` //
 	ServerVersion string                     `json:"serverVersion"`
+	Leader        string                     `json:"leader"`
 	Error         string                     `json:"error"`
 }
 

--- a/test/acceptance_with_go_client/schema_test.go
+++ b/test/acceptance_with_go_client/schema_test.go
@@ -98,11 +98,10 @@ func checkDuplicateClassErrors(t *testing.T, err error, tt testCase) {
 		require.Nil(t, json.Unmarshal([]byte(rawError.Msg), &clientErr))
 		require.Len(t, clientErr.Error, 1)
 		if tt.className1 == tt.className2 {
-			require.Equal(t, fmt.Sprintf("class name %q already exists", tt.className2), clientErr.Error[0].Message)
+			require.Contains(t, clientErr.Error[0].Message, "class already exists")
 		} else {
-			require.Equal(t,
-				fmt.Sprintf("class name %q already exists as a permutation of: %q. class names must be unique when lowercased",
-					tt.className2, tt.className1), clientErr.Error[0].Message)
+			require.Contains(t, clientErr.Error[0].Message, "class already exists")
+			require.Contains(t, clientErr.Error[0].Message, fmt.Sprintf("found similar class %q", tt.className1))
 		}
 	} else {
 		t.Fatalf("unexpected error: %v", err)

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -84,7 +84,7 @@ func Test_Authorization(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
 				authorizer := &authDenier{}
-				s := NewScheduler(authorizer, nil, nil, nil, nil, logger)
+				s := NewScheduler(authorizer, nil, nil, nil, nil, &fakeSchemaManger{}, logger)
 				require.NotNil(t, s)
 
 				args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -55,7 +55,7 @@ func (b *backupper) Backup(ctx context.Context,
 		ID:      id,
 		Classes: classes,
 	}
-	if _, err := b.backup(ctx, store, &req); err != nil {
+	if _, err := b.backup(store, &req); err != nil {
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
@@ -124,9 +124,7 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqStat, 
 // Moreover it starts a goroutine in the background which waits for the
 // next instruction from the coordinator (second phase).
 // It will start the backup as soon as it receives an ack, or abort otherwise
-func (b *backupper) backup(ctx context.Context,
-	store nodeStore, req *Request,
-) (CanCommitResponse, error) {
+func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, error) {
 	id := req.ID
 	expiration := req.Duration
 	if expiration > _TimeoutShardCommit {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -172,7 +172,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	}
 	initial := h.metaReader.ReadOnlyClass(className)
 
-	// first layer of defense is basic validation if class already exits
+	// first layer of defense is basic validation if class already exists
 	if initial != nil {
 		_, err := validateUpdatingMT(initial, updated)
 		if err != nil {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -32,7 +32,7 @@ var (
 
 func newMockExecutor(m *fakeMigrator, s *fakeMetaHandler) *executor {
 	logger, _ := test.NewNullLogger()
-	x := NewExecutor(m, s, logger)
+	x := NewExecutor(m, s, logger, func(string) error { return nil })
 	x.RegisterSchemaUpdateCallback(func(updatedSchema schema.Schema) {})
 	return x
 }

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -81,6 +81,10 @@ func (f *fakeDB) AddClass(cmd command.AddClassRequest) error {
 	return nil
 }
 
+func (f *fakeDB) RestoreClassDir(class string) error {
+	return nil
+}
+
 func (f *fakeDB) UpdateClass(cmd command.UpdateClassRequest) error {
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

    Upgrade backup functionality for compatibility with Raft Now
    
     Empty classes are backed up by the leader instead of all nodes
    
     The backup restoration process is divided into two phases:
    
      In phase 1, nodes restore classes in predefined temporary folders
    
      In phase 2, the actual restoration is executed by the Raft store
    
     Additionally, the scheduler now manages the restoration of all schema to enhance handling of eventual consistency

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
