### PR TITLE
Fix named vector groupby non-search aggregate queries

### DIFF
--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -22,7 +22,7 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params) (*aggr
 	var queue *IndexQueue
 
 	// we only need the index queue for vector search
-	if params.NearObject != nil || params.NearVector != nil || params.Hybrid != nil || params.GroupBy != nil || params.SearchVector != nil {
+	if params.NearObject != nil || params.NearVector != nil || params.Hybrid != nil || params.SearchVector != nil {
 		var err error
 		queue, err = s.getIndexQueue(params.TargetVector)
 		if err != nil {


### PR DESCRIPTION
### What's being changed:

Do not match on groupby when checking presence of targetvector in aggregate search

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
