### PR TITLE
Fix: update schema when PQ is enabled for a named vector index

### DIFF
--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -103,6 +103,7 @@ func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaO
 		}
 		meta.Class.VectorIndexConfig = u.VectorIndexConfig
 		meta.Class.InvertedIndexConfig = u.InvertedIndexConfig
+		meta.Class.VectorConfig = u.VectorConfig
 		meta.ClassVersion = cmd.Version
 		return nil
 	}


### PR DESCRIPTION
### What's being changed:

Prior to this patch, enabling PQ on a named vector index worked, and the async compression routine executed and succeeded as expected. However, the schema was not properly updated to reflect this.

Now, the named vector config is updated accordingly on the schema.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
