### PR TITLE
Fix cluster remote aggregate hybrid neartext

### DIFF
--- a/adapters/handlers/graphql/local/local_component_test.go
+++ b/adapters/handlers/graphql/local/local_component_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
-	"github.com/weaviate/weaviate/usecases/modules"
+	usecaseModules "github.com/weaviate/weaviate/usecases/modules"
 )
 
 // These tests are component tests for the local package including all its
@@ -207,7 +207,7 @@ type testCases []testCase
 func (tests testCases) AssertNoError(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modules := modules.NewProvider()
+			modules := usecaseModules.NewProvider()
 			localSchema, err := Build(&test.localSchema, nil, config.Config{}, modules)
 			require.Nil(t, err, test.name)
 
@@ -240,7 +240,7 @@ func (tests testCases) AssertNoError(t *testing.T) {
 func (tests testCases) AssertErrorLogs(t *testing.T, expectedMsg string) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modules := modules.NewProvider()
+			modules := usecaseModules.NewProvider()
 			logger, logsHook := logrus.NewNullLogger()
 			localSchema, err := Build(&test.localSchema, logger, config.Config{}, modules)
 			require.Nil(t, err, test.name)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -322,7 +322,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	}
 
 	appState.SchemaManager = schemaManager
-	appState.RemoteIndexIncoming = sharding.NewRemoteIndexIncoming(repo, appState.ClusterService.SchemaReader())
+	appState.RemoteIndexIncoming = sharding.NewRemoteIndexIncoming(repo, appState.ClusterService.SchemaReader(), appState.Modules)
 	appState.RemoteNodeIncoming = sharding.NewRemoteNodeIncoming(repo)
 	appState.RemoteReplicaIncoming = replica.NewRemoteReplicaIncoming(repo, appState.ClusterService.SchemaReader())
 

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/usecases/modules"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
@@ -350,7 +351,7 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 		}
 
 		node := nodes[rnd.Intn(len(nodes))]
