### PR TITLE
Add trivy vulnerability check on every pull request

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -39,12 +39,20 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork
     steps:
       - uses: actions/checkout@v4
-      - name: Scan for Vulnerabilities in Code
-        uses: Templum/govulncheck-action@v1.0.0
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-          package: ./...
-          fail-on-vuln: true
+          cache: true
+      - name: Run locally Docker build
+        run: docker build -t weaviate:${{ github.sha }} .
+      - name: Run Trivy vulnerability scanner for the built image
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: 'weaviate:${{ github.sha }}'
+          exit-code: '1'
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
   Unit-Tests:
     name: unit-tests
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 # This image gets grpc health check probe
 FROM build_base AS grpc_health_probe_builder
 ARG TARGETARCH
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.22 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.27 && \
       wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
       chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
### What's being changed:

This PR modifies the Vulnerability Check pipeline into using trivy from aquasec for vulnerability checks. It will first build the image and then run the check on the built image from the PR's source code.

Also, this PR bumps the version for the golang:alpine image, as well as the grpc_health_probe to v0.4.27 to solve vulnerabilities identified on them.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
