### PR TITLE
Replication: bubble up error on replication writes if shard init errors

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -219,13 +219,9 @@ func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string
 
 func (i *Index) CommitReplication(shard, requestID string) interface{} {
 	localShard, err := i.getOrInitLocalShard(context.Background(), shard)
-	// TODO-RAFT no error response on error?
 	if err != nil {
-		return nil
-	}
-	if localShard == nil {
 		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: shard},
+			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
 		}}
 	}
 	return localShard.commitReplication(context.Background(), requestID, &i.backupMutex)
@@ -235,7 +231,7 @@ func (i *Index) AbortReplication(shard, requestID string) interface{} {
 	localShard, err := i.getOrInitLocalShard(context.Background(), shard)
 	if err != nil {
 		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: shard},
+			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
 		}}
 	}
 	return localShard.abortReplication(context.Background(), requestID)


### PR DESCRIPTION
### What's being changed:
after syncing with changes from 1.24, some parts was adjusted, this PR add missing part by reporting error correctly on replication `Commit()` and `Abort()`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
