### PR TITLE
Fix nil-pointer deref panic on partial shard cleanup

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -979,8 +979,12 @@ func (s *Shard) Shutdown(ctx context.Context) error {
 		return err
 	}
 
-	if err = s.store.Shutdown(ctx); err != nil {
-		return errors.Wrap(err, "stop lsmkv store")
+	if s.store != nil {
+		// store would be nil if loading the objects bucket failed, as we would
+		// only return the store on success from s.initLSMStore()
+		if err = s.store.Shutdown(ctx); err != nil {
+			return errors.Wrap(err, "stop lsmkv store")
+		}
 	}
 
 	if s.dimensionTrackingInitialized.Load() {


### PR DESCRIPTION
### What's being changed:
```
// store would be nil if loading the objects bucket failed, as we would
// only return the store on success from s.initLSMStore()
```
-> don't try to shutdown an uninitialized store

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
