### PR TITLE
make replication broadcast use timeout-able context

### DIFF
--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
@@ -164,7 +165,9 @@ func (c *coordinator[T]) Push(ctx context.Context,
 		return nil, 0, fmt.Errorf("%w : class %q shard %q", err, c.Class, c.Shard)
 	}
 	level := state.Level
-	nodeCh := c.broadcast(ctx, state.Hosts, ask, level)
+	//nolint:govet // we expressely don't want to cancel that context as the timeout will take care of it
+	ctxWithTimeout, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	nodeCh := c.broadcast(ctxWithTimeout, state.Hosts, ask, level)
 	return c.commitAll(context.Background(), nodeCh, com), level, nil
 }
 

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -106,7 +106,7 @@ func TestReplicatorPutObject(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.WClient.On("PutObject", ctx, n, cls, shard, anyVal, obj).Return(resp, nil)
+			f.WClient.On("PutObject", mock.Anything, n, cls, shard, anyVal, obj).Return(resp, nil)
 			f.WClient.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
 		}
 		err := rep.PutObject(ctx, shard, obj, All)
@@ -118,13 +118,13 @@ func TestReplicatorPutObject(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 
-		f.WClient.On("PutObject", ctx, "A", cls, shard, anyVal, obj).Return(resp, errAny).After(time.Second * 10)
-		f.WClient.On("Abort", ctx, "A", cls, shard, anyVal).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, "A", cls, shard, anyVal, obj).Return(resp, errAny).After(time.Second * 10)
+		f.WClient.On("Abort", mock.Anything, "A", cls, shard, anyVal).Return(resp, nil)
 
-		f.WClient.On("PutObject", ctx, "B", cls, shard, anyVal, obj).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, "B", cls, shard, anyVal, obj).Return(resp, nil)
 		f.WClient.On("Commit", ctx, "B", cls, shard, anyVal, anyVal).Return(errAny)
 
-		f.WClient.On("PutObject", ctx, "C", cls, shard, anyVal, obj).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, "C", cls, shard, anyVal, obj).Return(resp, nil)
 		f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil)
 		err := rep.PutObject(ctx, shard, obj, One)
 		assert.Nil(t, err)
@@ -135,10 +135,10 @@ func TestReplicatorPutObject(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes[:2] {
-			f.WClient.On("PutObject", ctx, n, cls, shard, anyVal, obj).Return(resp, nil)
+			f.WClient.On("PutObject", mock.Anything, n, cls, shard, anyVal, obj).Return(resp, nil)
 			f.WClient.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
 		}
-		f.WClient.On("PutObject", ctx, "C", cls, shard, anyVal, obj).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, "C", cls, shard, anyVal, obj).Return(resp, nil)
 		f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
 			*resp = SimpleResponse{Errors: []Error{{Msg: "e3"}}}
@@ -151,10 +151,10 @@ func TestReplicatorPutObject(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
-		f.WClient.On("PutObject", ctx, nodes[0], cls, shard, anyVal, obj).Return(resp, nil)
-		f.WClient.On("PutObject", ctx, nodes[1], cls, shard, anyVal, obj).Return(resp, errAny)
-		f.WClient.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
-		f.WClient.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, nodes[0], cls, shard, anyVal, obj).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, nodes[1], cls, shard, anyVal, obj).Return(resp, errAny)
+		f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 		err := rep.PutObject(ctx, shard, obj, All)
 		assert.ErrorIs(t, err, errReplicas)
@@ -164,11 +164,11 @@ func TestReplicatorPutObject(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
-		f.WClient.On("PutObject", ctx, nodes[0], cls, shard, anyVal, obj).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, nodes[0], cls, shard, anyVal, obj).Return(resp, nil)
 		resp2 := SimpleResponse{[]Error{{Err: errAny}}}
