### PR TITLE
update auto schema to return the schema version

### DIFF
--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -95,7 +95,7 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	}
 	object.ID = id
 
-	err = m.autoSchemaManager.autoSchema(ctx, principal, true, object)
+	schemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, true, object)
 	if err != nil {
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}
@@ -121,7 +121,7 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 		return nil, err
 	}
 
-	err = m.vectorRepo.PutObject(ctx, object, object.Vector, object.Vectors, repl, 0)
+	err = m.vectorRepo.PutObject(ctx, object, object.Vector, object.Vectors, repl, schemaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("put object: %w", err)
 	}

--- a/usecases/objects/auto_schema_test.go
+++ b/usecases/objects/auto_schema_test.go
@@ -559,7 +559,7 @@ func Test_autoSchemaManager_autoSchema_emptyRequest(t *testing.T) {
 
 	var obj *models.Object
 
-	err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
+	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
 	assert.EqualError(t, fmt.Errorf(validation.ErrorMissingObject), err.Error())
 }
 
@@ -593,7 +593,7 @@ func Test_autoSchemaManager_autoSchema_create(t *testing.T) {
 	}
 	// when
 	schemaBefore := schemaManager.GetSchemaResponse
-	err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
+	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
 	schemaAfter := schemaManager.GetSchemaResponse
 
 	// then
@@ -674,7 +674,7 @@ func Test_autoSchemaManager_autoSchema_update(t *testing.T) {
 	assert.Equal(t, "age", (schemaBefore.Objects.Classes)[0].Properties[0].Name)
 	assert.Equal(t, "int", (schemaBefore.Objects.Classes)[0].Properties[0].DataType[0])
 
-	err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
+	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
 	require.Nil(t, err)
 
 	schemaAfter := schemaManager.GetSchemaResponse
@@ -1590,7 +1590,7 @@ func Test_autoSchemaManager_perform_withNested(t *testing.T) {
 		logger: logger,
 	}
 
-	err := manager.autoSchema(context.Background(), &models.Principal{}, true, object)
+	_, err := manager.autoSchema(context.Background(), &models.Principal{}, true, object)
 	require.NoError(t, err)
 
 	schemaAfter := schemaManager.GetSchemaResponse

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -43,6 +43,8 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	}
 	defer unlock()
 
+	ctx = classcache.ContextWithClassCache(ctx)
+
 	b.metrics.BatchDeleteInc()
 	defer b.metrics.BatchDeleteDec()
 

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -44,6 +44,8 @@ func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Prin
 	}
 	defer unlock()
 
+	ctx = classcache.ContextWithClassCache(ctx)
+
 	b.metrics.BatchRefInc()
 	defer b.metrics.BatchRefDec()
 

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -69,6 +69,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 		return NewErrNotFound("object %v could not be found", path)
 	}
 
+	// TODO-RAFT: Verify here how we want to fetch schemaVersion
 	err = m.vectorRepo.DeleteObject(ctx, class, id, repl, tenant, 0)
 	if err != nil {
 		return NewErrInternal("could not delete object from vector repo: %v", err)

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -71,7 +71,8 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{"not found", StatusNotFound, err}
 	}
 
-	if err = m.autoSchemaManager.autoSchema(ctx, principal, false, updates); err != nil {
+	var schemaVersion uint64
+	if schemaVersion, err = m.autoSchemaManager.autoSchema(ctx, principal, false, updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, NewErrInvalidUserInput("invalid object: %v", err)}
 	}
 
@@ -94,7 +95,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		updates.Properties = map[string]interface{}{}
 	}
 
-	return m.patchObject(ctx, principal, prevObj, updates, repl, propertiesToDelete, updates.Tenant, 0)
+	return m.patchObject(ctx, principal, prevObj, updates, repl, propertiesToDelete, updates.Tenant, schemaVersion)
 }
 
 // patchObject patches an existing object obj with updates

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -70,7 +70,8 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 		return nil, err
 	}
 
-	if err = m.autoSchemaManager.autoSchema(ctx, principal, false, updates); err != nil {
+	var schemaVersion uint64
+	if schemaVersion, err = m.autoSchemaManager.autoSchema(ctx, principal, false, updates); err != nil {
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}
 
@@ -95,7 +96,7 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 	updates.CreationTimeUnix = obj.Created
 	updates.LastUpdateTimeUnix = m.timeSource.Now()
 
-	class, schemaVersion, err := m.schemaManager.GetCachedClass(ctx, principal, className)
+	class, _, err := m.schemaManager.GetCachedClass(ctx, principal, className)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

Update auto schema to return the most up-to-date schemaVersion is got returned on read/writes. This subsequent schema version can then be used in subsequent write requests.

* Update auto schema to return schema version
* Update add/delete/merge/update/batch_add to use this new version.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
