### PR TITLE
unskip grpc batch insert skip after EC fix

### DIFF
--- a/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
+++ b/test/acceptance_with_go_client/grpc_tests/batch_grpc_test.go
@@ -39,8 +39,6 @@ func TestGRPC_Batch(t *testing.T) {
 }
 
 func TestGRPC_Batch_Cluster(t *testing.T) {
-	t.Skip("disabled due to eventual consistency failure. Re-enable when eventual consistency on batch is tackled. See: WEAVIATE-754")
-
 	ctx := context.Background()
 	compose, err := docker.New().
 		WithWeaviateClusterWithGRPC().


### PR DESCRIPTION
### What's being changed:

This test was skip waiting for an EC fix on the batch insert. This fix has landed on master and the test can be run now.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