-		res, err := node.repo.Aggregate(context.Background(), params, nil)
+		res, err := node.repo.Aggregate(context.Background(), params, modules.NewProvider())
 		require.Nil(t, err)
 
 		expectedResult := &aggregation.Result{

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -36,6 +36,7 @@ import (
 	modstgfs "github.com/weaviate/weaviate/modules/backup-filesystem"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/modules"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -99,7 +100,7 @@ func (n *node) init(dirName string, shardStateRaw []byte,
 
 	n.migrator = db.NewMigrator(n.repo, logger)
 
-	indices := clusterapi.NewIndices(sharding.NewRemoteIndexIncoming(n.repo, n.schemaManager),
+	indices := clusterapi.NewIndices(sharding.NewRemoteIndexIncoming(n.repo, n.schemaManager, modules.NewProvider()),
 		n.repo, clusterapi.NewNoopAuthHandler())
 	mux := http.NewServeMux()
 	mux.Handle("/indices/", indices.Indices())

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -200,7 +200,6 @@ type Index struct {
 	allocChecker     memwatch.AllocChecker
 	shardCreateLocks *esync.KeyLocker
 	shardInUseLocks  *esync.KeyRWLocker
-	modules          *modules.Provider
 }
 
 func (i *Index) GetShards() []ShardLike {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1867,7 +1867,7 @@ func (i *Index) aggregate(ctx context.Context,
 }
 
 func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
-	params aggregation.Params,
+	params aggregation.Params, mods interface{},
 ) (*aggregation.Result, error) {
 	shard, release, err := i.getOrInitLocalShardNoShutdown(ctx, shardName)
 	if err != nil {
@@ -1875,7 +1875,7 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 	}
 	defer release()
 
-	return shard.Aggregate(ctx, params, i.modules)
+	return shard.Aggregate(ctx, params, mods.(*modules.Provider))
 }
 
 func (i *Index) drop() error {

--- a/modules/text2vec-contextionary/helpers_test.go
+++ b/modules/text2vec-contextionary/helpers_test.go
@@ -31,6 +31,7 @@ import (
 	text2vecadditionalsempath "github.com/weaviate/weaviate/modules/text2vec-contextionary/additional/sempath"
 	text2vecadditionalprojector "github.com/weaviate/weaviate/usecases/modulecomponents/additional/projector"
 	text2vecneartext "github.com/weaviate/weaviate/usecases/modulecomponents/arguments/nearText"
+
 	"github.com/weaviate/weaviate/usecases/traverser"
 )
 

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_restart_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_restart_test.go
@@ -12,9 +12,10 @@
 package named_vectors_tests
 
 import (
-	"acceptance_tests_with_client/fixtures"
 	"context"
 	"testing"
+
+	"acceptance_tests_with_client/fixtures"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/require"

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -17,6 +17,7 @@ export QUERY_DEFAULTS_LIMIT=${QUERY_DEFAULTS_LIMIT:-"20"}
 export QUERY_MAXIMUM_RESULTS=${QUERY_MAXIMUM_RESULTS:-"10000"}
 export TRACK_VECTOR_DIMENSIONS=true
 export CLUSTER_HOSTNAME=${CLUSTER_HOSTNAME:-"weaviate-0"}
+export GPT4ALL_INFERENCE_API="http://localhost:8010"
 export DISABLE_TELEMETRY=true # disable telemetry for local development
 
 function go_run() {

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -63,7 +63,7 @@ type RemoteIndexIncomingRepo interface {
 		additional additional.Properties,
 	) ([]*storobj.Object, []float32, error)
 	IncomingAggregate(ctx context.Context, shardName string,
-		params aggregation.Params) (*aggregation.Result, error)
+		params aggregation.Params, modules interface{}) (*aggregation.Result, error)
 
 	IncomingFindUUIDs(ctx context.Context, shardName string,
 		filters *filters.LocalFilter) ([]strfmt.UUID, error)
@@ -85,14 +85,16 @@ type RemoteIndexIncomingRepo interface {
 }
 
 type RemoteIndexIncoming struct {
-	repo   RemoteIncomingRepo
-	schema RemoteIncomingSchema
+	repo    RemoteIncomingRepo
+	schema  RemoteIncomingSchema
+	modules interface{}
 }
 
-func NewRemoteIndexIncoming(repo RemoteIncomingRepo, schema RemoteIncomingSchema) *RemoteIndexIncoming {
+func NewRemoteIndexIncoming(repo RemoteIncomingRepo, schema RemoteIncomingSchema, modules interface{}) *RemoteIndexIncoming {
 	return &RemoteIndexIncoming{
-		repo:   repo,
-		schema: schema,
+		repo:    repo,
+		schema:  schema,
+		modules: modules,
 	}
 }
 
@@ -207,7 +209,7 @@ func (rii *RemoteIndexIncoming) Aggregate(ctx context.Context, indexName, shardN
 		return &aggregation.Result{}, nil
 	}
 
-	return index.IncomingAggregate(ctx, shardName, params)
+	return index.IncomingAggregate(ctx, shardName, params, rii.modules)
 }
 
 func (rii *RemoteIndexIncoming) FindUUIDs(ctx context.Context, indexName, shardName string,

--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -73,7 +73,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 		params.Certainty = certainty
 	}
 
-	if params.Hybrid != nil && params.Hybrid.Vector == nil && params.Hybrid.Query != "" {
+	if params.Hybrid != nil && params.Hybrid.Vector == nil {
 		targetVector := ""
 		if len(params.Hybrid.TargetVectors) == 1 {
 			targetVector = params.Hybrid.TargetVectors[0]


### PR DESCRIPTION
### What's being changed:

Aggregate hybrid neartext filters are currently failing because aggregate does not have access to moduleProvider.

This patch adds a field called modules to RemoteIndexIncoming and makes sure it is populated with the correct modules provider, sends this to the aggregations.

This fixes a problem with remote hybrid neartext filters in aggregations. Aggregations without hybrid neartext subsearches were not affected

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
