### PR TITLE
disable test due to eventual consistency

### DIFF
--- a/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
+++ b/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
@@ -12,11 +12,10 @@
 package grpc_tests
 
 import (
+	"acceptance_tests_with_client/fixtures"
 	"context"
 	"testing"
 	"time"
-
-	"acceptance_tests_with_client/fixtures"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +39,8 @@ func TestGRPC_Batch(t *testing.T) {
 }
 
 func TestGRPC_Batch_Cluster(t *testing.T) {
+	t.Skip("disabled due to eventual consistency failure. Re-enable when eventual consistency on batch is tackled. See: WEAVIATE-754")
+
 	ctx := context.Background()
 	compose, err := docker.New().
 		WithWeaviateClusterWithGRPC().

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -30,6 +30,10 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 		return 0, err
 	}
 
+	if class == nil {
+		return 0, fmt.Errorf("class is nil: %w", ErrNotFound)
+	}
+
 	if len(newProps) == 0 {
 		return 0, nil
 	}

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -124,10 +124,6 @@ func (h *Handler) DeleteClassProperty(ctx context.Context, principal *models.Pri
 
 func (h *Handler) setNewPropDefaults(class *models.Class, props ...*models.Property) error {
 	setPropertyDefaults(props...)
-	if err := validateUserProp(class, props...); err != nil {
-		return err
-	}
-
 	h.moduleConfig.SetSinglePropertyDefaults(class, props...)
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

* Disabling test as discussed to avoid red CI when merging RAFT to master. Will be re-enabled once eventual consistency issue is tackled.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
