### PR TITLE
fix deadlock by avoiding recursive locking in meta_class 

### DIFF
--- a/cluster/store/meta_class.go
+++ b/cluster/store/meta_class.go
@@ -39,7 +39,11 @@ func (m *metaClass) ClassInfo() (ci ClassInfo) {
 	defer m.RUnlock()
 	ci.Exists = true
 	ci.Properties = len(m.Class.Properties)
-	ci.MultiTenancy, _ = m.MultiTenancyConfig()
+	if m.Class.MultiTenancyConfig == nil {
+		ci.MultiTenancy = models.MultiTenancyConfig{}
+	} else {
+		ci.MultiTenancy = *m.Class.MultiTenancyConfig
+	}
 	ci.ReplicationFactor = 1
 	if m.Class.ReplicationConfig != nil && m.Class.ReplicationConfig.Factor > 1 {
 		ci.ReplicationFactor = int(m.Class.ReplicationConfig.Factor)


### PR DESCRIPTION
### What's being changed:

* Avoid recursive locking by reading directly the multi tenancy config instead of calling `MultiTenancyConfig` that will re-acquire the lock.
* Had a pass run with https://github.com/sasha-s/go-deadlock to find others -> all clear

Original fix by @etiennedi, re-opened to have a fix that is more in-line with the way the code base usually fix these problems (not a new function but instead reading the needed data while holding the lock).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9124531178
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
