### PR TITLE
Delete bloom tmp files before compaction

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -262,28 +262,34 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 		sg.segments[old2].countNetAdditions
 	sg.maintenanceLock.RUnlock()
 
-	sg.maintenanceLock.Lock()
+	err := func() error {
+		sg.maintenanceLock.Lock()
+		defer sg.maintenanceLock.Unlock()
+
+		leftSegment := sg.segments[old1]
+		rightSegment := sg.segments[old2]
+		newSegmentId := "segment-" + segmentID(leftSegment.path) + "_" + segmentID(rightSegment.path)
+
+		// delete any existing bloom tmp files in the form of segment-<seg1>_<seg2>*bloom.tmp
+		tmpFiles, err := filepath.Glob(filepath.Join(sg.dir, newSegmentId+"*bloom.tmp"))
+		if err != nil {
+			return errors.Wrap(err, "glob tmp files")
+		}
+
+		for _, tmpFile := range tmpFiles {
+			err = os.Remove(tmpFile)
+			if err != nil {
+				return errors.Wrap(err, "remove tmp file")
+			}
+		}
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
 
 	leftSegment := sg.segments[old1]
 	rightSegment := sg.segments[old2]
-	newSegmentId := "segment-" + segmentID(leftSegment.path) + "_" + segmentID(rightSegment.path)
-
-	// delete any existing bloom tmp files in the form of segment-<seg1>_<seg2>*bloom.tmp
-	tmpFiles, err := filepath.Glob(filepath.Join(sg.dir, newSegmentId+"*bloom.tmp"))
-	if err != nil {
-		sg.maintenanceLock.Unlock()
-		return errors.Wrap(err, "glob tmp files")
-	}
-
-	for _, tmpFile := range tmpFiles {
-		err = os.Remove(tmpFile)
-		if err != nil {
-			sg.maintenanceLock.Unlock()
-			return errors.Wrap(err, "remove tmp file")
-		}
-	}
-
-	sg.maintenanceLock.Unlock()
 
 	// WIP: we could add a random suffix to the tmp file to avoid conflicts
 	precomputedFiles, err := preComputeSegmentMeta(newPathTmp,

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -262,6 +262,30 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 		sg.segments[old2].countNetAdditions
 	sg.maintenanceLock.RUnlock()
 
+	sg.maintenanceLock.Lock()
+
+	leftSegment := sg.segments[old1]
+	rightSegment := sg.segments[old2]
+	newSegmentId := "segment-" + segmentID(leftSegment.path) + "_" + segmentID(rightSegment.path)
+
+	// delete any existing bloom tmp files in the form of segment-<seg1>_<seg2>*bloom.tmp
+	tmpFiles, err := filepath.Glob(filepath.Join(sg.dir, newSegmentId+"*bloom.tmp"))
+	if err != nil {
+		sg.maintenanceLock.Unlock()
+		return errors.Wrap(err, "glob tmp files")
+	}
+
+	for _, tmpFile := range tmpFiles {
+		err = os.Remove(tmpFile)
+		if err != nil {
+			sg.maintenanceLock.Unlock()
+			return errors.Wrap(err, "remove tmp file")
+		}
+	}
+
+	sg.maintenanceLock.Unlock()
+
+	// WIP: we could add a random suffix to the tmp file to avoid conflicts
 	precomputedFiles, err := preComputeSegmentMeta(newPathTmp,
 		updatedCountNetAdditions, sg.logger,
 		sg.useBloomFilter, sg.calcCountNetAdditions)
@@ -271,9 +295,6 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 
 	sg.maintenanceLock.Lock()
 	defer sg.maintenanceLock.Unlock()
-
-	leftSegment := sg.segments[old1]
-	rightSegment := sg.segments[old2]
 
 	if err := leftSegment.close(); err != nil {
 		return errors.Wrap(err, "close disk segment")


### PR DESCRIPTION
### What's being changed:

Remove bloom.tmp files from previous failed compaction

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
