### PR TITLE
fix schema updating racing with DB update

### DIFF
--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -123,13 +123,13 @@ func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaO
 		return nil
 	}
 
-	// Apply the DB change last otherwise we will error on the parsing of the class while updating the store.
-	// We need the schema to first parse the update and apply it so that we can use it in the DB update.
 	return db.apply(
 		cmd.GetType().String(),
 		func() error { return db.Schema.updateClass(req.Class.Class, update) },
 		func() error { return db.store.UpdateClass(req) },
 		schemaOnly,
+		// Apply the DB change last otherwise we will error on the parsing of the class while updating the store.
+		// We need the schema to first parse the update and apply it so that we can use it in the DB update.
 		applyDbLast,
 		triggerSchemaCallback,
 	)
@@ -141,7 +141,7 @@ func (db *localDB) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool) error
 		func() error { db.Schema.deleteClass(cmd.Class); return nil },
 		func() error { return db.store.DeleteClass(cmd.Class) },
 		schemaOnly,
-		applyDbLast,
+		applyDbFirst,
 		triggerSchemaCallback,
 	)
 }
@@ -179,7 +179,7 @@ func (db *localDB) UpdateShardStatus(cmd *command.ApplyRequest, schemaOnly bool)
 		func() error { return nil },
 		func() error { return db.store.UpdateShardStatus(&req) },
 		schemaOnly,
-		applyDbLast,
+		applyDbFirst,
 		skipSchemaCallback,
 	)
 }

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -75,6 +75,8 @@ type Indexer interface {
 	GetShardsStatus(class string) (models.ShardStatusList, error)
 	UpdateIndex(api.UpdateClassRequest) error
 
+	TriggerSchemaUpdateCallbacks()
+
 	// ReloadLocalDB reloads the local database using the latest schema.
 	ReloadLocalDB(ctx context.Context, all []api.UpdateClassRequest) error
 

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -57,6 +57,7 @@ func TestServiceEndpoints(t *testing.T) {
 	m.indexer.On("AddTenants", Anything, Anything).Return(nil)
 	m.indexer.On("UpdateTenants", Anything, Anything).Return(nil)
 	m.indexer.On("DeleteTenants", Anything, Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 
 	m.parser.On("ParseClass", mock.Anything).Return(nil)
 	m.parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(mock.Anything, nil)
@@ -362,6 +363,7 @@ func TestStoreApply(t *testing.T) {
 	doFirst := func(m *MockStore) {
 		m.indexer.On("Open", mock.Anything).Return(nil)
 		m.parser.On("ParseClass", mock.Anything).Return(nil)
+		m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 	}
 
 	cls := &models.Class{Class: "C1"}
@@ -465,6 +467,7 @@ func TestStoreApply(t *testing.T) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
 				m.indexer.On("RestoreClassDir", cls.Class).Return(nil)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
 				_, ok := ms.store.db.Schema.Classes["C1"]
@@ -517,6 +520,7 @@ func TestStoreApply(t *testing.T) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(mock.Anything, nil)
 				m.store.db.Schema.addClass(cls, ss, 1)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 		},
 		{
@@ -527,6 +531,7 @@ func TestStoreApply(t *testing.T) {
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
 				if _, ok := ms.store.db.Schema.Classes["C1"]; ok {
@@ -571,6 +576,7 @@ func TestStoreApply(t *testing.T) {
 			doBefore: func(m *MockStore) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, ss, 1)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
 				ok := false
@@ -941,6 +947,10 @@ func (m *MockIndexer) Open(ctx context.Context) error {
 func (m *MockIndexer) Close(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)
+}
+
+func (m *MockIndexer) TriggerSchemaUpdateCallbacks() {
+	m.Called()
 }
 
 type MockParser struct {

--- a/test/acceptance_with_python/conftest.py
+++ b/test/acceptance_with_python/conftest.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional, List, Generator, Protocol, Type, Dict, Tuple, Union
+from typing import Any, Optional, List, Generator, Protocol, Type, Dict, Tuple, Union, Callable
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -48,6 +48,16 @@ class CollectionFactory(Protocol):
     ) -> Collection[Any, Any]:
         """Typing for fixture."""
         ...
+
+@pytest.fixture
+def weaviate_client() -> Callable[[int, int], weaviate.WeaviateClient]:
+    def connect(http_port : int = 8080, grpc_port : int = 50051) -> weaviate.WeaviateClient:
+        return weaviate.connect_to_local(
+            port=http_port,
+            grpc_port=grpc_port,
+            additional_config=AdditionalConfig(timeout=(60, 120)),  # for image tests
+        )
+    return connect
 
 
 @pytest.fixture

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -4,3 +4,4 @@ pytest>=8.0.1,<9.0.0
 pytest-xdist==3.5.0
 
 black>=24.2.0,<25.0.0
+loguru>=0.7.2

--- a/test/acceptance_with_python/test_auto_schema_ec.py
+++ b/test/acceptance_with_python/test_auto_schema_ec.py
@@ -1,0 +1,49 @@
+import random
+import math
+from loguru import logger
+import weaviate
+import weaviate.classes as wvc
+import sys
+import pytest
+
+# The idea is that we append this number to collection or prop names. It is
+# meant to return the same number a lot of tiems, but not always. This way,
+# when it returns a number it has returned before, we're likely to hit an
+# existing col or prop, but occasionally we'll get something new.
+def random_number_with_frequent_collisions():
+    return math.floor(math.log(random.randint(1, 1000000), 2))
+
+@pytest.mark.skip(reason="currently python integration test run on a single node cluster, this test needs a dedicated 3 node cluster")
+def test_auto_schema_explicit_property_update_ec(weaviate_client) -> None:
+    clients :[weaviate.WeaviateClient] = [
+        weaviate_client(8080+1, 50051+1) for i in range(3)
+    ]
+    client = random.choice(clients)
+    client.collections.delete_all()
+    logger.info("cleanup completed")
+
+    for col_iter in range(25):
+        client = random.choice(clients)
+        col_name = f"ExplicitCollection{col_iter}"
+        logger.info(f"start collection {col_name}")
+        client.collections.create(
+            col_name,
+            vectorizer_config=wvc.config.Configure.Vectorizer.none(),
+            sharding_config=wvc.config.Configure.sharding(desired_count=random.randint(1, 3)),
+            replication_config=wvc.config.Configure.replication(factor=random.randint(1, 3)),
+        )
+        for i in range(50):
+            if i % 10 == 0:
+                logger.info(f"start iteration {i}")
+
+            client: weaviate.WeaviateClient = random.choice(clients)
+            with client.batch.fixed_size(10) as b:
+                for j in range(10):
+                    text_prop = f"text_{random_number_with_frequent_collisions()}"
+                    number_prop = f"number_{random_number_with_frequent_collisions()}"
+                    obj = {
+                        text_prop: text_prop,
+                        number_prop: random.randint(0, 10000),
+                    }
+                    b.add_object(col_name, obj)
+            assert len(client.batch.failed_objects) == 0

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -123,7 +123,6 @@ func (e *executor) DeleteClass(cls string) error {
 		"action": "delete_class",
 		"class":  cls,
 	}).Debug("deleting class")
-	e.TriggerSchemaUpdateCallbacks()
 
 	return nil
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -71,7 +71,6 @@ func (e *executor) AddClass(pl api.AddClassRequest) error {
 	if err := e.migrator.AddClass(ctx, pl.Class, pl.State); err != nil {
 		return fmt.Errorf("apply add class: %w", err)
 	}
-	e.triggerSchemaUpdateCallbacks()
 	return nil
 }
 
@@ -100,7 +99,6 @@ func (e *executor) UpdateClass(req api.UpdateClassRequest) error {
 		req.Class.InvertedIndexConfig); err != nil {
 		return errors.Wrap(err, "inverted index config")
 	}
-	e.triggerSchemaUpdateCallbacks()
 	return nil
 }
 
@@ -109,7 +107,6 @@ func (e *executor) UpdateIndex(req api.UpdateClassRequest) error {
 	if err := e.migrator.UpdateIndex(ctx, req.Class, req.State); err != nil {
 		return err
 	}
-	e.triggerSchemaUpdateCallbacks()
 	return nil
 }
 
@@ -126,7 +123,7 @@ func (e *executor) DeleteClass(cls string) error {
 		"action": "delete_class",
 		"class":  cls,
 	}).Debug("deleting class")
-	e.triggerSchemaUpdateCallbacks()
+	e.TriggerSchemaUpdateCallbacks()
 
 	return nil
 }
@@ -141,7 +138,6 @@ func (e *executor) AddProperty(className string, req api.AddPropertyRequest) err
 		"action": "add_property",
 		"class":  className,
 	}).Debug("adding property")
