### PR TITLE
Keep track of deleted tombstones across commit logs

### DIFF
--- a/adapters/repos/db/vector/hnsw/deserializer_test.go
+++ b/adapters/repos/db/vector/hnsw/deserializer_test.go
@@ -357,7 +357,10 @@ func TestDeserializerRemoveTombstone(t *testing.T) {
 		4: {},
 		5: {},
 	}
-	ids := []uint64{2, 3, 4, 5, 6}
+	ids := []uint64{2, 3, 4, 5, 7}
+	deletedTombstones := map[uint64]struct{}{
+		6: {},
+	}
 
 	for _, id := range ids {
 		val := make([]byte, 8)
@@ -368,15 +371,21 @@ func TestDeserializerRemoveTombstone(t *testing.T) {
 
 		reader := bufio.NewReader(data)
 
-		err := d.ReadRemoveTombstone(reader, tombstones)
+		err := d.ReadRemoveTombstone(reader, tombstones, deletedTombstones)
 		require.Nil(t, err)
 	}
 
-	expected := map[uint64]struct{}{
+	expectedTombstones := map[uint64]struct{}{
 		1: {},
 	}
 
-	assert.Equal(t, expected, tombstones)
+	expectedDeletedTombstones := map[uint64]struct{}{
+		6: {},
+		7: {},
+	}
+
+	assert.Equal(t, expectedTombstones, tombstones)
+	assert.Equal(t, expectedDeletedTombstones, deletedTombstones)
 }
 
 func TestDeserializerClearLinksAtLevel(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
- Fixes https://github.com/weaviate/weaviate/issues/5019
- The HNSW commit log deserializer now maintains a map of deleted tombstones
- When condensing, an add and remove tombstone converts into a no-op
- Have also added some more debug logs to the deserializer

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
