### PR TITLE
Fix shard loading on t activation, speed up BQ cache loading

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -334,8 +334,32 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 	ec := &errorcompounder.ErrorCompounder{}
 
 	for _, name := range updatesHot {
-		_, err := idx.getOrInitLocalShard(ctx, name)
+		shard, err := idx.getOrInitLocalShard(ctx, name)
 		ec.Add(err)
+		if err != nil {
+			continue
+		}
+
+		// if the shard is a lazy load shard, we need to force its activation now
+		asLL, ok := shard.(*LazyLoadShard)
+		if !ok {
+			continue
+		}
+
+		go func(name string) {
+			// The timeout is rather arbitrary. It's meant to be so high that it can
+			// never stop a valid tenant activation use case, but low enough to
+			// prevent a context-leak.
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+			defer cancel()
+
+			if err := asLL.Load(ctx); err != nil {
+				idx.logger.WithFields(logrus.Fields{
+					"action": "tenant_activation_lazy_laod_shard",
+					"shard":  name,
+				}).WithError(err).Errorf("loading shard %q failed", name)
+			}
+		}(name)
 	}
 
 	if len(updatesCold) > 0 {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -596,7 +596,7 @@ func (index *flat) UpdateUserConfig(updated schemaConfig.VectorIndexConfig, call
 		return errors.Errorf("config is not UserConfig, but %T", updated)
 	}
 
-	// Store automatically as a lock here would be very expensive, this value is
+	// Store atomically as a lock here would be very expensive, this value is
 	// read on every single user-facing search, which can be highly concurrent
 	atomic.StoreInt64(&index.rescore, extractCompressionRescore(parsed))
 
@@ -643,10 +643,39 @@ func (index *flat) PostStartup() {
 	cursor := index.store.Bucket(index.getCompressedBucketName()).Cursor()
 	defer cursor.Close()
 
+	// The idea here is to first read everything from disk in one go, then grow
+	// the cache just once before inserting all vectors. A previous iteration
+	// would grow the cache as part of the cursor loop and this ended up making
+	// up 75% of the CPU time needed. This new implementation with two loops is
+	// much more efficient and only ever-so-slightly more memory-consuming (about
+	// one additional struct per vector while loading. Should be negligible)
+	type vec struct {
+		id  uint64
+		vec []uint64
+	}
+
+	// The initial size of 10k is chosen fairly arbitrarily. The cost of growing
+	// this slice dynamically should be quite cheap compared to other operations
+	// involved here, e.g. disk reads.
+	vecs := make([]vec, 0, 10_000)
+	maxID := uint64(0)
+
 	for key, v := cursor.First(); key != nil; key, v = cursor.Next() {
 		id := binary.BigEndian.Uint64(key)
-		index.bqCache.Grow(id)
-		index.bqCache.Preload(id, uint64SliceFromByteSlice(v, make([]uint64, len(v)/8)))
+		vecs = append(vecs, vec{
+			id:  id,
+			vec: uint64SliceFromByteSlice(v, make([]uint64, len(v)/8)),
+		})
+		if id > maxID {
+			maxID = id
+		}
+	}
+
+	// Grow cache just once
+	index.bqCache.Grow(maxID)
+
+	for _, vec := range vecs {
+		index.bqCache.Preload(vec.id, vec.vec)
 	}
 }
 
@@ -714,10 +743,6 @@ func ValidateUserConfigUpdate(initial, updated schemaConfig.VectorIndexConfig) e
 			accessor: func(c flatent.UserConfig) interface{} { return c.Distance },
 		},
 		{
-			name:     "bq.cache",
-			accessor: func(c flatent.UserConfig) interface{} { return c.BQ.Cache },
-		},
-		{
 			name:     "pq.cache",
 			accessor: func(c flatent.UserConfig) interface{} { return c.PQ.Cache },
 		},
@@ -729,6 +754,10 @@ func ValidateUserConfigUpdate(initial, updated schemaConfig.VectorIndexConfig) e
 			name:     "bq",
 			accessor: func(c flatent.UserConfig) interface{} { return c.BQ.Enabled },
 		},
+		// as of v1.25.2, updating the BQ cache setting is now possible.
+		// Note that the change does not take effect until the tenant is
+		// reloaded, either from a complete restart or from
+		// activating/deactivating it.
 	}
 
 	for _, u := range immutableFields {

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -42,7 +42,7 @@ case $CONFIG in
   local-single-node)
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       PERSISTENCE_DATA_PATH="./data-weaviate-0" \
-      BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \ 
+      BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
       ENABLE_MODULES="backup-filesystem" \
       CLUSTER_IN_LOCALHOST=true \
       CLUSTER_GOSSIP_BIND_PORT="7100" \


### PR DESCRIPTION
This commit combines three changes:

1. It now forces loading of a shard when a tenant is deactivated. This happens in the background, but it is triggered immediately. Previoulsy this was delayed (by lazy shard-loading) until the actual request came in. This however defeated the purpose of activating the tenant beforehand, as it was not ready to go when the request came.

2. If the flat index is used with BQ-caching, this commit speeds up the preloading time considerably. Previously we would dynamically grow the index as we read through the cursor. This lead to a lot of unnecessary copying. By growing just once, I could improve the startup time from 1.3s to 0.3s for a flat index with 1.25M BQ vectors

3. In addition it is now possible to change the bq.cache setting for the flat index. Note that changes will not take effect until there is a restart/reload of the shard. This is by design to prevent 1,000s of active tenant shards from suddenly hammering disks because of a config change.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
