### PR TITLE
add missing wait for schema version on vector.PutObject

### DIFF
--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -105,11 +105,6 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	}
 	obj.LastUpdateTimeUnix = m.timeSource.Now()
 
-	err = m.vectorRepo.PutObject(ctx, obj, res.Vector, res.Vectors, repl, schemaVersion)
-	if err != nil {
-		return &Error{"repo.putobject", StatusInternalServerError, err}
-	}
-
 	// Ensure that the local schema has caught up to the version we used to validate
 	if err := m.schemaManager.WaitForUpdate(ctx, schemaVersion); err != nil {
 		return &Error{
@@ -118,6 +113,12 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 			Err:  err,
 		}
 	}
+
+	err = m.vectorRepo.PutObject(ctx, obj, res.Vector, res.Vectors, repl, schemaVersion)
+	if err != nil {
+		return &Error{"repo.putobject", StatusInternalServerError, err}
+	}
+
 	if err := m.updateRefVector(ctx, principal, input.Class, input.ID, tenant, class, schemaVersion); err != nil {
 		return &Error{"update ref vector", StatusInternalServerError, err}
 	}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -107,6 +107,10 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 		return nil, NewErrInternal("update object: %v", err)
 	}
 
+	if err := m.schemaManager.WaitForUpdate(ctx, schemaVersion); err != nil {
+		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", schemaVersion, err)
+	}
+
 	err = m.vectorRepo.PutObject(ctx, updates, updates.Vector, updates.Vectors, repl, schemaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("put object: %w", err)

--- a/usecases/objects/vector.go
+++ b/usecases/objects/vector.go
@@ -45,6 +45,10 @@ func (m *Manager) updateRefVector(ctx context.Context, principal *models.Princip
 				className, id, err)
 		}
 
+		if err := m.schemaManager.WaitForUpdate(ctx, schemaVersion); err != nil {
+			return fmt.Errorf("error waiting for local schema to catch up to version %d: %w", schemaVersion, err)
+		}
+
 		if err := m.vectorRepo.PutObject(ctx, obj, obj.Vector, obj.Vectors, nil, schemaVersion); err != nil {
 			return fmt.Errorf("put object: %w", err)
 		}


### PR DESCRIPTION
### What's being changed:
this PR 
 - add missing WaitForUpdate(schemaVersion) in missing places in `vectorRepo` interface
 - correct the psoition of `waitForUpdate` to be before `putObject()` gets called

[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9126773304/job/25095711879)
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
