### PR TITLE
RAFT: fix shutdown, force it for dependencies and convert to enterrors.GoWrapper

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -334,18 +334,14 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	explorer.SetSchemaGetter(schemaManager)
 	appState.Modules.SetSchemaGetter(schemaManager)
 
-	// TODO-RAFT START
-	go func() {
+	enterrors.GoWrapper(func() {
 		if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
 			appState.Logger.
 				WithField("action", "startup").
 				WithError(err).
 				Fatal("could not open cloud meta store")
 		}
-	}()
-
-	time.Sleep(2 * time.Second)
-	// TODO-RAFT END
+	}, appState.Logger)
 
 	batchManager := objects.NewBatchManager(vectorRepo, appState.Modules,
 		appState.Locks, schemaManager, appState.ServerConfig, appState.Logger,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -343,6 +343,10 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		}
 	}, appState.Logger)
 
+	// TODO-RAFT: refactor remove this sleep
+	// this sleep was used to block GraphQL and give time to RAFT to start.
+	time.Sleep(2 * time.Second)
+
 	batchManager := objects.NewBatchManager(vectorRepo, appState.Modules,
 		appState.Locks, schemaManager, appState.ServerConfig, appState.Logger,
 		appState.Authorizer, appState.Metrics)

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -748,6 +748,6 @@ func (m *Migrator) Shutdown(ctx context.Context) error {
 	if !m.db.StartupComplete() {
 		return nil
 	}
-	m.logger.Info("database was loaded before, closing ...")
+	m.logger.Info("closing loaded database ...")
 	return m.db.Shutdown(ctx)
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -743,6 +743,11 @@ func (m *Migrator) WaitForStartup(ctx context.Context) error {
 	return m.db.WaitForStartup(ctx)
 }
 
+// Shutdown no-op if db was never loaded
 func (m *Migrator) Shutdown(ctx context.Context) error {
+	if !m.db.StartupComplete() {
+		return nil
+	}
+	m.logger.Info("database was loaded before, closing ...")
 	return m.db.Shutdown(ctx)
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/store"
 	"github.com/weaviate/weaviate/cluster/transport"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
 // Service class serves as the primary entry point for the Raft layer, managing and coordinating
@@ -91,10 +92,10 @@ func (c *Service) Open(ctx context.Context, db store.Indexer) error {
 }
 
 func (c *Service) Close(ctx context.Context) error {
-	go func() {
+	enterrors.GoWrapper(func() {
 		c.closeBootstrapper <- struct{}{}
 		c.closeWaitForDB <- struct{}{}
-	}()
+	}, c.logger)
 
 	if err := c.Service.Close(ctx); err != nil {
 		return err

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -32,7 +32,7 @@ type Service struct {
 	rpcService *transport.Service
 	logger     *logrus.Logger
 
-	//closing channels
+	// closing channels
 	closeBootstrapper chan struct{}
 	noWaitForDB       chan struct{}
 }

--- a/cluster/store/bootstrap_test.go
+++ b/cluster/store/bootstrap_test.go
@@ -85,7 +85,7 @@ func TestBootStrapper(t *testing.T) {
 		b.jitter = time.Millisecond
 		test.doBefore(m)
 		ctx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
-		err := b.Do(ctx, test.servers, NewMockLogger(t).Logger, test.voter)
+		err := b.Do(ctx, test.servers, NewMockLogger(t).Logger, test.voter, make(chan struct{}))
 		cancel()
 		if test.success && err != nil {
 			t.Errorf("%s: %v", test.name, err)

--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -293,8 +293,8 @@ func (s *Service) LeaderWithID() (string, string) {
 	return string(addr), string(id)
 }
 
-func (s *Service) WaitUntilDBRestored(ctx context.Context, period time.Duration) error {
-	return s.store.WaitToRestoreDB(ctx, period)
+func (s *Service) WaitUntilDBRestored(ctx context.Context, period time.Duration, close chan struct{}) error {
+	return s.store.WaitToRestoreDB(ctx, period, close)
 }
 
 // QueryReadOnlyClass will verify that class is non empty and then build a Query that will be directed to the leader to

--- a/cluster/transport/client.go
+++ b/cluster/transport/client.go
@@ -131,10 +131,11 @@ func (cl *Client) Query(ctx context.Context, leaderAddress string, req *cmd.Quer
 	return c.Query(ctx, req)
 }
 
-func (cl *Client) Close() {
+func (cl *Client) Close() error {
 	if cl.leaderConn != nil {
-		cl.leaderConn.Close()
+		return cl.leaderConn.Close()
 	}
+	return nil
 }
 
 func (cl *Client) getConn(leaderAddress string) (*grpc.ClientConn, error) {


### PR DESCRIPTION
### What's being changed:
- if the database wasn't opened and we tried to close it it will block because there is no listener on the [shutdown channel yet](https://github.com/weaviate/weaviate/blob/2ba420cad3b22a52a285c7b5f30f9ea51f8a0029/adapters/repos/db/repo.go#L273), so this PR ignore closing if the db didn't startup. 

- pass channels to `bootsrapper` and `waiting for db` to break `for {}` on `Cloudsercice.close()` gets called 
- use `enterrors.GoWrapper` to wrap the raft go routine.
- remove sleep after init raft


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
