### PR TITLE
Range roaring set index

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4123,6 +4123,10 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
+        "indexRangeable": {
+          "type": "boolean",
+          "x-nullable": true
+        },
         "indexSearchable": {
           "type": "boolean",
           "x-nullable": true
@@ -4545,6 +4549,11 @@ func init() {
         },
         "indexInverted": {
           "description": "Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters, bm25 or hybrid search. This property has no affect on vectorization decisions done by modules (deprecated as of v1.19; use indexFilterable or/and indexSearchable instead)",
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "indexRangeable": {
+          "description": "Optional. TODO roaring-set-range",
           "type": "boolean",
           "x-nullable": true
         },
@@ -9659,6 +9668,10 @@ func init() {
           "type": "boolean",
           "x-nullable": true
         },
+        "indexRangeable": {
+          "type": "boolean",
+          "x-nullable": true
+        },
         "indexSearchable": {
           "type": "boolean",
           "x-nullable": true
@@ -10099,6 +10112,11 @@ func init() {
         },
         "indexInverted": {
           "description": "Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters, bm25 or hybrid search. This property has no affect on vectorization decisions done by modules (deprecated as of v1.19; use indexFilterable or/and indexSearchable instead)",
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "indexRangeable": {
+          "description": "Optional. TODO roaring-set-range",
           "type": "boolean",
           "x-nullable": true
         },

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -70,3 +70,7 @@ func TempBucketFromBucketName(bucketName string) string {
 func BucketSearchableFromPropNameLSM(propName string) string {
 	return BucketFromPropNameLSM(propName + "_searchable")
 }
+
+func BucketRangeableFromPropNameLSM(propName string) string {
+	return BucketFromPropNameLSM(propName + "_rangeable")
+}

--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -33,6 +33,7 @@ type Property struct {
 	Length             int
 	HasFilterableIndex bool // roaring set index
 	HasSearchableIndex bool // map index (with frequencies)
+	HasRangeableIndex  bool // roaring set index for ranged queries
 }
 
 type NilProperty struct {

--- a/adapters/repos/db/inverted/delta_analyzer.go
+++ b/adapters/repos/db/inverted/delta_analyzer.go
@@ -59,6 +59,7 @@ func Delta(previous, next []Property) DeltaResults {
 				Length:             nextProp.Length,
 				HasFilterableIndex: nextProp.HasFilterableIndex,
 				HasSearchableIndex: nextProp.HasSearchableIndex,
+				HasRangeableIndex:  nextProp.HasRangeableIndex,
 			})
 		}
 		if len(toDelete) > 0 {
@@ -68,6 +69,7 @@ func Delta(previous, next []Property) DeltaResults {
 				Length:             prevProp.Length,
 				HasFilterableIndex: nextProp.HasFilterableIndex,
 				HasSearchableIndex: nextProp.HasSearchableIndex,
+				HasRangeableIndex:  nextProp.HasRangeableIndex,
 			})
 		}
 		// special case to update optional length/nil indexes on
@@ -80,6 +82,7 @@ func Delta(previous, next []Property) DeltaResults {
 				Length:             0,
 				HasFilterableIndex: nextProp.HasFilterableIndex,
 				HasSearchableIndex: nextProp.HasSearchableIndex,
+				HasRangeableIndex:  nextProp.HasRangeableIndex,
 			})
 		}
 	}

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -207,6 +207,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 	var items []Countable
 	hasFilterableIndex := HasFilterableIndex(prop)
 	hasSearchableIndex := HasSearchableIndex(prop)
+	hasRangeableIndex := HasRangeableIndex(prop)
 
 	switch dt := schema.DataType(prop.DataType[0]); dt {
 	case schema.DataTypeTextArray:
@@ -327,6 +328,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		Length:             len(values),
 		HasFilterableIndex: hasFilterableIndex,
 		HasSearchableIndex: hasSearchableIndex,
+		HasRangeableIndex:  hasRangeableIndex,
 	}, nil
 }
 
@@ -347,6 +349,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 	propertyLength := -1 // will be overwritten for string/text, signals not to add the other types.
 	hasFilterableIndex := HasFilterableIndex(prop)
 	hasSearchableIndex := HasSearchableIndex(prop)
+	hasRangeableIndex := HasRangeableIndex(prop)
 
 	switch dt := schema.DataType(prop.DataType[0]); dt {
 	case schema.DataTypeText:
@@ -450,6 +453,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 		Length:             propertyLength,
 		HasFilterableIndex: hasFilterableIndex,
 		HasSearchableIndex: hasSearchableIndex,
+		HasRangeableIndex:  hasRangeableIndex,
 	}, nil
 }
 
@@ -516,6 +520,7 @@ func (a *Analyzer) analyzeRefPropCount(prop *models.Property,
 		Length:             len(value),
 		HasFilterableIndex: HasFilterableIndex(prop),
 		HasSearchableIndex: HasSearchableIndex(prop),
+		HasRangeableIndex:  HasRangeableIndex(prop),
 	}, nil
 }
 
@@ -532,6 +537,7 @@ func (a *Analyzer) analyzeRefProp(prop *models.Property,
 		Items:              items,
 		HasFilterableIndex: HasFilterableIndex(prop),
 		HasSearchableIndex: HasSearchableIndex(prop),
+		HasRangeableIndex:  HasRangeableIndex(prop),
 	}, nil
 }
 
@@ -593,30 +599,42 @@ func HasFilterableIndex(prop *models.Property) bool {
 	return *prop.IndexFilterable
 }
 
