### PR TITLE
fix nil ptr panic when closing raft leader client

### DIFF
--- a/cluster/transport/client.go
+++ b/cluster/transport/client.go
@@ -130,7 +130,9 @@ func (cl *Client) Query(ctx context.Context, leaderAddress string, req *cmd.Quer
 }
 
 func (cl *Client) Close() {
-	cl.leaderConn.Close()
+	if cl.leaderConn != nil {
+		cl.leaderConn.Close()
+	}
 }
 
 func (cl *Client) getConn(leaderAddress string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
### What's being changed:

Add a nil check to avoid a panic when closing the RAFT store and closing the leader client.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
