### PR TITLE
update UpdateShardStatus to use schema version

### DIFF
--- a/adapters/clients/remote_index_test.go
+++ b/adapters/clients/remote_index_test.go
@@ -139,7 +139,7 @@ func TestRemoteIndexUpdateShardStatus(t *testing.T) {
 	defer ts.Close()
 	client := newRemoteIndex(ts.Client())
 	t.Run("ConnectionError", func(t *testing.T) {
-		err := client.UpdateShardStatus(ctx, "", "C1", "S1", "NewStatus")
+		err := client.UpdateShardStatus(ctx, "", "C1", "S1", "NewStatus", 0)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "connect")
 	})
@@ -153,7 +153,7 @@ func TestRemoteIndexUpdateShardStatus(t *testing.T) {
 		n++
 	}
 	t.Run("Success", func(t *testing.T) {
-		err := client.UpdateShardStatus(ctx, fs.host, "C1", "S1", "NewStatus")
+		err := client.UpdateShardStatus(ctx, fs.host, "C1", "S1", "NewStatus", 0)
 		assert.Nil(t, err)
 	})
 }

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -119,7 +119,7 @@ type shards interface {
 	GetShardQueueSize(ctx context.Context, indexName, shardName string) (int64, error)
 	GetShardStatus(ctx context.Context, indexName, shardName string) (string, error)
 	UpdateShardStatus(ctx context.Context, indexName, shardName,
-		targetStatus string) error
+		targetStatus string, schemaVersion uint64) error
 
 	// Replication-specific
 	OverwriteObjects(ctx context.Context, indexName, shardName string,
@@ -1009,8 +1009,9 @@ func (i *indices) postUpdateShardStatus() http.Handler {
 				http.StatusBadRequest)
 			return
 		}
+		schemaVersion := extractSchemaVersionFromUrlQuery(r.URL.Query())
 
-		err = i.shards.UpdateShardStatus(r.Context(), index, shard, targetStatus)
+		err = i.shards.UpdateShardStatus(r.Context(), index, shard, targetStatus, schemaVersion)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -245,7 +245,7 @@ func (f *fakeRemoteClient) GetShardStatus(ctx context.Context,
 }
 
 func (f *fakeRemoteClient) UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,
-	targetStatus string,
+	targetStatus string, schemaVersion uint64,
 ) error {
 	return nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1922,14 +1922,14 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 	return shard.GetStatus().String(), nil
 }
 
-func (i *Index) updateShardStatus(ctx context.Context, shardName, targetStatus string) error {
+func (i *Index) updateShardStatus(ctx context.Context, shardName, targetStatus string, schemaVersion uint64) error {
 	if shard := i.localShard(shardName); shard != nil {
 		return shard.UpdateStatus(targetStatus)
 	}
-	return i.remote.UpdateShardStatus(ctx, shardName, targetStatus)
+	return i.remote.UpdateShardStatus(ctx, shardName, targetStatus, schemaVersion)
 }
 
-func (i *Index) IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string) error {
+func (i *Index) IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string, schemaVersion uint64) error {
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return ErrShardNotFound

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -241,7 +241,7 @@ func TestIndex_DropReadOnlyEmptyIndex(t *testing.T) {
 	class := &models.Class{Class: "deletetest"}
 	shard, index := testShard(t, ctx, class.Class)
 
-	err := index.updateShardStatus(ctx, shard.Name(), storagestate.StatusReadOnly.String())
+	err := index.updateShardStatus(ctx, shard.Name(), storagestate.StatusReadOnly.String(), 0)
 	require.Nil(t, err)
 
 	err = index.drop()

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -289,13 +289,13 @@ func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string
 	return idx.getShardsStatus(ctx, tenant)
 }
 
-func (m *Migrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string) error {
+func (m *Migrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		return errors.Errorf("cannot update shard status to a non-existing index for %s", className)
 	}
 
-	return idx.updateShardStatus(ctx, shardName, targetStatus)
+	return idx.updateShardStatus(ctx, shardName, targetStatus, schemaVersion)
 }
 
 // NewTenants creates new partitions and returns a commit func

--- a/cluster/proto/api/request.go
+++ b/cluster/proto/api/request.go
@@ -36,6 +36,7 @@ type DeleteClassRequest struct {
 
 type UpdateShardStatusRequest struct {
 	Class, Shard, Status string
+	SchemaVersion        uint64
 }
 
 type QueryReadOnlyClassRequest struct {

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -477,7 +477,7 @@ func (f *fakeRemoteClient) GetShardStatus(ctx context.Context,
 }
 
 func (f *fakeRemoteClient) UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,
-	targetStatus string,
+	targetStatus string, schemaVersion uint64,
 ) error {
 	return nil
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -202,7 +202,7 @@ func (e *executor) DeleteTenants(class string, req *api.DeleteTenantsRequest) er
 
 func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 	ctx := context.Background()
-	return e.migrator.UpdateShardStatus(ctx, req.Class, req.Shard, req.Status)
+	return e.migrator.UpdateShardStatus(ctx, req.Class, req.Shard, req.Status, req.SchemaVersion)
 }
 
 // TODO-RAFT START

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -204,8 +204,8 @@ func TestExecutor(t *testing.T) {
 	})
 	t.Run("UpdateShardStatus", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		req := &api.UpdateShardStatusRequest{Class: "A", Shard: "S", Status: "ST"}
-		migrator.On("UpdateShardStatus", Anything, "A", "S", "ST").Return(nil)
+		req := &api.UpdateShardStatusRequest{Class: "A", Shard: "S", Status: "ST", SchemaVersion: 123}
+		migrator.On("UpdateShardStatus", Anything, "A", "S", "ST", uint64(123)).Return(nil)
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.UpdateShardStatus(req))
 	})

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -350,8 +350,8 @@ func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant st
 	return args.Get(0).(map[string]string), args.Error(1)
 }
 
