### PR TITLE
Add latest tag to docker image only when it's a tag build

### DIFF
--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -27,10 +27,11 @@ function release() {
     tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_hash}"
   fi
 
-  args=("--build-arg=GITHASH=$git_hash" "--platform=linux/amd64,linux/arm64" "--target=weaviate" "-t=$tag_latest" "--push")
+  args=("--build-arg=GITHASH=$git_hash" "--platform=linux/amd64,linux/arm64" "--target=weaviate" "--push")
   if [ -n "$tag_exact" ]; then
     # exact tag on master
     args+=("-t=$tag_exact")
+    args+=("-t=$tag_latest")
   fi
   if [ -n "$tag_preview" ]; then
     # preview tag on PR builds


### PR DESCRIPTION
### What's being changed:

This PR changes how we tag our docker images, now we add `latest` tag only when it is a `tag build`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