+func HasRangeableIndex(prop *models.Property) bool {
+	if prop.IndexRangeable == nil {
+		return false
+	}
+	return *prop.IndexRangeable
+}
+
 func HasInvertedIndex(prop *models.Property) bool {
-	return HasFilterableIndex(prop) || HasSearchableIndex(prop)
+	return HasFilterableIndex(prop) || HasSearchableIndex(prop) || HasRangeableIndex(prop)
 }
 
 const (
 	// always
 	HasFilterableIndexIdProp = true
 	HasSearchableIndexIdProp = false
+	HasRangeableIndexIdProp  = false
 
 	// only if index.invertedIndexConfig.IndexTimestamps set
 	HasFilterableIndexTimestampProp = true
 	HasSearchableIndexTimestampProp = false
+	HasRangeableIndexTimestampProp  = false
 
 	// only if property.indexFilterable or property.indexSearchable set
 	HasFilterableIndexMetaCount = true
 	HasSearchableIndexMetaCount = false
+	HasRangeableIndexMetaCount  = false
 
 	// only if index.invertedIndexConfig.IndexNullState set
 	// and either property.indexFilterable or property.indexSearchable set
 	HasFilterableIndexPropNull = true
 	HasSearchableIndexPropNull = false
+	HasRangeableIndexPropNull  = false
 
 	// only if index.invertedIndexConfig.IndexPropertyLength set
 	// and either property.indexFilterable or property.indexSearchable set
 	HasFilterableIndexPropLength = true
 	HasSearchableIndexPropLength = false
+	HasRangeableIndexPropLength  = false
 )

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -600,10 +600,15 @@ func HasFilterableIndex(prop *models.Property) bool {
 }
 
 func HasRangeableIndex(prop *models.Property) bool {
-	if prop.IndexRangeable == nil {
+	switch dt, _ := schema.AsPrimitive(prop.DataType); dt {
+	case schema.DataTypeInt, schema.DataTypeNumber, schema.DataTypeDate:
+		if prop.IndexRangeable == nil {
+			return false
+		}
+		return *prop.IndexRangeable
+	default:
 		return false
 	}
-	return *prop.IndexRangeable
 }
 
 func HasAnyInvertedIndex(prop *models.Property) bool {

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -68,7 +68,7 @@ func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 			return nil, fmt.Errorf("prop %q has no datatype", prop.Name)
 		}
 
-		if !HasInvertedIndex(prop) {
+		if !HasAnyInvertedIndex(prop) {
 			continue
 		}
 
@@ -606,7 +606,7 @@ func HasRangeableIndex(prop *models.Property) bool {
 	return *prop.IndexRangeable
 }
 
-func HasInvertedIndex(prop *models.Property) bool {
+func HasAnyInvertedIndex(prop *models.Property) bool {
 	return HasFilterableIndex(prop) || HasSearchableIndex(prop) || HasRangeableIndex(prop)
 }
 

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -41,6 +41,7 @@ type propValuePair struct {
 	children           []*propValuePair
 	hasFilterableIndex bool
 	hasSearchableIndex bool
+	hasRangeableIndex  bool
 	Class              *models.Class // The schema
 	logger             logrus.FieldLogger
 }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -371,9 +371,9 @@ func (s *Searcher) extractReferenceCount(prop *models.Property, value interface{
 		return nil, err
 	}
 
-	hasFilterableIndex := HasFilterableIndexMetaCount && HasInvertedIndex(prop)
-	hasSearchableIndex := HasSearchableIndexMetaCount && HasInvertedIndex(prop)
-	hasRangeableIndex := HasRangeableIndexMetaCount && HasInvertedIndex(prop)
+	hasFilterableIndex := HasFilterableIndexMetaCount && HasAnyInvertedIndex(prop)
+	hasSearchableIndex := HasSearchableIndexMetaCount && HasAnyInvertedIndex(prop)
+	hasRangeableIndex := HasRangeableIndexMetaCount && HasAnyInvertedIndex(prop)
 
 	if !hasFilterableIndex && !hasSearchableIndex && !hasRangeableIndex {
 		return nil, inverted.NewMissingFilterableMetaCountIndexError(prop.Name)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -346,8 +346,9 @@ func (s *Searcher) extractPrimitiveProp(prop *models.Property, propType schema.D
 
 	hasFilterableIndex := HasFilterableIndex(prop)
 	hasSearchableIndex := HasSearchableIndex(prop)
+	hasRangeableIndex := HasRangeableIndex(prop)
 
-	if !hasFilterableIndex && !hasSearchableIndex {
+	if !hasFilterableIndex && !hasSearchableIndex && !hasRangeableIndex {
 		return nil, inverted.NewMissingFilterableIndexError(prop.Name)
 	}
 
@@ -357,6 +358,7 @@ func (s *Searcher) extractPrimitiveProp(prop *models.Property, propType schema.D
 		operator:           operator,
 		hasFilterableIndex: hasFilterableIndex,
 		hasSearchableIndex: hasSearchableIndex,
+		hasRangeableIndex:  hasRangeableIndex,
 		Class:              class,
 	}, nil
 }
@@ -371,8 +373,9 @@ func (s *Searcher) extractReferenceCount(prop *models.Property, value interface{
 
 	hasFilterableIndex := HasFilterableIndexMetaCount && HasInvertedIndex(prop)
 	hasSearchableIndex := HasSearchableIndexMetaCount && HasInvertedIndex(prop)
+	hasRangeableIndex := HasRangeableIndexMetaCount && HasInvertedIndex(prop)
 
-	if !hasFilterableIndex && !hasSearchableIndex {
+	if !hasFilterableIndex && !hasSearchableIndex && !hasRangeableIndex {
 		return nil, inverted.NewMissingFilterableMetaCountIndexError(prop.Name)
 	}
 
@@ -382,6 +385,7 @@ func (s *Searcher) extractReferenceCount(prop *models.Property, value interface{
 		operator:           operator,
 		hasFilterableIndex: hasFilterableIndex,
 		hasSearchableIndex: hasSearchableIndex,
+		hasRangeableIndex:  hasRangeableIndex,
 		Class:              class,
 	}, nil
 }
@@ -403,6 +407,7 @@ func (s *Searcher) extractGeoFilter(prop *models.Property, value interface{},
 		operator:           operator,
 		hasFilterableIndex: HasFilterableIndex(prop),
 		hasSearchableIndex: HasSearchableIndex(prop),
+		hasRangeableIndex:  HasRangeableIndex(prop),
 		Class:              class,
 	}, nil
 }
@@ -430,8 +435,9 @@ func (s *Searcher) extractUUIDFilter(prop *models.Property, value interface{},
 
 	hasFilterableIndex := HasFilterableIndex(prop)
 	hasSearchableIndex := HasSearchableIndex(prop)
+	hasRangeableIndex := HasRangeableIndex(prop)
 
-	if !hasFilterableIndex && !hasSearchableIndex {
+	if !hasFilterableIndex && !hasSearchableIndex && !hasRangeableIndex {
 		return nil, inverted.NewMissingFilterableIndexError(prop.Name)
 	}
 
@@ -441,6 +447,7 @@ func (s *Searcher) extractUUIDFilter(prop *models.Property, value interface{},
 		operator:           operator,
 		hasFilterableIndex: hasFilterableIndex,
 		hasSearchableIndex: hasSearchableIndex,
+		hasRangeableIndex:  hasRangeableIndex,
 		Class:              class,
 	}, nil
 }
@@ -556,8 +563,9 @@ func (s *Searcher) extractTokenizableProp(prop *models.Property, propType schema
 
 	hasFilterableIndex := HasFilterableIndex(prop) && !s.isFallbackToSearchable()
 	hasSearchableIndex := HasSearchableIndex(prop)
+	hasRangeableIndex := HasRangeableIndex(prop)
 
-	if !hasFilterableIndex && !hasSearchableIndex {
+	if !hasFilterableIndex && !hasSearchableIndex && !hasRangeableIndex {
 		return nil, inverted.NewMissingFilterableIndexError(prop.Name)
 	}
 
@@ -572,6 +580,7 @@ func (s *Searcher) extractTokenizableProp(prop *models.Property, propType schema
 			operator:           operator,
 			hasFilterableIndex: hasFilterableIndex,
 			hasSearchableIndex: hasSearchableIndex,
+			hasRangeableIndex:  hasRangeableIndex,
 			Class:              class,
 		})
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -32,7 +32,6 @@ func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
 	}
 	// all other operators perform operations on the inverted index which we
 	// can serve directly
-
 	switch b.Strategy() {
 	case lsmkv.StrategySetCollection:
 		return s.docBitmapInvertedSet(ctx, b, limit, pv)
@@ -89,7 +88,7 @@ func (s *Searcher) docBitmapInvertedRoaringSetRange(ctx context.Context, b *lsmk
 		return newDocBitmap(), fmt.Errorf("readerRoaringSetRange: invalid value length %d, should be 8 bytes", len(pv.value))
 	}
 
-	reader := lsmkv.NewBucketReaderRoaringSetRange(b.CursorRoaringSetRange)
+	reader := lsmkv.NewBucketReaderRoaringSetRange(b.CursorRoaringSetRange, s.logger)
 
 	docIds, err := reader.Read(ctx, binary.BigEndian.Uint64(pv.value), pv.operator)
 	if err != nil {

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -91,7 +91,7 @@ func (s *Searcher) docBitmapInvertedRoaringSetRange(ctx context.Context, b *lsmk
 
 	reader := lsmkv.NewBucketReaderRoaringSetRange(b.CursorRoaringSetRange)
 
-	docIds, err := reader.Read(ctx, binary.LittleEndian.Uint64(pv.value), pv.operator)
+	docIds, err := reader.Read(ctx, binary.BigEndian.Uint64(pv.value), pv.operator)
 	if err != nil {
 		return newDocBitmap(), fmt.Errorf("readerRoaringSetRange: %w", err)
 	}

--- a/adapters/repos/db/inverted/searcher_ref_filter.go
+++ b/adapters/repos/db/inverted/searcher_ref_filter.go
@@ -150,6 +150,7 @@ func (r *refFilterExtractor) emptyPropValuePair() *propValuePair {
 		operator:           filters.OperatorEqual,
 		hasFilterableIndex: HasFilterableIndex(r.property),
 		hasSearchableIndex: HasSearchableIndex(r.property),
+		hasRangeableIndex:  HasRangeableIndex(r.property),
 		Class:              r.class,
 	}
 }
@@ -186,6 +187,7 @@ func (r *refFilterExtractor) idToPropValuePairWithValue(v []byte,
 func (r *refFilterExtractor) chainedIDsToPropValuePair(ids []classUUIDPair) (*propValuePair, error) {
 	hasFilterableIndex := HasFilterableIndex(r.property)
 	hasSearchableIndex := HasSearchableIndex(r.property)
+	hasRangeableIndex := HasRangeableIndex(r.property)
 
 	children, err := r.idsToPropValuePairs(ids, hasFilterableIndex, hasSearchableIndex)
 	if err != nil {
@@ -198,6 +200,7 @@ func (r *refFilterExtractor) chainedIDsToPropValuePair(ids []classUUIDPair) (*pr
 		children:           children,
 		hasFilterableIndex: hasFilterableIndex,
 		hasSearchableIndex: hasSearchableIndex,
+		hasRangeableIndex:  hasRangeableIndex,
 		Class:              r.class,
 	}, nil
 }

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -841,7 +841,7 @@ func (b *Bucket) setNewActiveMemtable() error {
 		return errors.Wrap(err, "init commit logger")
 	}
 
-	mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics)
+	mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics, b.logger)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -22,11 +22,8 @@ type BucketOption func(b *Bucket) error
 
 func WithStrategy(strategy string) BucketOption {
 	return func(b *Bucket) error {
-		switch strategy {
-		case StrategyReplace, StrategyMapCollection, StrategySetCollection,
-			StrategyRoaringSet:
-		default:
-			return errors.Errorf("unrecognized strategy %q", strategy)
+		if err := CheckExpectedStrategy(strategy); err != nil {
+			return err
 		}
 
 		b.strategy = strategy

--- a/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range.go
@@ -1,0 +1,275 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+type BucketReaderRoaringSetRange struct {
+	cursorFn func() CursorRoaringSetRange
+}
+
+func NewBucketReaderRoaringSetRange(cursorFn func() CursorRoaringSetRange) *BucketReaderRoaringSetRange {
+	return &BucketReaderRoaringSetRange{
+		cursorFn: cursorFn,
+	}
+}
+
+func (r *BucketReaderRoaringSetRange) Read(ctx context.Context, value uint64,
+	operator filters.Operator,
+) (*sroar.Bitmap, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	switch operator {
+	case filters.OperatorEqual:
+		return r.equal(ctx, value)
+	case filters.OperatorNotEqual:
+		return r.notEqual(ctx, value)
+	case filters.OperatorGreaterThan:
+		return r.greaterThan(ctx, value)
+	case filters.OperatorGreaterThanEqual:
+		return r.greaterThanEqual(ctx, value)
+	case filters.OperatorLessThan:
+		return r.lessThan(ctx, value)
+	case filters.OperatorLessThanEqual:
+		return r.lessThanEqual(ctx, value)
+
+	default:
+		return nil, fmt.Errorf("operator %v not supported for strategy %q", operator.Name(), StrategyRoaringSetRange)
+	}
+}
+
+func (r *BucketReaderRoaringSetRange) greaterThanEqual(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
+	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
+	if !ok {
+		return resultBM, err
+	}
+
+	// all values are >= 0
+	if value == 0 {
+		return resultBM, nil
+	}
+
+	return r.mergeGreaterThanEqual(ctx, resultBM, cursor, value)
+}
+
+func (r *BucketReaderRoaringSetRange) greaterThan(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
+	// no value is > max uint64
+	if value == math.MaxUint64 {
+		return sroar.NewBitmap(), nil
+	}
+
+	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
+	if !ok {
+		return resultBM, err
+	}
+
+	return r.mergeGreaterThanEqual(ctx, resultBM, cursor, value+1)
+}
+
+func (r *BucketReaderRoaringSetRange) lessThanEqual(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
+	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
+	if !ok {
+		return resultBM, err
+	}
+
+	// all values are <= max uint64
+	if value == math.MaxUint64 {
+		return resultBM, nil
+	}
+
+	greaterThanEqualBM, err := r.mergeGreaterThanEqual(ctx, resultBM.Clone(), cursor, value+1)
+	if err != nil {
+		return nil, err
+	}
+	resultBM.AndNot(greaterThanEqualBM)
+	return resultBM, nil
+}
+
+func (r *BucketReaderRoaringSetRange) lessThan(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
+	// no value is < 0
+	if value == 0 {
+		return sroar.NewBitmap(), nil
+	}
+
+	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
+	if !ok {
+		return resultBM, err
+	}
+
+	greaterThanEqualBM, err := r.mergeGreaterThanEqual(ctx, resultBM.Clone(), cursor, value)
+	if err != nil {
+		return nil, err
+	}
+	resultBM.AndNot(greaterThanEqualBM)
+	return resultBM, nil
+}
+
+func (r *BucketReaderRoaringSetRange) equal(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
+	if value == 0 {
+		return r.lessThanEqual(ctx, value)
+	}
+	if value == math.MaxUint64 {
+		return r.greaterThanEqual(ctx, value)
+	}
+
+	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
+	if !ok {
+		return resultBM, err
+	}
+
+	return r.mergeEqual(ctx, resultBM, cursor, value)
+}
+
+func (r *BucketReaderRoaringSetRange) notEqual(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
+	if value == 0 {
+		return r.greaterThan(ctx, value)
+	}
+	if value == math.MaxUint64 {
+		return r.lessThan(ctx, value)
+	}
+
+	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
+	if !ok {
+		return resultBM, err
+	}
+
+	equalBM, err := r.mergeEqual(ctx, resultBM.Clone(), cursor, value)
+	if err != nil {
+		return nil, err
+	}
+	resultBM.AndNot(equalBM)
+	return resultBM, nil
+}
+
+func (r *BucketReaderRoaringSetRange) nonNullBMWithCursor(ctx context.Context) (*sroar.Bitmap, *noGapsCursor, bool, error) {
+	cursor := &noGapsCursor{cursor: r.cursorFn()}
+	_, nonNullBM, _ := cursor.first()
+
+	// if non-null bm is nil or empty, no values are present
+	if nonNullBM == nil || nonNullBM.IsEmpty() {
+		cursor.close()
+		return sroar.NewBitmap(), nil, false, nil
+	}
+
+	if ctx.Err() != nil {
+		cursor.close()
+		return nil, nil, false, ctx.Err()
+	}
+
+	return nonNullBM.Clone(), cursor, true, nil
+}
+
+func (r *BucketReaderRoaringSetRange) mergeGreaterThanEqual(ctx context.Context, resBM *sroar.Bitmap,
+	cursor *noGapsCursor, value uint64,
+) (*sroar.Bitmap, error) {
+	defer cursor.close()
+
+	for bit, bitBM, ok := cursor.next(); ok; bit, bitBM, ok = cursor.next() {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		// And/Or handle properly nil bitmaps, so bitBM == nil is fine
+		if value&(1<<(bit-1)) != 0 {
+			resBM.And(bitBM)
+		} else {
+			resBM.Or(bitBM)
+		}
+	}
+
+	return resBM, nil
+}
+
+func (r *BucketReaderRoaringSetRange) mergeEqual(ctx context.Context, resBM *sroar.Bitmap,
+	cursor *noGapsCursor, value uint64,
+) (*sroar.Bitmap, error) {
+	defer cursor.close()
+
+	resBM1 := resBM.Clone()
+	value1 := value + 1
+	for bit, bitBM, ok := cursor.next(); ok; bit, bitBM, ok = cursor.next() {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var b uint64 = 1 << (bit - 1)
+		if value&b != 0 {
+			resBM.And(bitBM)
+		} else {
+			resBM.Or(bitBM)
+		}
+		if value1&b != 0 {
+			resBM1.And(bitBM)
+		} else {
+			resBM1.Or(bitBM)
+		}
+	}
+
+	resBM.AndNot(resBM1)
+	return resBM, nil
+}
+
+type noGapsCursor struct {
+	cursor  CursorRoaringSetRange
+	key     uint8
+	started bool
+
+	lastKey uint8
+	lastVal *sroar.Bitmap
+	lastOk  bool
+}
+
+func (c *noGapsCursor) first() (uint8, *sroar.Bitmap, bool) {
+	c.started = true
+
+	c.lastKey, c.lastVal, c.lastOk = c.cursor.First()
+
+	c.key = 1
+	if c.lastOk && c.lastKey == 0 {
+		return 0, c.lastVal, true
+	}
+	return 0, nil, true
+}
+
+func (c *noGapsCursor) next() (uint8, *sroar.Bitmap, bool) {
+	if !c.started {
+		return c.first()
+	}
+
+	if c.key >= 65 {
+		return 0, nil, false
+	}
+
+	for c.lastOk && c.lastKey < c.key {
+		c.lastKey, c.lastVal, c.lastOk = c.cursor.Next()
+	}
+
+	key := c.key
+	c.key++
+	if c.lastOk && c.lastKey == key {
+		return key, c.lastVal, true
+	}
+	return key, nil, true
+}
+
+func (c *noGapsCursor) close() {
+	c.cursor.Close()
+}

--- a/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range.go
@@ -64,7 +64,6 @@ func (r *BucketReaderRoaringSetRange) Read(ctx context.Context, value uint64,
 
 func (r *BucketReaderRoaringSetRange) greaterThanEqual(ctx context.Context, value uint64) (*sroar.Bitmap, error) {
 	resultBM, cursor, ok, err := r.nonNullBMWithCursor(ctx)
-	// fmt.Printf("  ==> nn card %d\n", resultBM.GetCardinality())
 	if !ok {
 		return resultBM, err
 	}
@@ -182,7 +181,6 @@ func (r *BucketReaderRoaringSetRange) nonNullBMWithCursor(ctx context.Context) (
 	}
 
 	return nonNullBM, cursor, true, nil
-	// return nonNullBM.Clone(), cursor, true, nil
 }
 
 func (r *BucketReaderRoaringSetRange) mergeGreaterThanEqual(ctx context.Context, resBM *sroar.Bitmap,

--- a/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range_test.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
@@ -25,6 +26,8 @@ import (
 )
 
 func TestReaderRoaringSetRange(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
 	t.Run("with empty CursorRoaringSetRange", func(t *testing.T) {
 		values := []uint64{0, 1, 4, 5, 6, 12, 13, 14, 12345678901234567890, math.MaxUint64}
 		operators := []filters.Operator{
@@ -38,7 +41,7 @@ func TestReaderRoaringSetRange(t *testing.T) {
 
 		reader := NewBucketReaderRoaringSetRange(func() CursorRoaringSetRange {
 			return newFakeCursorRoaringSetRange(map[uint64]uint64{})
-		})
+		}, logger)
 
 		for _, operator := range operators {
 			t.Run(operator.Name(), func(t *testing.T) {
@@ -379,7 +382,7 @@ func TestReaderRoaringSetRange(t *testing.T) {
 				10:  0,  // 0000
 				20:  0,  // 0000
 			})
-		})
+		}, logger)
 
 		for _, tc := range testCases {
 			t.Run(tc.operator.Name(), func(t *testing.T) {
@@ -719,7 +722,7 @@ func TestReaderRoaringSetRange(t *testing.T) {
 				10:  math.MaxUint64,      // 1111..1111
 				20:  math.MaxUint64,      // 1111..1111
 			})
-		})
+		}, logger)
 
 		for _, tc := range testCases {
 			t.Run(tc.operator.Name(), func(t *testing.T) {

--- a/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/bucket_reader_roaring_set_range_test.go
@@ -1,0 +1,901 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+func TestReaderRoaringSetRange(t *testing.T) {
+	t.Run("with empty CursorRoaringSetRange", func(t *testing.T) {
+		values := []uint64{0, 1, 4, 5, 6, 12, 13, 14, 12345678901234567890, math.MaxUint64}
+		operators := []filters.Operator{
+			filters.OperatorGreaterThanEqual,
+			filters.OperatorGreaterThan,
+			filters.OperatorLessThanEqual,
+			filters.OperatorLessThan,
+			filters.OperatorEqual,
+			filters.OperatorNotEqual,
+		}
+
+		reader := NewBucketReaderRoaringSetRange(func() CursorRoaringSetRange {
+			return newFakeCursorRoaringSetRange(map[uint64]uint64{})
+		})
+
+		for _, operator := range operators {
+			t.Run(operator.Name(), func(t *testing.T) {
+				for _, value := range values {
+					t.Run(fmt.Sprintf("value %d", value), func(t *testing.T) {
+						bm, err := reader.Read(context.Background(), value, operator)
+
+						assert.NoError(t, err)
+						require.NotNil(t, bm)
+						assert.True(t, bm.IsEmpty())
+					})
+				}
+			})
+		}
+	})
+	t.Run("with populated CursorRoaringSetRange", func(t *testing.T) {
+		type testCase struct {
+			operator filters.Operator
+			value    uint64
+			expected []uint64
+		}
+
+		testCases := []testCase{
+			// greater than equal
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    0,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    1,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    4,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    5,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    6,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    12,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    13,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    14,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    12345678901234567890,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{},
+			},
+			// greater than
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    0,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    1,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    4,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    5,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    6,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    12,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    13,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    14,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    12345678901234567890,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64,
+				expected: []uint64{},
+			},
+			// less than equal
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    0,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    1,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    4,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    5,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    6,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    12,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    13,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    14,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    12345678901234567890,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			// less than
+			{
+				operator: filters.OperatorLessThan,
+				value:    0,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    1,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    4,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    5,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    6,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    12,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    13,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    14,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    12345678901234567890,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			// equal
+			{
+				operator: filters.OperatorEqual,
+				value:    0,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    1,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    4,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    5,
+				expected: []uint64{15, 25},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    6,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    12,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    13,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    14,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    12345678901234567890,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{},
+			},
+			// not equal
+			{
+				operator: filters.OperatorNotEqual,
+				value:    0,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    1,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    4,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    5,
+				expected: []uint64{10, 20, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    6,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    12,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    13,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    14,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    12345678901234567890,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+		}
+
+		reader := NewBucketReaderRoaringSetRange(func() CursorRoaringSetRange {
+			return newFakeCursorRoaringSetRange(map[uint64]uint64{
+				113: 13, // 1101
+				213: 13, // 1101
+				15:  5,  // 0101
+				25:  5,  // 0101
+				10:  0,  // 0000
+				20:  0,  // 0000
+			})
+		})
+
+		for _, tc := range testCases {
+			t.Run(tc.operator.Name(), func(t *testing.T) {
+				t.Run(fmt.Sprintf("value %d", tc.value), func(t *testing.T) {
+					bm, err := reader.Read(context.Background(), tc.value, tc.operator)
+
+					assert.NoError(t, err)
+					require.NotNil(t, bm)
+					assert.ElementsMatch(t, tc.expected, bm.ToArray())
+				})
+			})
+		}
+	})
+
+	t.Run("with populated CursorRoaringSetRange (high numbers)", func(t *testing.T) {
+		type testCase struct {
+			operator filters.Operator
+			value    uint64
+			expected []uint64
+		}
+
+		testCases := []testCase{
+			// greater than equal
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    0,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    12345,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 14,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 13,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 12,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 6,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 5,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 4,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64 - 1,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorGreaterThanEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{10, 20},
+			},
+			// greater than
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    0,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    12345,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 14,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 13,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 12,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 6,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 5,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 4,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64 - 1,
+				expected: []uint64{10, 20},
+			},
+			{
+				operator: filters.OperatorGreaterThan,
+				value:    math.MaxUint64,
+				expected: []uint64{},
+			},
+			// less than equal
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    0,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    12345,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 14,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 13,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 12,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 6,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 5,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 4,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64 - 1,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThanEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			// less than
+			{
+				operator: filters.OperatorLessThan,
+				value:    0,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    12345,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 14,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 13,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 12,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 6,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 5,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 4,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64 - 1,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorLessThan,
+				value:    math.MaxUint64,
+				expected: []uint64{15, 25, 113, 213},
+			},
+			// equal
+			{
+				operator: filters.OperatorEqual,
+				value:    0,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    12345,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 14,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 13,
+				expected: []uint64{113, 213},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 12,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 6,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 5,
+				expected: []uint64{15, 25},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 4,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64 - 1,
+				expected: []uint64{},
+			},
+			{
+				operator: filters.OperatorEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{10, 20},
+			},
+			// not equal
+			{
+				operator: filters.OperatorNotEqual,
+				value:    0,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    12345,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 14,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 13,
+				expected: []uint64{10, 20, 15, 25},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 12,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 6,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 5,
+				expected: []uint64{10, 20, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 4,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64 - 1,
+				expected: []uint64{10, 20, 15, 25, 113, 213},
+			},
+			{
+				operator: filters.OperatorNotEqual,
+				value:    math.MaxUint64,
+				expected: []uint64{15, 25, 113, 213},
+			},
+		}
+
+		reader := NewBucketReaderRoaringSetRange(func() CursorRoaringSetRange {
+			return newFakeCursorRoaringSetRange(map[uint64]uint64{
+				113: math.MaxUint64 - 13, // 1111..0010
+				213: math.MaxUint64 - 13, // 1111..0010
+				15:  math.MaxUint64 - 5,  // 1111..1010
+				25:  math.MaxUint64 - 5,  // 1111..1010
+				10:  math.MaxUint64,      // 1111..1111
+				20:  math.MaxUint64,      // 1111..1111
+			})
+		})
+
+		for _, tc := range testCases {
+			t.Run(tc.operator.Name(), func(t *testing.T) {
+				t.Run(fmt.Sprintf("value %d", tc.value), func(t *testing.T) {
+					bm, err := reader.Read(context.Background(), tc.value, tc.operator)
+
+					assert.NoError(t, err)
+					require.NotNil(t, bm)
+					assert.ElementsMatch(t, tc.expected, bm.ToArray())
+				})
+			})
+		}
+	})
+}
+
+func TestNoGapsCursor(t *testing.T) {
+	t.Run("with empty CursorRoaringSetRange", func(t *testing.T) {
+		c := &noGapsCursor{cursor: newFakeCursorRoaringSetRange(map[uint64]uint64{})}
+
+		k, v, ok := c.first()
+		require.Equal(t, uint8(0), k)
+		require.True(t, ok)
+		assert.Nil(t, v)
+
+		for i := uint8(1); i < 65; i++ {
+			k, v, ok = c.next()
+			require.Equal(t, i, k)
+			require.True(t, ok)
+			assert.Nil(t, v)
+		}
+
+		k, v, ok = c.next()
+		require.Equal(t, uint8(0), k)
+		require.False(t, ok)
+		assert.Nil(t, v)
+	})
+
+	t.Run("with populated CursorRoaringSetRange", func(t *testing.T) {
+		c := &noGapsCursor{cursor: newFakeCursorRoaringSetRange(map[uint64]uint64{
+			113: 13, // 1101
+			213: 13, // 1101
+			15:  5,  // 0101
+			25:  5,  // 0101
+			10:  0,  // 0000
+			20:  0,  // 0000
+		})}
+
+		k, v, ok := c.first()
+		require.Equal(t, uint8(0), k)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, v.ToArray())
+
+		expected := map[uint8][]uint64{
+			1: {15, 25, 113, 213},
+			3: {15, 25, 113, 213},
+			4: {113, 213},
+		}
+
+		for i := uint8(1); i < 65; i++ {
+			k, v, ok := c.next()
+			require.Equal(t, i, k)
+			require.True(t, ok)
+
+			if expectedV, ok := expected[i]; ok {
+				require.NotNil(t, v)
+				assert.ElementsMatch(t, expectedV, v.ToArray())
+			} else {
+				assert.Nil(t, v)
+			}
+		}
+
+		k, v, ok = c.next()
+		require.Equal(t, uint8(0), k)
+		require.False(t, ok)
+		assert.Nil(t, v)
+	})
+}
+
+func TestFakeCursorRoaringSetRange(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		c := newFakeCursorRoaringSetRange(map[uint64]uint64{})
+
+		k, v, ok := c.First()
+		assert.Equal(t, uint8(0), k)
+		require.False(t, ok)
+		assert.Nil(t, v)
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		c := newFakeCursorRoaringSetRange(map[uint64]uint64{
+			113: 13, // 1101
+			213: 13, // 1101
+			15:  5,  // 0101
+			25:  5,  // 0101
+			10:  0,  // 0000
+			20:  0,  // 0000
+		})
+
+		k, v, ok := c.First()
+		assert.Equal(t, uint8(0), k)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, v.ToArray())
+
+		k, v, ok = c.Next()
+		assert.Equal(t, uint8(1), k)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, v.ToArray())
+
+		k, v, ok = c.Next()
+		assert.Equal(t, uint8(3), k)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, v.ToArray())
+
+		k, v, ok = c.Next()
+		assert.Equal(t, uint8(4), k)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []uint64{113, 213}, v.ToArray())
+
+		k, v, ok = c.Next()
+		assert.Equal(t, uint8(0), k)
+		require.False(t, ok)
+		assert.Nil(t, v)
+	})
+}
+
+type fakeCursorRoaringSetRange struct {
+	bitmaps map[uint8]*sroar.Bitmap
+	bits    []uint8
+	pos     int
+}
+
+func newFakeCursorRoaringSetRange(docId2Val map[uint64]uint64) *fakeCursorRoaringSetRange {
+	bitmaps := make(map[uint8]*sroar.Bitmap, 65)
+
+	for docId, val := range docId2Val {
+		if bitmaps[0] == nil {
+			bitmaps[0] = sroar.NewBitmap()
+		}
+		bitmaps[0].Set(docId)
+
+		for i := uint8(0); i < 64; i++ {
+			if val&(1<<i) != 0 {
+				if bitmaps[i+1] == nil {
+					bitmaps[i+1] = sroar.NewBitmap()
+				}
+				bitmaps[i+1].Set(docId)
+			}
+		}
+	}
+
+	bits := make([]uint8, 0, len(bitmaps))
+	for bit := range bitmaps {
+		bits = append(bits, bit)
+	}
+	sort.Slice(bits, func(i, j int) bool { return bits[i] < bits[j] })
+
+	return &fakeCursorRoaringSetRange{
+		bitmaps: bitmaps,
+		bits:    bits,
+		pos:     0,
+	}
+}
+
+func (c *fakeCursorRoaringSetRange) First() (uint8, *sroar.Bitmap, bool) {
+	c.pos = 0
+	return c.Next()
+}
+
+func (c *fakeCursorRoaringSetRange) Next() (uint8, *sroar.Bitmap, bool) {
+	if c.pos >= len(c.bits) {
+		return 0, nil, false
+	}
+
+	bit := c.bits[c.pos]
+	c.pos++
+	return bit, c.bitmaps[bit], true
+}
+
+func (c *fakeCursorRoaringSetRange) Close() {}

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -65,7 +65,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		cl.pause()
 		defer cl.unpause()
 
-		mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics)
+		mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics, b.logger)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -13,14 +13,13 @@ package lsmkv
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
 func (b *Bucket) RoaringSetAddOne(key []byte, value uint64) error {
-	if err := checkStrategyRoaringSet(b.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err
 	}
 
@@ -31,7 +30,7 @@ func (b *Bucket) RoaringSetAddOne(key []byte, value uint64) error {
 }
 
 func (b *Bucket) RoaringSetRemoveOne(key []byte, value uint64) error {
-	if err := checkStrategyRoaringSet(b.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err
 	}
 
@@ -42,7 +41,7 @@ func (b *Bucket) RoaringSetRemoveOne(key []byte, value uint64) error {
 }
 
 func (b *Bucket) RoaringSetAddList(key []byte, values []uint64) error {
-	if err := checkStrategyRoaringSet(b.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err
 	}
 
@@ -53,7 +52,7 @@ func (b *Bucket) RoaringSetAddList(key []byte, values []uint64) error {
 }
 
 func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
-	if err := checkStrategyRoaringSet(b.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err
 	}
 
@@ -64,7 +63,7 @@ func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 }
 
 func (b *Bucket) RoaringSetGet(key []byte) (*sroar.Bitmap, error) {
-	if err := checkStrategyRoaringSet(b.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return nil, err
 	}
 
@@ -97,13 +96,4 @@ func (b *Bucket) RoaringSetGet(key []byte) (*sroar.Bitmap, error) {
 	}
 
 	return segments.Flatten(), nil
-}
-
-func checkStrategyRoaringSet(bucketStrat string) error {
-	if bucketStrat == StrategyRoaringSet {
-		return nil
-	}
-
-	return fmt.Errorf("this method requires a roaring set strategy, got: %s",
-		bucketStrat)
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -1,0 +1,34 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+func (b *Bucket) RoaringSetRangeAdd(key uint64, values ...uint64) error {
+	if err := CheckStrategyRoaringSetRange(b.strategy); err != nil {
+		return err
+	}
+
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	return b.active.roaringSetRangeAdd(key, values...)
+}
+
+func (b *Bucket) RoaringSetRangeRemove(key uint64, values ...uint64) error {
+	if err := CheckStrategyRoaringSetRange(b.strategy); err != nil {
+		return err
+	}
+
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	return b.active.roaringSetRangeRemove(key, values...)
+}

--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -50,6 +50,8 @@ func (p *commitloggerParser) Do() error {
 		return p.doCollection()
 	case StrategyRoaringSet:
 		return p.doRoaringSet()
+	case StrategyRoaringSetRange:
+		return p.doRoaringSetRange()
 	default:
 		return errors.Errorf("unknown strategy %s on commit log parse", p.strategy)
 	}

--- a/adapters/repos/db/lsmkv/commitlogger_parser_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_roaring_set_range.go
@@ -1,0 +1,35 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/weaviate/sroar"
+)
+
+func (p *commitloggerParser) doRoaringSetRange() error {
+	prs := &commitlogParserRoaringSet{
+		parser: p,
+		consume: func(key []byte, additions, deletions *sroar.Bitmap) error {
+			if len(key) != 8 {
+				return fmt.Errorf("commitloggerParser: invalid value length %d, should be 8 bytes", len(key))
+			}
+
+			return p.memtable.roaringSetRangeAddRemove(binary.BigEndian.Uint64(key),
+				additions.ToArray(), deletions.ToArray())
+		},
+	}
+
+	return prs.parse()
+}

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -253,6 +253,7 @@ func TestCompaction(t *testing.T) {
 			},
 		},
 
+		// RoaringSet
 		{
 			name: "compactionRoaringSetStrategy_Random",
 			f:    compactionRoaringSetStrategy_Random,
@@ -314,6 +315,72 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_FrequentPutDeleteOperations,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithKeepTombstones(true),
+			},
+		},
+
+		// RoaringSetRange
+		{
+			name: "compactionRoaringSetRangeStrategy_Random",
+			f:    compactionRoaringSetRangeStrategy_Random,
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy_Random_KeepTombstones",
+			f:    compactionRoaringSetRangeStrategy_Random,
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+				WithKeepTombstones(true),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy",
+			f: func(ctx context.Context, t *testing.T, opts []BucketOption) {
+				compactionRoaringSetRangeStrategy(ctx, t, opts, 1824, 1824)
+			},
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy_KeepTombstones",
+			f: func(ctx context.Context, t *testing.T, opts []BucketOption) {
+				compactionRoaringSetRangeStrategy(ctx, t, opts, 2384, 2384)
+			},
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+				WithKeepTombstones(true),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy_RemoveUnnecessary",
+			f:    compactionRoaringSetRangeStrategy_RemoveUnnecessary,
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy_RemoveUnnecessary_KeepTombstones",
+			f:    compactionRoaringSetRangeStrategy_RemoveUnnecessary,
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+				WithKeepTombstones(true),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations",
+			f:    compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations,
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
+			},
+		},
+		{
+			name: "compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations_KeepTombstones",
+			f:    compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations,
+			opts: []BucketOption{
+				WithStrategy(StrategyRoaringSetRange),
 				WithKeepTombstones(true),
 			},
 		},

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -53,9 +53,9 @@ func (b *Bucket) CursorRoaringSetKeyOnly() CursorRoaringSet {
 }
 
 func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
-	b.flushLock.RLock()
-
 	MustBeExpectedStrategy(b.strategy, StrategyRoaringSet)
+
+	b.flushLock.RLock()
 
 	innerCursors, unlockSegmentGroup := b.disk.newRoaringSetCursors()
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -12,8 +12,6 @@
 package lsmkv
 
 import (
-	"fmt"
-
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
@@ -57,10 +55,7 @@ func (b *Bucket) CursorRoaringSetKeyOnly() CursorRoaringSet {
 func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 	b.flushLock.RLock()
 
-	// TODO move to helper func
-	if err := checkStrategyRoaringSet(b.strategy); err != nil {
-		panic(fmt.Sprintf("CursorRoaringSet() called on strategy other than '%s'", StrategyRoaringSet))
-	}
+	MustBeExpectedStrategy(b.strategy, StrategyRoaringSet)
 
 	innerCursors, unlockSegmentGroup := b.disk.newRoaringSetCursors()
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_range.go
@@ -36,6 +36,7 @@ func (c *cursorRoaringSetRange) Next() (uint8, *sroar.Bitmap, bool) {
 }
 
 func (c *cursorRoaringSetRange) Close() {
+	c.combinedCursor.Close()
 	c.unlock()
 }
 
@@ -57,7 +58,7 @@ func (b *Bucket) CursorRoaringSetRange() CursorRoaringSetRange {
 	// cursors are in order from oldest to newest, with the memtable cursor
 	// being at the very top
 	return &cursorRoaringSetRange{
-		combinedCursor: roaringsetrange.NewCombinedCursor(innerCursors),
+		combinedCursor: roaringsetrange.NewCombinedCursor(innerCursors, b.logger),
 		unlock: func() {
 			unlockSegmentGroup()
 			b.flushLock.RUnlock()

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_range.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+)
+
+type CursorRoaringSetRange interface {
+	First() (uint8, *sroar.Bitmap, bool)
+	Next() (uint8, *sroar.Bitmap, bool)
+	Close()
+}
+
+type cursorRoaringSetRange struct {
+	combinedCursor *roaringsetrange.CombinedCursor
+	unlock         func()
+}
+
+func (c *cursorRoaringSetRange) First() (uint8, *sroar.Bitmap, bool) {
+	return c.combinedCursor.First()
+}
+
+func (c *cursorRoaringSetRange) Next() (uint8, *sroar.Bitmap, bool) {
+	return c.combinedCursor.Next()
+}
+
+func (c *cursorRoaringSetRange) Close() {
+	c.unlock()
+}
+
+func (b *Bucket) CursorRoaringSetRange() CursorRoaringSetRange {
+	MustBeExpectedStrategy(b.strategy, StrategyRoaringSetRange)
+
+	b.flushLock.RLock()
+
+	innerCursors, unlockSegmentGroup := b.disk.newRoaringSetRangeCursors()
+
+	// we have a flush-RLock, so we have the guarantee that the flushing state
+	// will not change for the lifetime of the cursor, thus there can only be two
+	// states: either a flushing memtable currently exists - or it doesn't
+	if b.flushing != nil {
+		innerCursors = append(innerCursors, b.flushing.newRoaringSetRangeCursor())
+	}
+	innerCursors = append(innerCursors, b.active.newRoaringSetRangeCursor())
+
+	// cursors are in order from oldest to newest, with the memtable cursor
+	// being at the very top
+	return &cursorRoaringSetRange{
+		combinedCursor: roaringsetrange.NewCombinedCursor(innerCursors),
+		unlock: func() {
+			unlockSegmentGroup()
+			b.flushLock.RUnlock()
+		},
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_memtable_roaring_set.go
@@ -12,14 +12,14 @@
 package lsmkv
 
 import (
-	roaringset2 "github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
-func (m *Memtable) newRoaringSetCursor() roaringset2.InnerCursor {
+func (m *Memtable) newRoaringSetCursor() roaringset.InnerCursor {
 	m.RLock()
 	defer m.RUnlock()
 
 	// Since FlattenInOrder makes deep copy of bst's nodes,
 	// no further memtable's locking in required on cursor's methods
-	return roaringset2.NewBinarySearchTreeCursor(m.roaringSet)
+	return roaringset.NewBinarySearchTreeCursor(m.roaringSet)
 }

--- a/adapters/repos/db/lsmkv/cursor_memtable_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_memtable_roaring_set_range.go
@@ -1,0 +1,25 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+)
+
+func (m *Memtable) newRoaringSetRangeCursor() roaringsetrange.InnerCursor {
+	m.RLock()
+	defer m.RUnlock()
+
+	// Since Nodes makes deep copy of memtable bitmaps,
+	// no further memtable's locking in required on cursor's methods
+	return roaringsetrange.NewMemtableCursor(m.roaringSetRange)
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_roaring_set.go
@@ -13,17 +13,17 @@ package lsmkv
 
 import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
-	roaringset2 "github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
-func (s *segment) newRoaringSetCursor() *roaringset2.SegmentCursor {
-	return roaringset2.NewSegmentCursor(s.contents[s.dataStartPos:s.dataEndPos],
+func (s *segment) newRoaringSetCursor() *roaringset.SegmentCursor {
+	return roaringset.NewSegmentCursor(s.contents[s.dataStartPos:s.dataEndPos],
 		&roaringSetSeeker{s.index})
 }
 
-func (sg *SegmentGroup) newRoaringSetCursors() ([]roaringset2.InnerCursor, func()) {
+func (sg *SegmentGroup) newRoaringSetCursors() ([]roaringset.InnerCursor, func()) {
 	sg.maintenanceLock.RLock()
-	out := make([]roaringset2.InnerCursor, len(sg.segments))
+	out := make([]roaringset.InnerCursor, len(sg.segments))
 
 	for i, segment := range sg.segments {
 		out[i] = segment.newRoaringSetCursor()

--- a/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
@@ -1,0 +1,31 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+)
+
+func (s *segment) newRoaringSetRangeCursor() *roaringsetrange.SegmentCursor {
+	return roaringsetrange.NewSegmentCursor(s.contents[s.dataStartPos:s.dataEndPos])
+}
+
+func (sg *SegmentGroup) newRoaringSetRangeCursors() ([]roaringsetrange.InnerCursor, func()) {
+	sg.maintenanceLock.RLock()
+
+	cursors := make([]roaringsetrange.InnerCursor, len(sg.segments))
+	for i, segment := range sg.segments {
+		cursors[i] = segment.newRoaringSetRangeCursor()
+	}
+
+	return cursors, sg.maintenanceLock.RUnlock
+}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -28,6 +29,7 @@ type Memtable struct {
 	keyMap             *binarySearchTreeMap
 	primaryIndex       *binarySearchTree
 	roaringSet         *roaringset.BinarySearchTree
+	roaringSetRange    *roaringsetrange.Memtable
 	commitlog          *commitLogger
 	size               uint64
 	path               string
@@ -49,6 +51,7 @@ func newMemtable(path string, strategy string,
 		keyMap:           &binarySearchTreeMap{},
 		primaryIndex:     &binarySearchTree{}, // todo, sort upfront
 		roaringSet:       &roaringset.BinarySearchTree{},
+		roaringSetRange:  roaringsetrange.NewMemtable(),
 		commitlog:        cl,
 		path:             path,
 		strategy:         strategy,

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -42,8 +43,8 @@ type Memtable struct {
 	metrics   *memtableMetrics
 }
 
-func newMemtable(path string, strategy string,
-	secondaryIndices uint16, cl *commitLogger, metrics *Metrics,
+func newMemtable(path string, strategy string, secondaryIndices uint16,
+	cl *commitLogger, metrics *Metrics, logger logrus.FieldLogger,
 ) (*Memtable, error) {
 	m := &Memtable{
 		key:              &binarySearchTree{},
@@ -51,7 +52,7 @@ func newMemtable(path string, strategy string,
 		keyMap:           &binarySearchTreeMap{},
 		primaryIndex:     &binarySearchTree{}, // todo, sort upfront
 		roaringSet:       &roaringset.BinarySearchTree{},
-		roaringSetRange:  roaringsetrange.NewMemtable(),
+		roaringSetRange:  roaringsetrange.NewMemtable(logger),
 		commitlog:        cl,
 		path:             path,
 		strategy:         strategy,

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -66,6 +66,11 @@ func (m *Memtable) flush() error {
 			return err
 		}
 
+	case StrategyRoaringSetRange:
+		if keys, err = m.flushDataRoaringSetRange(w); err != nil {
+			return err
+		}
+
 	case StrategyMapCollection:
 		if keys, err = m.flushDataMap(w); err != nil {
 			return err

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -50,6 +50,8 @@ func (m *Memtable) flush() error {
 	w := bufio.NewWriter(f)
 
 	var keys []segmentindex.Key
+	skipIndices := false
+
 	switch m.strategy {
 	case StrategyReplace:
 		if keys, err = m.flushDataReplace(w); err != nil {
@@ -70,6 +72,7 @@ func (m *Memtable) flush() error {
 		if keys, err = m.flushDataRoaringSetRange(w); err != nil {
 			return err
 		}
+		skipIndices = true
 
 	case StrategyMapCollection:
 		if keys, err = m.flushDataMap(w); err != nil {
@@ -80,14 +83,16 @@ func (m *Memtable) flush() error {
 		return fmt.Errorf("cannot flush strategy %s", m.strategy)
 	}
 
-	indices := &segmentindex.Indexes{
-		Keys:                keys,
-		SecondaryIndexCount: m.secondaryIndices,
-		ScratchSpacePath:    m.path + ".scratch.d",
-	}
+	if !skipIndices {
+		indices := &segmentindex.Indexes{
+			Keys:                keys,
+			SecondaryIndexCount: m.secondaryIndices,
+			ScratchSpacePath:    m.path + ".scratch.d",
+		}
 
-	if _, err := indices.WriteTo(w); err != nil {
-		return err
+		if _, err := indices.WriteTo(w); err != nil {
+			return err
+		}
 	}
 
 	if err := w.Flush(); err != nil {

--- a/adapters/repos/db/lsmkv/memtable_flush_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_roaring_set_range.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+)
+
+func (m *Memtable) flushDataRoaringSetRange(w io.Writer) ([]segmentindex.Key, error) {
+	nodes := m.roaringSetRange.Nodes()
+
+	totalDataLength := totalPayloadSizeRoaringSetRange(nodes)
+	header := segmentindex.Header{
+		IndexStart:       uint64(totalDataLength + segmentindex.HeaderSize),
+		Level:            0, // always level zero on a new one
+		Version:          0, // always version 0 for now
+		SecondaryIndices: 0,
+		Strategy:         segmentindex.StrategyRoaringSetRange,
+	}
+
+	_, err := header.WriteTo(w)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, node := range nodes {
+		sn, err := roaringsetrange.NewSegmentNode(node.Key, node.Additions, node.Deletions)
+		if err != nil {
+			return nil, fmt.Errorf("create segment node: %w", err)
+		}
+
+		_, err = w.Write(sn.ToBuffer())
+		if err != nil {
+			return nil, fmt.Errorf("write segment node %d: %w", i, err)
+		}
+	}
+
+	return make([]segmentindex.Key, 0), nil
+}
+
+func totalPayloadSizeRoaringSetRange(nodes []*roaringsetrange.MemtableNode) int {
+	var sum int
+	for _, node := range nodes {
+		sum += 8 // uint64 to segment length
+		sum += 1 // key (fixed size)
+		sum += 8 // uint64 to indicate length of additions bitmap
+		sum += len(node.Additions.ToBuffer())
+
+		if node.Key == 0 {
+			sum += 8 // uint64 to indicate length of deletions bitmap
+			sum += len(node.Deletions.ToBuffer())
+		}
+	}
+
+	return sum
+}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -22,7 +22,7 @@ func (m *Memtable) roaringSetAddOne(key []byte, value uint64) error {
 }
 
 func (m *Memtable) roaringSetAddList(key []byte, values []uint64) error {
-	if err := checkStrategyRoaringSet(m.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err
 	}
 
@@ -40,7 +40,7 @@ func (m *Memtable) roaringSetAddList(key []byte, values []uint64) error {
 }
 
 func (m *Memtable) roaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
-	if err := checkStrategyRoaringSet(m.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err
 	}
 
@@ -62,7 +62,7 @@ func (m *Memtable) roaringSetRemoveOne(key []byte, value uint64) error {
 }
 
 func (m *Memtable) roaringSetRemoveList(key []byte, values []uint64) error {
-	if err := checkStrategyRoaringSet(m.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err
 	}
 
@@ -80,7 +80,7 @@ func (m *Memtable) roaringSetRemoveList(key []byte, values []uint64) error {
 }
 
 func (m *Memtable) roaringSetRemoveBitmap(key []byte, bm *sroar.Bitmap) error {
-	if err := checkStrategyRoaringSet(m.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err
 	}
 
@@ -98,7 +98,7 @@ func (m *Memtable) roaringSetRemoveBitmap(key []byte, bm *sroar.Bitmap) error {
 }
 
 func (m *Memtable) roaringSetAddRemoveBitmaps(key []byte, additions *sroar.Bitmap, deletions *sroar.Bitmap) error {
-	if err := checkStrategyRoaringSet(m.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err
 	}
 
@@ -119,7 +119,7 @@ func (m *Memtable) roaringSetAddRemoveBitmaps(key []byte, additions *sroar.Bitma
 }
 
 func (m *Memtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
-	if err := checkStrategyRoaringSet(m.strategy); err != nil {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
 

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_range.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/binary"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+func (m *Memtable) roaringSetRangeAdd(key uint64, values ...uint64) error {
+	if err := CheckStrategyRoaringSetRange(m.strategy); err != nil {
+		return err
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.roaringSetRangeAddCommitLog(key, values, nil); err != nil {
+		return err
+	}
+
+	m.roaringSetRange.Insert(key, values)
+
+	m.roaringSetRangeAdjustMeta(len(values))
+	return nil
+}
+
+func (m *Memtable) roaringSetRangeRemove(key uint64, values ...uint64) error {
+	if err := CheckStrategyRoaringSetRange(m.strategy); err != nil {
+		return err
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.roaringSetRangeAddCommitLog(key, nil, values); err != nil {
+		return err
+	}
+
+	m.roaringSetRange.Delete(key, values)
+
+	m.roaringSetRangeAdjustMeta(len(values))
+	return nil
+}
+
+func (m *Memtable) roaringSetRangeAdjustMeta(entriesChanged int) {
+	// TODO roaring-set-range new estimations
+
+	// in the worst case roaring bitmaps take 2 bytes per entry. A reasonable
+	// estimation is therefore to take the changed entries and multiply them by
+	// 2.
+	m.size += uint64(entriesChanged * 2)
+	m.metrics.size(m.size)
+	m.updateDirtyAt()
+}
+
+func (m *Memtable) roaringSetRangeAddCommitLog(key uint64, additions []uint64, deletions []uint64) error {
+	// TODO roaring-set-range improved commit log
+
+	keyBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(keyBuf, key)
+	bmAdditions := roaringset.NewBitmap(additions...)
+	bmDeletions := roaringset.NewBitmap(deletions...)
+
+	if node, err := roaringset.NewSegmentNode(keyBuf, bmAdditions, bmDeletions); err != nil {
+		return errors.Wrap(err, "create node for commit log")
+	} else if err := m.commitlog.add(node); err != nil {
+		return errors.Wrap(err, "add node to commit log")
+	}
+	return nil
+}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
@@ -15,12 +15,14 @@ import (
 	"path"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
 func TestMemtableRoaringSet(t *testing.T) {
+	logger, _ := test.NewNullLogger()
 	memPath := func() string {
 		return path.Join(t.TempDir(), "fake")
 	}
@@ -29,7 +31,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -61,7 +63,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -91,7 +93,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -123,7 +125,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -149,7 +151,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -179,7 +181,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")
@@ -209,7 +211,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 		cl, err := newCommitLogger(memPath())
 		require.NoError(t, err)
 
-		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil)
+		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger)
 		require.Nil(t, err)
 
 		key1, key2 := []byte("key1"), []byte("key2")

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -25,10 +26,11 @@ import (
 func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	dir := t.TempDir()
 
+	logger, _ := test.NewNullLogger()
 	cl, err := newCommitLogger(dir)
 	require.NoError(t, err)
 
-	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, cl, nil)
+	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, cl, nil, logger)
 	require.Nil(t, err)
 	t.Cleanup(func() {
 		require.Nil(t, m.commitlog.close())

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -25,21 +25,22 @@ type (
 )
 
 type Metrics struct {
-	CompactionReplace    *prometheus.GaugeVec
-	CompactionSet        *prometheus.GaugeVec
-	CompactionMap        *prometheus.GaugeVec
-	CompactionRoaringSet *prometheus.GaugeVec
-	ActiveSegments       *prometheus.GaugeVec
-	bloomFilters         prometheus.ObserverVec
-	SegmentObjects       *prometheus.GaugeVec
-	SegmentSize          *prometheus.GaugeVec
-	SegmentCount         *prometheus.GaugeVec
-	startupDurations     prometheus.ObserverVec
-	startupDiskIO        prometheus.ObserverVec
-	objectCount          prometheus.Gauge
-	memtableDurations    prometheus.ObserverVec
-	memtableSize         *prometheus.GaugeVec
-	DimensionSum         *prometheus.GaugeVec
+	CompactionReplace         *prometheus.GaugeVec
+	CompactionSet             *prometheus.GaugeVec
+	CompactionMap             *prometheus.GaugeVec
+	CompactionRoaringSet      *prometheus.GaugeVec
+	CompactionRoaringSetRange *prometheus.GaugeVec
+	ActiveSegments            *prometheus.GaugeVec
+	bloomFilters              prometheus.ObserverVec
+	SegmentObjects            *prometheus.GaugeVec
+	SegmentSize               *prometheus.GaugeVec
+	SegmentCount              *prometheus.GaugeVec
+	startupDurations          prometheus.ObserverVec
+	startupDiskIO             prometheus.ObserverVec
+	objectCount               prometheus.Gauge
+	memtableDurations         prometheus.ObserverVec
+	memtableSize              *prometheus.GaugeVec
+	DimensionSum              *prometheus.GaugeVec
 
 	groupClasses bool
 }
@@ -70,6 +71,12 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		"shard_name": shardName,
 	})
 
+	roaringSetRange := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
+		"operation":  "compact_lsm_segments_stratroaringsetrange",
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
 	stratMap := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
 		"operation":  "compact_lsm_segments_stratmap",
 		"class_name": className,
@@ -77,11 +84,12 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	})
 
 	return &Metrics{
-		groupClasses:         promMetrics.Group,
-		CompactionReplace:    replace,
-		CompactionSet:        set,
-		CompactionMap:        stratMap,
-		CompactionRoaringSet: roaringSet,
+		groupClasses:              promMetrics.Group,
+		CompactionReplace:         replace,
+		CompactionSet:             set,
+		CompactionMap:             stratMap,
+		CompactionRoaringSet:      roaringSet,
+		CompactionRoaringSetRange: roaringSetRange,
 		ActiveSegments: promMetrics.LSMSegmentCount.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -105,11 +105,8 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		return nil, fmt.Errorf("parse header: %w", err)
 	}
 
-	switch header.Strategy {
-	case segmentindex.StrategyReplace, segmentindex.StrategySetCollection,
-		segmentindex.StrategyMapCollection, segmentindex.StrategyRoaringSet:
-	default:
-		return nil, fmt.Errorf("unsupported strategy in segment")
+	if err := segmentindex.CheckExpectedStrategy(header.Strategy); err != nil {
+		return nil, fmt.Errorf("unsupported strategy in segment: %w", err)
 	}
 
 	primaryIndex, err := header.PrimaryIndex(contents)

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -62,11 +62,8 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 		return nil, fmt.Errorf("parse header: %w", err)
 	}
 
-	switch header.Strategy {
-	case segmentindex.StrategyReplace, segmentindex.StrategySetCollection,
-		segmentindex.StrategyMapCollection, segmentindex.StrategyRoaringSet:
-	default:
-		return nil, fmt.Errorf("unsupported strategy in segment")
+	if err := segmentindex.CheckExpectedStrategy(header.Strategy); err != nil {
+		return nil, fmt.Errorf("unsupported strategy in segment: %w", err)
 	}
 
 	primaryIndex, err := header.PrimaryIndex(contents)

--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -11,6 +11,8 @@
 
 package segmentindex
 
+import "fmt"
+
 type Strategy uint16
 
 const (
@@ -19,3 +21,38 @@ const (
 	StrategyMapCollection
 	StrategyRoaringSet
 )
+
+func IsExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) bool {
+	if len(expectedStrategies) == 0 {
+		expectedStrategies = []Strategy{
+			StrategyReplace,
+			StrategySetCollection,
+			StrategyMapCollection,
+			StrategyRoaringSet,
+			StrategyRoaringSetRange,
+		}
+	}
+
+	for _, s := range expectedStrategies {
+		if s == strategy {
+			return true
+		}
+	}
+	return false
+}
+
+func CheckExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) error {
+	if IsExpectedStrategy(strategy, expectedStrategies...) {
+		return nil
+	}
+	if len(expectedStrategies) == 1 {
+		return fmt.Errorf("strategy %v expected, got %v", expectedStrategies[0], strategy)
+	}
+	return fmt.Errorf("one of strategies %v expected, got %v", expectedStrategies, strategy)
+}
+
+func MustBeExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) {
+	if err := CheckExpectedStrategy(strategy, expectedStrategies...); err != nil {
+		panic(err)
+	}
+}

--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -20,6 +20,7 @@ const (
 	StrategySetCollection
 	StrategyMapCollection
 	StrategyRoaringSet
+	StrategyRoaringSetRange
 )
 
 func IsExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) bool {

--- a/adapters/repos/db/roaringset/binary_search_tree_test.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_test.go
@@ -12,8 +12,13 @@
 package roaringset
 
 import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -203,4 +208,57 @@ func TestBSTRoaringSet_Flatten(t *testing.T) {
 			}
 		})
 	})
+}
+
+func BenchmarkBinarySearchTreeInsert(b *testing.B) {
+	count := uint64(10_000)
+	keys := make([][]byte, count)
+
+	// generate
+	for i := range keys {
+		bytes, err := lexicographicallySortableFloat64(float64(i))
+		require.NoError(b, err)
+		keys[i] = bytes
+	}
+
+	// shuffle
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := range keys {
+		j := r.Intn(i + 1)
+		keys[i], keys[j] = keys[j], keys[i]
+	}
+
+	insert := Insert{Additions: make([]uint64, 1)}
+	for i := 0; i < b.N; i++ {
+		m := &BinarySearchTree{}
+		for value := uint64(0); value < count; value++ {
+			insert.Additions[0] = value
+			m.Insert(keys[value], insert)
+		}
+	}
+}
+
+func lexicographicallySortableFloat64(in float64) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+
+	err := binary.Write(buf, binary.BigEndian, in)
+	if err != nil {
+		return nil, errors.Wrap(err, "serialize float64 value as big endian")
+	}
+
+	var out []byte
+	if in >= 0 {
+		// on positive numbers only flip the sign
+		out = buf.Bytes()
+		firstByte := out[0] ^ 0x80
+		out = append([]byte{firstByte}, out[1:]...)
+	} else {
+		// on negative numbers flip every bit
+		out = make([]byte, 8)
+		for i, b := range buf.Bytes() {
+			out[i] = b ^ 0xFF
+		}
+	}
+
+	return out, nil
 }

--- a/adapters/repos/db/roaringset/binary_search_tree_test.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_test.go
@@ -12,13 +12,8 @@
 package roaringset
 
 import (
-	"bytes"
-	"encoding/binary"
-	"math/rand"
 	"testing"
-	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -208,57 +203,4 @@ func TestBSTRoaringSet_Flatten(t *testing.T) {
 			}
 		})
 	})
-}
-
-func BenchmarkBinarySearchTreeInsert(b *testing.B) {
-	count := uint64(10_000)
-	keys := make([][]byte, count)
-
-	// generate
-	for i := range keys {
-		bytes, err := lexicographicallySortableFloat64(float64(i))
-		require.NoError(b, err)
-		keys[i] = bytes
-	}
-
-	// shuffle
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := range keys {
-		j := r.Intn(i + 1)
-		keys[i], keys[j] = keys[j], keys[i]
-	}
-
-	insert := Insert{Additions: make([]uint64, 1)}
-	for i := 0; i < b.N; i++ {
-		m := &BinarySearchTree{}
-		for value := uint64(0); value < count; value++ {
-			insert.Additions[0] = value
-			m.Insert(keys[value], insert)
-		}
-	}
-}
-
-func lexicographicallySortableFloat64(in float64) ([]byte, error) {
-	buf := bytes.NewBuffer(nil)
-
-	err := binary.Write(buf, binary.BigEndian, in)
-	if err != nil {
-		return nil, errors.Wrap(err, "serialize float64 value as big endian")
-	}
-
-	var out []byte
-	if in >= 0 {
-		// on positive numbers only flip the sign
-		out = buf.Bytes()
-		firstByte := out[0] ^ 0x80
-		out = append([]byte{firstByte}, out[1:]...)
-	} else {
-		// on negative numbers flip every bit
-		out = make([]byte, 8)
-		for i, b := range buf.Bytes() {
-			out[i] = b ^ 0xFF
-		}
-	}
-
-	return out, nil
 }

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -116,8 +116,8 @@ func (bml BitmapLayers) Merge() (BitmapLayer, error) {
 	left, right := bml[0], bml[1]
 
 	additions := left.Additions.Clone()
-	additions.Or(right.Additions)
 	additions.AndNot(right.Deletions)
+	additions.Or(right.Additions)
 
 	deletions := left.Deletions.Clone()
 	deletions.AndNot(right.Additions)

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -100,6 +100,27 @@ func (bml BitmapLayers) Flatten() *sroar.Bitmap {
 	return merged
 }
 
+// FlattenMutate works as Flatten but mutates passed bitmaps:
+// bml[0].Additions and bml[!=0].Deletions.
+// It is important to provide cloned bitmaps if original ones
+// are expected not to change.
+func (bml BitmapLayers) FlattenMutate() *sroar.Bitmap {
+	if len(bml) == 0 {
+		return sroar.NewBitmap()
+	}
+
+	merged := bml[0].Additions
+	for i := 1; i < len(bml); i++ {
+		// AndNot of only common set seems to be faster than AndNot of bigger set
+		// therefore call to And first
+		bml[i].Deletions.And(merged)
+		merged.AndNot(bml[i].Deletions)
+		merged.Or(bml[i].Additions)
+	}
+
+	return merged
+}
+
 // Merge turns two successive layers into one. It does not flatten the segment,
 // but keeps additions and deletions separate. This is because there are no
 // guarantees that the first segment was the root segment. A merge could run on

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -1,0 +1,293 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+// Compactor takes in a left and a right segment and merges them into a single
+// segment. The input segments are represented by cursors without their
+// respective segmentindexes. A new segmentindex is built from the merged nodes
+// without taking the old indexes into account at all.
+//
+// The left segment must precede the right one in its creation time, as the
+// compactor applies latest-takes-presence rules when there is a conflict.
+//
+// # Merging independent key/value pairs
+//
+// The new segment's nodes will be in sorted fashion (this is a requirement for
+// the segment index and segment cursors to function). To achieve a sorted end
+// result, the Compactor goes over both input cursors simultaneously and always
+// works on the smaller of the two keys. After a key/value pair has been added
+// to the output only the input cursor that provided the pair is advanced.
+//
+// # Merging key/value pairs with identical keys
+//
+// When both segment have a key/value pair with an overlapping key, the value
+// has to be merged. The merge logic is not part of the compactor itself.
+// Instead it makes use of [BitmapLayers.Merge].
+//
+// # Exit Criterium
+//
+// When both cursors no longer return values, all key/value pairs are
+// considered compacted. The compactor then deals with metadata.
+//
+// # Index and Header metadata
+//
+// Once the key/value pairs have been compacted, the input writer is rewinded
+// to be able to write the header metadata at the beginning of the file
+// Because of this, the input writer must be an [io.WriteSeeker],
+// such as [*os.File].
+//
+// The level of the resulting segment is the input level increased by one.
+// Levels help the "eligible for compaction" cycle to find suitable compaction
+// pairs.
+type Compactor struct {
+	left, right  *SegmentCursor
+	currentLevel uint16
+	// Tells if deletions or keys without corresponding values
+	// can be removed from merged segment.
+	// (left segment is root (1st) one, keepTombstones is off for bucket)
+	cleanupDeletions bool
+
+	w    io.WriteSeeker
+	bufw *bufio.Writer
+}
+
+// NewCompactor from left (older) and right (newer) seeker. See [Compactor] for
+// an explanation of what goes on under the hood, and why the input
+// requirements are the way they are.
+func NewCompactor(w io.WriteSeeker, left, right *SegmentCursor,
+	level uint16, cleanupDeletions bool,
+) *Compactor {
+	return &Compactor{
+		left:             left,
+		right:            right,
+		w:                w,
+		bufw:             bufio.NewWriterSize(w, 256*1024),
+		currentLevel:     level,
+		cleanupDeletions: cleanupDeletions,
+	}
+}
+
+// Do starts a compaction. See [Compactor] for an explanation of this process.
+func (c *Compactor) Do() error {
+	if err := c.init(); err != nil {
+		return fmt.Errorf("init: %w", err)
+	}
+
+	written, err := c.writeNodes()
+	if err != nil {
+		return fmt.Errorf("write keys: %w", err)
+	}
+
+	// flush buffered, so we can safely seek on underlying writer
+	if err := c.bufw.Flush(); err != nil {
+		return fmt.Errorf("flush buffered: %w", err)
+	}
+
+	dataEnd := segmentindex.HeaderSize + uint64(written)
+	if err := c.writeHeader(dataEnd); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Compactor) init() error {
+	// write a dummy header, we don't know the contents of the actual header yet,
+	// we will seek to the beginning and overwrite the actual header at the very
+	// end
+
+	if _, err := c.bufw.Write(make([]byte, segmentindex.HeaderSize)); err != nil {
+		return errors.Wrap(err, "write empty header")
+	}
+
+	return nil
+}
+
+func (c *Compactor) writeNodes() (int, error) {
+	nc := &nodeCompactor{
+		left:             c.left,
+		right:            c.right,
+		bufw:             c.bufw,
+		cleanupDeletions: c.cleanupDeletions,
+		emptyBitmap:      sroar.NewBitmap(),
+	}
+
+	if err := nc.loopThroughKeys(); err != nil {
+		return 0, err
+	}
+
+	return nc.written, nil
+}
+
+// writeHeader assumes that everything has been written to the underlying
+// writer and it is now safe to seek to the beginning and override the initial
+// header
+func (c *Compactor) writeHeader(startOfIndex uint64) error {
+	if _, err := c.w.Seek(0, io.SeekStart); err != nil {
+		return errors.Wrap(err, "seek to beginning to write header")
+	}
+
+	h := &segmentindex.Header{
+		Level:            c.currentLevel,
+		Version:          0,
+		SecondaryIndices: 0,
+		Strategy:         segmentindex.StrategyRoaringSetRange,
+		IndexStart:       startOfIndex,
+	}
+
+	if _, err := h.WriteTo(c.w); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// nodeCompactor is a helper type to improve the code structure of merging
+// nodes in a compaction
+type nodeCompactor struct {
+	left, right *SegmentCursor
+	bufw        *bufio.Writer
+	written     int
+
+	keyLeft, keyRight             uint8
+	valueLeft, valueRight         roaringset.BitmapLayer
+	okLeft, okRight               bool
+	deletionsLeft, deletionsRight *sroar.Bitmap
+
+	cleanupDeletions bool
+	emptyBitmap      *sroar.Bitmap
+}
+
+func (nc *nodeCompactor) loopThroughKeys() error {
+	nc.keyLeft, nc.valueLeft, nc.okLeft = nc.left.First()
+	if nc.okLeft && nc.keyLeft == 0 {
+		nc.deletionsLeft = nc.valueLeft.Deletions
+	} else {
+		nc.deletionsLeft = nc.emptyBitmap
+	}
+
+	nc.keyRight, nc.valueRight, nc.okRight = nc.right.First()
+	if nc.okRight && nc.keyRight == 0 {
+		nc.deletionsRight = nc.valueRight.Deletions
+	} else {
+		nc.deletionsRight = nc.emptyBitmap
+	}
+
+	var err error
+	for {
+		if !nc.okLeft && !nc.okRight {
+			return nil
+		}
+
+		if nc.okLeft && nc.okRight {
+			if nc.keyLeft == nc.keyRight {
+				err = nc.mergeIdenticalKeys()
+			} else if nc.keyLeft < nc.keyRight {
+				err = nc.takeLeftKey()
+			} else {
+				err = nc.takeRightKey()
+			}
+		} else if nc.okLeft {
+			err = nc.takeLeftKey()
+		} else {
+			err = nc.takeRightKey()
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (nc *nodeCompactor) mergeIdenticalKeys() error {
+	layers := roaringset.BitmapLayers{
+		{Additions: nc.valueLeft.Additions, Deletions: nc.deletionsLeft},
+		{Additions: nc.valueRight.Additions, Deletions: nc.deletionsRight},
+	}
+	if err := nc.mergeLayers(nc.keyLeft, layers, "merged"); err != nil {
+		return err
+	}
+
+	nc.keyLeft, nc.valueLeft, nc.okLeft = nc.left.Next()
+	nc.keyRight, nc.valueRight, nc.okRight = nc.right.Next()
+	return nil
+}
+
+func (nc *nodeCompactor) takeLeftKey() error {
+	layers := roaringset.BitmapLayers{
+		{Additions: nc.valueLeft.Additions, Deletions: nc.deletionsLeft},
+		{Additions: nc.emptyBitmap, Deletions: nc.deletionsRight},
+	}
+	if err := nc.mergeLayers(nc.keyLeft, layers, "left"); err != nil {
+		return err
+	}
+
+	nc.keyLeft, nc.valueLeft, nc.okLeft = nc.left.Next()
+	return nil
+}
+
+func (nc *nodeCompactor) takeRightKey() error {
+	layers := roaringset.BitmapLayers{
+		{Additions: nc.emptyBitmap, Deletions: nc.deletionsLeft},
+		{Additions: nc.valueRight.Additions, Deletions: nc.deletionsRight},
+	}
+	if err := nc.mergeLayers(nc.keyRight, layers, "right"); err != nil {
+		return err
+	}
+
+	nc.keyRight, nc.valueRight, nc.okRight = nc.right.Next()
+	return nil
+}
+
+func (nc *nodeCompactor) mergeLayers(key uint8, layers roaringset.BitmapLayers, name string) error {
+	merged, err := layers.Merge()
+	if err != nil {
+		return fmt.Errorf("merge bitmap layers for %s key %d: %w", name, key, err)
+	}
+
+	if additions, deletions, skip := nc.cleanupValues(merged.Additions, merged.Deletions); !skip {
+		sn, err := NewSegmentNode(key, additions, deletions)
+		if err != nil {
+			return fmt.Errorf("new segment node for %s key %d: %w", name, key, err)
+		}
+
+		n, err := nc.bufw.Write(sn.ToBuffer())
+		if err != nil {
+			return fmt.Errorf("write individual node for %s key %d: %w", name, key, err)
+		}
+
+		nc.written += n
+	}
+	return nil
+}
+
+func (nc *nodeCompactor) cleanupValues(additions, deletions *sroar.Bitmap,
+) (add, del *sroar.Bitmap, skip bool) {
+	if !nc.cleanupDeletions {
+		return additions, deletions, false
+	}
+	if !additions.IsEmpty() {
+		return additions, nc.emptyBitmap, false
+	}
+	return nil, nil, true
+}

--- a/adapters/repos/db/roaringsetrange/compactor_test.go
+++ b/adapters/repos/db/roaringsetrange/compactor_test.go
@@ -1,0 +1,385 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+func Test_Compactor(t *testing.T) {
+	type test struct {
+		name         string
+		left         []byte
+		right        []byte
+		expected     []segmentEntry
+		expectedRoot []segmentEntry
+	}
+
+	tests := []test{
+		{
+			name: "segments with nothing deleted",
+			left: createSegmentsFromEntries(t, []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{11, 22, 33},
+					deletions: []uint64{111},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{22},
+					deletions: []uint64{222}, // ignored
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{33},
+					deletions: []uint64{333}, // ignored
+				},
+			}),
+			right: createSegmentsFromEntries(t, []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{55, 66},
+					deletions: []uint64{444},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{55},
+					deletions: []uint64{555}, // ignored
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{66},
+					deletions: []uint64{666}, // ignored
+				},
+			}),
+			expected: []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{11, 22, 33, 55, 66},
+					deletions: []uint64{111, 444},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{22, 55},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{66},
+					deletions: []uint64{},
+				},
+			},
+			expectedRoot: []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{11, 22, 33, 55, 66},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{22, 55},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{66},
+					deletions: []uint64{},
+				},
+			},
+		},
+		{
+			name: "segments with everything overwritten",
+			left: createSegmentsFromEntries(t, []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{11, 22, 33, 44},
+					deletions: []uint64{111},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{22},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{44},
+					deletions: []uint64{},
+				},
+			}),
+			right: createSegmentsFromEntries(t, []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{22, 33, 44, 55},
+					deletions: []uint64{11, 22, 33, 44, 666},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{55},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{22},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(4),
+					additions: []uint64{44},
+					deletions: []uint64{},
+				},
+			}),
+			expected: []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{22, 33, 44, 55},
+					deletions: []uint64{11, 22, 33, 44, 111, 666},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{55},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{22},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(4),
+					additions: []uint64{44},
+					deletions: []uint64{},
+				},
+			},
+			expectedRoot: []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{22, 33, 44, 55},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{55},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{22},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(4),
+					additions: []uint64{44},
+					deletions: []uint64{},
+				},
+			},
+		},
+		{
+			name: "segments with everything deleted",
+			left: createSegmentsFromEntries(t, []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{11, 22, 33, 44},
+					deletions: []uint64{111},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{22},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{33},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{44},
+					deletions: []uint64{},
+				},
+			}),
+			right: createSegmentsFromEntries(t, []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{},
+					deletions: []uint64{11, 22, 33, 44},
+				},
+			}),
+			expected: []segmentEntry{
+				{
+					key:       uint8(0),
+					additions: []uint64{},
+					deletions: []uint64{11, 22, 33, 44, 111},
+				},
+				{
+					key:       uint8(1),
+					additions: []uint64{},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(2),
+					additions: []uint64{},
+					deletions: []uint64{},
+				},
+				{
+					key:       uint8(3),
+					additions: []uint64{},
+					deletions: []uint64{},
+				},
+			},
+			expectedRoot: []segmentEntry{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("[keep] "+test.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			leftCursor := NewSegmentCursor(test.left)
+			rightCursor := NewSegmentCursor(test.right)
+
+			segmentFile := filepath.Join(dir, "result.db")
+			f, err := os.Create(segmentFile)
+			require.NoError(t, err)
+
+			c := NewCompactor(f, leftCursor, rightCursor, 5, false)
+			require.NoError(t, c.Do())
+
+			require.NoError(t, f.Close())
+
+			f, err = os.Open(segmentFile)
+			require.NoError(t, err)
+
+			header, err := segmentindex.ParseHeader(f)
+			require.NoError(t, err)
+
+			segmentBytes, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			require.NoError(t, f.Close())
+
+			cu := NewSegmentCursor(segmentBytes[:header.IndexStart-segmentindex.HeaderSize])
+
+			i := 0
+			for k, l, ok := cu.First(); ok; k, l, ok = cu.Next() {
+				fmt.Printf("  ==> i %d\n", i)
+				fmt.Printf("  ==> k %d, add %v del %v\n\n", k, l.Additions.ToArray(), l.Deletions.ToArray())
+
+				// assert.Equal(t, test.expected[i].key, k)
+				// assert.Equal(t, test.expected[i].additions, l.Additions.ToArray())
+				// assert.Equal(t, test.expected[i].deletions, l.Deletions.ToArray())
+				i++
+			}
+
+			assert.Equal(t, len(test.expected), i, "all expected keys must have been hit")
+		})
+	}
+
+	for _, test := range tests {
+		t.Run("[cleanup] "+test.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			leftCursor := NewSegmentCursor(test.left)
+			rightCursor := NewSegmentCursor(test.right)
+
+			segmentFile := filepath.Join(dir, "result.db")
+			f, err := os.Create(segmentFile)
+			require.NoError(t, err)
+
+			c := NewCompactor(f, leftCursor, rightCursor, 5, true)
+			require.NoError(t, c.Do())
+
+			require.NoError(t, f.Close())
+
+			f, err = os.Open(segmentFile)
+			require.NoError(t, err)
+
+			header, err := segmentindex.ParseHeader(f)
+			require.NoError(t, err)
+
+			segmentBytes, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			require.NoError(t, f.Close())
+
+			cu := NewSegmentCursor(segmentBytes[:header.IndexStart-segmentindex.HeaderSize])
+
+			i := 0
+			for k, l, ok := cu.First(); ok; k, l, ok = cu.Next() {
+				assert.Equal(t, test.expectedRoot[i].key, k)
+				assert.Equal(t, test.expectedRoot[i].additions, l.Additions.ToArray())
+				assert.Empty(t, l.Deletions.ToArray())
+				i++
+			}
+
+			assert.Equal(t, len(test.expectedRoot), i, "all expected keys must have been hit")
+		})
+	}
+}
+
+type segmentEntry struct {
+	key       uint8
+	additions []uint64
+	deletions []uint64
+}
+
+func createSegmentsFromEntries(t *testing.T, entries []segmentEntry) []byte {
+	out := []byte{}
+
+	for _, entry := range entries {
+		add := roaringset.NewBitmap(entry.additions...)
+		del := roaringset.NewBitmap(entry.deletions...)
+		sn, err := NewSegmentNode(entry.key, add, del)
+		require.Nil(t, err)
+		out = append(out, sn.ToBuffer()...)
+	}
+
+	return out
+}

--- a/adapters/repos/db/roaringsetrange/cursor.go
+++ b/adapters/repos/db/roaringsetrange/cursor.go
@@ -1,0 +1,127 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+type CombinedCursor struct {
+	cursors []InnerCursor
+
+	inited    bool
+	states    []innerCursorState
+	deletions []*sroar.Bitmap
+}
+
+type InnerCursor interface {
+	First() (uint8, roaringset.BitmapLayer, bool)
+	Next() (uint8, roaringset.BitmapLayer, bool)
+}
+
+type innerCursorState struct {
+	key       uint8
+	additions *sroar.Bitmap
+	ok        bool
+}
+
+func NewCombinedCursor(innerCursors []InnerCursor) *CombinedCursor {
+	return &CombinedCursor{
+		cursors:   innerCursors,
+		inited:    false,
+		states:    make([]innerCursorState, len(innerCursors)),
+		deletions: make([]*sroar.Bitmap, len(innerCursors)),
+	}
+}
+
+func (c *CombinedCursor) First() (uint8, *sroar.Bitmap, bool) {
+	c.inited = true
+	for i, cursor := range c.cursors {
+		key, layer, ok := cursor.First()
+		if ok && key == 0 {
+			c.deletions[i] = layer.Deletions
+		} else {
+			c.deletions[i] = sroar.NewBitmap()
+		}
+
+		c.states[i] = innerCursorState{
+			key:       key,
+			additions: layer.Additions,
+			ok:        ok,
+		}
+	}
+
+	return c.combine()
+}
+
+func (c *CombinedCursor) Next() (uint8, *sroar.Bitmap, bool) {
+	if !c.inited {
+		return c.First()
+	}
+	return c.combine()
+}
+
+func (c *CombinedCursor) combine() (uint8, *sroar.Bitmap, bool) {
+	key, ids := c.getCursorIdsWithLowestKey()
+	if len(ids) == 0 {
+		return 0, nil, false
+	}
+
+	layers := roaringset.BitmapLayers{}
+	for i := range c.cursors {
+		var additions *sroar.Bitmap
+		if _, ok := ids[i]; ok {
+			additions = c.states[i].additions
+
+			// move forward used cursors
+			key, layer, ok := c.cursors[i].Next()
+			c.states[i] = innerCursorState{
+				key:       key,
+				additions: layer.Additions,
+				ok:        ok,
+			}
+		} else {
+			additions = sroar.NewBitmap()
+		}
+
+		layers = append(layers, roaringset.BitmapLayer{
+			Additions: additions,
+			Deletions: c.deletions[i],
+		})
+	}
+
+	return key, layers.Flatten(), true
+}
+
+func (c *CombinedCursor) getCursorIdsWithLowestKey() (uint8, map[int]struct{}) {
+	var lowestKey uint8
+	ids := map[int]struct{}{}
+
+	for id, state := range c.states {
+		if !state.ok {
+			continue
+		}
+
+		if len(ids) == 0 {
+			lowestKey = state.key
+			ids[id] = struct{}{}
+		} else if lowestKey == state.key {
+			ids[id] = struct{}{}
+		} else if lowestKey > state.key {
+			lowestKey = state.key
+			ids = map[int]struct{}{id: {}}
+		}
+	}
+
+	return lowestKey, ids
+}

--- a/adapters/repos/db/roaringsetrange/cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/cursor_test.go
@@ -1,0 +1,324 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+func TestCombinedCursor(t *testing.T) {
+	t.Run("single inner cursor", func(t *testing.T) {
+		createCursor := func() *CombinedCursor {
+			innerCursor := newFixedInnerCursor().
+				withEntry(0, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, []uint64{2, 3, 4, 22, 333}).
+				withEntry(1, []uint64{11, 22, 33}, []uint64{44}).
+				withEntry(2, []uint64{111, 222, 333}, []uint64{0})
+
+			return NewCombinedCursor([]InnerCursor{innerCursor})
+		}
+
+		t.Run("first and nexts", func(t *testing.T) {
+			cursor := createCursor()
+
+			key0, bm0, ok0 := cursor.First()
+			key1, bm1, ok1 := cursor.Next()
+			key2, bm2, ok2 := cursor.Next()
+			key3, bm3, ok3 := cursor.Next()
+			key4, bm4, ok4 := cursor.Next()
+
+			assert.Equal(t, uint8(0), key0)
+			assert.ElementsMatch(t, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, bm0.ToArray())
+			assert.True(t, ok0)
+
+			assert.Equal(t, uint8(1), key1)
+			assert.ElementsMatch(t, []uint64{11, 22, 33}, bm1.ToArray())
+			assert.True(t, ok1)
+
+			assert.Equal(t, uint8(2), key2)
+			assert.ElementsMatch(t, []uint64{111, 222, 333}, bm2.ToArray())
+			assert.True(t, ok2)
+
+			assert.Equal(t, uint8(0), key3)
+			assert.Empty(t, bm3.ToArray())
+			assert.False(t, ok3)
+
+			assert.Equal(t, uint8(0), key4)
+			assert.Empty(t, bm4.ToArray())
+			assert.False(t, ok4)
+		})
+
+		t.Run("only nexts", func(t *testing.T) {
+			cursor := createCursor()
+
+			key0, bm0, ok0 := cursor.Next()
+			key1, bm1, ok1 := cursor.Next()
+			key2, bm2, ok2 := cursor.Next()
+			key3, bm3, ok3 := cursor.Next()
+
+			assert.Equal(t, uint8(0), key0)
+			assert.ElementsMatch(t, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, bm0.ToArray())
+			assert.True(t, ok0)
+
+			assert.Equal(t, uint8(1), key1)
+			assert.ElementsMatch(t, []uint64{11, 22, 33}, bm1.ToArray())
+			assert.True(t, ok1)
+
+			assert.Equal(t, uint8(2), key2)
+			assert.ElementsMatch(t, []uint64{111, 222, 333}, bm2.ToArray())
+			assert.True(t, ok2)
+
+			assert.Equal(t, uint8(0), key3)
+			assert.Empty(t, bm3.ToArray())
+			assert.False(t, ok3)
+		})
+
+		t.Run("first, nexts and first again", func(t *testing.T) {
+			cursor := createCursor()
+
+			key0, bm0, ok0 := cursor.First()
+			key1, bm1, ok1 := cursor.Next()
+			key2, bm2, ok2 := cursor.Next()
+			key3, bm3, ok3 := cursor.Next()
+			key4, bm4, ok4 := cursor.First()
+			key5, bm5, ok5 := cursor.Next()
+			key6, bm6, ok6 := cursor.First()
+
+			assert.Equal(t, uint8(0), key0)
+			assert.ElementsMatch(t, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, bm0.ToArray())
+			assert.True(t, ok0)
+
+			assert.Equal(t, uint8(1), key1)
+			assert.ElementsMatch(t, []uint64{11, 22, 33}, bm1.ToArray())
+			assert.True(t, ok1)
+
+			assert.Equal(t, uint8(2), key2)
+			assert.ElementsMatch(t, []uint64{111, 222, 333}, bm2.ToArray())
+			assert.True(t, ok2)
+
+			assert.Equal(t, uint8(0), key3)
+			assert.Empty(t, bm3.ToArray())
+			assert.False(t, ok3)
+
+			assert.Equal(t, uint8(0), key4)
+			assert.ElementsMatch(t, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, bm4.ToArray())
+			assert.True(t, ok4)
+
+			assert.Equal(t, uint8(1), key5)
+			assert.ElementsMatch(t, []uint64{11, 22, 33}, bm5.ToArray())
+			assert.True(t, ok5)
+
+			assert.Equal(t, uint8(0), key6)
+			assert.ElementsMatch(t, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, bm6.ToArray())
+			assert.True(t, ok6)
+		})
+	})
+
+	t.Run("multiple inner cursors", func(t *testing.T) {
+		createCursor := func() *CombinedCursor {
+			innerCursor1 := newFixedInnerCursor().
+				withEntry(0, []uint64{1, 2, 3, 11, 22, 33, 111, 222, 333}, []uint64{}).
+				withEntry(1, []uint64{11, 22, 33}, []uint64{}).
+				withEntry(2, []uint64{111, 222, 333}, []uint64{})
+
+			innerCursor2 := newFixedInnerCursor().
+				withEntry(0, []uint64{4, 5, 6, 44, 55, 66, 444, 555, 666}, []uint64{2, 3, 4, 22, 33, 44, 222, 333, 444}).
+				withEntry(1, []uint64{44, 55, 66}, []uint64{44}).
+				withEntry(3, []uint64{444, 555, 666}, []uint64{0})
+
+			innerCursor3 := newFixedInnerCursor().
+				withEntry(0, []uint64{7, 8, 9, 77, 88, 99, 777, 888, 999}, []uint64{5, 6, 7, 55, 66, 77, 555, 666, 777}).
+				withEntry(3, []uint64{77, 88, 99}, []uint64{44}).
+				withEntry(4, []uint64{777, 888, 999}, []uint64{0})
+
+			return NewCombinedCursor([]InnerCursor{innerCursor1, innerCursor2, innerCursor3})
+		}
+
+		t.Run("first and nexts", func(t *testing.T) {
+			cursor := createCursor()
+
+			key0, bm0, ok0 := cursor.First()
+			key1, bm1, ok1 := cursor.Next()
+			key2, bm2, ok2 := cursor.Next()
+			key3, bm3, ok3 := cursor.Next()
+			key4, bm4, ok4 := cursor.Next()
+			key5, bm5, ok5 := cursor.Next()
+			key6, bm6, ok6 := cursor.Next()
+
+			assert.Equal(t, uint8(0), key0)
+			assert.ElementsMatch(t, []uint64{1, 4, 7, 8, 9, 11, 44, 77, 88, 99, 111, 444, 777, 888, 999}, bm0.ToArray())
+			assert.True(t, ok0)
+
+			assert.Equal(t, uint8(1), key1)
+			assert.ElementsMatch(t, []uint64{11, 44}, bm1.ToArray())
+			assert.True(t, ok1)
+
+			assert.Equal(t, uint8(2), key2)
+			assert.ElementsMatch(t, []uint64{111}, bm2.ToArray())
+			assert.True(t, ok2)
+
+			assert.Equal(t, uint8(3), key3)
+			assert.ElementsMatch(t, []uint64{444, 77, 88, 99}, bm3.ToArray())
+			assert.True(t, ok3)
+
+			assert.Equal(t, uint8(4), key4)
+			assert.ElementsMatch(t, []uint64{777, 888, 999}, bm4.ToArray())
+			assert.True(t, ok4)
+
+			assert.Equal(t, uint8(0), key5)
+			assert.Empty(t, bm5.ToArray())
+			assert.False(t, ok5)
+
+			assert.Equal(t, uint8(0), key6)
+			assert.Empty(t, bm6.ToArray())
+			assert.False(t, ok6)
+		})
+
+		t.Run("only nexts", func(t *testing.T) {
+			cursor := createCursor()
+
+			key0, bm0, ok0 := cursor.Next()
+			key1, bm1, ok1 := cursor.Next()
+			key2, bm2, ok2 := cursor.Next()
+			key3, bm3, ok3 := cursor.Next()
+			key4, bm4, ok4 := cursor.Next()
+			key5, bm5, ok5 := cursor.Next()
+			key6, bm6, ok6 := cursor.Next()
+
+			assert.Equal(t, uint8(0), key0)
+			assert.ElementsMatch(t, []uint64{1, 4, 7, 8, 9, 11, 44, 77, 88, 99, 111, 444, 777, 888, 999}, bm0.ToArray())
+			assert.True(t, ok0)
+
+			assert.Equal(t, uint8(1), key1)
+			assert.ElementsMatch(t, []uint64{11, 44}, bm1.ToArray())
+			assert.True(t, ok1)
+
+			assert.Equal(t, uint8(2), key2)
+			assert.ElementsMatch(t, []uint64{111}, bm2.ToArray())
+			assert.True(t, ok2)
+
+			assert.Equal(t, uint8(3), key3)
+			assert.ElementsMatch(t, []uint64{444, 77, 88, 99}, bm3.ToArray())
+			assert.True(t, ok3)
+
+			assert.Equal(t, uint8(4), key4)
+			assert.ElementsMatch(t, []uint64{777, 888, 999}, bm4.ToArray())
+			assert.True(t, ok4)
+
+			assert.Equal(t, uint8(0), key5)
+			assert.Empty(t, bm5.ToArray())
+			assert.False(t, ok5)
+
+			assert.Equal(t, uint8(0), key6)
+			assert.Empty(t, bm6.ToArray())
+			assert.False(t, ok6)
+		})
+
+		t.Run("first, nexts and first again", func(t *testing.T) {
+			cursor := createCursor()
+
+			key0, bm0, ok0 := cursor.First()
+			key1, bm1, ok1 := cursor.Next()
+			key2, bm2, ok2 := cursor.Next()
+			key3, bm3, ok3 := cursor.Next()
+			key4, bm4, ok4 := cursor.Next()
+			key5, bm5, ok5 := cursor.Next()
+			key6, bm6, ok6 := cursor.First()
+			key7, bm7, ok7 := cursor.Next()
+			key8, bm8, ok8 := cursor.First()
+
+			assert.Equal(t, uint8(0), key0)
+			assert.ElementsMatch(t, []uint64{1, 4, 7, 8, 9, 11, 44, 77, 88, 99, 111, 444, 777, 888, 999}, bm0.ToArray())
+			assert.True(t, ok0)
+
+			assert.Equal(t, uint8(1), key1)
+			assert.ElementsMatch(t, []uint64{11, 44}, bm1.ToArray())
+			assert.True(t, ok1)
+
+			assert.Equal(t, uint8(2), key2)
+			assert.ElementsMatch(t, []uint64{111}, bm2.ToArray())
+			assert.True(t, ok2)
+
+			assert.Equal(t, uint8(3), key3)
+			assert.ElementsMatch(t, []uint64{444, 77, 88, 99}, bm3.ToArray())
+			assert.True(t, ok3)
+
+			assert.Equal(t, uint8(4), key4)
+			assert.ElementsMatch(t, []uint64{777, 888, 999}, bm4.ToArray())
+			assert.True(t, ok4)
+
+			assert.Equal(t, uint8(0), key5)
+			assert.Empty(t, bm5.ToArray())
+			assert.False(t, ok5)
+
+			assert.Equal(t, uint8(0), key6)
+			assert.ElementsMatch(t, []uint64{1, 4, 7, 8, 9, 11, 44, 77, 88, 99, 111, 444, 777, 888, 999}, bm6.ToArray())
+			assert.True(t, ok6)
+
+			assert.Equal(t, uint8(1), key7)
+			assert.ElementsMatch(t, []uint64{11, 44}, bm7.ToArray())
+			assert.True(t, ok7)
+
+			assert.Equal(t, uint8(0), key8)
+			assert.ElementsMatch(t, []uint64{1, 4, 7, 8, 9, 11, 44, 77, 88, 99, 111, 444, 777, 888, 999}, bm8.ToArray())
+			assert.True(t, ok8)
+		})
+	})
+}
+
+type fixedInnerCursor struct {
+	entries []fixedInnerCursorEntry
+	pos     int
+}
+
+func newFixedInnerCursor() *fixedInnerCursor {
+	return &fixedInnerCursor{
+		entries: make([]fixedInnerCursorEntry, 0),
+		pos:     0,
+	}
+}
+
+func (c *fixedInnerCursor) withEntry(key uint8, additions []uint64, deletions []uint64) *fixedInnerCursor {
+	c.entries = append(c.entries, fixedInnerCursorEntry{
+		key:       key,
+		additions: additions,
+		deletions: deletions,
+	})
+	return c
+}
+
+func (c *fixedInnerCursor) First() (uint8, roaringset.BitmapLayer, bool) {
+	c.pos = 0
+	return c.Next()
+}
+
+func (c *fixedInnerCursor) Next() (uint8, roaringset.BitmapLayer, bool) {
+	if c.pos >= len(c.entries) {
+		return 0, roaringset.BitmapLayer{}, false
+	}
+
+	defer func() { c.pos++ }()
+	return c.entries[c.pos].key,
+		roaringset.BitmapLayer{
+			Additions: roaringset.NewBitmap(c.entries[c.pos].additions...),
+			Deletions: roaringset.NewBitmap(c.entries[c.pos].deletions...),
+		},
+		true
+}
+
+type fixedInnerCursorEntry struct {
+	key       uint8
+	additions []uint64
+	deletions []uint64
+}

--- a/adapters/repos/db/roaringsetrange/cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/cursor_test.go
@@ -14,11 +14,14 @@ package roaringsetrange
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
 func TestCombinedCursor(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
 	t.Run("single inner cursor", func(t *testing.T) {
 		createCursor := func() *CombinedCursor {
 			innerCursor := newFixedInnerCursor().
@@ -26,7 +29,7 @@ func TestCombinedCursor(t *testing.T) {
 				withEntry(1, []uint64{11, 22, 33}, []uint64{44}).
 				withEntry(2, []uint64{111, 222, 333}, []uint64{0})
 
-			return NewCombinedCursor([]InnerCursor{innerCursor})
+			return NewCombinedCursor([]InnerCursor{innerCursor}, logger)
 		}
 
 		t.Run("first and nexts", func(t *testing.T) {
@@ -142,7 +145,7 @@ func TestCombinedCursor(t *testing.T) {
 				withEntry(3, []uint64{77, 88, 99}, []uint64{44}).
 				withEntry(4, []uint64{777, 888, 999}, []uint64{0})
 
-			return NewCombinedCursor([]InnerCursor{innerCursor1, innerCursor2, innerCursor3})
+			return NewCombinedCursor([]InnerCursor{innerCursor1, innerCursor2, innerCursor3}, logger)
 		}
 
 		t.Run("first and nexts", func(t *testing.T) {

--- a/adapters/repos/db/roaringsetrange/memtable.go
+++ b/adapters/repos/db/roaringsetrange/memtable.go
@@ -1,0 +1,110 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+type Memtable struct {
+	bitsAdditions map[uint8]*sroar.Bitmap
+	nnAdditions   *sroar.Bitmap
+	nnDeletions   *sroar.Bitmap
+}
+
+func NewMemtable() *Memtable {
+	return &Memtable{
+		bitsAdditions: make(map[uint8]*sroar.Bitmap),
+		nnAdditions:   sroar.NewBitmap(),
+		nnDeletions:   sroar.NewBitmap(),
+	}
+}
+
+func (m *Memtable) Insert(key uint64, values []uint64) {
+	if len(values) == 0 {
+		return
+	}
+
+	bmValues := roaringset.NewBitmap(values...)
+	m.nnDeletions.Or(bmValues)
+	m.nnAdditions.Or(bmValues)
+
+	for i := uint8(0); i < 64; i++ {
+		bitAdditions, ok := m.bitsAdditions[i]
+
+		if key&(1<<i) == 0 {
+			if ok {
+				bitAdditions.AndNot(bmValues)
+			}
+		} else {
+			if ok {
+				bitAdditions.Or(bmValues)
+			} else {
+				m.bitsAdditions[i] = bmValues.Clone()
+			}
+		}
+	}
+}
+
+func (m *Memtable) Delete(key uint64, values []uint64) {
+	if len(values) == 0 {
+		return
+	}
+
+	bmValues := roaringset.NewBitmap(values...)
+	m.nnDeletions.Or(bmValues)
+
+	bmValues.And(m.nnAdditions)
+	if bmValues.IsEmpty() {
+		return
+	}
+
+	m.nnAdditions.AndNot(bmValues)
+	for _, bitAdditions := range m.bitsAdditions {
+		bitAdditions.AndNot(bmValues)
+	}
+}
+
+func (m *Memtable) Nodes() []*MemtableNode {
+	if m.nnAdditions.IsEmpty() && m.nnDeletions.IsEmpty() {
+		return []*MemtableNode{}
+	}
+
+	nodes := make([]*MemtableNode, 1, 1+len(m.bitsAdditions))
+	nodes[0] = &MemtableNode{
+		Key:       0,
+		Additions: roaringset.Condense(m.nnAdditions),
+		Deletions: roaringset.Condense(m.nnDeletions),
+	}
+
+	bmEmpty := sroar.NewBitmap()
+	l := 1
+	for i := uint8(0); i < 64; i++ {
+		if bitAdditions, ok := m.bitsAdditions[i]; ok && !bitAdditions.IsEmpty() {
+			l++
+			nodes = append(nodes, &MemtableNode{
+				Key:       i + 1,
+				Additions: roaringset.Condense(bitAdditions),
+				Deletions: bmEmpty,
+			})
+		}
+	}
+
+	return nodes[:l]
+}
+
+type MemtableNode struct {
+	Key       uint8
+	Additions *sroar.Bitmap
+	Deletions *sroar.Bitmap
+}

--- a/adapters/repos/db/roaringsetrange/memtable_cursor.go
+++ b/adapters/repos/db/roaringsetrange/memtable_cursor.go
@@ -1,0 +1,44 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+type MemtableCursor struct {
+	nodes   []*MemtableNode
+	nextPos int
+}
+
+func NewMemtableCursor(memtable *Memtable) *MemtableCursor {
+	return &MemtableCursor{nodes: memtable.Nodes()}
+}
+
+func (c *MemtableCursor) First() (uint8, roaringset.BitmapLayer, bool) {
+	c.nextPos = 0
+	return c.Next()
+}
+
+func (c *MemtableCursor) Next() (uint8, roaringset.BitmapLayer, bool) {
+	if c.nextPos >= len(c.nodes) {
+		return 0, roaringset.BitmapLayer{}, false
+	}
+
+	mn := c.nodes[c.nextPos]
+	c.nextPos++
+
+	return mn.Key, roaringset.BitmapLayer{
+		Additions: mn.Additions,
+		Deletions: mn.Deletions,
+	}, true
+}

--- a/adapters/repos/db/roaringsetrange/memtable_cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/memtable_cursor_test.go
@@ -1,0 +1,164 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemtableCursor(t *testing.T) {
+	mem := NewMemtable()
+	mem.Insert(13, []uint64{113, 213}) // ...1101
+	mem.Insert(5, []uint64{15, 25})    // ...0101
+	mem.Insert(0, []uint64{10, 20})    // ...0000
+
+	t.Run("starting from beginning", func(t *testing.T) {
+		c := NewMemtableCursor(mem)
+		key, layer, ok := c.First()
+		require.True(t, ok)
+		assert.Equal(t, uint8(0), key)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer.Deletions.ToArray())
+	})
+
+	t.Run("starting from beginning, page through all", func(t *testing.T) {
+		c := NewMemtableCursor(mem)
+
+		key1, layer1, ok1 := c.First()
+		key2, layer2, ok2 := c.Next()
+		key3, layer3, ok3 := c.Next()
+		key4, layer4, ok4 := c.Next()
+		key5, layer5, ok5 := c.Next()
+		key6, layer6, ok6 := c.Next()
+
+		require.True(t, ok1)
+		assert.Equal(t, uint8(0), key1)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer1.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer1.Deletions.ToArray())
+
+		require.True(t, ok2)
+		assert.Equal(t, uint8(1), key2)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer2.Additions.ToArray())
+		assert.True(t, layer2.Deletions.IsEmpty())
+
+		require.True(t, ok3)
+		assert.Equal(t, uint8(3), key3)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer3.Additions.ToArray())
+		assert.True(t, layer3.Deletions.IsEmpty())
+
+		require.True(t, ok4)
+		assert.Equal(t, uint8(4), key4)
+		assert.ElementsMatch(t, []uint64{113, 213}, layer4.Additions.ToArray())
+		assert.True(t, layer4.Deletions.IsEmpty())
+
+		assert.False(t, ok5)
+		assert.Equal(t, uint8(0), key5)
+		assert.Nil(t, layer5.Additions)
+		assert.Nil(t, layer5.Deletions)
+
+		assert.False(t, ok6)
+		assert.Equal(t, uint8(0), key6)
+		assert.Nil(t, layer6.Additions)
+		assert.Nil(t, layer6.Deletions)
+	})
+
+	t.Run("no first, page through all", func(t *testing.T) {
+		c := NewMemtableCursor(mem)
+
+		key1, layer1, ok1 := c.Next()
+		key2, layer2, ok2 := c.Next()
+		key3, layer3, ok3 := c.Next()
+		key4, layer4, ok4 := c.Next()
+		key5, layer5, ok5 := c.Next()
+		key6, layer6, ok6 := c.Next()
+
+		require.True(t, ok1)
+		assert.Equal(t, uint8(0), key1)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer1.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer1.Deletions.ToArray())
+
+		require.True(t, ok2)
+		assert.Equal(t, uint8(1), key2)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer2.Additions.ToArray())
+		assert.True(t, layer2.Deletions.IsEmpty())
+
+		require.True(t, ok3)
+		assert.Equal(t, uint8(3), key3)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer3.Additions.ToArray())
+		assert.True(t, layer3.Deletions.IsEmpty())
+
+		require.True(t, ok4)
+		assert.Equal(t, uint8(4), key4)
+		assert.ElementsMatch(t, []uint64{113, 213}, layer4.Additions.ToArray())
+		assert.True(t, layer4.Deletions.IsEmpty())
+
+		assert.False(t, ok5)
+		assert.Equal(t, uint8(0), key5)
+		assert.Nil(t, layer5.Additions)
+		assert.Nil(t, layer5.Deletions)
+
+		assert.False(t, ok6)
+		assert.Equal(t, uint8(0), key6)
+		assert.Nil(t, layer6.Additions)
+		assert.Nil(t, layer6.Deletions)
+	})
+
+	t.Run("starting from beginning, page through all, start again", func(t *testing.T) {
+		c := NewMemtableCursor(mem)
+
+		key1, layer1, ok1 := c.First()
+		key2, layer2, ok2 := c.Next()
+		key3, layer3, ok3 := c.Next()
+		key4, layer4, ok4 := c.Next()
+		key5, layer5, ok5 := c.Next()
+		key6, layer6, ok6 := c.First()
+		key7, layer7, ok7 := c.Next()
+
+		require.True(t, ok1)
+		assert.Equal(t, uint8(0), key1)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer1.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer1.Deletions.ToArray())
+
+		require.True(t, ok2)
+		assert.Equal(t, uint8(1), key2)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer2.Additions.ToArray())
+		assert.True(t, layer2.Deletions.IsEmpty())
+
+		require.True(t, ok3)
+		assert.Equal(t, uint8(3), key3)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer3.Additions.ToArray())
+		assert.True(t, layer3.Deletions.IsEmpty())
+
+		require.True(t, ok4)
+		assert.Equal(t, uint8(4), key4)
+		assert.ElementsMatch(t, []uint64{113, 213}, layer4.Additions.ToArray())
+		assert.True(t, layer4.Deletions.IsEmpty())
+
+		assert.False(t, ok5)
+		assert.Equal(t, uint8(0), key5)
+		assert.Nil(t, layer5.Additions)
+		assert.Nil(t, layer5.Deletions)
+
+		require.True(t, ok6)
+		assert.Equal(t, uint8(0), key6)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer6.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, layer6.Deletions.ToArray())
+
+		require.True(t, ok7)
+		assert.Equal(t, uint8(1), key7)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, layer7.Additions.ToArray())
+		assert.True(t, layer7.Deletions.IsEmpty())
+	})
+}

--- a/adapters/repos/db/roaringsetrange/memtable_cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/memtable_cursor_test.go
@@ -14,12 +14,15 @@ package roaringsetrange
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMemtableCursor(t *testing.T) {
-	mem := NewMemtable()
+	logger, _ := test.NewNullLogger()
+
+	mem := NewMemtable(logger)
 	mem.Insert(13, []uint64{113, 213}) // ...1101
 	mem.Insert(5, []uint64{15, 25})    // ...0101
 	mem.Insert(0, []uint64{10, 20})    // ...0000

--- a/adapters/repos/db/roaringsetrange/memtable_test.go
+++ b/adapters/repos/db/roaringsetrange/memtable_test.go
@@ -12,8 +12,13 @@
 package roaringsetrange
 
 import (
+	"bytes"
+	"encoding/binary"
+	"math/rand"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,4 +201,92 @@ func TestMemtable(t *testing.T) {
 		assert.True(t, nodeNN.Additions.IsEmpty())
 		assert.ElementsMatch(t, []uint64{11, 22, 33, 44}, nodeNN.Deletions.ToArray())
 	})
+}
+
+func BenchmarkMemtableInsert(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	count := uint64(100_000)
+	keys := make([]uint64, count)
+
+	// generate
+	for i := range keys {
+		bytes, err := lexicographicallySortableFloat64(float64(i) / 3)
+		require.NoError(b, err)
+		value := binary.BigEndian.Uint64(bytes)
+		keys[i] = value
+	}
+
+	// shuffle
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := range keys {
+		j := r.Intn(i + 1)
+		keys[i], keys[j] = keys[j], keys[i]
+	}
+
+	val := make([]uint64, 1)
+	for i := 0; i < b.N; i++ {
+		m := NewMemtable(logger)
+		for value := uint64(0); value < count; value++ {
+			val[0] = value
+			m.Insert(keys[value], val)
+		}
+	}
+}
+
+func BenchmarkMemtableFlatten(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	count := uint64(100_000)
+	keys := make([]uint64, count)
+
+	// generate
+	for i := range keys {
+		bytes, err := lexicographicallySortableFloat64(float64(i) / 3)
+		require.NoError(b, err)
+		value := binary.BigEndian.Uint64(bytes)
+		keys[i] = value
+	}
+
+	// shuffle
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := range keys {
+		j := r.Intn(i + 1)
+		keys[i], keys[j] = keys[j], keys[i]
+	}
+
+	val := make([]uint64, 1)
+	m := NewMemtable(logger)
+	for value := uint64(0); value < count; value++ {
+		val[0] = value
+		m.Insert(keys[value], val)
+	}
+	// m.Close()
+
+	for i := 0; i < b.N; i++ {
+		m.Nodes()
+	}
+}
+
+func lexicographicallySortableFloat64(in float64) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+
+	err := binary.Write(buf, binary.BigEndian, in)
+	if err != nil {
+		return nil, errors.Wrap(err, "serialize float64 value as big endian")
+	}
+
+	var out []byte
+	if in >= 0 {
+		// on positive numbers only flip the sign
+		out = buf.Bytes()
+		firstByte := out[0] ^ 0x80
+		out = append([]byte{firstByte}, out[1:]...)
+	} else {
+		// on negative numbers flip every bit
+		out = make([]byte, 8)
+		for i, b := range buf.Bytes() {
+			out[i] = b ^ 0xFF
+		}
+	}
+
+	return out, nil
 }

--- a/adapters/repos/db/roaringsetrange/memtable_test.go
+++ b/adapters/repos/db/roaringsetrange/memtable_test.go
@@ -1,0 +1,196 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemtable(t *testing.T) {
+	t.Run("empty returns no nodes", func(t *testing.T) {
+		m := NewMemtable()
+		nodes := m.Nodes()
+
+		assert.Empty(t, nodes)
+	})
+
+	t.Run("returns only nodes for set bits - unique inserts", func(t *testing.T) {
+		m := NewMemtable()
+		m.Insert(13, []uint64{113, 213}) // ...1101
+		m.Insert(5, []uint64{15, 25})    // ...0101
+		m.Insert(0, []uint64{10, 20})    // ...0000
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 3+1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, nodeNN.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{10, 20, 15, 25, 113, 213}, nodeNN.Deletions.ToArray())
+
+		node0 := nodes[1]
+		assert.Equal(t, uint8(1), node0.Key)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, node0.Additions.ToArray())
+		assert.True(t, node0.Deletions.IsEmpty())
+
+		node2 := nodes[2]
+		assert.Equal(t, uint8(3), node2.Key)
+		assert.ElementsMatch(t, []uint64{15, 25, 113, 213}, node2.Additions.ToArray())
+		assert.True(t, node2.Deletions.IsEmpty())
+
+		node3 := nodes[3]
+		assert.Equal(t, uint8(4), node3.Key)
+		assert.ElementsMatch(t, []uint64{113, 213}, node3.Additions.ToArray())
+		assert.True(t, node3.Deletions.IsEmpty())
+	})
+
+	t.Run("returns only nodes for set bits - overwriting inserts", func(t *testing.T) {
+		m := NewMemtable()
+		m.Insert(13, []uint64{11, 22, 33}) // ...1101
+		m.Insert(5, []uint64{11, 22})      // ...0101
+		m.Insert(0, []uint64{11})          // ...0000
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 3+1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Deletions.ToArray())
+
+		node0 := nodes[1]
+		assert.Equal(t, uint8(1), node0.Key)
+		assert.ElementsMatch(t, []uint64{22, 33}, node0.Additions.ToArray())
+		assert.True(t, node0.Deletions.IsEmpty())
+
+		node2 := nodes[2]
+		assert.Equal(t, uint8(3), node2.Key)
+		assert.ElementsMatch(t, []uint64{22, 33}, node2.Additions.ToArray())
+		assert.True(t, node2.Deletions.IsEmpty())
+
+		node3 := nodes[3]
+		assert.Equal(t, uint8(4), node3.Key)
+		assert.ElementsMatch(t, []uint64{33}, node3.Additions.ToArray())
+		assert.True(t, node3.Deletions.IsEmpty())
+	})
+
+	t.Run("returns only nodes for set bits - overwriting inserts with deletes", func(t *testing.T) {
+		m := NewMemtable()
+		m.Insert(13, []uint64{11, 22, 33}) // ...1101
+		m.Delete(5, []uint64{11, 22})      // ...0101
+		m.Insert(5, []uint64{11, 22})      // ...0101
+		m.Delete(0, []uint64{11})          // ...0000
+		m.Insert(0, []uint64{11})          // ...0000
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 3+1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Deletions.ToArray())
+
+		node0 := nodes[1]
+		assert.Equal(t, uint8(1), node0.Key)
+		assert.ElementsMatch(t, []uint64{22, 33}, node0.Additions.ToArray())
+		assert.True(t, node0.Deletions.IsEmpty())
+
+		node2 := nodes[2]
+		assert.Equal(t, uint8(3), node2.Key)
+		assert.ElementsMatch(t, []uint64{22, 33}, node2.Additions.ToArray())
+		assert.True(t, node2.Deletions.IsEmpty())
+
+		node3 := nodes[3]
+		assert.Equal(t, uint8(4), node3.Key)
+		assert.ElementsMatch(t, []uint64{33}, node3.Additions.ToArray())
+		assert.True(t, node3.Deletions.IsEmpty())
+	})
+
+	t.Run("delete does not mind key value", func(t *testing.T) {
+		m := NewMemtable()
+		m.Delete(13, []uint64{33}) // ...1101
+		m.Delete(5, []uint64{22})  // ...0101
+		m.Delete(0, []uint64{11})  // ...0000
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.True(t, nodeNN.Additions.IsEmpty())
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Deletions.ToArray())
+	})
+
+	t.Run("deletes all", func(t *testing.T) {
+		m := NewMemtable()
+		m.Insert(13, []uint64{33}) // ...1101
+		m.Delete(13, []uint64{33}) // ...1101
+		m.Insert(5, []uint64{22})  // ...0101
+		m.Insert(0, []uint64{11})  // ...0000
+		m.Delete(5, []uint64{22})  // ...0101
+		m.Delete(0, []uint64{11})  // ...0000
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.True(t, nodeNN.Additions.IsEmpty())
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Deletions.ToArray())
+	})
+
+	t.Run("deletes all but one", func(t *testing.T) {
+		m := NewMemtable()
+		m.Insert(13, []uint64{33}) // ...1101
+		m.Delete(13, []uint64{33}) // ...1101
+		m.Insert(5, []uint64{22})  // ...0101
+		m.Insert(0, []uint64{11})  // ...0000
+		m.Delete(0, []uint64{11})  // ...0000
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 2+1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.ElementsMatch(t, []uint64{22}, nodeNN.Additions.ToArray())
+		assert.ElementsMatch(t, []uint64{11, 22, 33}, nodeNN.Deletions.ToArray())
+
+		node0 := nodes[1]
+		assert.Equal(t, uint8(1), node0.Key)
+		assert.ElementsMatch(t, []uint64{22}, node0.Additions.ToArray())
+		assert.True(t, node0.Deletions.IsEmpty())
+
+		node2 := nodes[2]
+		assert.Equal(t, uint8(3), node2.Key)
+		assert.ElementsMatch(t, []uint64{22}, node2.Additions.ToArray())
+		assert.True(t, node2.Deletions.IsEmpty())
+	})
+
+	t.Run("delete removes values regardless of key being deleted", func(t *testing.T) {
+		m := NewMemtable()
+		m.Insert(13, []uint64{33})              // ...00001101
+		m.Insert(5, []uint64{22})               // ...00000101
+		m.Insert(0, []uint64{11})               // ...00000000
+		m.Delete(123, []uint64{11, 22, 33, 44}) // ...01111011
+
+		nodes := m.Nodes()
+		require.Len(t, nodes, 1)
+
+		nodeNN := nodes[0]
+		assert.Equal(t, uint8(0), nodeNN.Key)
+		assert.True(t, nodeNN.Additions.IsEmpty())
+		assert.ElementsMatch(t, []uint64{11, 22, 33, 44}, nodeNN.Deletions.ToArray())
+	})
+}