-		f.WClient.On("PutObject", ctx, nodes[1], cls, shard, anyVal, obj).Return(resp2, nil)
-		f.WClient.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
-		f.WClient.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("PutObject", mock.Anything, nodes[1], cls, shard, anyVal, obj).Return(resp2, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 		err := rep.PutObject(ctx, shard, obj, All)
 		assert.ErrorIs(t, err, errReplicas)
@@ -179,7 +179,7 @@ func TestReplicatorPutObject(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.WClient.On("PutObject", ctx, n, cls, shard, anyVal, obj).Return(resp, nil)
+			f.WClient.On("PutObject", mock.Anything, n, cls, shard, anyVal, obj).Return(resp, nil)
 		}
 		f.WClient.On("Commit", ctx, nodes[0], "C1", shard, anyVal, anyVal).Return(nil)
 		f.WClient.On("Commit", ctx, nodes[1], "C1", shard, anyVal, anyVal).Return(errAny)
@@ -203,7 +203,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.WClient.On("MergeObject", ctx, n, cls, shard, anyVal, merge).Return(resp, nil)
+			f.WClient.On("MergeObject", mock.Anything, n, cls, shard, anyVal, merge).Return(resp, nil)
 			f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
 		}
 		err := rep.MergeObject(ctx, shard, merge, All)
@@ -214,10 +214,10 @@ func TestReplicatorMergeObject(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
-		f.WClient.On("MergeObject", ctx, nodes[0], cls, shard, anyVal, merge).Return(resp, nil)
-		f.WClient.On("MergeObject", ctx, nodes[1], cls, shard, anyVal, merge).Return(resp, errAny)
-		f.WClient.On("Abort", ctx, nodes[0], cls, shard, anyVal).Return(resp, nil)
-		f.WClient.On("Abort", ctx, nodes[1], cls, shard, anyVal).Return(resp, nil)
+		f.WClient.On("MergeObject", mock.Anything, nodes[0], cls, shard, anyVal, merge).Return(resp, nil)
+		f.WClient.On("MergeObject", mock.Anything, nodes[1], cls, shard, anyVal, merge).Return(resp, errAny)
+		f.WClient.On("Abort", mock.Anything, nodes[0], cls, shard, anyVal).Return(resp, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
 		err := rep.MergeObject(ctx, shard, merge, All)
 		assert.ErrorIs(t, err, errReplicas)
@@ -227,11 +227,11 @@ func TestReplicatorMergeObject(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
-		f.WClient.On("MergeObject", ctx, nodes[0], cls, shard, anyVal, merge).Return(resp, nil)
+		f.WClient.On("MergeObject", mock.Anything, nodes[0], cls, shard, anyVal, merge).Return(resp, nil)
 		resp2 := SimpleResponse{[]Error{{Err: errAny}}}
-		f.WClient.On("MergeObject", ctx, nodes[1], cls, shard, anyVal, merge).Return(resp2, nil)
-		f.WClient.On("Abort", ctx, nodes[0], cls, shard, anyVal).Return(resp, nil)
-		f.WClient.On("Abort", ctx, nodes[1], cls, shard, anyVal).Return(resp, nil)
+		f.WClient.On("MergeObject", mock.Anything, nodes[1], cls, shard, anyVal, merge).Return(resp2, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[0], cls, shard, anyVal).Return(resp, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
 		err := rep.MergeObject(ctx, shard, merge, All)
 		assert.ErrorIs(t, err, errReplicas)
@@ -242,7 +242,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.WClient.On("MergeObject", ctx, n, cls, shard, anyVal, merge).Return(resp, nil)
+			f.WClient.On("MergeObject", mock.Anything, n, cls, shard, anyVal, merge).Return(resp, nil)
 		}
 		f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil)
 		f.WClient.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)
@@ -266,12 +266,12 @@ func TestReplicatorDeleteObject(t *testing.T) {
 		rep := factory.newReplicator()
 		resp := SimpleResponse{Errors: make([]Error, 1)}
 		for _, n := range nodes[:2] {
-			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid).Return(resp, nil)
 			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
 		}
-		client.On("DeleteObject", ctx, "C", cls, shard, anyVal, uuid).Return(SimpleResponse{}, errAny)
+		client.On("DeleteObject", mock.Anything, "C", cls, shard, anyVal, uuid).Return(SimpleResponse{}, errAny)
 		for _, n := range nodes {
-			client.On("Abort", ctx, n, "C1", shard, anyVal).Return(resp, nil)
+			client.On("Abort", mock.Anything, n, "C1", shard, anyVal).Return(resp, nil)
 		}
 
 		err := rep.DeleteObject(ctx, shard, uuid, All)
@@ -285,7 +285,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 		rep := factory.newReplicator()
 		resp := SimpleResponse{Errors: make([]Error, 1)}
 		for _, n := range nodes {
-			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid).Return(resp, nil)
 			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
 		}
 		assert.Nil(t, rep.DeleteObject(ctx, shard, uuid, All))
