### PR TITLE
Re-add schemaOnly parameter when applying raft log entries and ensure we reloadDB on catching up

### DIFF
--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -291,7 +291,7 @@ func (db *DB) localNodeStatistics() (*models.Statistics, error) {
 		IsVoter:                 stats["is_voter"].(bool),
 		Open:                    stats["open"].(bool),
 		Bootstrapped:            stats["bootstrapped"].(bool),
-		InitialLastAppliedIndex: stats["initial_last_applied_index"].(uint64),
+		InitialLastAppliedIndex: stats["last_store_log_applied_index"].(uint64),
 		DbLoaded:                stats["db_loaded"].(bool),
 		Candidates:              stats["candidates"],
 		Raft:                    raft,

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -291,7 +291,7 @@ func (db *DB) localNodeStatistics() (*models.Statistics, error) {
 		IsVoter:                 stats["is_voter"].(bool),
 		Open:                    stats["open"].(bool),
 		Bootstrapped:            stats["bootstrapped"].(bool),
-		InitialLastAppliedIndex: stats["last_store_log_applied_index"].(uint64),
+		InitialLastAppliedIndex: stats["initial_last_applied_index"].(uint64),
 		DbLoaded:                stats["db_loaded"].(bool),
 		Candidates:              stats["candidates"],
 		Raft:                    raft,

--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -275,8 +275,10 @@ func (db *localDB) apply(op applyOp) error {
 		return fmt.Errorf("%w: %s: %w", errSchema, op.op, err)
 	}
 
-	if err := op.updateStore(); err != nil {
-		return fmt.Errorf("%w: %s: %w", errDB, op.op, err)
+	if !op.schemaOnly {
+		if err := op.updateStore(); err != nil {
+			return fmt.Errorf("%w: %s: %w", errDB, op.op, err)
+		}
 	}
 
 	// Always trigger the schema callback last

--- a/cluster/store/db.go
+++ b/cluster/store/db.go
@@ -40,7 +40,7 @@ func (db *localDB) SetIndexer(idx Indexer) {
 	db.Schema.shardReader = idx
 }
 
-func (db *localDB) AddClass(cmd *command.ApplyRequest, nodeID string) error {
+func (db *localDB) AddClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {
 	req := command.AddClassRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -57,12 +57,13 @@ func (db *localDB) AddClass(cmd *command.ApplyRequest, nodeID string) error {
 			op:                    cmd.GetType().String(),
 			updateSchema:          func() error { return db.Schema.addClass(req.Class, req.State, cmd.Version) },
 			updateStore:           func() error { return db.store.AddClass(req) },
+			schemaOnly:            schemaOnly,
 			triggerSchemaCallback: true,
 		},
 	)
 }
 
-func (db *localDB) RestoreClass(cmd *command.ApplyRequest, nodeID string) error {
+func (db *localDB) RestoreClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {
 	req := command.AddClassRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -86,6 +87,7 @@ func (db *localDB) RestoreClass(cmd *command.ApplyRequest, nodeID string) error 
 			op:                    cmd.GetType().String(),
 			updateSchema:          func() error { return db.Schema.addClass(req.Class, req.State, cmd.Version) },
 			updateStore:           func() error { return db.store.AddClass(req) },
+			schemaOnly:            schemaOnly,
 			triggerSchemaCallback: true,
 		},
 	)
@@ -93,7 +95,7 @@ func (db *localDB) RestoreClass(cmd *command.ApplyRequest, nodeID string) error 
 
 // UpdateClass modifies the vectors and inverted indexes associated with a class
 // Other class properties are handled by separate functions
-func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string) error {
+func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {
 	req := command.UpdateClassRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -128,23 +130,25 @@ func (db *localDB) UpdateClass(cmd *command.ApplyRequest, nodeID string) error {
 			op:                    cmd.GetType().String(),
 			updateSchema:          func() error { return db.Schema.updateClass(req.Class.Class, update) },
 			updateStore:           func() error { return db.store.UpdateClass(req) },
+			schemaOnly:            schemaOnly,
 			triggerSchemaCallback: true,
 		},
 	)
 }
 
-func (db *localDB) DeleteClass(cmd *command.ApplyRequest) error {
+func (db *localDB) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool) error {
 	return db.apply(
 		applyOp{
 			op:                    cmd.GetType().String(),
 			updateSchema:          func() error { db.Schema.deleteClass(cmd.Class); return nil },
 			updateStore:           func() error { return db.store.DeleteClass(cmd.Class) },
+			schemaOnly:            schemaOnly,
 			triggerSchemaCallback: true,
 		},
 	)
 }
 
-func (db *localDB) AddProperty(cmd *command.ApplyRequest) error {
+func (db *localDB) AddProperty(cmd *command.ApplyRequest, schemaOnly bool) error {
 	req := command.AddPropertyRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -158,12 +162,13 @@ func (db *localDB) AddProperty(cmd *command.ApplyRequest) error {
 			op:                    cmd.GetType().String(),
 			updateSchema:          func() error { return db.Schema.addProperty(cmd.Class, cmd.Version, req.Properties...) },
 			updateStore:           func() error { return db.store.AddProperty(cmd.Class, req) },
+			schemaOnly:            schemaOnly,
 			triggerSchemaCallback: true,
 		},
 	)
 }
 
-func (db *localDB) UpdateShardStatus(cmd *command.ApplyRequest) error {
+func (db *localDB) UpdateShardStatus(cmd *command.ApplyRequest, schemaOnly bool) error {
 	req := command.UpdateShardStatusRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -174,11 +179,12 @@ func (db *localDB) UpdateShardStatus(cmd *command.ApplyRequest) error {
 			op:           cmd.GetType().String(),
 			updateSchema: func() error { return nil },
 			updateStore:  func() error { return db.store.UpdateShardStatus(&req) },
+			schemaOnly:   schemaOnly,
 		},
 	)
 }
 
-func (db *localDB) AddTenants(cmd *command.ApplyRequest) error {
+func (db *localDB) AddTenants(cmd *command.ApplyRequest, schemaOnly bool) error {
 	req := &command.AddTenantsRequest{}
 	if err := gproto.Unmarshal(cmd.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -189,11 +195,12 @@ func (db *localDB) AddTenants(cmd *command.ApplyRequest) error {
 			op:           cmd.GetType().String(),
 			updateSchema: func() error { return db.Schema.addTenants(cmd.Class, cmd.Version, req) },
 			updateStore:  func() error { return db.store.AddTenants(cmd.Class, req) },
+			schemaOnly:   schemaOnly,
 		},
 	)
 }
 
-func (db *localDB) UpdateTenants(cmd *command.ApplyRequest) (n int, err error) {
+func (db *localDB) UpdateTenants(cmd *command.ApplyRequest, schemaOnly bool) (n int, err error) {
 	req := &command.UpdateTenantsRequest{}
 	if err := gproto.Unmarshal(cmd.SubCommand, req); err != nil {
 		return 0, fmt.Errorf("%w: %w", errBadRequest, err)
@@ -204,11 +211,12 @@ func (db *localDB) UpdateTenants(cmd *command.ApplyRequest) (n int, err error) {
 			op:           cmd.GetType().String(),
 			updateSchema: func() error { n, err = db.Schema.updateTenants(cmd.Class, cmd.Version, req); return err },
 			updateStore:  func() error { return db.store.UpdateTenants(cmd.Class, req) },
+			schemaOnly:   schemaOnly,
 		},
 	)
 }
 
-func (db *localDB) DeleteTenants(cmd *command.ApplyRequest) error {
+func (db *localDB) DeleteTenants(cmd *command.ApplyRequest, schemaOnly bool) error {
 	req := &command.DeleteTenantsRequest{}
 	if err := gproto.Unmarshal(cmd.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", errBadRequest, err)
@@ -219,6 +227,7 @@ func (db *localDB) DeleteTenants(cmd *command.ApplyRequest) error {
 			op:           cmd.GetType().String(),
 			updateSchema: func() error { return db.Schema.deleteTenants(cmd.Class, cmd.Version, req) },
 			updateStore:  func() error { return db.store.DeleteTenants(cmd.Class, req) },
+			schemaOnly:   schemaOnly,
 		},
 	)
 }
@@ -238,6 +247,7 @@ type applyOp struct {
 	op                    string
 	updateSchema          func() error
 	updateStore           func() error
+	schemaOnly            bool
 	triggerSchemaCallback bool
 }
 


### PR DESCRIPTION
## What's being changed:

Reverts weaviate/weaviate#4882. Re-add the schema only check in the db.apply function and add a new atomic `dbAndRaftAligned` that is set to true once RAFT has caught up and re-applied log entries after a restart and we no longer need to use schema only.

This is necessary because on restart RAFT will re-apply log entries from disk to update the in-memory representation. As our DB operations *are not* truly idempotent we want to use a `schemaOnly` parameter to avoid updating the DB and only update the in-memory schema representation. 

For example given the following order of operations (Operation -> In memory SchemaState | DBState)
```
1. AddClass(c1)        -> classes=[c1] | object["c1"] = []
2. DeleteClass(c1)     -> classes=[]   | object[]     = []
3. AddClass(c1)        -> classes=[c1] | object["c1"] = []
4. AddObject(c1, obj1) -> classes=[c1] | object["c1"] = [obj1]
```

If a node is to restart, it will replay the raft log entries (which are 1, 2 and 3 above) but *not* the data related operations as these are not handled by RAFT. On restarting a node the following sequence is happening
```
0. Initial state            -> classes=[]   | object["c1"] = [obj1]
2. (Replay) AddClass(c1)    -> classes=[c1] | object["c1"] = [obj1]
3. (Replay) DeleteClass(c1) -> classes=[]   | object[]     = [] <-- Here we lose data by *also* dropping obj1
4. (Replay) AddClass(c1)    -> classes=[c1] | object[]     = []
```

With this change when we are replaying log operation we avoid updating the DB until we have caught up and then reload the DB representation to ensure we have everything loading as is represented in the up-to-date schema.


## Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

