### PR TITLE
fix(text2vec/bedrock): correct url for bedrock inference service

### DIFF
--- a/modules/text2vec-aws/clients/aws.go
+++ b/modules/text2vec-aws/clients/aws.go
@@ -37,12 +37,8 @@ var (
 )
 
 func buildBedrockUrl(service, region, model string) string {
-	serviceName := service
-	if strings.HasPrefix(model, "cohere") {
-		serviceName = fmt.Sprintf("%s-runtime", serviceName)
-	}
-	urlTemplate := "https://%s.%s.amazonaws.com/model/%s/invoke"
-	return fmt.Sprintf(urlTemplate, serviceName, region, model)
+	urlTemplate := "https://%s-runtime.%s.amazonaws.com/model/%s/invoke"
+	return fmt.Sprintf(urlTemplate, service, region, model)
 }
 
 func buildSagemakerUrl(service, region, endpoint string) string {


### PR DESCRIPTION
#3940 

### What's being changed:
Bedrock URL for inference service

Bedrock invoke model documentation: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html

Unless i'm missing something here, weaviate should use this url

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
