### PR TITLE
replication: replica fail early on getters with no-retry errors

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -15,12 +15,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"regexp"
 
 	"github.com/go-openapi/strfmt"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -364,6 +366,12 @@ func (i *replicatedIndices) getObjectsDigest() http.Handler {
 		}
 
 		results, err := i.shards.DigestObjects(r.Context(), index, shard, ids)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, "digest objects: "+err.Error(),
+				http.StatusUnprocessableEntity)
+			return
+		}
+
 		if err != nil {
 			http.Error(w, "digest objects: "+err.Error(),
 				http.StatusInternalServerError)
@@ -580,6 +588,12 @@ func (i *replicatedIndices) getObject() http.Handler {
 		)
 
 		resp, err = i.shards.FetchObject(r.Context(), index, shard, strfmt.UUID(id))
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, "digest objects: "+err.Error(),
+				http.StatusUnprocessableEntity)
+			return
+		}
+
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -631,6 +645,11 @@ func (i *replicatedIndices) getObjectsMulti() http.Handler {
 		}
 
 		resp, err := i.shards.FetchObjects(r.Context(), index, shard, ids)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, "digest objects: "+err.Error(),
+				http.StatusUnprocessableEntity)
+			return
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -28,7 +28,7 @@ func Serve(appState *state.State) {
 		Debugf("serving cluster api on port %d", port)
 
 	schema := NewSchema(appState.SchemaManager.TxManager(), auth)
-	indices := NewIndices(appState.RemoteIndexIncoming, appState.DB, auth)
+	indices := NewIndices(appState.RemoteIndexIncoming, appState.DB, auth, appState.Logger)
 	replicatedIndices := NewReplicatedIndices(appState.RemoteReplicaIncoming, appState.Scaler, auth)
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager(), auth)
 	nodes := NewNodes(appState.RemoteNodeIncoming, auth)

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -99,7 +99,7 @@ func (n *node) init(dirName string, shardStateRaw []byte,
 
 	n.migrator = db.NewMigrator(n.repo, logger)
 
-	indices := clusterapi.NewIndices(sharding.NewRemoteIndexIncoming(n.repo), n.repo, clusterapi.NewNoopAuthHandler())
+	indices := clusterapi.NewIndices(sharding.NewRemoteIndexIncoming(n.repo), n.repo, clusterapi.NewNoopAuthHandler(), logger)
 	mux := http.NewServeMux()
 	mux.Handle("/indices/", indices.Indices())
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -38,12 +38,14 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/autocut"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
@@ -105,7 +107,12 @@ func (m *shardMap) Load(name string) ShardLike {
 	if !ok {
 		return nil
 	}
-	return v.(ShardLike)
+
+	shard, ok := v.(ShardLike)
+	if !ok {
+		return nil
+	}
+	return shard
 }
 
 // Store sets a shard giving its name and value
@@ -928,6 +935,10 @@ func (i *Index) IncomingGetObject(ctx context.Context, shardName string,
 		return nil, errShardNotFound
 	}
 
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	}
+
 	return shard.ObjectByID(ctx, id, props, additional)
 }
 
@@ -937,6 +948,10 @@ func (i *Index) IncomingMultiGetObjects(ctx context.Context, shardName string,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return nil, errShardNotFound
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.MultiObjectByID(ctx, wrapIDsInMulti(ids))
@@ -1061,6 +1076,10 @@ func (i *Index) IncomingExists(ctx context.Context, shardName string,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return false, errShardNotFound
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return false, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.Exists(ctx, id)
@@ -1220,6 +1239,9 @@ func (i *Index) objectSearchByShard(ctx context.Context, limit int, filters *fil
 						"local shard object search %s: %w", shard.ID(), err)
 				}
 			} else {
+
+				i.logger.WithField("shardName", shardName).Debug("shard was not found locally, search for object remotely")
+
 				objs, scores, nodeName, err = i.remote.SearchShard(
 					ctx, shardName, nil, limit, filters, keywordRanking,
 					sort, cursor, nil, addlProps, i.replicationEnabled())
@@ -1320,6 +1342,9 @@ func (i *Index) singleLocalShardObjectVectorSearch(ctx context.Context, searchVe
 		return nil, nil, errors.Wrapf(err, "shard %s", shard.ID())
 	}
 
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	}
 	return res, resDists, nil
 }
 
@@ -1461,6 +1486,10 @@ func (i *Index) IncomingSearch(ctx context.Context, shardName string,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return nil, nil, errShardNotFound
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	if searchVector == nil {
@@ -1636,6 +1665,10 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return nil, errShardNotFound
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.Aggregate(ctx, params)
@@ -1815,6 +1848,11 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	if shard == nil {
 		return 0, errShardNotFound
 	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return 0, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	}
+
 	return shard.Queue().Size(), nil
 }
 
@@ -1854,6 +1892,10 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return "", errShardNotFound
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return "", enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 	return shard.GetStatus().String(), nil
 }
