### PR TITLE
Fix multi-node classifications

### DIFF
--- a/adapters/handlers/rest/clusterapi/classifications.go
+++ b/adapters/handlers/rest/clusterapi/classifications.go
@@ -16,5 +16,7 @@ type classifications struct {
 }
 
 func NewClassifications(manager txManager, auth auth) *classifications {
-	return &classifications{txHandler{manager: manager, auth: auth}}
+	return &classifications{
+		newTxHandler(manager, auth, classifyTX),
+	}
 }

--- a/adapters/handlers/rest/clusterapi/schema.go
+++ b/adapters/handlers/rest/clusterapi/schema.go
@@ -16,5 +16,7 @@ type schema struct {
 }
 
 func NewSchema(manager txManager, auth auth) *schema {
-	return &schema{txHandler{manager: manager, auth: auth}}
+	return &schema{
+		newTxHandler(manager, auth, schemaTX),
+	}
 }


### PR DESCRIPTION
### What's being changed:

Since v1.16, multi-node classifications were broken due to schema tx handler changes introduced with that version. This PR patches the issues, restoring the functionality of cluster-wide classifications.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