-	e.triggerSchemaUpdateCallbacks()
 	return nil
 }
 
@@ -239,7 +235,7 @@ func (e *executor) rebuildGQL(s models.Schema) {
 	}
 }
 
-func (e *executor) triggerSchemaUpdateCallbacks() {
+func (e *executor) TriggerSchemaUpdateCallbacks() {
 	e.rebuildGQL(e.store.ReadOnlySchema())
 }
 

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -126,6 +126,10 @@ func (f *fakeDB) GetShardsStatus(class string) (models.ShardStatusList, error) {
 	return args.Get(0).(models.ShardStatusList), nil
 }
 
+func (f *fakeDB) TriggerSchemaUpdateCallbacks() {
+	f.Called()
+}
+
 type fakeAuthorizer struct {
 	err error
 }


### PR DESCRIPTION
### What's being changed:

Currently EC fixes wait on a given schema version to be applied to the RAFT schema to ensure that they can proceed. However the schema update is actually 2 steps
1. Update schema
2. Update DB indexes

Updating the schema on step 1 would make any goroutine waiting for the schema version to be applied to consider that it has been applied and proceed. However when adding properties, the DB changes are necessary as we create the needed resources to write the data. 

This fix reverse the order in which operation are executed so that any side effect from the apply to the DB is done *before* the schema representation is updated, on the operations where the DB update is not dependent on the schema.
This encompass so far
* AddTenant
* UpdateTenant
* DeleteTenant
* UpdateClass

These updates are therefore left unchanged and will have their schema updates applied first before their DB updates. We should revisit in the future so that DB changes can be applied regardless of the schema current state.

In all cases the schema callbacks trigger has been moved to the RAFT module to ensure it is done once both the DB and the schema have applied.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
