### PR TITLE
fix: read repair acceptance test

### DIFF
--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -438,6 +438,17 @@ func restartNode1(ctx context.Context, t *testing.T, compose *docker.DockerCompo
 		require.Nil(t, compose.StartAt(ctx, 2))
 		return nil
 	})
+
+	// TODO-RAFT: all our tests shall have min. 3 Nodes to form a quorum
+	if len(compose.Containers()) > 2 {
+		eg.Go(func() error { // restart node 3
+			time.Sleep(3 * time.Second) // wait for member list initialization
+			stopNodeAt(ctx, t, compose, 3)
+			require.Nil(t, compose.StartAt(ctx, 3))
+			return nil
+		})
+	}
+
 	eg.Wait()
 	<-time.After(3 * time.Second) // wait for initialization
 }

--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -64,7 +64,7 @@ func immediateReplicaCRUD(t *testing.T) {
 	defer cancel()
 
 	compose, err := docker.New().
-		With2NodeCluster().
+		With3NodeCluster().
 		WithText2VecContextionary().
 		Start(ctx)
 	require.Nil(t, err)
@@ -80,11 +80,11 @@ func immediateReplicaCRUD(t *testing.T) {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 2,
+			Factor: 3,
 		}
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 2,
+			Factor: 3,
 		}
 		helper.CreateClass(t, articleClass)
 	})
@@ -438,16 +438,12 @@ func restartNode1(ctx context.Context, t *testing.T, compose *docker.DockerCompo
 		require.Nil(t, compose.StartAt(ctx, 2))
 		return nil
 	})
-
-	// TODO-RAFT: all our tests shall have min. 3 Nodes to form a quorum
-	if len(compose.Containers()) > 2 {
-		eg.Go(func() error { // restart node 3
-			time.Sleep(3 * time.Second) // wait for member list initialization
-			stopNodeAt(ctx, t, compose, 3)
-			require.Nil(t, compose.StartAt(ctx, 3))
-			return nil
-		})
-	}
+	eg.Go(func() error { // restart node 3
+		time.Sleep(3 * time.Second) // wait for member list initialization
+		stopNodeAt(ctx, t, compose, 3)
+		require.Nil(t, compose.StartAt(ctx, 3))
+		return nil
+	})
 
 	eg.Wait()
 	<-time.After(3 * time.Second) // wait for initialization

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -81,6 +81,7 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
+		time.Sleep(5 * time.Second)
 	})
 
 	repairObj := models.Object{
@@ -106,6 +107,7 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 1", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 1)
+		time.Sleep(10 * time.Second)
 	})
 
 	t.Run("assert new object read repair was made", func(t *testing.T) {

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -31,7 +31,7 @@ func readRepair(t *testing.T) {
 	defer cancel()
 
 	compose, err := docker.New().
-		With2NodeCluster().
+		With3NodeCluster().
 		WithText2VecContextionary().
 		Start(ctx)
 	require.Nil(t, err)
@@ -47,12 +47,12 @@ func readRepair(t *testing.T) {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 2,
+			Factor: 3,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 2,
+			Factor: 3,
 		}
 		helper.CreateClass(t, articleClass)
 	})
@@ -106,6 +106,7 @@ func readRepair(t *testing.T) {
 	})
 
 	t.Run("stop node 1", func(t *testing.T) {
+		time.Sleep(3 * time.Second) // wait before killing a leader so that data replicated to followers
 		stopNodeAt(ctx, t, compose, 1)
 		time.Sleep(10 * time.Second)
 	})
@@ -140,15 +141,17 @@ func readRepair(t *testing.T) {
 		require.True(t, exists)
 	})
 
-	t.Run("assert updated object read repair was made", func(t *testing.T) {
+	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
+	})
 
-		exists, err := objectExistsCL(t, compose.GetWeaviate().URI(),
+	t.Run("assert updated object read repair was made", func(t *testing.T) {
+		exists, err := objectExistsCL(t, compose.ContainerURI(1),
 			replaceObj.Class, replaceObj.ID, replica.One)
 		require.Nil(t, err)
 		require.True(t, exists)
 
-		resp, err := getObjectCL(t, compose.GetWeaviate().URI(),
+		resp, err := getObjectCL(t, compose.ContainerURI(1),
 			repairObj.Class, repairObj.ID, replica.One)
 		require.Nil(t, err)
 		assert.Equal(t, replaceObj.ID, resp.ID)

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -81,7 +81,6 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
-		time.Sleep(5 * time.Second)
 	})
 
 	repairObj := models.Object{

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -108,7 +108,7 @@ func readRepair(t *testing.T) {
 	t.Run("stop node 1", func(t *testing.T) {
 		time.Sleep(3 * time.Second) // wait before killing a leader so that data replicated to followers
 		stopNodeAt(ctx, t, compose, 1)
-		time.Sleep(10 * time.Second)
+		time.Sleep(15 * time.Second)
 	})
 
 	t.Run("assert new object read repair was made", func(t *testing.T) {

--- a/test/acceptance/replication/read_repair_test.go
+++ b/test/acceptance/replication/read_repair_test.go
@@ -81,7 +81,6 @@ func readRepair(t *testing.T) {
 
 	t.Run("stop node 2", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
-		time.Sleep(5 * time.Second)
 	})
 
 	repairObj := models.Object{
@@ -106,9 +105,7 @@ func readRepair(t *testing.T) {
 	})
 
 	t.Run("stop node 1", func(t *testing.T) {
-		time.Sleep(3 * time.Second) // wait before killing a leader so that data replicated to followers
 		stopNodeAt(ctx, t, compose, 1)
-		time.Sleep(15 * time.Second)
 	})
 
 	t.Run("assert new object read repair was made", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
this PR fixes read repair test, by increasing the Weaviate nodes to `3` to make sure we can form a quorum for RAFT and also update immediate replication test to use 3 nodes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
