### PR TITLE
Fix parsing of tenant in `/schema/{className}/shards?tenant={tenant}`

### DIFF
--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -168,19 +168,14 @@ func (s *schemaHandlers) getClusterStatus(params schema.SchemaClusterStatusParam
 func (s *schemaHandlers) getShardsStatus(params schema.SchemaObjectsShardsGetParams,
 	principal *models.Principal,
 ) middleware.Responder {
-	// TODO-RAFT START
-	// Fix changed interface GetShardsStatus -> ShardsStatus
-	// Previous definition:
-	// status, err := s.manager.GetShardsStatus(params.HTTPRequest.Context(), principal, params.ClassName, tenant)
-	// var tenant string
-	// if params.Tenant == nil {
-	// 	tenant = ""
-	// } else {
-	// 	tenant = *params.Tenant
-	// }
+	var tenant string
+	if params.Tenant == nil {
+		tenant = ""
+	} else {
+		tenant = *params.Tenant
+	}
 
-	status, err := s.manager.ShardsStatus(params.HTTPRequest.Context(), principal, params.ClassName)
-	// TODO-RAFT END
+	status, err := s.manager.ShardsStatus(params.HTTPRequest.Context(), principal, params.ClassName, tenant)
 	if err != nil {
 		s.metricRequestsTotal.logError("", err)
 		switch err.(type) {

--- a/cluster/store/retry_schema.go
+++ b/cluster/store/retry_schema.go
@@ -111,8 +111,8 @@ func (rs retrySchema) CopyShardingState(class string) (ss *sharding.State) {
 	return res
 }
 
-func (rs retrySchema) GetShardsStatus(class string) (models.ShardStatusList, error) {
-	return rs.schema.GetShardsStatus(class)
+func (rs retrySchema) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+	return rs.schema.GetShardsStatus(class, tenant)
 }
 
 func (rs retrySchema) Len() int { return rs.schema.len() }

--- a/cluster/store/schema.go
+++ b/cluster/store/schema.go
@@ -178,12 +178,12 @@ func (s *schema) CopyShardingState(class string) (*sharding.State, uint64) {
 	return meta.CopyShardingState()
 }
 
-func (s *schema) GetShardsStatus(class string) (models.ShardStatusList, error) {
-	return s.shardReader.GetShardsStatus(class)
+func (s *schema) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+	return s.shardReader.GetShardsStatus(class, tenant)
 }
 
 type shardReader interface {
-	GetShardsStatus(class string) (models.ShardStatusList, error)
+	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 }
 
 func NewSchema(nodeID string, shardReader shardReader) *schema {

--- a/cluster/store/schema_test.go
+++ b/cluster/store/schema_test.go
@@ -231,7 +231,7 @@ func TestSchemaReaderClass(t *testing.T) {
 	assert.Empty(t, shard)
 	assert.Empty(t, sc.ShardFromUUID("Cx", nil))
 
-	_, err = sc.GetShardsStatus("C")
+	_, err = sc.GetShardsStatus("C", "")
 	assert.Nil(t, err)
 
 	// Add MT Class
@@ -307,7 +307,7 @@ type MockShardReader struct {
 	err error
 }
 
-func (m *MockShardReader) GetShardsStatus(class string) (models.ShardStatusList, error) {
+func (m *MockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
 	return m.lst, m.err
 }
 

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -72,7 +72,7 @@ type Indexer interface {
 	UpdateTenants(class string, req *api.UpdateTenantsRequest) error
 	DeleteTenants(class string, req *api.DeleteTenantsRequest) error
 	UpdateShardStatus(*api.UpdateShardStatusRequest) error
-	GetShardsStatus(class string) (models.ShardStatusList, error)
+	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 	UpdateIndex(api.UpdateClassRequest) error
 
 	// ReloadLocalDB reloads the local database using the latest schema.

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -928,8 +928,8 @@ func (m *MockIndexer) UpdateShardStatus(req *cmd.UpdateShardStatusRequest) error
 	return args.Error(0)
 }
 
-func (m *MockIndexer) GetShardsStatus(class string) (models.ShardStatusList, error) {
-	args := m.Called(class)
+func (m *MockIndexer) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+	args := m.Called(class, tenant)
 	return models.ShardStatusList{}, args.Error(1)
 }
 

--- a/test/acceptance/multi_tenancy/get_shards_status_with_tenant_test.go
+++ b/test/acceptance/multi_tenancy/get_shards_status_with_tenant_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package test
 
 import (

--- a/test/acceptance/multi_tenancy/get_shards_status_with_tenant_test.go
+++ b/test/acceptance/multi_tenancy/get_shards_status_with_tenant_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestGetShardsStatusWithTenant(t *testing.T) {
+	testClass := models.Class{
+		Class: "ClassGetShardsStatusWithTenant",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	defer func() {
+		helper.DeleteClass(t, testClass.Class)
+	}()
+
+	helper.CreateClass(t, &testClass)
+	helper.CreateTenants(t, testClass.Class, []*models.Tenant{
+		{
+			Name: "tenant1",
+		},
+		{
+			Name: "tenant2",
+		},
+	})
+
+	t.Run("get shards status with tenant string", func(t *testing.T) {
+		tenant := "tenant1"
+		client := helper.Client(t)
+		res, err := client.Schema.SchemaObjectsShardsGet(
+			schema.
+				NewSchemaObjectsShardsGetParams().
+				WithClassName(testClass.Class).
+				WithTenant(&tenant),
+			nil,
+		)
+		helper.AssertRequestOk(t, res, err, nil)
+	})
+
+	t.Run("get shards status with empty tenant string", func(t *testing.T) {
+		tenant := ""
+		client := helper.Client(t)
+		res, err := client.Schema.SchemaObjectsShardsGet(
+			schema.
+				NewSchemaObjectsShardsGetParams().
+				WithClassName(testClass.Class).
+				WithTenant(&tenant),
+			nil,
+		)
+		helper.AssertRequestOk(t, res, err, nil)
+	})
+
+	t.Run("get shards status with nil pointer", func(t *testing.T) {
+		client := helper.Client(t)
+		res, err := client.Schema.SchemaObjectsShardsGet(
+			schema.
+				NewSchemaObjectsShardsGetParams().
+				WithClassName(testClass.Class).
+				WithTenant(nil),
+			nil,
+		)
+		helper.AssertRequestOk(t, res, err, nil)
+	})
+}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -107,7 +107,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:       "ShardsStatus",
-			additionalArgs:   []interface{}{"className"},
+			additionalArgs:   []interface{}{"className", "tenant"},
 			expectedVerb:     "list",
 			expectedResource: "schema/className/shards",
 		},

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -210,7 +210,7 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 
 func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
 	ctx := context.Background()
-	shardsStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant) // tenant needed here
+	shardsStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -208,13 +208,9 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 	return e.migrator.UpdateShardStatus(ctx, req.Class, req.Shard, req.Status, req.SchemaVersion)
 }
 
-// TODO-RAFT START
-// change GetShardsStatus() to accept a tenant parameter
-// TODO-RAFT END
-
-func (e *executor) GetShardsStatus(class string) (models.ShardStatusList, error) {
+func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
 	ctx := context.Background()
-	shardsStatus, err := e.migrator.GetShardsStatus(ctx, class, "") // tenant needed here
+	shardsStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant) // tenant needed here
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -190,7 +190,7 @@ func TestExecutor(t *testing.T) {
 		status := map[string]string{"A": "B"}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, nil)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus("A")
+		_, err := x.GetShardsStatus("A", "")
 		assert.Nil(t, err)
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestExecutor(t *testing.T) {
 		status := map[string]string{"A": "B"}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, ErrAny)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus("A")
+		_, err := x.GetShardsStatus("A", "")
 		assert.ErrorIs(t, err, ErrAny)
 	})
 	t.Run("UpdateShardStatus", func(t *testing.T) {

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -226,8 +226,8 @@ func (f *fakeMetaHandler) Read(class string, reader func(*models.Class, *shardin
 	return args.Error(0)
 }
 
-func (f *fakeMetaHandler) GetShardsStatus(class string) (models.ShardStatusList, error) {
-	args := f.Called(class)
+func (f *fakeMetaHandler) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+	args := f.Called(class, tenant)
 	return args.Get(0).(models.ShardStatusList), args.Error(1)
 }
 

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -71,7 +71,7 @@ type metaReader interface {
 	ShardOwner(class, shard string) (string, error)
 	TenantShard(class, tenant string) (string, string)
 	Read(class string, reader func(*models.Class, *sharding.State) error) error
-	GetShardsStatus(class string) (models.ShardStatusList, error)
+	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 
 	// WithVersion endpoints return the data with the schema version
 	ClassInfoWithVersion(ctx context.Context, class string, version uint64) (store.ClassInfo, error)
@@ -206,14 +206,14 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 }
 
 func (h *Handler) ShardsStatus(ctx context.Context,
-	principal *models.Principal, class string,
+	principal *models.Principal, class, tenant string,
 ) (models.ShardStatusList, error) {
 	err := h.Authorizer.Authorize(principal, "list", fmt.Sprintf("schema/%s/shards", class))
 	if err != nil {
 		return nil, err
 	}
 
-	return h.metaReader.GetShardsStatus(class)
+	return h.metaReader.GetShardsStatus(class, tenant)
 }
 
 // JoinNode adds the given node to the cluster.

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -121,8 +121,8 @@ func (f *fakeDB) UpdateShardStatus(cmd *command.UpdateShardStatusRequest) error 
 	return nil
 }
 
-func (f *fakeDB) GetShardsStatus(class string) (models.ShardStatusList, error) {
-	args := f.Called(class)
+func (f *fakeDB) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+	args := f.Called(class, tenant)
 	return args.Get(0).(models.ShardStatusList), nil
 }
 


### PR DESCRIPTION
### What's being changed:

This PR addresses a regression associated with the `/schema/{className}/shards` endpoint whereby the query parameter `tenant` was not being handled at all leading to failures in the Python integration tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
