### PR TITLE
[RAFT] Only involve leader for tenant status when necessary

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -182,6 +182,12 @@ func (f *fakeSchemaManager) TenantsShards(class string, tenants ...string) (map[
 	return res, nil
 }
 
+func (f *fakeSchemaManager) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}
+
 func (f *fakeSchemaManager) ShardFromUUID(class string, uuid []byte) string {
 	ss := f.shardState
 	return ss.Shard("", string(uuid))

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -81,6 +81,12 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
+func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}
+
 func (f *fakeSchemaGetter) ShardFromUUID(class string, uuid []byte) string {
 	ss := f.shardState
 	return ss.Shard("", string(uuid))

--- a/adapters/repos/db/file_structure_migration_test.go
+++ b/adapters/repos/db/file_structure_migration_test.go
@@ -300,6 +300,10 @@ func (sg *fakeMigrationSchemaGetter) TenantsShards(class string, tenants ...stri
 	return nil, nil
 }
 
+func (f *fakeMigrationSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	return nil, nil
+}
+
 func (sg *fakeMigrationSchemaGetter) ShardFromUUID(class string, uuid []byte) string {
 	return ""
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1419,7 +1419,7 @@ func (i *Index) targetShardNames(tenant string) ([]string, error) {
 		return []string{}, objects.NewErrMultiTenancy(fmt.Errorf("tenant name is empty"))
 	}
 
-	tenantShards, err := i.getSchema.TenantsShards(className, tenant)
+	tenantShards, err := i.getSchema.OptimisticTenantStatus(className, tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -58,6 +58,12 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
+func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}
+
 func (f *fakeSchemaGetter) ShardFromUUID(class string, uuid []byte) string { return "" }
 
 func (f *fakeSchemaGetter) Nodes() []string {

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -64,6 +64,12 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
+func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}
+
 func (f *fakeSchemaGetter) ShardFromUUID(class string, uuid []byte) string { return string(uuid) }
 
 func (f *fakeSchemaGetter) Nodes() []string {

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -84,6 +84,12 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
+func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}
+
 func (f *fakeSchemaGetter) ShardFromUUID(class string, uuid []byte) string {
 	ss := f.shardState
 	return ss.Shard("", string(uuid))

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -63,6 +63,7 @@ type SchemaGetter interface {
 	CopyShardingState(class string) *sharding.State
 	ShardOwner(class, shard string) (string, error)
 	TenantsShards(class string, tenants ...string) (map[string]string, error)
+	OptimisticTenantStatus(class string, tenants string) (map[string]string, error)
 	ShardFromUUID(class string, uuid []byte) string
 	ShardReplicas(class, shard string) ([]string, error)
 }
@@ -357,6 +358,58 @@ func (m *Manager) TenantsShards(class string, tenants ...string) (map[string]str
 	tenants = slices.Compact(tenants)
 	status, _, err := m.metaWriter.QueryTenantsShards(class, tenants...)
 	return status, err
+}
+
+// OptimisticTenantStatus tries to query the local state first. It is
+// optimistic that the state has already propagated correctly. If the state is
+// unexpected, i.e. either the tenant is not found at all or the status is
+// COLD, it will double-check with the leader.
+//
+// This way we accept false positives (for HOT tenants), but guarantee that there will never be
+// false negatives (i.e. tenants labelled as COLD that the leader thinks should
+// be HOT).
+//
+// This means:
+//
+//   - If a tenant is HOT locally (true positive), we proceed normally
+//   - If a tenant is HOT locally, but should be COLD (false positive), we still
+//     proceed. This is a conscious decision to keep the happy path free from
+//     (expensive) leader lookups.
+//   - If a tenant is not found locally, we assume it was recently created, but
+//     the state hasn't propagated yet. To verify, we check with the leader.
+//   - If a tenant is found locally, but is marked as COLD, we assume it was
+//     recently turned HOT, but the state hasn't propagated yet. To verify, we
+//     check with the leader
+//
+// Overall, we keep the (very common) happy path, free from expensive
+// leader-lookups and only fall back to the leader if the local result implies
+// an unhappy path.
+func (m *Manager) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	var foundTenant bool
+	var status string
+	err := m.metaReader.Read(class, func(_ *models.Class, ss *sharding.State) error {
+		t, ok := ss.Physical[tenant]
+		if !ok {
+			return nil
+		}
+
+		foundTenant = true
+		status = t.Status
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if !foundTenant || status != models.TenantActivityStatusHOT {
+		// either no state at all or state does not imply happy path -> delegate to
+		// leader
+		return m.TenantsShards(class, tenant)
+	}
+
+	return map[string]string{
+		tenant: status,
+	}, nil
 }
 
 func (m *Manager) ShardOwner(class, shard string) (string, error) {

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -252,6 +252,12 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
+func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}
+
 func (f *fakeSchemaGetter) ShardFromUUID(class string, uuid []byte) string { return string(uuid) }
 
 func (f *fakeSchemaGetter) Nodes() []string {

--- a/usecases/traverser/hybrid/fakes_for_test.go
+++ b/usecases/traverser/hybrid/fakes_for_test.go
@@ -88,3 +88,9 @@ func (f *fakeSchemaManager) ShardFromUUID(class string, uuid []byte) string {
 func (f *fakeSchemaManager) TenantsShards(class string, tenants ...string) (map[string]string, error) {
 	return nil, nil
 }
+
+func (f *fakeSchemaManager) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+	res := map[string]string{}
+	res[tenant] = models.TenantActivityStatusHOT
+	return res, nil
+}


### PR DESCRIPTION
### What's being changed:

- Always relying on the local state for tenant status is error prone because it could miss a recent update
- Always relying on the RAFT leader state is very expensive – especially under high query load
- Instead we're using an optimistic way, see method desription below
- All tests for this were run as an external stress test that [can be found here](https://gist.github.com/etiennedi/497063da7b35431501c41690e2ad9e6e). <-- This should probably become a chaos pipeline against a 3-node cluster.

```go
// OptimisticTenantStatus tries to query the local state first. It is
// optimistic that the state has already propagated correctly. If the state is
// unexpected, i.e. either the tenant is not found at all or the status is
// COLD, it will double-check with the leader.
//
// This way we accept false positives (for HOT tenants), but guarantee that there will never be
// false negatives (i.e. tenants labelled as COLD that the leader thinks should
// be HOT).
//
// This means:
//
//   - If a tenant is HOT locally (true positive), we proceed normally
//   - If a tenant is HOT locally, but should be COLD (false positive), we still
//     proceed. This is a conscious decision to keep the happy path free from
//     (expensive) leader lookups.
//   - If a tenant is not found locally, we assume it was recently created, but
//     the state hasn't propagated yet. To verify, we check with the leader.
//   - If a tenant is found locally, but is marked as COLD, we assume it was
//     recently turned HOT, but the state hasn't propagated yet. To verify, we
//     check with the leader
//
// Overall, we keep the (very common) happy path, free from expensive
// leader-lookups and only fall back to the leader if the local result implies
// an unhappy path.
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
