### PR TITLE
Remove unsearchable properties

### DIFF
--- a/adapters/repos/db/aggregations_fixtures_for_test.go
+++ b/adapters/repos/db/aggregations_fixtures_for_test.go
@@ -36,6 +36,25 @@ var productClass = &models.Class{
 	},
 }
 
+func boolRef(b bool) *bool {
+	return &b
+}
+
+var notIndexedClass = &models.Class{
+	Class:               "NotIndexedClass",
+	VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+	InvertedIndexConfig: invertedConfig(),
+	Properties: []*models.Property{
+		{
+			Name:            "name",
+			DataType:        schema.DataTypeText.PropString(),
+			Tokenization:    models.PropertyTokenizationWhitespace,
+			IndexFilterable: boolRef(false),
+			IndexInverted:   boolRef(false),
+		},
+	},
+}
+
 var companyClass = &models.Class{
 	Class:               "AggregationsTestCompany",
 	VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -129,6 +129,7 @@ func prepareCompanyTestSchemaAndData(repo *DB,
 			Objects: &models.Schema{
 				Classes: []*models.Class{
 					productClass,
+					notIndexedClass,
 					companyClass,
 					arrayTypesClass,
 					customerClass,
@@ -147,6 +148,8 @@ func prepareCompanyTestSchemaAndData(repo *DB,
 				migrator.AddClass(context.Background(), arrayTypesClass, schemaGetter.shardState))
 			require.Nil(t,
 				migrator.AddClass(context.Background(), customerClass, schemaGetter.shardState))
+			require.Nil(t,
+				migrator.AddClass(context.Background(), notIndexedClass, schemaGetter.shardState))
 		})
 
 		schemaGetter.schema = schema
@@ -156,6 +159,20 @@ func prepareCompanyTestSchemaAndData(repo *DB,
 				t.Run(fmt.Sprintf("importing product %d", i), func(t *testing.T) {
 					fixture := models.Object{
 						Class:      productClass.Class,
+						ID:         productsIds[i],
+						Properties: schema,
+					}
+					require.Nil(t,
+						repo.PutObject(context.Background(), &fixture, []float32{0.1, 0.2, 0.01, 0.2}, nil, nil, 0))
+				})
+			}
+		})
+
+		t.Run("import products into notIndexed class", func(t *testing.T) {
+			for i, schema := range products {
+				t.Run(fmt.Sprintf("importing product %d", i), func(t *testing.T) {
+					fixture := models.Object{
+						Class:      notIndexedClass.Class,
 						ID:         productsIds[i],
 						Properties: schema,
 					}

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -124,6 +124,9 @@ func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.
 		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", fa.params.ClassName)
 	}
 	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
+
+	kw.ChooseSearchableProperties(class)
+
 	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, fa.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, fa.classSearcher,
 		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -48,6 +48,8 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 	}
 	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
 
+	kw.ChooseSearchableProperties(class)
+
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, a.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, a.classSearcher,
 		a.GetPropertyLengthTracker(), a.logger, a.shardVersion,

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -114,6 +114,14 @@ func SetupClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGetter, lo
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vTrue,
 			},
+			// Test that bm25f handles this property being unsearchable
+			{
+				Name:            "notSearchable",
+				DataType:        schema.DataTypeTextArray.PropString(),
+				Tokenization:    models.PropertyTokenizationWhitespace,
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+			},
 		},
 	}
 

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -79,6 +79,7 @@ func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList
 			return nil, nil, inverted.NewMissingSearchableIndexError(property)
 		}
 	}
+
 	class := b.getClass(className.String())
 	if class == nil {
 		return nil, nil, fmt.Errorf("could not find class %s in schema", className)

--- a/test/acceptance_with_go_client/named_vectors_tests/named_vectors_restart_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/named_vectors_restart_test.go
@@ -12,9 +12,10 @@
 package named_vectors_tests
 
 import (
-	"acceptance_tests_with_client/fixtures"
 	"context"
 	"testing"
+
+	"acceptance_tests_with_client/fixtures"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/require"

--- a/usecases/traverser/hybrid_group_by.go
+++ b/usecases/traverser/hybrid_group_by.go
@@ -13,6 +13,7 @@ package traverser
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
@@ -24,7 +25,9 @@ func (e *Explorer) groupSearchResults(ctx context.Context, sr search.Results, gr
 	groupsOrdered := []string{}
 	groups := map[string][]search.Result{}
 
-	for _, result := range sr {
+	fmt.Println("-----------------")
+	for i, result := range sr {
+		fmt.Println("result", i, result.ID, result.Dist, result.Vector, result.Object().Properties)
 
 		prop_i := result.Object().Properties
 		prop := prop_i.(map[string]interface{})

--- a/usecases/traverser/hybrid_group_by.go
+++ b/usecases/traverser/hybrid_group_by.go
@@ -13,7 +13,6 @@ package traverser
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
@@ -25,10 +24,7 @@ func (e *Explorer) groupSearchResults(ctx context.Context, sr search.Results, gr
 	groupsOrdered := []string{}
 	groups := map[string][]search.Result{}
 
-	fmt.Println("-----------------")
-	for i, result := range sr {
-		fmt.Println("result", i, result.ID, result.Dist, result.Vector, result.Object().Properties)
-
+	for _, result := range sr {
 		prop_i := result.Object().Properties
 		prop := prop_i.(map[string]interface{})
 		val, ok := prop[groupBy.Property].(string)


### PR DESCRIPTION
### What's being changed:

Fixes https://github.com/weaviate/weaviate/issues/4869

Some aggregate hybrid searches were failing when bm25f attempted to search proeprties that didn't have an index.  This patch removes unindexed properties from the search list, allowing the search to complete successfully

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
