### PR TITLE
Schema v2 idempotent tenants

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -266,6 +266,7 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 		stopwords:             sd,
 		indexCheckpoints:      checkpts,
 		allocChecker:          memwatch.NewDummyMonitor(),
+		shardCreateLocks:      newShardCreateLocks(),
 	}
 	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
 	idx.initCycleCallbacksNoop()
@@ -274,11 +275,10 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 	}
 
 	shardName := shardState.AllPhysicalShards()[0]
-	shard, err := idx.initShard(ctx, shardName, class, nil)
+	err = idx.initAndStoreShard(ctx, shardName, class, nil)
 	require.NoError(t, err)
 
-	idx.shards.Store(shardName, shard)
-	return shard, idx
+	return idx.shards.Load(shardName), idx
 }
 
 func testObject(className string) *storobj.Object {

--- a/adapters/repos/db/idempotent_integration_test.go
+++ b/adapters/repos/db/idempotent_integration_test.go
@@ -375,19 +375,17 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		}()
 
 		t.Run("add tenants", func(t *testing.T) {
-			commit, err := localMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
+			err := localMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
 				{Name: "tenant1", Status: models.TenantActivityStatusHOT},
 			})
 			require.Nil(t, err)
-			commit(true)
-			commit, err = remoteMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
+			err = remoteMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
 				{Name: "tenant1", Status: models.TenantActivityStatusHOT},
 				{Name: "tenant2", Status: models.TenantActivityStatusHOT},
 				{Name: "tenant3", Status: models.TenantActivityStatusCOLD},
 				{Name: "tenant4", Status: models.TenantActivityStatusHOT},
 			})
 			require.Nil(t, err)
-			commit(true)
 		})
 
 		t.Run("before index update", func(t *testing.T) {
@@ -458,17 +456,15 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		}()
 
 		t.Run("add tenants", func(t *testing.T) {
-			commit, err := localMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
+			err := localMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
 				{Name: "tenant1", Status: models.TenantActivityStatusHOT},
 				{Name: "tenant2", Status: models.TenantActivityStatusHOT},
 			})
 			require.Nil(t, err)
-			commit(true)
-			commit, err = remoteMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
+			err = remoteMigrator.NewTenants(ctx, localClass, []*schemaUC.CreateTenantPayload{
 				{Name: "tenant1", Status: models.TenantActivityStatusHOT},
 			})
 			require.Nil(t, err)
-			commit(true)
 		})
 
 		t.Run("before index update", func(t *testing.T) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -39,10 +38,10 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
-	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/autocut"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -195,8 +194,9 @@ type Index struct {
 
 	// always true if lazy shard loading is off, in the case of lazy shard
 	// loading will be set to true once the last shard was loaded.
-	allShardsReady atomic.Bool
-	allocChecker   memwatch.AllocChecker
+	allShardsReady   atomic.Bool
+	allocChecker     memwatch.AllocChecker
+	shardCreateLocks *shardCreateLocks
 }
 
 func (i *Index) GetShards() []ShardLike {
@@ -265,6 +265,7 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 		backupMutex:         backupMutex{log: logger, retryDuration: mutexRetryDuration, notifyDuration: mutexNotifyDuration},
 		indexCheckpoints:    indexCheckpoints,
 		allocChecker:        allocChecker,
+		shardCreateLocks:    newShardCreateLocks(),
 	}
 	index.closingCtx, index.closingCancel = context.WithCancel(context.Background())
 
@@ -288,11 +289,12 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 	return index, nil
 }
 
+// since called in Index's constructor there is no risk same shard will be inited/created in parallel,
+// therefore shardCreateLocks are not used here
 func (i *Index) initAndStoreShards(ctx context.Context, shardState *sharding.State, class *models.Class,
 	promMetrics *monitoring.PrometheusMetrics,
 ) error {
 	if i.Config.DisableLazyLoadShards {
-
 		eg := enterrors.NewErrorGroupWrapper(i.logger)
 		eg.SetLimit(_NUMCPU)
 
@@ -363,34 +365,27 @@ func (i *Index) initAndStoreShards(ctx context.Context, shardState *sharding.Sta
 	return nil
 }
 
+// used to init/create shard in different moments of index's lifecycle, therefore it needs to be called
+// within shardCreateLocks to prevent parallel create/init of the same shard
 func (i *Index) initAndStoreShard(ctx context.Context, shardName string, class *models.Class,
 	promMetrics *monitoring.PrometheusMetrics,
 ) error {
-	shard, err := i.initShard(ctx, shardName, class, promMetrics)
-	if err != nil {
-		return err
-	}
-	i.shards.Store(shardName, shard)
-	return nil
-}
-
-func (i *Index) initShard(ctx context.Context, shardName string, class *models.Class,
-	promMetrics *monitoring.PrometheusMetrics,
-) (ShardLike, error) {
 	if i.Config.DisableLazyLoadShards {
 		if err := i.allocChecker.CheckMappingAndReserve(3, int(lsmkv.FlushAfterDirtyDefault.Seconds())); err != nil {
-			return nil, errors.Wrap(err, "memory pressure: cannot init shard")
+			return errors.Wrap(err, "memory pressure: cannot init shard")
 		}
 
 		shard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints)
 		if err != nil {
-			return nil, fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
+			return fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
 		}
-		return shard, nil
+		i.shards.Store(shardName, shard)
+		return nil
 	}
 
 	shard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints, i.allocChecker)
-	return shard, nil
+	i.shards.Store(shardName, shard)
+	return nil
 }
 
 // Iterate over all objects in the index, applying the callback function to each one.  Adding or removing objects during iteration is not supported.
@@ -604,7 +599,7 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object,
 	}
 
 	// no replication, remote shard
