### PR TITLE
Change modelId setting to model in Ollama modules

### DIFF
--- a/modules/generative-ollama/clients/ollama.go
+++ b/modules/generative-ollama/clients/ollama.go
@@ -68,7 +68,7 @@ func (v *ollama) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 
 	ollamaUrl := v.getOllamaUrl(ctx, settings.ApiEndpoint())
 	input := generateInput{
-		Model:  settings.ModelID(),
+		Model:  settings.Model(),
 		Prompt: prompt,
 		Stream: false,
 	}

--- a/modules/generative-ollama/config/class_settings.go
+++ b/modules/generative-ollama/config/class_settings.go
@@ -20,12 +20,12 @@ import (
 
 const (
 	apiEndpointProperty = "apiEndpoint"
-	modelIDProperty     = "modelId"
+	modelProperty       = "model"
 )
 
 const (
 	DefaultApiEndpoint = "http://localhost:11434"
-	DefaultModelID     = "llama3"
+	DefaultModel       = "llama3"
 )
 
 type classSettings struct {
@@ -45,9 +45,9 @@ func (ic *classSettings) Validate(class *models.Class) error {
 	if ic.ApiEndpoint() == "" {
 		return errors.New("apiEndpoint cannot be empty")
 	}
-	model := ic.ModelID()
+	model := ic.Model()
 	if model == "" {
-		return errors.New("modelId cannot be empty")
+		return errors.New("model cannot be empty")
 	}
 	return nil
 }
@@ -60,6 +60,6 @@ func (ic *classSettings) ApiEndpoint() string {
 	return ic.getStringProperty(apiEndpointProperty, DefaultApiEndpoint)
 }
 
-func (ic *classSettings) ModelID() string {
-	return ic.getStringProperty(modelIDProperty, DefaultModelID)
+func (ic *classSettings) Model() string {
+	return ic.getStringProperty(modelProperty, DefaultModel)
 }

--- a/modules/generative-ollama/config/class_settings_test.go
+++ b/modules/generative-ollama/config/class_settings_test.go
@@ -41,7 +41,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "everything non default configured",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"modelId": "mistral",
+					"model": "mistral",
 				},
 			},
 			wantApiEndpoint: "http://localhost:11434",
@@ -52,10 +52,10 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "empty model",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"modelId": "",
+					"model": "",
 				},
 			},
-			wantErr: errors.New("modelId cannot be empty"),
+			wantErr: errors.New("model cannot be empty"),
 		},
 	}
 	for _, tt := range tests {
@@ -66,7 +66,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				require.Error(t, err)
 				assert.Equal(t, tt.wantErr.Error(), err.Error())
 			} else {
-				assert.Equal(t, tt.wantModel, ic.ModelID())
+				assert.Equal(t, tt.wantModel, ic.Model())
 			}
 		})
 	}

--- a/modules/text2vec-ollama/vectorizer/class_settings.go
+++ b/modules/text2vec-ollama/vectorizer/class_settings.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	apiEndpointProperty = "apiEndpoint"
-	modelIDProperty     = "modelId"
+	modelProperty       = "model"
 )
 
 const (
@@ -29,7 +29,7 @@ const (
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	DefaultApiEndpoint           = "http://localhost:11434"
-	DefaultModelID               = "nomic-embed-text"
+	DefaultModel                 = "nomic-embed-text"
 )
 
 type classSettings struct {
@@ -48,8 +48,8 @@ func (ic *classSettings) Validate(class *models.Class) error {
 	if ic.ApiEndpoint() == "" {
 		return errors.New("apiEndpoint cannot be empty")
 	}
-	if ic.ModelID() == "" {
-		return errors.New("modelId cannot be empty")
+	if ic.Model() == "" {
+		return errors.New("model cannot be empty")
 	}
 	return nil
 }
@@ -58,14 +58,10 @@ func (ic *classSettings) getStringProperty(name, defaultValue string) string {
 	return ic.BaseClassSettings.GetPropertyAsString(name, defaultValue)
 }
 
-func (ic *classSettings) getDefaultModel() string {
-	return DefaultModelID
-}
-
 func (ic *classSettings) ApiEndpoint() string {
 	return ic.getStringProperty(apiEndpointProperty, DefaultApiEndpoint)
 }
 
-func (ic *classSettings) ModelID() string {
-	return ic.getStringProperty(modelIDProperty, ic.getDefaultModel())
+func (ic *classSettings) Model() string {
+	return ic.getStringProperty(modelProperty, DefaultModel)
 }

--- a/modules/text2vec-ollama/vectorizer/class_settings_test.go
+++ b/modules/text2vec-ollama/vectorizer/class_settings_test.go
@@ -27,7 +27,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		name            string
 		cfg             moduletools.ClassConfig
 		wantApiEndpoint string
-		wantModelID     string
+		wantModel       string
 		wantErr         error
 	}{
 		{
@@ -36,7 +36,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				classConfig: map[string]interface{}{},
 			},
 			wantApiEndpoint: "http://localhost:11434",
-			wantModelID:     "nomic-embed-text",
+			wantModel:       "nomic-embed-text",
 			wantErr:         nil,
 		},
 		{
@@ -44,11 +44,11 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"apiEndpoint": "https://localhost:11434",
-					"modelId":     "future-text-embed",
+					"model":       "future-text-embed",
 				},
 			},
 			wantApiEndpoint: "https://localhost:11434",
-			wantModelID:     "future-text-embed",
+			wantModel:       "future-text-embed",
 			wantErr:         nil,
 		},
 		{
@@ -56,7 +56,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"apiEndpoint": "",
-					"modelId":     "test",
+					"model":       "test",
 				},
 			},
 			wantErr: errors.Errorf("apiEndpoint cannot be empty"),
