### PR TITLE
Support auto-tenant toggling on MT-enabled classes

### DIFF
--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -112,6 +112,7 @@ func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaO
 		meta.Class.VectorIndexConfig = u.VectorIndexConfig
 		meta.Class.InvertedIndexConfig = u.InvertedIndexConfig
 		meta.Class.VectorConfig = u.VectorConfig
+		meta.Class.MultiTenancyConfig = u.MultiTenancyConfig
 		meta.ClassVersion = cmd.Version
 		return nil
 	}

--- a/entities/schema/multi_tenancy.go
+++ b/entities/schema/multi_tenancy.go
@@ -24,6 +24,17 @@ func MultiTenancyEnabled(class *models.Class) bool {
 	return false
 }
 
+func AutoTenantCreationEnabled(class *models.Class) bool {
+	if class == nil {
+		return false
+	}
+
+	if class.MultiTenancyConfig != nil {
+		return class.MultiTenancyConfig.AutoTenantCreation
+	}
+	return false
+}
+
 func ActivityStatus(status string) string {
 	if status == "" {
 		return models.TenantActivityStatusHOT

--- a/test/acceptance/multi_tenancy/class_creation_test.go
+++ b/test/acceptance/multi_tenancy/class_creation_test.go
@@ -15,7 +15,9 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/batch"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
 )
@@ -54,4 +56,90 @@ func TestClassMultiTenancyDisabledSchemaPrint(t *testing.T) {
 
 	classReturn := helper.GetClass(t, testClass.Class)
 	require.NotNil(t, classReturn.MultiTenancyConfig)
+}
+
+func TestClassMultiTenancyToggleAutoTenant(t *testing.T) {
+	createObjectToCheckAutoTenant := func(t *testing.T, object *models.Object) *models.ObjectsGetResponse {
+		t.Helper()
+		params := batch.NewBatchObjectsCreateParams().
+			WithBody(batch.BatchObjectsCreateBody{
+				Objects: []*models.Object{object},
+			})
+		resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
+		helper.AssertRequestOk(t, resp, err, nil)
+		require.NotNil(t, resp)
+		require.Len(t, resp.Payload, 1)
+		return resp.Payload[0]
+	}
+
+	testClass := models.Class{
+		Class: "AutoTenantToggle",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			AutoTenantCreation: false,
+			Enabled:            true,
+		},
+	}
+	helper.CreateClass(t, &testClass)
+	defer func() {
+		helper.DeleteClass(t, testClass.Class)
+	}()
+
+	t.Run("autotenant not set, fail to create object with nonexistent tenant", func(t *testing.T) {
+		resp := createObjectToCheckAutoTenant(t,
+			&models.Object{
+				Class: "AutoTenantToggle",
+				Properties: map[string]interface{}{
+					"stringProp": "value",
+				},
+				Tenant: "non-existent",
+			},
+		)
+
+		require.NotNil(t, resp.Result)
+		require.NotNil(t, resp.Result.Errors)
+		require.Len(t, resp.Result.Errors.Error, 1)
+		assert.Equal(t, resp.Result.Errors.Error[0].Message, `tenant not found: "non-existent"`)
+	})
+
+	t.Run("autotenant toggled on, successfully create object", func(t *testing.T) {
+		fetched := helper.GetClass(t, testClass.Class)
+		fetched.MultiTenancyConfig.AutoTenantCreation = true
+		helper.UpdateClass(t, fetched)
+
+		resp := createObjectToCheckAutoTenant(t,
+			&models.Object{
+				Class: "AutoTenantToggle",
+				Properties: map[string]interface{}{
+					"stringProp": "value",
+				},
+				Tenant: "now-exists",
+			},
+		)
+
+		require.NotNil(t, resp.Result)
+		require.Nil(t, resp.Result.Errors)
+		success := "SUCCESS"
+		assert.EqualValues(t, resp.Result.Status, &success)
+	})
+
+	t.Run("autotenant toggled back off, fail to create object with nonexistent tenant", func(t *testing.T) {
+		fetched := helper.GetClass(t, testClass.Class)
+		fetched.MultiTenancyConfig.AutoTenantCreation = false
+		helper.UpdateClass(t, fetched)
+
+		resp := createObjectToCheckAutoTenant(t,
+			&models.Object{
+				Class: "AutoTenantToggle",
+				Properties: map[string]interface{}{
+					"stringProp": "value",
+				},
+				Tenant: "still-nonexistent",
+			},
+		)
+
+		require.NotNil(t, resp.Result)
+		require.NotNil(t, resp.Result.Errors)
+		require.Len(t, resp.Result.Errors.Error, 1)
+		assert.Equal(t, resp.Result.Errors.Error[0].Message, `tenant not found: "still-nonexistent"`)
+	})
 }

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -664,7 +664,7 @@ func validateUpdatingMT(current, update *models.Class) (enabled bool, err error)
 		}
 	}
 	if !enabled && schema.AutoTenantCreationEnabled(update) {
-		err = fmt.Errorf("can't enabled autoTenantCreation on a non-multi-tenant class")
+		err = fmt.Errorf("can't enable autoTenantCreation on a non-multi-tenant class")
 	}
 	return
 }

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -663,6 +663,9 @@ func validateUpdatingMT(current, update *models.Class) (enabled bool, err error)
 			err = fmt.Errorf("enabling multi-tenancy for an existing class is not supported")
 		}
 	}
+	if !enabled && schema.AutoTenantCreationEnabled(update) {
+		err = fmt.Errorf("can't enabled autoTenantCreation on a non-multi-tenant class")
+	}
 	return
 }
 


### PR DESCRIPTION
### What's being changed:

Introduces `multiTenancyConfig.autoTenantCreation` toggling with class updates. This allows the autotenant process (#3741) to be turned on/off dynamically on an existing class. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
