### PR TITLE
RAFT: fix downgrade by conditioning migrate & apply

### DIFF
--- a/cluster/store/service.go
+++ b/cluster/store/service.go
@@ -227,7 +227,8 @@ func (s *Service) DeleteTenants(class string, req *cmd.DeleteTenantsRequest) (ui
 
 func (s *Service) StoreSchemaV1() error {
 	command := &cmd.ApplyRequest{
-		Type: cmd.ApplyRequest_TYPE_STORE_SCHEMA_V1,
+		Type:    cmd.ApplyRequest_TYPE_STORE_SCHEMA_V1,
+		Version: s.store.raft.AppliedIndex(),
 	}
 	_, err := s.Execute(command)
 	return err

--- a/cluster/store/store.go
+++ b/cluster/store/store.go
@@ -380,9 +380,18 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 	}
 }
 
-// StoreSchemaV1() is responsible for saving new schema (RAFT) to boltDB
-func (st *Store) StoreSchemaV1() error {
-	return st.saveLegacySchema(st.db.Schema.States())
+// StoreSchemaV1 is responsible for saving new schema (RAFT) to boltDB
+func (st *Store) StoreSchemaV1(cmd *command.ApplyRequest) error {
+	req := &command.ApplyRequest{}
+	if err := gproto.Unmarshal(cmd.SubCommand, req); err != nil {
+		return fmt.Errorf("%w: %w", errBadRequest, err)
+	}
+
+	if err := st.VersionedSchemaReader().WaitForUpdate(context.Background(), req.Version); err != nil {
+		return err
+	}
+
+	return st.saveLegacySchema(st.VersionedSchemaReader().schema.States())
 }
 
 func (st *Store) Close(ctx context.Context) error {
@@ -719,7 +728,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		ret.Error = st.db.DeleteTenants(&cmd, schemaOnly)
 
 	case api.ApplyRequest_TYPE_STORE_SCHEMA_V1:
-		ret.Error = st.StoreSchemaV1()
+		ret.Error = st.StoreSchemaV1(&cmd)
 
 	default:
 		// This could occur when a new command has been introduced in a later app version

--- a/cluster/store/store_test.go
+++ b/cluster/store/store_test.go
@@ -450,7 +450,6 @@ func TestStoreApply(t *testing.T) {
 				nil)},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("AddClass", mock.Anything).Return(nil)
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
@@ -500,7 +499,6 @@ func TestStoreApply(t *testing.T) {
 			doBefore: func(m *MockStore) {
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
 				m.indexer.On("RestoreClassDir", cls.Class).Return(nil)
-				m.indexer.On("AddClass", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -553,7 +551,6 @@ func TestStoreApply(t *testing.T) {
 			doBefore: func(m *MockStore) {
 				m.indexer.On("Open", mock.Anything).Return(nil)
 				m.parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(mock.Anything, nil)
-				m.indexer.On("UpdateClass", mock.Anything).Return(nil)
 				m.store.db.Schema.addClass(cls, ss, 1)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
@@ -565,7 +562,6 @@ func TestStoreApply(t *testing.T) {
 				nil)},
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
-				m.indexer.On("DeleteClass", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -610,7 +606,6 @@ func TestStoreApply(t *testing.T) {
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
 				m.store.db.Schema.addClass(cls, ss, 1)
-				m.indexer.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 			doAfter: func(ms *MockStore) error {
@@ -641,7 +636,6 @@ func TestStoreApply(t *testing.T) {
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
 				m.parser.On("ParseClass", mock.Anything).Return(nil)
-				m.indexer.On("UpdateShardStatus", mock.Anything).Return(nil)
 				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 			},
 		},
@@ -670,8 +664,6 @@ func TestStoreApply(t *testing.T) {
 				m.store.db.Schema.addClass(cls, &sharding.State{
 					Physical: map[string]sharding.Physical{"T1": {}},
 				}, 1)
-
-				m.indexer.On("AddTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				if _, ok := ms.store.db.Schema.Classes["C1"].Sharding.Physical["T1"]; !ok {
@@ -730,7 +722,6 @@ func TestStoreApply(t *testing.T) {
 					Status:         models.TenantActivityStatusHOT,
 				}}}
 				m.store.db.Schema.addClass(cls, ss, 1)
-				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				want := map[string]sharding.Physical{"T1": {
@@ -773,7 +764,6 @@ func TestStoreApply(t *testing.T) {
 			resp: Response{Error: nil},
 			doBefore: func(m *MockStore) {
 				m.store.db.Schema.addClass(cls, &sharding.State{Physical: map[string]sharding.Physical{"T1": {}}}, 1)
-				m.indexer.On("DeleteTenants", mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				if len(ms.store.db.Schema.Classes["C1"].Sharding.Physical) != 0 {


### PR DESCRIPTION
### What's being changed:
- make migration conditional if the node was empty only because it will force restore 
- load the DB with `dbLoaded` flag to report ready only if the node was empty on start, otherwise it will be loaded after catching up
- `schemaOnly` flag remove the condition about `lastAppliedIndexOnStart` 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
