### PR TITLE
Added store-specific statistics to existing raft statistics

### DIFF
--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -274,7 +274,7 @@ func (s *Service) Remove(ctx context.Context, id string) error {
 	return err
 }
 
-func (s *Service) Stats() map[string]string {
+func (s *Service) Stats() map[string]any {
 	// log.Printf("membership.Stats")
 	return s.store.Stats()
 }

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -416,8 +416,8 @@ func (f *Store) FindSimilarClass(name string) string {
 	return f.db.Schema.ClassEqual(name)
 }
 
-// Stats returns some internal statistics from this store, for informational/debugging
-// purposes only. The statistics directly from raft have their keys prefixed with "raft_".
+// Stats returns internal statistics from this store, for informational/debugging purposes only.
+// The statistics directly from raft have their keys prefixed with "raft_".
 // See https://pkg.go.dev/github.com/hashicorp/raft#Raft.Stats for the default raft stats.
 //
 // The values of "leader_address" and "leader_id" are the respective address/ID for the current

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -417,7 +417,9 @@ func (f *Store) FindSimilarClass(name string) string {
 }
 
 // Stats returns internal statistics from this store, for informational/debugging purposes only.
-// The statistics directly from raft have their keys prefixed with "raft_".
+//
+// The statistics directly from raft are nested under the "raft" key. If the raft statistics are
+// not yet available, then the "raft" key will not exist.
 // See https://pkg.go.dev/github.com/hashicorp/raft#Raft.Stats for the default raft stats.
 //
 // The values of "leader_address" and "leader_id" are the respective address/ID for the current
@@ -463,15 +465,9 @@ func (st *Store) Stats() map[string]any {
 	stats["last_applied_index"] = st.lastAppliedIndex.Load()
 	stats["db_loaded"] = st.dbLoaded.Load()
 
-	if st.raft == nil {
-		// In this case, the "raft_" prefixed keys won't exist
-		return stats
-	}
-	// Get and add the raft stats
-	raftStats := st.raft.Stats()
-	// Add the "raft_" prefix to the stats keys which come directly from raft
-	for k, v := range raftStats {
-		stats[fmt.Sprintf("raft_%s", k)] = v
+	// If the raft stats exist, add them as a nested map
+	if st.raft != nil {
+		stats["raft"] = st.raft.Stats()
 	}
 	return stats
 }

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -245,7 +245,7 @@ func TestServiceEndpoints(t *testing.T) {
 	// Stats
 	stats := srv.Stats()
 	// stats:raft_state
-	assert.Equal(t, "Leader", stats["raft_state"])
+	assert.Equal(t, "Leader", stats["raft"].(map[string]string)["state"])
 	// stats:leader_address
 	leaderAddress := string(stats["leader_address"].(raft.ServerAddress))
 	splitAddress := strings.Split(leaderAddress, ":")

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -83,8 +83,8 @@ func (f *fakeMetaHandler) Remove(ctx context.Context, nodeID string) error {
 	return args.Error(0)
 }
 
-func (f *fakeMetaHandler) Stats() map[string]string {
-	return map[string]string{}
+func (f *fakeMetaHandler) Stats() map[string]any {
+	return map[string]any{}
 }
 
 func (f *fakeMetaHandler) StoreSchemaV1() error {

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -51,7 +51,7 @@ type metaWriter interface {
 	// Cluster related operations
 	Join(_ context.Context, nodeID, raftAddr string, voter bool) error
 	Remove(_ context.Context, nodeID string) error
-	Stats() map[string]string
+	Stats() map[string]any
 	StoreSchemaV1() error
 }
 
@@ -239,7 +239,7 @@ func (h *Handler) RemoveNode(ctx context.Context, node string) error {
 }
 
 // Statistics is used to return a map of various internal stats. This should only be used for informative purposes or debugging.
-func (h *Handler) Statistics() map[string]string {
+func (h *Handler) Statistics() map[string]any {
 	return h.metaWriter.Stats()
 }
 


### PR DESCRIPTION
### What's being changed:

Adds some new store-specific statistics in addition to the existing raft statistics surfaced from `cluster/store` via the URL path `v1/cluster/statistics`. The hope is that these statistics will be useful for informational/debugging purposes.

I've left some comments on specific lines in the PR with questions for reviewers, looking forward to hearing your thoughts and incorporating any feedback/suggestions.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: N/A
- [ ] Chaos pipeline run or not necessary. Link to pipeline: N/A
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

### Extra Details

Ran a sanity check with curl as shown below:

```shell
# shell 1
tools/dev/restart_dev_environment.sh && tools/dev/run_dev_server.sh

# shell 2
tools/dev/run_dev_server.sh second-node

# shell 3
tools/dev/run_dev_server.sh third-node

# shell 4
curl localhost:8080/v1/cluster/statistics
```

```shell
# example response from curl
{
  "bootstrapped": true,
  "candidates": {},
  "db_loaded": true,
  "initial_last_applied_index": 0,
  "is_voter": true,
  "last_applied_index": 0,
  "leader_address": "172.20.10.6:8300",
  "leader_id": "weaviate-0",
  "open": true,
  "raft": {
    "applied_index": "5",
    "commit_index": "5",
    "fsm_pending": "0",
    "last_contact": "0",
    "last_log_index": "5",
    "last_log_term": "2",
    "last_snapshot_index": "0",
    "last_snapshot_term": "0",
    "latest_configuration": "[{Suffrage:Voter ID:weaviate-1 Address:172.20.10.6:8302} {Suffrage:Voter ID:weaviate-2 Address:172.20.10.6:8304} {Suffrage:Voter ID:weaviate-0 Address:172.20.10.6:8300}]",
    "latest_configuration_index": "0",
    "num_peers": "2",
    "protocol_version": "3",
    "protocol_version_max": "3",
    "protocol_version_min": "0",
    "snapshot_version_max": "1",
    "snapshot_version_min": "0",
    "state": "Leader",
    "term": "2"
  },
  "ready": true
}
```

Also ran this on the other nodes as well (ports 8081, 8082) and got similar responses.

Performance-wise this appears to run roughly as fast as any other endpoint when run with the default local-development setup.

```shell
time curl localhost:8080/v1/cluster/statistics
# curl localhost:8080/v1/cluster/statistics  0.01s user 0.01s system 66% cpu 0.021 total
```