### PR TITLE
Fix score extraction

### DIFF
--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -417,7 +417,13 @@ func (db *DB) getStoreObjectsWithScores(res []*storobj.Object, scores []float32,
 	if offset == 0 && limit == 0 {
 		return nil, nil
 	}
-	return res[offset:limit], scores[offset:limit]
+	res = res[offset:limit]
+	// not all search results have scores
+	if len(scores) == 0 {
+		return res, scores
+	}
+
+	return res, scores[offset:limit]
 }
 
 func (db *DB) getDists(dists []float32, pagination *filters.Pagination) []float32 {

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -29,6 +29,7 @@ services:
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
       DISABLE_TELEMETRY: true
       DISABLE_RECOVERY_ON_PANIC: true
+      QUERY_MAXIMUM_RESULTS: 10005
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -471,7 +471,10 @@ func SearchResultsWithScore(in []*Object, scores []float32, additional additiona
 	out := make(search.Results, len(in))
 
 	for i, elem := range in {
-		score := scores[i]
+		score := float32(0.0)
+		if len(scores) > i {
+			score = scores[i]
+		}
 		out[i] = elem.SearchResultWithScoreAndTenant(additional, score, tenant)
 	}
 

--- a/test/acceptance_with_python/test_limits.py
+++ b/test/acceptance_with_python/test_limits.py
@@ -1,0 +1,16 @@
+import weaviate
+import weaviate.classes as wvc
+
+from conftest import CollectionFactory
+
+
+def test_requesting_more_than_the_default_limit(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        vectorizer_config=wvc.config.Configure.Vectorizer.none(),
+    )
+    # This bug is somewhat hard to trigger and needs two things:
+    # 1. A higher than default QUERY_MAXIMUM_RESULTS in the weaviate config
+    # 2. Adding more objects than the default limit to the collection
+    # 3. Querying, so the limit is lower than the limit, but that limit+offset are higher than the default limit
+    collection.data.insert_many([{} for _ in range(10001)])
+    collection.query.fetch_objects(limit=9999, offset=2)


### PR DESCRIPTION
### What's being changed:

This was introduced in 1.24

For some searches no scores are returned, other parts of the code expect them to be present. This PR adds handling for not-present scores, but it might be necessary to check why the scores are expected now

Other version: https://github.com/weaviate/weaviate/pull/5067

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
