### PR TITLE
Fix Azure OpenAI batch endpoint handling

### DIFF
--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -185,7 +185,7 @@ func (v *vectorizer) GetApiKeyHash(ctx context.Context, config moduletools.Class
 	return sha256.Sum256([]byte(key))
 }
 
-func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	rpm, _ := modulecomponents.GetRateLimitFromContext(ctx, "Cohere", DefaultRPM, 0)
 
 	execAfterRequestFunction := func(limits *modulecomponents.RateLimits, tokensUsed int, deductRequest bool) {

--- a/modules/text2vec-cohere/clients/cohere_test.go
+++ b/modules/text2vec-cohere/clients/cohere_test.go
@@ -207,7 +207,7 @@ func TestClient(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Cohere-Ratelimit-RequestPM-Embedding", []string{"50"})
 
-		rl := c.GetVectorizerRateLimit(ctxWithValue)
+		rl := c.GetVectorizerRateLimit(ctxWithValue, fakeClassConfig{classConfig: map[string]interface{}{}})
 		assert.Equal(t, 50, rl.LimitRequests)
 		assert.Equal(t, 50, rl.RemainingRequests)
 	})

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -75,7 +75,7 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
@@ -112,7 +112,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context, config moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
 }
 

--- a/modules/text2vec-huggingface/clients/huggingface.go
+++ b/modules/text2vec-huggingface/clients/huggingface.go
@@ -231,7 +231,7 @@ func (v *vectorizer) GetApiKeyHash(ctx context.Context, config moduletools.Class
 	return sha256.Sum256([]byte(key))
 }
 
-func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	rpm, _ := modulecomponents.GetRateLimitFromContext(ctx, "Cohere", DefaultRPM, 0)
 
 	execAfterRequestFunction := func(limits *modulecomponents.RateLimits, tokensUsed int, deductRequest bool) {

--- a/modules/text2vec-huggingface/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-huggingface/vectorizer/fakes_for_test.go
@@ -47,7 +47,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context, config moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
 }
 

--- a/modules/text2vec-jinaai/clients/jinaai.go
+++ b/modules/text2vec-jinaai/clients/jinaai.go
@@ -222,7 +222,7 @@ func (v *vectorizer) GetApiKeyHash(ctx context.Context, config moduletools.Class
 	return sha256.Sum256([]byte(key))
 }
 
-func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	rpm, _ := modulecomponents.GetRateLimitFromContext(ctx, "Jinaai", DefaultRPM, 0)
 
 	execAfterRequestFunction := func(limits *modulecomponents.RateLimits, tokensUsed int, deductRequest bool) {

--- a/modules/text2vec-jinaai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-jinaai/vectorizer/fakes_for_test.go
@@ -47,7 +47,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
 }
 

--- a/modules/text2vec-octoai/clients/octoai.go
+++ b/modules/text2vec-octoai/clients/octoai.go
@@ -201,7 +201,7 @@ func (v *vectorizer) GetApiKeyHash(ctx context.Context, config moduletools.Class
 	return sha256.Sum256([]byte(key))
 }
 
-func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	rpm, _ := modulecomponents.GetRateLimitFromContext(ctx, "OctoAI", DefaultRPM, 0)
 
 	execAfterRequestFunction := func(limits *modulecomponents.RateLimits, tokensUsed int, deductRequest bool) {

--- a/modules/text2vec-octoai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-octoai/vectorizer/fakes_for_test.go
@@ -47,7 +47,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
 }
 

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -254,8 +254,13 @@ func (v *client) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig)
 	return sha256.Sum256([]byte(key))
 }
 
-func (v *client) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
-	rpm, tpm := modulecomponents.GetRateLimitFromContext(ctx, "Openai", 0, 0)
+func (v *client) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
+	config := v.getVectorizationConfig(cfg)
+	name := "Openai"
+	if config.IsAzure {
+		name = "Azure"
+	}
+	rpm, tpm := modulecomponents.GetRateLimitFromContext(ctx, name, 0, 0)
 	return &modulecomponents.RateLimits{
 		RemainingTokens:   tpm,
 		LimitTokens:       tpm,

--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -258,7 +258,7 @@ func TestClient(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Openai-Ratelimit-RequestPM-Embedding", []string{"50"})
 
-		rl := c.GetVectorizerRateLimit(ctxWithValue)
+		rl := c.GetVectorizerRateLimit(ctxWithValue, fakeClassConfig{})
 		assert.Equal(t, 50, rl.LimitRequests)
 		assert.Equal(t, 50, rl.RemainingRequests)
 	})
@@ -268,7 +268,7 @@ func TestClient(t *testing.T) {
 
 		ctxWithValue := context.WithValue(context.Background(), "X-Openai-Ratelimit-TokenPM-Embedding", []string{"60"})
 
-		rl := c.GetVectorizerRateLimit(ctxWithValue)
+		rl := c.GetVectorizerRateLimit(ctxWithValue, fakeClassConfig{})
 		assert.Equal(t, 60, rl.LimitTokens)
 		assert.Equal(t, 60, rl.RemainingTokens)
 	})

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -19,6 +19,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 )
 
