### PR TITLE
Update the schema version parsing to not always return 0

### DIFF
--- a/adapters/handlers/rest/clusterapi/schema_version.go
+++ b/adapters/handlers/rest/clusterapi/schema_version.go
@@ -21,9 +21,7 @@ import (
 func extractSchemaVersionFromUrlQuery(values url.Values) uint64 {
 	var schemaVersion uint64
 	if v := values.Get(replica.SchemaVersionKey); v != "" {
-		if vAsUint64, err := strconv.ParseUint(v, 10, 64); err != nil {
-			schemaVersion = vAsUint64
-		}
+		schemaVersion, _ = strconv.ParseUint(v, 10, 64)
 	}
 	return schemaVersion
 }


### PR DESCRIPTION
### What's being changed:

* Replicas node never consider the schema version sent from coordinator because the parsing function would always return 0

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
