### PR TITLE
Adding more tests around the dynamic index and fixing an existing bug

### DIFF
--- a/entities/vectorindex/dynamic/config.go
+++ b/entities/vectorindex/dynamic/config.go
@@ -83,20 +83,18 @@ func ParseAndValidateConfig(input interface{}) (schemaConfig.VectorIndexConfig, 
 	}
 
 	hnswConfig, ok := asMap["hnsw"]
-	if !ok || hnswConfig == nil {
-		return uc, nil
-	}
+	if ok && hnswConfig != nil {
+		hnswUC, err := hnsw.ParseAndValidateConfig(hnswConfig)
+		if err != nil {
+			return uc, err
+		}
 
-	hnswUC, err := hnsw.ParseAndValidateConfig(hnswConfig)
-	if err != nil {
-		return uc, err
+		castedHnswUC, ok := hnswUC.(hnsw.UserConfig)
+		if !ok {
+			return uc, fmt.Errorf("invalid hnsw configuration")
+		}
+		uc.HnswUC = castedHnswUC
 	}
-
-	castedHnswUC, ok := hnswUC.(hnsw.UserConfig)
-	if !ok {
-		return uc, fmt.Errorf("invalid hnsw configuration")
-	}
-	uc.HnswUC = castedHnswUC
 
 	flatConfig, ok := asMap["flat"]
 	if !ok || flatConfig == nil {

--- a/entities/vectorindex/dynamic/config_test.go
+++ b/entities/vectorindex/dynamic/config_test.go
@@ -76,6 +76,190 @@ func Test_DynamicUserConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "threshold is properly set",
+			input: map[string]interface{}{
+				"threshold": float64(100),
+			},
+			expected: UserConfig{
+				Distance:  common.DefaultDistanceMetric,
+				Threshold: 100,
+				HnswUC: hnsw.UserConfig{
+					CleanupIntervalSeconds: hnsw.DefaultCleanupIntervalSeconds,
+					MaxConnections:         hnsw.DefaultMaxConnections,
+					EFConstruction:         hnsw.DefaultEFConstruction,
+					VectorCacheMaxObjects:  common.DefaultVectorCacheMaxObjects,
+					EF:                     hnsw.DefaultEF,
+					Skip:                   hnsw.DefaultSkip,
+					FlatSearchCutoff:       hnsw.DefaultFlatSearchCutoff,
+					DynamicEFMin:           hnsw.DefaultDynamicEFMin,
+					DynamicEFMax:           hnsw.DefaultDynamicEFMax,
+					DynamicEFFactor:        hnsw.DefaultDynamicEFFactor,
+					Distance:               common.DefaultDistanceMetric,
+					PQ: hnsw.PQConfig{
+						Enabled:       hnsw.DefaultPQEnabled,
+						Segments:      hnsw.DefaultPQSegments,
+						Centroids:     hnsw.DefaultPQCentroids,
+						TrainingLimit: hnsw.DefaultPQTrainingLimit,
+						Encoder: hnsw.PQEncoder{
+							Type:         hnsw.DefaultPQEncoderType,
+							Distribution: hnsw.DefaultPQEncoderDistribution,
+						},
+					},
+				},
+				FlatUC: flat.UserConfig{
+					VectorCacheMaxObjects: common.DefaultVectorCacheMaxObjects,
+					Distance:              common.DefaultDistanceMetric,
+					PQ: flat.CompressionUserConfig{
+						Enabled:      flat.DefaultCompressionEnabled,
+						RescoreLimit: flat.DefaultCompressionRescore,
+						Cache:        flat.DefaultVectorCache,
+					},
+					BQ: flat.CompressionUserConfig{
+						Enabled:      flat.DefaultCompressionEnabled,
+						RescoreLimit: flat.DefaultCompressionRescore,
+						Cache:        flat.DefaultVectorCache,
+					},
+				},
+			},
+		},
+		{
+			name: "hnsw is properly set",
+			input: map[string]interface{}{
+				"hnsw": map[string]interface{}{
+					"cleanupIntervalSeconds": float64(11),
+					"maxConnections":         float64(12),
+					"efConstruction":         float64(13),
+					"vectorCacheMaxObjects":  float64(14),
+					"ef":                     float64(15),
+					"flatSearchCutoff":       float64(16),
+					"dynamicEfMin":           float64(17),
+					"dynamicEfMax":           float64(18),
+					"dynamicEfFactor":        float64(19),
+					"pq": map[string]interface{}{
+						"enabled":        true,
+						"bitCompression": false,
+						"segments":       float64(64),
+						"centroids":      float64(200),
+						"trainingLimit":  float64(100),
+						"encoder": map[string]interface{}{
+							"type": hnsw.PQEncoderTypeKMeans,
+						},
+					},
+				},
+			},
+			expected: UserConfig{
+				Distance:  common.DefaultDistanceMetric,
+				Threshold: DefaultThreshold,
+				HnswUC: hnsw.UserConfig{
+					CleanupIntervalSeconds: 11,
+					MaxConnections:         12,
+					EFConstruction:         13,
+					VectorCacheMaxObjects:  14,
+					EF:                     15,
+					FlatSearchCutoff:       16,
+					DynamicEFMin:           17,
+					DynamicEFMax:           18,
+					DynamicEFFactor:        19,
+					Distance:               common.DefaultDistanceMetric,
+					PQ: hnsw.PQConfig{
+						Enabled:       true,
+						Segments:      64,
+						Centroids:     200,
+						TrainingLimit: 100,
+						Encoder: hnsw.PQEncoder{
+							Type:         hnsw.DefaultPQEncoderType,
+							Distribution: hnsw.DefaultPQEncoderDistribution,
+						},
+					},
+				},
+				FlatUC: flat.UserConfig{
+					VectorCacheMaxObjects: common.DefaultVectorCacheMaxObjects,
+					Distance:              common.DefaultDistanceMetric,
+					PQ: flat.CompressionUserConfig{
+						Enabled:      flat.DefaultCompressionEnabled,
+						RescoreLimit: flat.DefaultCompressionRescore,
+						Cache:        flat.DefaultVectorCache,
+					},
+					BQ: flat.CompressionUserConfig{
+						Enabled:      flat.DefaultCompressionEnabled,
+						RescoreLimit: flat.DefaultCompressionRescore,
+						Cache:        flat.DefaultVectorCache,
+					},
+				},
+			},
+		},
+		{
+			name: "flat is properly set",
+			input: map[string]interface{}{
+				"flat": map[string]interface{}{
+					"vectorCacheMaxObjects": float64(100),
+					"distance":              "cosine",
+					"bq": map[string]interface{}{
+						"enabled":      true,
+						"rescoreLimit": float64(100),
+						"cache":        true,
+					},
+				},
+			},
+			expected: UserConfig{
+				Distance:  common.DefaultDistanceMetric,
+				Threshold: DefaultThreshold,
+				HnswUC: hnsw.UserConfig{
+					CleanupIntervalSeconds: hnsw.DefaultCleanupIntervalSeconds,
+					MaxConnections:         hnsw.DefaultMaxConnections,
+					EFConstruction:         hnsw.DefaultEFConstruction,
+					VectorCacheMaxObjects:  common.DefaultVectorCacheMaxObjects,
+					EF:                     hnsw.DefaultEF,
+					Skip:                   hnsw.DefaultSkip,
+					FlatSearchCutoff:       hnsw.DefaultFlatSearchCutoff,
+					DynamicEFMin:           hnsw.DefaultDynamicEFMin,
+					DynamicEFMax:           hnsw.DefaultDynamicEFMax,
+					DynamicEFFactor:        hnsw.DefaultDynamicEFFactor,
+					Distance:               common.DefaultDistanceMetric,
+					PQ: hnsw.PQConfig{
+						Enabled:       hnsw.DefaultPQEnabled,
+						Segments:      hnsw.DefaultPQSegments,
+						Centroids:     hnsw.DefaultPQCentroids,
+						TrainingLimit: hnsw.DefaultPQTrainingLimit,
+						Encoder: hnsw.PQEncoder{
+							Type:         hnsw.DefaultPQEncoderType,
+							Distribution: hnsw.DefaultPQEncoderDistribution,
+						},
+					},
+				},
+				FlatUC: flat.UserConfig{
+					VectorCacheMaxObjects: 100,
+					Distance:              common.DefaultDistanceMetric,
+					PQ: flat.CompressionUserConfig{
+						Enabled:      false,
+						RescoreLimit: flat.DefaultCompressionRescore,
+						Cache:        flat.DefaultVectorCache,
+					},
+					BQ: flat.CompressionUserConfig{
+						Enabled:      true,
+						RescoreLimit: 100,
+						Cache:        true,
+					},
+				},
+			},
+		},
+		{
+			name: "pq enabled with flat returns error",
+			input: map[string]interface{}{
+				"flat": map[string]interface{}{
+					"vectorCacheMaxObjects": float64(100),
+					"distance":              "cosine",
+					"pq": map[string]interface{}{
+						"enabled":      true,
+						"rescoreLimit": float64(100),
+						"cache":        true,
+					},
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "PQ is not currently supported for flat indices",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What's being changed:

When parsing the dynamic index config, if there is no hnsw config (meaning we should use the default values for hnsw) the flat index is not read. The correct flow should be that we do parse the flat config even though the hnsw config is not present. This logic is solved in this PR.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
