### PR TITLE
make default CLUSTER_HOSTNAME consistent between memberlist and RAFT

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -60,9 +60,7 @@ func (ba BasicAuth) Enabled() bool {
 func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *State, err error) {
 	cfg := memberlist.DefaultLANConfig()
 	cfg.LogOutput = newLogParser(logger)
-	if userConfig.Hostname != "" {
-		cfg.Name = userConfig.Hostname
-	}
+	cfg.Name = userConfig.Hostname
 	state := State{
 		config: userConfig,
 		delegate: delegate{
@@ -96,7 +94,6 @@ func Init(userConfig Config, dataPath string, logger logrus.FieldLogger) (_ *Sta
 			Error("memberlist not created")
 		return nil, errors.Wrap(err, "create member list")
 	}
-
 	var joinAddr []string
 	if userConfig.Join != "" {
 		joinAddr = strings.Split(userConfig.Join, ",")

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -631,8 +631,13 @@ func parseResourceUsageEnvVars() (ResourceUsage, error) {
 func parseClusterConfig() (cluster.Config, error) {
 	cfg := cluster.Config{}
 
-	if v := os.Getenv("CLUSTER_HOSTNAME"); v != "" {
-		cfg.Hostname = v
+	// by default memberlist assigns hostname to os.Hostname() incase hostname is empty
+	//ref: https://github.com/hashicorp/memberlist/blob/3f82dc10a89f82efe300228752f7077d0d9f87e4/config.go#L303
+	// it's handled at parseClusterConfig step to be consistent from the config start point and conveyed to all
+	// underlying functions see parseRAFTConfig(..) for example
+	cfg.Hostname = os.Getenv("CLUSTER_HOSTNAME")
+	if cfg.Hostname == "" {
+		cfg.Hostname, _ = os.Hostname()
 	}
 	cfg.Join = os.Getenv("CLUSTER_JOIN")
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -632,7 +632,7 @@ func parseClusterConfig() (cluster.Config, error) {
 	cfg := cluster.Config{}
 
 	// by default memberlist assigns hostname to os.Hostname() incase hostname is empty
-	//ref: https://github.com/hashicorp/memberlist/blob/3f82dc10a89f82efe300228752f7077d0d9f87e4/config.go#L303
+	// ref: https://github.com/hashicorp/memberlist/blob/3f82dc10a89f82efe300228752f7077d0d9f87e4/config.go#L303
 	// it's handled at parseClusterConfig step to be consistent from the config start point and conveyed to all
 	// underlying functions see parseRAFTConfig(..) for example
 	cfg.Hostname = os.Getenv("CLUSTER_HOSTNAME")

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -255,6 +255,7 @@ func TestEnvironmentMemtable_MaxDuration(t *testing.T) {
 }
 
 func TestEnvironmentParseClusterConfig(t *testing.T) {
+	hostname, _ := os.Hostname()
 	tests := []struct {
 		name           string
 		envVars        map[string]string
@@ -270,6 +271,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				"CLUSTER_ADVERTISE_PORT":   "9999",
 			},
 			expectedResult: cluster.Config{
+				Hostname:       hostname,
 				GossipBindPort: 7100,
 				DataBindPort:   7101,
 				AdvertiseAddr:  "193.0.0.1",
@@ -279,6 +281,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 		{
 			name: "valid cluster config - no ports and advertiseaddr provided",
 			expectedResult: cluster.Config{
+				Hostname:       hostname,
 				GossipBindPort: DefaultGossipBindPort,
 				DataBindPort:   DefaultGossipBindPort + 1,
 				AdvertiseAddr:  "",
@@ -290,6 +293,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				"CLUSTER_GOSSIP_BIND_PORT": "7777",
 			},
 			expectedResult: cluster.Config{
+				Hostname:       hostname,
 				GossipBindPort: 7777,
 				DataBindPort:   7778,
 			},
@@ -317,6 +321,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				"CLUSTER_IGNORE_SCHEMA_SYNC": "true",
 			},
 			expectedResult: cluster.Config{
+				Hostname:                hostname,
 				GossipBindPort:          7946,
 				DataBindPort:            7947,
 				IgnoreStartupSchemaSync: true,


### PR DESCRIPTION
### What's being changed:
[by default memberlist assigns hostname to os.Hostname() incase hostname is empty](https://github.com/hashicorp/memberlist/blob/3f82dc10a89f82efe300228752f7077d0d9f87e4/config.go#L303)

with this PR we are going to handle that at parseClusterConfig step to be consistent from the config start point and conveyed to all underlying functions see [parseRAFTConfig(..) usgae for example](https://github.com/weaviate/weaviate/blob/7c570d31fde0f4f9a3c8f621455488e478aab489/usecases/config/environment.go#L356)
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
