### PR TITLE
Add raft suffix to version number

### DIFF
--- a/adapters/handlers/rest/doc.go
+++ b/adapters/handlers/rest/doc.go
@@ -18,7 +18,7 @@
 //	  https
 //	Host: localhost
 //	BasePath: /v1
-//	Version: 1.24.6
+//	Version: 1.25.0-raft
 //	Contact: Weaviate<hello@weaviate.io> https://github.com/weaviate
 //
 //	Consumes:

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -48,7 +48,7 @@ func init() {
       "url": "https://github.com/weaviate",
       "email": "hello@weaviate.io"
     },
-    "version": "1.24.6"
+    "version": "1.25.0-raft"
   },
   "basePath": "/v1",
   "paths": {
@@ -5136,7 +5136,7 @@ func init() {
       "url": "https://github.com/weaviate",
       "email": "hello@weaviate.io"
     },
-    "version": "1.24.6"
+    "version": "1.25.0-raft"
   },
   "basePath": "/v1",
   "paths": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1980,7 +1980,7 @@
     },
     "description": "Cloud-native, modular vector database",
     "title": "Weaviate",
-    "version": "1.24.6"
+    "version": "1.25.0-raft"
   },
   "parameters": {
     "CommonAfterParameterQuery": {


### PR DESCRIPTION
### What's being changed:

This PR adds `*-raft` suffix to Weaviate's version number as a temporary solution to be able to differentiate Raft and none-raft versions of Weaviate. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
