### PR TITLE
Concurrent batch vectorization requests

### DIFF
--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -164,10 +164,12 @@ func (b *Batch) batchWorker() {
 			if rateLimit.CanSendFullBatch(numRequests, job.tokenSum) {
 				rateLimit.ReservedRequests += numRequests
 				rateLimit.ReservedTokens += job.tokenSum
+				fmt.Println("Concurrent batch", job.cfg)
 				go b.sendBatch(job, objCounter, dummyRateLimit(), timePerToken, numRequests, true)
 				break
 			} else if b.concurrentBatches.Load() < 1 {
 				// block so no concurrent batch can be sent
+				fmt.Println("Sequential batch", job.cfg)
 				b.sendBatch(job, objCounter, rateLimit, timePerToken, 0, false)
 				break
 			}

--- a/usecases/modulecomponents/client_results.go
+++ b/usecases/modulecomponents/client_results.go
@@ -56,10 +56,6 @@ func (rl *RateLimits) CanSendFullBatch(numRequests int, batchTokens int) bool {
 	return percentageOfRequests <= 15 && percentageOfTokens <= 15
 }
 
-func (rl *RateLimits) updateUsagePercentage() bool {
-	return rl.RemainingRequests == 0 && rl.RemainingTokens == 0
-}
-
 func (rl *RateLimits) IsInitialized() bool {
 	return rl.RemainingRequests == 0 && rl.RemainingTokens == 0
 }

--- a/usecases/modulecomponents/client_results.go
+++ b/usecases/modulecomponents/client_results.go
@@ -48,8 +48,13 @@ func (rl *RateLimits) CanSendFullBatch(numRequests int, batchTokens int) bool {
 	}
 
 	// also make sure that we do not "spend" all the rate limit at once
-	percentageOfRequests := numRequests * 100 / rl.LimitRequests
-	percentageOfTokens := batchTokens * 100 / rl.LimitTokens
+	var percentageOfRequests, percentageOfTokens int
+	if rl.LimitRequests > 0 {
+		percentageOfRequests = numRequests * 100 / rl.LimitRequests
+	}
+	if rl.LimitTokens > 0 {
+		percentageOfTokens = batchTokens * 100 / rl.LimitTokens
+	}
 
 	// the clients aim for 10s per batch, or 6 batches per minute in sequential-mode. 15% is somewhat below that to
 	// account for some variance in the rate limits


### PR DESCRIPTION
### What's being changed:

Send batch requests concurrently if the rate limit is high enough, otherwise keep sequential batching. For example Cohere allows 10k requests/min and we can basically send as many requests in parallel as we want.

With this the 100k sphere dataset with 2 named vectors was vectorized in ~2min using cohere and `collection.batch.fixed_size(concurrent_requests=20, batch_size=96)`.

To test use this python client branch https://github.com/weaviate/weaviate-python-client/pull/981 and the profiling/test_sphere.py script.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
