### PR TITLE
fix data race on nodes in memberlist for NodeAddress access

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -208,9 +208,16 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 func (s *State) NodeAddress(id string) string {
 	s.listLock.RLock()
 	defer s.listLock.RUnlock()
-	for _, mem := range s.list.Members() {
-		if mem.Name == id {
-			return mem.Addr.String()
+
+	// create copy of list to avoid data race
+	members := make([]memberlist.Node, len(s.list.Members()))
+	for idx, m := range s.list.Members() {
+		members[idx] = *m
+	}
+
+	for _, node := range members {
+		if node.Name == id {
+			return node.Addr.String()
 		}
 	}
 	return ""


### PR DESCRIPTION
### What's being changed:
this PR create a copy of the member list node, given that we can access the node concurrently to get the address while we don't own the lock to lock access the node and already a RLock was in place but it seems that's not enough because the nodes in the list could be updated while we are accessing it.
```
==================
WARNING: DATA RACE
Write at 0x00c00282cc10 by goroutine 71:
  github.com/hashicorp/memberlist.(*Memberlist).aliveNode()
      /go/pkg/mod/github.com/hashicorp/memberlist@v0.5.1/state.go:1137 +0x2dac
  github.com/hashicorp/memberlist.(*Memberlist).handleAlive()
      /go/pkg/mod/github.com/hashicorp/memberlist@v0.5.1/net.go:741 +0x69a
  github.com/hashicorp/memberlist.(*Memberlist).packetHandler()
      /go/pkg/mod/github.com/hashicorp/memberlist@v0.5.1/net.go:516 +0x1c6
  github.com/hashicorp/memberlist.newMemberlist.func7()
      /go/pkg/mod/github.com/hashicorp/memberlist@v0.5.1/memberlist.go:238 +0x33

Previous read at 0x00c00282cc10 by goroutine 196:
  github.com/weaviate/weaviate/usecases/cluster.(*State).NodeAddress()
      /go/src/github.com/weaviate/weaviate/usecases/cluster/state.go:213 +0x1b2
  github.com/weaviate/weaviate/cluster/store.(*addrResolver).ServerAddr()
      /go/src/github.com/weaviate/weaviate/cluster/store/transport.go:47 +0x72
  github.com/hashicorp/raft.(*NetworkTransport).getProviderAddressOrFallback()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/net_transport.go:379 +0xaa
  github.com/hashicorp/raft.(*NetworkTransport).getConnFromAddressProvider()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/net_transport.go:373 +0x52
  github.com/hashicorp/raft.(*NetworkTransport).genericRPC()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/net_transport.go:463 +0x85
  github.com/hashicorp/raft.(*NetworkTransport).AppendEntries()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/net_transport.go:452 +0x9b
  github.com/hashicorp/raft.(*Raft).heartbeat()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/replication.go:407 +0x62d
  github.com/hashicorp/raft.(*Raft).replicate.func1()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/replication.go:141 +0x46
  github.com/hashicorp/raft.(*raftState).goFunc.func1()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/state.go:149 +0x92

Goroutine 71 (running) created at:
  github.com/hashicorp/memberlist.newMemberlist()
      /go/pkg/mod/github.com/hashicorp/memberlist@v0.5.1/memberlist.go:238 +0x180a
  github.com/hashicorp/memberlist.Create()
      /go/pkg/mod/github.com/hashicorp/memberlist@v0.5.1/memberlist.go:249 +0x2e
  github.com/weaviate/weaviate/usecases/cluster.Init()
      /go/src/github.com/weaviate/weaviate/usecases/cluster/state.go:91 +0x5e6
  github.com/weaviate/weaviate/adapters/handlers/rest.startupRoutine()
      /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:602 +0x1836
  github.com/weaviate/weaviate/adapters/handlers/rest.MakeAppState()
      /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:139 +0x72
  github.com/weaviate/weaviate/adapters/handlers/rest.configureAPI()
      /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:450 +0x115
  github.com/weaviate/weaviate/adapters/handlers/rest.(*Server).ConfigureAPI()
      /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/server.go:68 +0x95e
  main.main()
      /go/src/github.com/weaviate/weaviate/cmd/weaviate-server/main.go:62 +0x90b

Goroutine 196 (running) created at:
  github.com/hashicorp/raft.(*raftState).goFunc()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/state.go:147 +0xe5
  github.com/hashicorp/raft.(*Raft).replicate()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/replication.go:141 +0x1d4
  github.com/hashicorp/raft.(*Raft).startStopReplication.func1()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/raft.go:559 +0x38
  github.com/hashicorp/raft.(*raftState).goFunc.func1()
      /go/pkg/mod/github.com/hashicorp/raft@v1.5.0/state.go:149 +0x92
```

w.r.t. https://github.com/weaviate/weaviate/actions/runs/8743047895/job/23993384594?pr=4716
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
