### PR TITLE
RAFT: fix data race on registering call backs and atomic lastAppliedI…

### DIFF
--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -174,7 +174,7 @@ type Store struct {
 	candidates map[string]string
 
 	// lastAppliedIndexOnStart represents the index of the last applied command when the store is opened.
-	lastAppliedIndexOnStart uint64
+	lastAppliedIndexOnStart atomic.Uint64
 
 	// lastAppliedIndex index of latest update to the store
 	lastAppliedIndex atomic.Uint64
@@ -237,10 +237,11 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	}
 
 	rLog := rLog{st.logStore}
-	st.lastAppliedIndexOnStart, err = rLog.LastAppliedCommand()
+	l, err := rLog.LastAppliedCommand()
 	if err != nil {
 		return fmt.Errorf("read log last command: %w", err)
 	}
+	st.lastAppliedIndexOnStart.Store(l)
 
 	st.log.WithFields(logrus.Fields{
 		"name":                 st.nodeID,
@@ -250,7 +251,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("raft.NewRaft %v %w", st.transport.LocalAddr(), err)
 	}
-	if st.lastAppliedIndexOnStart <= st.raft.LastIndex() {
+	if st.lastAppliedIndexOnStart.Load() <= st.raft.LastIndex() {
 		// this should include empty and non empty node
 		st.openDatabase(ctx)
 	}
@@ -260,7 +261,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	st.log.WithFields(logrus.Fields{
 		"raft_applied_index":           st.raft.AppliedIndex(),
 		"raft_last_index":              st.raft.LastIndex(),
-		"last_store_log_applied_index": st.lastAppliedIndexOnStart,
+		"last_store_log_applied_index": st.lastAppliedIndexOnStart.Load(),
 		"last_store_applied_index":     st.lastAppliedIndex.Load(),
 		"last_snapshot_index":          snapshotIndex(st.snapshotStore),
 	}).Info("raft node constructed")
@@ -538,7 +539,7 @@ func (st *Store) Stats() map[string]any {
 	stats["open"] = st.open.Load()
 	stats["bootstrapped"] = st.bootstrapped.Load()
 	stats["candidates"] = st.candidates
-	stats["last_store_log_applied_index"] = st.lastAppliedIndexOnStart
+	stats["last_store_log_applied_index"] = st.lastAppliedIndexOnStart.Load()
 	stats["last_applied_index"] = st.lastAppliedIndex.Load()
 	stats["db_loaded"] = st.dbLoaded.Load()
 
@@ -641,16 +642,16 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	// schemaOnly is necessary so that on restart when we are re-applying RAFT log entries to our in-memory schema we
 	// don't update the database. This can lead to dataloss for example if we drop then re-add a class.
 	// If we don't have any last applied index on start, schema only is always false.
-	schemaOnly := st.lastAppliedIndexOnStart != 0 && l.Index <= st.lastAppliedIndexOnStart
+	schemaOnly := st.lastAppliedIndexOnStart.Load() != 0 && l.Index <= st.lastAppliedIndexOnStart.Load()
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
-		if st.lastAppliedIndexOnStart != 0 && l.Index == st.lastAppliedIndexOnStart {
+		if st.lastAppliedIndexOnStart.Load() != 0 && l.Index == st.lastAppliedIndexOnStart.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,
 				"log_name":                     l.Type.String(),
 				"log_index":                    l.Index,
-				"last_store_log_applied_index": st.lastAppliedIndexOnStart,
+				"last_store_log_applied_index": st.lastAppliedIndexOnStart.Load(),
 			}).Debug("reloading local DB as RAFT and local DB are now caught up")
 			cs := make([]command.UpdateClassRequest, len(st.db.Schema.Classes))
 			i := 0
@@ -908,10 +909,10 @@ func (st *Store) reloadDBFromSnapshot() bool {
 		snapIndex := snapshotIndex(st.snapshotStore)
 		st.log.WithFields(logrus.Fields{
 			"last_applied_index":           st.lastAppliedIndex.Load(),
-			"last_store_log_applied_index": st.lastAppliedIndexOnStart,
+			"last_store_log_applied_index": st.lastAppliedIndexOnStart.Load(),
 			"last_snapshot_index":          snapIndex,
 		}).Info("load local db from snapshot")
-		if st.lastAppliedIndexOnStart <= snapIndex {
+		if st.lastAppliedIndexOnStart.Load() <= snapIndex {
 			st.openDatabase(ctx)
 			return true
 		}
@@ -928,7 +929,7 @@ func (st *Store) reloadDBFromSnapshot() bool {
 	st.db.store.ReloadLocalDB(context.Background(), cs)
 
 	st.dbLoaded.Store(true)
-	st.lastAppliedIndexOnStart = 0
+	st.lastAppliedIndexOnStart.Store(0)
 	return true
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -23,9 +24,12 @@ import (
 )
 
 type executor struct {
-	store           metaReader
-	migrator        Migrator
-	callbacks       []func(updatedSchema schema.Schema)
+	store    metaReader
+	migrator Migrator
+
+	callbacksLock sync.RWMutex
+	callbacks     []func(updatedSchema schema.Schema)
+
 	logger          logrus.FieldLogger
 	restoreClassDir func(string) error
 }
@@ -223,6 +227,9 @@ func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList
 }
 
 func (e *executor) rebuildGQL(s models.Schema) {
+	e.callbacksLock.RLock()
+	defer e.callbacksLock.RUnlock()
+
 	for _, cb := range e.callbacks {
 		cb(schema.Schema{
 			Objects: &s,
@@ -238,5 +245,8 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 // type update callback. The callbacks will be called any time we persist a
 // schema update
 func (e *executor) RegisterSchemaUpdateCallback(callback func(updatedSchema schema.Schema)) {
+	e.callbacksLock.Lock()
+	defer e.callbacksLock.Unlock()
+
 	e.callbacks = append(e.callbacks, callback)
 }


### PR DESCRIPTION
…ndexOnStart

Apply it could be called concurrently, so we convert `lastAppliedIndexOnStart` to `atomic` 
 
also sometime we end up in data race situations 
```
WARNING: DATA RACE
2024-05-14 11:34:02 Write at 0x00c00288e0c0 by main goroutine:
2024-05-14 11:34:02   github.com/weaviate/weaviate/usecases/schema.(*executor).RegisterSchemaUpdateCallback()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/usecases/schema/executor.go:218 +0x4a5c
2024-05-14 11:34:02   github.com/weaviate/weaviate/adapters/handlers/rest.MakeAppState()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:363 +0x49b8
2024-05-14 11:34:02   github.com/weaviate/weaviate/adapters/handlers/rest.configureAPI()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:464 +0xe4
2024-05-14 11:34:02   github.com/weaviate/weaviate/adapters/handlers/rest.(*Server).ConfigureAPI()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/server.go:68 +0x720
2024-05-14 11:34:02   main.main()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cmd/weaviate-server/main.go:62 +0x6f0
2024-05-14 11:34:02 
2024-05-14 11:34:02 Previous read at 0x00c00288e0c0 by goroutine 128:
2024-05-14 11:34:02   github.com/weaviate/weaviate/usecases/schema.(*executor).rebuildGQL()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/usecases/schema/executor.go:203 +0xf0
2024-05-14 11:34:02   github.com/weaviate/weaviate/usecases/schema.(*executor).TriggerSchemaUpdateCallbacks()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/usecases/schema/executor.go:211 +0x28
2024-05-14 11:34:02   github.com/weaviate/weaviate/cluster/store.(*localDB).apply()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cluster/store/db.go:286 +0x144
2024-05-14 11:34:02   github.com/weaviate/weaviate/cluster/store.(*localDB).AddClass()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cluster/store/db.go:55 +0x520
2024-05-14 11:34:02   github.com/weaviate/weaviate/cluster/store.(*Store).Apply()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cluster/store/store.go:674 +0xaf4
2024-05-14 11:34:02   github.com/hashicorp/raft.(*Raft).runFSM.func1()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/vendor/github.com/hashicorp/raft/fsm.go:101 +0x2d4
2024-05-14 11:34:02   github.com/hashicorp/raft.(*Raft).runFSM.func2()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/vendor/github.com/hashicorp/raft/fsm.go:124 +0x6a4
2024-05-14 11:34:02   github.com/hashicorp/raft.(*Raft).runFSM()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/vendor/github.com/hashicorp/raft/fsm.go:240 +0x508
2024-05-14 11:34:02   github.com/hashicorp/raft.(*Raft).runFSM-fm()
2024-05-14 11:34:02       <autogenerated>:1 +0x34
2024-05-14 11:34:02   github.com/hashicorp/raft.(*raftState).goFunc.func1()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/vendor/github.com/hashicorp/raft/state.go:149 +0x8c
2024-05-14 11:34:02 
2024-05-14 11:34:02 Goroutine 128 (running) created at:
2024-05-14 11:34:02   github.com/hashicorp/raft.(*raftState).goFunc()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/vendor/github.com/hashicorp/raft/state.go:147 +0xd8
2024-05-14 11:34:02   github.com/hashicorp/raft.NewRaft()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/vendor/github.com/hashicorp/raft/api.go:605 +0x12ac
2024-05-14 11:34:02   github.com/weaviate/weaviate/cluster/store.(*Store).Open()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cluster/store/store.go:251 +0x448
2024-05-14 11:34:02   github.com/weaviate/weaviate/cluster/store.(*Service).Open()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cluster/store/service.go:58 +0x180
2024-05-14 11:34:02   github.com/weaviate/weaviate/cluster.(*Service).Open()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/cluster/cluster.go:67 +0x1ac
2024-05-14 11:34:02   github.com/weaviate/weaviate/adapters/handlers/rest.MakeAppState.func3()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:340 +0x6c
2024-05-14 11:34:02   github.com/weaviate/weaviate/entities/errors.GoWrapper.func1()
2024-05-14 11:34:02       /go/src/github.com/weaviate/weaviate/entities/errors/go_wrapper.go:34 +0x90
```
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
