### PR TITLE
Fix schema repair: include tenant activity status

### DIFF
--- a/adapters/repos/schema/store.go
+++ b/adapters/repos/schema/store.go
@@ -444,11 +444,21 @@ func (r *store) Save(ctx context.Context, ss ucs.State) error {
 		return nil
 	}
 
+	r.log.WithField("action", "save_schema").
+		Infof("Current schema state outdated, updating schema store")
+
 	f := func(tx *bolt.Tx) error {
 		root := tx.Bucket(schemaBucket)
 		return r.saveAllTx(ctx, root, ss)(tx)
 	}
-	return r.db.Update(f)
+
+	err = r.db.Update(f)
+	if err == nil {
+		r.log.WithField("action", "save_schema").
+			Infof("Schema store successfully updated")
+	}
+
+	return err
 }
 
 func (r *store) saveAllTx(ctx context.Context, root *bolt.Bucket, ss ucs.State) func(tx *bolt.Tx) error {
@@ -479,7 +489,12 @@ func (r *store) saveAllTx(ctx context.Context, root *bolt.Bucket, ss ucs.State) 
 			if err := r.updateClass(b, payload); err != nil {
 				return fmt.Errorf("update bucket %q: %w", cls.Class, err)
 			}
+			r.log.WithField("action", "update_schema_store").
+				Debugf("Class updated: %s", cls.Class)
 		}
+
+		r.log.WithField("action", "update_schema_store").
+			Debug("All classes updated")
 
 		return nil
 	}

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -16,7 +16,7 @@ export ORIGIN=${ORIGIN:-"http://localhost:8080"}
 export QUERY_DEFAULTS_LIMIT=${QUERY_DEFAULTS_LIMIT:-"20"}
 export QUERY_MAXIMUM_RESULTS=${QUERY_MAXIMUM_RESULTS:-"10000"}
 export TRACK_VECTOR_DIMENSIONS=true
-export CLUSTER_HOSTNAME=${CLUSTER_HOSTNAME:-"node1"}
+export CLUSTER_HOSTNAME=${CLUSTER_HOSTNAME:-"weaviate-0"}
 export DISABLE_TELEMETRY=true # disable telemetry for local development
 
 function go_run() {
@@ -57,9 +57,9 @@ case $CONFIG in
       GRPC_PORT=50052 \
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
-      PERSISTENCE_DATA_PATH="./data-node2" \
-      BACKUP_FILESYSTEM_PATH="${PWD}/backups-node2" \
-      CLUSTER_HOSTNAME="node2" \
+      PERSISTENCE_DATA_PATH="./data-weaviate-1" \
+      BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-1" \
+      CLUSTER_HOSTNAME="weaviate-1" \
       CLUSTER_GOSSIP_BIND_PORT="7102" \
       CLUSTER_DATA_BIND_PORT="7103" \
       CLUSTER_JOIN="localhost:7100" \
@@ -78,8 +78,8 @@ case $CONFIG in
         GRPC_PORT=50053 \
         CONTEXTIONARY_URL=localhost:9999 \
         AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
-        PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-node3" \
-        CLUSTER_HOSTNAME="node3" \
+        PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-2" \
+        CLUSTER_HOSTNAME="weaviate-2" \
         CLUSTER_GOSSIP_BIND_PORT="7104" \
         CLUSTER_DATA_BIND_PORT="7105" \
         CLUSTER_JOIN="localhost:7100" \

--- a/usecases/schema/read_consensus.go
+++ b/usecases/schema/read_consensus.go
@@ -63,10 +63,9 @@ func newReadConsensus(parser parserFn,
 			current := typed.(ReadSchemaPayload).Schema
 			if err := Equal(previous, current); err != nil {
 				diff := Diff("previous", previous, "current", current)
-				logger.WithFields(logrusStartupSyncFields()).WithFields(logrus.Fields{
-					"diff": diff,
-				}).Errorf("trying to reach cluster consensus on schema: %v", err)
-
+				logger.WithFields(logrusStartupSyncFields()).
+					Errorf("Trying to reach cluster consensus on schema: %v", err)
+				logger.WithFields(logrusStartupSyncFields()).Tracef("diff: %+v", diff)
 				return nil, fmt.Errorf("did not reach consensus on schema in cluster: %w", err)
 			}
 		}
@@ -157,7 +156,9 @@ func equalSharding(l, r map[string]*sharding.State) error {
 		}
 		for k, lu := range u.Physical {
 			if !reflect.DeepEqual(lu, v.Physical[k]) {
-				return fmt.Errorf("class %q: physical shard %q", cls, k)
+				return fmt.Errorf(
+					"class %q: physical shard %q, u: %+v, v: %+v",
+					cls, k, lu, v.Physical[k])
 			}
 		}
 

--- a/usecases/schema/schema_repair.go
+++ b/usecases/schema/schema_repair.go
@@ -243,8 +243,8 @@ func determineRepairsNeeded(states comparisonUnit) repairSet {
 					repairs.tenants[className] = append(repairs.tenants[className], phys)
 					continue
 				}
-				_, found = anomalySS.Physical[name]
-				if !found {
+				localPhys, found := anomalySS.Physical[name]
+				if !found || phys.ActivityStatus() != localPhys.ActivityStatus() {
 					repairs.tenants[className] = append(repairs.tenants[className], phys)
 				}
 			}

--- a/usecases/schema/startup_cluster_sync.go
+++ b/usecases/schema/startup_cluster_sync.go
@@ -201,9 +201,9 @@ func (m *Manager) validateSchemaCorruption(ctx context.Context) error {
 		return nil
 	}
 	if err := m.schemaCache.RLockGuard(cmp); err != nil {
-		m.logger.WithFields(logrusStartupSyncFields()).WithFields(logrus.Fields{
-			"diff": diff,
-		}).Warning("mismatch between local schema and remote (other nodes consensus) schema")
+		m.logger.WithFields(logrusStartupSyncFields()).
+			Warning("Mismatch between local schema and remote (other nodes consensus) schema")
+		m.logger.WithFields(logrusStartupSyncFields()).Tracef("diff: %+v", diff)
 		if m.clusterState.SkipSchemaRepair() {
 			return fmt.Errorf("corrupt cluster: other nodes have consensus on schema, "+
 				"but local node has a different (non-null) schema: %w", err)


### PR DESCRIPTION
### What's being changed:

Previous schema repair algorithm did not consider the activity status of tenants, leading to an improper repair which can result in a failed cluster startup.

For example: 
Given a 3 node cluster with out of sync tenant statuses, where all nodes are restarted one after another. The first node starts fine, it's the memberlist originator. The second node is repaired against the first node's schema, but repaired improperly with the wrong status. The cluster thinks it is in sync, even though it isn't. The third node is started and attempts to join, but from it's perspective, the first 2 nodes do *not* have a consensus on the schema, and therefore cannot proceed to initialize.

Also in this PR:
- Improved startup logging 
- Improved local server script

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
