### PR TITLE
Ensure `classCache` is added to the context before validate objects call

### DIFF
--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -34,6 +35,7 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	}
 	defer unlock()
 
+	ctx = classcache.ContextWithClassCache(ctx)
 	err = m.validateObjectAndNormalizeNames(ctx, principal, repl, obj, nil)
 	if err != nil {
 		return NewErrInvalidUserInput("invalid object: %v", err)


### PR DESCRIPTION
### What's being changed:

A call to inject the `classCache` into the context was missing when calling `ValidateObjects` within the `/v1/objects/validate` call. This caused the TS client integration tests to fail like so:
```bash
Expected: "The request to Weaviate failed with status code: 422 and message: {\"error\":[{\"message\":\"invalid object: invalid text property 'stringProp' on class 'DataJourneyTestThing': not a string, but json.Number\"}]}"
Received: "The request to Weaviate failed with status code: 422 and message: {\"error\":[{\"message\":\"invalid object: context does not contain classCache\"}]}"
```

This PR ensures that the `classCache` is injected appropriately

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
