### PR TITLE
Better error handling during LSM store initialization

### DIFF
--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -134,6 +134,7 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
 		// bucket.
 		s.logger.
 			WithFields(logrus.Fields{
+				"action":   "lsm_create_or_load_bucket",
 				"root_dir": s.rootDir,
 				"dir":      s.dir,
 				"bucket":   bucketName,

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -118,7 +119,29 @@ func (s *Store) bucketDir(bucketName string) string {
 //	b := store.Bucket("my_bucket_name")
 func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
 	opts ...BucketOption,
-) error {
+) (err error) {
+	defer func() {
+		p := recover()
+		if p == nil {
+			// happy path
+			return
+		}
+
+		err = fmt.Errorf("unexpected error loading bucket %q at path %q: %v",
+			bucketName, s.rootDir, p)
+		// logger is already annotated to identify the store (e.g. collection +
+		// shard), we only need to annotate it with the exact path of this
+		// bucket.
+		s.logger.
+			WithFields(logrus.Fields{
+				"root_dir": s.rootDir,
+				"dir":      s.dir,
+				"bucket":   bucketName,
+			}).
+			WithError(err).Errorf("unexpected error loading shard")
+		debug.PrintStack()
+	}()
+
 	var bucketLock *sync.Mutex
 
 	s.bucketAccessLock.Lock()


### PR DESCRIPTION
### What's being changed:
* Catch panics inside `(*lsmkv.Store).CreateOrLoadBucket()` and treat them as unexpected errors
* Annotate error precisely so it can be narrowed down to the exact bucket that has an issue
* This helps mitigate whatever the issue is

### Example:
<img width="1427" alt="Screenshot 2024-06-01 at 9 16 40 AM" src="https://github.com/weaviate/weaviate/assets/8974479/83a769c3-40a6-49f0-8aa9-c5de37132623">


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
