### PR TITLE
ISSUE-4234 Add pagination to Get Tenants endpoint

### DIFF
--- a/adapters/handlers/grpc/v1/tenants.go
+++ b/adapters/handlers/grpc/v1/tenants.go
@@ -27,7 +27,7 @@ func (s *Service) tenantsGet(ctx context.Context, principal *models.Principal, r
 	var err error
 	var tenants []*models.Tenant
 	if req.Params == nil {
-		tenants, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, []string{})
+		tenants, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, []string{}, &req.After, &req.Limit)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +38,7 @@ func (s *Service) tenantsGet(ctx context.Context, principal *models.Principal, r
 			if len(requestedNames) == 0 {
 				return nil, fmt.Errorf("must specify at least one tenant name")
 			}
-			tenants, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, requestedNames)
+			tenants, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, requestedNames, &req.After, &req.Limit)
 			if err != nil {
 				return nil, err
 			}

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2797,6 +2797,18 @@ func init() {
             "description": "If consistency is true, the request will be proxied to the leader to ensure strong schema consistency",
             "name": "consistency",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "If tenant is provided, the pagination cursor will start after this tenant.",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "The maximum number of tenants to return.",
+            "name": "limit",
+            "in": "query"
           }
         ],
         "responses": {
@@ -8174,6 +8186,18 @@ func init() {
             "description": "If consistency is true, the request will be proxied to the leader to ensure strong schema consistency",
             "name": "consistency",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "description": "If tenant is provided, the pagination cursor will start after this tenant.",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "The maximum number of tenants to return.",
+            "name": "limit",
+            "in": "query"
           }
         ],
         "responses": {

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -274,7 +274,7 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 func (s *schemaHandlers) getTenants(params schema.TenantsGetParams,
 	principal *models.Principal,
 ) middleware.Responder {
-	tenants, err := s.manager.GetConsistentTenants(params.HTTPRequest.Context(), principal, params.ClassName, *params.Consistency, nil)
+	tenants, err := s.manager.GetConsistentTenants(params.HTTPRequest.Context(), principal, params.ClassName, *params.Consistency, nil, params.After, params.Limit)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch err.(type) {
@@ -292,7 +292,7 @@ func (s *schemaHandlers) getTenants(params schema.TenantsGetParams,
 }
 
 func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principal *models.Principal) middleware.Responder {
-	if err := s.manager.ConsistentTenantExists(params.HTTPRequest.Context(), principal, params.ClassName, *params.Consistency, params.TenantName); err != nil {
+	if err := s.manager.ConsistentTenantExists(params.HTTPRequest.Context(), principal, params.ClassName, *params.Consistency, params.TenantName, nil, nil); err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		if err == schemaUC.ErrNotFound {
 			return schema.NewTenantExistsNotFound()

--- a/adapters/handlers/rest/operations/schema/tenants_get_parameters.go
+++ b/adapters/handlers/rest/operations/schema/tenants_get_parameters.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -49,6 +50,10 @@ type TenantsGetParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*If tenant is provided, the pagination cursor will start after this tenant.
+	  In: query
+	*/
+	After *string
 	/*
 	  Required: true
 	  In: path
@@ -59,6 +64,10 @@ type TenantsGetParams struct {
 	  Default: true
 	*/
 	Consistency *bool
+	/*The maximum number of tenants to return.
+	  In: query
+	*/
+	Limit *int64
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -70,6 +79,13 @@ func (o *TenantsGetParams) BindRequest(r *http.Request, route *middleware.Matche
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qAfter, qhkAfter, _ := qs.GetOK("after")
+	if err := o.bindAfter(qAfter, qhkAfter, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	rClassName, rhkClassName, _ := route.Params.GetOK("className")
 	if err := o.bindClassName(rClassName, rhkClassName, route.Formats); err != nil {
 		res = append(res, err)
@@ -78,9 +94,32 @@ func (o *TenantsGetParams) BindRequest(r *http.Request, route *middleware.Matche
 	if err := o.bindConsistency(r.Header[http.CanonicalHeaderKey("consistency")], true, route.Formats); err != nil {
 		res = append(res, err)
 	}
+
+	qLimit, qhkLimit, _ := qs.GetOK("limit")
+	if err := o.bindLimit(qLimit, qhkLimit, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindAfter binds and validates parameter After from query.
+func (o *TenantsGetParams) bindAfter(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.After = &raw
+
 	return nil
 }
 
@@ -117,6 +156,29 @@ func (o *TenantsGetParams) bindConsistency(rawData []string, hasKey bool, format
 		return errors.InvalidType("consistency", "header", "bool", raw)
 	}
 	o.Consistency = &value
+
+	return nil
+}
+
+// bindLimit binds and validates parameter Limit from query.
+func (o *TenantsGetParams) bindLimit(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertInt64(raw)
+	if err != nil {
+		return errors.InvalidType("limit", "query", "int64", raw)
+	}
+	o.Limit = &value
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/schema/tenants_get_urlbuilder.go
+++ b/adapters/handlers/rest/operations/schema/tenants_get_urlbuilder.go
@@ -21,11 +21,16 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
+
+	"github.com/go-openapi/swag"
 )
 
 // TenantsGetURL generates an URL for the tenants get operation
 type TenantsGetURL struct {
 	ClassName string
+
+	After *string
+	Limit *int64
 
 	_basePath string
 	// avoid unkeyed usage
@@ -65,6 +70,26 @@ func (o *TenantsGetURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var afterQ string
+	if o.After != nil {
+		afterQ = *o.After
+	}
+	if afterQ != "" {
+		qs.Set("after", afterQ)
+	}
+
+	var limitQ string
+	if o.Limit != nil {
+		limitQ = swag.FormatInt64(*o.Limit)
+	}
+	if limitQ != "" {
+		qs.Set("limit", limitQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/client/schema/tenants_get_parameters.go
+++ b/client/schema/tenants_get_parameters.go
@@ -73,6 +73,12 @@ TenantsGetParams contains all the parameters to send to the API endpoint
 */
 type TenantsGetParams struct {
 
+	/* After.
+
+	   If tenant is provided, the pagination cursor will start after this tenant.
+	*/
+	After *string
+
 	// ClassName.
 	ClassName string
 
@@ -83,6 +89,12 @@ type TenantsGetParams struct {
 	   Default: true
 	*/
 	Consistency *bool
+
+	/* Limit.
+
+	   The maximum number of tenants to return.
+	*/
+	Limit *int64
 
 	timeout    time.Duration
 	Context    context.Context
@@ -148,6 +160,17 @@ func (o *TenantsGetParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAfter adds the after to the tenants get params
+func (o *TenantsGetParams) WithAfter(after *string) *TenantsGetParams {
+	o.SetAfter(after)
+	return o
+}
+
+// SetAfter adds the after to the tenants get params
+func (o *TenantsGetParams) SetAfter(after *string) {
+	o.After = after
+}
+
 // WithClassName adds the className to the tenants get params
 func (o *TenantsGetParams) WithClassName(className string) *TenantsGetParams {
 	o.SetClassName(className)
@@ -170,6 +193,17 @@ func (o *TenantsGetParams) SetConsistency(consistency *bool) {
 	o.Consistency = consistency
 }
 
+// WithLimit adds the limit to the tenants get params
+func (o *TenantsGetParams) WithLimit(limit *int64) *TenantsGetParams {
+	o.SetLimit(limit)
+	return o
+}
+
+// SetLimit adds the limit to the tenants get params
+func (o *TenantsGetParams) SetLimit(limit *int64) {
+	o.Limit = limit
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *TenantsGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -177,6 +211,23 @@ func (o *TenantsGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
+
+	if o.After != nil {
+
+		// query param after
+		var qrAfter string
+
+		if o.After != nil {
+			qrAfter = *o.After
+		}
+		qAfter := qrAfter
+		if qAfter != "" {
+
+			if err := r.SetQueryParam("after", qAfter); err != nil {
+				return err
+			}
+		}
+	}
 
 	// path param className
 	if err := r.SetPathParam("className", o.ClassName); err != nil {
@@ -188,6 +239,23 @@ func (o *TenantsGetParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		// header param consistency
 		if err := r.SetHeaderParam("consistency", swag.FormatBool(*o.Consistency)); err != nil {
 			return err
+		}
+	}
+
+	if o.Limit != nil {
+
+		// query param limit
+		var qrLimit int64
+
+		if o.Limit != nil {
+			qrLimit = *o.Limit
+		}
+		qLimit := swag.FormatInt64(qrLimit)
+		if qLimit != "" {
+
+			if err := r.SetQueryParam("limit", qLimit); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cluster/proto/api/request.go
+++ b/cluster/proto/api/request.go
@@ -51,6 +51,8 @@ type QueryReadOnlyClassResponse struct {
 type QueryTenantsRequest struct {
 	Class   string
 	Tenants []string // If empty, all tenants are returned
+	After   *string
+	Limit   *int64
 }
 
 type TenantWithVersion struct {

--- a/cluster/schema/manager_query.go
+++ b/cluster/schema/manager_query.go
@@ -60,7 +60,7 @@ func (sm *SchemaManager) QueryTenants(req *cmd.QueryRequest) ([]byte, error) {
 	}
 
 	// Read the tenants
-	tenants, err := sm.schema.getTenants(subCommand.Class, subCommand.Tenants)
+	tenants, err := sm.schema.getTenants(subCommand.Class, subCommand.Tenants, subCommand.After, subCommand.Limit)
 	if err != nil {
 		return []byte{}, fmt.Errorf("could not get tenants: %w", err)
 	}

--- a/cluster/utils/priorityqueue/queue.go
+++ b/cluster/utils/priorityqueue/queue.go
@@ -1,0 +1,105 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package priorityqueue
+
+// StringPriorityQueue is a max-heap priority queue for string items.
+type StringPriorityQueue struct {
+	items []string
+}
+
+// NewMaxStringPriorityQueue constructs a priority queue with the specified initial capacity (initial length is always 0).
+func NewMaxStringPriorityQueue(capacity int) *StringPriorityQueue {
+	return &StringPriorityQueue{
+		items: make([]string, 0, capacity),
+	}
+}
+
+// Pop removes the next max string in the queue and returns it.
+func (q *StringPriorityQueue) Pop() string {
+	if len(q.items) == 0 {
+		panic("string priority queue is empty")
+	}
+	out := q.items[0]
+	q.items[0] = q.items[len(q.items)-1]
+	q.items = q.items[:len(q.items)-1]
+	q.heapify(0)
+	return out
+}
+
+// Top peeks at the next item in the queue.
+func (q *StringPriorityQueue) Top() string {
+	return q.items[0]
+}
+
+// Len returns the length of the queue.
+func (q *StringPriorityQueue) Len() int {
+	return len(q.items)
+}
+
+// Cap returns the remaining capacity of the queue.
+func (q *StringPriorityQueue) Cap() int {
+	return cap(q.items)
+}
+
+// Reset clears all strings from the queue.
+func (q *StringPriorityQueue) Reset() {
+	q.items = q.items[:0]
+}
+
+// ResetCap drops existing queue strings, and allocates a new queue with the given capacity.
+func (q *StringPriorityQueue) ResetCap(capacity int) {
+	q.items = make([]string, 0, capacity)
+}
+
+// Insert adds the provided string to the queue.
+func (q *StringPriorityQueue) Insert(item string) int {
+	return q.insert(item)
+}
+
+func (q *StringPriorityQueue) insert(item string) int {
+	q.items = append(q.items, item)
+	i := len(q.items) - 1
+	for i != 0 && q.items[i] > q.items[q.parent(i)] {
+		q.swap(i, q.parent(i))
+		i = q.parent(i)
+	}
+	return i
+}
+
+func (q *StringPriorityQueue) left(i int) int { return 2*i + 1 }
+
+func (q *StringPriorityQueue) right(i int) int { return 2*i + 2 }
+
+func (q *StringPriorityQueue) parent(i int) int { return (i - 1) / 2 }
+
+func (q *StringPriorityQueue) swap(i, j int) {
+	q.items[i], q.items[j] = q.items[j], q.items[i]
+}
+
+// heapify maintains the max-heap property.
+func (q *StringPriorityQueue) heapify(i int) {
+	left := q.left(i)
+	right := q.right(i)
+	largest := i
+	if left < len(q.items) && q.items[left] > q.items[i] {
+		largest = left
+	}
+
+	if right < len(q.items) && q.items[right] > q.items[largest] {
+		largest = right
+	}
+
+	if largest != i {
+		q.swap(i, largest)
+		q.heapify(largest)
+	}
+}

--- a/grpc/generated/protocol/v1/tenants.pb.go
+++ b/grpc/generated/protocol/v1/tenants.pb.go
@@ -81,6 +81,8 @@ type TenantsGetRequest struct {
 	//
 	//	*TenantsGetRequest_Names
 	Params isTenantsGetRequest_Params `protobuf_oneof:"params"`
+	After  string                     `protobuf:"bytes,4,opt,name=after,proto3" json:"after,omitempty"`
+	Limit  int64                      `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
 }
 
 func (x *TenantsGetRequest) Reset() {
@@ -134,6 +136,20 @@ func (x *TenantsGetRequest) GetNames() *TenantNames {
 		return x.Names
 	}
 	return nil
+}
+
+func (x *TenantsGetRequest) GetAfter() string {
+	if x != nil {
+		return x.After
+	}
+	return ""
+}
+
+func (x *TenantsGetRequest) GetLimit() int64 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
 }
 
 type isTenantsGetRequest_Params interface {

--- a/grpc/proto/v1/tenants.proto
+++ b/grpc/proto/v1/tenants.proto
@@ -21,6 +21,8 @@ message TenantsGetRequest {
   oneof params {
     TenantNames names = 2;
   };
+  string after = 4;
+  int64 limit = 5;
 }
 
 message TenantNames {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -4626,6 +4626,20 @@
             "default": true,
             "type": "boolean",
             "description": "If consistency is true, the request will be proxied to the leader to ensure strong schema consistency"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If tenant is provided, the pagination cursor will start after this tenant."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "description": "The maximum number of tenants to return."
           }
         ],
         "responses": {

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -27,6 +27,11 @@ import (
 // A component-test like test suite that makes sure that every available UC is
 // potentially protected with the Authorization plugin
 func Test_Schema_Authorization(t *testing.T) {
+	var (
+		after = "after"
+		limit = int64(1)
+	)
+
 	type testCase struct {
 		methodName       string
 		additionalArgs   []interface{}
@@ -128,19 +133,19 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:       "GetTenants",
-			additionalArgs:   []interface{}{"className"},
+			additionalArgs:   []interface{}{"className", &after, &limit},
 			expectedVerb:     "get",
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "GetConsistentTenants",
-			additionalArgs:   []interface{}{"className", false, []string{}},
+			additionalArgs:   []interface{}{"className", false, []string{}, &after, &limit},
 			expectedVerb:     "get",
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "ConsistentTenantExists",
-			additionalArgs:   []interface{}{"className", false, "P1"},
+			additionalArgs:   []interface{}{"className", false, "P1", &after, &limit},
 			expectedVerb:     "get",
 			expectedResource: tenantsPath,
 		},

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -121,6 +121,15 @@ func (f *fakeMetaHandler) ClassInfoWithVersion(ctx context.Context, class string
 	return args.Get(0).(clusterSchema.ClassInfo), args.Error(1)
 }
 
+func (f *fakeMetaHandler) GetConsistentTenants(ctx context.Context, class string, consistency bool, after *string, tenant *int64) ([]*models.Tenant, error) {
+	args := f.Called(ctx, class, consistency, after, tenant)
+	rTenant := args.Get(0)
+	if rTenant == nil {
+		return nil, args.Error(1)
+	}
+	return rTenant.([]*models.Tenant), args.Error(1)
+}
+
 func (f *fakeMetaHandler) QuerySchema() (models.Schema, error) {
 	args := f.Called()
 	return args.Get(0).(models.Schema), args.Error(1)
@@ -137,9 +146,14 @@ func (f *fakeMetaHandler) QueryReadOnlyClasses(classes ...string) (map[string]ve
 	return models.(map[string]versioned.Class), nil
 }
 
-func (f *fakeMetaHandler) QueryTenants(class string, tenants []string) ([]*models.Tenant, uint64, error) {
-	args := f.Called(class)
-	return nil, 0, args.Error(0)
+func (f *fakeMetaHandler) QueryTenants(class string, tenants []string, after *string, limit *int64) ([]*models.Tenant, uint64, error) {
+	args := f.Called(class, after, limit)
+	tenant := args.Get(0)
+	if tenant == nil {
+		return nil, 0, args.Error(2)
+	}
+	shardVersion := args.Get(1)
+	return tenant.([]*models.Tenant), shardVersion.(uint64), args.Error(2)
 }
 
 func (f *fakeMetaHandler) QueryShardOwner(class, shard string) (string, uint64, error) {

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -47,7 +47,7 @@ type metaWriter interface {
 	QueryReadOnlyClasses(names ...string) (map[string]versioned.Class, error)
 	QuerySchema() (models.Schema, error)
 	// QueryTenants returns the tenants for a class. If tenants is empty, all tenants are returned.
-	QueryTenants(class string, tenants []string) ([]*models.Tenant, uint64, error)
+	QueryTenants(class string, tenants []string, after *string, limit *int64) ([]*models.Tenant, uint64, error)
 	QueryShardOwner(class, shard string) (string, uint64, error)
 	QueryTenantsShards(class string, tenants ...string) (map[string]string, uint64, error)
 	QueryShardingState(class string) (*sharding.State, uint64, error)


### PR DESCRIPTION
Updated GetConsistentTenants endpoint with `after` and `limit` vars in order to implement pagination for th endpoint. This required refactoring the following: the implementation of QueryTenantRequest by adding the `after` and `limit` vars. Also, the implementation of getTenants (original handler.getTenant and cluster/store schema .getTenants) method with the addition of `after` and `limit` vars  which included the addition of implementation of pagination in its code definition.

Note, we created priority queue package to represent a max-heap of string  items. This is used to implement pagination.

`after` is the tenant for which GET of tenants will be after. `limit` is the limit of tenants we GET.

Added test for GetConsistenTenants endpoint.

Added additional test case for QueryTenants test case in cluster store test for TestServiceEndpoints to ensure after and limit worked correctly with the cluster store as well.