### PR TITLE
Allow migration from Raft to take as much time as necessary

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -296,14 +296,14 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		}
 	}
 
-	appState.CloudService = rCluster.New(rConfig)
+	appState.ClusterService = rCluster.New(rConfig)
 	executor := schema.NewExecutor(migrator,
-		appState.CloudService.SchemaReader(),
+		appState.ClusterService.SchemaReader(),
 		appState.Logger, backup.RestoreClassDir(dataPath),
 	)
 	schemaManager, err := schemaUC.NewManager(migrator,
-		appState.CloudService.Service,
-		appState.CloudService.SchemaReader(),
+		appState.ClusterService.Service,
+		appState.ClusterService.SchemaReader(),
 		schemaRepo,
 		appState.Logger, appState.Authorizer, appState.ServerConfig.Config,
 		vectorIndex.ParseAndValidateConfig, appState.Modules, inverted.ValidateConfig,
@@ -334,7 +334,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 	// TODO-RAFT START
 	go func() {
-		if err := appState.CloudService.Open(context.Background(), executor); err != nil {
+		if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
 			appState.Logger.
 				WithField("action", "startup").
 				WithError(err).
@@ -482,7 +482,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.Authorizer,
 		clients.NewClusterBackups(appState.ClusterHttpClient),
 		appState.DB, appState.Modules,
-		membership{appState.Cluster, appState.CloudService},
+		membership{appState.Cluster, appState.ClusterService},
 		appState.SchemaManager,
 		appState.Logger)
 	setupBackupHandlers(api, backupScheduler, appState.Metrics, appState.Logger)
@@ -525,7 +525,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		if err := appState.CloudService.Close(ctx); err != nil {
+		if err := appState.ClusterService.Close(ctx); err != nil {
 			panic(err)
 		}
 	}

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -207,7 +207,7 @@ func addLiveAndReadyness(state *state.State, next http.Handler) http.Handler {
 
 		if r.URL.String() == "/v1/.well-known/ready" {
 			code := http.StatusServiceUnavailable
-			if state.CloudService.Ready() && state.Cluster.ClusterHealthScore() == 0 {
+			if state.ClusterService.Ready() && state.Cluster.ClusterHealthScore() == 0 {
 				code = http.StatusOK
 			}
 			w.WriteHeader(code)

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -70,9 +70,8 @@ type State struct {
 	ClusterHttpClient  *http.Client
 	ReindexCtxCancel   context.CancelFunc
 	MemWatch           *memwatch.Monitor
-	/// TODO-RAFT START
-	CloudService *rCluster.Service
-	/// TODO-RAFT END
+
+	ClusterService *rCluster.Service
 }
 
 // GetGraphQL is the safe way to retrieve GraphQL from the state as it can be

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -23,7 +23,6 @@ import (
 
 // Service class serves as the primary entry point for the Raft layer, managing and coordinating
 // the key functionalities of the distributed consensus protocol.
-
 type Service struct {
 	*store.Service
 	raftAddr string

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -44,7 +44,9 @@ func NewService(store *Store, client client) *Service {
 	return &Service{store: store, cl: client, log: store.log}
 }
 
-// / RAFT-TODO Documentation
+// Open opens this store service and marked as such.
+// It constructs a new Raft node using the provided configuration.
+// If there is any old state, such as snapshots, logs, peers, etc., all of those will be restored
 func (s *Service) Open(ctx context.Context, db Indexer) error {
 	s.log.Info("starting raft sub-system ...")
 	s.store.SetDB(db)


### PR DESCRIPTION
Specify a timeout for Raft operations, set to 24 hours, which we believe should be sufficient

Previously, the migration timeout was set to the bootstrapping timeout, resulting in migration failure if it exceeded the timeout

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
