### PR TITLE
Do not validate the model for openai with a different base url

### DIFF
--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -232,8 +232,6 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("when X-OpenAI-BaseURL header is passed", func(t *testing.T) {
-		server := httptest.NewServer(&fakeHandler{t: t})
-		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
 
 		config := ent.VectorizationConfig{
@@ -255,8 +253,6 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("pass rate limit headers requests", func(t *testing.T) {
-		server := httptest.NewServer(&fakeHandler{t: t})
-		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
 
 		ctxWithValue := context.WithValue(context.Background(),
@@ -268,8 +264,6 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("pass rate limit headers tokens", func(t *testing.T) {
-		server := httptest.NewServer(&fakeHandler{t: t})
-		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
 
 		ctxWithValue := context.WithValue(context.Background(), "X-Openai-Ratelimit-TokenPM-Embedding", []string{"60"})
@@ -409,7 +403,8 @@ func Test_getModelString(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := New("apiKey", "", "", 0, nullLogger())
-				if got := v.getModelString(tt.args.docType, tt.args.model, "document", tt.args.version); got != tt.want {
+				config := ent.VectorizationConfig{Type: tt.args.docType, Model: tt.args.model, ModelVersion: tt.args.version}
+				if got := v.getModelString(config, "document"); got != tt.want {
 					t.Errorf("vectorizer.getModelString() = %v, want %v", got, tt.want)
 				}
 			})
@@ -479,7 +474,9 @@ func Test_getModelString(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := New("apiKey", "", "", 0, nullLogger())
-				if got := v.getModelString(tt.args.docType, tt.args.model, "query", tt.args.version); got != tt.want {
+				config := ent.VectorizationConfig{Type: tt.args.docType, Model: tt.args.model, ModelVersion: tt.args.version}
+
+				if got := v.getModelString(config, "query"); got != tt.want {
 					t.Errorf("vectorizer.getModelString() = %v, want %v", got, tt.want)
 				}
 			})

--- a/modules/text2vec-openai/ent/class_settings_test.go
+++ b/modules/text2vec-openai/ent/class_settings_test.go
@@ -131,6 +131,15 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantErr: errors.New("wrong OpenAI model name, available model names are: [ada babbage curie davinci text-embedding-3-small text-embedding-3-large]"),
 		},
 		{
+			name: "third party provider",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model":   "model-that-openai-does-not-have",
+					"baseURL": "https://something-else.com",
+				},
+			},
+		},
+		{
 			name: "wrong properties",
 			cfg: &fakeClassConfig{
 				classConfig: map[string]interface{}{

--- a/modules/text2vec-openai/ent/vectorization_config.go
+++ b/modules/text2vec-openai/ent/vectorization_config.go
@@ -17,5 +17,6 @@ type VectorizationConfig struct {
 	DeploymentID                            string `json:"deploymentId"`
 	ApiVersion                              string
 	IsAzure                                 bool
+	IsThirdPartyProvider                    bool
 	Dimensions                              *int64
 }

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -43,7 +43,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 
 		tke, err := tiktoken.EncodingForModel(icheck.Model())
 		if err != nil { // fail all objects as they all have the same model
-			return nil, nil, false, err
+			tke, _ = tiktoken.EncodingForModel("text-embedding-ada-002")
 		}
 
 		// prepare input for vectorizer, and send it to the queue. Prepare here to avoid work in the queue-worker


### PR DESCRIPTION
### What's being changed:

Don't validate the model if we're not using an openai baseurl - many other embedding-providers have an API that is compatible to OpenAI, but their models are different. With this change our users can use these providers without a specific module.

Python client code to test:
```
    collection = client.collections.create(
        "Products",
        properties=[
            wvc.config.Property(name="name", data_type=wvc.config.DataType.TEXT),
            wvc.config.Property(name="description", data_type=wvc.config.DataType.TEXT),
        ],
        vectorizer_config=wvc.config.Configure.Vectorizer.text2vec_openai(base_url="https://text.octoai.run", model="thenlper/gte-large"),
    )
    client.integrations.configure([wvc.config.Integrations.openai(api_key=API_KEY)])

```


### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