@@ -66,10 +66,10 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"apiEndpoint": "http://localhost:8080",
-					"modelId":     "",
+					"model":       "",
 				},
 			},
-			wantErr: errors.Errorf("modelId cannot be empty"),
+			wantErr: errors.Errorf("model cannot be empty"),
 		},
 	}
 	for _, tt := range tests {
@@ -84,7 +84,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				}}), tt.wantErr.Error())
 			} else {
 				assert.Equal(t, tt.wantApiEndpoint, ic.ApiEndpoint())
-				assert.Equal(t, tt.wantModelID, ic.ModelID())
+				assert.Equal(t, tt.wantModel, ic.Model())
 			}
 		})
 	}

--- a/modules/text2vec-ollama/vectorizer/objects.go
+++ b/modules/text2vec-ollama/vectorizer/objects.go
@@ -60,7 +60,7 @@ func (v *Vectorizer) object(ctx context.Context, object *models.Object, cfg modu
 	text := v.objectVectorizer.Texts(ctx, object, icheck)
 	res, err := v.client.Vectorize(ctx, text, ent.VectorizationConfig{
 		ApiEndpoint: icheck.ApiEndpoint(),
-		Model:       icheck.ModelID(),
+		Model:       icheck.Model(),
 	})
 	if err != nil {
 		return nil, err

--- a/modules/text2vec-ollama/vectorizer/texts.go
+++ b/modules/text2vec-ollama/vectorizer/texts.go
@@ -28,7 +28,7 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	for i := range inputs {
 		res, err := v.client.Vectorize(ctx, inputs[i], ent.VectorizationConfig{
 			ApiEndpoint: settings.ApiEndpoint(),
-			Model:       settings.ModelID(),
+			Model:       settings.Model(),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "remote client vectorize")

--- a/test/docker/ollama.go
+++ b/test/docker/ollama.go
@@ -38,7 +38,7 @@ func startOllama(ctx context.Context, networkName, hostname, model string) (*Doc
 	port := nat.Port("11434/tcp")
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:    "ollama/ollama:0.1.30",
+			Image:    "ollama/ollama:0.1.33",
 			Hostname: hostname,
 			Networks: []string{networkName},
 			NetworkAliases: map[string][]string{

--- a/test/modules/generative-ollama/ollama_generative_test.go
+++ b/test/modules/generative-ollama/ollama_generative_test.go
@@ -68,7 +68,7 @@ func testGenerativeOllama(host, ollamaApiEndpoint string) func(t *testing.T) {
 				class.ModuleConfig = map[string]interface{}{
 					"generative-ollama": map[string]interface{}{
 						"apiEndpoint": ollamaApiEndpoint,
-						"modelId":     tt.generativeModel,
+						"model":       tt.generativeModel,
 					},
 				}
 				// create schema

--- a/test/modules/text2vec-ollama/ollama_vectorizer_test.go
+++ b/test/modules/text2vec-ollama/ollama_vectorizer_test.go
@@ -49,6 +49,7 @@ func testText2VecOllama(host, ollamaApiEndpoint string) func(t *testing.T) {
 							"properties":         []interface{}{"description"},
 							"vectorizeClassName": false,
 							"apiEndpoint":        ollamaApiEndpoint,
+							"model":              "nomic-embed-text",
 						},
 					},
 					VectorIndexType: "flat",


### PR DESCRIPTION
### What's being changed:

Changed `modelId` to `model` in `generative-ollama` and `tex2vec-ollama` modules.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
