### PR TITLE
Fix backup restore with `include` & `exclude`

### DIFF
--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -263,8 +263,9 @@ func (c *coordinator) restoreClasses(
 		return
 	}
 	errors := make([]string, 0, 5)
+	hasReqClasses := len(req.Classes) > 0
 	for _, cls := range schema {
-		if len(req.Classes) > 0 && !slices.Contains(req.Classes, cls.Name) {
+		if hasReqClasses && !slices.Contains(req.Classes, cls.Name) {
 			continue
 		}
 		if err := c.schema.RestoreClass(ctx, &cls, req.NodeMapping); err != nil {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -156,6 +156,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		ID:          req.ID,
 		Backend:     req.Backend,
 		Compression: req.Compression,
+		Classes:     meta.Classes(),
 	}
 	err = s.restorer.Restore(ctx, store, &rReq, meta, schema)
 	if err != nil {


### PR DESCRIPTION
### What's being changed:

Currently, any `include` and `exclude` parameters supplied to a backup restore job are ignore by the restore process. This PR fixes that by passing `meta.Classes` to `Restore` and using it to skip classes in the schema that are not in `meta.Classes`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
