### PR TITLE
RAFT: support back RF scale increase

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -1105,7 +1105,7 @@ func (i *indices) postShard() http.Handler {
 func (i *indices) putShardReinit() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		args := i.regexpShardReinit.FindStringSubmatch(r.URL.Path)
-		fmt.Println(args)
+
 		if len(args) != 3 {
 			http.Error(w, "invalid URI", http.StatusBadRequest)
 			return

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -258,6 +258,7 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 			RootPath:            tmpDir,
 			ClassName:           schema.ClassName(class.Class),
 			QueryMaximumResults: maxResults,
+			ReplicationFactor:   NewAtomicInt64(1),
 		},
 		invertedIndexConfig:   iic,
 		vectorIndexUserConfig: vic,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -557,7 +557,7 @@ type IndexConfig struct {
 	MemtablesMaxActiveSeconds int
 	MaxSegmentSize            int64
 	HNSWMaxLogSize            int64
-	ReplicationFactor         int64
+	ReplicationFactor         *atomic.Int64
 	AvoidMMap                 bool
 	DisableLazyLoadShards     bool
 
@@ -688,7 +688,7 @@ func (i *Index) IncomingPutObject(ctx context.Context, shardName string,
 }
 
 func (i *Index) replicationEnabled() bool {
-	return i.Config.ReplicationFactor > 1
+	return i.Config.ReplicationFactor.Load() > 1
 }
 
 // parseDateFieldsInProps checks the schema for the current class for which

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -113,7 +113,9 @@ func (m *shardMap) Load(name string) ShardLike {
 	if !ok {
 		return nil
 	}
-	return v.(ShardLike)
+	s := v.(ShardLike)
+	s.active()
+	return s
 }
 
 // Store sets a shard giving its name and value
@@ -1726,10 +1728,18 @@ func (i *Index) getOrInitLocalShardNoShutdown(ctx context.Context, shardName str
 		return nil, func() {}, err
 	}
 
+	if shard != nil {
+		// we mark the shard is active and not shut
+		// we need later to call preventShutdown to be
+		// able to use the release()
+		shard.active()
+	}
+
 	release, err := shard.preventShutdown()
 	if err != nil {
 		return nil, func() {}, err
 	}
+
 	return shard, release, nil
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -113,7 +113,6 @@ func (m *shardMap) Load(name string) ShardLike {
 	if !ok {
 		return nil
 	}
-
 	return v.(ShardLike)
 }
 
@@ -1731,7 +1730,6 @@ func (i *Index) getOrInitLocalShardNoShutdown(ctx context.Context, shardName str
 	if err != nil {
 		return nil, func() {}, err
 	}
-
 	return shard, release, nil
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -113,9 +113,8 @@ func (m *shardMap) Load(name string) ShardLike {
 	if !ok {
 		return nil
 	}
-	s := v.(ShardLike)
-	s.active()
-	return s
+
+	return v.(ShardLike)
 }
 
 // Store sets a shard giving its name and value
@@ -1726,13 +1725,6 @@ func (i *Index) getOrInitLocalShardNoShutdown(ctx context.Context, shardName str
 	shard, err := i.getOrInitLocalShard(ctx, shardName)
 	if err != nil {
 		return nil, func() {}, err
-	}
-
-	if shard != nil {
-		// we mark the shard is active and not shut
-		// we need later to call preventShutdown to be
-		// able to use the release()
-		shard.active()
 	}
 
 	release, err := shard.preventShutdown()

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -103,8 +103,9 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 	// create index with data
 	shardState := singleShardState()
 	index, err := NewIndex(testCtx(), IndexConfig{
-		RootPath:  dirName,
-		ClassName: schema.ClassName(class.Class),
+		RootPath:          dirName,
+		ClassName:         schema.ClassName(class.Class),
+		ReplicationFactor: NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -163,8 +164,9 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 
 	// recreate the index
 	index, err = NewIndex(testCtx(), IndexConfig{
-		RootPath:  dirName,
-		ClassName: schema.ClassName(class.Class),
+		RootPath:          dirName,
+		ClassName:         schema.ClassName(class.Class),
+		ReplicationFactor: NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema:     fakeSchema,
@@ -273,8 +275,9 @@ func TestIndex_DropReadOnlyIndexWithData(t *testing.T) {
 
 	shardState := singleShardState()
 	index, err := NewIndex(ctx, IndexConfig{
-		RootPath:  dirName,
-		ClassName: schema.ClassName(class.Class),
+		RootPath:          dirName,
+		ClassName:         schema.ClassName(class.Class),
+		ReplicationFactor: NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -332,6 +335,7 @@ func emptyIdx(t *testing.T, rootDir string, class *models.Class) *Index {
 		RootPath:              rootDir,
 		ClassName:             schema.ClassName(class.Class),
 		DisableLazyLoadShards: true,
+		ReplicationFactor:     NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(invertedConfig()),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			shardState: shardState,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync/atomic"
 	"time"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -94,7 +95,7 @@ func (db *DB) init(ctx context.Context) error {
 				TrackVectorDimensions:     db.config.TrackVectorDimensions,
 				AvoidMMap:                 db.config.AvoidMMap,
 				DisableLazyLoadShards:     db.config.DisableLazyLoadShards,
-				ReplicationFactor:         class.ReplicationConfig.Factor,
+				ReplicationFactor:         NewAtomicInt64(class.ReplicationConfig.Factor),
 			}, db.schemaGetter.CopyShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),
@@ -167,4 +168,10 @@ func fileExists(file string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func NewAtomicInt64(val int64) *atomic.Int64 {
+	aval := &atomic.Int64{}
+	aval.Store(val)
+	return aval
 }

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -28,14 +28,16 @@ func TestShardActivity(t *testing.T) {
 		indices: map[string]*Index{
 			"Col1": {
 				Config: IndexConfig{
-					ClassName: "Col1",
+					ClassName:         "Col1",
+					ReplicationFactor: NewAtomicInt64(1),
 				},
 				partitioningEnabled: true,
 				shards:              shardMap{},
 			},
 			"NonMT": {
 				Config: IndexConfig{
-					ClassName: "NonMT",
+					ClassName:         "NonMT",
+					ReplicationFactor: NewAtomicInt64(1),
 				},
 				partitioningEnabled: false,
 				shards:              shardMap{},

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -244,11 +244,10 @@ func (i *Index) IncomingFilePutter(ctx context.Context, shardName,
 }
 
 func (i *Index) IncomingCreateShard(ctx context.Context, className string, shardName string) error {
-	shard, err := i.getOrInitLocalShard(ctx, shardName)
-	if err != nil {
+	if _, err := i.getOrInitLocalShard(ctx, shardName); err != nil {
 		return fmt.Errorf("incoming create shard: %w", err)
 	}
-	return shard.activate()
+	return nil
 }
 
 func (i *Index) IncomingReinitShard(ctx context.Context,

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -253,12 +254,34 @@ func (i *Index) IncomingCreateShard(ctx context.Context, className string, shard
 func (i *Index) IncomingReinitShard(ctx context.Context,
 	shardName string,
 ) error {
-	shard, err := i.getOrInitLocalShard(ctx, shardName)
-	if err != nil {
-		return fmt.Errorf("shard %q does not exist locally", shardName)
+	shard := func() ShardLike {
+		i.shardInUseLocks.Lock(shardName)
+		defer i.shardInUseLocks.Unlock(shardName)
+
+		return i.shards.Load(shardName)
+	}()
+
+	if shard != nil {
+		err := func() error {
+			i.shardCreateLocks.Lock(shardName)
+			defer i.shardCreateLocks.Unlock(shardName)
+
+			i.shards.LoadAndDelete(shardName)
+
+			if err := shard.Shutdown(ctx); err != nil {
+				if !errors.Is(err, errAlreadyShutdown) {
+					return err
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
 	}
 
-	return shard.reinit(ctx)
+	_, err := i.getOrInitLocalShard(ctx, shardName)
+	return err
 }
 
 func (s *Shard) filePutter(ctx context.Context,
@@ -278,31 +301,6 @@ func (s *Shard) filePutter(ctx context.Context,
 	}
 
 	return f, nil
-}
-
-func (s *Shard) reinit(ctx context.Context) error {
-	if err := s.Shutdown(ctx); err != nil {
-		return fmt.Errorf("shutdown shard: %w", err)
-	}
-
-	if err := s.initNonVector(ctx, nil); err != nil {
-		return fmt.Errorf("reinit non-vector: %w", err)
-	}
-
-	if s.hasTargetVectors() {
-		if err := s.initTargetVectors(ctx); err != nil {
-			return fmt.Errorf("reinit vector: %w", err)
-		}
-	} else {
-		if err := s.initLegacyVector(ctx); err != nil {
-			return fmt.Errorf("reinit vector: %w", err)
-		}
-	}
-	s.activate()
-	s.initCycleCallbacks()
-	s.initDimensionTracking()
-
-	return nil
 }
 
 // OverwriteObjects if their state didn't change in the meantime

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -244,10 +244,11 @@ func (i *Index) IncomingFilePutter(ctx context.Context, shardName,
 }
 
 func (i *Index) IncomingCreateShard(ctx context.Context, className string, shardName string) error {
-	if _, err := i.getOrInitLocalShard(ctx, shardName); err != nil {
+	shard, err := i.getOrInitLocalShard(ctx, shardName)
+	if err != nil {
 		return fmt.Errorf("incoming create shard: %w", err)
 	}
-	return nil
+	return shard.activate()
 }
 
 func (i *Index) IncomingReinitShard(ctx context.Context,
@@ -298,7 +299,7 @@ func (s *Shard) reinit(ctx context.Context) error {
 			return fmt.Errorf("reinit vector: %w", err)
 		}
 	}
-
+	s.activate()
 	s.initCycleCallbacks()
 	s.initDimensionTracking()
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -110,7 +110,6 @@ type ShardLike interface {
 	Queues() map[string]*IndexQueue
 	Shutdown(context.Context) error // Shutdown the shard
 	preventShutdown() (release func(), err error)
-	activate() error
 
 	// TODO tests only
 	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor,
@@ -133,7 +132,6 @@ type ShardLike interface {
 
 	commitReplication(context.Context, string, *backupMutex) interface{}
 	abortReplication(context.Context, string) replica.SimpleResponse
-	reinit(context.Context) error
 	filePutter(context.Context, string) (io.WriteCloser, error)
 
 	// TODO tests only
@@ -1052,14 +1050,6 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		return errors.Wrap(err, "stop lsmkv store")
 	}
 
-	return nil
-}
-
-// activate makes sure the shut flag is false
-func (s *Shard) activate() error {
-	s.shutdownLock.Lock()
-	defer s.shutdownLock.Unlock()
-	s.shut = false
 	return nil
 }
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -418,14 +418,6 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	return l.shard.Shutdown(ctx)
 }
 
-func (l *LazyLoadShard) activate() error {
-	if err := l.Load(context.Background()); err != nil {
-		return fmt.Errorf("LazyLoadShard::activate: %w", err)
-	}
-
-	return l.shard.activate()
-}
-
 func (l *LazyLoadShard) preventShutdown() (release func(), err error) {
 	if err := l.Load(context.Background()); err != nil {
 		return nil, fmt.Errorf("LazyLoadShard::preventShutdown: %w", err)
@@ -510,13 +502,6 @@ func (l *LazyLoadShard) commitReplication(ctx context.Context, shardID string, m
 func (l *LazyLoadShard) abortReplication(ctx context.Context, shardID string) replica.SimpleResponse {
 	l.mustLoad()
 	return l.shard.abortReplication(ctx, shardID)
-}
-
-func (l *LazyLoadShard) reinit(ctx context.Context) error {
-	if err := l.Load(ctx); err != nil {
-		return err
-	}
-	return l.shard.reinit(ctx)
 }
 
 func (l *LazyLoadShard) filePutter(ctx context.Context, shardID string) (io.WriteCloser, error) {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -418,12 +418,12 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	return l.shard.Shutdown(ctx)
 }
 
-func (l *LazyLoadShard) active() error {
+func (l *LazyLoadShard) activate() error {
 	if err := l.Load(context.Background()); err != nil {
-		return fmt.Errorf("LazyLoadShard::load: %w", err)
+		return fmt.Errorf("LazyLoadShard::activate: %w", err)
 	}
 
-	return l.shard.active()
+	return l.shard.activate()
 }
 
 func (l *LazyLoadShard) preventShutdown() (release func(), err error) {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -418,6 +418,14 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	return l.shard.Shutdown(ctx)
 }
 
+func (l *LazyLoadShard) active() error {
+	if err := l.Load(context.Background()); err != nil {
+		return fmt.Errorf("LazyLoadShard::load: %w", err)
+	}
+
+	return l.shard.active()
+}
+
 func (l *LazyLoadShard) preventShutdown() (release func(), err error) {
 	if err := l.Load(context.Background()); err != nil {
 		return nil, fmt.Errorf("LazyLoadShard::preventShutdown: %w", err)

--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -112,16 +112,12 @@ func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaO
 		meta.Class.VectorIndexConfig = u.VectorIndexConfig
 		meta.Class.InvertedIndexConfig = u.InvertedIndexConfig
 		meta.Class.VectorConfig = u.VectorConfig
-		// TODO: fix PushShard issues before enabling scale out
-		//       https://github.com/weaviate/weaviate/issues/4840
-		// meta.Class.ReplicationConfig = u.ReplicationConfig
+		meta.Class.ReplicationConfig = u.ReplicationConfig
 		meta.Class.MultiTenancyConfig = u.MultiTenancyConfig
 		meta.ClassVersion = cmd.Version
-		// TODO: fix PushShard issues before enabling scale out
-		//       https://github.com/weaviate/weaviate/issues/4840
-		// if req.State != nil {
-		// 	meta.Sharding = *req.State
-		// }
+		if req.State != nil {
+			meta.Sharding = *req.State
+		}
 		return nil
 	}
 

--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -252,7 +252,7 @@ func immediateReplicaCRUD(t *testing.T) {
 		})
 
 		t.Run("OnNode-1", func(t *testing.T) {
-			_, err := getObjectFromNode(t, compose.ContainerURI(1), "Article", articleIDs[0], "node2")
+			_, err := getObjectFromNode(t, compose.ContainerURI(1), "Article", articleIDs[0], "node1")
 			assert.Equal(t, &objects.ObjectsClassGetNotFound{}, err)
 		})
 		t.Run("OnNode-2", func(t *testing.T) {
@@ -292,12 +292,11 @@ func immediateReplicaCRUD(t *testing.T) {
 }
 
 func eventualReplicaCRUD(t *testing.T) {
-	t.Skip("Skip until https://github.com/weaviate/weaviate/issues/4840 is resolved")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	compose, err := docker.New().
-		WithWeaviateCluster().
+		With3NodeCluster().
 		WithText2VecContextionary().
 		Start(ctx)
 	require.Nil(t, err)
@@ -340,36 +339,58 @@ func eventualReplicaCRUD(t *testing.T) {
 		createObjects(t, compose.GetWeaviate().URI(), batch)
 	})
 
-	t.Run("configure classes to replicate to node 2", func(t *testing.T) {
+	t.Run("configure classes to replicate to node 3", func(t *testing.T) {
 		ac := helper.GetClass(t, "Article")
 		ac.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 2,
+			Factor: 3,
 		}
 		helper.UpdateClass(t, ac)
 
 		pc := helper.GetClass(t, "Paragraph")
 		pc.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 2,
+			Factor: 3,
 		}
 		helper.UpdateClass(t, pc)
 	})
 
-	t.Run("StopNode-1", func(t *testing.T) {
-		stopNodeAt(ctx, t, compose, 1)
+	t.Run("StopNode-3", func(t *testing.T) {
+		stopNodeAt(ctx, t, compose, 3)
 	})
 
 	t.Run("assert all previous data replicated to node 2", func(t *testing.T) {
-		// TODO-RAFT : we need to avoid any sleeps, come back and remove it
-		// sleep 2 sec to make sure data not affected by EC issue
-		time.Sleep(2 * time.Second)
-		resp := gqlGet(t, compose.GetWeaviateNode2().URI(), "Article", replica.One)
+		resp := gqlGet(t, compose.GetWeaviateNode2().URI(), "Article", replica.Quorum)
 		assert.Len(t, resp, len(articleIDs))
-		resp = gqlGet(t, compose.GetWeaviateNode2().URI(), "Paragraph", replica.One)
+		resp = gqlGet(t, compose.GetWeaviateNode2().URI(), "Paragraph", replica.Quorum)
 		assert.Len(t, resp, len(paragraphIDs))
 	})
 
-	t.Run("RestartNode-1", func(t *testing.T) {
-		restartNode1(ctx, t, compose)
+	t.Run("RestartNode-3", func(t *testing.T) {
+		startNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("configure classes to replicate to node 3", func(t *testing.T) {
+		ac := helper.GetClass(t, "Article")
+		ac.ReplicationConfig = &models.ReplicationConfig{
+			Factor: 3,
+		}
+		helper.UpdateClass(t, ac)
+
+		pc := helper.GetClass(t, "Paragraph")
+		pc.ReplicationConfig = &models.ReplicationConfig{
+			Factor: 3,
+		}
+		helper.UpdateClass(t, pc)
+	})
+
+	t.Run("assert all previous data replicated to node 3", func(t *testing.T) {
+		resp := gqlGet(t, compose.GetWeaviateNode3().URI(), "Article", replica.All)
+		assert.Len(t, resp, len(articleIDs))
+		resp = gqlGet(t, compose.GetWeaviateNode3().URI(), "Paragraph", replica.All)
+		assert.Len(t, resp, len(paragraphIDs))
+	})
+
+	t.Run("RestartCluster", func(t *testing.T) {
+		restartCluster(ctx, t, compose)
 	})
 
 	t.Run("assert any future writes are replicated", func(t *testing.T) {
@@ -401,27 +422,35 @@ func eventualReplicaCRUD(t *testing.T) {
 			})
 
 			t.Run("RestartNode-2", func(t *testing.T) {
-				err = compose.Start(ctx, compose.GetWeaviateNode2().Name())
+				startNodeAt(ctx, t, compose, 2)
+			})
+
+			t.Run("PatchedOnNode-3", func(t *testing.T) {
+				after, err := getObjectFromNode(t, compose.GetWeaviateNode3().URI(), "Article", articleIDs[0], "node3")
 				require.Nil(t, err)
+
+				newVal, ok := after.Properties.(map[string]interface{})["title"]
+				require.True(t, ok)
+				assert.Equal(t, newTitle, newVal)
 			})
 		})
 
 		t.Run("DeleteObject", func(t *testing.T) {
-			t.Run("OnNode-1", func(t *testing.T) {
-				deleteObject(t, compose.GetWeaviate().URI(), "Article", articleIDs[0])
-			})
-
-			t.Run("StopNode-1", func(t *testing.T) {
-				stopNodeAt(ctx, t, compose, 1)
-			})
-
 			t.Run("OnNode-2", func(t *testing.T) {
-				_, err := getObjectFromNode(t, compose.GetWeaviateNode2().URI(), "Article", articleIDs[0], "node2")
+				deleteObject(t, compose.GetWeaviateNode2().URI(), "Article", articleIDs[0])
+			})
+
+			t.Run("StopNode-2", func(t *testing.T) {
+				stopNodeAt(ctx, t, compose, 2)
+			})
+
+			t.Run("OnNode-1", func(t *testing.T) {
+				_, err := getObjectFromNode(t, compose.GetWeaviate().URI(), "Article", articleIDs[0], "node1")
 				assert.Equal(t, &objects.ObjectsClassGetNotFound{}, err)
 			})
 
-			t.Run("RestartNode-1", func(t *testing.T) {
-				restartNode1(ctx, t, compose)
+			t.Run("RestartNode-2", func(t *testing.T) {
+				startNodeAt(ctx, t, compose, 2)
 			})
 		})
 
@@ -441,15 +470,14 @@ func eventualReplicaCRUD(t *testing.T) {
 			})
 
 			t.Run("RestartNode-2", func(t *testing.T) {
-				err = compose.Start(ctx, compose.GetWeaviateNode2().Name())
-				require.Nil(t, err)
+				startNodeAt(ctx, t, compose, 2)
 			})
 		})
 	})
 }
 
-func restartNode1(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-	// since node1 is the gossip "leader", node 2 must be stopped and restarted
+func restartCluster(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
+	// since node1 is the gossip "leader", node 2 and 3 must be stopped and restarted
 	// after node1 to re-facilitate internode communication
 	eg := errgroup.Group{}
 	eg.Go(func() error {

--- a/test/acceptance/replication/crud_test.go
+++ b/test/acceptance/replication/crud_test.go
@@ -369,20 +369,6 @@ func eventualReplicaCRUD(t *testing.T) {
 		startNodeAt(ctx, t, compose, 3)
 	})
 
-	t.Run("configure classes to replicate to node 3", func(t *testing.T) {
-		ac := helper.GetClass(t, "Article")
-		ac.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 3,
-		}
-		helper.UpdateClass(t, ac)
-
-		pc := helper.GetClass(t, "Paragraph")
-		pc.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 3,
-		}
-		helper.UpdateClass(t, pc)
-	})
-
 	t.Run("assert all previous data replicated to node 3", func(t *testing.T) {
 		resp := gqlGet(t, compose.GetWeaviateNode3().URI(), "Article", replica.All)
 		assert.Len(t, resp, len(articleIDs))

--- a/test/acceptance/replication/scale_test.go
+++ b/test/acceptance/replication/scale_test.go
@@ -29,12 +29,11 @@ import (
 )
 
 func multiShardScaleOut(t *testing.T) {
-	t.Skip("Skip until https://github.com/weaviate/weaviate/issues/4840 is resolved")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	compose, err := docker.New().
-		WithWeaviateCluster().
+		With3NodeCluster().
 		WithText2VecContextionary().
 		Start(ctx)
 	require.Nil(t, err)
@@ -134,9 +133,6 @@ func multiShardScaleOut(t *testing.T) {
 
 	t.Run("kill a node and check contents of remaining node", func(t *testing.T) {
 		stopNodeAt(ctx, t, compose, 2)
-		// TODO-RAFT : we need to avoid any sleeps, come back and remove it
-		// sleep 2 sec to make sure data not affected by EC issue
-		time.Sleep(2 * time.Second)
 		p := gqlGet(t, compose.GetWeaviate().URI(), paragraphClass.Class, replica.One)
 		assert.Len(t, p, 10)
 		a := gqlGet(t, compose.GetWeaviate().URI(), articleClass.Class, replica.One)

--- a/test/acceptance/replication/scale_test.go
+++ b/test/acceptance/replication/scale_test.go
@@ -98,17 +98,20 @@ func multiShardScaleOut(t *testing.T) {
 	})
 
 	t.Run("assert paragraphs were scaled out", func(t *testing.T) {
-		n := getNodes(t, compose.GetWeaviate().URI())
-		var shardsFound int
-		for _, node := range n.Nodes {
-			for _, shard := range node.Shards {
-				if shard.Class == paragraphClass.Class {
-					assert.EqualValues(t, 10, shard.ObjectCount)
-					shardsFound++
+		// shard.ObjectCount is eventually consistent, see Bucket::CountAsync()
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			n := getNodes(t, compose.GetWeaviate().URI())
+			var shardsFound int
+			for _, node := range n.Nodes {
+				for _, shard := range node.Shards {
+					if shard.Class == paragraphClass.Class {
+						assert.EqualValues(collect, int64(10), shard.ObjectCount)
+						shardsFound++
+					}
 				}
 			}
-		}
-		assert.Equal(t, 2, shardsFound)
+			assert.Equal(collect, 2, shardsFound)
+		}, 10*time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("scale out articles", func(t *testing.T) {
@@ -118,17 +121,20 @@ func multiShardScaleOut(t *testing.T) {
 	})
 
 	t.Run("assert articles were scaled out", func(t *testing.T) {
-		n := getNodes(t, compose.GetWeaviate().URI())
-		var shardsFound int
-		for _, node := range n.Nodes {
-			for _, shard := range node.Shards {
-				if shard.Class == articleClass.Class {
-					assert.EqualValues(t, 10, shard.ObjectCount)
-					shardsFound++
+		// shard.ObjectCount is eventually consistent, see Bucket::CountAsync()
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			n := getNodes(t, compose.GetWeaviate().URI())
+			var shardsFound int
+			for _, node := range n.Nodes {
+				for _, shard := range node.Shards {
+					if shard.Class == articleClass.Class {
+						assert.EqualValues(collect, int64(10), shard.ObjectCount)
+						shardsFound++
+					}
 				}
 			}
-		}
-		assert.Equal(t, 2, shardsFound)
+			assert.Equal(collect, 2, shardsFound)
+		}, 10*time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("kill a node and check contents of remaining node", func(t *testing.T) {

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -134,6 +134,10 @@ func (d *DockerCompose) GetWeaviateNode2() *DockerContainer {
 	return d.getContainerByName(Weaviate2)
 }
 
+func (d *DockerCompose) GetWeaviateNode3() *DockerContainer {
+	return d.getContainerByName(Weaviate3)
+}
+
 func (d *DockerCompose) GetText2VecTransformers() *DockerContainer {
 	return d.getContainerByName(Text2VecTransformers)
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -234,7 +234,7 @@ function run_acceptance_graphql_tests() {
 
 function run_acceptance_replication_tests() {
   for pkg in $(go list ./.../ | grep 'test/acceptance/replication'); do
-    if ! go test -count 1 -race "$pkg"; then
+    if ! go test -count 1 -v -race "$pkg"; then
       echo "Test for $pkg failed" >&2
       return 1
     fi

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -222,23 +222,21 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 			return err
 		}
 
-		// TODO: fix PushShard issues before enabling scale out
-		//       https://github.com/weaviate/weaviate/issues/4840
-		//initialRF := initial.ReplicationConfig.Factor
-		//updatedRF := updated.ReplicationConfig.Factor
-		//
-		//if initialRF != updatedRF {
-		//	ss, _, err := h.metaWriter.QueryShardingState(className)
-		//	if err != nil {
-		//		return fmt.Errorf("query sharding state for %q: %w", className, err)
-		//	}
-		//	shardingState, err = h.scaleOut.Scale(ctx, className, ss.Config, initialRF, updatedRF)
-		//	if err != nil {
-		//		return fmt.Errorf(
-		//			"scale %q from %d replicas to %d: %w",
-		//			className, initialRF, updatedRF, err)
-		//	}
-		//}
+		initialRF := initial.ReplicationConfig.Factor
+		updatedRF := updated.ReplicationConfig.Factor
+
+		if initialRF != updatedRF {
+			ss, _, err := h.metaWriter.QueryShardingState(className)
+			if err != nil {
+				return fmt.Errorf("query sharding state for %q: %w", className, err)
+			}
+			shardingState, err = h.scaleOut.Scale(ctx, className, ss.Config, initialRF, updatedRF)
+			if err != nil {
+				return fmt.Errorf(
+					"scale %q from %d replicas to %d: %w",
+					className, initialRF, updatedRF, err)
+			}
+		}
 
 		if err := validateImmutableFields(initial, updated); err != nil {
 			return err

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -98,6 +98,11 @@ func (e *executor) UpdateClass(req api.UpdateClassRequest) error {
 		req.Class.InvertedIndexConfig); err != nil {
 		return errors.Wrap(err, "inverted index config")
 	}
+
+	if err := e.migrator.UpdateReplicationFactor(ctx, className, req.Class.ReplicationConfig.Factor); err != nil {
+		return fmt.Errorf("replication index update: %w", err)
+	}
+
 	return nil
 }
 

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -43,6 +43,9 @@ func TestExecutor(t *testing.T) {
 	cls := &models.Class{
 		Class:             "A",
 		VectorIndexConfig: flat.NewDefaultUserConfig(),
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor: 1,
+		},
 	}
 	store.On("ReadOnlySchema").Return(models.Schema{})
 	store.On("ReadOnlyClass", "A", mock.Anything).Return(cls)

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -323,6 +323,10 @@ func (f *fakeMigrator) UpdateInvertedIndexConfig(ctx context.Context, className 
 	return args.Error(0)
 }
 
+func (f *fakeMigrator) UpdateReplicationFactor(ctx context.Context, className string, factor int64) error {
+	return nil
+}
+
 func (f *fakeMigrator) WaitForStartup(ctx context.Context) error {
 	args := f.Called(ctx)
 	return args.Error(0)

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -59,6 +59,7 @@ type Migrator interface {
 	ValidateInvertedIndexConfigUpdate(old, updated *models.InvertedIndexConfig) error
 	UpdateInvertedIndexConfig(ctx context.Context, className string,
 		updated *models.InvertedIndexConfig) error
+	UpdateReplicationFactor(ctx context.Context, className string, factor int64) error
 	WaitForStartup(context.Context) error
 	Shutdown(context.Context) error
 }

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -132,12 +132,6 @@ func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, e
 		return nil, err
 	}
 
-	// TODO: fix PushShard issues before enabling scale out
-	//       https://github.com/weaviate/weaviate/issues/4840
-	if class.ReplicationConfig.Factor != update.ReplicationConfig.Factor {
-		return nil, fmt.Errorf("updating replication factor is not supported yet")
-	}
-
 	if err := validateImmutableFields(class, update); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:
this PR : 
- improve the acceptance tests for replication 
- enable back raft replication factor increase, see https://github.com/weaviate/weaviate/pull/4841, https://github.com/weaviate/weaviate/pull/4851
- resolves https://github.com/weaviate/weaviate/issues/4840 

links : [chaos pipeline for activate and deactivate tenants](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/8971542843/job/24637500143?pr=207)

PR https://github.com/weaviate/weaviate/pull/4913
  - shards reinit method called initNonVector on nil class, therefore shard's store had no access to props buckets (no bucket for title found errors)
  - db update called after class was updated did not change Index::Config replication factor, so replicationEnabled method still returned false - making coordinator node do not propagating changes to replicas, only to itself
  
### Review checklist
- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
