### PR TITLE
Remove superfluous `findEntrypoint` in delete logic

### DIFF
--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -207,9 +207,6 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		n.graph.pools.visitedListsLock.RLock()
 		n.graph.pools.visitedLists.Return(visited)
 		n.graph.pools.visitedListsLock.RUnlock()
-		if err := n.pickEntrypoint(); err != nil {
-			return errors.Wrap(err, "pick entrypoint at level beginning")
-		}
 		// use dynamic max connections only during tombstone cleanup
 		maxConnections = n.maximumConnections(level)
 	} else {

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (h *hnsw) findAndConnectNeighbors(node *vertex,


### PR DESCRIPTION
## What's being changed:
* Removes all logic to find entry points from `reassignNeighbor` during HNSW delete cleanup
* The old logic would perform a search that needed an entry point
* The new logic recursively follows edges, so the node in question essentially is the entrypoint. No neutral entrypoint is necessary anymore
* For cases where `findEntrypoint` is actually needed, copy deny list _only_ if the entrypoint is unusable. This saves the expensive copy which is not needed on the happy path

## Validated using go benchmarker

Initial results (before deletes):
```
INFO[0070] Benchmark result                              api=grpc count=500 ef=16 failed=0 limit=10 mean=1.025199ms parallel=10 qps=9467.067348300565 recall=0.8655999999999991
INFO[0070] Benchmark result                              api=grpc count=500 ef=24 failed=0 limit=10 mean=1.053768ms parallel=10 qps=9213.454909416168 recall=0.9097999999999987
INFO[0070] Benchmark result                              api=grpc count=500 ef=32 failed=0 limit=10 mean=1.209932ms parallel=10 qps=8050.573704008582 recall=0.9341999999999988
INFO[0070] Benchmark result                              api=grpc count=500 ef=48 failed=0 limit=10 mean=1.500785ms parallel=10 qps=6317.801221200651 recall=0.9517999999999989
INFO[0070] Benchmark result                              api=grpc count=500 ef=64 failed=0 limit=10 mean=1.747242ms parallel=10 qps=5594.319527951318 recall=0.963199999999999
INFO[0070] Benchmark result                              api=grpc count=500 ef=96 failed=0 limit=10 mean=2.217309ms parallel=10 qps=4407.316854675311 recall=0.9761999999999993
INFO[0070] Benchmark result                              api=grpc count=500 ef=128 failed=0 limit=10 mean=3.243241ms parallel=10 qps=2952.2517562207636 recall=0.9841999999999995
INFO[0070] Benchmark result                              api=grpc count=500 ef=256 failed=0 limit=10 mean=4.4247ms parallel=10 qps=2179.9893657502753 recall=0.9913999999999997
INFO[0071] Benchmark result                              api=grpc count=500 ef=512 failed=0 limit=10 mean=7.431054ms parallel=10 qps=1308.4352617922766 recall=0.9955999999999997
```

Results after 10 iterations:
```
INFO[0399] Benchmark result                              api=grpc count=500 ef=16 failed=0 limit=10 mean=1.050205ms parallel=10 qps=9108.995913194329 recall=0.8413999999999983
INFO[0400] Benchmark result                              api=grpc count=500 ef=24 failed=0 limit=10 mean=1.036908ms parallel=10 qps=9202.432872945432 recall=0.8921999999999984
INFO[0400] Benchmark result                              api=grpc count=500 ef=32 failed=0 limit=10 mean=1.077703ms parallel=10 qps=8899.535264488582 recall=0.9193999999999989
INFO[0400] Benchmark result                              api=grpc count=500 ef=48 failed=0 limit=10 mean=1.359177ms parallel=10 qps=7191.403430857489 recall=0.9437999999999986
INFO[0400] Benchmark result                              api=grpc count=500 ef=64 failed=0 limit=10 mean=1.615267ms parallel=10 qps=5928.713176480847 recall=0.9593999999999988
INFO[0400] Benchmark result                              api=grpc count=500 ef=96 failed=0 limit=10 mean=2.185487ms parallel=10 qps=4378.954743502725 recall=0.9745999999999991
INFO[0400] Benchmark result                              api=grpc count=500 ef=128 failed=0 limit=10 mean=2.504089ms parallel=10 qps=3807.03654564732 recall=0.9815999999999994
INFO[0400] Benchmark result                              api=grpc count=500 ef=256 failed=0 limit=10 mean=4.16963ms parallel=10 qps=2296.946137067881 recall=0.9911999999999997
INFO[0401] Benchmark result                              api=grpc count=500 ef=512 failed=0 limit=10 mean=7.098344ms parallel=10 qps=1365.2574504747672 recall=0.9945999999999998

```


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
