### PR TITLE
hotfix: activate/deactivate tenants with 1ms sleep

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -753,7 +753,8 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 			out[pos] = err
 			continue
 		}
-
+		// sleep to handle eventual consistency
+		time.Sleep(time.Millisecond)
 		group := byShard[shardName]
 		group.objects = append(group.objects, obj)
 		group.pos = append(group.pos, pos)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -753,6 +753,8 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 			out[pos] = err
 			continue
 		}
+		// TODO-RAFT: remove and fix eventual consistency when batch add
+		// is RAFT ready from followers prospective
 		// sleep to handle eventual consistency
 		time.Sleep(time.Millisecond)
 		group := byShard[shardName]


### PR DESCRIPTION
### What's being changed:
this sleep has the power to handle eventual consistency issue with activate/deactivate tenants as a workaround until we have the AddBatch ready from the follower side to create tenant on object addition    

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
