### PR TITLE
Support raft rf scale (part 2)

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -258,6 +258,7 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 			RootPath:            tmpDir,
 			ClassName:           schema.ClassName(class.Class),
 			QueryMaximumResults: maxResults,
+			ReplicationFactor:   NewAtomicInt64(1),
 		},
 		invertedIndexConfig:   iic,
 		vectorIndexUserConfig: vic,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -557,7 +557,7 @@ type IndexConfig struct {
 	MemtablesMaxActiveSeconds int
 	MaxSegmentSize            int64
 	HNSWMaxLogSize            int64
-	ReplicationFactor         atomic.Int64
+	ReplicationFactor         *atomic.Int64
 	AvoidMMap                 bool
 	DisableLazyLoadShards     bool
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -557,7 +557,7 @@ type IndexConfig struct {
 	MemtablesMaxActiveSeconds int
 	MaxSegmentSize            int64
 	HNSWMaxLogSize            int64
-	ReplicationFactor         int64
+	ReplicationFactor         atomic.Int64
 	AvoidMMap                 bool
 	DisableLazyLoadShards     bool
 
@@ -688,7 +688,7 @@ func (i *Index) IncomingPutObject(ctx context.Context, shardName string,
 }
 
 func (i *Index) replicationEnabled() bool {
-	return i.Config.ReplicationFactor > 1
+	return i.Config.ReplicationFactor.Load() > 1
 }
 
 // parseDateFieldsInProps checks the schema for the current class for which

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -103,8 +103,9 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 	// create index with data
 	shardState := singleShardState()
 	index, err := NewIndex(testCtx(), IndexConfig{
-		RootPath:  dirName,
-		ClassName: schema.ClassName(class.Class),
+		RootPath:          dirName,
+		ClassName:         schema.ClassName(class.Class),
+		ReplicationFactor: NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -163,8 +164,9 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 
 	// recreate the index
 	index, err = NewIndex(testCtx(), IndexConfig{
-		RootPath:  dirName,
-		ClassName: schema.ClassName(class.Class),
+		RootPath:          dirName,
+		ClassName:         schema.ClassName(class.Class),
+		ReplicationFactor: NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema:     fakeSchema,
@@ -273,8 +275,9 @@ func TestIndex_DropReadOnlyIndexWithData(t *testing.T) {
 
 	shardState := singleShardState()
 	index, err := NewIndex(ctx, IndexConfig{
-		RootPath:  dirName,
-		ClassName: schema.ClassName(class.Class),
+		RootPath:          dirName,
+		ClassName:         schema.ClassName(class.Class),
+		ReplicationFactor: NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -332,6 +335,7 @@ func emptyIdx(t *testing.T, rootDir string, class *models.Class) *Index {
 		RootPath:              rootDir,
 		ClassName:             schema.ClassName(class.Class),
 		DisableLazyLoadShards: true,
+		ReplicationFactor:     NewAtomicInt64(1),
 	}, shardState, inverted.ConfigFromModel(invertedConfig()),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			shardState: shardState,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -170,7 +170,8 @@ func fileExists(file string) (bool, error) {
 	return true, nil
 }
 
-func NewAtomicInt64(val int64) (aval atomic.Int64) {
+func NewAtomicInt64(val int64) *atomic.Int64 {
+	aval := &atomic.Int64{}
 	aval.Store(val)
-	return
+	return aval
 }

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync/atomic"
 	"time"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -94,7 +95,7 @@ func (db *DB) init(ctx context.Context) error {
 				TrackVectorDimensions:     db.config.TrackVectorDimensions,
 				AvoidMMap:                 db.config.AvoidMMap,
 				DisableLazyLoadShards:     db.config.DisableLazyLoadShards,
-				ReplicationFactor:         class.ReplicationConfig.Factor,
+				ReplicationFactor:         NewAtomicInt64(class.ReplicationConfig.Factor),
 			}, db.schemaGetter.CopyShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),
@@ -167,4 +168,9 @@ func fileExists(file string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func NewAtomicInt64(val int64) (aval atomic.Int64) {
+	aval.Store(val)
+	return
 }

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -28,14 +28,16 @@ func TestShardActivity(t *testing.T) {
 		indices: map[string]*Index{
 			"Col1": {
 				Config: IndexConfig{
-					ClassName: "Col1",
+					ClassName:         "Col1",
+					ReplicationFactor: NewAtomicInt64(1),
 				},
 				partitioningEnabled: true,
 				shards:              shardMap{},
 			},
 			"NonMT": {
 				Config: IndexConfig{
-					ClassName: "NonMT",
+					ClassName:         "NonMT",
+					ReplicationFactor: NewAtomicInt64(1),
 				},
 				partitioningEnabled: false,
 				shards:              shardMap{},

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -253,12 +254,34 @@ func (i *Index) IncomingCreateShard(ctx context.Context, className string, shard
 func (i *Index) IncomingReinitShard(ctx context.Context,
 	shardName string,
 ) error {
-	shard, err := i.getOrInitLocalShard(ctx, shardName)
-	if err != nil {
-		return fmt.Errorf("shard %q does not exist locally", shardName)
+	shard := func() ShardLike {
+		i.shardInUseLocks.Lock(shardName)
+		defer i.shardInUseLocks.Unlock(shardName)
+
+		return i.shards.Load(shardName)
+	}()
+
+	if shard != nil {
+		err := func() error {
+			i.shardCreateLocks.Lock(shardName)
+			defer i.shardCreateLocks.Unlock(shardName)
+
+			i.shards.LoadAndDelete(shardName)
+
+			if err := shard.Shutdown(ctx); err != nil {
+				if !errors.Is(err, errAlreadyShutdown) {
+					return err
+				}
+			}
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
 	}
 
-	return shard.reinit(ctx)
+	_, err := i.getOrInitLocalShard(ctx, shardName)
+	return err
 }
 
 func (s *Shard) filePutter(ctx context.Context,
@@ -278,31 +301,6 @@ func (s *Shard) filePutter(ctx context.Context,
 	}
 
 	return f, nil
-}
-
-func (s *Shard) reinit(ctx context.Context) error {
-	if err := s.Shutdown(ctx); err != nil {
-		return fmt.Errorf("shutdown shard: %w", err)
-	}
-
-	if err := s.initNonVector(ctx, nil); err != nil {
-		return fmt.Errorf("reinit non-vector: %w", err)
-	}
-
-	if s.hasTargetVectors() {
-		if err := s.initTargetVectors(ctx); err != nil {
-			return fmt.Errorf("reinit vector: %w", err)
-		}
-	} else {
-		if err := s.initLegacyVector(ctx); err != nil {
-			return fmt.Errorf("reinit vector: %w", err)
-		}
-	}
-	s.activate()
-	s.initCycleCallbacks()
-	s.initDimensionTracking()
-
-	return nil
 }
 
 // OverwriteObjects if their state didn't change in the meantime

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -110,7 +110,6 @@ type ShardLike interface {
 	Queues() map[string]*IndexQueue
 	Shutdown(context.Context) error // Shutdown the shard
 	preventShutdown() (release func(), err error)
-	activate() error
 
 	// TODO tests only
 	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor,
@@ -133,7 +132,6 @@ type ShardLike interface {
 
 	commitReplication(context.Context, string, *backupMutex) interface{}
 	abortReplication(context.Context, string) replica.SimpleResponse
-	reinit(context.Context) error
 	filePutter(context.Context, string) (io.WriteCloser, error)
 
 	// TODO tests only
@@ -1052,14 +1050,6 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		return errors.Wrap(err, "stop lsmkv store")
 	}
 
-	return nil
-}
-
-// activate makes sure the shut flag is false
-func (s *Shard) activate() error {
-	s.shutdownLock.Lock()
-	defer s.shutdownLock.Unlock()
-	s.shut = false
 	return nil
 }
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -418,14 +418,6 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	return l.shard.Shutdown(ctx)
 }
 
-func (l *LazyLoadShard) activate() error {
-	if err := l.Load(context.Background()); err != nil {
-		return fmt.Errorf("LazyLoadShard::activate: %w", err)
-	}
-
-	return l.shard.activate()
-}
-
 func (l *LazyLoadShard) preventShutdown() (release func(), err error) {
 	if err := l.Load(context.Background()); err != nil {
 		return nil, fmt.Errorf("LazyLoadShard::preventShutdown: %w", err)
@@ -510,13 +502,6 @@ func (l *LazyLoadShard) commitReplication(ctx context.Context, shardID string, m
 func (l *LazyLoadShard) abortReplication(ctx context.Context, shardID string) replica.SimpleResponse {
 	l.mustLoad()
 	return l.shard.abortReplication(ctx, shardID)
-}
-
-func (l *LazyLoadShard) reinit(ctx context.Context) error {
-	if err := l.Load(ctx); err != nil {
-		return err
-	}
-	return l.shard.reinit(ctx)
 }
 
 func (l *LazyLoadShard) filePutter(ctx context.Context, shardID string) (io.WriteCloser, error) {

--- a/test/acceptance/replication/scale_test.go
+++ b/test/acceptance/replication/scale_test.go
@@ -98,17 +98,20 @@ func multiShardScaleOut(t *testing.T) {
 	})
 
 	t.Run("assert paragraphs were scaled out", func(t *testing.T) {
-		n := getNodes(t, compose.GetWeaviate().URI())
-		var shardsFound int
-		for _, node := range n.Nodes {
-			for _, shard := range node.Shards {
-				if shard.Class == paragraphClass.Class {
-					assert.EqualValues(t, 10, shard.ObjectCount)
-					shardsFound++
+		// shard.ObjectCount is eventually consistent, see Bucket::CountAsync()
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			n := getNodes(t, compose.GetWeaviate().URI())
+			var shardsFound int
+			for _, node := range n.Nodes {
+				for _, shard := range node.Shards {
+					if shard.Class == paragraphClass.Class {
+						assert.EqualValues(collect, int64(10), shard.ObjectCount)
+						shardsFound++
+					}
 				}
 			}
-		}
-		assert.Equal(t, 2, shardsFound)
+			assert.Equal(collect, 2, shardsFound)
+		}, 10*time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("scale out articles", func(t *testing.T) {
@@ -118,17 +121,20 @@ func multiShardScaleOut(t *testing.T) {
 	})
 
 	t.Run("assert articles were scaled out", func(t *testing.T) {
-		n := getNodes(t, compose.GetWeaviate().URI())
-		var shardsFound int
-		for _, node := range n.Nodes {
-			for _, shard := range node.Shards {
-				if shard.Class == articleClass.Class {
-					assert.EqualValues(t, 10, shard.ObjectCount)
-					shardsFound++
+		// shard.ObjectCount is eventually consistent, see Bucket::CountAsync()
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			n := getNodes(t, compose.GetWeaviate().URI())
+			var shardsFound int
+			for _, node := range n.Nodes {
+				for _, shard := range node.Shards {
+					if shard.Class == articleClass.Class {
+						assert.EqualValues(collect, int64(10), shard.ObjectCount)
+						shardsFound++
+					}
 				}
 			}
-		}
-		assert.Equal(t, 2, shardsFound)
+			assert.Equal(collect, 2, shardsFound)
+		}, 10*time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("kill a node and check contents of remaining node", func(t *testing.T) {

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -98,6 +98,11 @@ func (e *executor) UpdateClass(req api.UpdateClassRequest) error {
 		req.Class.InvertedIndexConfig); err != nil {
 		return errors.Wrap(err, "inverted index config")
 	}
+
+	if err := e.migrator.UpdateReplicationFactor(ctx, className, req.Class.ReplicationConfig.Factor); err != nil {
+		return fmt.Errorf("replication index update: %w", err)
+	}
+
 	return nil
 }
 

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -43,6 +43,9 @@ func TestExecutor(t *testing.T) {
 	cls := &models.Class{
 		Class:             "A",
 		VectorIndexConfig: flat.NewDefaultUserConfig(),
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor: 1,
+		},
 	}
 	store.On("ReadOnlySchema").Return(models.Schema{})
 	store.On("ReadOnlyClass", "A", mock.Anything).Return(cls)

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -323,6 +323,10 @@ func (f *fakeMigrator) UpdateInvertedIndexConfig(ctx context.Context, className 
 	return args.Error(0)
 }
 
+func (f *fakeMigrator) UpdateReplicationFactor(ctx context.Context, className string, factor int64) error {
+	return nil
+}
+
 func (f *fakeMigrator) WaitForStartup(ctx context.Context) error {
 	args := f.Called(ctx)
 	return args.Error(0)

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -59,6 +59,7 @@ type Migrator interface {
 	ValidateInvertedIndexConfigUpdate(old, updated *models.InvertedIndexConfig) error
 	UpdateInvertedIndexConfig(ctx context.Context, className string,
 		updated *models.InvertedIndexConfig) error
+	UpdateReplicationFactor(ctx context.Context, className string, factor int64) error
 	WaitForStartup(context.Context) error
 	Shutdown(context.Context) error
 }


### PR DESCRIPTION
### What's being changed:
- changes approach to shard reinit: removes dedicated method, uses Shard::Shutdown() followed by NewShard() calls.
- updates replication factor on Index::Config when scaling out to fix `Index::replicationEnabled()` calls after scaling.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
