### PR TITLE
Improve error message: Annotate failing segment with segment path on load

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -73,7 +73,16 @@ type diskIndex interface {
 func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	existsLower existsOnLowerSegmentsFn, mmapContents bool,
 	useBloomFilter bool, calcCountNetAdditions bool, overwriteDerived bool,
-) (*segment, error) {
+) (_ *segment, err error) {
+	defer func() {
+		p := recover()
+		if p == nil {
+			return
+		}
+
+		err = fmt.Errorf("unexpected error loading segment %q: %v", path, p)
+	}()
+
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open file: %w", err)


### PR DESCRIPTION
### What's being changed:
* If a segment cannot be loaded, e.g. because it is corrupt, we now print the exact name of the affected segment

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