--- a/adapters/repos/db/roaringsetrange/memtable_test.go
+++ b/adapters/repos/db/roaringsetrange/memtable_test.go
@@ -259,7 +259,6 @@ func BenchmarkMemtableFlatten(b *testing.B) {
 		val[0] = value
 		m.Insert(keys[value], val)
 	}
-	// m.Close()
 
 	for i := 0; i < b.N; i++ {
 		m.Nodes()

--- a/adapters/repos/db/roaringsetrange/segment_cursor.go
+++ b/adapters/repos/db/roaringsetrange/segment_cursor.go
@@ -1,0 +1,55 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+// A SegmentCursor iterates over all key-value pairs in a single disk segment.
+// You can start at the beginning using [*SegmentCursor.First] and move forward
+// using [*SegmentCursor.Next]
+type SegmentCursor struct {
+	data       []byte
+	nextOffset uint64
+}
+
+// NewSegmentCursor creates a cursor for a single disk segment. Make sure that
+// the data buf is already sliced correctly to start at the payload, as calling
+// [*SegmentCursor.First] will start reading at offset 0 relative to the passed
+// in buffer. Similarly, the buffer may only contain payloads, as the buffer end
+// is used to determine if more keys can be found.
+//
+// Therefore if the payload is part of a longer continuous buffer, the cursor
+// should be initialized with data[payloadStartPos:payloadEndPos]
+func NewSegmentCursor(data []byte) *SegmentCursor {
+	return &SegmentCursor{data: data, nextOffset: 0}
+}
+
+func (c *SegmentCursor) First() (uint8, roaringset.BitmapLayer, bool) {
+	c.nextOffset = 0
+	return c.Next()
+}
+
+func (c *SegmentCursor) Next() (uint8, roaringset.BitmapLayer, bool) {
+	if c.nextOffset >= uint64(len(c.data)) {
+		return 0, roaringset.BitmapLayer{}, false
+	}
+
+	sn := NewSegmentNodeFromBuffer(c.data[c.nextOffset:])
+	c.nextOffset += sn.Len()
+
+	return sn.Key(), roaringset.BitmapLayer{
+		Additions: sn.Additions(),
+		Deletions: sn.Deletions(),
+	}, true
+}

--- a/adapters/repos/db/roaringsetrange/segment_cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_cursor_test.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+func TestSegmentCursor(t *testing.T) {
+	seg := createDummySegment(t, 5)
+
+	t.Run("starting from beginning", func(t *testing.T) {
+		c := NewSegmentCursor(seg)
+		key, layer, ok := c.First()
+		require.True(t, ok)
+		assert.Equal(t, uint8(0), key)
+		assert.Equal(t, []uint64{0, 1}, layer.Additions.ToArray())
+		assert.Equal(t, []uint64{2, 3}, layer.Deletions.ToArray())
+	})
+
+	t.Run("starting from beginning, page through all", func(t *testing.T) {
+		c := NewSegmentCursor(seg)
+		i := uint64(0)
+		for key, layer, ok := c.First(); ok; key, layer, ok = c.Next() {
+			assert.Equal(t, uint8(i), key)
+			assert.Equal(t, []uint64{i * 4, i*4 + 1}, layer.Additions.ToArray())
+
+			if i == 0 {
+				assert.Equal(t, []uint64{2, 3}, layer.Deletions.ToArray())
+			} else {
+				assert.True(t, layer.Deletions.IsEmpty())
+			}
+			i++
+		}
+
+		assert.Equal(t, uint64(5), i)
+	})
+
+	t.Run("no first, page through all", func(t *testing.T) {
+		c := NewSegmentCursor(seg)
+		i := uint64(0)
+		for key, layer, ok := c.Next(); ok; key, layer, ok = c.Next() {
+			assert.Equal(t, uint8(i), key)
+			assert.Equal(t, []uint64{i * 4, i*4 + 1}, layer.Additions.ToArray())
+
+			if i == 0 {
+				assert.Equal(t, []uint64{2, 3}, layer.Deletions.ToArray())
+			} else {
+				assert.True(t, layer.Deletions.IsEmpty())
+			}
+			i++
+		}
+
+		assert.Equal(t, uint64(5), i)
+	})
+}
+
+func createDummySegment(t *testing.T, count uint64) []byte {
+	out := []byte{}
+
+	for i := uint64(0); i < count; i++ {
+		key := uint8(i)
+		add := roaringset.NewBitmap(i*4, i*4+1)
+		del := roaringset.NewBitmap(i*4+2, i*4+3) // ignored for key != 0
+		sn, err := NewSegmentNode(key, add, del)
+		require.Nil(t, err)
+
+		out = append(out, sn.ToBuffer()...)
+	}
+
+	return out
+}

--- a/adapters/repos/db/roaringsetrange/segment_node.go
+++ b/adapters/repos/db/roaringsetrange/segment_node.go
@@ -1,0 +1,142 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"encoding/binary"
+
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+// SegmentNode stores one Key-Value pair in
+// the LSM Segment.  It uses a single []byte internally. As a result there is
+// no decode step required at runtime. Instead you can use
+//
+//   - [*SegmentNode.Key]
+//   - [*SegmentNode.Additions]
+//   - [*SegmentNode.Deletions]
+//
+// to access the contents. Those helpers in turn do not require a decoding
+// step. The accessor methods that return Roaring Bitmaps only point to
+// existing memory.
+//
+// This makes the SegmentNode very fast to access at query time, even when it
+// contains a large amount of data.
+//
+// The internal structure of the data is:
+//
+//	byte begin-start    | description
+//	--------------------|-----------------------------------------------------
+//	0:8                 | uint64 indicating the total length of the node,
+//	                    | this is used in cursors to identify the next node.
+//	8:9					| key
+//	9:17                | uint64 length indicator for additions sraor bitmap (x)
+//	17:(17+x)           | additions bitmap
+//	(17+x):(25+x)       | uint64 length indicator for deletions sroar bitmap (y)
+//	(25+x):(25+x+y)     | deletions bitmap
+//						| deletion indicator and bitmaps are used only for key == 0
+type SegmentNode struct {
+	data []byte
+}
+
+// Len indicates the total length of the [SegmentNode]. When reading multiple
+// segments back-2-back, such as in a cursor situation, the offset of element
+// (n+1) is the offset of element n + Len()
+func (sn *SegmentNode) Len() uint64 {
+	return binary.LittleEndian.Uint64(sn.data[0:8])
+}
+
+// Additions returns the additions roaring bitmap with shared state. Only use
+// this method if you can guarantee that you will only use it while holding a
+// maintenance lock or can otherwise be sure that no compaction can occur.
+func (sn *SegmentNode) Additions() *sroar.Bitmap {
+	rw := byteops.NewReadWriter(sn.data)
+	rw.MoveBufferToAbsolutePosition(9)
+	return sroar.FromBuffer(rw.ReadBytesFromBufferWithUint64LengthIndicator())
+}
+
+// Deletions returns the deletions roaring bitmap with shared state. Only use
+// this method if you can guarantee that you will only use it while holding a
+// maintenance lock or can otherwise be sure that no compaction can occur.
+func (sn *SegmentNode) Deletions() *sroar.Bitmap {
+	rw := byteops.NewReadWriter(sn.data)
+	rw.MoveBufferToAbsolutePosition(8)
+	if key := rw.ReadUint8(); key != 0 {
+		return sroar.NewBitmap()
+	}
+	rw.DiscardBytesFromBufferWithUint64LengthIndicator()
+	return sroar.FromBuffer(rw.ReadBytesFromBufferWithUint64LengthIndicator())
+}
+
+func (sn *SegmentNode) Key() uint8 {
+	rw := byteops.NewReadWriter(sn.data)
+	rw.MoveBufferToAbsolutePosition(8)
+	return rw.ReadUint8()
+}
+
+func NewSegmentNode(key uint8, additions, deletions *sroar.Bitmap) (*SegmentNode, error) {
+	additionsBuf := additions.ToBuffer()
+	var deletionsBuf []byte
+
+	// total len + key + length indicators + payload
+	expectedSize := 8 + 1 + 8 + len(additionsBuf)
+
+	if key == 0 {
+		deletionsBuf = deletions.ToBuffer()
+		expectedSize += 8 + len(deletionsBuf)
+	}
+
+	sn := SegmentNode{data: make([]byte, expectedSize)}
+
+	rw := byteops.NewReadWriter(sn.data)
+	// reserve the first 8 bytes for the offset, which will be written at the very end
+	rw.MoveBufferPositionForward(8)
+	rw.CopyBytesToBuffer([]byte{key})
+
+	if err := rw.CopyBytesToBufferWithUint64LengthIndicator(additionsBuf); err != nil {
+		return nil, err
+	}
+
+	if key == 0 {
+		if err := rw.CopyBytesToBufferWithUint64LengthIndicator(deletionsBuf); err != nil {
+			return nil, err
+		}
+	}
+
+	offset := rw.Position
+	rw.MoveBufferToAbsolutePosition(0)
+	rw.WriteUint64(uint64(offset))
+
+	return &sn, nil
+}
+
+// ToBuffer returns the internal buffer without copying data. Only use this,
+// when you can be sure that it's safe to share the data, or create your own
+// copy.
+//
+// It truncates the buffer at is own length, in case it was initialized with a
+// long buffer that only had a beginning offset, but no end. Such a situation
+// may occur with cursors. If we then returned the whole buffer and don't know
+// what the caller plans on doing with the data, we risk passing around too
+// much memory. Truncating at the length prevents this and has no other
+// negative effects.
+func (sn *SegmentNode) ToBuffer() []byte {
+	return sn.data[:sn.Len()]
+}
+
+// NewSegmentNodeFromBuffer creates a new segment node by using the underlying
+// buffer without copying data. Only use this when you can be sure that it's
+// safe to share the data or create your own copy.
+func NewSegmentNodeFromBuffer(buf []byte) *SegmentNode {
+	return &SegmentNode{data: buf}
+}

--- a/adapters/repos/db/roaringsetrange/segment_node_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_node_test.go
@@ -1,0 +1,133 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+func TestSegmentNode_WithDeletions(t *testing.T) {
+	key := uint8(0)
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7}
+
+	sn, err := NewSegmentNode(key, roaringset.NewBitmap(additions...), roaringset.NewBitmap(deletions...))
+	require.Nil(t, err)
+	buf := sn.ToBuffer()
+	assert.Equal(t, sn.Len(), uint64(len(buf)))
+	assert.Equal(t, key, sn.Key())
+	assert.ElementsMatch(t, additions, sn.Additions().ToArray())
+	assert.ElementsMatch(t, deletions, sn.Deletions().ToArray())
+
+	snBuf := NewSegmentNodeFromBuffer(buf)
+	assert.Equal(t, snBuf.Len(), uint64(len(buf)))
+	assert.Equal(t, key, snBuf.Key())
+	assert.ElementsMatch(t, additions, snBuf.Additions().ToArray())
+	assert.ElementsMatch(t, deletions, snBuf.Deletions().ToArray())
+}
+
+func TestSegmentNode_WithoutDeletions(t *testing.T) {
+	key := uint8(63)
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7} // ignored
+
+	sn, err := NewSegmentNode(key, roaringset.NewBitmap(additions...), roaringset.NewBitmap(deletions...))
+	require.Nil(t, err)
+	buf := sn.ToBuffer()
+	assert.Equal(t, sn.Len(), uint64(len(buf)))
+	assert.Equal(t, key, sn.Key())
+	assert.ElementsMatch(t, additions, sn.Additions().ToArray())
+	assert.True(t, sn.Deletions().IsEmpty())
+
+	snBuf := NewSegmentNodeFromBuffer(buf)
+	assert.Equal(t, snBuf.Len(), uint64(len(buf)))
+	assert.Equal(t, key, snBuf.Key())
+	assert.ElementsMatch(t, additions, snBuf.Additions().ToArray())
+	assert.True(t, snBuf.Deletions().IsEmpty())
+}
+
+func TestSegmentNode_WithDeletions_InitializingFromBufferTooLarge(t *testing.T) {
+	key := uint8(0)
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7}
+
+	sn, err := NewSegmentNode(key, roaringset.NewBitmap(additions...), roaringset.NewBitmap(deletions...))
+	require.Nil(t, err)
+	buf := sn.ToBuffer()
+	assert.Equal(t, sn.Len(), uint64(len(buf)))
+
+	bufTooLarge := make([]byte, 3*len(buf))
+	copy(bufTooLarge, buf)
+
+	snBuf := NewSegmentNodeFromBuffer(bufTooLarge)
+	// assert that the buffer self reports the useful length, not the length of
+	// the initialization buffer
+	assert.Equal(t, snBuf.Len(), uint64(len(buf)))
+	// assert that ToBuffer() returns a buffer that is no longer than the useful
+	// length
+	assert.Equal(t, len(buf), len(snBuf.ToBuffer()))
+
+	assert.Equal(t, key, snBuf.Key())
+	assert.ElementsMatch(t, additions, snBuf.Additions().ToArray())
+	assert.ElementsMatch(t, deletions, snBuf.Deletions().ToArray())
+}
+
+func TestSegmentNode_WithoutDeletions_InitializingFromBufferTooLarge(t *testing.T) {
+	key := uint8(63)
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7} // ignored
+
+	sn, err := NewSegmentNode(key, roaringset.NewBitmap(additions...), roaringset.NewBitmap(deletions...))
+	require.Nil(t, err)
+	buf := sn.ToBuffer()
+	assert.Equal(t, sn.Len(), uint64(len(buf)))
+
+	bufTooLarge := make([]byte, 3*len(buf))
+	copy(bufTooLarge, buf)
+
+	snBuf := NewSegmentNodeFromBuffer(bufTooLarge)
+	// assert that the buffer self reports the useful length, not the length of
+	// the initialization buffer
+	assert.Equal(t, snBuf.Len(), uint64(len(buf)))
+	// assert that ToBuffer() returns a buffer that is no longer than the useful
+	// length
+	assert.Equal(t, len(buf), len(snBuf.ToBuffer()))
+
+	assert.Equal(t, key, snBuf.Key())
+	assert.ElementsMatch(t, additions, snBuf.Additions().ToArray())
+	assert.True(t, snBuf.Deletions().IsEmpty())
+}
+
+func TestSegmentNode_DeletionsNotStoredForNon0Key(t *testing.T) {
+	key1 := uint8(0)
+	key2 := uint8(15)
+	key3 := uint8(63)
+	additions := roaringset.NewBitmap(1, 2, 3, 4, 6)
+	deletions := roaringset.NewBitmap(5, 7)
+
+	sn1, err := NewSegmentNode(key1, additions, deletions)
+	require.Nil(t, err)
+	sn2, err := NewSegmentNode(key2, additions, deletions)
+	require.Nil(t, err)
+	sn3, err := NewSegmentNode(key3, additions, deletions)
+	require.Nil(t, err)
+
+	assert.Greater(t, sn1.Len(), sn2.Len())
+	assert.Equal(t, sn2.Len(), sn3.Len())
+	assert.False(t, sn1.Deletions().IsEmpty())
+	assert.True(t, sn2.Deletions().IsEmpty())
+	assert.True(t, sn3.Deletions().IsEmpty())
+}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -159,8 +159,8 @@ type ShardLike interface {
 	addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error
-	addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error
-	deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error
+	addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
+	deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	pairPropertyWithFrequency(docID uint64, freq, propLen float32) lsmkv.MapPair
 
 	setFallbackToSearchable(fallback bool)

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -1244,7 +1244,11 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 	if inverted.HasRangeableIndex(prop) {
 		if err := s.store.CreateOrLoadBucket(ctx,
 			helpers.BucketRangeableFromPropNameLSM(prop.Name),
-			append(bucketOpts, lsmkv.WithStrategy(lsmkv.StrategyRoaringSetRange))...,
+			append(bucketOpts,
+				lsmkv.WithStrategy(lsmkv.StrategyRoaringSetRange),
+				lsmkv.WithUseBloomFilter(false),
+				lsmkv.WithCalcCountNetAdditions(false),
+			)...,
 		); err != nil {
 			return err
 		}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -1156,7 +1156,7 @@ func (s *Shard) dynamicMemtableSizing() lsmkv.BucketOption {
 
 func (s *Shard) createPropertyIndex(ctx context.Context, eg *enterrors.ErrorGroupWrapper, props ...*models.Property) error {
 	for _, prop := range props {
-		if !inverted.HasInvertedIndex(prop) {
+		if !inverted.HasAnyInvertedIndex(prop) {
 			continue
 		}
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -1228,8 +1228,7 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 	}
 
 	if inverted.HasSearchableIndex(prop) {
-		searchableBucketOpts := append(bucketOpts,
-			lsmkv.WithStrategy(lsmkv.StrategyMapCollection), lsmkv.WithPread(s.index.Config.AvoidMMap))
+		searchableBucketOpts := append(bucketOpts, lsmkv.WithStrategy(lsmkv.StrategyMapCollection))
 		if s.versioner.Version() < 2 {
 			searchableBucketOpts = append(searchableBucketOpts, lsmkv.WithLegacyMapSorting())
 		}
@@ -1237,6 +1236,15 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 		if err := s.store.CreateOrLoadBucket(ctx,
 			helpers.BucketSearchableFromPropNameLSM(prop.Name),
 			searchableBucketOpts...,
+		); err != nil {
+			return err
+		}
+	}
+
+	if inverted.HasRangeableIndex(prop) {
+		if err := s.store.CreateOrLoadBucket(ctx,
+			helpers.BucketRangeableFromPropNameLSM(prop.Name),
+			append(bucketOpts, lsmkv.WithStrategy(lsmkv.StrategyRoaringSetRange))...,
 		); err != nil {
 			return err
 		}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -157,7 +157,10 @@ type ShardLike interface {
 	publishDimensionMetrics(ctx context.Context)
 
 	addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
+	deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error
+	addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error
+	deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error
 	pairPropertyWithFrequency(docID uint64, freq, propLen float32) lsmkv.MapPair
 
 	setFallbackToSearchable(fallback bool)
@@ -167,7 +170,6 @@ type ShardLike interface {
 	putObjectLSM(object *storobj.Object, idBytes []byte) (objectInsertStatus, error)
 	mayUpsertObjectHashTree(object *storobj.Object, idBytes []byte, status objectInsertStatus) error
 	mutableMergeObjectLSM(merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error)
-	deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error
 	updatePropertySpecificIndices(object *storobj.Object, status objectInsertStatus) error
 	updateVectorIndexIgnoreDelete(vector []float32, status objectInsertStatus) error

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -570,6 +570,11 @@ func (l *LazyLoadShard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint6
 	return l.shard.addToPropertySetBucket(bucket, docID, key)
 }
 
+func (l *LazyLoadShard) addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error {
+	l.mustLoad()
+	return l.shard.addToPropertyRangeBucket(bucket, docID, key)
+}
+
 func (l *LazyLoadShard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {
 	l.mustLoad()
 	return l.shard.addToPropertyMapBucket(bucket, pair, key)
@@ -620,6 +625,11 @@ func (l *LazyLoadShard) mutableMergeObjectLSM(merge objects.MergeDocument, idByt
 func (l *LazyLoadShard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
 	l.mustLoad()
 	return l.shard.deleteFromPropertySetBucket(bucket, docID, key)
+}
+
+func (l *LazyLoadShard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error {
+	l.mustLoad()
+	return l.shard.deleteFromPropertyRangeBucket(bucket, docID, key)
 }
 
 func (l *LazyLoadShard) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -570,7 +570,7 @@ func (l *LazyLoadShard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint6
 	return l.shard.addToPropertySetBucket(bucket, docID, key)
 }
 
-func (l *LazyLoadShard) addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error {
+func (l *LazyLoadShard) addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
 	l.mustLoad()
 	return l.shard.addToPropertyRangeBucket(bucket, docID, key)
 }
@@ -627,7 +627,7 @@ func (l *LazyLoadShard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID 
 	return l.shard.deleteFromPropertySetBucket(bucket, docID, key)
 }
 
-func (l *LazyLoadShard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error {
+func (l *LazyLoadShard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
 	l.mustLoad()
 	return l.shard.deleteFromPropertyRangeBucket(bucket, docID, key)
 }

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -299,11 +299,13 @@ func (b *referencesBatcher) analyzeRef(obj *storobj.Object, ref objects.BatchRef
 		Items:              countItems,
 		HasFilterableIndex: inverted.HasFilterableIndexMetaCount && inverted.HasInvertedIndex(prop),
 		HasSearchableIndex: inverted.HasSearchableIndexMetaCount && inverted.HasInvertedIndex(prop),
+		HasRangeableIndex:  inverted.HasRangeableIndexMetaCount && inverted.HasInvertedIndex(prop),
 	}, {
 		Name:               ref.From.Property.String(),
 		Items:              valueItems,
 		HasFilterableIndex: inverted.HasFilterableIndex(prop),
 		HasSearchableIndex: inverted.HasSearchableIndex(prop),
+		HasRangeableIndex:  inverted.HasRangeableIndex(prop),
 	}}, nil
 }
 

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -297,9 +297,9 @@ func (b *referencesBatcher) analyzeRef(obj *storobj.Object, ref objects.BatchRef
 	return []inverted.Property{{
 		Name:               helpers.MetaCountProp(ref.From.Property.String()),
 		Items:              countItems,
-		HasFilterableIndex: inverted.HasFilterableIndexMetaCount && inverted.HasInvertedIndex(prop),
-		HasSearchableIndex: inverted.HasSearchableIndexMetaCount && inverted.HasInvertedIndex(prop),
-		HasRangeableIndex:  inverted.HasRangeableIndexMetaCount && inverted.HasInvertedIndex(prop),
+		HasFilterableIndex: inverted.HasFilterableIndexMetaCount && inverted.HasAnyInvertedIndex(prop),
+		HasSearchableIndex: inverted.HasSearchableIndexMetaCount && inverted.HasAnyInvertedIndex(prop),
+		HasRangeableIndex:  inverted.HasRangeableIndexMetaCount && inverted.HasAnyInvertedIndex(prop),
 	}, {
 		Name:               ref.From.Property.String(),
 		Items:              valueItems,

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -62,7 +62,7 @@ func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []in
 			// 1. They are not in the schema map ( == nil)
 			// 2. Their inverted index is enabled
 			_, ok := schemaMap[prop.Name]
-			if !ok && inverted.HasInvertedIndex(prop) {
+			if !ok && inverted.HasAnyInvertedIndex(prop) {
 				nilProps = append(nilProps, inverted.NilProperty{
 					Name:                prop.Name,
 					AddToPropertyLength: isPropertyForLength(dt),

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -172,6 +172,12 @@ func (s *Shard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key [
 	return bucket.RoaringSetAddOne(key, docID)
 }
 
+func (s *Shard) addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error {
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyRoaringSetRange)
+
+	return bucket.RoaringSetRangeAdd(key, docID)
+}
+
 func (s *Shard) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket,
 	item inverted.MergeItem,
 ) error {

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -154,13 +154,13 @@ func (s *Shard) pairPropertyWithFrequency(docID uint64, freq, propLen float32) l
 }
 
 func (s *Shard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
 
 	return bucket.MapSet(key, pair)
 }
 
 func (s *Shard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
 
 	if bucket.Strategy() == lsmkv.StrategySetCollection {
 		docIDBytes := make([]byte, 8)

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -94,7 +94,7 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 func (s *Shard) deleteInvertedIndexItemWithFrequencyLSM(bucket *lsmkv.Bucket,
 	item inverted.Countable, docID uint64,
 ) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
 
 	docIDBytes := make([]byte, 8)
 	// Shard Index version 2 requires BigEndian for sorting, if the shard was
@@ -141,7 +141,7 @@ func (s *Shard) deleteFromPropertyNullIndex(propName string, docID uint64, isNul
 }
 
 func (s *Shard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	lsmkv.CheckExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
 
 	if bucket.Strategy() == lsmkv.StrategySetCollection {
 		docIDBytes := make([]byte, 8)

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -152,3 +152,9 @@ func (s *Shard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, 
 
 	return bucket.RoaringSetRemoveOne(key, docID)
 }
+
+func (s *Shard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key uint64) error {
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyRoaringSetRange)
+
+	return bucket.RoaringSetRangeRemove(key, docID)
+}

--- a/entities/deepcopy/models_deepcopy.go
+++ b/entities/deepcopy/models_deepcopy.go
@@ -62,6 +62,7 @@ func Prop(p *models.Property) *models.Property {
 		Tokenization:    p.Tokenization,
 		IndexFilterable: ptrBoolCopy(p.IndexFilterable),
 		IndexSearchable: ptrBoolCopy(p.IndexSearchable),
+		IndexRangeable:  ptrBoolCopy(p.IndexRangeable),
 	}
 }
 

--- a/entities/models/nested_property.go
+++ b/entities/models/nested_property.go
@@ -41,6 +41,9 @@ type NestedProperty struct {
 	// index filterable
 	IndexFilterable *bool `json:"indexFilterable,omitempty"`
 
+	// index rangeable
+	IndexRangeable *bool `json:"indexRangeable,omitempty"`
+
 	// index searchable
 	IndexSearchable *bool `json:"indexSearchable,omitempty"`
 

--- a/entities/models/property.go
+++ b/entities/models/property.go
@@ -44,6 +44,9 @@ type Property struct {
 	// Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters, bm25 or hybrid search. This property has no affect on vectorization decisions done by modules (deprecated as of v1.19; use indexFilterable or/and indexSearchable instead)
 	IndexInverted *bool `json:"indexInverted,omitempty"`
 
+	// Optional. TODO roaring-set-range
+	IndexRangeable *bool `json:"indexRangeable,omitempty"`
+
 	// Optional. Should this property be indexed in the inverted index. Defaults to true. Applicable only to properties of data type text and text[]. If you choose false, you will not be able to use this property in bm25 or hybrid search. This property has no affect on vectorization decisions done by modules
 	IndexSearchable *bool `json:"indexSearchable,omitempty"`
 

--- a/entities/schema/collection.go
+++ b/entities/schema/collection.go
@@ -121,6 +121,9 @@ type Property struct {
 	// Optional. Should this property be indexed in the inverted index. Defaults to true. Applicable only to properties of data type text and text[]. If you choose false, you will not be able to use this property in bm25 or hybrid search. This property has no affect on vectorization decisions done by modules
 	IndexSearchable bool `json:"indexSearchable,omitempty"`
 
+	// TODO roaring-set-range
+	IndexRangeable bool `json:"indexSearchable,omitempty"`
+
 	// Configuration specific to modules this Weaviate instance has installed
 	ModuleConfig map[string]interface{} `json:"moduleConfig,omitempty"`
 
@@ -146,6 +149,9 @@ type NestedProperty struct {
 	// index searchable
 	IndexSearchable bool `json:"index_searchable,omitempty"`
 
+	// index rangeable
+	IndexRangeable bool `json:"index_rangeable,omitempty"`
+
 	// nested properties
 	NestedProperties []NestedProperty `json:"nested_properties,omitempty"`
 
@@ -169,6 +175,11 @@ func NestedPropertyFromModel(m models.NestedProperty) NestedProperty {
 		n.IndexSearchable = *m.IndexSearchable
 	} else {
 		n.IndexSearchable = true
+	}
+	if m.IndexRangeable != nil {
+		n.IndexRangeable = *m.IndexRangeable
+	} else {
+		n.IndexRangeable = false
 	}
 	n.Name = m.Name
 	n.Tokenization = m.Tokenization
@@ -195,6 +206,8 @@ func NestedPropertyToModel(n NestedProperty) models.NestedProperty {
 	m.IndexFilterable = &indexFilterable
 	indexSearchable := n.IndexSearchable
 	m.IndexSearchable = &indexSearchable
+	indexRangeable := n.IndexRangeable
+	m.IndexRangeable = &indexRangeable
 	m.Name = n.Name
 	m.Tokenization = n.Tokenization
 	if len(n.NestedProperties) > 0 {
@@ -230,6 +243,11 @@ func PropertyFromModel(m models.Property) Property {
 	} else {
 		p.IndexSearchable = true
 	}
+	if m.IndexRangeable != nil {
+		p.IndexRangeable = *m.IndexRangeable
+	} else {
+		p.IndexRangeable = false
+	}
 	if v, ok := m.ModuleConfig.(map[string]interface{}); ok {
 		p.ModuleConfig = v
 	}
@@ -259,6 +277,8 @@ func PropertyToModel(p Property) models.Property {
 	m.IndexInverted = &indexInverted
 	indexSearchable := p.IndexSearchable
 	m.IndexSearchable = &indexSearchable
+	indexRangeable := p.IndexRangeable
+	m.IndexRangeable = &indexRangeable
 	m.ModuleConfig = p.ModuleConfig
 	m.Name = p.Name
 	m.Tokenization = p.Tokenization

--- a/entities/schema/collection.go
+++ b/entities/schema/collection.go
@@ -122,7 +122,7 @@ type Property struct {
 	IndexSearchable bool `json:"indexSearchable,omitempty"`
 
 	// TODO roaring-set-range
-	IndexRangeable bool `json:"indexSearchable,omitempty"`
+	IndexRangeable bool `json:"indexRangeable,omitempty"`
 
 	// Configuration specific to modules this Weaviate instance has installed
 	ModuleConfig map[string]interface{} `json:"moduleConfig,omitempty"`

--- a/entities/schema/collection_model_test.go
+++ b/entities/schema/collection_model_test.go
@@ -67,6 +67,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 						DataType:        DataTypeObject.PropString(),
 						IndexFilterable: &vTrue,
 						IndexSearchable: &vFalse,
+						IndexRangeable:  &vFalse,
 						Tokenization:    "",
 						NestedProperties: []*models.NestedProperty{
 							{
@@ -122,6 +123,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeInt.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 							},
 							{
@@ -129,6 +131,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeNumber.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 							},
 							{
@@ -136,6 +139,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeText.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								Tokenization:    models.PropertyTokenizationWord,
 							},
 							{
@@ -143,6 +147,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeObject.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 								NestedProperties: []*models.NestedProperty{
 									{
@@ -150,6 +155,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeBoolean.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 									{
@@ -157,6 +163,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeNumberArray.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 								},
@@ -166,6 +173,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeObjectArray.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 								NestedProperties: []*models.NestedProperty{
 									{
@@ -173,6 +181,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeBoolean.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 									{
@@ -180,6 +189,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeNumberArray.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 								},
@@ -208,6 +218,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 						IndexFilterable: &vTrue,
 						IndexInverted:   &vTrue,
 						IndexSearchable: &vFalse,
+						IndexRangeable:  &vFalse,
 						Tokenization:    "",
 						ModuleConfig:    emptyModuleConfig,
 						NestedProperties: []*models.NestedProperty{
@@ -215,72 +226,84 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								Name:            "text",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeText.PropString(),
 							},
 							{
 								Name:            "texts",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeTextArray.PropString(),
 							},
 							{
 								Name:            "number",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeNumber.PropString(),
 							},
 							{
 								Name:            "numbers",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeNumberArray.PropString(),
 							},
 							{
 								Name:            "int",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeInt.PropString(),
 							},
 							{
 								Name:            "ints",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeIntArray.PropString(),
 							},
 							{
 								Name:            "date",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeDate.PropString(),
 							},
 							{
 								Name:            "dates",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeDateArray.PropString(),
 							},
 							{
 								Name:            "bool",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeBoolean.PropString(),
 							},
 							{
 								Name:            "bools",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeBooleanArray.PropString(),
 							},
 							{
 								Name:            "uuid",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeUUID.PropString(),
 							},
 							{
 								Name:            "uuids",
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								DataType:        DataTypeUUIDArray.PropString(),
 							},
 							{
@@ -288,6 +311,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeInt.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 							},
 							{
@@ -295,6 +319,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeNumber.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 							},
 							{
@@ -302,6 +327,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeText.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vTrue,
+								IndexRangeable:  &vFalse,
 								Tokenization:    models.PropertyTokenizationWord,
 							},
 							{
@@ -309,6 +335,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeObject.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 								NestedProperties: []*models.NestedProperty{
 									{
@@ -316,6 +343,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeBoolean.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 									{
@@ -323,6 +351,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeNumberArray.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 								},
@@ -332,6 +361,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 								DataType:        DataTypeObjectArray.PropString(),
 								IndexFilterable: &vTrue,
 								IndexSearchable: &vFalse,
+								IndexRangeable:  &vFalse,
 								Tokenization:    "",
 								NestedProperties: []*models.NestedProperty{
 									{
@@ -339,6 +369,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeBoolean.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 									{
@@ -346,6 +377,7 @@ func TestCollectionFromAndToModel(t *testing.T) {
 										DataType:        DataTypeNumberArray.PropString(),
 										IndexFilterable: &vTrue,
 										IndexSearchable: &vFalse,
+										IndexRangeable:  &vFalse,
 										Tokenization:    "",
 									},
 								},

--- a/entities/schema/test_utils/nested_properties.go
+++ b/entities/schema/test_utils/nested_properties.go
@@ -35,6 +35,7 @@ func AssertNestedPropsMatch(t *testing.T, nestedPropsA, nestedPropsB []*models.N
 		assert.Equal(t, npA.DataType, npB.DataType)
 		assert.Equal(t, npA.IndexFilterable, npB.IndexFilterable)
 		assert.Equal(t, npA.IndexSearchable, npB.IndexSearchable)
+		assert.Equal(t, npA.IndexRangeable, npB.IndexRangeable)
 		assert.Equal(t, npA.Tokenization, npB.Tokenization)
 
 		if _, isNested := schema.AsNested(npA.DataType); isNested {

--- a/entities/schema/test_utils/properties.go
+++ b/entities/schema/test_utils/properties.go
@@ -35,6 +35,7 @@ func AssertPropsMatch(t *testing.T, propsA, propsB []*models.Property) {
 		assert.Equal(t, pA.DataType, pB.DataType)
 		assert.Equal(t, pA.IndexFilterable, pB.IndexFilterable)
 		assert.Equal(t, pA.IndexSearchable, pB.IndexSearchable)
+		assert.Equal(t, pA.IndexRangeable, pB.IndexRangeable)
 		assert.Equal(t, pA.Tokenization, pB.Tokenization)
 
 		if _, isNested := schema.AsNested(pA.DataType); isNested {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -738,6 +738,11 @@
           "type": "boolean",
           "x-nullable": true
         },
+        "indexRangeable": {
+          "description": "Optional. TODO roaring-set-range",
+          "type": "boolean",
+          "x-nullable": true
+        },
         "tokenization": {
           "description": "Determines tokenization of the property as separate words or whole field. Optional. Applies to text and text[] data types. Allowed values are `word` (default; splits on any non-alphanumerical, lowercases), `lowercase` (splits on white spaces, lowercases), `whitespace` (splits on white spaces), `field` (trims). Not supported for remaining data types",
           "type": "string",
@@ -797,6 +802,10 @@
           "x-nullable": true
         },
         "indexSearchable": {
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "indexRangeable": {
           "type": "boolean",
           "x-nullable": true
         },

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -656,7 +656,7 @@ func Test_Validation_PropertyIndexing(t *testing.T) {
 								indexFilterable: filterable,
 								indexSearchable: searchable,
 								expectedErrContains: []string{
-									"`indexInverted` is deprecated and can not be set together with `indexFilterable` or `indexSearchable`",
+									"`indexInverted` is deprecated and can not be set together with `indexFilterable`, `indexSearchable` or `indexRangeable`",
 								},
 							})
 							continue

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -28,6 +28,7 @@ var validatorsNestedProperty = []validatorNestedProperty{
 	validateNestedPropertyTokenization,
 	validateNestedPropertyIndexFilterable,
 	validateNestedPropertyIndexSearchable,
+	validateNestedPropertyIndexRangeable,
 }
 
 func validateNestedProperties(properties []*models.NestedProperty, propNamePrefix string) error {
@@ -163,6 +164,34 @@ func validateNestedPropertyIndexSearchable(property *models.NestedProperty,
 	}
 	if *property.IndexSearchable {
 		return fmt.Errorf("Property '%s': `indexSearchable` is not allowed for other than text/text[] data types",
+			propName)
+	}
+
+	return nil
+}
+
+// indexRangeable allowed for number/int/date data types
+func validateNestedPropertyIndexRangeable(property *models.NestedProperty,
+	primitiveDataType, _ schema.DataType,
+	isPrimitive, _ bool, propNamePrefix string,
+) error {
+	propName := propNamePrefix + "." + property.Name
+
+	// at this point indexRangeable should be set (either by user or by defaults)
+	if property.IndexRangeable == nil {
+		return fmt.Errorf("Property '%s': `indexRangeable` not set", propName)
+	}
+
+	if isPrimitive {
+		switch primitiveDataType {
+		case schema.DataTypeNumber, schema.DataTypeInt, schema.DataTypeDate:
+			return nil
+		default:
+			// do nothing
+		}
+	}
+	if *property.IndexRangeable {
+		return fmt.Errorf("Property '%s': `indexRangeable` is not allowed for other than number/int/date data types",
 			propName)
 	}
 

--- a/usecases/schema/validation_test.go
+++ b/usecases/schema/validation_test.go
@@ -34,6 +34,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 						DataType:        schema.DataTypeInt.PropString(),
 						IndexFilterable: &vFalse,
 						IndexSearchable: &vFalse,
+						IndexRangeable:  &vFalse,
 						Tokenization:    "",
 					},
 				}
@@ -45,6 +46,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						}
@@ -53,6 +55,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:        ndt.PropString(),
 							IndexFilterable: &vFalse,
 							IndexSearchable: &vFalse,
+							IndexRangeable:  &vFalse,
 							Tokenization:    "",
 							NestedProperties: []*models.NestedProperty{
 								{
@@ -60,6 +63,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 									DataType:         ndt.PropString(),
 									IndexFilterable:  &vFalse,
 									IndexSearchable:  &vFalse,
+									IndexRangeable:   &vFalse,
 									Tokenization:     "",
 									NestedProperties: nestedProperties,
 								},
@@ -98,6 +102,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        pdt.PropString(),
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    tokenization,
 			})
 		}
@@ -109,6 +114,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:         ndt.PropString(),
 					IndexFilterable:  &vFalse,
 					IndexSearchable:  &vFalse,
+					IndexRangeable:   &vFalse,
 					Tokenization:     "",
 					NestedProperties: nestedProperties,
 				}
@@ -117,6 +123,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -124,6 +131,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},
@@ -149,6 +157,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 						DataType:        pdt.PropString(),
 						IndexFilterable: &vFalse,
 						IndexSearchable: &vFalse,
+						IndexRangeable:  &vFalse,
 						Tokenization:    "",
 					},
 				}
@@ -160,6 +169,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						}
@@ -168,6 +178,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:        ndt.PropString(),
 							IndexFilterable: &vFalse,
 							IndexSearchable: &vFalse,
+							IndexRangeable:  &vFalse,
 							Tokenization:    "",
 							NestedProperties: []*models.NestedProperty{
 								{
@@ -175,6 +186,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 									DataType:         ndt.PropString(),
 									IndexFilterable:  &vFalse,
 									IndexSearchable:  &vFalse,
+									IndexRangeable:   &vFalse,
 									Tokenization:     "",
 									NestedProperties: nestedProperties,
 								},
@@ -203,6 +215,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 						DataType:        pdt.PropString(),
 						IndexFilterable: &vFalse,
 						IndexSearchable: &vFalse,
+						IndexRangeable:  &vFalse,
 						Tokenization:    "",
 					},
 				}
@@ -214,6 +227,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						}
@@ -222,6 +236,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:        ndt.PropString(),
 							IndexFilterable: &vFalse,
 							IndexSearchable: &vFalse,
+							IndexRangeable:  &vFalse,
 							Tokenization:    "",
 							NestedProperties: []*models.NestedProperty{
 								{
@@ -229,6 +244,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 									DataType:         ndt.PropString(),
 									IndexFilterable:  &vFalse,
 									IndexSearchable:  &vFalse,
+									IndexRangeable:   &vFalse,
 									Tokenization:     "",
 									NestedProperties: nestedProperties,
 								},
@@ -255,6 +271,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        []string{"SomeClass"},
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    "",
 			},
 		}
@@ -266,6 +283,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:         ndt.PropString(),
 					IndexFilterable:  &vFalse,
 					IndexSearchable:  &vFalse,
+					IndexRangeable:   &vFalse,
 					Tokenization:     "",
 					NestedProperties: nestedProperties,
 				}
@@ -274,6 +292,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -281,6 +300,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},
@@ -306,6 +326,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 				}
 				propLvl2Primitives := &models.Property{
@@ -313,6 +334,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -320,6 +342,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:        ndt.PropString(),
 							IndexFilterable: &vFalse,
 							IndexSearchable: &vFalse,
+							IndexRangeable:  &vFalse,
 							Tokenization:    "",
 						},
 					},
@@ -355,6 +378,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 						DataType:        pdt.PropString(),
 						IndexFilterable: &vFalse,
 						IndexSearchable: &vFalse,
+						IndexRangeable:  &vFalse,
 						Tokenization:    models.PropertyTokenizationWord,
 					},
 				}
@@ -366,6 +390,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						}
@@ -374,6 +399,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:        ndt.PropString(),
 							IndexFilterable: &vFalse,
 							IndexSearchable: &vFalse,
+							IndexRangeable:  &vFalse,
 							Tokenization:    "",
 							NestedProperties: []*models.NestedProperty{
 								{
@@ -381,6 +407,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 									DataType:         ndt.PropString(),
 									IndexFilterable:  &vFalse,
 									IndexSearchable:  &vFalse,
+									IndexRangeable:   &vFalse,
 									Tokenization:     "",
 									NestedProperties: nestedProperties,
 								},
@@ -407,6 +434,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        schema.DataTypeInt.PropString(),
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    "",
 			},
 		}
@@ -418,6 +446,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -425,6 +454,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     models.PropertyTokenizationWord,
 							NestedProperties: nestedProperties,
 						},
@@ -464,6 +494,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        pdt.PropString(),
 				IndexFilterable: &vTrue,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    tokenization,
 			})
 		}
@@ -475,6 +506,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:         ndt.PropString(),
 					IndexFilterable:  &vFalse,
 					IndexSearchable:  &vFalse,
+					IndexRangeable:   &vFalse,
 					Tokenization:     "",
 					NestedProperties: nestedProperties,
 				}
@@ -483,6 +515,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -490,6 +523,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},
@@ -513,6 +547,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        schema.DataTypeBlob.PropString(),
 				IndexFilterable: &vTrue,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    "",
 			},
 		}
@@ -524,6 +559,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:         ndt.PropString(),
 					IndexFilterable:  &vFalse,
 					IndexSearchable:  &vFalse,
+					IndexRangeable:   &vFalse,
 					Tokenization:     "",
 					NestedProperties: nestedProperties,
 				}
@@ -532,6 +568,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -539,6 +576,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},
@@ -563,6 +601,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        schema.DataTypeInt.PropString(),
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    "",
 			},
 		}
@@ -574,6 +613,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vTrue,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -581,6 +621,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},
@@ -605,6 +646,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        pdt.PropString(),
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vTrue,
+				IndexRangeable:  &vFalse,
 				Tokenization:    models.PropertyTokenizationWord,
 			})
 		}
@@ -616,6 +658,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:         ndt.PropString(),
 					IndexFilterable:  &vFalse,
 					IndexSearchable:  &vFalse,
+					IndexRangeable:   &vFalse,
 					Tokenization:     "",
 					NestedProperties: nestedProperties,
 				}
@@ -624,6 +667,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -631,6 +675,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},
@@ -666,6 +711,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        pdt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vTrue,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 				})
 
@@ -676,6 +722,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vFalse,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						}
@@ -684,6 +731,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:        ndt.PropString(),
 							IndexFilterable: &vFalse,
 							IndexSearchable: &vFalse,
+							IndexRangeable:  &vFalse,
 							Tokenization:    "",
 							NestedProperties: []*models.NestedProperty{
 								{
@@ -691,6 +739,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 									DataType:         ndt.PropString(),
 									IndexFilterable:  &vFalse,
 									IndexSearchable:  &vFalse,
+									IndexRangeable:   &vFalse,
 									Tokenization:     "",
 									NestedProperties: nestedProperties,
 								},
@@ -717,6 +766,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 				DataType:        schema.DataTypeInt.PropString(),
 				IndexFilterable: &vFalse,
 				IndexSearchable: &vFalse,
+				IndexRangeable:  &vFalse,
 				Tokenization:    "",
 			},
 		}
