### PR TITLE
Fix an issue introduced in `v1.24.9` where HNSW commit logs are no longer optimized

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -239,7 +239,7 @@ func asTimeStamp(in string) (int64, error) {
 	return strconv.ParseInt(strings.TrimSuffix(in, ".condensed"), 10, 64)
 }
 
-type condensor interface {
+type Condensor interface {
 	Do(filename string) error
 }
 
@@ -250,7 +250,7 @@ type hnswCommitLogger struct {
 
 	rootPath          string
 	id                string
-	condensor         condensor
+	condensor         Condensor
 	logger            logrus.FieldLogger
 	maxSizeIndividual int64
 	maxSizeCombining  int64
@@ -534,9 +534,9 @@ func (l *hnswCommitLogger) condenseOldLogs() (bool, error) {
 					"size":   s.Size(),
 				}).WithError(err).
 					Warnf("skipping hnsw condensing due to memory pressure")
+				return false, nil
 			}
 
-			return false, nil
 		}
 
 		return true, l.condensor.Do(candidate)

--- a/adapters/repos/db/vector/hnsw/commit_logger_functional_options.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_functional_options.go
@@ -35,3 +35,10 @@ func WithAllocChecker(mm memwatch.AllocChecker) CommitlogOption {
 		return nil
 	}
 }
+
+func WithCondensor(condensor Condensor) CommitlogOption {
+	return func(l *hnswCommitLogger) error {
+		l.condensor = condensor
+		return nil
+	}
+}

--- a/adapters/repos/db/vector/hnsw/commit_logger_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_test.go
@@ -12,9 +12,17 @@
 package hnsw
 
 import (
+	"context"
+	"fmt"
 	_ "fmt"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 type MockDirEntry struct {
@@ -64,3 +72,126 @@ func TestRemoveTmpScratchOrHiddenFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestCondenseLoop(t *testing.T) {
+	scratchDir := t.TempDir()
+	commitLogDir := createCondensorTestData(t, scratchDir)
+	shutdown := createTestCommitLoggerWithOptions(t, scratchDir, "main", WithCondensor(&fakeCondensor{}))
+	defer shutdown()
+
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		files, err := os.ReadDir(commitLogDir)
+		assert.Nil(t, err)
+
+		// all existing files should be condensed, but there is of course also an
+		// active log, so we expect 2 files in total
+		assert.Len(t, files, 2)
+
+		fileNames := make([]string, 0, len(files))
+		for _, file := range files {
+			fileNames = append(fileNames, file.Name())
+		}
+
+		assert.ElementsMatch(t, []string{"1000.condensed", "1004"}, fileNames)
+	}, 5*time.Second, 50*time.Millisecond, "Condense loop did not run")
+}
+
+func TestCondenseLoop_WithAllocChecker(t *testing.T) {
+	scratchDir := t.TempDir()
+	commitLogDir := createCondensorTestData(t, scratchDir)
+	shutdown := createTestCommitLoggerWithOptions(t, scratchDir, "main",
+		WithCondensor(&fakeCondensor{}), WithAllocChecker(&fakeAllocChecker{}))
+	defer shutdown()
+
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		files, err := os.ReadDir(commitLogDir)
+		assert.Nil(t, err)
+
+		// all existing files should be condensed, but there is of course also an
+		// active log, so we expect 2 files in total
+		assert.Len(t, files, 2)
+
+		fileNames := make([]string, 0, len(files))
+		for _, file := range files {
+			fileNames = append(fileNames, file.Name())
+		}
+
+		assert.ElementsMatch(t, []string{"1000.condensed", "1004"}, fileNames)
+	}, 5*time.Second, 50*time.Millisecond, "Condense loop did not run")
+}
+
+func TestCondenseLoop_WithAllocChecker_OOM(t *testing.T) {
+	scratchDir := t.TempDir()
+	commitLogDir := createCondensorTestData(t, scratchDir)
+	shutdown := createTestCommitLoggerWithOptions(t, scratchDir, "main",
+		WithCondensor(&fakeCondensor{}), WithAllocChecker(&fakeAllocChecker{shouldErr: true}))
+	defer shutdown()
+
+	assert.Never(t, func() bool {
+		files, err := os.ReadDir(commitLogDir)
+		assert.Nil(t, err)
+		// we're OOM the files should not change on disk
+		// the combiner can still run even when OOM, this means, we expect
+		// 1000.condensed and 1001.condensed to be condensed into a single file
+		// (1000), but all the other files(1002, 1003, 1004) should still be there
+		return len(files) < 4
+	}, 2*time.Second, 50*time.Millisecond, "files should not change")
+}
+
+type fakeCondensor struct{}
+
+func (f fakeCondensor) Do(fileName string) error {
+	os.Rename(fileName, fmt.Sprintf("%s.condensed", fileName))
+	return nil
+}
+
+func createCondensorTestData(t *testing.T, scratchDir string) string {
+	commitLogDir := fmt.Sprintf("%s/main.hnsw.commitlog.d", scratchDir)
+
+	os.MkdirAll(commitLogDir, os.ModePerm)
+
+	// create dummy data
+	_, err := os.Create(fmt.Sprintf("%s/1000.condensed", commitLogDir))
+	require.Nil(t, err)
+	_, err = os.Create(fmt.Sprintf("%s/1001.condensed", commitLogDir))
+	require.Nil(t, err)
+	_, err = os.Create(fmt.Sprintf("%s/1002", commitLogDir))
+	require.Nil(t, err)
+	_, err = os.Create(fmt.Sprintf("%s/1003", commitLogDir))
+	require.Nil(t, err)
+	_, err = os.Create(fmt.Sprintf("%s/1004", commitLogDir)) // active log
+	require.Nil(t, err)
+
+	return commitLogDir
+}
+
+func createTestCommitLoggerWithOptions(t *testing.T, scratchDir string, name string, options ...CommitlogOption) func() {
+	logger, _ := test.NewNullLogger()
+	cbg := cyclemanager.NewCallbackGroup("test", logger, 10)
+	ticker := cyclemanager.NewLinearTicker(50*time.Millisecond, 60*time.Millisecond, 1)
+	cm := cyclemanager.NewManager(ticker, cbg.CycleCallback, logger)
+	cl, err := NewCommitLogger(scratchDir, name, logger, cbg, options...)
+	require.Nil(t, err)
+	cm.Start()
+
+	return func() {
+		cl.Shutdown(context.Background())
+		cm.Stop(context.Background())
+	}
+}
+
+type fakeAllocChecker struct {
+	shouldErr bool
+}
+
+func (f fakeAllocChecker) CheckAlloc(sizeInBytes int64) error {
+	if f.shouldErr {
+		return fmt.Errorf("can't allocate %d bytes", sizeInBytes)
+	}
+	return nil
+}
+
+func (f fakeAllocChecker) CheckMappingAndReserve(numberMappings int64, reservationTimeInS int) error {
+	return nil
+}
+func (f fakeAllocChecker) Refresh() {}


### PR DESCRIPTION
## Background
* `v1.24.9` introduced new memory guardrails.
* One of said guardrails was broken for the HNSW condenser, i.e. the logic that removes redundancies and keeps the HNSW commit logs over time
  * Instead of skipping the condensing when the node is out-of-memory, it always skipped it
* Without condensing startup times can degrade severly

## This PR
* fixes the bug
* introduces a new elaborate test to test the happy path, as well as the out-of-memory path

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
