### PR TITLE
backup:scheduler: compare and error based on major versions only

### DIFF
--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -26,6 +26,8 @@ import (
 // Version of backup structure
 const (
 	// Version > version1 support compression
+	// "2.1" support restore on 2 phases
+	// "2.0" support compression
 	Version = "2.0"
 	// version1 store plain files without compression
 	version1 = "1.0"

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -227,7 +227,7 @@ func (r *restorer) validate(ctx context.Context, store *nodeStore, req *Request)
 	if err := meta.Validate(meta.Version > version1); err != nil {
 		return nil, nil, fmt.Errorf("corrupted backup file: %w", err)
 	}
-	if v := meta.Version; v > Version {
+	if v := meta.Version; v[0] > Version[0] {
 		return nil, nil, fmt.Errorf("%s: %s > %s", errMsgHigherVersion, v, Version)
 	}
 	cs := meta.List()

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -274,7 +274,7 @@ func (s *Scheduler) validateRestoreRequest(ctx context.Context, store coordStore
 	if err := meta.Validate(); err != nil {
 		return nil, fmt.Errorf("corrupted backup file: %w", err)
 	}
-	if v := meta.Version; v > Version {
+	if v := meta.Version; v[0] > Version[0] {
 		return nil, fmt.Errorf("%s: %s > %s", errMsgHigherVersion, v, Version)
 	}
 	cs := meta.Classes()


### PR DESCRIPTION
### What's being changed:

the version was changed during raft impl. to 2.1 instead of 2.0 [here](https://github.com/weaviate/weaviate/pull/4619/files#diff-07990adc31916b6a5a8c6b809bd1826421b29b8c4b95dd0a43ccb5cbe3fb6c9aR29) . this PR change is made to compare major version comparisons only to avoid unnecessarily errors

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
