### PR TITLE
fix expired context on dimension tracking

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -307,7 +307,7 @@ func (s *Shard) reinit(ctx context.Context) error {
 	}
 
 	s.initCycleCallbacks()
-	s.initDimensionTracking(ctx)
+	s.initDimensionTracking()
 
 	return nil
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -256,7 +256,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		}
 	}
 
-	s.initDimensionTracking(ctx)
+	s.initDimensionTracking()
 
 	if asyncEnabled() {
 		f := func() {


### PR DESCRIPTION
Fixes #5091. 

A recent fix made the LSM cursor respect the context correctly. However, that bug hid that dimension tracking was running with an expired context. This fix now makes sure the context is correct. 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
