### PR TITLE
Optimize locking for HNSW flat search

### DIFF
--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -27,13 +27,12 @@ func (h *hnsw) flatSearch(queryVector []float32, limit int,
 
 	it := allowList.Iterator()
 	for candidate, ok := it.Next(); ok; candidate, ok = it.Next() {
-		h.RLock()
 		// Hot fix for https://github.com/weaviate/weaviate/issues/1937
 		// this if statement mitigates the problem but it doesn't resolve the issue
 		if candidate >= nodeSize {
 			h.logger.WithField("action", "flatSearch").
 				Debugf("trying to get candidate: %v but we only have: %v elements.",
-					candidate, len(h.nodes))
+					candidate, nodeSize)
 			continue
 		}
 


### PR DESCRIPTION
### What's being changed:

- In cases where a filter has low selectivity (by default using `40,000` from `flatSearchCutoff` we resort to flat search on HNSW and just consider the filtered set.
- This PR optimizes the locking on flat search, `h.nodes` is only retrieved once, because `h.nodes` is only expected to grow (or be deleted) so we don't need to lock for each allow list candidate. This improved flat search performance by approximately 35% on test OpenAI datasets.
- I have also downgraded the Warning message to debug. It is expected the filter can be larger than `h.nodes` in the case of async indexing.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
