### PR TITLE
[Raft][Observability] Observe durations of schema reads and writes for local and leader reads

### DIFF
--- a/cluster/store/retry_schema.go
+++ b/cluster/store/retry_schema.go
@@ -15,8 +15,10 @@ import (
 	"context"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -30,6 +32,11 @@ type retrySchema struct {
 }
 
 func (rs retrySchema) ClassInfo(class string) (ci ClassInfo) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"ClassInfo"))
+	defer t.ObserveDuration()
+
 	res, _ := rs.ClassInfoWithVersion(context.TODO(), class, 0)
 	return res
 }
@@ -41,12 +48,21 @@ func (rs retrySchema) ClassEqual(name string) string {
 }
 
 func (rs retrySchema) MultiTenancy(class string) models.MultiTenancyConfig {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"MultiTenancy"))
+	defer t.ObserveDuration()
 	res, _ := rs.MultiTenancyWithVersion(context.TODO(), class, 0)
 	return res
 }
 
 // Read performs a read operation `reader` on the specified class and sharding state
 func (rs retrySchema) Read(class string, reader func(*models.Class, *sharding.State) error) error {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"Read"))
+	defer t.ObserveDuration()
+
 	return rs.retry(func(s *schema) error {
 		return s.Read(class, reader)
 	})
@@ -55,6 +71,11 @@ func (rs retrySchema) Read(class string, reader func(*models.Class, *sharding.St
 // ReadOnlyClass returns a shallow copy of a class.
 // The copy is read-only and should not be modified.
 func (rs retrySchema) ReadOnlyClass(class string) (cls *models.Class) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"ReadOnlyClass"))
+	defer t.ObserveDuration()
+
 	res, _ := rs.ReadOnlyClassWithVersion(context.TODO(), class, 0)
 	return res
 }
@@ -79,38 +100,73 @@ func (rs retrySchema) metaClass(class string) (meta *metaClass) {
 // therefore, we perform a shallow copy of the existing properties.
 // This implementation assumes that individual properties are overwritten rather than partially updated
 func (rs retrySchema) ReadOnlySchema() models.Schema {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"ReadOnlySchema"))
+	defer t.ObserveDuration()
+
 	return rs.schema.ReadOnlySchema()
 }
 
 // ShardOwner returns the node owner of the specified shard
 func (rs retrySchema) ShardOwner(class, shard string) (owner string, err error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"ShardOwner"))
+	defer t.ObserveDuration()
+
 	res, err := rs.ShardOwnerWithVersion(context.TODO(), class, shard, 0)
 	return res, err
 }
 
 // ShardFromUUID returns shard name of the provided uuid
 func (rs retrySchema) ShardFromUUID(class string, uuid []byte) (shard string) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"ShardFromUUID"))
+	defer t.ObserveDuration()
+
 	res, _ := rs.ShardFromUUIDWithVersion(context.TODO(), class, uuid, 0)
 	return res
 }
 
 // ShardReplicas returns the replica nodes of a shard
 func (rs retrySchema) ShardReplicas(class, shard string) (nodes []string, err error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"ShardReplicas"))
+	defer t.ObserveDuration()
+
 	res, err := rs.ShardReplicasWithVersion(context.TODO(), class, shard, 0)
 	return res, err
 }
 
 // TenantsShards returns shard name for the provided tenant and its activity status
 func (rs retrySchema) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"TenantsShards"))
+	defer t.ObserveDuration()
+
 	return rs.TenantsShardsWithVersion(context.TODO(), 0, class, tenants...)
 }
 
 func (rs retrySchema) CopyShardingState(class string) (ss *sharding.State) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"CopyShardingState"))
+	defer t.ObserveDuration()
+
 	res, _ := rs.CopyShardingStateWithVersion(context.TODO(), class, 0)
 	return res
 }
 
 func (rs retrySchema) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues(
+			"GetShardsStatus"))
+	defer t.ObserveDuration()
+
 	return rs.schema.GetShardsStatus(class, tenant)
 }
 

--- a/cluster/store/schema_version.go
+++ b/cluster/store/schema_version.go
@@ -14,7 +14,9 @@ package store
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -31,6 +33,11 @@ func (s versionedSchema) ClassInfo(ctx context.Context,
 	class string,
 	v uint64,
 ) (ClassInfo, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"ClassInfo"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	return s.schema.ClassInfo(class), err
 }
@@ -39,7 +46,11 @@ func (s versionedSchema) MultiTenancy(ctx context.Context,
 	class string,
 	v uint64,
 ) (models.MultiTenancyConfig, error) {
-	// MT is immutable
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"MultiTenancy"))
+	defer t.ObserveDuration()
+
 	if info := s.schema.ClassInfo(class); info.Exists {
 		return info.MultiTenancy, nil
 	}
@@ -53,6 +64,11 @@ func (s versionedSchema) Read(ctx context.Context,
 	reader func(*models.Class,
 		*sharding.State) error,
 ) error {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"Read"))
+	defer t.ObserveDuration()
+
 	if err := s.WaitForUpdate(ctx, v); err != nil {
 		return err
 	}
