### PR TITLE
Add Pagination to Get Tenants Endpoint

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2778,6 +2778,18 @@ func init() {
             "description": "If consistency is true, the request will be proxied to the leader to ensure strong schema consistency",
             "name": "consistency",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "If tenant is provided, the pagination cursor will start after this tenant.",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "The maximum number of tenants to return.",
+            "name": "limit",
+            "in": "query"
           }
         ],
         "responses": {
@@ -7988,6 +8000,18 @@ func init() {
             "description": "If consistency is true, the request will be proxied to the leader to ensure strong schema consistency",
             "name": "consistency",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "If tenant is provided, the pagination cursor will start after this tenant.",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "The maximum number of tenants to return.",
+            "name": "limit",
+            "in": "query"
           }
         ],
         "responses": {

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -240,7 +240,7 @@ func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 	}
 
 	s.metricRequestsTotal.logOk(params.ClassName)
-	return schema.NewTenantsCreateOK() //.WithPayload(created)
+	return schema.NewTenantsCreateOK() // .WithPayload(created)
 }
 
 func (s *schemaHandlers) updateTenants(params schema.TenantsUpdateParams,
@@ -290,7 +290,7 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 func (s *schemaHandlers) getTenants(params schema.TenantsGetParams,
 	principal *models.Principal,
 ) middleware.Responder {
-	tenants, err := s.manager.GetConsistentTenants(params.HTTPRequest.Context(), principal, params.ClassName, *params.Consistency)
+	tenants, err := s.manager.GetConsistentTenants(params.HTTPRequest.Context(), principal, params.ClassName, *params.Consistency, params.After, params.Limit)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch err.(type) {

--- a/adapters/handlers/rest/operations/schema/tenants_get_parameters.go
+++ b/adapters/handlers/rest/operations/schema/tenants_get_parameters.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -49,6 +50,10 @@ type TenantsGetParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*If tenant is provided, the pagination cursor will start after this tenant.
+	  In: query
+	*/
+	After *string
 	/*
 	  Required: true
 	  In: path
@@ -59,6 +64,10 @@ type TenantsGetParams struct {
 	  Default: true
 	*/
 	Consistency *bool
+	/*The maximum number of tenants to return.
+	  In: query
+	*/
+	Limit *int64
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -70,6 +79,13 @@ func (o *TenantsGetParams) BindRequest(r *http.Request, route *middleware.Matche
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qAfter, qhkAfter, _ := qs.GetOK("after")
+	if err := o.bindAfter(qAfter, qhkAfter, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	rClassName, rhkClassName, _ := route.Params.GetOK("className")
 	if err := o.bindClassName(rClassName, rhkClassName, route.Formats); err != nil {
 		res = append(res, err)
@@ -78,9 +94,32 @@ func (o *TenantsGetParams) BindRequest(r *http.Request, route *middleware.Matche
 	if err := o.bindConsistency(r.Header[http.CanonicalHeaderKey("consistency")], true, route.Formats); err != nil {
 		res = append(res, err)
 	}
+
+	qLimit, qhkLimit, _ := qs.GetOK("limit")
+	if err := o.bindLimit(qLimit, qhkLimit, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindAfter binds and validates parameter After from query.
+func (o *TenantsGetParams) bindAfter(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.After = &raw
+
 	return nil
 }
 
@@ -117,6 +156,29 @@ func (o *TenantsGetParams) bindConsistency(rawData []string, hasKey bool, format
 		return errors.InvalidType("consistency", "header", "bool", raw)
 	}
 	o.Consistency = &value
+
+	return nil
+}
+
+// bindLimit binds and validates parameter Limit from query.
+func (o *TenantsGetParams) bindLimit(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertInt64(raw)
+	if err != nil {
+		return errors.InvalidType("limit", "query", "int64", raw)
+	}
+	o.Limit = &value
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/schema/tenants_get_urlbuilder.go
+++ b/adapters/handlers/rest/operations/schema/tenants_get_urlbuilder.go
@@ -21,11 +21,16 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
+
+	"github.com/go-openapi/swag"
 )
 
 // TenantsGetURL generates an URL for the tenants get operation
 type TenantsGetURL struct {
 	ClassName string
+
+	After *string
+	Limit *int64
 
 	_basePath string
 	// avoid unkeyed usage
@@ -65,6 +70,26 @@ func (o *TenantsGetURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var afterQ string
+	if o.After != nil {
+		afterQ = *o.After
+	}
+	if afterQ != "" {
+		qs.Set("after", afterQ)
+	}
+
+	var limitQ string
+	if o.Limit != nil {
+		limitQ = swag.FormatInt64(*o.Limit)
+	}
+	if limitQ != "" {
+		qs.Set("limit", limitQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/client/schema/tenants_get_parameters.go
+++ b/client/schema/tenants_get_parameters.go
@@ -73,6 +73,12 @@ TenantsGetParams contains all the parameters to send to the API endpoint
 */
 type TenantsGetParams struct {
 
+	/* After.
+
+	   If tenant is provided, the pagination cursor will start after this tenant.
+	*/
+	After *string
+
 	// ClassName.
 	ClassName string
 
@@ -83,6 +89,12 @@ type TenantsGetParams struct {
 	   Default: true
 	*/
 	Consistency *bool
+
+	/* Limit.
+
+	   The maximum number of tenants to return.
+	*/
+	Limit *int64
 
 	timeout    time.Duration
 	Context    context.Context
@@ -148,6 +160,17 @@ func (o *TenantsGetParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAfter adds the after to the tenants get params
+func (o *TenantsGetParams) WithAfter(after *string) *TenantsGetParams {
+	o.SetAfter(after)
+	return o
+}
+
+// SetAfter adds the after to the tenants get params
+func (o *TenantsGetParams) SetAfter(after *string) {
+	o.After = after
+}
+
 // WithClassName adds the className to the tenants get params
 func (o *TenantsGetParams) WithClassName(className string) *TenantsGetParams {
 	o.SetClassName(className)
@@ -170,6 +193,17 @@ func (o *TenantsGetParams) SetConsistency(consistency *bool) {
 	o.Consistency = consistency
 }
 
+// WithLimit adds the limit to the tenants get params
+func (o *TenantsGetParams) WithLimit(limit *int64) *TenantsGetParams {
+	o.SetLimit(limit)
+	return o
+}
+
+// SetLimit adds the limit to the tenants get params
+func (o *TenantsGetParams) SetLimit(limit *int64) {
+	o.Limit = limit
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *TenantsGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -177,6 +211,23 @@ func (o *TenantsGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
+
+	if o.After != nil {
+
+		// query param after
+		var qrAfter string
+
+		if o.After != nil {
+			qrAfter = *o.After
+		}
+		qAfter := qrAfter
+		if qAfter != "" {
+
+			if err := r.SetQueryParam("after", qAfter); err != nil {
+				return err
+			}
+		}
+	}
 
 	// path param className
 	if err := r.SetPathParam("className", o.ClassName); err != nil {
@@ -188,6 +239,23 @@ func (o *TenantsGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		// header param consistency
 		if err := r.SetHeaderParam("consistency", swag.FormatBool(*o.Consistency)); err != nil {
 			return err
+		}
+	}
+
+	if o.Limit != nil {
+
+		// query param limit
+		var qrLimit int64
+
+		if o.Limit != nil {
+			qrLimit = *o.Limit
+		}
+		qLimit := swag.FormatInt64(qrLimit)
+		if qLimit != "" {
+
+			if err := r.SetQueryParam("limit", qLimit); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cluster/proto/api/request.go
+++ b/cluster/proto/api/request.go
@@ -49,6 +49,8 @@ type QueryReadOnlyClassResponse struct {
 
 type QueryTenantsRequest struct {
 	Class string
+	After *string
+	Limit *int64
 }
 
 type TenantWithVersion struct {

--- a/cluster/store/query.go
+++ b/cluster/store/query.go
@@ -98,7 +98,7 @@ func (st *Store) QueryTenants(req *cmd.QueryRequest) ([]byte, error) {
 	}
 
 	// Read the tenants
-	tenants, err := st.db.Schema.getTenants(subCommand.Class)
+	tenants, err := st.db.Schema.getTenants(subCommand.Class, subCommand.After, subCommand.Limit)
 	if err != nil {
 		return []byte{}, fmt.Errorf("could not get tenants: %w", err)
 	}

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -338,9 +338,9 @@ func (s *Service) QuerySchema() (models.Schema, error) {
 
 // QueryTenants build a Query to read the tenants of a given class that will be directed to the leader to ensure we
 // will read the class with strong consistency
-func (s *Service) QueryTenants(class string) ([]*models.Tenant, uint64, error) {
+func (s *Service) QueryTenants(class string, after *string, limit *int64) ([]*models.Tenant, uint64, error) {
 	// Build the query and execute it
-	req := cmd.QueryTenantsRequest{Class: class}
+	req := cmd.QueryTenantsRequest{Class: class, After: after, Limit: limit}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
 		return []*models.Tenant{}, 0, fmt.Errorf("marshal request: %w", err)

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -4507,7 +4507,20 @@
             "default": true,
             "type": "boolean",
             "description": "If consistency is true, the request will be proxied to the leader to ensure strong schema consistency"
-          }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If tenant is provided, the pagination cursor will start after this tenant."
+           },
+           {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "description": "The maximum number of tenants to return."
+           }
         ],
         "responses": {
           "200": {

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -32,6 +32,10 @@ import (
 // potentially protected with the Authorization plugin
 
 func Test_Schema_Authorization(t *testing.T) {
+	var (
+		after = "after"
+		limit = int64(1)
+	)
 	type testCase struct {
 		methodName       string
 		additionalArgs   []interface{}
@@ -127,13 +131,13 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:       "GetTenants",
-			additionalArgs:   []interface{}{"className"},
+			additionalArgs:   []interface{}{"className", &after, &limit},
 			expectedVerb:     "get",
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "GetConsistentTenants",
-			additionalArgs:   []interface{}{"className", false},
+			additionalArgs:   []interface{}{"className", false, &after, &limit},
 			expectedVerb:     "get",
 			expectedResource: tenantsPath,
 		},

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -73,6 +73,14 @@ func (f *fakeMetaHandler) DeleteTenants(class string, req *command.DeleteTenants
 	return 0, args.Error(0)
 }
 
+func (f *fakeMetaHandler) GetConsistentTenants(ctx context.Context, class string, consistency bool, after *string, tenant *int64) ([]*models.Tenant, error) {
+	args := f.Called(ctx, class, consistency, after, tenant)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.Tenant), args.Error(1)
+}
+
 func (f *fakeMetaHandler) Join(ctx context.Context, nodeID, raftAddr string, voter bool) error {
 	args := f.Called(ctx, nodeID, raftAddr, voter)
 	return args.Error(0)
@@ -129,9 +137,12 @@ func (f *fakeMetaHandler) QueryReadOnlyClass(class string) (*models.Class, uint6
 	return model.(*models.Class), 0, nil
 }
 
-func (f *fakeMetaHandler) QueryTenants(class string) ([]*models.Tenant, uint64, error) {
-	args := f.Called(class)
-	return nil, 0, args.Error(0)
+func (f *fakeMetaHandler) QueryTenants(class string, after *string, limit *int64) ([]*models.Tenant, uint64, error) {
+	args := f.Called(class, after, limit)
+	if args.Get(0) == nil {
+		return nil, 0, args.Error(2)
+	}
+	return args.Get(0).([]*models.Tenant), args.Get(1).(uint64), args.Error(2)
 }
 
 func (f *fakeMetaHandler) QueryShardOwner(class, shard string) (string, uint64, error) {

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -28,6 +28,7 @@ import (
 )
 
 var ErrNotFound = errors.New("not found")
+var ErrNotEnabled = errors.New("multi-tenancy not enabled")
 
 type metaWriter interface {
 	// Schema writes operation
@@ -45,7 +46,7 @@ type metaWriter interface {
 	// from an up to date schema.
 	QueryReadOnlyClass(name string) (*models.Class, uint64, error)
 	QuerySchema() (models.Schema, error)
-	QueryTenants(class string) ([]*models.Tenant, uint64, error)
+	QueryTenants(class string, after *string, limit *int64) ([]*models.Tenant, uint64, error)
 	QueryShardOwner(class, shard string) (string, uint64, error)
 
 	// Cluster related operations

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -348,7 +348,7 @@ func (m *Manager) ResolveParentNodes(class, shardName string) (map[string]string
 }
 
 func (m *Manager) TenantShard(class, tenant string) (string, string) {
-	tenants, _, err := m.metaWriter.QueryTenants(class)
+	tenants, _, err := m.metaWriter.QueryTenants(class, nil, nil)
 	if err != nil {
 		return "", ""
 	}


### PR DESCRIPTION
Add Pagination to GetConsistentTenants endpoint

Updated GetConsistentTenants endpoint with `after` and `limit` vars in  to implement pagination for th endpoint. This required  the following: the implementation of QueryTenantRequest by  the `after` and `limit` vars. Also, the implementation of  (original handler.getTenant and cluster/store schema.getTenants) method with the addition of `after` and `limit` vars  which the addition of implementation of pagination in its code. Note, we now create the tenant slice based on the limit
size, or if it's not set, the len of `ss.Physical`.

`after` is the tenant for which GET of tenants will be AFTER.
`limit` is the limit of tenants we GET.

Added test for GetConsistenTenants endpoint.

Added additional test case for QueryTenants test case in cluster store for TestServiceEndpoints to ensure after and limit worked correctly the cluster store as well.

Note, I did not create a test for the old `GetTenants` method previously used for the GET Tenants before the `GetConsistentTenants` was created recently even though I updated its private getTenants implementation to handle pagination, which is used in `GetConsistentTenants`, because this function appears to be no longer used. Should I remove it as part of this change?

Close #4234 
