### PR TITLE
Bump aquasecurity/trivy-action from 0.20.0 to 0.22.0

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Run locally Docker build
         run: docker build -t weaviate:${{ github.sha }} .
       - name: Run Trivy vulnerability scanner for the built image
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.22.0
         with:
           image-ref: 'weaviate:${{ github.sha }}'
           exit-code: '1'


### PR DESCRIPTION
### What's being changed:

Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.20.0 to 0.22.0.
- [Release notes](https://github.com/aquasecurity/trivy-action/releases)
- [Commits](https://github.com/aquasecurity/trivy-action/compare/0.20.0...0.22.0)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