-func (f *fakeMigrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string) error {
-	args := f.Called(ctx, className, shardName, targetStatus)
+func (f *fakeMigrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error {
+	args := f.Called(ctx, className, shardName, targetStatus, schemaVersion)
 	return args.Error(0)
 }
 

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -50,7 +50,7 @@ type Migrator interface {
 	DeleteTenants(ctx context.Context, class string, tenants []string) (commit func(success bool), err error)
 
 	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
-	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string) error
+	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error
 
 	UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error
 	ValidateVectorIndexConfigsUpdate(old, updated map[string]schemaConfig.VectorIndexConfig) error

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -89,8 +89,7 @@ type RemoteIndexClient interface {
 		uuids []strfmt.UUID, dryRun bool, schemaVersion uint64) objects.BatchSimpleObjects
 	GetShardQueueSize(ctx context.Context, hostName, indexName, shardName string) (int64, error)
 	GetShardStatus(ctx context.Context, hostName, indexName, shardName string) (string, error)
-	UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,
-		targetStatus string) error
+	UpdateShardStatus(ctx context.Context, hostName, indexName, shardName, targetStatus string, schemaVersion uint64) error
 
 	PutFile(ctx context.Context, hostName, indexName, shardName, fileName string,
 		payload io.ReadSeekCloser) error
@@ -352,7 +351,7 @@ func (ri *RemoteIndex) GetShardStatus(ctx context.Context, shardName string) (st
 	return ri.client.GetShardStatus(ctx, host, ri.class, shardName)
 }
 
-func (ri *RemoteIndex) UpdateShardStatus(ctx context.Context, shardName, targetStatus string) error {
+func (ri *RemoteIndex) UpdateShardStatus(ctx context.Context, shardName, targetStatus string, schemaVersion uint64) error {
 	owner, err := ri.stateGetter.ShardOwner(ri.class, shardName)
 	if err != nil {
 		return fmt.Errorf("class %s has no physical shard %q: %w", ri.class, shardName, err)
@@ -363,7 +362,7 @@ func (ri *RemoteIndex) UpdateShardStatus(ctx context.Context, shardName, targetS
 		return errors.Errorf("resolve node name %q to host", owner)
 	}
 
-	return ri.client.UpdateShardStatus(ctx, host, ri.class, shardName, targetStatus)
+	return ri.client.UpdateShardStatus(ctx, host, ri.class, shardName, targetStatus, schemaVersion)
 }
 
 func (ri *RemoteIndex) queryReplicas(

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -66,7 +66,7 @@ type RemoteIndexIncomingRepo interface {
 		uuids []strfmt.UUID, dryRun bool, schemaVersion uint64) objects.BatchSimpleObjects
 	IncomingGetShardQueueSize(ctx context.Context, shardName string) (int64, error)
 	IncomingGetShardStatus(ctx context.Context, shardName string) (string, error)
-	IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string) error
+	IncomingUpdateShardStatus(ctx context.Context, shardName, targetStatus string, schemaVersion uint64) error
 	IncomingOverwriteObjects(ctx context.Context, shard string,
 		vobjects []*objects.VObject) ([]replica.RepairResponse, error)
 	IncomingDigestObjects(ctx context.Context, shardName string,
@@ -251,14 +251,14 @@ func (rii *RemoteIndexIncoming) GetShardStatus(ctx context.Context,
 }
 
 func (rii *RemoteIndexIncoming) UpdateShardStatus(ctx context.Context,
-	indexName, shardName, targetStatus string,
+	indexName, shardName, targetStatus string, schemaVersion uint64,
 ) error {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
 		return errors.Errorf("local index %q not found", indexName)
 	}
 
-	return index.IncomingUpdateShardStatus(ctx, shardName, targetStatus)
+	return index.IncomingUpdateShardStatus(ctx, shardName, targetStatus, schemaVersion)
 }
 
 func (rii *RemoteIndexIncoming) FilePutter(ctx context.Context,


### PR DESCRIPTION
### What's being changed:

Update UpdateShardStatus function to take into account schemaVersion and ensure it is propagated via client to cluster api and recovered on server side.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
