### PR TITLE
Add slow query reporter to ObjectSearch and ObjectVectorSearch

### DIFF
--- a/adapters/repos/db/helpers/slow_queries.go
+++ b/adapters/repos/db/helpers/slow_queries.go
@@ -50,7 +50,7 @@ func NewSlowQueryReporterFromEnv(logger logrus.FieldLogger) SlowQueryReporter {
 		return &NoopSlowReporter{}
 	}
 
-	threshold := 5 * time.Second
+	threshold := defaultSlowLogThreshold
 	if thresholdStr, ok := os.LookupEnv(thresholdEnvVar); ok {
 		thresholdP, err := time.ParseDuration(thresholdStr)
 		if err != nil {

--- a/adapters/repos/db/helpers/slow_queries.go
+++ b/adapters/repos/db/helpers/slow_queries.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	enabledEnvVar   = "QUERY_SLOW_LOG_ENABLED"
+	thresholdEnvVar = "QUERY_SLOW_LOG_THRESHOLD"
+)
+
+type SlowQueryReporter interface {
+	LogIfSlow(time.Time, map[string]any)
+}
+
+type BaseSlowReporter struct {
+	threshold time.Duration
+	log       logrus.FieldLogger
+}
+
+func NewSlowQueryReporterFromEnv(logger logrus.FieldLogger) SlowQueryReporter {
+	enabled := false
+	if enabledStr, ok := os.LookupEnv(enabledEnvVar); ok {
+		// TODO: Log warning if bool can't be parsed
+		enabled, _ = strconv.ParseBool(enabledStr)
+	}
+	if !enabled {
+		return &NoopSlowReporter{}
+	}
+
+	threshold := 5 * time.Second
+	if thresholdStr, ok := os.LookupEnv(thresholdEnvVar); ok {
+		thresholdP, err := time.ParseDuration(thresholdStr)
+		if err != nil {
+			logger.WithField("action", "startup").Warningf("Unexpected value \"%s\" for %s. Please set a duration (i.e. 10s). Continuing with default value (%s).", thresholdStr, thresholdEnvVar, threshold)
+		} else {
+			threshold = thresholdP
+		}
+	}
+	return NewSlowQueryReporter(threshold, logger)
+}
+
+func NewSlowQueryReporter(threshold time.Duration, logger logrus.FieldLogger) *BaseSlowReporter {
+	logger.WithField("action", "startup").Printf("Starting SlowQueryReporter with %s threshold", threshold)
+	return &BaseSlowReporter{
+		threshold: threshold,
+		log:       logger,
+	}
+}
+
+// LogIfSlow prints a warning log if the request takes longer than the threshold.
+// Usage:
+//
+//		startTime := time.Now()
+//		defer s.slowQueryReporter.LogIfSlow(startTime, map[string]any{
+//			"key": "value"
+//	  })
+//
+// TODO (sebneira): Consider providing fields out of the box (e.g. shard info). Right now we're
+// limited because of circular dependencies.
+func (sq *BaseSlowReporter) LogIfSlow(startTime time.Time, fields map[string]any) {
+	took := time.Since(startTime)
+	if took > sq.threshold {
+		sq.log.WithFields(fields).Warn(fmt.Sprintf("Slow query detected (%s)", took.Round(time.Millisecond)))
+	}
+}
+
+// NoopSlowReporter is used when the reporter is disabled.
+type NoopSlowReporter struct{}
+
+func (sq *NoopSlowReporter) LogIfSlow(startTime time.Time, fields map[string]any) {
+}

--- a/adapters/repos/db/helpers/slow_queries.go
+++ b/adapters/repos/db/helpers/slow_queries.go
@@ -45,6 +45,7 @@ func NewSlowQueryReporterFromEnv(logger logrus.FieldLogger) SlowQueryReporter {
 	if enabledStr, ok := os.LookupEnv(enabledEnvVar); ok {
 		// TODO: Log warning if bool can't be parsed
 		enabled, _ = strconv.ParseBool(enabledStr)
+		fmt.Println("en", enabledStr, enabled)
 	}
 	if !enabled {
 		return &NoopSlowReporter{}

--- a/adapters/repos/db/helpers/slow_queries_test.go
+++ b/adapters/repos/db/helpers/slow_queries_test.go
@@ -1,0 +1,73 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlowQueryReporter_LogIfSlow(t *testing.T) {
+	tests := map[string]struct {
+		// input
+		enabled   bool
+		threshold time.Duration
+		latencyMs int
+		expected  any
+		fields    map[string]any
+
+		// output
+		expectLog bool
+		message   string
+	}{
+		"sanity": {
+			enabled:   true,
+			threshold: 200 * time.Millisecond,
+			latencyMs: 2000,
+			fields:    map[string]any{"foo": "bar"},
+
+			expectLog: true,
+			message:   "Slow query detected (2s)",
+		},
+		"fast query": {
+			enabled:   true,
+			threshold: 100 * time.Millisecond,
+			latencyMs: 50,
+			fields:    map[string]any{"foo": "bar"},
+
+			expectLog: false,
+			message:   "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+			logger.Error("Helloerror")
+			sq := NewSlowQueryReporter(tt.threshold, logger)
+
+			startTime := time.Now().Add(-time.Duration(tt.latencyMs) * time.Millisecond)
+
+			// Call method
+			sq.LogIfSlow(startTime, tt.fields)
+
+			// Assertions
+			if tt.expectLog {
+				assert.Equal(t, tt.message, hook.LastEntry().Message)
+				assert.Equal(t, logrus.Fields(tt.fields), hook.LastEntry().Data)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/helpers/slow_queries_test.go
+++ b/adapters/repos/db/helpers/slow_queries_test.go
@@ -110,6 +110,11 @@ func TestSlowQueryReporterFromEnv(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			// Unset env from previous cases
+			// TODO: Pass config instead of using env directly to avoid this
+			os.Unsetenv(enabledEnvVar)
+			os.Unsetenv(thresholdEnvVar)
+
 			if tt.enabledStr != "" {
 				os.Setenv(enabledEnvVar, tt.enabledStr)
 			}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -159,20 +159,21 @@ type ShardLike interface {
 // database files for all the objects it owns. How a shard is determined for a
 // target object (e.g. Murmur hash, etc.) is still open at this point
 type Shard struct {
-	index            *Index // a reference to the underlying index, which in turn contains schema information
-	queue            *IndexQueue
-	queues           map[string]*IndexQueue
-	name             string
-	store            *lsmkv.Store
-	counter          *indexcounter.Counter
-	indexCheckpoints *indexcheckpoint.Checkpoints
-	vectorIndex      VectorIndex
-	vectorIndexes    map[string]VectorIndex
-	metrics          *Metrics
-	promMetrics      *monitoring.PrometheusMetrics
-	propertyIndices  propertyspecific.Indices
-	propLenTracker   *inverted.JsonShardMetaData
-	versioner        *shardVersioner
+	index             *Index // a reference to the underlying index, which in turn contains schema information
+	queue             *IndexQueue
+	queues            map[string]*IndexQueue
+	name              string
+	store             *lsmkv.Store
+	counter           *indexcounter.Counter
+	indexCheckpoints  *indexcheckpoint.Checkpoints
+	vectorIndex       VectorIndex
+	vectorIndexes     map[string]VectorIndex
+	metrics           *Metrics
+	promMetrics       *monitoring.PrometheusMetrics
+	slowQueryReporter helpers.SlowQueryReporter
+	propertyIndices   propertyspecific.Indices
+	propLenTracker    *inverted.JsonShardMetaData
+	versioner         *shardVersioner
 
 	status              storagestate.Status
 	statusLock          sync.Mutex
@@ -212,11 +213,12 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		promMetrics: promMetrics,
 		metrics: NewMetrics(index.logger, promMetrics,
 			string(index.Config.ClassName), shardName),
-		stopMetrics:      make(chan struct{}),
-		replicationMap:   pendingReplicaTasks{Tasks: make(map[string]replicaTask, 32)},
-		centralJobQueue:  jobQueueCh,
-		indexCheckpoints: indexCheckpoints,
-		status:           storagestate.StatusLoading,
+		slowQueryReporter: helpers.NewSlowQueryReporterFromEnv(index.logger),
+		stopMetrics:       make(chan struct{}),
+		replicationMap:    pendingReplicaTasks{Tasks: make(map[string]replicaTask, 32)},
+		centralJobQueue:   jobQueueCh,
+		indexCheckpoints:  indexCheckpoints,
+		status:            storagestate.StatusLoading,
 	}
 	s.initCycleCallbacks()
 

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -188,6 +188,20 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 	keywordRanking *searchparams.KeywordRanking, sort []filters.Sort, cursor *filters.Cursor,
 	additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
+	var err error
+
+	// Report slow queries if this method takes longer than expected
+	startTime := time.Now()
+	defer func() {
+		s.slowQueryReporter.LogIfSlow(startTime, map[string]any{
+			"collection": s.index.Config.ClassName,
+			"shard":      s.ID(),
+			"tenant":     s.tenant(),
+			"query":      "ObjectSearch",
+			"version":    s.versioner.Version(),
+		})
+	}()
+
 	if keywordRanking != nil {
 		if v := s.versioner.Version(); v < 2 {
 			return nil, nil, errors.Errorf(
@@ -197,13 +211,11 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 
 		var bm25objs []*storobj.Object
 		var bm25count []float32
-		var err error
 		var objs helpers.AllowList
 		var filterDocIds helpers.AllowList
 
 		if filters != nil {
-			objs, err = inverted.NewSearcher(s.index.logger, s.store,
-				s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices,
+			objs, err = inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.GetSchemaSkipAuth(), s.propertyIndices,
 				s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
 				s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit,
 				s.bitmapFactory).
@@ -256,6 +268,17 @@ func (s *Shard) getIndexQueue(targetVector string) (*IndexQueue, error) {
 }
 
 func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVector []float32, targetVector string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties) ([]*storobj.Object, []float32, error) {
+	startTime := time.Now()
+	defer func() {
+		s.slowQueryReporter.LogIfSlow(startTime, map[string]any{
+			"collection": s.index.Config.ClassName,
+			"shard":      s.ID(),
+			"tenant":     s.tenant(),
+			"query":      "ObjectVectorSearch",
+			"version":    s.versioner.Version(),
+		})
+	}()
+
 	var (
 		ids       []uint64
 		dists     []float32


### PR DESCRIPTION
### Context:

There has been some latency issues due to corrupted tenants, which can be pretty difficult to track down. Hopefully this can help us identify these tenants and correlate them to latency increases across the board.

### What's being changed:

Added a Slow Query log for `ObjectSearch` and `ObjectVectorSearch`. It will log a simple "Slow query detected" warning with significant information as its fields. Hopefully this can help us track down patterns on lagging tenants/shards.

This can be enabled with env var `QUERY_SLOW_LOG_ENABLED`.
The threshold is defaulted to 10 seconds and can be modified with `QUERY_SLOW_LOG_THRESHOLD`.

I'm wondering if it would be wise to add this to any docs.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

### To do:

- I intend to merge this to 1.24 and 1.25 (and main?)
- I'd like to report this as a counter metric as well. I'll do this in a later PR since I need to read up on how metrics work in weaviate and have to double-check the dimensionality is not going to be an issue.
