### PR TITLE
raft: remove schemaOnly and rename lastAppliedIndexOnStart

### DIFF
--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -291,7 +291,7 @@ func (db *DB) localNodeStatistics() (*models.Statistics, error) {
 		IsVoter:                 stats["is_voter"].(bool),
 		Open:                    stats["open"].(bool),
 		Bootstrapped:            stats["bootstrapped"].(bool),
-		InitialLastAppliedIndex: stats["initial_last_applied_index"].(uint64),
+		InitialLastAppliedIndex: stats["last_store_log_applied_index"].(uint64),
 		DbLoaded:                stats["db_loaded"].(bool),
 		Candidates:              stats["candidates"],
 		Raft:                    raft,

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -514,8 +514,8 @@ func (f *Store) FindSimilarClass(name string) string {
 // The value of "candidates" is a map[string]string of the current candidates IDs/addresses,
 // see Store.candidates.
 //
-// The value of "initial_last_applied_index" is the index of the last applied command found when
-// the store was opened, see Store.initialLastAppliedIndex.
+// The value of "last_store_log_applied_index" is the index of the last applied command found when
+// the store was opened, see Store.lastAppliedIndexOnStart.
 //
 // The value of "last_applied_index" is the index of the latest update to the store,
 // see Store.lastAppliedIndex.


### PR DESCRIPTION
### What's being changed:
after doing always schema and db all together we don't need schema only field 

connected to https://github.com/weaviate/weaviate/pull/4878
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
