### PR TITLE
add retry on failure in CI for tests instability

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -125,7 +125,13 @@ jobs:
           go-version: '1.21'
           cache: true
       - name: Acceptance tests (modules)
-        run: ./test/run.sh ${{ matrix.test }}
+        uses: nick-fields/retry@v2
+        with:
+          # 15 Minute is a large enough timeout for most of our tests
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./test/run.sh ${{ matrix.test }}
+          on_retry_command: ./test/run.sh --cleanup
   Modules-Acceptance-Tests-large:
     name: modules-acceptance-tests-large
     runs-on: ubuntu-latest-4-cores
@@ -141,7 +147,13 @@ jobs:
           go-version: '1.21'
           cache: true
       - name: Acceptance tests Large (modules)
-        run: ./test/run.sh ${{ matrix.test }}
+        uses: nick-fields/retry@v2
+        with:
+          # 15 Minute is a large enough timeout for most of our tests
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./test/run.sh ${{ matrix.test }}
+          on_retry_command: ./test/run.sh --cleanup
   Modules-Acceptance-Tests-gcp:
     name: modules-acceptance-tests-gcp
     runs-on: ubuntu-latest
@@ -183,7 +195,7 @@ jobs:
         if : ${{ env.run_pipeline == 'true' || startsWith(github.ref, 'refs/tags') }}
         run: PALM_APIKEY=$(gcloud auth print-access-token) ./test/run.sh ${{ matrix.test }}
   Acceptance-Tests:
-    name: acceptance-tests  
+    name: acceptance-tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -197,10 +209,16 @@ jobs:
           go-version: '1.21'
           cache: true
       - name: Acceptance tests
+        uses: nick-fields/retry@v2
         env:
           WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
-          WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}        
-        run: ./test/run.sh ${{ matrix.test }}
+          WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}
+        with:
+          # 15 Minute is a large enough timeout for most of our tests
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./test/run.sh ${{ matrix.test }}
+          on_retry_command: ./test/run.sh --cleanup
   Codecov:
     needs: [Unit-Tests, Integration-Tests]
     name: codecov

--- a/test/run.sh
+++ b/test/run.sh
@@ -20,6 +20,7 @@ function main() {
   run_benchmark=false
   run_module_only_backup_tests=false
   run_module_except_backup_tests=false
+  run_cleanup=false
 
   while [[ "$#" -gt 0 ]]; do
       case $1 in
@@ -38,6 +39,7 @@ function main() {
           --acceptance-module-tests-only-backup|--modules-backup-only|-mob) run_all_tests=false; run_module_tests=true; run_module_only_backup_tests=true;;
           --acceptance-module-tests-except-backup|--modules-except-backup|-meb) run_all_tests=false; run_module_tests=true; run_module_except_backup_tests=true; echo $run_module_except_backup_tests ;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
+          --cleanup) run_all_tests=false; run_cleanup=true;;
           --help|-h) printf '%s\n' \
               "Options:"\
               "--unit-only | -u"\
@@ -123,7 +125,7 @@ function main() {
     ./test/acceptance_with_python/run.sh
     echo_green "Python tests successful"
   fi
-  
+
   if $only_module; then
     mod=${only_module_value//--only-module-/}
     echo_green "Running module acceptance tests for $mod..."
@@ -135,7 +137,7 @@ function main() {
         return 1
       fi
       echo_green "Module acceptance tests for $mod successful"
-    done    
+    done
   fi
   if $run_module_tests; then
     echo_green "Running module acceptance tests..."
@@ -143,6 +145,10 @@ function main() {
     echo_green "Weaviate image successfully built, run module tests..."
     run_module_tests "$@"
     echo_green "Module acceptance tests successful"
+  fi
+  if $run_cleanup; then
+    echo_green "Cleaning up all running docker containers..."
+    docker rm -f $(docker ps -a -q)
   fi
   echo "Done!"
 }


### PR DESCRIPTION
### What's being changed:

As we have CI instability, add a retry on failure mechanism in the CI to ensure that failing tests will be re-run to avoid manual intervention.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