@@ -728,6 +778,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 					DataType:        ndt.PropString(),
 					IndexFilterable: &vFalse,
 					IndexSearchable: &vFalse,
+					IndexRangeable:  &vFalse,
 					Tokenization:    "",
 					NestedProperties: []*models.NestedProperty{
 						{
@@ -735,6 +786,7 @@ func Test_Validation_NestedProperties(t *testing.T) {
 							DataType:         ndt.PropString(),
 							IndexFilterable:  &vFalse,
 							IndexSearchable:  &vTrue,
+							IndexRangeable:   &vFalse,
 							Tokenization:     "",
 							NestedProperties: nestedProperties,
 						},


### PR DESCRIPTION
### What's being changed:
Adresses https://github.com/weaviate/weaviate/issues/3739

Introduces new type of index (called `rangeable`) implemented using roaring bitmaps to improve performance of range queries (`>=`, `>`, `<=` and `<`).
Index can be turned on by setting property's `indexRangeable` value to true (similar to `indexFilterable` or `indexSearchable`). By default `indexRangeable` is turned off.
Index can be used only for data types represented internally by 64bits numbers: namely `int`, `number` and `date` (but not its array counterparts `int[]`, `number[]`, `date[]`).

If index both index `filterable` and index `rangeable` are available for property, operators `Equal` and `NotEqual` are handled by `filterable` index, while `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual` are handled by rangeable index. If only one of the indexes is configured for property, all 6 operators are handled by available index.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
