### PR TITLE
Add support for X-Google-Vertex-Api-Key header in multi2vec-palm module

### DIFF
--- a/modules/multi2vec-palm/clients/palm.go
+++ b/modules/multi2vec-palm/clients/palm.go
@@ -175,6 +175,9 @@ func (v *palm) checkResponse(statusCode int, palmApiError *palmApiError) error {
 }
 
 func (v *palm) getApiKey(ctx context.Context) (string, error) {
+	if apiKeyValue := v.getValueFromContext(ctx, "X-Google-Vertex-Api-Key"); apiKeyValue != "" {
+		return apiKeyValue, nil
+	}
 	if apiKeyValue := v.getValueFromContext(ctx, "X-Google-Api-Key"); apiKeyValue != "" {
 		return apiKeyValue, nil
 	}
@@ -185,7 +188,7 @@ func (v *palm) getApiKey(ctx context.Context) (string, error) {
 		return v.apiKey, nil
 	}
 	return "", errors.New("no api key found " +
-		"neither in request header: X-Palm-Api-Key or X-Google-Api-Key " +
+		"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key " +
 		"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY")
 }
 

--- a/modules/multi2vec-palm/clients/palm_test.go
+++ b/modules/multi2vec-palm/clients/palm_test.go
@@ -167,7 +167,7 @@ func TestClient(t *testing.T) {
 
 		require.NotNil(t, err)
 		assert.Equal(t, err.Error(), "Google API Key: no api key found "+
-			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key "+
+			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key "+
 			"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY")
 	})
 
@@ -187,7 +187,7 @@ func TestClient(t *testing.T) {
 
 		require.NotNil(t, err)
 		assert.Equal(t, err.Error(), "Google API Key: no api key found "+
-			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key "+
+			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key "+
 			"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY")
 	})
 }


### PR DESCRIPTION
### What's being changed:

Add support for `X-Google-Vertex-Api-Key` header in `multi2vec-palm` module

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
