### PR TITLE
Schema v2 props upsert

### DIFF
--- a/cluster/store/meta_class.go
+++ b/cluster/store/meta_class.go
@@ -140,7 +140,7 @@ func (m *metaClass) AddProperty(v uint64, props ...*models.Property) error {
 // mergeProps makes sure duplicates are not created by ignoring new props
 // with the same names as old props.
 // If property of nested type is present in both new and old slices,
-// final property is created by merging new propertu into copy of old one
+// final property is created by merging new property into copy of old one
 func mergeProps(old, new []*models.Property) []*models.Property {
 	mergedProps := make([]*models.Property, len(old), len(old)+len(new))
 	copy(mergedProps, old)

--- a/cluster/store/meta_class.go
+++ b/cluster/store/meta_class.go
@@ -18,6 +18,7 @@ import (
 
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
+	entSchema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"golang.org/x/exp/slices"
 )
@@ -130,32 +131,44 @@ func (m *metaClass) AddProperty(v uint64, props ...*models.Property) error {
 	defer m.Unlock()
 
 	// update all at once to prevent race condition with concurrent readers
-	src := filterOutDuplicates(m.Class.Properties, props)
-	dest := make([]*models.Property, len(src)+len(props))
-	copy(dest, append(src, props...))
-	m.Class.Properties = dest
+	mergedProps := mergeProps(m.Class.Properties, props)
+	m.Class.Properties = mergedProps
 	m.ClassVersion = v
 	return nil
 }
 
-// filterOutDuplicates removes from the old any existing property could cause duplication
-func filterOutDuplicates(old, new []*models.Property) []*models.Property {
+// mergeProps makes sure duplicates are not created by ignoring new props
+// with the same names as old props.
+// If property of nested type is present in both new and old slices,
+// final property is created by merging new propertu into copy of old one
+func mergeProps(old, new []*models.Property) []*models.Property {
+	mergedProps := make([]*models.Property, len(old), len(old)+len(new))
+	copy(mergedProps, old)
+
 	// create memory to avoid duplication
-	var newUnique []*models.Property
-	mem := make(map[string]int, len(new))
-	for idx := range new {
-		mem[strings.ToLower(new[idx].Name)] = idx
-	}
-
-	// pick only what is not in the new proprieties
+	mem := make(map[string]int, len(old))
 	for idx := range old {
-		if _, exists := mem[strings.ToLower(old[idx].Name)]; exists {
-			continue
-		}
-		newUnique = append(newUnique, old[idx])
+		mem[strings.ToLower(old[idx].Name)] = idx
 	}
 
-	return newUnique
+	// pick ones not present in old slice or merge nested properties
+	// if already present
+	for idx := range new {
+		if oldIdx, exists := mem[strings.ToLower(new[idx].Name)]; !exists {
+			mergedProps = append(mergedProps, new[idx])
+		} else {
+			nestedProperties, merged := entSchema.MergeRecursivelyNestedProperties(
+				mergedProps[oldIdx].NestedProperties,
+				new[idx].NestedProperties)
+			if merged {
+				propCopy := *mergedProps[oldIdx]
+				propCopy.NestedProperties = nestedProperties
+				mergedProps[oldIdx] = &propCopy
+			}
+		}
+	}
+
+	return mergedProps
 }
 
 func (m *metaClass) AddTenants(nodeID string, req *command.AddTenantsRequest, v uint64) error {

--- a/entities/schema/nested_properties.go
+++ b/entities/schema/nested_properties.go
@@ -13,9 +13,9 @@ package schema
 
 import "github.com/weaviate/weaviate/entities/models"
 
-// merges nestPropsNew with nestPropsOld
-// returns new slice without changing input ones
-// and bool indicating whether there was changes done comparing to base slice
+// Merges nestPropsNew with nestPropsOld
+// Returns new slice without changing input ones and
+// bool indicating whether merged slice is different than the old one
 func MergeRecursivelyNestedProperties(nestPropsOld, nestPropsNew []*models.NestedProperty,
 ) ([]*models.NestedProperty, bool) {
 	merged := false
@@ -50,6 +50,7 @@ func MergeRecursivelyNestedProperties(nestPropsOld, nestPropsNew []*models.Neste
 	return nestPropsMerged, merged
 }
 
+// Determines diff between nestPropsNew and nestPropsOld slices
 func DiffRecursivelyNestedProperties(nestPropsOld, nestPropsNew []*models.NestedProperty,
 ) []*models.NestedProperty {
 	nestPropsDiff := make([]*models.NestedProperty, 0, len(nestPropsNew))

--- a/entities/schema/nested_properties.go
+++ b/entities/schema/nested_properties.go
@@ -13,37 +13,70 @@ package schema
 
 import "github.com/weaviate/weaviate/entities/models"
 
-// merges nPropsExt with nPropsBase
+// merges nestPropsNew with nestPropsOld
 // returns new slice without changing input ones
 // and bool indicating whether there was changes done comparing to base slice
-func MergeRecursivelyNestedProperties(nPropsBase, nPropsExt []*models.NestedProperty,
+func MergeRecursivelyNestedProperties(nestPropsOld, nestPropsNew []*models.NestedProperty,
 ) ([]*models.NestedProperty, bool) {
 	merged := false
-	nProps := make([]*models.NestedProperty, len(nPropsBase), len(nPropsBase)+len(nPropsExt))
-	copy(nProps, nPropsBase)
+	nestPropsMerged := make([]*models.NestedProperty, len(nestPropsOld), len(nestPropsOld)+len(nestPropsNew))
+	copy(nestPropsMerged, nestPropsOld)
 
 	existingIndexMap := map[string]int{}
-	for index := range nProps {
-		existingIndexMap[nProps[index].Name] = index
+	for i := range nestPropsMerged {
+		existingIndexMap[nestPropsMerged[i].Name] = i
 	}
 
-	for _, nProp := range nPropsExt {
-		index, exists := existingIndexMap[nProp.Name]
+	for _, nestPropNew := range nestPropsNew {
+		i, exists := existingIndexMap[nestPropNew.Name]
 		if !exists {
-			existingIndexMap[nProp.Name] = len(nProps)
-			nProps = append(nProps, nProp)
+			existingIndexMap[nestPropNew.Name] = len(nestPropsMerged)
+			nestPropsMerged = append(nestPropsMerged, nestPropNew)
 			merged = true
-		} else if _, isNested := AsNested(nProps[index].DataType); isNested {
-			if mergedProps, mergedNested := MergeRecursivelyNestedProperties(nProps[index].NestedProperties,
-				nProp.NestedProperties,
-			); mergedNested {
-				nPropCopy := *nProps[index]
-				nProps[index] = &nPropCopy
-				nProps[index].NestedProperties = mergedProps
+		} else if _, isNested := AsNested(nestPropsMerged[i].DataType); isNested {
+			if recurNestProps, recurMerged := MergeRecursivelyNestedProperties(
+				nestPropsMerged[i].NestedProperties,
+				nestPropNew.NestedProperties,
+			); recurMerged {
+				nestPropCopy := *nestPropsMerged[i]
+				nestPropCopy.NestedProperties = recurNestProps
+
+				nestPropsMerged[i] = &nestPropCopy
 				merged = true
 			}
 		}
 	}
 
-	return nProps, merged
+	return nestPropsMerged, merged
+}
+
+func DiffRecursivelyNestedProperties(nestPropsOld, nestPropsNew []*models.NestedProperty,
+) []*models.NestedProperty {
+	nestPropsDiff := make([]*models.NestedProperty, 0, len(nestPropsNew))
+
+	existingIndexMap := map[string]int{}
+	for i := range nestPropsOld {
+		existingIndexMap[nestPropsOld[i].Name] = i
+	}
+
+	for _, nestPropNew := range nestPropsNew {
+		i, exists := existingIndexMap[nestPropNew.Name]
+		if !exists {
+			existingIndexMap[nestPropNew.Name] = len(nestPropsDiff)
+			nestPropsDiff = append(nestPropsDiff, nestPropNew)
+		} else if _, isNested := AsNested(nestPropsOld[i].DataType); isNested {
+			if recurNestProps := DiffRecursivelyNestedProperties(
+				nestPropsOld[i].NestedProperties,
+				nestPropNew.NestedProperties,
+			); len(recurNestProps) > 0 {
+				nestPropCopy := *nestPropsOld[i]
+				nestPropCopy.NestedProperties = recurNestProps
+
+				existingIndexMap[nestPropCopy.Name] = len(nestPropsDiff)
+				nestPropsDiff = append(nestPropsDiff, &nestPropCopy)
+			}
+		}
+	}
+
+	return nestPropsDiff
 }

--- a/entities/schema/nested_properties_test.go
+++ b/entities/schema/nested_properties_test.go
@@ -251,3 +251,174 @@ func Test_MergeRecursivelyNestedProperties(t *testing.T) {
 		test_utils.AssertNestedPropsMatch(t, mergedProps_2_1, nestedProps)
 	})
 }
+
+func Test_DiffRecursivelyNestedProperties(t *testing.T) {
+	vFalse := false
+	vTrue := true
+
+	emptyProps := []*models.NestedProperty{}
+	nestedProps1 := []*models.NestedProperty{
+		{
+			Name:            "nested_int",
+			DataType:        schema.DataTypeInt.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "nested_text",
+			DataType:        schema.DataTypeText.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vTrue,
+			Tokenization:    models.PropertyTokenizationWord,
+		},
+		{
+			Name:            "nested_objects",
+			DataType:        schema.DataTypeObjectArray.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:            "nested_bool_lvl2",
+					DataType:        schema.DataTypeBoolean.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+				{
+					Name:            "nested_numbers_lvl2",
+					DataType:        schema.DataTypeNumberArray.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+			},
+		},
+	}
+	nestedProps2 := []*models.NestedProperty{
+		{
+			Name:            "nested_number",
+			DataType:        schema.DataTypeNumber.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "nested_text",
+			DataType:        schema.DataTypeText.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vTrue,
+			Tokenization:    models.PropertyTokenizationField, // different setting than (1)
+		},
+		{
+			Name:            "nested_objects",
+			DataType:        schema.DataTypeObjectArray.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:            "nested_date_lvl2",
+					DataType:        schema.DataTypeDate.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+				{
+					Name:            "nested_numbers_lvl2",
+					DataType:        schema.DataTypeNumberArray.PropString(),
+					IndexFilterable: &vFalse, // different setting than (1)
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+			},
+		},
+	}
+
+	mergedProps_1_2 := []*models.NestedProperty{
+		{
+			Name:            "nested_number",
+			DataType:        schema.DataTypeNumber.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "nested_objects",
+			DataType:        schema.DataTypeObjectArray.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:            "nested_date_lvl2",
+					DataType:        schema.DataTypeDate.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+			},
+		},
+	}
+
+	mergedProps_2_1 := []*models.NestedProperty{
+		{
+			Name:            "nested_int",
+			DataType:        schema.DataTypeInt.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "nested_objects",
+			DataType:        schema.DataTypeObjectArray.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:            "nested_bool_lvl2",
+					DataType:        schema.DataTypeBoolean.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+			},
+		},
+	}
+
+	t.Run("empty + nested", func(t *testing.T) {
+		nestedProps := schema.DiffRecursivelyNestedProperties(emptyProps, nestedProps1)
+
+		assert.Equal(t, nestedProps1, nestedProps)
+	})
+
+	t.Run("nested + empty", func(t *testing.T) {
+		nestedProps := schema.DiffRecursivelyNestedProperties(nestedProps1, emptyProps)
+
+		assert.Empty(t, nestedProps)
+	})
+
+	t.Run("2 x nested", func(t *testing.T) {
+		nestedProps := schema.DiffRecursivelyNestedProperties(nestedProps1, nestedProps1)
+
+		assert.Empty(t, nestedProps)
+	})
+
+	t.Run("nested1 + nested2", func(t *testing.T) {
+		nestedProps := schema.DiffRecursivelyNestedProperties(nestedProps1, nestedProps2)
+
+		assert.NotEqual(t, nestedProps1, nestedProps)
+		assert.NotEqual(t, nestedProps2, nestedProps)
+		test_utils.AssertNestedPropsMatch(t, mergedProps_1_2, nestedProps)
+	})
+
+	t.Run("nested2 + nested1", func(t *testing.T) {
+		nestedProps := schema.DiffRecursivelyNestedProperties(nestedProps2, nestedProps1)
+
+		assert.NotEqual(t, nestedProps1, nestedProps)
+		assert.NotEqual(t, nestedProps2, nestedProps)
+		test_utils.AssertNestedPropsMatch(t, mergedProps_2_1, nestedProps)
+	})
+}

--- a/entities/schema/properties.go
+++ b/entities/schema/properties.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import "github.com/weaviate/weaviate/entities/models"
+
+// DedupProperties removes from newProps slice properties already present in oldProps slice.
+// If property of nested type (object/object[]) is present in both slices,
+// diff is calculated to contain only those nested properties that are missing from
+// old property model
+func DedupProperties(oldProps, newProps []*models.Property) []*models.Property {
+	uniqueProps := make([]*models.Property, 0, len(newProps))
+
+	oldPropsByName := make(map[string]int, len(oldProps))
+	for idx := range oldProps {
+		oldPropsByName[oldProps[idx].Name] = idx
+	}
+	uniquePropsByName := make(map[string]int, len(newProps))
+	markedToDiff := make([]string, 0, len(newProps))
+
+	for _, newProp := range newProps {
+		propName := LowercaseFirstLetter(newProp.Name)
+
+		uniqueIdx, uniqueExists := uniquePropsByName[propName]
+		if !uniqueExists {
+			oldIdx, oldExists := oldPropsByName[propName]
+			if !oldExists {
+				uniquePropsByName[propName] = len(uniqueProps)
+				uniqueProps = append(uniqueProps, newProp)
+			} else {
+				oldProp := oldProps[oldIdx]
+				if _, isNested := AsNested(oldProp.DataType); isNested {
+					mergedNestedProps, merged := MergeRecursivelyNestedProperties(
+						oldProp.NestedProperties, newProp.NestedProperties)
+					if merged {
+						oldPropCopy := *oldProp
+						oldPropCopy.NestedProperties = mergedNestedProps
+						uniquePropsByName[propName] = len(uniqueProps)
+						uniqueProps = append(uniqueProps, &oldPropCopy)
+
+						markedToDiff = append(markedToDiff, propName)
+					}
+				}
+			}
+		} else {
+			uniqueProp := uniqueProps[uniqueIdx]
+			if _, isNested := AsNested(uniqueProp.DataType); isNested {
+				mergedNestedProps, merged := MergeRecursivelyNestedProperties(
+					uniqueProp.NestedProperties, newProp.NestedProperties)
+				if merged {
+					uniquePropCopy := *uniqueProp
+					uniquePropCopy.NestedProperties = mergedNestedProps
+					uniqueProps[uniqueIdx] = &uniquePropCopy
+				}
+			}
+		}
+	}
+
+	for _, propName := range markedToDiff {
+		uniqueIdx := uniquePropsByName[propName]
+		oldIdx := oldPropsByName[propName]
+
+		diffNestedProps := DiffRecursivelyNestedProperties(
+			oldProps[oldIdx].NestedProperties, uniqueProps[uniqueIdx].NestedProperties)
+		uniqueProps[uniqueIdx].NestedProperties = diffNestedProps
+	}
+
+	return uniqueProps
+}

--- a/entities/schema/properties_test.go
+++ b/entities/schema/properties_test.go
@@ -1,0 +1,631 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/test_utils"
+)
+
+func Test_DedupProperties(t *testing.T) {
+	vFalse := false
+	vTrue := true
+
+	nestedProps1 := []*models.NestedProperty{
+		{
+			Name:            "nested_int",
+			DataType:        schema.DataTypeInt.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "nested_text",
+			DataType:        schema.DataTypeText.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vTrue,
+			Tokenization:    models.PropertyTokenizationWord,
+		},
+		{
+			Name:            "nested_objects",
+			DataType:        schema.DataTypeObjectArray.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:            "nested_bool_lvl2",
+					DataType:        schema.DataTypeBoolean.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+				{
+					Name:            "nested_numbers_lvl2",
+					DataType:        schema.DataTypeNumberArray.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+			},
+		},
+	}
+	nestedProps2 := []*models.NestedProperty{
+		{
+			Name:            "nested_number",
+			DataType:        schema.DataTypeNumber.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "nested_text",
+			DataType:        schema.DataTypeText.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vTrue,
+			Tokenization:    models.PropertyTokenizationField, // different setting than (1)
+		},
+		{
+			Name:            "nested_objects",
+			DataType:        schema.DataTypeObjectArray.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name:            "nested_date_lvl2",
+					DataType:        schema.DataTypeDate.PropString(),
+					IndexFilterable: &vTrue,
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+				{
+					Name:            "nested_numbers_lvl2",
+					DataType:        schema.DataTypeNumberArray.PropString(),
+					IndexFilterable: &vFalse, // different setting than (1)
+					IndexSearchable: &vFalse,
+					Tokenization:    "",
+				},
+			},
+		},
+	}
+
+	props1 := []*models.Property{
+		{
+			Name:            "text",
+			DataType:        schema.DataTypeText.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vTrue,
+			Tokenization:    models.PropertyTokenizationWord,
+		},
+		{
+			Name:            "number",
+			DataType:        schema.DataTypeNumber.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:             "both_diff_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+		{
+			Name:             "both_diff_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+		{
+			Name:             "both_same_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+		{
+			Name:             "both_same_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+		{
+			Name:             "one_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+		{
+			Name:             "one_dup_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+		{
+			Name:             "one_dup_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+	}
+	props2 := []*models.Property{
+		{
+			Name:            "text",
+			DataType:        schema.DataTypeText.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    models.PropertyTokenizationWord,
+		},
+		{
+			Name:            "int",
+			DataType:        schema.DataTypeInt.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:            "bool",
+			DataType:        schema.DataTypeBoolean.PropString(),
+			IndexFilterable: &vTrue,
+			IndexSearchable: &vFalse,
+			Tokenization:    "",
+		},
+		{
+			Name:             "both_diff_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+		{
+			Name:             "both_diff_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+		{
+			Name:             "both_same_json1",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+		{
+			Name:             "both_same_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+		{
+			Name:             "one_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+		{
+			Name:             "one_dup_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps2,
+		},
+		{
+			Name:             "one_dup_json2",
+			DataType:         schema.DataTypeObject.PropString(),
+			IndexFilterable:  &vFalse,
+			IndexSearchable:  &vFalse,
+			Tokenization:     "",
+			NestedProperties: nestedProps1,
+		},
+	}
+
+	t.Run("props1 + props2", func(t *testing.T) {
+		props := schema.DedupProperties(props1, props2)
+
+		test_utils.AssertPropsMatch(t, props, []*models.Property{
+			{
+				Name:            "int",
+				DataType:        schema.DataTypeInt.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+			{
+				Name:            "bool",
+				DataType:        schema.DataTypeBoolean.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+			{
+				Name:            "both_diff_json1",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_number",
+						DataType:        schema.DataTypeNumber.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_date_lvl2",
+								DataType:        schema.DataTypeDate.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:            "both_diff_json2",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_int",
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_bool_lvl2",
+								DataType:        schema.DataTypeBoolean.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:            "one_json2",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_number",
+						DataType:        schema.DataTypeNumber.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_text",
+						DataType:        schema.DataTypeText.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vTrue,
+						Tokenization:    models.PropertyTokenizationField, // different setting than (1)
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_date_lvl2",
+								DataType:        schema.DataTypeDate.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+							{
+								Name:            "nested_numbers_lvl2",
+								DataType:        schema.DataTypeNumberArray.PropString(),
+								IndexFilterable: &vFalse, // different setting than (1)
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:            "one_dup_json2",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_int",
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_number",
+						DataType:        schema.DataTypeNumber.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_text",
+						DataType:        schema.DataTypeText.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vTrue,
+						Tokenization:    models.PropertyTokenizationField, // from (2)
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_bool_lvl2",
+								DataType:        schema.DataTypeBoolean.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+							{
+								Name:            "nested_date_lvl2",
+								DataType:        schema.DataTypeDate.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+							{
+								Name:            "nested_numbers_lvl2",
+								DataType:        schema.DataTypeNumberArray.PropString(),
+								IndexFilterable: &vFalse, // from (2)
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("props2 + props1", func(t *testing.T) {
+		props := schema.DedupProperties(props2, props1)
+
+		test_utils.AssertPropsMatch(t, props, []*models.Property{
+			{
+				Name:            "number",
+				DataType:        schema.DataTypeNumber.PropString(),
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+			},
+			{
+				Name:            "both_diff_json1",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_int",
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_bool_lvl2",
+								DataType:        schema.DataTypeBoolean.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:            "both_diff_json2",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_number",
+						DataType:        schema.DataTypeNumber.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_date_lvl2",
+								DataType:        schema.DataTypeDate.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:            "one_json1",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_int",
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_text",
+						DataType:        schema.DataTypeText.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vTrue,
+						Tokenization:    models.PropertyTokenizationWord,
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_bool_lvl2",
+								DataType:        schema.DataTypeBoolean.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+							{
+								Name:            "nested_numbers_lvl2",
+								DataType:        schema.DataTypeNumberArray.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:            "one_dup_json1",
+				DataType:        schema.DataTypeObject.PropString(),
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+				Tokenization:    "",
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "nested_int",
+						DataType:        schema.DataTypeInt.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_number",
+						DataType:        schema.DataTypeNumber.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+					},
+					{
+						Name:            "nested_text",
+						DataType:        schema.DataTypeText.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vTrue,
+						Tokenization:    models.PropertyTokenizationWord, // from (1)
+					},
+					{
+						Name:            "nested_objects",
+						DataType:        schema.DataTypeObjectArray.PropString(),
+						IndexFilterable: &vTrue,
+						IndexSearchable: &vFalse,
+						Tokenization:    "",
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:            "nested_bool_lvl2",
+								DataType:        schema.DataTypeBoolean.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+							{
+								Name:            "nested_date_lvl2",
+								DataType:        schema.DataTypeDate.PropString(),
+								IndexFilterable: &vTrue,
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+							{
+								Name:            "nested_numbers_lvl2",
+								DataType:        schema.DataTypeNumberArray.PropString(),
+								IndexFilterable: &vTrue, // from (1)
+								IndexSearchable: &vFalse,
+								Tokenization:    "",
+							},
+						},
+					},
+				},
+			},
+		})
+	})
+}

--- a/entities/schema/test_utils/properties.go
+++ b/entities/schema/test_utils/properties.go
@@ -1,0 +1,44 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func AssertPropsMatch(t *testing.T, propsA, propsB []*models.Property) {
+	require.Len(t, propsB, len(propsA), "props: different length")
+
+	pMap := map[string]int{}
+	for idx, p := range propsA {
+		pMap[p.Name] = idx
+	}
+
+	for _, pB := range propsB {
+		require.Contains(t, pMap, pB.Name)
+		pA := propsA[pMap[pB.Name]]
+
+		assert.Equal(t, pA.DataType, pB.DataType)
+		assert.Equal(t, pA.IndexFilterable, pB.IndexFilterable)
+		assert.Equal(t, pA.IndexSearchable, pB.IndexSearchable)
+		assert.Equal(t, pA.Tokenization, pB.Tokenization)
+
+		if _, isNested := schema.AsNested(pA.DataType); isNested {
+			AssertNestedPropsMatch(t, pA.NestedProperties, pB.NestedProperties)
+		}
+	}
+}

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -78,10 +77,7 @@ func (v *Validator) properties(ctx context.Context, class *models.Class,
 		}
 
 		// properties in the class are saved with lower case first letter
-		propertyKeyLowerCase := strings.ToLower(propertyKey[:1])
-		if len(propertyKey) > 1 {
-			propertyKeyLowerCase += propertyKey[1:]
-		}
+		propertyKeyLowerCase := schema.LowercaseFirstLetter(propertyKey)
 		property, err := schema.GetPropertyByName(class, propertyKeyLowerCase)
 		if err != nil {
 			return err

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -355,19 +355,6 @@ func migratePropertySettings(props ...*models.Property) {
 	migratePropertyIndexInverted(props...)
 }
 
-func mergeClassExistedProp(class *models.Class, props ...*models.Property) {
-	existingNames := map[string]int{}
-	for idx, p := range class.Properties {
-		existingNames[strings.ToLower(p.Name)] = idx
-	}
-
-	for _, p := range props {
-		if idx, ok := existingNames[strings.ToLower(p.Name)]; ok {
-			class.Properties[idx].NestedProperties, _ = schema.MergeRecursivelyNestedProperties(class.Properties[idx].NestedProperties, p.NestedProperties)
-		}
-	}
-}
-
 // as of v1.19 DataTypeString and DataTypeStringArray are deprecated
 // here both are changed to Text/TextArray
 // and proper, backward compatible tokenization

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -54,8 +54,8 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 	}
 
 	existingNames := make(map[string]bool, len(class.Properties))
-	for _, prop := range class.Properties {
-		if !merge {
+	if !merge {
+		for _, prop := range class.Properties {
 			existingNames[strings.ToLower(prop.Name)] = true
 		}
 	}
@@ -64,14 +64,14 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 		return 0, err
 	}
 
-	migratePropertySettings(newProps...)
-
 	// TODO-RAFT use UpdateProperty() for adding/merging property when index idempotence exists
 	// revisit when index idempotence exists and/or allowing merging properties on index.
 	props := schema.DedupProperties(class.Properties, newProps)
 	if len(props) == 0 {
 		return 0, nil
 	}
+
+	migratePropertySettings(props...)
 
 	return h.metaWriter.AddProperty(class.Class, props...)
 }

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -54,9 +54,9 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 	}
 
 	existingNames := make(map[string]bool, len(class.Properties))
-	if !merge {
-		for _, p := range class.Properties {
-			existingNames[strings.ToLower(p.Name)] = true
+	for _, prop := range class.Properties {
+		if !merge {
+			existingNames[strings.ToLower(prop.Name)] = true
 		}
 	}
 
@@ -68,44 +68,12 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 
 	// TODO-RAFT use UpdateProperty() for adding/merging property when index idempotence exists
 	// revisit when index idempotence exists and/or allowing merging properties on index.
-	new, old := split(class.Properties, newProps)
-	if len(old) > 0 {
-		mergeClassExistedProp(class, old...)
-		if _, err = h.metaWriter.UpdateClass(class, nil); err != nil {
-			return 0, err
-		}
-	}
-
-	if len(new) == 0 {
+	props := schema.DedupProperties(class.Properties, newProps)
+	if len(props) == 0 {
 		return 0, nil
 	}
 
-	return h.metaWriter.AddProperty(class.Class, new...)
-}
-
-// split does split the passed properties based in their existence
-// it shouldn't be needed once we have idempotence on Add/Update Property
-// it's used to diff what need to be added and what to update.
-func split(old, new []*models.Property) (propertiesToAdd, propertiesToUpdate []*models.Property) {
-	exPropMap := make(map[string]int, len(old))
-	for index := range old {
-		exPropMap[old[index].Name] = index
-	}
-
-	for _, prop := range new {
-		index, exists := exPropMap[schema.LowercaseFirstLetter(prop.Name)]
-		if !exists {
-			propertiesToAdd = append(propertiesToAdd, prop)
-		} else if _, isNested := schema.AsNested(old[index].DataType); isNested {
-			mergedNestedProperties, merged := schema.MergeRecursivelyNestedProperties(old[index].NestedProperties,
-				prop.NestedProperties)
-			if merged {
-				prop.NestedProperties = mergedNestedProperties
-				propertiesToUpdate = append(propertiesToUpdate, prop)
-			}
-		}
-	}
-	return
+	return h.metaWriter.AddProperty(class.Class, props...)
 }
 
 // DeleteClassProperty from existing Schema


### PR DESCRIPTION
### What's being changed:
- autoschema uses class schema fetched from leader (instead local one) to determine whether new class or properties should be added based on incoming object
- `Handler::AddClassProperty` method does not call `metaWriter::UpdateClass`, calling only `metaWriter::AddProperty` to add new primitive property or update nested property 
- `metaClass::AddProperty` merges nested properties of incoming and existing property, instead replacing existing property with incoming one

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
