### PR TITLE
refact: leader error distinguish between election and network issues

### DIFF
--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -466,6 +466,10 @@ func removeNilTenants(tenants []*cmd.Tenant) []*cmd.Tenant {
 	return tenants[:n]
 }
 
+// leaderErr decorates ErrLeaderNotFound by distinguishing between
+// normal election happening and there is no leader been chosen yet
+// and if it can't reach the other nodes either for intercluster
+// communication issues or other nodes were down.
 func (s *Service) leaderErr() error {
 	if s.store.addResolver != nil && len(s.store.addResolver.notResolvedNodes) > 0 {
 		var nodes []string

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -238,7 +239,7 @@ func (s *Service) Execute(req *cmd.ApplyRequest) (uint64, error) {
 
 	leader := s.store.Leader()
 	if leader == "" {
-		return 0, ErrLeaderNotFound
+		return 0, s.leaderErr()
 	}
 	resp, err := s.cl.Apply(leader, req)
 	if err != nil {
@@ -259,7 +260,7 @@ func (s *Service) Join(ctx context.Context, id, addr string, voter bool) error {
 	}
 	leader := s.store.Leader()
 	if leader == "" {
-		return ErrLeaderNotFound
+		return s.leaderErr()
 	}
 	req := &cmd.JoinPeerRequest{Id: id, Address: addr, Voter: voter}
 	_, err := s.cl.Join(ctx, leader, req)
@@ -273,7 +274,7 @@ func (s *Service) Remove(ctx context.Context, id string) error {
 	}
 	leader := s.store.Leader()
 	if leader == "" {
-		return ErrLeaderNotFound
+		return s.leaderErr()
 	}
 	req := &cmd.RemovePeerRequest{Id: id}
 	_, err := s.cl.Remove(ctx, leader, req)
@@ -448,7 +449,7 @@ func (s *Service) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryR
 
 	leader := s.store.Leader()
 	if leader == "" {
-		return &cmd.QueryResponse{}, ErrLeaderNotFound
+		return &cmd.QueryResponse{}, s.leaderErr()
 	}
 
 	return s.cl.Query(ctx, leader, req)
@@ -463,4 +464,18 @@ func removeNilTenants(tenants []*cmd.Tenant) []*cmd.Tenant {
 		}
 	}
 	return tenants[:n]
+}
+
+func (s *Service) leaderErr() error {
+	if s.store.addResolver != nil && len(s.store.addResolver.notResolvedNodes) > 0 {
+		var nodes []string
+		for n := range s.store.addResolver.notResolvedNodes {
+			nodes = append(nodes, string(n))
+		}
+
+		return fmt.Errorf("%w, can not resolve nodes [%s]",
+			ErrLeaderNotFound,
+			strings.Join(nodes, ","))
+	}
+	return ErrLeaderNotFound
 }

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -232,12 +232,18 @@ func (h *Handler) JoinNode(ctx context.Context, node string, nodePort string, vo
 		nodePort = fmt.Sprintf("%d", config.DefaultRaftPort)
 	}
 
-	return h.metaWriter.Join(ctx, node, nodeAddr+":"+nodePort, voter)
+	if err := h.metaWriter.Join(ctx, node, nodeAddr+":"+nodePort, voter); err != nil {
+		return fmt.Errorf("node failed to join cluster: %w", err)
+	}
+	return nil
 }
 
 // RemoveNode removes the given node from the cluster.
 func (h *Handler) RemoveNode(ctx context.Context, node string) error {
-	return h.metaWriter.Remove(ctx, node)
+	if err := h.metaWriter.Remove(ctx, node); err != nil {
+		return fmt.Errorf("node failed to leave cluster: %w", err)
+	}
+	return nil
 }
 
 // Statistics is used to return a map of various internal stats. This should only be used for informative purposes or debugging.


### PR DESCRIPTION
### What's being changed:
- add some details to raft leader error like `Op` type `join, remove, query, backup` 
- collect info about nodes if the `addrResolver` wasn't able to detect their ip and append them to the error.

those changes should help to detect : 
 - what is the operation was requested. 
 - if the error is just `leader not found` that would mean there is election is in place.
 - if the error contains names of other nodes, that would mean either the other nodes are down or there is intercluster communication issue  

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
