### PR TITLE
raft: refactor db opening & logging

### DIFF
--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -248,19 +248,6 @@ func (db *localDB) Load(ctx context.Context, nodeID string) error {
 	return nil
 }
 
-// Reload updates an already opened local database with the newest schema.
-// It updates existing indexes and adds new ones as necessary
-func (db *localDB) Reload() error {
-	cs := make([]command.UpdateClassRequest, len(db.Schema.Classes))
-	i := 0
-	for _, v := range db.Schema.Classes {
-		cs[i] = command.UpdateClassRequest{Class: &v.Class, State: &v.Sharding}
-		i++
-	}
-	db.store.ReloadLocalDB(context.Background(), cs)
-	return nil
-}
-
 func (db *localDB) Close(ctx context.Context) (err error) {
 	return db.store.Close(ctx)
 }

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -387,7 +387,7 @@ func TestServicePanics(t *testing.T) {
 
 	// Cannot Open File Store
 	m.indexer.On("Open", mock.Anything).Return(errAny)
-	assert.Panics(t, func() { m.store.loadDatabase(context.TODO()) })
+	assert.Panics(t, func() { m.store.openDatabase(context.TODO()) })
 }
 
 func TestStoreApply(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
this PR does some refactor as part of series of PRs 

- it add some info and logging 
- renames store `reloadDB` `reloadDBFromSnapshot`
- remove `db.ReloadDB ` and move it's logic under `reloadDBFromSnapshot` because basically it does update the whole schema from the snapshot and it's the only place used 

Linked 
- https://github.com/weaviate/weaviate/pull/4876
- https://github.com/weaviate/weaviate/pull/4878
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
