### PR TITLE
Fix/cluster-log-formatting

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -52,7 +52,7 @@ func New(cfg store.Config) *Service {
 // Open internal RPC service to handle node communication,
 // bootstrap the Raft node, and restore the database state
 func (c *Service) Open(ctx context.Context, db store.Indexer) error {
-	c.logger.Info("open cluster service", "servers", c.config.ServerName2PortMap)
+	c.logger.WithField("servers", c.config.ServerName2PortMap).Info("open cluster service")
 	if err := c.rpcService.Open(); err != nil {
 		return fmt.Errorf("start rpc service: %w", err)
 	}

--- a/cluster/store/bootstrap.go
+++ b/cluster/store/bootstrap.go
@@ -65,14 +65,14 @@ func (b *Bootstrapper) Do(ctx context.Context, serverPortMap map[string]int, lg 
 		case <-ticker.C:
 			// try to join an existing cluster
 			if leader, err := b.join(ctx, servers, voter); err == nil {
-				lg.Info("successfully joined cluster", "leader", leader)
+				lg.WithField("leader", leader).Info("successfully joined cluster")
 				return nil
 			}
 
 			if voter {
 				// notify other servers about readiness of this node to be joined
 				if err := b.notify(ctx, servers); err != nil {
-					lg.Error("notify all peers", "servers", servers, "err", err)
+					lg.WithField("servers", servers).WithError(err).Error("notify all peers")
 				}
 			}
 

--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -73,7 +73,8 @@ func (db *localDB) RestoreClass(cmd *command.ApplyRequest, nodeID string, schema
 	req.State.SetLocalName(nodeID)
 
 	if err := db.store.RestoreClassDir(cmd.Class); err != nil {
-		db.log.Error("restore class directory from backup %s: "+err.Error(), "class", cmd.Class)
+		db.log.WithField("class", cmd.Class).WithError(err).
+			Error("restore class directory from backup")
 		// continue since we need to add class to the schema anyway
 	}
 

--- a/cluster/store/query.go
+++ b/cluster/store/query.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (st *Store) Query(req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
-	st.log.Debug("server.query", "type", req.Type)
+	st.log.WithField("type", req.Type).Debug("server.query")
 
 	var payload []byte
 	var err error
@@ -54,7 +54,7 @@ func (st *Store) Query(req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
 		// This could occur when a new command has been introduced in a later app version
 		// At this point, we need to panic so that the app undergo an upgrade during restart
 		const msg = "consider upgrading to newer version"
-		st.log.Error("unknown command", "type", req.Type, "more", msg)
+		st.log.WithField("type", req.Type).WithField("more", msg).Error("unknown command")
 		return &cmd.QueryResponse{}, fmt.Errorf("unknown command type %s: %s", req.Type, msg)
 	}
 	return &cmd.QueryResponse{Payload: payload}, nil

--- a/cluster/store/query.go
+++ b/cluster/store/query.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
@@ -54,7 +55,10 @@ func (st *Store) Query(req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
 		// This could occur when a new command has been introduced in a later app version
 		// At this point, we need to panic so that the app undergo an upgrade during restart
 		const msg = "consider upgrading to newer version"
-		st.log.WithField("type", req.Type).WithField("more", msg).Error("unknown command")
+		st.log.WithFields(logrus.Fields{
+			"type": req.Type,
+			"more": msg,
+		}).Error("unknown command")
 		return &cmd.QueryResponse{}, fmt.Errorf("unknown command type %s: %s", req.Type, msg)
 	}
 	return &cmd.QueryResponse{Payload: payload}, nil

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -60,7 +60,7 @@ func (s *Service) Close(ctx context.Context) (err error) {
 	if !s.store.IsVoter() {
 		s.log.Info("removing this node from cluster prior to shutdown ...")
 		if err := s.Remove(ctx, s.store.ID()); err != nil {
-			s.log.Error("remove this node from cluster: " + err.Error())
+			s.log.WithError(err).Error("remove this node from cluster")
 		} else {
 			s.log.Info("successfully removed this node from the cluster.")
 		}

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -249,7 +249,11 @@ func (s *Service) Execute(req *cmd.ApplyRequest) (uint64, error) {
 }
 
 func (s *Service) Join(ctx context.Context, id, addr string, voter bool) error {
-	// log.Printf("membership.join %v %v %v", id, addr, voter)
+	s.log.WithFields(logrus.Fields{
+		"id":      id,
+		"address": addr,
+		"voter":   voter,
+	}).Debug("membership.join")
 	if s.store.IsLeader() {
 		return s.store.Join(id, addr, voter)
 	}
@@ -263,7 +267,7 @@ func (s *Service) Join(ctx context.Context, id, addr string, voter bool) error {
 }
 
 func (s *Service) Remove(ctx context.Context, id string) error {
-	// log.Printf("membership.remove %v ", id)
+	s.log.WithField("id", id).Debug("membership.remove")
 	if s.store.IsLeader() {
 		return s.store.Remove(id)
 	}
@@ -277,7 +281,7 @@ func (s *Service) Remove(ctx context.Context, id string) error {
 }
 
 func (s *Service) Stats() map[string]any {
-	// log.Printf("membership.Stats")
+	s.log.Debug("membership.stats")
 	return s.store.Stats()
 }
 

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -237,17 +237,16 @@ func (st *Store) Open(ctx context.Context) (err error) {
 		st.loadDatabase(ctx)
 	}
 
-	st.log.Info("construct a new raft node", "name", st.nodeID)
+	st.log.WithField("name", st.nodeID).Info("construct a new raft node")
 	st.raft, err = raft.NewRaft(st.raftConfig(), st, logCache, st.logStore, st.snapshotStore, st.transport)
 	if err != nil {
 		return fmt.Errorf("raft.NewRaft %v %w", st.transport.LocalAddr(), err)
 	}
 	st.lastAppliedIndex.Store(st.raft.AppliedIndex())
-	st.log.Info("raft node",
-		"raft_applied_index", st.raft.AppliedIndex(),
-		"raft_last_index", st.raft.LastIndex(),
-		"last_log_applied_index", st.initialLastAppliedIndex,
-		"last_snapshot_index", lastSnapshotIndex)
+	st.log.WithField("raft_applied_index", st.raft.AppliedIndex()).
+		WithField("raft_last_index", st.raft.LastIndex()).
+		WithField("last_log_applied_index", st.initialLastAppliedIndex).
+		WithField("last_snapshot_index", lastSnapshotIndex).Info("raft node")
 
 	// There's no hard limit on the migration, so it should take as long as necessary.
 	// However, we believe that 1 day should be more than sufficient.
@@ -293,7 +292,8 @@ func (st *Store) init() (logCache *raft.LogCache, err error) {
 		return nil, fmt.Errorf("transport address=%v tcpAddress=%v maxPool=%v timeOut=%v: %w",
 			address, tcpAddr, tcpMaxPool, tcpTimeout, err)
 	}
-	st.log.Info("tcp transport", "address", address, "tcpMaxPool", tcpMaxPool, "tcpTimeout", tcpTimeout)
+	st.log.WithField("address", address).WithField("tcpMaxPool", tcpMaxPool).
+		WithField("tcpTimeout", tcpTimeout).Info("tcp transport")
 
 	return
 }
@@ -305,7 +305,7 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 	for range t.C {
 
 		if leader := st.Leader(); leader != "" {
-			st.log.Info("current Leader", "address", leader)
+			st.log.WithField("address", leader).Info("current Leader")
 		} else {
 			continue
 		}
@@ -340,7 +340,7 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 		if st.IsLeader() && st.db.Schema.len() == 0 && st.loadLegacySchema != nil {
 			st.log.Info("starting migration from old schema")
 			if err := migrate(); err != nil {
-				st.log.Error("migrate from old schema: %v" + err.Error())
+				st.log.WithError(err).Error("migrate from old schema")
 			} else {
 				st.log.Info("migration from the old schema has been successfully completed")
 			}
@@ -364,7 +364,7 @@ func (st *Store) Close(ctx context.Context) (err error) {
 	if st.IsLeader() {
 		st.log.Info("transferring leadership to another server")
 		if err := st.raft.LeadershipTransfer().Error(); err != nil {
-			st.log.Error("transferring leadership: " + err.Error())
+			st.log.WithError(err).Error("transferring leadership")
 		} else {
 			st.log.Info("successfully transferred leadership to another server")
 		}
@@ -433,7 +433,8 @@ func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, 
 			if idx = st.lastAppliedIndex.Load(); idx >= version {
 				return nil
 			} else {
-				st.log.Debug("wait for update version", "got", idx, "want", version) // TODO-RAFT remove
+				st.log.WithField("got", idx).WithField("want", version).
+					Debug("wait for update version") // TODO-RAFT remove
 			}
 		}
 	}
@@ -535,7 +536,7 @@ func (st *Store) LeaderWithID() (raft.ServerAddress, raft.ServerID) {
 }
 
 func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
-	st.log.Debug("server.execute", "type", req.Type, "class", req.Class)
+	st.log.WithField("type", req.Type).WithField("class", req.Class).Debug("server.execute")
 
 	cmdBytes, err := proto.Marshal(req)
 	if err != nil {
@@ -543,7 +544,7 @@ func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 	}
 	classInfo := st.db.Schema.ClassInfo(req.Class)
 	if req.Type == api.ApplyRequest_TYPE_RESTORE_CLASS && classInfo.Exists {
-		st.log.Info("class already restored", "class", req.Class)
+		st.log.WithField("class", req.Class).Info("class already restored")
 		return 0, nil
 	}
 	if req.Type == api.ApplyRequest_TYPE_ADD_CLASS {
@@ -571,14 +572,14 @@ func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 // method was called on the same Raft node as the FSM.
 func (st *Store) Apply(l *raft.Log) interface{} {
 	ret := Response{Version: l.Index}
-	st.log.Debug("apply command", "type", l.Type, "index", l.Index)
+	st.log.WithField("type", l.Type).WithField("index", l.Index).Debug("apply command")
 	if l.Type != raft.LogCommand {
-		st.log.Info("not a valid command", "type", l.Type, "index", l.Index)
+		st.log.WithField("type", l.Type).WithField("index", l.Index).Info("not a valid command")
 		return ret
 	}
 	cmd := api.ApplyRequest{}
 	if err := gproto.Unmarshal(l.Data, &cmd); err != nil {
-		st.log.Error("decode command: " + err.Error())
+		st.log.WithError(err).Error("decode command")
 		panic("error proto un-marshalling log data")
 	}
 
@@ -592,7 +593,8 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 			st.loadDatabase(context.Background())
 		}
 		if ret.Error != nil {
-			st.log.Error("apply command: "+ret.Error.Error(), "type", l.Type, "index", l.Index)
+			st.log.WithField("type", l.Type).WithField("index", l.Index).WithError(ret.Error).
+				Error("apply command")
 		}
 	}()
 
@@ -633,7 +635,8 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		// This could occur when a new command has been introduced in a later app version
 		// At this point, we need to panic so that the app undergo an upgrade during restart
 		const msg = "consider upgrading to newer version"
-		st.log.Error("unknown command", "type", cmd.Type, "class", cmd.Class, "more", msg)
+		st.log.WithField("type", cmd.Type).WithField("class", cmd.Class).WithField("more", msg).
+			Error("unknown command")
 		panic(fmt.Sprintf("unknown command type=%d class=%s more=%s", cmd.Type, cmd.Class, msg))
 	}
 
@@ -652,18 +655,19 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 	st.log.Info("restoring schema from snapshot")
 	defer func() {
 		if err := rc.Close(); err != nil {
-			st.log.Error("restore snapshot: close reader: " + err.Error())
+			st.log.WithError(err).Error("restore snapshot: close reader")
 		}
 	}()
 
 	if err := st.db.Schema.Restore(rc, st.db.parser); err != nil {
-		st.log.Error("restoring schema from snapshot: " + err.Error())
+		st.log.WithError(err).Error("restoring schema from snapshot")
 		return fmt.Errorf("restore schema from snapshot: %w", err)
 	}
 	st.log.Info("successfully restored schema from snapshot")
 
 	if st.reloadDB() {
-		st.log.Info("successfully reloaded indexes from snapshot", "n", st.db.Schema.len())
+		st.log.WithField("n", st.db.Schema.len()).
+			Info("successfully reloaded indexes from snapshot")
 	}
 
 	if st.raft != nil {
@@ -721,7 +725,8 @@ func (st *Store) Notify(id, addr string) (err error) {
 
 	st.candidates[id] = addr
 	if len(st.candidates) < st.bootstrapExpect {
-		st.log.Debug("number of candidates", "expect", st.bootstrapExpect, "got", st.candidates)
+		st.log.WithField("expect", st.bootstrapExpect).WithField("got", st.candidates).
+			Debug("number of candidates")
 		return nil
 	}
 	candidates := make([]raft.Server, 0, len(st.candidates))
@@ -736,11 +741,11 @@ func (st *Store) Notify(id, addr string) (err error) {
 		i++
 	}
 
-	st.log.Info("starting cluster bootstrapping", "candidates", candidates)
+	st.log.WithField("candidates", candidates).Info("starting cluster bootstrapping")
 
 	fut := st.raft.BootstrapCluster(raft.Configuration{Servers: candidates})
 	if err := fut.Error(); err != nil {
-		st.log.Error("bootstrapping cluster: " + err.Error())
+		st.log.WithError(err).Error("bootstrapping cluster")
 		if !errors.Is(err, raft.ErrCantBootstrap) {
 			return err
 		}
@@ -788,12 +793,12 @@ func (st *Store) loadDatabase(ctx context.Context) {
 
 	st.log.Info("loading local db")
 	if err := st.db.Load(ctx, st.nodeID); err != nil {
-		st.log.Error("cannot restore database: " + err.Error())
+		st.log.WithError(err).Error("cannot restore database")
 		panic("error restoring database")
 	}
 
 	st.dbLoaded.Store(true)
-	st.log.Info("database has been successfully loaded", "n", st.db.Schema.len())
+	st.log.WithField("n", st.db.Schema.len()).Info("database has been successfully loaded")
 }
 
 // reloadDB reloads the node's local db. If the db is already loaded, it will be reloaded.
@@ -809,8 +814,9 @@ func (st *Store) reloadDB() bool {
 	if !st.dbLoaded.CompareAndSwap(true, false) {
 		// the snapshot already includes the state from the raft log
 		snapIndex := snapshotIndex(st.snapshotStore)
-		st.log.Info("load local db from snapshot", "last_log_applied_index",
-			st.initialLastAppliedIndex, "last_snapshot_index", snapIndex)
+		st.log.WithField("last_applied_index", st.lastAppliedIndex).
+			WithField("initial_last_applied_index", st.initialLastAppliedIndex).
+			WithField("last_snapshot_index", snapIndex).Info("load local db from snapshot")
 		if st.initialLastAppliedIndex <= snapIndex {
 			st.loadDatabase(ctx)
 			return true
@@ -820,7 +826,7 @@ func (st *Store) reloadDB() bool {
 
 	st.log.Info("reload local db: loading indexes ...")
 	if err := st.db.Reload(); err != nil {
-		st.log.Error("cannot reload database: " + err.Error())
+		st.log.WithError(err).Error("cannot reload database")
 		panic(fmt.Sprintf("cannot reload database: %v", err))
 	}
 

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -441,7 +441,7 @@ func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, 
 				st.log.WithFields(logrus.Fields{
 					"got":  idx,
 					"want": version,
-				}).Debug("wait for update version") // TODO-RAFT remove
+				}).Debug("wait for update version")
 			}
 		}
 	}

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -814,7 +814,7 @@ func (st *Store) reloadDB() bool {
 	if !st.dbLoaded.CompareAndSwap(true, false) {
 		// the snapshot already includes the state from the raft log
 		snapIndex := snapshotIndex(st.snapshotStore)
-		st.log.WithField("last_applied_index", st.lastAppliedIndex).
+		st.log.WithField("last_applied_index", st.lastAppliedIndex.Load()).
 			WithField("initial_last_applied_index", st.initialLastAppliedIndex).
 			WithField("last_snapshot_index", snapIndex).Info("load local db from snapshot")
 		if st.initialLastAppliedIndex <= snapIndex {

--- a/cluster/transport/service.go
+++ b/cluster/transport/service.go
@@ -112,7 +112,7 @@ func (s *Service) Open() error {
 	cmd.RegisterClusterServiceServer(s.grpcServer, s)
 	go func() {
 		if err := s.grpcServer.Serve(s.ln); err != nil {
-			s.log.Error("serving incoming requests: " + err.Error())
+			s.log.WithError(err).Error("serving incoming requests")
 			panic("error accepting incoming requests")
 		}
 	}()

--- a/cluster/transport/service.go
+++ b/cluster/transport/service.go
@@ -98,7 +98,7 @@ func (s *Service) Leader() string {
 }
 
 func (s *Service) Open() error {
-	s.log.Info("starting cloud rpc server ...", "address", s.address)
+	s.log.WithField("address", s.address).Info("starting cloud rpc server ...")
 	if s.address == "" {
 		return fmt.Errorf("address of rpc server cannot be empty")
 	}

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -185,7 +185,7 @@ func (d *delegate) LocalState(join bool) []byte {
 	}
 	bytes, err := x.marshal()
 	if err != nil {
-		d.log.WithField("action", "delegate.local_state.marshal").Error(err)
+		d.log.WithField("action", "delegate.local_state.marshal").WithError(err).Error("failed to marshal local state")
 		return nil
 	}
 	return bytes

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -144,7 +144,7 @@ func (d *delegate) init(diskSpace func(path string) (DiskUsage, error)) error {
 	space, err := diskSpace(d.dataPath)
 	if err != nil {
 		lastTime = lastTime.Add(-minUpdatePeriod)
-		d.log.Errorf("calculate disk space: %v", err)
+		d.log.WithError(err).Error("calculate disk space")
 	}
 
 	d.setOwnSpace(space)
@@ -185,7 +185,8 @@ func (d *delegate) LocalState(join bool) []byte {
 	}
 	bytes, err := x.marshal()
 	if err != nil {
-		d.log.WithField("action", "delegate.local_state.marshal").WithError(err).Error("failed to marshal local state")
+		d.log.WithField("action", "delegate.local_state.marshal").WithError(err).
+			Error("failed to marshal local state")
 		return nil
 	}
 	return bytes
@@ -202,8 +203,10 @@ func (d *delegate) MergeRemoteState(data []byte, join bool) {
 	}
 	var x spaceMsg
 	if err := x.unmarshal(data); err != nil || x.Node == "" {
-		d.log.WithField("action", "delegate.merge_remote.unmarshal").
-			WithField("data", string(data)).Error(err)
+		d.log.WithFields(logrus.Fields{
+			"action": "delegate.merge_remote.unmarshal",
+			"data":   string(data),
+		}).WithError(err).Error("failed to unmarshal remote state")
 		return
 	}
 	info := NodeInfo{x.DiskUsage, time.Now().UnixMilli()}
@@ -268,7 +271,8 @@ func (d *delegate) updater(period, minPeriod time.Duration, du func(path string)
 		}
 		space, err := du(d.dataPath)
 		if err != nil {
-			d.log.WithField("action", "delegate.local_state.disk_usage").Error(err)
+			d.log.WithField("action", "delegate.local_state.disk_usage").WithError(err).
+				Error("du func error in updater")
 		} else {
 			d.setOwnSpace(space)
 		}

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -272,7 +272,7 @@ func (d *delegate) updater(period, minPeriod time.Duration, du func(path string)
 		space, err := du(d.dataPath)
 		if err != nil {
 			d.log.WithField("action", "delegate.local_state.disk_usage").WithError(err).
-				Error("du func error in updater")
+				Error("disk space updater failed")
 		} else {
 			d.setOwnSpace(space)
 		}

--- a/usecases/cluster/log_workaround.go
+++ b/usecases/cluster/log_workaround.go
@@ -33,7 +33,7 @@ func (l *logParser) Write(in []byte) (int, error) {
 	res := l.regexp.FindSubmatch(in)
 	if len(res) != 4 {
 		// unable to parse log message
-		l.logrus.Warnf("unable to parse memberlist log message: %s", in)
+		l.logrus.WithField("in", in).Warn("unable to parse memberlist log message")
 	}
 
 	switch string(res[2]) {
@@ -46,7 +46,7 @@ func (l *logParser) Write(in []byte) (int, error) {
 	case "INFO":
 		l.logrus.Info(string(res[3]))
 	default:
-		l.logrus.Warnf("unable to parse memberlist log level from message: %s", in)
+		l.logrus.WithField("in", in).Warn("unable to parse memberlist log level from message")
 	}
 
 	return len(in), nil

--- a/usecases/cluster/transactions_read.go
+++ b/usecases/cluster/transactions_read.go
@@ -59,7 +59,7 @@ func (c *TxManager) CloseReadTransaction(ctx context.Context,
 			c.logger.WithFields(logrus.Fields{
 				"action": "broadcast_abort_read_transaction",
 				"id":     tx.ID,
-			}).WithError(err).Errorf("broadcast tx (read-only) abort failed")
+			}).WithError(err).Error("broadcast tx (read-only) abort failed")
 		}
 
 		return errors.Wrap(err, "broadcast commit read transaction")

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -116,11 +116,11 @@ func (e *executor) UpdateIndex(req api.UpdateClassRequest) error {
 func (e *executor) DeleteClass(cls string) error {
 	ctx := context.Background()
 	if err := e.migrator.DropClass(ctx, cls); err != nil {
-		e.logger.WithField("action", "delete_class").
-			WithField("class", cls).Errorf("migrator: %v", err)
+		e.logger.WithField("action", "delete_class").WithField("class", cls).WithError(err).
+			Errorf("migrator")
 	}
 
-	e.logger.WithField("action", "delete_class").WithField("class", cls).Debug("")
+	e.logger.WithField("action", "delete_class").WithField("class", cls).Debug("deleting class")
 	e.triggerSchemaUpdateCallbacks()
 
 	return nil
@@ -132,7 +132,7 @@ func (e *executor) AddProperty(className string, req api.AddPropertyRequest) err
 		return err
 	}
 
-	e.logger.WithField("action", "add_property").WithField("class", className)
+	e.logger.WithField("action", "add_property").WithField("class", className).Debug("adding property")
 	e.triggerSchemaUpdateCallbacks()
 	return nil
 }
@@ -176,7 +176,7 @@ func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest) er
 
 	if err := e.migrator.UpdateTenants(ctx, cls, updates); err != nil {
 		e.logger.WithField("action", "update_tenants").
-			WithField("class", class).Error(err)
+			WithField("class", class).WithError(err).Error("error updating tenants")
 		return err
 	}
 	return nil
@@ -186,7 +186,7 @@ func (e *executor) DeleteTenants(class string, req *api.DeleteTenantsRequest) er
 	ctx := context.Background()
 	if err := e.migrator.DeleteTenants(ctx, class, req.Tenants); err != nil {
 		e.logger.WithField("action", "delete_tenants").
-			WithField("class", class).Error(err)
+			WithField("class", class).WithError(err).Error("error deleting tenants")
 	}
 	return nil
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -116,11 +116,16 @@ func (e *executor) UpdateIndex(req api.UpdateClassRequest) error {
 func (e *executor) DeleteClass(cls string) error {
 	ctx := context.Background()
 	if err := e.migrator.DropClass(ctx, cls); err != nil {
-		e.logger.WithField("action", "delete_class").WithField("class", cls).WithError(err).
-			Errorf("migrator")
+		e.logger.WithFields(logrus.Fields{
+			"action": "delete_class",
+			"class":  cls,
+		}).WithError(err).Errorf("migrator")
 	}
 
-	e.logger.WithField("action", "delete_class").WithField("class", cls).Debug("deleting class")
+	e.logger.WithFields(logrus.Fields{
+		"action": "delete_class",
+		"class":  cls,
+	}).Debug("deleting class")
 	e.triggerSchemaUpdateCallbacks()
 
 	return nil
@@ -132,7 +137,10 @@ func (e *executor) AddProperty(className string, req api.AddPropertyRequest) err
 		return err
 	}
 
-	e.logger.WithField("action", "add_property").WithField("class", className).Debug("adding property")
+	e.logger.WithFields(logrus.Fields{
+		"action": "add_property",
+		"class":  className,
+	}).Debug("adding property")
 	e.triggerSchemaUpdateCallbacks()
 	return nil
 }
@@ -175,8 +183,10 @@ func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest) er
 	}
 
 	if err := e.migrator.UpdateTenants(ctx, cls, updates); err != nil {
-		e.logger.WithField("action", "update_tenants").
-			WithField("class", class).WithError(err).Error("error updating tenants")
+		e.logger.WithFields(logrus.Fields{
+			"action": "update_tenants",
+			"class":  class,
+		}).WithError(err).Error("error updating tenants")
 		return err
 	}
 	return nil
@@ -185,8 +195,10 @@ func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest) er
 func (e *executor) DeleteTenants(class string, req *api.DeleteTenantsRequest) error {
 	ctx := context.Background()
 	if err := e.migrator.DeleteTenants(ctx, class, req.Tenants); err != nil {
-		e.logger.WithField("action", "delete_tenants").
-			WithField("class", class).WithError(err).Error("error deleting tenants")
+		e.logger.WithFields(logrus.Fields{
+			"action": "delete_tenants",
+			"class":  class,
+		}).WithError(err).Error("error deleting tenants")
 	}
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

The raft logging was recently updated to use logrus instead of slog (see https://github.com/weaviate/weaviate/pull/4753). However, most uses of the logger in the `cluster/` directory (and some outside of that directory) were not updated to use the `WithField` (and similar functions) functionality of logrus.

For example, without this PR some of the logs look like this (note that all the strings are concatenated):

```sh
INFO[0000] tcp transportaddress192.168.0.14:8300tcpMaxPool3tcpTimeout10s
```

After this PR the logs will look like this:

```sh
INFO[0000] tcp transport                                 address="192.168.0.14:8300" tcpMaxPool=3 tcpTimeout=10s
```

This PR updates (most of) the logger usage following these conventions:

1. Use `WithField` for dynamic values.
2. If there are 2+ fields, use `WithFields` instead of `WithField`.
3. For errors, use `WithError` and log a static error message.
4. Only use formatting (e.g.: `Infof` instead of `Info`) when needed.

It's likely that I missed some poorly formatted logs, but hopefully I found the majority of them (used a combo of grepping and following references). Any bad logging calls I missed can be fixed in follow up PRs.

This PR should be a fairly low risk change.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
