### PR TITLE
RAFT:GRPC:tweak the client service config

### DIFF
--- a/cluster/transport/client.go
+++ b/cluster/transport/client.go
@@ -35,11 +35,12 @@ const serviceConfig = `
 					"service": "weaviate.internal.cluster.ClusterService", "method": "Query"
 				}
 			],
+			"waitForReady": true,			
 			"retryPolicy": {
 				"MaxAttempts": 5,
 				"BackoffMultiplier": 2,
 				"InitialBackoff": "0.5s",
-				"MaxBackoff": "3s",
+				"MaxBackoff": "5s",
 				"RetryableStatusCodes": [
 					"ABORTED",
 					"RESOURCE_EXHAUSTED",


### PR DESCRIPTION
### What's being changed:
a tweak for the client grpc service config to not fail immediately if the connection is not ready
also increase the backoff to avoid throttling the leader and mitigate `leader not found` in case  of election is in progress

ref: https://grpc.io/docs/guides/service-config/ 

```
With wait-for-ready enabled, if a client cannot connect to a backend, the RPC will be delayed instead of immediately failing.
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
