### PR TITLE
use GHA action for goreleaser install

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -215,11 +215,12 @@ jobs:
         with:
           go-version: '1.21'
           cache: true
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
       - name: goreleaser
         run: |
-          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
-          sudo apt update
-          sudo apt install goreleaser
           GIT_HASH=$(git rev-parse --short HEAD) goreleaser build  --clean --snapshot
       - name: Upload macos
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What's being changed:

Change the install step of goreleaser to use the GHA recommended by go releaser and see if it circumvent the issue we are encountering with microsoft repo breaking apt update/upgrade.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
