### PR TITLE
add new GHA ci check to detect protobuf breaking changes

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -14,6 +14,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  Buf-Checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-lint-action@v1
+        with:
+          input: "cluster/proto"
+      - uses: bufbuild/buf-breaking-action@v1
+        if: github.event_name == 'pull_request'
+        with:
+          input: "cluster/proto"
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${{ github.event.pull_request.base.ref }},subdir=cluster/proto"
   Run-Swagger:
     name: run-swagger
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What's being changed:

Add a new GHA CI step to ensure that we are not breaking our internal protobuf definition for RAFT schema changes.

Example breaking changes
```
diff --git a/cluster/proto/api/message.proto b/cluster/proto/api/message.proto
index 9b90b252d..58e6250e0 100644
--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -11,9 +11,8 @@ service ClusterService {
 }

 message JoinPeerRequest {
-  string id = 1;
-  string address = 2;
-  bool voter = 3;
+  string address = 1;
+  bool voter = 2;
 }

 message JoinPeerResponse {
 ```

Example output when running against that diff
```
cluster/proto/api/message.proto:13:1:Previously present field "3" with name "voter" on message "JoinPeerRequest" was deleted.
cluster/proto/api/message.proto:14:3:Field "1" with name "address" on message "JoinPeerRequest" changed option "json_name" from "id" to "address".
cluster/proto/api/message.proto:14:10:Field "1" on message "JoinPeerRequest" changed name from "id" to "address".
cluster/proto/api/message.proto:15:3:Field "2" with name "voter" on message "JoinPeerRequest" changed option "json_name" from "address" to "voter".
cluster/proto/api/message.proto:15:3:Field "2" on message "JoinPeerRequest" changed type from "string" to "bool".
cluster/proto/api/message.proto:15:8:Field "2" on message "JoinPeerRequest" changed name from "address" to "voter".
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
