### PR TITLE
update go to 1.22

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Run Swagger
         run: ./tools/gen-code-from-swagger.sh
@@ -42,9 +42,9 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@v1.0.0
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           package: ./...
-          fail-on-vuln: false
+          fail-on-vuln: true
   Unit-Tests:
     name: unit-tests
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh ${{ matrix.test }}
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Acceptance tests Large (modules)
         run: ./test/run.sh ${{ matrix.test }}
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: check
         env:
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Acceptance tests
         env:
@@ -199,7 +199,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: goreleaser
         run: |
@@ -251,7 +251,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: start weaviate
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "1.21"
+          goversion: "1.22"
           project_path: "./cmd/weaviate-server"
           extra_files: LICENSE README.md
           ldflags: -w -extldflags "-static" -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 ###############################################################################
 # Base build image
-FROM golang:1.21-alpine AS build_base
+FROM golang:1.22-alpine AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -168,4 +168,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.22
+go 1.22.0

--- a/go.mod
+++ b/go.mod
@@ -168,4 +168,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.22

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -1,6 +1,6 @@
 module acceptance_tests_with_client
 
-go 1.21
+go 1.22
 
 replace github.com/weaviate/weaviate => ../..
 

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -1,6 +1,6 @@
 module github.com/weaviate/weaviate/test/benchmark_bm25
 
-go 1.21
+go 1.22
 
 replace github.com/weaviate/weaviate => ../..
 


### PR DESCRIPTION
### What's being changed:

* Update go to 1.22 to avoid https://pkg.go.dev/vuln/GO-2024-2687

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
