### PR TITLE
avoid double RLock call on schema mutex

### DIFF
--- a/cluster/store/schema.go
+++ b/cluster/store/schema.go
@@ -274,8 +274,8 @@ func (s *schema) getTenants(class string) ([]*models.Tenant, error) {
 	// To avoid races between checking that multi tenancy is enabled and reading from the class itself,
 	// ensure we fetch both using the same lock.
 	// We will then read the tenants from the class using the more specific meta lock
-	info := s.ClassInfo(class)
-	meta := s.metaClass(class)
+	info := s.Classes[class].ClassInfo()
+	meta := s.Classes[class]
 	s.RUnlock()
 
 	// Check that the class exists, and that multi tenancy is enabled


### PR DESCRIPTION
### What's being changed:

Golang RWMutex are Write-preferred mutexes, this means that Write-locks will forbid further acquisition of the lock from reader until they can acquire and resolve. In this particular case we are calling RLock when we already hold an RLock on the schema mutex. Due to writer preference that might cause a deadlock where the write-lock will forbid the reader to double acquire the lock and the reader will never free the first lock.

Change the code to avoid calling twice RLock.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
