### PR TITLE
fix: don't return shutdown error incase the shard was already shutdow…

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1958,7 +1958,10 @@ func (i *Index) Shutdown(ctx context.Context) error {
 	// TODO allow every resource cleanup to run, before returning early with error
 	if err := i.ForEachShardConcurrently(func(name string, shard ShardLike) error {
 		if err := shard.Shutdown(ctx); err != nil {
-			return errors.Wrapf(err, "shutdown shard %q", name)
+			if !errors.Is(err, errAlreadyShutdown) {
+				return errors.Wrapf(err, "shutdown shard %q", name)
+			}
+			i.logger.WithField("shard", shard.Name()).Debug("was already shut or dropped")
 		}
 		return nil
 	}); err != nil {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -363,9 +363,12 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 				idx.shards.LoadAndDelete(name)
 
 				if err := shard.Shutdown(ctx); err != nil {
-					ec.Add(err)
-					idx.logger.WithField("action", "shutdown_shard").
-						WithField("shard", shard.ID()).Error(err)
+					if !errors.Is(err, errAlreadyShutdown) {
+						ec.Add(err)
+						idx.logger.WithField("action", "shutdown_shard").
+							WithField("shard", shard.ID()).Error(err)
+					}
+					m.logger.WithField("shard", shard.Name()).Debug("was already shut or dropped")
 				}
 				return nil
 			})

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -64,6 +64,8 @@ import (
 
 const IdLockPoolSize = 128
 
+var errAlreadyShutdown = errors.New("already shut or dropped")
+
 type ShardLike interface {
 	Index() *Index                                                                      // Get the parent index
 	Name() string                                                                       // Get the shard name
@@ -1045,7 +1047,7 @@ func (s *Shard) preventShutdown() (release func(), err error) {
 	defer s.shutdownLock.RUnlock()
 
 	if s.shut {
-		return func() {}, fmt.Errorf("shard %q already shut or dropped", s.name)
+		return func() {}, errAlreadyShutdown
 	}
 
 	s.inUseCounter.Add(1)
@@ -1088,7 +1090,7 @@ func (s *Shard) checkEligibleForShutdown() (eligible bool, err error) {
 	defer s.shutdownLock.Unlock()
 
 	if s.shut {
-		return false, fmt.Errorf("shard %q already shut or dropped", s.name)
+		return false, errAlreadyShutdown
 	}
 
 	if s.inUseCounter.Load() == 0 {


### PR DESCRIPTION
if we call db.Shutdown() , we end up sometimes  in situations where the shard was already shutdown, this PR ignore that error on calling db.Shutdown() -> index.Shutdown()

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