@@ -298,7 +298,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 		rep := factory.newReplicator()
 		resp := SimpleResponse{Errors: make([]Error, 1)}
 		for _, n := range nodes[:2] {
-			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid).Return(resp, nil)
 			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*SimpleResponse)
 				*resp = SimpleResponse{
@@ -306,7 +306,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 				}
 			}
 		}
-		client.On("DeleteObject", ctx, "C", cls, shard, anyVal, uuid).Return(resp, nil)
+		client.On("DeleteObject", mock.Anything, "C", cls, shard, anyVal, uuid).Return(resp, nil)
 		client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
 			*resp = SimpleResponse{
@@ -325,7 +325,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 		rep := factory.newReplicator()
 		resp := SimpleResponse{Errors: make([]Error, 1)}
 		for _, n := range nodes[:2] {
-			client.On("DeleteObject", ctx, n, cls, shard, anyVal, uuid).Return(resp, nil)
+			client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid).Return(resp, nil)
 			client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*SimpleResponse)
 				*resp = SimpleResponse{
@@ -333,7 +333,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 				}
 			}
 		}
-		client.On("DeleteObject", ctx, "C", cls, shard, anyVal, uuid).Return(resp, nil)
+		client.On("DeleteObject", mock.Anything, "C", cls, shard, anyVal, uuid).Return(resp, nil)
 		client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
 			*resp = SimpleResponse{
@@ -359,10 +359,10 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		factory := newFakeFactory("C1", shard, nodes)
 		client := factory.WClient
 		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
-		client.On("DeleteObjects", ctx, nodes[0], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
-		client.On("DeleteObjects", ctx, nodes[1], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, errAny)
+		client.On("DeleteObjects", mock.Anything, nodes[0], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
+		client.On("DeleteObjects", mock.Anything, nodes[1], cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, errAny)
 		for _, n := range nodes {
-			client.On("Abort", ctx, n, "C1", shard, anyVal).Return(SimpleResponse{}, nil)
+			client.On("Abort", mock.Anything, n, "C1", shard, anyVal).Return(SimpleResponse{}, nil)
 		}
 		result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, false, All)
 		assert.Equal(t, len(result), 2)
@@ -376,7 +376,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		client := factory.WClient
 		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		for _, n := range nodes {
-			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
+			client.On("DeleteObjects", mock.Anything, n, cls, shard, anyVal, docIDs, false).Return(SimpleResponse{}, nil)
 			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(errAny)
 		}
 		result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, false, All)
@@ -389,7 +389,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		for _, n := range nodes {
-			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+			client.On("DeleteObjects", mock.Anything, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
 			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
 				resp := args[5].(*DeleteBatchResponse)
 				*resp = DeleteBatchResponse{
@@ -409,7 +409,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		for _, n := range nodes {
-			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+			client.On("DeleteObjects", mock.Anything, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
 			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
 				resp := args[5].(*DeleteBatchResponse)
 				*resp = DeleteBatchResponse{
@@ -429,8 +429,8 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		rep := factory.newReplicator()
 		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
-		client.On("DeleteObjects", ctx, nodes[0], cls, shard, anyVal, docIDs, false).Return(resp1, nil)
-		client.On("DeleteObjects", ctx, nodes[1], cls, shard, anyVal, docIDs, false).Return(resp1, errAny)
+		client.On("DeleteObjects", mock.Anything, nodes[0], cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+		client.On("DeleteObjects", mock.Anything, nodes[1], cls, shard, anyVal, docIDs, false).Return(resp1, errAny)
 		client.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
 			resp := args[5].(*DeleteBatchResponse)
 			*resp = DeleteBatchResponse{
@@ -449,7 +449,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 		docIDs := []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2")}
 		resp1 := SimpleResponse{}
 		for _, n := range nodes {
-			client.On("DeleteObjects", ctx, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
+			client.On("DeleteObjects", mock.Anything, n, cls, shard, anyVal, docIDs, false).Return(resp1, nil)
 		}
 		for _, n := range nodes[:2] {
 			client.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(args mock.Arguments) {
@@ -485,7 +485,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{Errors: make([]Error, 3)}
 		for _, n := range nodes {
-			f.WClient.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp, nil)
+			f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs).Return(resp, nil)
 			f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
 		}
 		errs := rep.PutObjects(ctx, shard, objs, All)
@@ -496,13 +496,13 @@ func TestReplicatorPutObjects(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		for _, n := range nodes[:2] {
-			f.WClient.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
+			f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs).Return(resp1, nil)
 			f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*SimpleResponse)
 				*resp = SimpleResponse{Errors: []Error{{}, {}, {Msg: "e3"}}}
 			}
 		}
-		f.WClient.On("PutObjects", ctx, "C", cls, shard, anyVal, objs).Return(resp1, nil)
+		f.WClient.On("PutObjects", mock.Anything, "C", cls, shard, anyVal, objs).Return(resp1, nil)
 		f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
 			*resp = SimpleResponse{Errors: make([]Error, 3)}
@@ -516,13 +516,13 @@ func TestReplicatorPutObjects(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		for _, n := range nodes[:2] {
-			f.WClient.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
+			f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs).Return(resp1, nil)
 			f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*SimpleResponse)
 				*resp = SimpleResponse{Errors: []Error{{}}}
 			}
 		}
-		f.WClient.On("PutObjects", ctx, "C", cls, shard, anyVal, objs).Return(resp1, nil)
+		f.WClient.On("PutObjects", mock.Anything, "C", cls, shard, anyVal, objs).Return(resp1, nil)
 		f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
 			*resp = SimpleResponse{Errors: []Error{{Msg: "e3"}}}
@@ -534,10 +534,10 @@ func TestReplicatorPutObjects(t *testing.T) {
 	t.Run("PhaseOneConnectionError", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
-		f.WClient.On("PutObjects", ctx, nodes[0], cls, shard, anyVal, objs).Return(resp1, nil)
-		f.WClient.On("PutObjects", ctx, nodes[1], cls, shard, anyVal, objs).Return(resp1, errAny)
-		f.WClient.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
-		f.WClient.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
+		f.WClient.On("PutObjects", mock.Anything, nodes[0], cls, shard, anyVal, objs).Return(resp1, nil)
+		f.WClient.On("PutObjects", mock.Anything, nodes[1], cls, shard, anyVal, objs).Return(resp1, errAny)
+		f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
 
 		errs := rep.PutObjects(ctx, shard, objs, All)
 		assert.Equal(t, 3, len(errs))
@@ -547,11 +547,11 @@ func TestReplicatorPutObjects(t *testing.T) {
 	t.Run("PhaseOneUnsuccessfulResponse", func(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
-		f.WClient.On("PutObjects", ctx, nodes[0], cls, shard, anyVal, objs).Return(resp1, nil)
+		f.WClient.On("PutObjects", mock.Anything, nodes[0], cls, shard, anyVal, objs).Return(resp1, nil)
 		resp2 := SimpleResponse{[]Error{{Msg: "E1"}, {Msg: "E2"}}}
-		f.WClient.On("PutObjects", ctx, nodes[1], cls, shard, anyVal, objs).Return(resp2, nil)
-		f.WClient.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
-		f.WClient.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
+		f.WClient.On("PutObjects", mock.Anything, nodes[1], cls, shard, anyVal, objs).Return(resp2, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
 
 		errs := rep.PutObjects(ctx, shard, objs, All)
 		assert.Equal(t, 3, len(errs))
@@ -564,7 +564,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		f := newFakeFactory(cls, shard, nodes)
 		rep := f.newReplicator()
 		for _, n := range nodes {
-			f.WClient.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
+			f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs).Return(resp1, nil)
 		}
 		f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
@@ -584,7 +584,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		rep := f.newReplicator()
 		node2Errs := []Error{{Msg: "E1"}, {}, {Msg: "E3"}}
 		for _, n := range nodes {
-			f.WClient.On("PutObjects", ctx, n, cls, shard, anyVal, objs).Return(resp1, nil)
+			f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs).Return(resp1, nil)
 		}
 		f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 			resp := a[5].(*SimpleResponse)
@@ -616,7 +616,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.WClient.On("AddReferences", ctx, n, cls, shard, anyVal, refs).Return(resp, nil)
+			f.WClient.On("AddReferences", mock.Anything, n, cls, shard, anyVal, refs).Return(resp, nil)
 			f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
 		}
 		errs := rep.AddReferences(ctx, shard, refs, All)
@@ -627,10 +627,10 @@ func TestReplicatorAddReferences(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
-		f.WClient.On("AddReferences", ctx, nodes[0], cls, shard, anyVal, refs).Return(resp, nil)
-		f.WClient.On("AddReferences", ctx, nodes[1], cls, shard, anyVal, refs).Return(resp, errAny)
-		f.WClient.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
-		f.WClient.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("AddReferences", mock.Anything, nodes[0], cls, shard, anyVal, refs).Return(resp, nil)
+		f.WClient.On("AddReferences", mock.Anything, nodes[1], cls, shard, anyVal, refs).Return(resp, errAny)
+		f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 		errs := rep.AddReferences(ctx, shard, refs, All)
 		assert.Equal(t, 2, len(errs))
@@ -641,11 +641,11 @@ func TestReplicatorAddReferences(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
-		f.WClient.On("AddReferences", ctx, nodes[0], cls, shard, anyVal, refs).Return(resp, nil)
+		f.WClient.On("AddReferences", mock.Anything, nodes[0], cls, shard, anyVal, refs).Return(resp, nil)
 		resp2 := SimpleResponse{[]Error{{Msg: "E1"}, {Msg: "E2"}}}
-		f.WClient.On("AddReferences", ctx, nodes[1], cls, shard, anyVal, refs).Return(resp2, nil)
-		f.WClient.On("Abort", ctx, nodes[0], "C1", shard, anyVal).Return(resp, nil)
-		f.WClient.On("Abort", ctx, nodes[1], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("AddReferences", mock.Anything, nodes[1], cls, shard, anyVal, refs).Return(resp2, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
+		f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 		errs := rep.AddReferences(ctx, shard, refs, All)
 		assert.Equal(t, 2, len(errs))
@@ -659,7 +659,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 		rep := f.newReplicator()
 		resp := SimpleResponse{}
 		for _, n := range nodes {
-			f.WClient.On("AddReferences", ctx, n, cls, shard, anyVal, refs).Return(resp, nil)
+			f.WClient.On("AddReferences", mock.Anything, n, cls, shard, anyVal, refs).Return(resp, nil)
 		}
 		f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil)
 		f.WClient.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)


### PR DESCRIPTION
### What's being changed:

* Make replication use a background context to avoid cancelling replication to node after consistency level is reached.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
