### PR TITLE
gh-2496 Return vectorized query with results

### DIFF
--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -432,6 +432,8 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 			if params.AdditionalProperties.Distance {
 				additionalProperties["distance"] = res.Dist
 			}
+			// Add the query_vector to the additional properties
+			additionalProperties["query_vector"] = searchVector
 		}
 
 		if params.AdditionalProperties.ID {

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -98,10 +98,16 @@ func Test_Explorer_GetClass(t *testing.T) {
 			assert.Equal(t,
 				map[string]interface{}{
 					"name": "Foo",
+					"_additional": map[string]interface{}{
+						"query_vector": []float32{0.8, 0.2, 0.7},
+					},
 				}, res[0])
 			assert.Equal(t,
 				map[string]interface{}{
 					"age": 200,
+					"_additional": map[string]interface{}{
+						"query_vector": []float32{0.8, 0.2, 0.7},
+					},
 				}, res[1])
 		})
 
@@ -659,7 +665,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 			search.AssertExpectations(t)
 		})
 
-		t.Run("response must contain concepts2", func(t *testing.T) {
+		t.Run("response must contain concepts9", func(t *testing.T) {
 			require.Len(t, res, 2)
 			assert.Equal(t,
 				map[string]interface{}{
@@ -1127,6 +1133,9 @@ func Test_Explorer_GetClass(t *testing.T) {
 				ID: "id2",
 				Schema: map[string]interface{}{
 					"name": "Bar",
+					"_additional": map[string]interface{}{
+						"query_vector": []float32{1, 2, 3},
+					},
 				},
 			},
 		}
@@ -2170,10 +2179,16 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 			assert.Equal(t,
 				map[string]interface{}{
 					"name": "Foo",
+					"_additional": map[string]interface{}{
+						"query_vector": []float32{1, 2, 3},
+					},
 				}, res[0])
 			assert.Equal(t,
 				map[string]interface{}{
 					"age": 200,
+					"_additional": map[string]interface{}{
+						"query_vector": []float32{1, 2, 3},
+					},
 				}, res[1])
 		})
 	})
@@ -2717,6 +2732,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 								},
 							},
 						},
+						"query_vector": []float32{1, 2, 3},
 					},
 				}, res[0])
 			assert.Equal(t,
@@ -2741,6 +2757,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 								},
 							},
 						},
+						"query_vector": []float32{1, 2, 3},
 					},
 				}, res[1])
 		})

--- a/usecases/traverser/explorer_validate_filters_test.go
+++ b/usecases/traverser/explorer_validate_filters_test.go
@@ -374,6 +374,9 @@ func Test_Explorer_GetClass_WithFilters(t *testing.T) {
 						ID: "id1",
 						Schema: map[string]interface{}{
 							"name": "Foo",
+							"_additional": map[string]interface{}{
+								"query_vector": []float32{0.8, 0.2, 0.7},
+							},
 						},
 					},
 				}
@@ -405,6 +408,9 @@ func Test_Explorer_GetClass_WithFilters(t *testing.T) {
 						assert.Equal(t,
 							map[string]interface{}{
 								"name": "Foo",
+								"_additional": map[string]interface{}{
+									"query_vector": []float32{0.8, 0.2, 0.7},
+								},
 							}, res[0])
 					})
 				} else {


### PR DESCRIPTION
### What's being changed:
Addition of query_vector Property:

Modify the `searchResultsToGetResponseWithType` method in explorer.go to include a new property query_vector in the _additional map

https://glide.agenticlabs.com/sharing?userId=65bae7547a39e05fc421bd8c&taskId=QJhig4U

Weaviate noob and go noob, feedback welcome

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
