### PR TITLE
RAFT: avoid rebuilding GQL twice

### DIFF
--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -61,7 +61,6 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 			return fmt.Errorf("restore index %q: %w", i, err)
 		}
 	}
-	e.rebuildGQL(models.Schema{Classes: cs})
 	return nil
 }
 
@@ -231,19 +230,16 @@ func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList
 	return resp, nil
 }
 
-func (e *executor) rebuildGQL(s models.Schema) {
+func (e *executor) TriggerSchemaUpdateCallbacks() {
 	e.callbacksLock.RLock()
 	defer e.callbacksLock.RUnlock()
 
+	s := e.store.ReadOnlySchema()
 	for _, cb := range e.callbacks {
 		cb(schema.Schema{
 			Objects: &s,
 		})
 	}
-}
-
-func (e *executor) TriggerSchemaUpdateCallbacks() {
-	e.rebuildGQL(e.store.ReadOnlySchema())
 }
 
 // RegisterSchemaUpdateCallback allows other usecases to register a primitive


### PR DESCRIPTION
### What's being changed:
this fix some panic in availability of the GQL provider by avoiding rebuilding GQL in db reloads, given there is no need to rebuild the GQL specially on `reloadDB()` and it's redundant, given that the db will be reloaded from the schema and we trigger rebuilding GQL on schema updates.



```
github.com/weaviate/weaviate/modules/text2vec-transformers.(*TransformersModule).Arguments(0xc003cd3810)
	/go/src/github.com/weaviate/weaviate/modules/text2vec-transformers/nearText.go:26 +0x3d
github.com/weaviate/weaviate/usecases/modules.(*Provider).GetArguments(0xc003874910, 0xc0022cc018)
	/go/src/github.com/weaviate/weaviate/usecases/modules/modules.go:356 +0x2f8
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.buildGetClassField(0x4485c5?, 0xc0022cc018, {0x2fabd08?, 0xc003874910}, 0xc002c94960?)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/local/get/class_builder_fields.go:242 +0xd1c
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.(*classBuilder).classField(0xc002234b00, 0xc0022cc018, 0xc002c948d0?)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/local/get/class_builder.go:102 +0x169
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.(*classBuilder).kinds(0xc00280a3f0?, 0xc003aa3d40)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/local/get/class_builder.go:83 +0x350
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.(*classBuilder).objects(...)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/local/get/class_builder.go:65
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.Build(0xc00280a3f0, {0x2fbf6b0, 0xc003814500}, {0x2fabd08, 0xc003874910})
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/local/get/get.go:47 +0x117
github.com/weaviate/weaviate/adapters/handlers/graphql/local.Build(_, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, 0x186a0, {{0xc00005c042, ...}}, ...}, ...)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/local/local.go:29 +0x76
github.com/weaviate/weaviate/adapters/handlers/graphql.buildGraphqlSchema(_, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, 0x186a0, {{0xc00005c042, ...}}, ...}, ...)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/schema.go:87 +0xb8
github.com/weaviate/weaviate/adapters/handlers/graphql.Build(_, {_, _}, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, ...}, ...)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/graphql/schema.go:57 +0x278
github.com/weaviate/weaviate/adapters/handlers/rest.rebuildGraphQL({_}, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, 0x186a0, {{0xc00005c042, ...}}, ...}, ...)
	/go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_server.go:70 +0xff
github.com/weaviate/weaviate/adapters/handlers/rest.MakeAppState.makeUpdateSchemaCall.func6({0xc003cfa2c0?})
	/go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_server.go:52 +0x17b
github.com/weaviate/weaviate/usecases/schema.(*executor).rebuildGQL(0xc003cfa2a0, {{0xc000132a78, 0x1, 0x1}, {0x0, 0x0}, {0x0, 0x0}})
	/go/src/github.com/weaviate/weaviate/usecases/schema/executor.go:239 +0x1ca
github.com/weaviate/weaviate/usecases/schema.(*executor).ReloadLocalDB(0xc003cfa2a0, {0x2fa6888, 0x3ee7600}, {0xc002469070, 0x1, 0xc003ae9508?})
	/go/src/github.com/weaviate/weaviate/usecases/schema/executor.go:64 +0x3dc
github.com/weaviate/weaviate/cluster/store.(*Store).reloadDBFromSchema(0xc003cf7440)
	/go/src/github.com/weaviate/weaviate/cluster/store/store.go:944 +0x2eb
github.com/weaviate/weaviate/cluster/store.(*Store).Apply.func1()
	/go/src/github.com/weaviate/weaviate/cluster/store/store.go:660 +0x41d
github.com/weaviate/weaviate/cluster/store.(*Store).Apply(0xc003cf7440, 0xc0024ade00)
	/go/src/github.com/weaviate/weaviate/cluster/store/store.go:730 +0x11e6
github.com/hashicorp/raft.(*Raft).runFSM.func1(0xc0024627c0)
	/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/fsm.go:101 +0x3ac
github.com/hashicorp/raft.(*Raft).runFSM.func2({0xc0000b1600, 0x2, 0x4?})
	/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/fsm.go:124 +0x8a9
github.com/hashicorp/raft.(*Raft).runFSM(0xc0027842c0)
	/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/fsm.go:240 +0x734
github.com/hashicorp/raft.(*raftState).goFunc.func1()
	/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/state.go:149 +0x93
```
[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9138970555)
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