-	if i.localShard(shardName) == nil {
+	if !i.isLocalShard(shardName) {
 		if err := i.remote.PutObject(ctx, shardName, object, schemaVersion); err != nil {
 			return fmt.Errorf("put remote object: shard=%q: %w", shardName, err)
 		}
@@ -614,10 +609,14 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object,
 	// no replication, local shard
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	err = ErrShardNotFound
-	if shard := i.localShard(shardName); shard != nil { // does shard still exist
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
+		err = ErrShardNotFound
+	} else {
 		err = shard.PutObject(ctx, object)
 	}
+
 	if err != nil {
 		return fmt.Errorf("put local object: shard=%q: %w", shardName, err)
 	}
@@ -630,8 +629,9 @@ func (i *Index) IncomingPutObject(ctx context.Context, shardName string,
 ) error {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	localShard := i.localShard(shardName)
-	if localShard == nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return ErrShardNotFound
 	}
 
@@ -646,7 +646,7 @@ func (i *Index) IncomingPutObject(ctx context.Context, shardName string,
 		return err
 	}
 
-	if err := localShard.PutObject(ctx, object); err != nil {
+	if err := shard.PutObject(ctx, object); err != nil {
 		return err
 	}
 
@@ -792,14 +792,15 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 			if replProps != nil {
 				errs = i.replicator.PutObjects(ctx, shardName, group.objects,
 					replica.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
-			} else if i.localShard(shardName) == nil {
+			} else if !i.isLocalShard(shardName) {
 				errs = i.remote.BatchPutObjects(ctx, shardName, group.objects, schemaVersion)
 			} else {
 				i.backupMutex.RLockGuard(func() error {
-					if shard := i.localShard(shardName); shard != nil {
-						errs = shard.PutObjectBatch(ctx, group.objects)
-					} else {
+					shard, err := i.getOrInitLocalShard(ctx, shardName)
+					if err != nil {
 						errs = duplicateErr(ErrShardNotFound, len(group.objects))
+					} else {
+						errs = shard.PutObjectBatch(ctx, group.objects)
 					}
 					return nil
 				})
@@ -831,8 +832,9 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 ) []error {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	localShard := i.localShard(shardName)
-	if localShard == nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return duplicateErr(ErrShardNotFound, len(objects))
 	}
 
@@ -849,7 +851,7 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 		}
 	}
 
-	return localShard.PutObjectBatch(ctx, objects)
+	return shard.PutObjectBatch(ctx, objects)
 }
 
 // return value map[int]error gives the error for the index as it received it
@@ -888,14 +890,15 @@ func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchRefere
 		var errs []error
 		if i.replicationEnabled() {
 			errs = i.replicator.AddReferences(ctx, shardName, group.refs, replica.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
-		} else if i.localShard(shardName) == nil {
+		} else if !i.isLocalShard(shardName) {
 			errs = i.remote.BatchAddReferences(ctx, shardName, group.refs, schemaVersion)
 		} else {
 			i.backupMutex.RLockGuard(func() error {
-				if shard := i.localShard(shardName); shard != nil {
-					errs = shard.AddReferencesBatch(ctx, group.refs)
-				} else {
+				shard, err := i.getOrInitLocalShard(ctx, shardName)
+				if err != nil {
 					errs = duplicateErr(ErrShardNotFound, len(group.refs))
+				} else {
+					errs = shard.AddReferencesBatch(ctx, group.refs)
 				}
 				return nil
 			})
@@ -914,12 +917,13 @@ func (i *Index) IncomingBatchAddReferences(ctx context.Context, shardName string
 ) []error {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	localShard := i.localShard(shardName)
-	if localShard == nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return duplicateErr(ErrShardNotFound, len(refs))
 	}
 
-	return localShard.AddReferencesBatch(ctx, refs)
+	return shard.AddReferencesBatch(ctx, refs)
 }
 
 func (i *Index) objectByID(ctx context.Context, id strfmt.UUID,
@@ -955,15 +959,18 @@ func (i *Index) objectByID(ctx context.Context, id strfmt.UUID,
 		return obj, err
 	}
 
-	if shard := i.localShard(shardName); shard != nil {
-		obj, err = shard.ObjectByID(ctx, id, props, addl)
-		if err != nil {
-			return obj, fmt.Errorf("get local object: shard=%s: %w", shardName, err)
+	if !i.isLocalShard(shardName) {
+		if obj, err = i.remote.GetObject(ctx, shardName, id, props, addl); err != nil {
+			return obj, fmt.Errorf("get remote object: shard=%s: %w", shardName, err)
 		}
 	} else {
-		obj, err = i.remote.GetObject(ctx, shardName, id, props, addl)
+		shard, err := i.getOrInitLocalShard(ctx, shardName)
 		if err != nil {
-			return obj, fmt.Errorf("get remote object: shard=%s: %w", shardName, err)
+			return obj, ErrShardNotFound
+		} else {
+			if obj, err = shard.ObjectByID(ctx, id, props, addl); err != nil {
+				return obj, fmt.Errorf("get local object: shard=%s: %w", shardName, err)
+			}
 		}
 	}
 
@@ -974,8 +981,8 @@ func (i *Index) IncomingGetObject(ctx context.Context, shardName string,
 	id strfmt.UUID, props search.SelectProperties,
 	additional additional.Properties,
 ) (*storobj.Object, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return nil, ErrShardNotFound
 	}
 
@@ -985,8 +992,8 @@ func (i *Index) IncomingGetObject(ctx context.Context, shardName string,
 func (i *Index) IncomingMultiGetObjects(ctx context.Context, shardName string,
 	ids []strfmt.UUID,
 ) ([]*storobj.Object, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return nil, ErrShardNotFound
 	}
 
@@ -1025,15 +1032,20 @@ func (i *Index) multiObjectByID(ctx context.Context,
 		var objects []*storobj.Object
 		var err error
 
-		if shard := i.localShard(shardName); shard != nil {
-			objects, err = shard.MultiObjectByID(ctx, group.ids)
-			if err != nil {
-				return nil, errors.Wrapf(err, "shard %s", shard.ID())
-			}
-		} else {
+		if !i.isLocalShard(shardName) {
 			objects, err = i.remote.MultiGetObjects(ctx, shardName, extractIDsFromMulti(group.ids))
 			if err != nil {
 				return nil, errors.Wrapf(err, "remote shard %s", shardName)
+			}
+		} else {
+			shard, err := i.getOrInitLocalShard(ctx, shardName)
+			if err != nil {
+				err = ErrShardNotFound
+			} else {
+				objects, err = shard.MultiObjectByID(ctx, group.ids)
+			}
+			if err != nil {
+				return nil, errors.Wrapf(err, "shard %s", shardId(i.ID(), shardName))
 			}
 		}
 
@@ -1092,26 +1104,33 @@ func (i *Index) exists(ctx context.Context, id strfmt.UUID,
 		return i.replicator.Exists(ctx, cl, shardName, id)
 	}
 
-	if shard := i.localShard(shardName); shard != nil {
-		exists, err = shard.Exists(ctx, id)
-		if err != nil {
-			err = fmt.Errorf("exists locally: shard=%q: %w", shardName, err)
-		}
-	} else {
-		owner, _ := i.getSchema.ShardOwner(i.Config.ClassName.String(), shardName)
+	if !i.isLocalShard(shardName) {
 		exists, err = i.remote.Exists(ctx, shardName, id)
 		if err != nil {
+			owner, _ := i.getSchema.ShardOwner(i.Config.ClassName.String(), shardName)
 			err = fmt.Errorf("exists remotely: shard=%q owner=%q: %w", shardName, owner, err)
 		}
+	} else {
+		var shard ShardLike
+		shard, err = i.getOrInitLocalShard(ctx, shardName)
+		if err != nil {
+			err = ErrShardNotFound
+		} else {
+			exists, err = shard.Exists(ctx, id)
+			if err != nil {
+				err = fmt.Errorf("exists locally: shard=%q: %w", shardName, err)
+			}
+		}
 	}
+
 	return exists, err
 }
 
 func (i *Index) IncomingExists(ctx context.Context, shardName string,
 	id strfmt.UUID,
 ) (bool, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return false, ErrShardNotFound
 	}
 
@@ -1260,14 +1279,7 @@ func (i *Index) objectSearchByShard(ctx context.Context, limit int, filters *fil
 				err      error
 			)
 
-			if shard := i.localShard(shardName); shard != nil {
-				nodeName = i.getSchema.NodeName()
-				objs, scores, err = shard.ObjectSearch(ctx, limit, filters, keywordRanking, sort, cursor, addlProps)
-				if err != nil {
-					return fmt.Errorf(
-						"local shard object search %s: %w", shard.ID(), err)
-				}
-			} else {
+			if !i.isLocalShard(shardName) {
 				objs, scores, nodeName, err = i.remote.SearchShard(
 					ctx, shardName, nil, "", limit, filters, keywordRanking,
 					sort, cursor, nil, addlProps, i.replicationEnabled())
@@ -1275,6 +1287,18 @@ func (i *Index) objectSearchByShard(ctx context.Context, limit int, filters *fil
 					return fmt.Errorf(
 						"remote shard object search %s: %w", shardName, err)
 				}
+			} else {
+				shard, err := i.getOrInitLocalShard(ctx, shardName)
+				if err != nil {
+					err = ErrShardNotFound
+				} else {
+					objs, scores, err = shard.ObjectSearch(ctx, limit, filters, keywordRanking, sort, cursor, addlProps)
+				}
+				if err != nil {
+					return fmt.Errorf(
+						"local shard object search %s: %w", shard.ID(), err)
+				}
+				nodeName = i.getSchema.NodeName()
 			}
 
 			if i.replicationEnabled() {
@@ -1362,14 +1386,17 @@ func (i *Index) singleLocalShardObjectVectorSearch(ctx context.Context, searchVe
 	sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties,
 	shardName string,
 ) ([]*storobj.Object, []float32, error) {
-	shard := i.localShard(shardName)
-	res, resDists, err := shard.ObjectVectorSearch(
-		ctx, searchVector, targetVector, dist, limit, filters, sort, groupBy, additional)
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "shard %s", shard.ID())
+		return nil, nil, errors.Wrapf(err, "shard %s", shardId(i.ID(), shardName))
+	} else {
+		res, resDists, err := shard.ObjectVectorSearch(
+			ctx, searchVector, targetVector, dist, limit, filters, sort, groupBy, additional)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "shard %s", shard.ID())
+		}
+		return res, resDists, nil
 	}
-
-	return res, resDists, nil
 }
 
 // to be called after validating multi-tenancy
@@ -1406,7 +1433,7 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 	}
 
 	if len(shardNames) == 1 {
-		if i.localShard(shardNames[0]) != nil {
+		if i.isLocalShard(shardNames[0]) {
 			return i.singleLocalShardObjectVectorSearch(ctx, searchVector, targetVector, dist, limit, filters,
 				sort, groupBy, additional, shardNames[0])
 		}
@@ -1437,21 +1464,25 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 				err      error
 			)
 
-			if shard := i.localShard(shardName); shard != nil {
-				nodeName = i.getSchema.NodeName()
-				res, resDists, err = shard.ObjectVectorSearch(
-					ctx, searchVector, targetVector, dist, limit, filters, sort, groupBy, additional)
-				if err != nil {
-					return errors.Wrapf(err, "shard %s", shard.ID())
-				}
-
-			} else {
+			if !i.isLocalShard(shardName) {
 				res, resDists, nodeName, err = i.remote.SearchShard(ctx,
 					shardName, searchVector, targetVector, limit, filters,
 					nil, sort, nil, groupBy, additional, i.replicationEnabled())
 				if err != nil {
 					return errors.Wrapf(err, "remote shard %s", shardName)
 				}
+			} else {
+				shard, err := i.getOrInitLocalShard(ctx, shardName)
+				if err != nil {
+					err = ErrShardNotFound
+				} else {
+					res, resDists, err = shard.ObjectVectorSearch(
+						ctx, searchVector, targetVector, dist, limit, filters, sort, groupBy, additional)
+				}
+				if err != nil {
+					return errors.Wrapf(err, "shard %s", shard.ID())
+				}
+				nodeName = i.getSchema.NodeName()
 			}
 			if i.replicationEnabled() {
 				storobj.AddOwnership(res, nodeName, shardName)
@@ -1509,8 +1540,8 @@ func (i *Index) IncomingSearch(ctx context.Context, shardName string,
 	sort []filters.Sort, cursor *filters.Cursor, groupBy *searchparams.GroupBy,
 	additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return nil, nil, ErrShardNotFound
 	}
 
@@ -1556,7 +1587,7 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 	}
 
 	// no replication, remote shard
-	if i.localShard(shardName) == nil {
+	if !i.isLocalShard(shardName) {
 		if err := i.remote.DeleteObject(ctx, shardName, id, schemaVersion); err != nil {
 			return fmt.Errorf("delete remote object: shard=%q: %w", shardName, err)
 		}
@@ -1566,8 +1597,11 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 	// no replication, local shard
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	err = ErrShardNotFound
-	if shard := i.localShard(shardName); shard != nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
+		err = ErrShardNotFound
+	} else {
 		err = shard.DeleteObject(ctx, id)
 	}
 	if err != nil {
@@ -1581,15 +1615,55 @@ func (i *Index) IncomingDeleteObject(ctx context.Context, shardName string,
 ) error {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	shard := i.localShard(shardName)
-	if shard == nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return ErrShardNotFound
 	}
 	return shard.DeleteObject(ctx, id)
 }
 
-func (i *Index) localShard(name string) ShardLike {
-	return i.shards.Load(name)
+func (i *Index) isLocalShard(name string) bool {
+	if i.shards.Load(name) != nil {
+		return true
+	}
+
+	node, err := i.getSchema.ShardOwner(i.Config.ClassName.String(), name)
+	if err != nil {
+		return false
+	}
+
+	return i.getSchema.NodeName() == node
+}
+
+// Intended to run on "receiver" nodes, where local shard
+// is expected to exist and be active
+// Method first tries to get shard from Index::shards map,
+// or inits shard and adds it to the map if shard was not found
+func (i *Index) getOrInitLocalShard(ctx context.Context, shardName string) (ShardLike, error) {
+	if shard := i.shards.Load(shardName); shard != nil {
+		return shard, nil
+	}
+
+	className := i.Config.ClassName.String()
+	class := i.getSchema.ReadOnlyClass(className)
+	return i.initLocalShard(ctx, shardName, class)
+}
+
+func (i *Index) initLocalShard(ctx context.Context, shardName string, class *models.Class) (ShardLike, error) {
+	// make sure same shard is not inited in parallel
+	i.shardCreateLocks.Lock(shardName)
+	defer i.shardCreateLocks.Unlock(shardName)
+
+	// check if created in the meantime by concurrent call
+	if shard := i.shards.Load(shardName); shard != nil {
+		return shard, nil
+	}
+
+	if err := i.initAndStoreShard(ctx, shardName, class, i.metrics.baseMetrics); err != nil {
+		return nil, err
+	}
+	return i.shards.Load(shardName), nil
 }
 
 func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
@@ -1616,7 +1690,7 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 	}
 
 	// no replication, remote shard
-	if i.localShard(shardName) == nil {
+	if !i.isLocalShard(shardName) {
 		if err := i.remote.MergeObject(ctx, shardName, merge, schemaVersion); err != nil {
 			return fmt.Errorf("update remote object: shard=%q: %w", shardName, err)
 		}
@@ -1626,8 +1700,11 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 	// no replication, local shard
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	err = ErrShardNotFound
-	if shard := i.localShard(shardName); shard != nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
+		err = ErrShardNotFound
+	} else {
 		err = shard.MergeObject(ctx, merge)
 	}
 	if err != nil {
@@ -1642,8 +1719,9 @@ func (i *Index) IncomingMergeObject(ctx context.Context, shardName string,
 ) error {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	shard := i.localShard(shardName)
-	if shard == nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return ErrShardNotFound
 	}
 
@@ -1666,10 +1744,16 @@ func (i *Index) aggregate(ctx context.Context,
 	for j, shardName := range shardNames {
 		var err error
 		var res *aggregation.Result
-		if shard := i.localShard(shardName); shard != nil {
-			res, err = shard.Aggregate(ctx, params)
-		} else {
+		if !i.isLocalShard(shardName) {
 			res, err = i.remote.Aggregate(ctx, shardName, params)
+		} else {
+			var shard ShardLike
+			shard, err = i.getOrInitLocalShard(ctx, shardName)
+			if err != nil {
+				err = ErrShardNotFound
+			} else {
+				res, err = shard.Aggregate(ctx, params)
+			}
 		}
 		if err != nil {
 			return nil, errors.Wrapf(err, "shard %s", shardName)
@@ -1684,8 +1768,8 @@ func (i *Index) aggregate(ctx context.Context,
 func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 	params aggregation.Params,
 ) (*aggregation.Result, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return nil, ErrShardNotFound
 	}
 
@@ -1731,58 +1815,38 @@ func (i *Index) drop() error {
 	return os.RemoveAll(i.path())
 }
 
-// dropShards deletes shards in a transactional manner.
-// To confirm the deletion, the user must call Commit(true).
-// To roll back the deletion, the user must call Commit(false)
-func (i *Index) dropShards(names []string) (commit func(success bool), err error) {
-	shards := make(map[string]ShardLike, len(names))
+func (i *Index) dropShards(names []string) error {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
 
-	// mark deleted shards
-	for _, name := range names {
-		prev, ok := i.shards.Swap(name, nil) // mark
-		if !ok {                             // shard doesn't exit
-			i.shards.LoadAndDelete(name) // rollback nil value created by swap()
-			continue
-		}
-		if prev != nil {
-			shards[name] = prev
-		}
-	}
-
-	rollback := func() {
-		for name, shard := range shards {
-			i.shards.CompareAndSwap(name, nil, shard)
-		}
-	}
-
+	ec := &errorcompounder.ErrorCompounder{}
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU * 2)
-	commit = func(success bool) {
-		if !success {
-			rollback()
-			return
-		}
-		// detach shards
-		for name := range shards {
-			i.shards.LoadAndDelete(name)
-		}
 
-		// drop shards
-		for _, shard := range shards {
-			shard := shard
-			eg.Go(func() error {
-				if err := shard.drop(); err != nil {
-					i.logger.WithField("action", "drop_shard").
-						WithField("shard", shard.ID()).Error(err)
-				}
-				return nil
-			}, shard)
-		}
+	for _, name := range names {
+		name := name
+		eg.Go(func() error {
+			i.shardCreateLocks.Lock(name)
+			defer i.shardCreateLocks.Unlock(name)
+
+			shard, ok := i.shards.Swap(name, nil) // swap shard for nil
+			i.shards.LoadAndDelete(name)          // then remove entry
+
+			if !ok || shard == nil {
+				return nil // shard already does not exist (or inactive)
+			}
+
+			if err := shard.drop(); err != nil {
+				ec.Add(err)
+				i.logger.WithField("action", "drop_shard").
+					WithField("shard", shard.ID()).Error(err)
+			}
+			return nil
+		})
 	}
 
-	return commit, eg.Wait()
+	eg.Wait()
+	return ec.ToError()
 }
 
 func (i *Index) Shutdown(ctx context.Context) error {
@@ -1832,6 +1896,7 @@ func (i *Index) stopCycleManagers(ctx context.Context, usecase string) error {
 func (i *Index) getShardsQueueSize(ctx context.Context, tenant string) (map[string]int64, error) {
 	shardsQueueSize := make(map[string]int64)
 
+	// TODO-RAFT should be strongly consistent?
 	shardState := i.getSchema.CopyShardingState(i.Config.ClassName.String())
 	shardNames := shardState.AllPhysicalShards()
 
@@ -1844,7 +1909,7 @@ func (i *Index) getShardsQueueSize(ctx context.Context, tenant string) (map[stri
 		if !shardState.IsLocalShard(shardName) {
 			size, err = i.remote.GetShardQueueSize(ctx, shardName)
 		} else {
-			shard := i.localShard(shardName)
+			shard := i.shards.Load(shardName)
 			if shard == nil {
 				err = errors.Errorf("shard %s does not exist", shardName)
 			} else {
@@ -1868,10 +1933,11 @@ func (i *Index) getShardsQueueSize(ctx context.Context, tenant string) (map[stri
 }
 
 func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string) (int64, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return 0, ErrShardNotFound
 	}
+
 	if !shard.hasTargetVectors() {
 		return shard.Queue().Size(), nil
 	}
@@ -1885,6 +1951,7 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
 	shardsStatus := make(map[string]string)
 
+	// TODO-RAFT should be strongly consistent?
 	shardState := i.getSchema.CopyShardingState(i.Config.ClassName.String())
 	shardNames := shardState.AllPhysicalShards()
 
@@ -1897,7 +1964,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 		if !shardState.IsLocalShard(shardName) {
 			status, err = i.remote.GetShardStatus(ctx, shardName)
 		} else {
-			shard := i.localShard(shardName)
+			shard := i.shards.Load(shardName)
 			if shard == nil {
 				err = errors.Errorf("shard %s does not exist", shardName)
 			} else {
@@ -1915,23 +1982,28 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 }
 
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return "", ErrShardNotFound
 	}
 	return shard.GetStatus().String(), nil
 }
 
 func (i *Index) updateShardStatus(ctx context.Context, shardName, targetStatus string, schemaVersion uint64) error {
-	if shard := i.localShard(shardName); shard != nil {
-		return shard.UpdateStatus(targetStatus)
+	if !i.isLocalShard(shardName) {
+		return i.remote.UpdateShardStatus(ctx, shardName, targetStatus, schemaVersion)
 	}
-	return i.remote.UpdateShardStatus(ctx, shardName, targetStatus, schemaVersion)
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
+		return ErrShardNotFound
+	}
+	return shard.UpdateStatus(targetStatus)
 }
 
 func (i *Index) IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string, schemaVersion uint64) error {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return ErrShardNotFound
 	}
 	return shard.UpdateStatus(targetStatus)
@@ -1961,11 +2033,16 @@ func (i *Index) findUUIDs(ctx context.Context,
 
 	results := make(map[string][]strfmt.UUID)
 	for _, shardName := range shardNames {
-
-		if shard := retryGetLocalShard(i, shardName); shard != nil {
-			results[shardName], err = shard.FindUUIDs(ctx, filters)
-		} else {
+		if !i.isLocalShard(shardName) {
 			results[shardName], err = i.remote.FindUUIDs(ctx, shardName, filters)
+		} else {
+			var shard ShardLike
+			shard, err = i.getOrInitLocalShard(ctx, shardName)
+			if err != nil {
+				err = ErrShardNotFound
+			} else {
+				results[shardName], err = shard.FindUUIDs(ctx, filters)
+			}
 		}
 
 		if err != nil {
@@ -1979,8 +2056,8 @@ func (i *Index) findUUIDs(ctx context.Context,
 func (i *Index) IncomingFindUUIDs(ctx context.Context, shardName string,
 	filters *filters.LocalFilter,
 ) ([]strfmt.UUID, error) {
-	shard := i.localShard(shardName)
-	if shard == nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return nil, ErrShardNotFound
 	}
 
@@ -2014,14 +2091,15 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 			if i.replicationEnabled() {
 				objs = i.replicator.DeleteObjects(ctx, shardName, uuids,
 					dryRun, replica.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
-			} else if i.localShard(shardName) == nil {
+			} else if !i.isLocalShard(shardName) {
 				objs = i.remote.DeleteObjectBatch(ctx, shardName, uuids, dryRun, schemaVersion)
 			} else {
 				i.backupMutex.RLockGuard(func() error {
-					if shard := i.localShard(shardName); shard != nil {
-						objs = shard.DeleteObjectBatch(ctx, uuids, dryRun)
-					} else {
+					shard, err := i.getOrInitLocalShard(ctx, shardName)
+					if err != nil {
 						objs = objects.BatchSimpleObjects{objects.BatchSimpleObject{Err: ErrShardNotFound}}
+					} else {
+						objs = shard.DeleteObjectBatch(ctx, uuids, dryRun)
 					}
 					return nil
 				})
@@ -2047,8 +2125,9 @@ func (i *Index) IncomingDeleteObjectBatch(ctx context.Context, shardName string,
 ) objects.BatchSimpleObjects {
 	i.backupMutex.RLock()
 	defer i.backupMutex.RUnlock()
-	shard := i.localShard(shardName)
-	if shard == nil {
+
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return objects.BatchSimpleObjects{
 			objects.BatchSimpleObject{Err: ErrShardNotFound},
 		}
@@ -2077,17 +2156,6 @@ func objectSearchPreallocate(limit int, shards []string) ([]*storobj.Object, []f
 	scores := make([]float32, 0, capacity)
 
 	return objects, scores
-}
-
-func (i *Index) addNewShard(ctx context.Context,
-	class *models.Class, shardName string,
-) error {
-	if shard := i.localShard(shardName); shard != nil {
-		return fmt.Errorf("shard %q exists already", shardName)
-	}
-
-	// TODO: metrics
-	return i.initAndStoreShard(ctx, shardName, class, i.metrics.baseMetrics)
 }
 
 func (i *Index) validateMultiTenancy(tenant string) error {
@@ -2127,15 +2195,39 @@ func convertToVectorIndexConfigs(configs map[string]models.VectorConfig) map[str
 	return nil
 }
 
-// retryGetLocalShard is a wrapper around getting localShard used
-// to handle eventual consistency.
-func retryGetLocalShard(i *Index, name string) ShardLike {
-	var sl ShardLike
-	backoff.Retry(func() error {
-		if sl = i.localShard(name); sl == nil {
-			return fmt.Errorf("does not exists")
-		}
-		return nil
-	}, utils.NewBackoff())
-	return sl
+type shardCreateLocks struct {
+	main  *sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newShardCreateLocks() *shardCreateLocks {
+	return &shardCreateLocks{
+		main:  new(sync.Mutex),
+		locks: make(map[string]*sync.Mutex),
+	}
+}
+
+func (l *shardCreateLocks) Lock(name string) {
+	l.shardLock(name).Lock()
+}
+
+func (l *shardCreateLocks) Unlock(name string) {
+	l.shardLock(name).Unlock()
+}
+
+func (l *shardCreateLocks) Locked(name string, callback func()) {
+	l.Lock(name)
+	defer l.Unlock(name)
+
+	callback()
+}
+
+func (l *shardCreateLocks) shardLock(name string) *sync.Mutex {
+	l.main.Lock()
+	defer l.main.Unlock()
+
+	if _, ok := l.locks[name]; !ok {
+		l.locks[name] = new(sync.Mutex)
+	}
+	return l.locks[name]
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -172,14 +172,11 @@ func (m *Migrator) updateIndexTenants(ctx context.Context, idx *Index,
 func (m *Migrator) updateIndexAddTenants(ctx context.Context, idx *Index,
 	incomingClass *models.Class, incomingSS *sharding.State,
 ) error {
-	for name, phys := range incomingSS.Physical {
+	for shardName, phys := range incomingSS.Physical {
 		// Only load the tenant if activity status == HOT
 		if schemaUC.IsLocalActiveTenant(&phys, m.db.schemaGetter.NodeName()) {
-			loaded := idx.shards.Load(name)
-			if loaded == nil {
-				if err := idx.initAndStoreShard(ctx, name, incomingClass, m.db.promMetrics); err != nil {
-					return fmt.Errorf("add missing tenant shard %s during update index: %w", name, err)
-				}
+			if _, err := idx.initLocalShard(ctx, shardName, incomingClass); err != nil {
+				return fmt.Errorf("add missing tenant shard %s during update index: %w", shardName, err)
 			}
 		}
 	}
@@ -199,12 +196,9 @@ func (m *Migrator) updateIndexDeleteTenants(ctx context.Context,
 	})
 
 	if len(toRemove) > 0 {
-		commit, err := idx.dropShards(toRemove)
-		if err != nil {
-			commit(false)
+		if err := idx.dropShards(toRemove); err != nil {
 			return fmt.Errorf("drop tenant shards %v during update index: %w", toRemove, err)
 		}
-		commit(true)
 	}
 	return nil
 }
@@ -212,12 +206,9 @@ func (m *Migrator) updateIndexDeleteTenants(ctx context.Context,
 func (m *Migrator) updateIndexAddShards(ctx context.Context, idx *Index,
 	incomingClass *models.Class, incomingSS *sharding.State,
 ) error {
-	for _, shard := range incomingSS.AllLocalPhysicalShards() {
-		loaded := idx.shards.Load(shard)
-		if loaded == nil {
-			if err := idx.initAndStoreShard(ctx, shard, incomingClass, m.db.promMetrics); err != nil {
-				return fmt.Errorf("add missing shard %s during update index: %w", shard, err)
-			}
+	for _, shardName := range incomingSS.AllLocalPhysicalShards() {
+		if _, err := idx.initLocalShard(ctx, shardName, incomingClass); err != nil {
+			return fmt.Errorf("add missing shard %s during update index: %w", shardName, err)
 		}
 	}
 	return nil
@@ -298,195 +289,91 @@ func (m *Migrator) UpdateShardStatus(ctx context.Context, className, shardName, 
 	return idx.updateShardStatus(ctx, shardName, targetStatus, schemaVersion)
 }
 
-// NewTenants creates new partitions and returns a commit func
-// that can be used to either commit or rollback the partitions
-func (m *Migrator) NewTenants(ctx context.Context, class *models.Class, creates []*schemaUC.CreateTenantPayload) (commit func(success bool), err error) {
+// NewTenants creates new partitions
+func (m *Migrator) NewTenants(ctx context.Context, class *models.Class, creates []*schemaUC.CreateTenantPayload) error {
 	idx := m.db.GetIndex(schema.ClassName(class.Class))
 	if idx == nil {
-		return nil, fmt.Errorf("cannot find index for %q", class.Class)
+		return fmt.Errorf("cannot find index for %q", class.Class)
 	}
 
-	shards := make(map[string]ShardLike, len(creates))
-	rollback := func() {
-		for name, shard := range shards {
-			if err := shard.drop(); err != nil {
-				m.logger.WithField("action", "drop_shard").
-					WithField("class", class.Class).
-					Errorf("cannot drop self created shard %s: %v", name, err)
-			}
-		}
-	}
-	commit = func(success bool) {
-		if success {
-			for name, shard := range shards {
-				idx.shards.Store(name, shard)
-			}
-			return
-		}
-		rollback()
-	}
-	defer func() {
-		if err != nil {
-			rollback()
-		}
-	}()
-
+	ec := &errorcompounder.ErrorCompounder{}
 	for _, pl := range creates {
-		if shard := idx.shards.Load(pl.Name); shard != nil {
-			continue
-		}
 		if pl.Status != models.TenantActivityStatusHOT {
 			continue // skip creating inactive shards
 		}
 
-		shard, err := idx.initShard(ctx, pl.Name, class, m.db.promMetrics)
-		if err != nil {
-			return nil, fmt.Errorf("cannot create partition %q: %w", pl, err)
-		}
-		shards[pl.Name] = shard
+		_, err := idx.getOrInitLocalShard(ctx, pl.Name)
+		ec.Add(err)
 	}
-
-	return commit, nil
+	return ec.ToError()
 }
 
 // UpdateTenans activates or deactivates tenant partitions and returns a commit func
 // that can be used to either commit or rollback the changes
-func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updates []*schemaUC.UpdateTenantPayload) (commit func(success bool), err error) {
+func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updates []*schemaUC.UpdateTenantPayload) error {
 	idx := m.db.GetIndex(schema.ClassName(class.Class))
 	if idx == nil {
-		return nil, fmt.Errorf("cannot find index for %q", class.Class)
+		return fmt.Errorf("cannot find index for %q", class.Class)
 	}
 
-	shardsToHot := make([]string, 0, len(updates))
-	shardsToCold := make([]string, 0, len(updates))
-	shardsHotted := make(map[string]ShardLike)
-	shardsColded := make(map[string]ShardLike)
-
-	rollbackHotted := func() {
-		eg := enterrors.NewErrorGroupWrapper(m.logger)
-		eg.SetLimit(2 * _NUMCPU)
-		for name, shard := range shardsHotted {
-			name, shard := name, shard
-			eg.Go(func() error {
-				if err := shard.Shutdown(ctx); err != nil {
-					idx.logger.WithField("action", "rollback_shutdown_shard").
-						WithField("shard", shard.ID()).
-						Errorf("cannot shutdown self activated shard %q: %s", name, err)
-				}
-				return nil
-			}, name, shard)
+	updatesHot := make([]string, 0, len(updates))
+	updatesCold := make([]string, 0, len(updates))
+	for _, update := range updates {
+		switch update.Status {
+		case models.TenantActivityStatusHOT:
+			updatesHot = append(updatesHot, update.Name)
+		case models.TenantActivityStatusCOLD:
+			updatesCold = append(updatesCold, update.Name)
 		}
-		eg.Wait()
-	}
-	rollbackColded := func() {
-		for name, shard := range shardsColded {
-			idx.shards.CompareAndSwap(name, nil, shard)
-		}
-	}
-	rollback := func() {
-		rollbackHotted()
-		rollbackColded()
 	}
 
-	commitHotted := func() {
-		for name, shard := range shardsHotted {
-			idx.shards.Store(name, shard)
-		}
-	}
-	commitColded := func() {
-		for name := range shardsColded {
-			idx.shards.LoadAndDelete(name)
-		}
+	ec := &errorcompounder.ErrorCompounder{}
 
-		eg := enterrors.NewErrorGroupWrapper(m.logger)
-		eg.SetLimit(_NUMCPU * 2)
-		for name, shard := range shardsColded {
-			name, shard := name, shard
-			eg.Go(func() error {
-				if err := shard.Shutdown(ctx); err != nil {
-					idx.logger.WithField("action", "shutdown_shard").
-						WithField("shard", shard.ID()).
-						Errorf("cannot shutdown shard %q: %s", name, err)
-				}
-				return nil
-			}, name, shard)
-		}
-		eg.Wait()
-	}
-	commit = func(success bool) {
-		if !success {
-			rollback()
-			return
-		}
-		commitHotted()
-		commitColded()
+	for _, name := range updatesHot {
+		_, err := idx.getOrInitLocalShard(ctx, name)
+		ec.Add(err)
 	}
 
-	applyHot := func() error {
-		for _, name := range shardsToHot {
-			// shard already hot
-			if shard := idx.shards.Load(name); shard != nil {
-				continue
-			}
-
-			shard, err := idx.initShard(ctx, name, class, m.db.promMetrics)
-			if err != nil {
-				return fmt.Errorf("cannot activate shard '%s': %w", name, err)
-			}
-			shardsHotted[name] = shard
-		}
-		return nil
-	}
-	applyCold := func() error {
+	if len(updatesCold) > 0 {
 		idx.backupMutex.RLock()
 		defer idx.backupMutex.RUnlock()
 
-		for _, name := range shardsToCold {
-			shard, ok := idx.shards.Swap(name, nil) // mark as deactivated
-			if !ok {                                // shard doesn't exit (already cold)
-				idx.shards.LoadAndDelete(name) // rollback nil value created by swap()
-				continue
-			}
-			if shard != nil {
-				shardsColded[name] = shard
-			}
+		eg := enterrors.NewErrorGroupWrapper(m.logger)
+		eg.SetLimit(_NUMCPU * 2)
+
+		for _, name := range updatesCold {
+			name := name
+			eg.Go(func() error {
+				idx.shardCreateLocks.Lock(name)
+				defer idx.shardCreateLocks.Unlock(name)
+
+				shard, ok := idx.shards.Swap(name, nil) // swap shard for nil
+				idx.shards.LoadAndDelete(name)          // then remove entry
+
+				if !ok || shard == nil {
+					return nil // shard already does not exist or inactive
+				}
+
+				if err := shard.Shutdown(ctx); err != nil {
+					ec.Add(err)
+					idx.logger.WithField("action", "shutdown_shard").
+						WithField("shard", shard.ID()).Error(err)
+				}
+				return nil
+			})
 		}
-		return nil
+		eg.Wait()
 	}
-
-	for _, tu := range updates {
-		switch tu.Status {
-		case models.TenantActivityStatusHOT:
-			shardsToHot = append(shardsToHot, tu.Name)
-		case models.TenantActivityStatusCOLD:
-			shardsToCold = append(shardsToCold, tu.Name)
-		}
-	}
-
-	defer func() {
-		if err != nil {
-			rollback()
-		}
-	}()
-
-	if err := applyHot(); err != nil {
-		return nil, err
-	}
-	if err := applyCold(); err != nil {
-		return nil, err
-	}
-
-	return commit, nil
+	return ec.ToError()
 }
 
-// DeleteTenants deletes tenants and returns a commit func
-// that can be used to either commit or rollback deletion
-func (m *Migrator) DeleteTenants(ctx context.Context, class string, tenants []string) (commit func(success bool), err error) {
-	idx := m.db.GetIndex(schema.ClassName(class))
-	if idx == nil {
-		return func(bool) {}, nil
+// DeleteTenants deletes tenants
+// CAUTION: will not delete inactive tenants (shard files will not be removed)
+func (m *Migrator) DeleteTenants(ctx context.Context, class string, tenants []string) error {
+	if idx := m.db.GetIndex(schema.ClassName(class)); idx != nil {
+		return idx.dropShards(tenants)
 	}
-	return idx.dropShards(tenants)
+	return nil
 }
 
 func (m *Migrator) UpdateVectorIndexConfig(ctx context.Context,

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -153,11 +153,9 @@ func (e *executor) AddTenants(class string, req *api.AddTenantsRequest) error {
 		return fmt.Errorf("class %q: %w", class, ErrNotFound)
 	}
 	ctx := context.Background()
-	commit, err := e.migrator.NewTenants(ctx, cls, updates)
-	if err != nil {
+	if err := e.migrator.NewTenants(ctx, cls, updates); err != nil {
 		return fmt.Errorf("migrator.new_tenants: %w", err)
 	}
-	commit(true) // commit new adding new tenant
 	return nil
 }
 
@@ -176,27 +174,20 @@ func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest) er
 		})
 	}
 
-	commit, err := e.migrator.UpdateTenants(ctx, cls, updates)
-	if err != nil {
+	if err := e.migrator.UpdateTenants(ctx, cls, updates); err != nil {
 		e.logger.WithField("action", "update_tenants").
 			WithField("class", class).Error(err)
 		return err
 	}
-
-	commit(true) // commit update of tenants
 	return nil
 }
 
 func (e *executor) DeleteTenants(class string, req *api.DeleteTenantsRequest) error {
 	ctx := context.Background()
-	commit, err := e.migrator.DeleteTenants(ctx, class, req.Tenants)
-	if err != nil {
+	if err := e.migrator.DeleteTenants(ctx, class, req.Tenants); err != nil {
 		e.logger.WithField("action", "delete_tenants").
 			WithField("class", class).Error(err)
 	}
-
-	commit(true) // commit deletion of tenants
-
 	return nil
 }
 

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -115,20 +115,19 @@ func TestExecutor(t *testing.T) {
 		assert.Nil(t, x.AddProperty("A", req))
 	})
 
-	commit := func(success bool) {}
 	tenants := []*api.Tenant{{Name: "T1"}, {Name: "T2"}}
 
 	t.Run("DeleteTenants", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		req := &api.DeleteTenantsRequest{}
-		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(commit, nil)
+		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(nil)
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.DeleteTenants("A", req))
 	})
 	t.Run("DeleteTenantsWithError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		req := &api.DeleteTenantsRequest{}
-		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(commit, ErrAny)
+		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.DeleteTenants("A", req))
 	})
@@ -136,7 +135,7 @@ func TestExecutor(t *testing.T) {
 	t.Run("UpdateTenants", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		req := &api.UpdateTenantsRequest{Tenants: tenants}
-		migrator.On("UpdateTenants", Anything, cls, Anything).Return(commit, nil)
+		migrator.On("UpdateTenants", Anything, cls, Anything).Return(nil)
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.UpdateTenants("A", req))
 	})
@@ -153,7 +152,7 @@ func TestExecutor(t *testing.T) {
 	t.Run("UpdateTenantsError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		req := &api.UpdateTenantsRequest{Tenants: tenants}
-		migrator.On("UpdateTenants", Anything, cls, Anything).Return(commit, ErrAny)
+		migrator.On("UpdateTenants", Anything, cls, Anything).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
 		assert.ErrorIs(t, x.UpdateTenants("A", req), ErrAny)
 	})
@@ -161,7 +160,7 @@ func TestExecutor(t *testing.T) {
 	t.Run("AddTenants", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		req := &api.AddTenantsRequest{Tenants: tenants}
-		migrator.On("NewTenants", Anything, cls, Anything).Return(commit, nil)
+		migrator.On("NewTenants", Anything, cls, Anything).Return(nil)
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.AddTenants("A", req))
 	})
@@ -174,7 +173,7 @@ func TestExecutor(t *testing.T) {
 	t.Run("AddTenantsError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		req := &api.AddTenantsRequest{Tenants: tenants}
-		migrator.On("NewTenants", Anything, cls, Anything).Return(commit, ErrAny)
+		migrator.On("NewTenants", Anything, cls, Anything).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
 		assert.ErrorIs(t, x.AddTenants("A", req), ErrAny)
 	})

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -330,19 +330,19 @@ func (f *fakeMigrator) UpdateProperty(ctx context.Context, className string, pro
 	return nil
 }
 
-func (f *fakeMigrator) NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) (commit func(success bool), err error) {
+func (f *fakeMigrator) NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) error {
 	args := f.Called(ctx, class, creates)
-	return args.Get(0).(func(success bool)), args.Error(1)
+	return args.Error(0)
 }
 
-func (f *fakeMigrator) UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) (commit func(success bool), err error) {
+func (f *fakeMigrator) UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) error {
 	args := f.Called(ctx, class, updates)
-	return args.Get(0).(func(success bool)), args.Error(1)
+	return args.Error(0)
 }
 
-func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants []string) (commit func(success bool), err error) {
+func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants []string) error {
 	args := f.Called(ctx, class, tenants)
-	return args.Get(0).(func(success bool)), args.Error(1)
+	return args.Error(0)
 }
 
 func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -45,9 +45,9 @@ type Migrator interface {
 		propName string, newName *string) error
 	UpdateIndex(ctx context.Context, class *models.Class, shardingState *sharding.State) error
 
-	NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) (commit func(success bool), err error)
-	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) (commit func(success bool), err error)
-	DeleteTenants(ctx context.Context, class string, tenants []string) (commit func(success bool), err error)
+	NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) error
+	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) error
+	DeleteTenants(ctx context.Context, class string, tenants []string) error
 
 	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error


### PR DESCRIPTION
### What's being changed:
- simplifies `NewTenants`, `UpdateTenants`, `DeleteTenants` not to used transactional approach.
- introduces `getOrInitLocalShard` method meant to be run on `receiver` node. It creates or inits (activates) existing shard/tenant.
- introduces `isLocalShard` method which checks whether shard is local based on schema, not fact of being active at local node
- replaces `localShard` with `getOrInitLocalShard` and `isLocalShard` depending on use case
- removes `retryGetLocalShard` method as `getOrInitLocalShard` will make sure shard is inited when requested


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
