### PR TITLE
raft: open db on service.Open instead on apply

### DIFF
--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -252,7 +252,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("raft.NewRaft %v %w", st.transport.LocalAddr(), err)
 	}
-	if st.lastAppliedIndex.Load() <= st.raft.AppliedIndex() {
+	if st.initialLastAppliedIndex <= st.raft.LastIndex() {
 		// this should include empty and non empty node
 		st.openDatabase(ctx)
 	}

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -448,8 +448,12 @@ func TestStoreApply(t *testing.T) {
 				cmd.ApplyRequest_TYPE_ADD_CLASS,
 				cmd.AddClassRequest{Class: cls, State: ss},
 				nil)},
-			resp:     Response{Error: nil},
-			doBefore: doFirst,
+			resp: Response{Error: nil},
+			doBefore: func(m *MockStore) {
+				m.indexer.On("AddClass", mock.Anything).Return(nil)
+				m.parser.On("ParseClass", mock.Anything).Return(nil)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+			},
 			doAfter: func(ms *MockStore) error {
 				_, ok := ms.store.db.Schema.Classes["C1"]
 				if !ok {
@@ -496,6 +500,7 @@ func TestStoreApply(t *testing.T) {
 			doBefore: func(m *MockStore) {
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
 				m.indexer.On("RestoreClassDir", cls.Class).Return(nil)
+				m.indexer.On("AddClass", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -548,6 +553,7 @@ func TestStoreApply(t *testing.T) {
 			doBefore: func(m *MockStore) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(mock.Anything, nil)
+				m.indexer.On("UpdateClass", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, ss, 1)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
@@ -559,6 +565,7 @@ func TestStoreApply(t *testing.T) {
 				nil)},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
+				m.indexer.On("DeleteClass", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -603,6 +610,7 @@ func TestStoreApply(t *testing.T) {
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
 				m.store.db.Schema.addClass(cls, ss, 1)
+				m.indexer.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -630,8 +638,12 @@ func TestStoreApply(t *testing.T) {
 			name: "UpdateShard/Success",
 			req: raft.Log{Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_UPDATE_SHARD_STATUS,
 				cmd.UpdateShardStatusRequest{Class: "C1"}, nil)},
-			resp:     Response{Error: nil},
-			doBefore: doFirst,
+			resp: Response{Error: nil},
+			doBefore: func(m *MockStore) {
+				m.parser.On("ParseClass", mock.Anything).Return(nil)
+				m.indexer.On("UpdateShardStatus", mock.Anything).Return(nil)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+			},
 		},
 		{
 			name:     "AddTenant/Unmarshal",
@@ -658,6 +670,8 @@ func TestStoreApply(t *testing.T) {
 				m.store.db.Schema.addClass(cls, &sharding.State{
 					Physical: map[string]sharding.Physical{"T1": {}},
 				}, 1)
+
+				m.indexer.On("AddTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				if _, ok := ms.store.db.Schema.Classes["C1"].Sharding.Physical["T1"]; !ok {
@@ -716,6 +730,7 @@ func TestStoreApply(t *testing.T) {
 					Status:         models.TenantActivityStatusHOT,
 				}}}
 				m.store.db.Schema.addClass(cls, ss, 1)
+				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				want := map[string]sharding.Physical{"T1": {
@@ -758,6 +773,7 @@ func TestStoreApply(t *testing.T) {
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
 				m.store.db.Schema.addClass(cls, &sharding.State{Physical: map[string]sharding.Physical{"T1": {}}}, 1)
+				m.indexer.On("DeleteTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				if len(ms.store.db.Schema.Classes["C1"].Sharding.Physical) != 0 {

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -392,7 +392,6 @@ func TestServicePanics(t *testing.T) {
 
 func TestStoreApply(t *testing.T) {
 	doFirst := func(m *MockStore) {
-		m.indexer.On("Open", mock.Anything).Return(nil)
 		m.parser.On("ParseClass", mock.Anything).Return(nil)
 		m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 	}
@@ -495,7 +494,6 @@ func TestStoreApply(t *testing.T) {
 				nil)},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
 				m.indexer.On("RestoreClassDir", cls.Class).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
@@ -561,7 +559,6 @@ func TestStoreApply(t *testing.T) {
 				nil)},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -605,7 +602,6 @@ func TestStoreApply(t *testing.T) {
 			},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, ss, 1)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
@@ -659,7 +655,6 @@ func TestStoreApply(t *testing.T) {
 			})},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, &sharding.State{
 					Physical: map[string]sharding.Physical{"T1": {}},
 				}, 1)
@@ -720,7 +715,6 @@ func TestStoreApply(t *testing.T) {
 					BelongsToNodes: []string{"NODE-2"},
 					Status:         models.TenantActivityStatusHOT,
 				}}}
-				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, ss, 1)
 			},
 			doAfter: func(ms *MockStore) error {
@@ -763,7 +757,6 @@ func TestStoreApply(t *testing.T) {
 				nil, &cmd.DeleteTenantsRequest{Tenants: []string{"T1", "T2"}})},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, &sharding.State{Physical: map[string]sharding.Physical{"T1": {}}}, 1)
 			},
 			doAfter: func(ms *MockStore) error {
@@ -776,27 +769,29 @@ func TestStoreApply(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		m := NewMockStore(t, "Node-1", 9091)
-		store := m.Store(tc.doBefore)
-		ret := store.Apply(&tc.req)
-		resp, ok := ret.(Response)
-		if !ok {
-			t.Errorf("%s: response has wrong type", tc.name)
-		}
-		if got, want := resp.Error, tc.resp.Error; want != nil {
-			if !errors.Is(resp.Error, tc.resp.Error) {
-				t.Errorf("%s: error want: %v got: %v", tc.name, want, got)
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMockStore(t, "Node-1", 9091)
+			store := m.Store(tc.doBefore)
+			ret := store.Apply(&tc.req)
+			resp, ok := ret.(Response)
+			if !ok {
+				t.Errorf("%s: response has wrong type", tc.name)
 			}
-		} else if got != nil {
-			t.Errorf("%s: error want: nil got: %v", tc.name, got)
-		}
-		if tc.doAfter != nil {
-			if err := tc.doAfter(&m); err != nil {
-				t.Errorf("%s check updates: %v", tc.name, err)
+			if got, want := resp.Error, tc.resp.Error; want != nil {
+				if !errors.Is(resp.Error, tc.resp.Error) {
+					t.Errorf("%s: error want: %v got: %v", tc.name, want, got)
+				}
+			} else if got != nil {
+				t.Errorf("%s: error want: nil got: %v", tc.name, got)
 			}
-			m.indexer.AssertExpectations(t)
-			m.parser.AssertExpectations(t)
-		}
+			if tc.doAfter != nil {
+				if err := tc.doAfter(&m); err != nil {
+					t.Errorf("%s check updates: %v", tc.name, err)
+				}
+				m.indexer.AssertExpectations(t)
+				m.parser.AssertExpectations(t)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### What's being changed:
this PR avoid reopening the db with every apply and instead does it at the beginning when we start newRaft

this pr is part of series of PRs
https://github.com/weaviate/weaviate/pull/4876
https://github.com/weaviate/weaviate/pull/4878


Why: we ended up in situation we made assumption that the database has to be updated before schema and that caused some confusion. 

How:
Old approach:
 open database at the beginning only if the node was fresh 
 open the db again on apply command 
separate between commands to be applied on db or schema only based on newAppliedIndex <= initialLastAppliedIndex

New approach: 
always open database at the beginning of raft init if there is something to catch up on 
always updating both database and schema at the same time by applying schema 1st then the database, so that schema has the validation logic to protect any updates from going to the database


[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9007009497) 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