+const dummyLimit = 10000000
+
 func GetRateLimitsFromHeader(header http.Header) *modulecomponents.RateLimits {
 	requestsReset, err := time.ParseDuration(header.Get("x-ratelimit-reset-requests"))
 	if err != nil {
@@ -28,11 +30,23 @@ func GetRateLimitsFromHeader(header http.Header) *modulecomponents.RateLimits {
 	if err != nil {
 		tokensReset = 0
 	}
+	limitRequests := getHeaderInt(header, "x-ratelimit-limit-requests")
+	limitTokens := getHeaderInt(header, "x-ratelimit-limit-tokens")
+	remainingRequests := getHeaderInt(header, "x-ratelimit-remaining-requests")
+	remainingTokens := getHeaderInt(header, "x-ratelimit-remaining-tokens")
+
+	// azure returns 0 as limit, make sure this does not block anything by setting a high value
+	if limitTokens == 0 && remainingTokens > 0 {
+		limitTokens = dummyLimit
+	}
+	if limitRequests == 0 && remainingRequests > 0 {
+		limitTokens = dummyLimit
+	}
 	return &modulecomponents.RateLimits{
-		LimitRequests:     getHeaderInt(header, "x-ratelimit-limit-requests"),
-		LimitTokens:       getHeaderInt(header, "x-ratelimit-limit-tokens"),
-		RemainingRequests: getHeaderInt(header, "x-ratelimit-remaining-requests"),
-		RemainingTokens:   getHeaderInt(header, "x-ratelimit-remaining-tokens"),
+		LimitRequests:     limitRequests,
+		LimitTokens:       limitTokens,
+		RemainingRequests: remainingRequests,
+		RemainingTokens:   remainingTokens,
 		ResetRequests:     time.Now().Add(requestsReset),
 		ResetTokens:       time.Now().Add(tokensReset),
 	}

--- a/modules/text2vec-openai/vectorizer/batch_test.go
+++ b/modules/text2vec-openai/vectorizer/batch_test.go
@@ -81,6 +81,13 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "has error again"}},
 		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{3: fmt.Errorf("context deadline exceeded or cancelled"), 5: fmt.Errorf("context deadline exceeded or cancelled")}},
+		{name: "azure limit without total Limit", objects: []*models.Object{
+			{Class: "Car", Properties: map[string]interface{}{"test": "azureTokens 15"}}, // set azure limit without total Limit
+			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long"}},
+			{Class: "Car", Properties: map[string]interface{}{"test": "something"}},
+			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},
+			{Class: "Car", Properties: map[string]interface{}{"test": "all works"}},
+		}, skip: []bool{false, false, false, true, false}},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -50,6 +50,13 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 			rateLimit.LimitTokens = 2 * rate
 		}
 
+		azureTok := len("azureTokens ")
+		if len(text[i]) >= azureTok && text[i][:azureTok] == "azureTokens " {
+			rate, _ := strconv.Atoi(text[i][tok:])
+			rateLimit.RemainingTokens = rate
+			rateLimit.LimitTokens = 0
+		}
+
 		req := len("requests ")
 		if len(text[i]) >= req && text[i][:req] == "requests " {
 			reqs, _ := strconv.Atoi(strings.Split(text[i][req:], " ")[0])
@@ -82,7 +89,7 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
@@ -119,7 +126,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{}
 }
 

--- a/modules/text2vec-voyageai/clients/voyageai.go
+++ b/modules/text2vec-voyageai/clients/voyageai.go
@@ -188,7 +188,7 @@ func (v *vectorizer) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassCon
 	return sha256.Sum256([]byte(key))
 }
 
-func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (v *vectorizer) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	rpm, tpm := modulecomponents.GetRateLimitFromContext(ctx, "Voyageai", defaultRPM, defaultTPM)
 	execAfterRequestFunction := func(limits *modulecomponents.RateLimits, tokensUsed int, deductRequest bool) {
 		// refresh is after 60 seconds but leave a bit of room for errors. Otherwise, we only deduct the request that just happened

--- a/modules/text2vec-voyageai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-voyageai/vectorizer/fakes_for_test.go
@@ -74,7 +74,7 @@ func (c *fakeBatchClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 
@@ -111,7 +111,7 @@ func (c *fakeClient) VectorizeQuery(ctx context.Context,
 	}, nil
 }
 
-func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{RemainingTokens: 0, RemainingRequests: 0, LimitTokens: 0, ResetTokens: time.Now(), ResetRequests: time.Now()}
 }
 

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -49,7 +49,7 @@ type BatchJob struct {
 type BatchClient interface {
 	Vectorize(ctx context.Context, input []string,
 		config moduletools.ClassConfig) (*modulecomponents.VectorizationResult, *modulecomponents.RateLimits, error)
-	GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits
+	GetVectorizerRateLimit(ctx context.Context, config moduletools.ClassConfig) *modulecomponents.RateLimits
 	GetApiKeyHash(ctx context.Context, config moduletools.ClassConfig) [32]byte
 }
 
@@ -97,7 +97,7 @@ func (b *Batch) batchWorker() {
 		// check if we already have rate limits for the current api key and reuse them if possible
 		rateLimit, ok := rateLimitPerApiKey[job.apiKeyHash]
 		if !ok {
-			rateLimit = b.client.GetVectorizerRateLimit(job.ctx)
+			rateLimit = b.client.GetVectorizerRateLimit(job.ctx, job.cfg)
 		} else {
 			rateLimit.CheckForReset()
 		}

--- a/usecases/modulecomponents/batch/fakes_for_test.go
+++ b/usecases/modulecomponents/batch/fakes_for_test.go
@@ -81,7 +81,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 	}, rateLimit, reqError
 }
 
-func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context) *modulecomponents.RateLimits {
+func (c *fakeBatchClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
 	return &modulecomponents.RateLimits{RemainingTokens: c.defaultTPM, RemainingRequests: c.defaultRPM, LimitTokens: c.defaultTPM, LimitRequests: c.defaultRPM, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 }
 


### PR DESCRIPTION
### What's being changed:

The header returned by azure openAi looks different than from openai (ofc it does -_-) - it misses the totalLimit for requests/tokens and just sends 0 instead. This sets a high dummy value in this case to avoid that some checks get triggered.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
