### PR TITLE
store.Service.Ready is flaky in cluster/store/sotre_test.go, poll for 2s instead of 1s wait to improve robustness

### DIFF
--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -86,14 +86,8 @@ func TestServiceEndpoints(t *testing.T) {
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1))
-	time.Sleep(time.Second)
-	assert.True(t, srv.Ready())
-	for i := 0; i < 20; i++ {
-		if srv.store.IsLeader() {
-			break
-		}
-		time.Sleep(time.Millisecond * 100)
-	}
+	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
+	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
 	assert.True(t, srv.store.IsLeader())
 	schema := srv.SchemaReader()
 	assert.Equal(t, schema.Len(), 0)
@@ -258,16 +252,24 @@ func TestServiceEndpoints(t *testing.T) {
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1))
-	time.Sleep(time.Second)
-	assert.True(t, srv.Ready())
-	for i := 0; i < 20; i++ {
-		if srv.store.IsLeader() {
-			break
-		}
-		time.Sleep(time.Millisecond * 100)
-	}
+	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
+	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
 	clInfo, _ := srv.store.db.Schema.ClassInfo("C", 0)
 	assert.Equal(t, info, clInfo)
+}
+
+// Runs the provided function `predicate` up to `n` times, sleeping `sleepDuration` between each
+// function call until `f` returns true or returns false if all `n` calls return false.
+// Useful in tests which require an unknown but bounded delay where the component under test has
+// a way to indicate when it's ready to proceed.
+func tryNTimesWithWait(n int, sleepDuration time.Duration, predicate func() bool) bool {
+	for i := 0; i < n; i++ {
+		if predicate() {
+			return true
+		}
+		time.Sleep(sleepDuration)
+	}
+	return false
 }
 
 func TestServiceStoreInit(t *testing.T) {


### PR DESCRIPTION
### What's being changed

When running `cluster/store/store_test.go`, I noticed that there is some flakiness related to the sleep before the `srv.Ready` calls (details below). This is a proposed improvement which polls `srv.Ready` until it returns true (or false if it does not). The helper test function used the existing code which waits for the leader. Note that this does not fix the underlying cause of the flakiness, just makes the test a bit more robust to unexpected delays in the service becoming ready.

I used this script to investigate/verify the fix:

```py
# flaky_test.py
import subprocess

for i in range(50):
    print(i)
    subprocess.run(["go", "test", "-count", "1", "-timeout", "30s", "-run", "^TestServiceEndpoints$", "github.com/weaviate/weaviate/cluster/store"], check=True)
```

Before the changes, this failed on the 8th run with the delay

```sh
python3 flaky_test.py 
0
ok      github.com/weaviate/weaviate/cluster/store      5.622s
1
ok      github.com/weaviate/weaviate/cluster/store      4.772s
2
ok      github.com/weaviate/weaviate/cluster/store      4.991s
3
ok      github.com/weaviate/weaviate/cluster/store      4.750s
4
ok      github.com/weaviate/weaviate/cluster/store      4.813s
5
ok      github.com/weaviate/weaviate/cluster/store      4.830s
6
ok      github.com/weaviate/weaviate/cluster/store      4.741s
7
2024-04-17T09:34:36.809+0100 [INFO]  raft: initial configuration: index=0 servers=[]
2024-04-17T09:34:36.809+0100 [INFO]  raft: entering follower state: follower="Node at 127.0.0.1:62358 [Follower]" leader-address= leader-id=
2024-04-17T09:34:38.131+0100 [WARN]  raft: heartbeat timeout reached, starting election: last-leader-addr= last-leader-id=
2024-04-17T09:34:38.131+0100 [INFO]  raft: entering candidate state: node="Node at 127.0.0.1:62358 [Candidate]" term=2
2024-04-17T09:34:38.162+0100 [INFO]  raft: election won: term=2 tally=1
2024-04-17T09:34:38.162+0100 [INFO]  raft: entering leader state: leader="Node at 127.0.0.1:62358 [Leader]"
2024-04-17T09:34:39.091+0100 [INFO]  raft: updating configuration: command=AddVoter server-id=Node-1 server-addr=localhost:62358 servers="[{Suffrage:Voter ID:Node-1 Address:localhost:62358}]"
2024-04-17T09:34:39.099+0100 [INFO]  raft: updating configuration: command=AddNonvoter server-id=Node-1 server-addr=localhost:62358 servers="[{Suffrage:Voter ID:Node-1 Address:localhost:62358}]"
2024-04-17T09:34:39.117+0100 [INFO]  raft: starting snapshot up to: index=15
2024-04-17T09:34:39.117+0100 [INFO]  snapshot: creating new snapshot: path=/var/folders/hv/3nzzhc317hl3q_6hv821vvg00000gn/T/TestServiceEndpoints1653252214/001/snapshots/2-15-1713342879117.tmp
2024-04-17T09:34:39.138+0100 [INFO]  raft: snapshot complete up to: index=15
2024-04-17T09:34:39.158+0100 [INFO]  raft: starting restore from snapshot: id=2-15-1713342879117 last-index=15 last-term=2 size-in-bytes=559
2024-04-17T09:34:39.159+0100 [INFO]  raft: snapshot restore progress: id=2-15-1713342879117 last-index=15 last-term=2 size-in-bytes=559 read-bytes=559 percent-complete="100.00%"
2024-04-17T09:34:39.159+0100 [INFO]  raft: restored from snapshot: id=2-15-1713342879117 last-index=15 last-term=2 size-in-bytes=559
2024-04-17T09:34:39.159+0100 [INFO]  raft: initial configuration: index=14 servers="[{Suffrage:Voter ID:Node-1 Address:localhost:62358}]"
2024-04-17T09:34:39.159+0100 [INFO]  raft: entering follower state: follower="Node at 127.0.0.1:62358 [Follower]" leader-address= leader-id=
2024-04-17T09:34:41.160+0100 [WARN]  raft: heartbeat timeout reached, starting election: last-leader-addr= last-leader-id=
2024-04-17T09:34:41.160+0100 [INFO]  raft: entering candidate state: node="Node at 127.0.0.1:62358 [Candidate]" term=3
2024-04-17T09:34:41.195+0100 [INFO]  raft: election won: term=3 tally=1
2024-04-17T09:34:41.195+0100 [INFO]  raft: entering leader state: leader="Node at 127.0.0.1:62358 [Leader]"
--- FAIL: TestServiceEndpoints (4.53s)
    store_test.go:262: 
                Error Trace:    /Users/nate/Repos/weaviate/cluster/store/store_test.go:262
                Error:          Should be true
                Test:           TestServiceEndpoints
FAIL
FAIL    github.com/weaviate/weaviate/cluster/store      4.864s
FAIL
Traceback (most recent call last):
  File "/Users/nate/Repos/weaviate/flaky_test.py", line 6, in <module>
    subprocess.run(["go", "test", "-count", "1", "-timeout", "30s", "-run", "^TestServiceEndpoints$", "github.com/weaviate/weaviate/cluster/store"], check=True)
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['go', 'test', '-count', '1', '-timeout', '30s', '-run', '^TestServiceEndpoints$', 'github.com/weaviate/weaviate/cluster/store']' returned non-zero exit status 1.
```

After the change, all 50 test runs succeeded.

Note that this change could result in the tests running slightly faster or slower than before since instead of the hardcoded 1 second wait, we may now wait ~any amount of time between 0 and 2 seconds (just picked an arbitrary but reasonable seeming n/sleepDuration).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: N/A
- [ ] Chaos pipeline run or not necessary. Link to pipeline: N/A
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. N/A
