### PR TITLE
RAFT: use update index to update class directly from raft command

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -143,24 +143,6 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		}
 	}
 
-	{ // add/remove missing shards
-		if incomingSS.PartitioningEnabled {
-			if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
-			}
-		} else {
-			if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
-			}
-		}
-	}
-
-	{ // add missing properties
-		if err := m.updateIndexAddMissingProperties(ctx, idx, incomingClass); err != nil {
-			return err
-		}
-	}
-
 	{ // update index configs
 		if schemaUC.HasTargetVectors(incomingClass) {
 			if err := idx.updateVectorIndexConfigs(ctx, schemaUC.AsVectorIndexConfigs(incomingClass)); err != nil {
@@ -177,6 +159,30 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		}
 
 	}
+
+	{ // add missing properties
+		if err := m.updateIndexAddMissingProperties(ctx, idx, incomingClass); err != nil {
+			return err
+		}
+	}
+
+	// break early if state is nil
+	if incomingSS == nil {
+		return nil
+	}
+
+	{ // add/remove missing shards
+		if incomingSS.PartitioningEnabled {
+			if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
+				return err
+			}
+		} else {
+			if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -145,13 +145,15 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 	}
 
 	{ // add/remove missing shards
-		if incomingSS.PartitioningEnabled {
-			if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
-			}
-		} else {
-			if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
+		if incomingSS != nil {
+			if incomingSS.PartitioningEnabled {
+				if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
+					return err
+				}
+			} else {
+				if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -186,7 +186,7 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 			}
 		}
 
-		old := idx.vectorIndexUserConfigs
+		old := idx.invertedIndexConfig
 		new := inverted.ConfigFromModel(incomingClass.InvertedIndexConfig)
 		if !reflect.DeepEqual(old, new) {
 			if err := idx.updateInvertedIndexConfig(ctx, new); err != nil {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -164,17 +164,7 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		}
 	}
 
-	{ // update inverted index config
-		old := idx.vectorIndexUserConfigs
-		new := inverted.ConfigFromModel(incomingClass.InvertedIndexConfig)
-		if !reflect.DeepEqual(old, new) {
-			if err := idx.updateInvertedIndexConfig(ctx, new); err != nil {
-				return fmt.Errorf("inverted index config: %w", err)
-			}
-		}
-	}
-
-	{ // update vector index configs
+	{ // update index configs
 		if schemaUC.HasTargetVectors(incomingClass) {
 			old := idx.vectorIndexUserConfigs
 			new := schemaUC.AsVectorIndexConfigs(incomingClass)
@@ -195,7 +185,16 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 				}
 			}
 		}
+
+		old := idx.vectorIndexUserConfigs
+		new := inverted.ConfigFromModel(incomingClass.InvertedIndexConfig)
+		if !reflect.DeepEqual(old, new) {
+			if err := idx.updateInvertedIndexConfig(ctx, new); err != nil {
+				return fmt.Errorf("inverted index config: %w", err)
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -162,10 +162,21 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		}
 	}
 
-	{ // update index configs
+	{ // update inverted index config
+		old := idx.vectorIndexUserConfigs
+		new := inverted.ConfigFromModel(incomingClass.InvertedIndexConfig)
+		if !reflect.DeepEqual(old, new) {
+			if err := idx.updateInvertedIndexConfig(ctx, new); err != nil {
+				return fmt.Errorf("inverted index config: %w", err)
+			}
+		}
+	}
+
+	{ // update vector index configs
 		if schemaUC.HasTargetVectors(incomingClass) {
 			old := idx.vectorIndexUserConfigs
 			new := schemaUC.AsVectorIndexConfigs(incomingClass)
+
 			if !reflect.DeepEqual(old, new) {
 				if err := idx.updateVectorIndexConfigs(ctx, new); err != nil {
 					return fmt.Errorf("vector index configs update: %w", err)
@@ -175,18 +186,11 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		} else {
 			old := idx.vectorIndexUserConfig
 			new := schemaUC.AsVectorIndexConfig(incomingClass)
+
 			if !reflect.DeepEqual(old, new) {
 				if err := idx.updateVectorIndexConfig(ctx, new); err != nil {
 					return fmt.Errorf("vector index config update: %w", err)
 				}
-			}
-		}
-
-		old := idx.vectorIndexUserConfigs
-		new := inverted.ConfigFromModel(incomingClass.InvertedIndexConfig)
-		if !reflect.DeepEqual(old, new) {
-			if err := idx.updateInvertedIndexConfig(ctx, new); err != nil {
-				return fmt.Errorf("inverted index config: %w", err)
 			}
 		}
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -144,13 +144,15 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 	}
 
 	{ // add/remove missing shards
-		if incomingSS.PartitioningEnabled {
-			if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
-			}
-		} else {
-			if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
+		if incomingSS != nil {
+			if incomingSS.PartitioningEnabled {
+				if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
+					return err
+				}
+			} else {
+				if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -143,6 +143,24 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		}
 	}
 
+	{ // add/remove missing shards
+		if incomingSS.PartitioningEnabled {
+			if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
+				return err
+			}
+		} else {
+			if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
+				return err
+			}
+		}
+	}
+
+	{ // add missing properties
+		if err := m.updateIndexAddMissingProperties(ctx, idx, incomingClass); err != nil {
+			return err
+		}
+	}
+
 	{ // update index configs
 		if schemaUC.HasTargetVectors(incomingClass) {
 			if err := idx.updateVectorIndexConfigs(ctx, schemaUC.AsVectorIndexConfigs(incomingClass)); err != nil {
@@ -157,32 +175,7 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 		if err := idx.updateInvertedIndexConfig(ctx, inverted.ConfigFromModel(incomingClass.InvertedIndexConfig)); err != nil {
 			return fmt.Errorf("inverted index config: %w", err)
 		}
-
 	}
-
-	{ // add missing properties
-		if err := m.updateIndexAddMissingProperties(ctx, idx, incomingClass); err != nil {
-			return err
-		}
-	}
-
-	// break early if state is nil
-	if incomingSS == nil {
-		return nil
-	}
-
-	{ // add/remove missing shards
-		if incomingSS.PartitioningEnabled {
-			if err := m.updateIndexTenants(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
-			}
-		} else {
-			if err := m.updateIndexAddShards(ctx, idx, incomingClass, incomingSS); err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -213,7 +213,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	}
 
 	initial := h.metaReader.ReadOnlyClass(className)
-	shardingState := &sharding.State{}
+	var shardingState *sharding.State
 
 	// first layer of defense is basic validation if class already exists
 	if initial != nil {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -213,7 +213,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	}
 
 	initial := h.metaReader.ReadOnlyClass(className)
-	var shardingState *sharding.State
+	var shardingState = &sharding.State{}
 
 	// first layer of defense is basic validation if class already exists
 	if initial != nil {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -213,7 +213,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	}
 
 	initial := h.metaReader.ReadOnlyClass(className)
-	var shardingState = &sharding.State{}
+	shardingState := &sharding.State{}
 
 	// first layer of defense is basic validation if class already exists
 	if initial != nil {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -251,7 +251,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 
 func (h *Handler) setClassDefaults(class *models.Class) {
 	// set only when no target vectors configured
-	if !hasTargetVectors(class) {
+	if !HasTargetVectors(class) {
 		if class.Vectorizer == "" {
 			class.Vectorizer = h.config.DefaultVectorizerModule
 		}
@@ -628,7 +628,7 @@ func (h *Handler) validatePropertyIndexing(prop *models.Property) error {
 }
 
 func (m *Handler) validateVectorSettings(class *models.Class) error {
-	if !hasTargetVectors(class) {
+	if !HasTargetVectors(class) {
 		if err := m.validateVectorizer(class.Vectorizer); err != nil {
 			return err
 		}

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
@@ -80,33 +79,11 @@ func (e *executor) RestoreClassDir(class string) error {
 }
 
 func (e *executor) UpdateClass(req api.UpdateClassRequest) error {
-	className := req.Class.Class
-	ctx := context.Background()
-
-	if hasTargetVectors(req.Class) {
-		if err := e.migrator.UpdateVectorIndexConfigs(ctx, className, asVectorIndexConfigs(req.Class)); err != nil {
-			return fmt.Errorf("vector index configs update: %w", err)
-		}
-	} else {
-		if err := e.migrator.UpdateVectorIndexConfig(ctx,
-			className, asVectorIndexConfig(req.Class)); err != nil {
-			return fmt.Errorf("vector index config update: %w", err)
-		}
-	}
-
-	if err := e.migrator.UpdateInvertedIndexConfig(ctx, className,
-		req.Class.InvertedIndexConfig); err != nil {
-		return errors.Wrap(err, "inverted index config")
-	}
-	return nil
+	return e.UpdateIndex(req)
 }
 
 func (e *executor) UpdateIndex(req api.UpdateClassRequest) error {
-	ctx := context.Background()
-	if err := e.migrator.UpdateIndex(ctx, req.Class, req.State); err != nil {
-		return err
-	}
-	return nil
+	return e.migrator.UpdateIndex(context.Background(), req.Class, req.State)
 }
 
 func (e *executor) DeleteClass(cls string) error {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -84,27 +84,10 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("UpdateIndex", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		migrator.On("UpdateVectorIndexConfig", Anything, "A", Anything).Return(nil)
-		migrator.On("UpdateInvertedIndexConfig", Anything, "A", Anything).Return(nil)
+		migrator.On("UpdateIndex", Anything, Anything).Return(nil)
 
 		x := newMockExecutor(migrator, store)
 		assert.Nil(t, x.UpdateClass(api.UpdateClassRequest{Class: cls}))
-	})
-
-	t.Run("UpdateVectorIndexConfig", func(t *testing.T) {
-		migrator := &fakeMigrator{}
-		migrator.On("UpdateVectorIndexConfig", Anything, "A", Anything).Return(ErrAny)
-
-		x := newMockExecutor(migrator, store)
-		assert.ErrorIs(t, x.UpdateClass(api.UpdateClassRequest{Class: cls}), ErrAny)
-	})
-	t.Run("UpdateInvertedIndexConfig", func(t *testing.T) {
-		migrator := &fakeMigrator{}
-		migrator.On("UpdateVectorIndexConfig", Anything, "A", Anything).Return(nil)
-		migrator.On("UpdateInvertedIndexConfig", Anything, "A", Anything).Return(ErrAny)
-
-		x := newMockExecutor(migrator, store)
-		assert.ErrorIs(t, x.UpdateClass(api.UpdateClassRequest{Class: cls}), ErrAny)
 	})
 
 	t.Run("AddProperty", func(t *testing.T) {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -298,29 +298,13 @@ func (f *fakeMigrator) UpdateShardStatus(ctx context.Context, className, shardNa
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error {
-	args := f.Called(ctx, className, updated)
-	return args.Error(0)
-}
-
 func (*fakeMigrator) ValidateVectorIndexConfigsUpdate(old, updated map[string]schemaConfig.VectorIndexConfig,
-) error {
-	return nil
-}
-
-func (*fakeMigrator) UpdateVectorIndexConfigs(ctx context.Context, className string,
-	updated map[string]schemaConfig.VectorIndexConfig,
 ) error {
 	return nil
 }
 
 func (*fakeMigrator) ValidateInvertedIndexConfigUpdate(old, updated *models.InvertedIndexConfig) error {
 	return nil
-}
-
-func (f *fakeMigrator) UpdateInvertedIndexConfig(ctx context.Context, className string, updated *models.InvertedIndexConfig) error {
-	args := f.Called(ctx, className, updated)
-	return args.Error(0)
 }
 
 func (f *fakeMigrator) WaitForStartup(ctx context.Context) error {

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -52,13 +52,8 @@ type Migrator interface {
 	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error
 
-	UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error
 	ValidateVectorIndexConfigsUpdate(old, updated map[string]schemaConfig.VectorIndexConfig) error
-	UpdateVectorIndexConfigs(ctx context.Context, className string,
-		updated map[string]schemaConfig.VectorIndexConfig) error
 	ValidateInvertedIndexConfigUpdate(old, updated *models.InvertedIndexConfig) error
-	UpdateInvertedIndexConfig(ctx context.Context, className string,
-		updated *models.InvertedIndexConfig) error
 	WaitForStartup(context.Context) error
 	Shutdown(context.Context) error
 }

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -60,7 +60,7 @@ func (m *Parser) ParseClass(class *models.Class) error {
 
 func (m *Parser) parseVectorIndexConfig(class *models.Class,
 ) error {
-	if !hasTargetVectors(class) {
+	if !HasTargetVectors(class) {
 		parsed, err := m.parseGivenVectorIndexConfig(class.VectorIndexType, class.VectorIndexConfig)
 		if err != nil {
 			return err
@@ -152,9 +152,9 @@ func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, e
 		return nil, err
 	}
 
-	if hasTargetVectors(update) {
+	if HasTargetVectors(update) {
 		if err := p.validator.ValidateVectorIndexConfigsUpdate(
-			asVectorIndexConfigs(class), asVectorIndexConfigs(update)); err != nil {
+			AsVectorIndexConfigs(class), AsVectorIndexConfigs(update)); err != nil {
 			return nil, err
 		}
 	} else {
@@ -188,7 +188,7 @@ func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, e
 	return update, nil
 }
 
-func hasTargetVectors(class *models.Class) bool {
+func HasTargetVectors(class *models.Class) bool {
 	return len(class.VectorConfig) > 0
 }
 
@@ -261,7 +261,7 @@ func validateVectorConfigsParityAndImmutables(initial, updated *models.Class) er
 	return nil
 }
 
-func asVectorIndexConfigs(c *models.Class) map[string]schemaConfig.VectorIndexConfig {
+func AsVectorIndexConfigs(c *models.Class) map[string]schemaConfig.VectorIndexConfig {
 	if c.VectorConfig == nil {
 		return nil
 	}
@@ -273,7 +273,7 @@ func asVectorIndexConfigs(c *models.Class) map[string]schemaConfig.VectorIndexCo
 	return cfgs
 }
 
-func asVectorIndexConfig(c *models.Class) schemaConfig.VectorIndexConfig {
+func AsVectorIndexConfig(c *models.Class) schemaConfig.VectorIndexConfig {
 	validCfg, ok := c.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
 	if !ok {
 		return nil

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -112,7 +112,7 @@ func (h *Handler) validatePropModuleConfig(class *models.Class, props ...*models
 			return fmt.Errorf("%v property config invalid", prop.Name)
 		}
 
-		if !hasTargetVectors(class) {
+		if !HasTargetVectors(class) {
 			configuredVectorizers := make([]string, 0, len(modconfig))
 			for modName := range modconfig {
 				if err := h.vectorizerValidator.ValidateVectorizer(modName); err == nil {


### PR DESCRIPTION
### What's being changed:
this change get use directly of the `db.UpdateInex()` which is an idempotent db function to upsert class. also move the logic of updating the index config to the migrator instead of store to make sure we have one place of updating class 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
