### PR TITLE
Make sure shard is properly cleaned up on partial load

### DIFF
--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -211,6 +211,12 @@ func NewIndexQueue(
 // Close immediately closes the queue and waits for workers to finish their current tasks.
 // Any pending vectors are discarded.
 func (q *IndexQueue) Close() error {
+	if q == nil {
+		// queue was never initialized, possibly because of a failed shard
+		// initialization. No op.
+		return nil
+	}
+
 	// check if the queue is closed
 	if q.ctx.Err() != nil {
 		return nil

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -122,13 +122,12 @@ func (s *Shard) initDimensionTracking() {
 	// https://github.com/weaviate/weaviate/issues/5091
 	rootCtx := context.Background()
 	if s.index.Config.TrackVectorDimensions {
+		s.dimensionTrackingInitialized.Store(true)
+
 		// The timeout is rather arbitrary, it's just meant to prevent a context
 		// leak. The actual work should be much faster.
 		ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 		defer cancel()
-		defer func() {
-			s.dimensionTrackingInitialized.Store(true)
-		}()
 
 		// always send vector dimensions at startup if tracking is enabled
 		s.publishDimensionMetrics(ctx)


### PR DESCRIPTION
Fixes #5100 

With lazy shard loading, you could get into a situation where a shard was only partially initialized if loading a bucket failed. On the next query, we would try to initialize it again. Unfortunately, that led to some buckets being initialized twice. This also means we had competing threads trying to run compactions on the same files, thus corrupting data.

This PR fixes this by making sure shard loading is atomic: Either a shard is fully loaded, or not. If loading fails, everything already loaded to that point is stopped again. For this, it makes the `(*Shard).Shutdown()` method idempotent, it simply skips stuff that hasn't been loaded yet. Without this change it would block forever. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
