### PR TITLE
Fix extracting near object vector for named vector classes

### DIFF
--- a/usecases/traverser/near_params_vector.go
+++ b/usecases/traverser/near_params_vector.go
@@ -186,6 +186,14 @@ func (v *nearParamsVector) classFindVector(ctx context.Context, className string
 			return nil, "", fmt.Errorf("vector not found for target: %v", targetVector)
 		}
 		return res.Vectors[targetVector], targetVector, nil
+	} else {
+		if len(res.Vectors) == 1 {
+			for key, vec := range res.Vectors {
+				return vec, key, nil
+			}
+		} else if len(res.Vectors) > 1 {
+			return nil, "", errors.New("multiple vectors found, specify target vector")
+		}
 	}
 	return res.Vector, targetVector, nil
 }
@@ -202,6 +210,14 @@ func (v *nearParamsVector) crossClassFindVector(ctx context.Context, id strfmt.U
 		if targetVector != "" {
 			if len(res[0].Vectors) == 0 || res[0].Vectors[targetVector] == nil {
 				return nil, "", fmt.Errorf("vector not found for target: %v", targetVector)
+			}
+		} else {
+			if len(res[0].Vectors) == 1 {
+				for key, vec := range res[0].Vectors {
+					return vec, key, nil
+				}
+			} else if len(res[0].Vectors) > 1 {
+				return nil, "", errors.New("multiple vectors found, specify target vector")
 			}
 		}
 		return res[0].Vector, targetVector, nil

--- a/usecases/traverser/near_params_vector_test.go
+++ b/usecases/traverser/near_params_vector_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
@@ -283,6 +284,79 @@ func Test_nearParamsVector_vectorFromParams(t *testing.T) {
 	}
 }
 
+func Test_nearParamsVector_multiVectorFromParams(t *testing.T) {
+	type args struct {
+		ctx          context.Context
+		nearVector   *searchparams.NearVector
+		nearObject   *searchparams.NearObject
+		moduleParams map[string]interface{}
+		className    string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		want             []float32
+		wantErr          bool
+		wantTargetVector string
+	}{
+		{
+			name: "Should get vector from nearObject with single multi vector no target vector",
+			args: args{
+				nearObject: &searchparams.NearObject{
+					ID: "uuid",
+				},
+				className: "SingleMultiVector",
+			},
+			want:             []float32{2.0, 2.0, 2.0},
+			wantErr:          false,
+			wantTargetVector: "Vector",
+		},
+		{
+			name: "Should get vector from nearObject with single multi vector and target vector",
+			args: args{
+				nearObject: &searchparams.NearObject{
+					ID:            "uuid",
+					TargetVectors: []string{"Vector"},
+				},
+				className: "SingleMultiVector",
+			},
+			want:             []float32{2.0, 2.0, 2.0},
+			wantErr:          false,
+			wantTargetVector: "Vector",
+		},
+		{
+			name: "Should get vector from nearObject with multi vector no target vector",
+			args: args{
+				nearObject: &searchparams.NearObject{
+					ID:            "uuid",
+					TargetVectors: []string{"B"},
+				},
+				className: "MultiMultiVector",
+			},
+			want:             []float32{4.0, 4.0, 4.0},
+			wantErr:          false,
+			wantTargetVector: "B",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &nearParamsVector{
+				modulesProvider: &fakeModulesProvider{},
+				search:          &fakeNearParamsSearcher{},
+			}
+			got, targetVector, err := e.vectorFromParams(tt.args.ctx, tt.args.nearVector, tt.args.nearObject, tt.args.moduleParams, tt.args.className, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nearParamsVector.vectorFromParams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("nearParamsVector.vectorFromParams() = %v, want %v", got, tt.want)
+			}
+			assert.Equal(t, tt.wantTargetVector, targetVector)
+		})
+	}
+}
+
 func Test_nearParamsVector_extractCertaintyFromParams(t *testing.T) {
 	type args struct {
 		nearVector   *searchparams.NearVector
@@ -387,6 +461,19 @@ func (f *fakeNearParamsSearcher) Object(ctx context.Context, className string, i
 	if className == "SpecifiedClass" {
 		return &search.Result{
 			Vector: []float32{0.0, 0.0, 0.0},
+		}, nil
+	} else if className == "SingleMultiVector" {
+		return &search.Result{
+			Vectors: models.Vectors{
+				"Vector": []float32{2.0, 2.0, 2.0},
+			},
+		}, nil
+	} else if className == "MultiMultiVector" {
+		return &search.Result{
+			Vectors: models.Vectors{
+				"A": []float32{3.0, 3.0, 3.0},
+				"B": []float32{4.0, 4.0, 4.0},
+			},
 		}, nil
 	} else {
 		return &search.Result{


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug whereby a `NearObject` search on a class with Named Vectors configured and only one unspecified vector would fail to find the vector leading to a internal error like:
```
explorer: get class: vector search: object vector search at index testcollectionqueryminimaloptions:
shard testcollectionqueryminimaloptions_mHrn5EOC74wr: vector search: knn search:
distance between entrypoint and query node: got a nil or zero-length vector as search vector
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
