### PR TITLE
fix:hnsw: data race on findNewLocalEntrypoint

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -595,7 +595,7 @@ func (h *hnsw) findNewLocalEntrypoint(denyList helpers.AllowList, targetLevel in
 		// currently available level
 		h.RLock()
 		defer h.RUnlock()
-		return h.getEntrypoint(), h.currentMaximumLayer, nil
+		return h.entryPointID, h.currentMaximumLayer, nil
 	}
 
 	h.metrics.TombstoneFindLocalEntrypoint()

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -593,6 +593,8 @@ func (h *hnsw) findNewLocalEntrypoint(denyList helpers.AllowList, targetLevel in
 		// we can just use the global one, as the global one is guaranteed to be
 		// present on every level, i.e. it is always chosen from the highest
 		// currently available level
+		h.RLock()
+		defer h.RUnlock()
 		return h.getEntrypoint(), h.currentMaximumLayer, nil
 	}
 


### PR DESCRIPTION
### What's being changed:
there is a data race on https://github.com/weaviate/weaviate/actions/runs/8725785034/job/23939591967?pr=4698 
this PR  should fix the race 


it tries to access it on 
 `/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:507`  and  
`/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:596`
```
==================
WARNING: DATA RACE
Write at 0x00c002890578 by goroutine 141:
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).deleteEntrypoint()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:507 +0x185
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).Delete()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:84 +0x833
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.TestDelete_WithConcurrentEntrypointDeletionAndTombstoneCleanup.func4.2()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete_test.go:332 +0x164

Previous read at 0x00c002890578 by goroutine 140:
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).findNewLocalEntrypoint()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:596 +0x22c
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).reassignNeighbor()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:[44](https://github.com/weaviate/weaviate/actions/runs/8725785034/job/23939591967?pr=4698#step:4:45)6 +0xceb
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).cleanUpTombstonedNodes()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:251 +0x670
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).CleanUpTombstonedNodes()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete.go:211 +0x130
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.TestDelete_WithConcurrentEntrypointDeletionAndTombstoneCleanup.func4.1()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete_test.go:325 +0xb4

Goroutine 141 (running) created at:
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.TestDelete_WithConcurrentEntrypointDeletionAndTombstoneCleanup.func4()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete_test.go:329 +0x2a7
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:16[48](https://github.com/weaviate/weaviate/actions/runs/8725785034/job/23939591967?pr=4698#step:4:49) +0x44

Goroutine 140 (running) created at:
  github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.TestDelete_WithConcurrentEntrypointDeletionAndTombstoneCleanup.func4()
      /home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/delete_test.go:323 +0x16b
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1648 +0x44
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
