### PR TITLE
chore: remove commented out method in repos/sorter package

### DIFF
--- a/adapters/repos/db/sorter/comparable_creator.go
+++ b/adapters/repos/db/sorter/comparable_creator.go
@@ -43,10 +43,6 @@ func (c *comparableCreator) createFromBytesWithPayload(docID uint64, objData []b
 	return &comparable{docID, values, payload}
 }
 
-// func (c *comparableCreator) createFromObject(object *storobj.Object) *comparable {
-// 	return c.createFromObjectWithPayload(object, nil)
-// }
-
 func (c *comparableCreator) createFromObjectWithPayload(object *storobj.Object, payload interface{}) *comparable {
 	values := make([]interface{}, len(c.propNames))
 	for level, propName := range c.propNames {


### PR DESCRIPTION
### What's being changed:
Found method `createFromObject` to be commented out, and
not having any references to it in the current codebase.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