@@ -1920,6 +1962,10 @@ func (i *Index) IncomingFindUUIDs(ctx context.Context, shardName string,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return nil, errShardNotFound
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.FindUUIDs(ctx, filters)

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -22,9 +22,11 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -374,6 +376,9 @@ func (db *DB) DigestObjects(ctx context.Context,
 	class, shardName string, ids []strfmt.UUID,
 ) (result []replica.RepairResponse, err error) {
 	index := db.GetIndex(schema.ClassName(class))
+	if index == nil {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s index not found", class))
+	}
 	return index.digestObjects(ctx, shardName, ids)
 }
 
@@ -384,6 +389,10 @@ func (i *Index) digestObjects(ctx context.Context,
 	s := i.localShard(shardName)
 	if s == nil {
 		return nil, fmt.Errorf("shard %q not found locally", shardName)
+	}
+
+	if s.GetStatus() == storagestate.StatusLoading {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	multiIDs := make([]multi.Identifier, len(ids))
@@ -431,6 +440,9 @@ func (db *DB) FetchObject(ctx context.Context,
 	class, shardName string, id strfmt.UUID,
 ) (objects.Replica, error) {
 	index := db.GetIndex(schema.ClassName(class))
+	if index == nil {
+		return objects.Replica{}, enterrors.NewErrUnprocessable(fmt.Errorf("local %s index is not found", class))
+	}
 	return index.readRepairGetObject(ctx, shardName, id)
 }
 
@@ -440,6 +452,10 @@ func (i *Index) readRepairGetObject(ctx context.Context,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return objects.Replica{}, fmt.Errorf("shard %q does not exist locally", shardName)
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return objects.Replica{}, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	obj, err := shard.ObjectByID(ctx, id, nil, additional.Properties{})
@@ -468,6 +484,9 @@ func (db *DB) FetchObjects(ctx context.Context,
 	class, shardName string, ids []strfmt.UUID,
 ) ([]objects.Replica, error) {
 	index := db.GetIndex(schema.ClassName(class))
+	if index == nil {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s index not found", class))
+	}
 	return index.fetchObjects(ctx, shardName, ids)
 }
 
@@ -477,6 +496,10 @@ func (i *Index) fetchObjects(ctx context.Context,
 	shard := i.localShard(shardName)
 	if shard == nil {
 		return nil, fmt.Errorf("shard %q does not exist locally", shardName)
+	}
+
+	if shard.GetStatus() == storagestate.StatusLoading {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	objs, err := shard.MultiObjectByID(ctx, wrapIDsInMulti(ids))

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -247,39 +247,12 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	}
 	s.NotifyReady()
 
-	simulateLoadTime()
-
 	if exists {
 		s.index.logger.Printf("Completed loading shard %s in %s", s.ID(), time.Since(before))
 	} else {
 		s.index.logger.Printf("Created shard %s in %s", s.ID(), time.Since(before))
 	}
 	return s, nil
-}
-
-func simulateLoadTime() {
-	loadTime, ok := os.LookupEnv("SIMULATE_LOAD_TIME")
-	if !ok {
-		return
-	}
-
-	d, err := time.ParseDuration(loadTime)
-	if err != nil {
-		d = 30 * time.Second
-	}
-	loadCtx, cancelLoadCtx := context.WithTimeout(context.Background(), d)
-	defer cancelLoadCtx()
-
-	c := time.Tick(1 * time.Second)
-
-	for {
-		select {
-		case <-loadCtx.Done():
-			return
-		case <-c:
-			fmt.Println("Waiting for shard to be ready")
-		}
-	}
 }
 
 func (s *Shard) initVector(ctx context.Context) error {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -256,6 +256,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	}
 	return s, nil
 }
+
 func simulateLoadTime() {
 	loadTime, ok := os.LookupEnv("SIMULATE_LOAD_TIME")
 	if !ok {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -205,6 +205,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		replicationMap:   pendingReplicaTasks{Tasks: make(map[string]replicaTask, 32)},
 		centralJobQueue:  jobQueueCh,
 		indexCheckpoints: indexCheckpoints,
+		status:           storagestate.StatusLoading,
 	}
 	s.initCycleCallbacks()
 
@@ -246,12 +247,38 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	}
 	s.NotifyReady()
 
+	simulateLoadTime()
+
 	if exists {
 		s.index.logger.Printf("Completed loading shard %s in %s", s.ID(), time.Since(before))
 	} else {
 		s.index.logger.Printf("Created shard %s in %s", s.ID(), time.Since(before))
 	}
 	return s, nil
+}
+func simulateLoadTime() {
+	loadTime, ok := os.LookupEnv("SIMULATE_LOAD_TIME")
+	if !ok {
+		return
+	}
+
+	d, err := time.ParseDuration(loadTime)
+	if err != nil {
+		d = 30 * time.Second
+	}
+	loadCtx, cancelLoadCtx := context.WithTimeout(context.Background(), d)
+	defer cancelLoadCtx()
+
+	c := time.Tick(1 * time.Second)
+
+	for {
+		select {
+		case <-loadCtx.Done():
+			return
+		case <-c:
+			fmt.Println("Waiting for shard to be ready")
+		}
+	}
 }
 
 func (s *Shard) initVector(ctx context.Context) error {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -133,7 +133,6 @@ func (l *LazyLoadShard) NotifyReady() {
 }
 
 func (l *LazyLoadShard) GetStatus() storagestate.Status {
-	l.mustLoad()
 	return l.shard.GetStatus()
 }
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -133,6 +133,7 @@ func (l *LazyLoadShard) NotifyReady() {
 }
 
 func (l *LazyLoadShard) GetStatus() storagestate.Status {
+	l.mustLoad()
 	return l.shard.GetStatus()
 }
 

--- a/entities/storagestate/status.go
+++ b/entities/storagestate/status.go
@@ -16,6 +16,7 @@ import "errors"
 const (
 	StatusReadOnly Status = "READONLY"
 	StatusIndexing Status = "INDEXING"
+	StatusLoading  Status = "LOADING"
 	StatusReady    Status = "READY"
 )
 

--- a/test/acceptance_with_go_client/filters_tests/regex_test.go
+++ b/test/acceptance_with_go_client/filters_tests/regex_test.go
@@ -12,9 +12,10 @@
 package filters_tests
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"testing"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -173,7 +173,7 @@ func (c *coordinator[T]) Pull(ctx context.Context,
 		return nil, state, fmt.Errorf("%w : class %q shard %q", err, c.Class, c.Shard)
 	}
 	level := state.Level
-	replyCh := make(chan _Result[T], level)
+	replyCh := make(chan _Result[T], len(state.Hosts)-level)
 
 	candidates := state.Hosts[:level]                          // direct ones
 	candidatePool := make(chan string, len(state.Hosts)-level) // remaining ones

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
@@ -130,7 +131,7 @@ func (rii *RemoteIndexIncoming) GetObject(ctx context.Context, indexName,
 ) (*storobj.Object, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return nil, errors.Errorf("local index %q not found", indexName)
+		return nil, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingGetObject(ctx, shardName, id, selectProperties, additional)
@@ -141,7 +142,7 @@ func (rii *RemoteIndexIncoming) Exists(ctx context.Context, indexName,
 ) (bool, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return false, errors.Errorf("local index %q not found", indexName)
+		return false, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingExists(ctx, shardName, id)
@@ -174,7 +175,7 @@ func (rii *RemoteIndexIncoming) MultiGetObjects(ctx context.Context, indexName,
 ) ([]*storobj.Object, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return nil, errors.Errorf("local index %q not found", indexName)
+		return nil, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingMultiGetObjects(ctx, shardName, ids)
@@ -187,7 +188,7 @@ func (rii *RemoteIndexIncoming) Search(ctx context.Context, indexName, shardName
 ) ([]*storobj.Object, []float32, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return nil, nil, errors.Errorf("local index %q not found", indexName)
+		return nil, nil, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingSearch(
@@ -199,7 +200,7 @@ func (rii *RemoteIndexIncoming) Aggregate(ctx context.Context, indexName, shardN
 ) (*aggregation.Result, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return nil, errors.Errorf("local index %q not found", indexName)
+		return nil, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingAggregate(ctx, shardName, params)
@@ -210,7 +211,7 @@ func (rii *RemoteIndexIncoming) FindUUIDs(ctx context.Context, indexName, shardN
 ) ([]strfmt.UUID, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return nil, errors.Errorf("local index %q not found", indexName)
+		return nil, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingFindUUIDs(ctx, shardName, filters)
@@ -233,7 +234,7 @@ func (rii *RemoteIndexIncoming) GetShardQueueSize(ctx context.Context,
 ) (int64, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return 0, errors.Errorf("local index %q not found", indexName)
+		return 0, enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingGetShardQueueSize(ctx, shardName)
@@ -244,7 +245,7 @@ func (rii *RemoteIndexIncoming) GetShardStatus(ctx context.Context,
 ) (string, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return "", errors.Errorf("local index %q not found", indexName)
+		return "", enterrors.NewErrUnprocessable(errors.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingGetShardStatus(ctx, shardName)
@@ -310,7 +311,7 @@ func (rii *RemoteIndexIncoming) DigestObjects(ctx context.Context,
 ) ([]replica.RepairResponse, error) {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
 	if index == nil {
-		return nil, fmt.Errorf("local index %q not found", indexName)
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local index %q not found", indexName))
 	}
 
 	return index.IncomingDigestObjects(ctx, shardName, ids)


### PR DESCRIPTION
### What's being changed:
this PR: 
 - introduces a new sharding state `LOADING` which shall be assigned to a shard once created and changed later when the shard notify raady to `READY`
 - it forces all replication `GET` to respond early with non retriable error if index is not existsing yet or Shard isnot ready yet
 
 this **decision** was made to return non-retriable error in case the index doesn't exists or shard status is `LOADING` in order to move faster with candidates in the pool for replication get with different *CL*
 
 this shall resolve https://github.com/weaviate/weaviate/issues/5020

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
