### PR TITLE
Set dimension parameter only when we vectorize text or images using multi2vec-palm module

### DIFF
--- a/modules/multi2vec-palm/clients/palm.go
+++ b/modules/multi2vec-palm/clients/palm.go
@@ -161,10 +161,13 @@ func (v *palm) getPayload(text, img, vid string, config ent.VectorizationConfig)
 			VideoSegmentConfig: videoSegmentConfig{IntervalSec: &config.VideoIntervalSeconds},
 		}
 	}
-	return embeddingsRequest{
-		Instances:  []instance{inst},
-		Parameters: parameters{Dimension: config.Dimensions},
+	req := embeddingsRequest{
+		Instances: []instance{inst},
 	}
+	if inst.Video == nil {
+		req.Parameters = parameters{Dimension: config.Dimensions}
+	}
+	return req
 }
 
 func (v *palm) checkResponse(statusCode int, palmApiError *palmApiError) error {


### PR DESCRIPTION
### What's being changed:

Set dimension parameter only when we vectorize text or images using multi2vec-palm module

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
