### PR TITLE
Significantly improve MTTR when number of tenants is massive

### DIFF
--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -132,16 +132,15 @@ func Test_Schema_Authorization(t *testing.T) {
 
 		for _, method := range allExportedMethods(&Manager{}) {
 			switch method {
-			case "RegisterSchemaUpdateCallback",
-				"UpdateMeta", "GetSchemaSkipAuth", "IndexedInverted", "RLock", "RUnlock", "Lock", "Unlock",
-				"TryLock", "RLocker", "TryRLock", // introduced by sync.Mutex in go 1.18
-				"Nodes", "NodeName", "ClusterHealthScore", "ClusterStatus", "ResolveParentNodes",
-				"CopyShardingState", "TxManager", "RestoreClass",
-				"ShardOwner", "TenantShard", "ShardFromUUID", "LockGuard", "RLockGuard", "ShardReplicas",
-				"StartServing", "Shutdown": // internal methods to indicate readiness state
-				// don't require auth on methods which are exported because other
-				// packages need to call them for maintenance and other regular jobs,
-				// but aren't user facing
+			case "RegisterSchemaUpdateCallback", "UpdateMeta", "GetSchemaSkipAuth",
+				"IndexedInverted", "RLock", "RUnlock", "Lock", "Unlock", "TryLock",
+				"RLocker", "TryRLock", "Nodes", "NodeName", "ClusterHealthScore",
+				"ClusterStatus", "ResolveParentNodes", "CopyShardingState", "TxManager",
+				"RestoreClass", "ShardOwner", "TenantShard", "ShardFromUUID", "LockGuard",
+				"RLockGuard", "ShardReplicas", "StartServing", "Shutdown", "EqualEnough":
+				// internal methods to indicate readiness state don't require auth on
+				// methods which are exported because other packages need to call them
+				// for maintenance and other regular jobs, but aren't user facing
 				continue
 			}
 			assert.Contains(t, testedMethods, method)

--- a/usecases/schema/cache.go
+++ b/usecases/schema/cache.go
@@ -44,6 +44,48 @@ func NewState(nClasses int) State {
 	}
 }
 
+func (s State) EqualEnough(other *State) bool {
+	// Same number of classes
+	eqClassLen := len(s.ObjectSchema.Classes) == len(other.ObjectSchema.Classes)
+	if !eqClassLen {
+		return false
+	}
+
+	// Same sharding state length
+	eqSSLen := len(s.ShardingState) == len(other.ShardingState)
+	if !eqSSLen {
+		return false
+	}
+
+	for cls, ss1ss := range s.ShardingState {
+		// Same sharding state keys
+		ss2ss, ok := other.ShardingState[cls]
+		if !ok {
+			return false
+		}
+
+		// Same number of physical shards
+		eqPhysLen := len(ss1ss.Physical) == len(ss2ss.Physical)
+		if !eqPhysLen {
+			return false
+		}
+
+		for shard, ss1phys := range ss1ss.Physical {
+			// Same physical shard contents and status
+			ss2phys, ok := ss2ss.Physical[shard]
+			if !ok {
+				return false
+			}
+			eqActivStat := ss1phys.ActivityStatus() == ss2phys.ActivityStatus()
+			if !eqActivStat {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 type schemaCache struct {
 	sync.RWMutex
 	State


### PR DESCRIPTION
### What's being changed:

When a node which contains a large number of tenants (100k+) is restarted, it can take many minutes until the node is serving requests. Investigation revealed that each time the sever is started, the entire schema store is truncated, and reconstructed unnecessarily. 

This PR avoids this process by making an equivalency check between the schema cache and the persisted db contents. If the contents are the same, we don't need to do anything, greatly improving recovery time.

Note: a future improvement would be the introduction of a means to conduct a byte-level comparison between schema state objects. The equality check included in this PR is "good enough", but a more exhaustive comparison would always be better.

Closes #4634 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