@@ -66,6 +82,11 @@ func (s versionedSchema) ReadOnlyClass(ctx context.Context,
 	class string,
 	v uint64,
 ) (*models.Class, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"ReadOnlyClass"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	cls, _ := s.schema.ReadOnlyClass(class)
 	return cls, err
@@ -76,6 +97,11 @@ func (s versionedSchema) ShardOwner(ctx context.Context,
 	class, shard string,
 	v uint64,
 ) (string, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"ShardOwner"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	owner, _, sErr := s.schema.ShardOwner(class, shard)
 	if sErr != nil && err == nil {
@@ -88,6 +114,11 @@ func (s versionedSchema) ShardOwner(ctx context.Context,
 func (s versionedSchema) ShardFromUUID(ctx context.Context,
 	class string, uuid []byte, v uint64,
 ) (string, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"ShardFromUUID"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	shard, _ := s.schema.ShardFromUUID(class, uuid)
 	return shard, err
@@ -98,6 +129,11 @@ func (s versionedSchema) ShardReplicas(
 	ctx context.Context, class, shard string,
 	v uint64,
 ) ([]string, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"ShardReplicas"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	nodes, _, sErr := s.schema.ShardReplicas(class, shard)
 	if sErr != nil && err == nil {
@@ -110,6 +146,11 @@ func (s versionedSchema) ShardReplicas(
 func (s versionedSchema) TenantsShards(ctx context.Context,
 	v uint64, class string, tenants ...string,
 ) (map[string]string, uint64, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"TenantsShards"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	status, version := s.schema.TenantsShards(class, tenants...)
 	return status, version, err
@@ -118,6 +159,11 @@ func (s versionedSchema) TenantsShards(ctx context.Context,
 func (s versionedSchema) CopyShardingState(ctx context.Context,
 	class string, v uint64,
 ) (*sharding.State, error) {
+	t := prometheus.NewTimer(
+		monitoring.GetMetrics().SchemaWaitForVersion.WithLabelValues(
+			"CopyShardingState"))
+	defer t.ObserveDuration()
+
 	err := s.WaitForUpdate(ctx, v)
 	ss, _ := s.schema.CopyShardingState(class)
 	return ss, err


### PR DESCRIPTION
### What's being changed:
add metrics for typical schema operations:
- local reads
- leader reads
- writes (always leader)
- local read with wait_for_version

For more details, see:
```go
		SchemaWrites: promauto.NewSummaryVec(prometheus.SummaryOpts{
			Name: "schema_writes_seconds",
			Help: "Duration of schema writes (which always involve the leader)",
		}, []string{"type"}),
		SchemaReadsLocal: promauto.NewSummaryVec(prometheus.SummaryOpts{
			Name: "schema_reads_local_seconds",
			Help: "Duration of local schema reads that do not involve the leader",
		}, []string{"type"}),
		SchemaReadsLeader: promauto.NewSummaryVec(prometheus.SummaryOpts{
			Name: "schema_reads_leader_seconds",
			Help: "Duration of schema reads that are passed to the leader",
		}, []string{"type"}),
		SchemaWaitForVersion: promauto.NewSummaryVec(prometheus.SummaryOpts{
			Name: "schema_wait_for_version_seconds",
			Help: "Duration of waiting for a schema version to be reached",
		}, []string{"type"}),
```

For some examples, see:
```prometheus
# TYPE schema_reads_leader_seconds summary
schema_reads_leader_seconds_sum{type="TYPE_GET_SCHEMA"} 0.001267917
schema_reads_leader_seconds_count{type="TYPE_GET_SCHEMA"} 2
schema_reads_leader_seconds_sum{type="TYPE_GET_TENANTS_SHARDS"} 0.13462870599999996
schema_reads_leader_seconds_count{type="TYPE_GET_TENANTS_SHARDS"} 306
# HELP schema_reads_local_seconds Duration of local schema reads that do not involve the leader
# TYPE schema_reads_local_seconds summary
schema_reads_local_seconds_sum{type="Read"} 0.0006110440000000001
schema_reads_local_seconds_count{type="Read"} 307
schema_reads_local_seconds_sum{type="ReadOnlyClass"} 0.15842147300000012
schema_reads_local_seconds_count{type="ReadOnlyClass"} 2434
schema_reads_local_seconds_sum{type="ReadOnlySchema"} 0.002360370000000001
schema_reads_local_seconds_count{type="ReadOnlySchema"} 364
schema_reads_local_seconds_sum{type="ShardReplicas"} 25.759868835999985
schema_reads_local_seconds_count{type="ShardReplicas"} 306
# HELP schema_writes_seconds Duration of schema writes (which always involve the leader)
# TYPE schema_writes_seconds summary
schema_writes_seconds_sum{type="TYPE_ADD_CLASS"} 0.327315
schema_writes_seconds_count{type="TYPE_ADD_CLASS"} 11
schema_writes_seconds_sum{type="TYPE_ADD_TENANT"} 8.408649545999996
schema_writes_seconds_count{type="TYPE_ADD_TENANT"} 307
schema_writes_seconds_sum{type="TYPE_DELETE_CLASS"} 3.1660556649999996
schema_writes_seconds_count{type="TYPE_DELETE_CLASS"} 20
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
