### PR TITLE
Refactor dto.Get struct

### DIFF
--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -661,8 +661,7 @@ func testBatchImportObjects(repo *DB) func(t *testing.T) {
 							Offset: 0,
 							Limit:  10,
 						},
-						SearchVector: []float32{1, 2, 3},
-					})
+					}, "", []float32{1, 2, 3})
 					require.Nil(t, err)
 					assert.Len(t, res, 2)
 				})

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -377,12 +377,11 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 			// to remove the additional storage updates. By still including this
 			// test we verify that such an update is indeed no longer necessary
 			res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-				ClassName:    "AddingBatchReferencesTestSource",
-				SearchVector: []float32{0.49},
+				ClassName: "AddingBatchReferencesTestSource",
 				Pagination: &filters.Pagination{
 					Limit: 1,
 				},
-			})
+			}, "", []float32{0.49})
 
 			require.Nil(t, err)
 			require.Len(t, res, 1)

--- a/adapters/repos/db/classification.go
+++ b/adapters/repos/db/classification.go
@@ -61,8 +61,7 @@ func (db *DB) ZeroShotSearch(ctx context.Context, vector []float32,
 	filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
 	res, err := db.VectorSearch(ctx, dto.GetParams{
-		ClassName:    class,
-		SearchVector: vector,
+		ClassName: class,
 		Pagination: &filters.Pagination{
 			Limit: 1,
 		},
@@ -70,7 +69,7 @@ func (db *DB) ZeroShotSearch(ctx context.Context, vector []float32,
 		AdditionalProperties: additional.Properties{
 			Vector: true,
 		},
-	})
+	}, "", vector)
 
 	return res, err
 }
@@ -84,8 +83,7 @@ func (db *DB) AggregateNeighbors(ctx context.Context, vector []float32,
 	mergedFilter := mergeUserFilterWithRefCountFilter(filter, class, properties,
 		libfilters.OperatorGreaterThan, 0)
 	res, err := db.VectorSearch(ctx, dto.GetParams{
-		ClassName:    class,
-		SearchVector: vector,
+		ClassName: class,
 		Pagination: &filters.Pagination{
 			Limit: k,
 		},
@@ -93,7 +91,7 @@ func (db *DB) AggregateNeighbors(ctx context.Context, vector []float32,
 		AdditionalProperties: additional.Properties{
 			Vector: true,
 		},
-	})
+	}, "", vector)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregate neighbors: search neighbors")
 	}

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -197,12 +197,11 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 
 			node := nodes[rnd.Intn(len(nodes))]
 			res, err := node.repo.VectorSearch(context.Background(), dto.GetParams{
-				SearchVector: query,
 				Pagination: &filters.Pagination{
 					Limit: 25,
 				},
 				ClassName: distributedClass,
-			})
+			}, "", query)
 			assert.Nil(t, err)
 			for i, obj := range res {
 				assert.Equal(t, groundTruth[i].ID, obj.ID, fmt.Sprintf("at pos %d", i))

--- a/adapters/repos/db/crud_deletion_integration_test.go
+++ b/adapters/repos/db/crud_deletion_integration_test.go
@@ -74,12 +74,11 @@ func TestDeleteJourney(t *testing.T) {
 	t.Run("verify vector search results are initially as expected",
 		func(t *testing.T) {
 			res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-				ClassName:    "UpdateTestClass",
-				SearchVector: searchVector,
+				ClassName: "UpdateTestClass",
 				Pagination: &filters.Pagination{
 					Limit: 100,
 				},
-			})
+			}, "", searchVector)
 
 			expectedOrder := []interface{}{
 				"element-0", "element-2", "element-3", "element-1",
@@ -139,12 +138,11 @@ func TestDeleteJourney(t *testing.T) {
 
 	t.Run("verify new vector search results are as expected", func(t *testing.T) {
 		res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-			ClassName:    "UpdateTestClass",
-			SearchVector: searchVector,
+			ClassName: "UpdateTestClass",
 			Pagination: &filters.Pagination{
 				Limit: 100,
 			},
-		})
+		}, "", searchVector)
 
 		expectedOrder := []interface{}{
 			"element-2", "element-3", "element-1",
@@ -181,12 +179,11 @@ func TestDeleteJourney(t *testing.T) {
 
 	t.Run("verify new vector search results are as expected", func(t *testing.T) {
 		res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-			ClassName:    "UpdateTestClass",
-			SearchVector: searchVector,
+			ClassName: "UpdateTestClass",
 			Pagination: &filters.Pagination{
 				Limit: 100,
 			},
-		})
+		}, "", searchVector)
 
 		expectedOrder := []interface{}{
 			"element-2", "element-3",
@@ -212,12 +209,11 @@ func TestDeleteJourney(t *testing.T) {
 
 	t.Run("delete the index", func(t *testing.T) {
 		res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-			ClassName:    "UpdateTestClass",
-			SearchVector: searchVector,
+			ClassName: "UpdateTestClass",
 			Pagination: &filters.Pagination{
 				Limit: 100,
 			},
-		})
+		}, "", searchVector)
 
 		expectedOrder := []interface{}{
 			"element-2", "element-3",

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -446,12 +446,11 @@ func TestCRUD(t *testing.T) {
 		searchVector := []float32{2.9, 1.1, 0.5, 8.01}
 
 		params := dto.GetParams{
-			SearchVector: searchVector,
-			ClassName:    "TheBestThingClass",
-			Pagination:   &filters.Pagination{Limit: 10},
-			Filters:      nil,
+			ClassName:  "TheBestThingClass",
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters:    nil,
 		}
-		res, err := repo.VectorSearch(context.Background(), params)
+		res, err := repo.VectorSearch(context.Background(), params, "", searchVector)
 
 		require.Nil(t, err)
 		require.Len(t, res, 1, "got exactly one result")
@@ -475,10 +474,9 @@ func TestCRUD(t *testing.T) {
 
 	t.Run("searching by class type", func(t *testing.T) {
 		params := dto.GetParams{
-			SearchVector: nil,
-			ClassName:    "TheBestThingClass",
-			Pagination:   &filters.Pagination{Limit: 10},
-			Filters:      nil,
+			ClassName:  "TheBestThingClass",
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters:    nil,
 		}
 		res, err := repo.Search(context.Background(), params)
 
@@ -1052,13 +1050,12 @@ func TestCRUD(t *testing.T) {
 		func(t *testing.T) {
 			searchVector := []float32{2.9, 1.1, 0.5, 8.01}
 			params := dto.GetParams{
-				SearchVector: searchVector,
-				ClassName:    "TheBestThingClass",
-				Pagination:   &filters.Pagination{Limit: 10},
-				Filters:      nil,
+				ClassName:  "TheBestThingClass",
+				Pagination: &filters.Pagination{Limit: 10},
+				Filters:    nil,
 			}
 
-			res, err := repo.VectorSearch(context.Background(), params)
+			res, err := repo.VectorSearch(context.Background(), params, "", searchVector)
 
 			require.Nil(t, err)
 			assert.Len(t, res, 0)
@@ -1067,13 +1064,12 @@ func TestCRUD(t *testing.T) {
 	t.Run("searching by vector for a single action class again after deletion", func(t *testing.T) {
 		searchVector := []float32{2.9, 1.1, 0.5, 8.01}
 		params := dto.GetParams{
-			SearchVector: searchVector,
-			ClassName:    "TheBestActionClass",
-			Pagination:   &filters.Pagination{Limit: 10},
-			Filters:      nil,
+			ClassName:  "TheBestActionClass",
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters:    nil,
 		}
 
-		res, err := repo.VectorSearch(context.Background(), params)
+		res, err := repo.VectorSearch(context.Background(), params, "", searchVector)
 
 		require.Nil(t, err)
 		assert.Len(t, res, 0)
@@ -1636,8 +1632,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				Offset: 0,
 				Limit:  total,
 			},
-			SearchVector: randomVector(r, 7),
-		})
+		}, "", randomVector(r, 7))
 		require.Nil(t, err)
 		assert.Len(t, res, 0) // we skipped the vector on half the elements, so we should now match half
 	})
@@ -1662,8 +1657,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				Offset: 0,
 				Limit:  total,
 			},
-			SearchVector: randomVector(r, 7),
-		})
+		}, "", randomVector(r, 7))
 		require.Nil(t, err)
 		assert.Len(t, res, total/2) // we skipped the vector on half the elements, so we should now match half
 	})
@@ -1676,8 +1670,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 				Offset: 0,
 				Limit:  total,
 			},
-			SearchVector: randomVector(r, 7),
-		})
+		}, "", randomVector(r, 7))
 		require.Nil(t, err)
 		// we skipped the vector on half the elements, and cut the list in half with
 		// the filter, so we're only expected a quarter of the total size now
@@ -1777,9 +1770,8 @@ func TestVectorSearch_ByDistance(t *testing.T) {
 			NearVector: &searchparams.NearVector{
 				Distance: 0.1,
 			},
-			SearchVector:         searchVector,
 			AdditionalProperties: additional.Properties{Distance: true},
-		})
+		}, "", searchVector)
 		require.Nil(t, err)
 		require.NotEmpty(t, results)
 		// ensure that we receive more results than
@@ -1804,9 +1796,8 @@ func TestVectorSearch_ByDistance(t *testing.T) {
 				Distance: 0.1,
 				ID:       searchObject.String(),
 			},
-			SearchVector:         searchVector,
 			AdditionalProperties: additional.Properties{Distance: true},
-		})
+		}, "", searchVector)
 		require.Nil(t, err)
 		require.NotEmpty(t, results)
 		// ensure that we receive more results than
@@ -1916,9 +1907,8 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 			NearVector: &searchparams.NearVector{
 				Certainty: 0.9,
 			},
-			SearchVector:         searchVector,
 			AdditionalProperties: additional.Properties{Certainty: true},
-		})
+		}, "", searchVector)
 		require.Nil(t, err)
 		require.NotEmpty(t, results)
 		// ensure that we receive more results than
@@ -1943,9 +1933,8 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 				Certainty: 0.9,
 				ID:        searchObject.String(),
 			},
-			SearchVector:         searchVector,
 			AdditionalProperties: additional.Properties{Certainty: true},
-		})
+		}, "", searchVector)
 		require.Nil(t, err)
 		require.NotEmpty(t, results)
 		// ensure that we receive more results than

--- a/adapters/repos/db/crud_null_objects_integration_test.go
+++ b/adapters/repos/db/crud_null_objects_integration_test.go
@@ -61,10 +61,9 @@ func TestFilterNullStateError(t *testing.T) {
 	}
 
 	params := dto.GetParams{
-		SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
-		ClassName:    class.Class,
-		Pagination:   &filters.Pagination{Limit: 5},
-		Filters:      nilFilter,
+		ClassName:  class.Class,
+		Pagination: &filters.Pagination{Limit: 5},
+		Filters:    nilFilter,
 	}
 	_, err = repo.Search(context.Background(), params)
 	require.NotNil(t, err)

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -92,12 +92,11 @@ func TestUpdateJourney(t *testing.T) {
 	t.Run("verify vector search results are initially as expected",
 		func(t *testing.T) {
 			res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-				ClassName:    "UpdateTestClass",
-				SearchVector: searchVector,
+				ClassName: "UpdateTestClass",
 				Pagination: &filters.Pagination{
 					Limit: 100,
 				},
-			})
+			}, "", searchVector)
 
 			expectedInAnyOrder := []interface{}{
 				"element-0", "element-1", "element-2", "element-3",
@@ -172,12 +171,11 @@ func TestUpdateJourney(t *testing.T) {
 
 	t.Run("verify new vector search results are as expected", func(t *testing.T) {
 		res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-			ClassName:    "UpdateTestClass",
-			SearchVector: searchVector,
+			ClassName: "UpdateTestClass",
 			Pagination: &filters.Pagination{
 				Limit: 100,
 			},
-		})
+		}, "", searchVector)
 
 		expectedInAnyOrder := []interface{}{
 			"element-0", "element-1", "element-2", "element-3",
@@ -235,12 +233,11 @@ func TestUpdateJourney(t *testing.T) {
 
 	t.Run("verify new vector search results are as expected", func(t *testing.T) {
 		res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-			ClassName:    "UpdateTestClass",
-			SearchVector: searchVector,
+			ClassName: "UpdateTestClass",
 			Pagination: &filters.Pagination{
 				Limit: 100,
 			},
-		})
+		}, "", searchVector)
 
 		expectedInAnyOrder := []interface{}{
 			"element-0", "element-1", "element-2", "element-3",

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -191,10 +191,9 @@ func testPrimitivePropsWithNoLengthIndex(repo *DB) func(t *testing.T) {
 					test.limit = 100
 				}
 				params := dto.GetParams{
-					SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
-					ClassName:    carClass.Class,
-					Pagination:   &filters.Pagination{Limit: test.limit},
-					Filters:      test.filter,
+					ClassName:  carClass.Class,
+					Pagination: &filters.Pagination{Limit: test.limit},
+					Filters:    test.filter,
 				}
 				res, err := repo.Search(context.Background(), params)
 				if len(test.ErrMsg) > 0 {
@@ -575,10 +574,9 @@ func testPrimitiveProps(repo *DB) func(t *testing.T) {
 					test.limit = 100
 				}
 				params := dto.GetParams{
-					SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
-					ClassName:    carClass.Class,
-					Pagination:   &filters.Pagination{Limit: test.limit},
-					Filters:      test.filter,
+					ClassName:  carClass.Class,
+					Pagination: &filters.Pagination{Limit: test.limit},
+					Filters:    test.filter,
 				}
 				res, err := repo.Search(context.Background(), params)
 				if len(test.ErrMsg) > 0 {
@@ -606,10 +604,9 @@ func testPrimitivePropsWithLimit(repo *DB) func(t *testing.T) {
 			limit := 1
 
 			params := dto.GetParams{
-				SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
-				ClassName:    carClass.Class,
-				Pagination:   &filters.Pagination{Limit: limit},
-				Filters:      buildFilter("horsepower", 2, gt, dtInt), // would otherwise return 3 results
+				ClassName:  carClass.Class,
+				Pagination: &filters.Pagination{Limit: limit},
+				Filters:    buildFilter("horsepower", 2, gt, dtInt), // would otherwise return 3 results
 			}
 			res, err := repo.Search(context.Background(), params)
 			require.Nil(t, err)
@@ -620,10 +617,9 @@ func testPrimitivePropsWithLimit(repo *DB) func(t *testing.T) {
 			limit := 1
 
 			params := dto.GetParams{
-				SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
-				ClassName:    carClass.Class,
-				Pagination:   &filters.Pagination{Limit: limit},
-				Filters:      buildFilter("horsepower", 20000, lt, dtInt), // would otherwise return 3 results
+				ClassName:  carClass.Class,
+				Pagination: &filters.Pagination{Limit: limit},
+				Filters:    buildFilter("horsepower", 20000, lt, dtInt), // would otherwise return 3 results
 			}
 			res, err := repo.Search(context.Background(), params)
 			require.Nil(t, err)
@@ -702,7 +698,6 @@ func testChainedPrimitiveProps(repo *DB,
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				params := dto.GetParams{
-					// SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
 					ClassName:  carClass.Class,
 					Pagination: &filters.Pagination{Limit: 100},
 					Filters:    test.filter,

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -1348,10 +1348,9 @@ func TestFilterPropertyLengthError(t *testing.T) {
 	}
 
 	params := dto.GetParams{
-		SearchVector: []float32{0.1, 0.1, 0.1, 1.1, 0.1},
-		ClassName:    class.Class,
-		Pagination:   &filters.Pagination{Limit: 5},
-		Filters:      LengthFilter,
+		ClassName:  class.Class,
+		Pagination: &filters.Pagination{Limit: 5},
+		Filters:    LengthFilter,
 	}
 	_, err = repo.Search(context.Background(), params)
 	require.NotNil(t, err)

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -662,7 +662,7 @@ func Test_Merge_UntouchedPropsCorrectlyIndexed(t *testing.T) {
 							Pagination: &filters.Pagination{Limit: 5},
 							Filters:    tc.filter,
 						}
-						res, err := repo.VectorSearch(context.Background(), params)
+						res, err := repo.VectorSearch(context.Background(), params, "", nil)
 						require.Nil(t, err)
 						require.Len(t, res, 1)
 
@@ -913,7 +913,7 @@ func Test_MergeDocIdPreserved_PropsCorrectlyIndexed(t *testing.T) {
 							Pagination: &filters.Pagination{Limit: 5},
 							Filters:    tc.filter,
 						}
-						res, err := repo.VectorSearch(context.Background(), params)
+						res, err := repo.VectorSearch(context.Background(), params, "", nil)
 						require.Nil(t, err)
 						require.Len(t, res, 1)
 

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -410,12 +410,11 @@ func makeTestRetrievingBaseClass(repo *DB, data []*models.Object,
 		t.Run("retrieve through class-level vector search", func(t *testing.T) {
 			do := func(t *testing.T, limit, expected int) {
 				res, err := repo.VectorSearch(context.Background(), dto.GetParams{
-					SearchVector: queryVec,
 					Pagination: &filters.Pagination{
 						Limit: limit,
 					},
 					ClassName: "TestClass",
-				})
+				}, "", queryVec)
 				assert.Nil(t, err)
 				assert.Len(t, res, expected)
 				for i, obj := range res {

--- a/adapters/repos/db/ranked_fusion_test.go
+++ b/adapters/repos/db/ranked_fusion_test.go
@@ -858,7 +858,7 @@ func (f *fakeObjectSearcher) Search(context.Context, dto.GetParams) ([]search.Re
 	return nil, nil
 }
 
-func (f *fakeObjectSearcher) VectorSearch(context.Context, dto.GetParams) ([]search.Result, error) {
+func (f *fakeObjectSearcher) VectorSearch(context.Context, dto.GetParams, string, []float32) ([]search.Result, error) {
 	return nil, nil
 }
 

--- a/adapters/repos/db/restart_journey_integration_test.go
+++ b/adapters/repos/db/restart_journey_integration_test.go
@@ -148,12 +148,11 @@ func TestRestartJourney(t *testing.T) {
 		t.Run("find object through vector index", func(t *testing.T) {
 			res, err := repo.VectorSearch(context.Background(),
 				dto.GetParams{
-					ClassName:    "Class",
-					SearchVector: []float32{0.05, 0.1, 0.15},
+					ClassName: "Class",
 					Pagination: &filters.Pagination{
 						Limit: 1,
 					},
-				})
+				}, "", []float32{0.05, 0.1, 0.15})
 			require.Nil(t, err)
 			require.Len(t, res, 1)
 			assert.Equal(t, "the band is just fantastic that is really what I think",
@@ -231,12 +230,11 @@ func TestRestartJourney(t *testing.T) {
 		t.Run("find object through vector index", func(t *testing.T) {
 			res, err := newRepo.VectorSearch(context.Background(),
 				dto.GetParams{
-					ClassName:    "Class",
-					SearchVector: []float32{0.05, 0.1, 0.15},
+					ClassName: "Class",
 					Pagination: &filters.Pagination{
 						Limit: 1,
 					},
-				})
+				}, "", []float32{0.05, 0.1, 0.15})
 			require.Nil(t, err)
 			require.Len(t, res, 1)
 			assert.Equal(t, "the band is just fantastic that is really what I think",

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -106,9 +106,9 @@ func (db *DB) Search(ctx context.Context, params dto.GetParams) ([]search.Result
 }
 
 func (db *DB) VectorSearch(ctx context.Context,
-	params dto.GetParams,
+	params dto.GetParams, targetVector string, searchVector []float32,
 ) ([]search.Result, error) {
-	if params.SearchVector == nil {
+	if searchVector == nil {
 		return db.Search(ctx, params)
 	}
 
@@ -123,7 +123,7 @@ func (db *DB) VectorSearch(ctx context.Context,
 	}
 
 	targetDist := extractDistanceFromParams(params)
-	res, dists, err := idx.objectVectorSearch(ctx, params.SearchVector, params.TargetVector,
+	res, dists, err := idx.objectVectorSearch(ctx, searchVector, targetVector,
 		targetDist, totalLimit, params.Filters, params.Sort, params.GroupBy,
 		params.AdditionalProperties, params.ReplicationProperties, params.Tenant)
 	if err != nil {

--- a/entities/dto/dto.go
+++ b/entities/dto/dto.go
@@ -54,7 +54,6 @@ type GetParams struct {
 	KeywordRanking          *searchparams.KeywordRanking
 	HybridSearch            *searchparams.HybridSearch
 	GroupBy                 *searchparams.GroupBy
-	SearchVector            []float32
 	TargetVector            string
 	TargetVectorCombination *TargetCombination
 	Group                   *GroupParams

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -207,7 +207,7 @@ func (f *fakeVectorRepoKNN) ZeroShotSearch(ctx context.Context, vector []float32
 }
 
 func (f *fakeVectorRepoKNN) VectorSearch(ctx context.Context,
-	params dto.GetParams,
+	params dto.GetParams, targetVector string, searchVector []float32,
 ) ([]search.Result, error) {
 	f.Lock()
 	defer f.Unlock()
@@ -297,9 +297,9 @@ func (f *fakeVectorRepoContextual) BatchPutObjects(ctx context.Context, objects 
 }
 
 func (f *fakeVectorRepoContextual) VectorSearch(ctx context.Context,
-	params dto.GetParams,
+	params dto.GetParams, targetVector string, searchVector []float32,
 ) ([]search.Result, error) {
-	if params.SearchVector == nil {
+	if searchVector == nil {
 		filteredTargets := matchClassName(f.targets, params.ClassName)
 		return filteredTargets, nil
 	}
@@ -310,12 +310,12 @@ func (f *fakeVectorRepoContextual) VectorSearch(ctx context.Context,
 	filteredTargets := matchClassName(f.targets, params.ClassName)
 	results := filteredTargets
 	sort.SliceStable(results, func(i, j int) bool {
-		simI, err := cosineSim(results[i].Vector, params.SearchVector)
+		simI, err := cosineSim(results[i].Vector, searchVector)
 		if err != nil {
 			panic(err.Error())
 		}
 
-		simJ, err := cosineSim(results[j].Vector, params.SearchVector)
+		simJ, err := cosineSim(results[j].Vector, searchVector)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -105,7 +105,7 @@ type VectorRepo interface {
 	AggregateNeighbors(ctx context.Context, vector []float32,
 		class string, properties []string, k int,
 		filter *libfilters.LocalFilter) ([]NeighborRef, error)
-	VectorSearch(ctx context.Context, params dto.GetParams) ([]search.Result, error)
+	VectorSearch(ctx context.Context, params dto.GetParams, targetVector string, searchVector []float32) ([]search.Result, error)
 	ZeroShotSearch(ctx context.Context, vector []float32,
 		class string, properties []string,
 		filter *libfilters.LocalFilter) ([]search.Result, error)

--- a/usecases/classification/classifier_vector_repo.go
+++ b/usecases/classification/classifier_vector_repo.go
@@ -35,7 +35,7 @@ func (r *vectorClassSearchRepo) VectorClassSearch(ctx context.Context,
 		Pagination: params.Pagination,
 		ClassName:  params.ClassName,
 		Properties: r.getProperties(params.Properties),
-	})
+	}, "", nil)
 }
 
 func (r *vectorClassSearchRepo) getProperties(properties []string) search.SelectProperties {

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -213,7 +213,7 @@ func (f *fakeVectorRepoKNN) ZeroShotSearch(ctx context.Context, vector []float32
 }
 
 func (f *fakeVectorRepoKNN) VectorSearch(ctx context.Context,
-	params dto.GetParams,
+	params dto.GetParams, targetVector string, searchVector []float32,
 ) ([]search.Result, error) {
 	f.Lock()
 	defer f.Unlock()
@@ -303,9 +303,9 @@ func (f *fakeVectorRepoContextual) BatchPutObjects(ctx context.Context, objects 
 }
 
 func (f *fakeVectorRepoContextual) VectorSearch(ctx context.Context,
-	params dto.GetParams,
+	params dto.GetParams, targetVector string, searchVector []float32,
 ) ([]search.Result, error) {
-	if params.SearchVector == nil {
+	if searchVector == nil {
 		filteredTargets := matchClassName(f.targets, params.ClassName)
 		return filteredTargets, nil
 	}
@@ -316,12 +316,12 @@ func (f *fakeVectorRepoContextual) VectorSearch(ctx context.Context,
 	filteredTargets := matchClassName(f.targets, params.ClassName)
 	results := filteredTargets
 	sort.SliceStable(results, func(i, j int) bool {
-		simI, err := cosineSim(results[i].Vector, params.SearchVector)
+		simI, err := cosineSim(results[i].Vector, searchVector)
 		if err != nil {
 			panic(err.Error())
 		}
 
-		simJ, err := cosineSim(results[j].Vector, params.SearchVector)
+		simJ, err := cosineSim(results[j].Vector, searchVector)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -80,9 +80,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 		search.
-			On("VectorSearch", expectedParamsToSearch).
+			On("VectorSearch", expectedParamsToSearch, []float32{0.8, 0.2, 0.7}).
 			Return(searchResults, nil)
 
 		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
@@ -223,11 +222,12 @@ func Test_Explorer_GetClass(t *testing.T) {
 					}}},
 				})
 				expectedParamsToSearch := params
+				var vector []float32
 				search.
 					On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
 					Return(&searchRes, nil)
 				search.
-					On("VectorSearch", expectedParamsToSearch).
+					On("VectorSearch", expectedParamsToSearch, vector).
 					Return(searchResults, nil)
 				metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
@@ -299,11 +299,13 @@ func Test_Explorer_GetClass(t *testing.T) {
 				}}},
 			})
 			expectedParamsToSearch := params
+			var vector []float32
+
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
 				Return(&searchRes, nil)
 			search.
-				On("VectorSearch", expectedParamsToSearch).
+				On("VectorSearch", expectedParamsToSearch, vector).
 				Return(searchResults, nil)
 			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
@@ -376,11 +378,13 @@ func Test_Explorer_GetClass(t *testing.T) {
 				}}},
 			})
 			expectedParamsToSearch := params
+			var vector []float32
+
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
 				Return(&searchRes, nil)
 			search.
-				On("VectorSearch", expectedParamsToSearch).
+				On("VectorSearch", expectedParamsToSearch, vector).
 				Return(searchResults, nil)
 			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
@@ -451,11 +455,13 @@ func Test_Explorer_GetClass(t *testing.T) {
 				}}},
 			})
 			expectedParamsToSearch := params
+			var vector []float32
+
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
 				Return(&searchRes, nil)
 			search.
-				On("VectorSearch", expectedParamsToSearch).
+				On("VectorSearch", expectedParamsToSearch, vector).
 				Return(searchResults, nil)
 			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
@@ -517,9 +523,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 					}}},
 				})
 				expectedParamsToSearch := params
-				expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 				search.
-					On("VectorSearch", expectedParamsToSearch).
+					On("VectorSearch", expectedParamsToSearch, []float32{0.8, 0.2, 0.7}).
 					Return(searchResults, nil)
 				metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
 
@@ -569,9 +574,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 					}}},
 				})
 				expectedParamsToSearch := params
-				expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 				search.
-					On("VectorSearch", expectedParamsToSearch).
+					On("VectorSearch", expectedParamsToSearch, []float32{0.8, 0.2, 0.7}).
 					Return(searchResults, nil)
 				metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
 
@@ -647,7 +651,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -706,10 +709,9 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 		expectedParamsToSearch.AdditionalProperties.Vector = true
 		search.
-			On("VectorSearch", expectedParamsToSearch).
+			On("VectorSearch", expectedParamsToSearch, []float32{0.8, 0.2, 0.7}).
 			Return(searchResults, nil)
 		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
 
@@ -762,7 +764,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -819,7 +820,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -900,7 +900,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -967,7 +966,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1024,7 +1022,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1080,7 +1077,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		search.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1176,7 +1172,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		searcher.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1283,7 +1278,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		searcher.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1394,7 +1388,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1553,7 +1546,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -1783,7 +1775,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -2040,7 +2031,6 @@ func Test_Explorer_GetClass(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = nil
 		searcher.
 			On("Search", expectedParamsToSearch).
 			Return(searchResults, nil)
@@ -2152,9 +2142,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 		search.
-			On("VectorSearch", expectedParamsToSearch).
+			On("VectorSearch", expectedParamsToSearch, []float32{1, 2, 3}).
 			Return(searchResults, nil)
 		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
@@ -2215,9 +2204,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				}}},
 			})
 			expectedParamsToSearch := params
-			expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 			search.
-				On("VectorSearch", expectedParamsToSearch).
+				On("VectorSearch", expectedParamsToSearch, []float32{1, 2, 3}).
 				Return(searchResults, nil)
 			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
@@ -2270,9 +2258,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				}}},
 			})
 			expectedParamsToSearch := params
-			expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 			search.
-				On("VectorSearch", expectedParamsToSearch).
+				On("VectorSearch", expectedParamsToSearch, []float32{1, 2, 3}).
 				Return(searchResults, nil)
 			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
@@ -2443,10 +2430,9 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 	t.Run("when the distance prop is set", func(t *testing.T) {
 		params := dto.GetParams{
-			Filters:      nil,
-			ClassName:    "BestClass",
-			Pagination:   &filters.Pagination{Limit: 100},
-			SearchVector: []float32{1.0, 2.0, 3.0},
+			Filters:    nil,
+			ClassName:  "BestClass",
+			Pagination: &filters.Pagination{Limit: 100},
 			AdditionalProperties: additional.Properties{
 				Distance: true,
 			},
@@ -2481,10 +2467,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = []float32{1.0, 2.0, 3.0}
-		// expectedParamsToSearch.SearchVector = nil
 		search.
-			On("VectorSearch", expectedParamsToSearch).
+			On("VectorSearch", expectedParamsToSearch, []float32{1.0, 2.0, 3.0}).
 			Return(searchResults, nil)
 		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
@@ -2510,10 +2494,9 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 	t.Run("when the certainty prop is set", func(t *testing.T) {
 		params := dto.GetParams{
-			Filters:      nil,
-			ClassName:    "BestClass",
-			Pagination:   &filters.Pagination{Limit: 100},
-			SearchVector: []float32{1.0, 2.0, 3.0},
+			Filters:    nil,
+			ClassName:  "BestClass",
+			Pagination: &filters.Pagination{Limit: 100},
 			AdditionalProperties: additional.Properties{
 				Certainty: true,
 			},
@@ -2551,10 +2534,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 		schemaGetter.SetVectorIndexConfig(hnsw.UserConfig{Distance: "cosine"})
 		explorer.schemaGetter = schemaGetter
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = []float32{1.0, 2.0, 3.0}
-		// expectedParamsToSearch.SearchVector = nil
 		search.
-			On("VectorSearch", expectedParamsToSearch).
+			On("VectorSearch", expectedParamsToSearch, []float32{1.0, 2.0, 3.0}).
 			Return(searchResults, nil)
 		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
@@ -2679,10 +2660,9 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 			}}},
 		})
 		expectedParamsToSearch := params
-		expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 		expectedParamsToSearch.AdditionalProperties.Vector = true // any custom additional params will trigger vector
 		searcher.
-			On("VectorSearch", expectedParamsToSearch).
+			On("VectorSearch", expectedParamsToSearch, []float32{1, 2, 3}).
 			Return(searchResults, nil)
 		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 

--- a/usecases/traverser/explorer_validate_filters_test.go
+++ b/usecases/traverser/explorer_validate_filters_test.go
@@ -390,7 +390,7 @@ func Test_Explorer_GetClass_WithFilters(t *testing.T) {
 
 				if test.expectedError == nil {
 					search.
-						On("VectorSearch", mock.Anything).
+						On("VectorSearch", mock.Anything, mock.Anything).
 						Return(searchResults, nil)
 
 					res, err := explorer.GetClass(context.Background(), params)

--- a/usecases/traverser/explorer_validate_sort_test.go
+++ b/usecases/traverser/explorer_validate_sort_test.go
@@ -385,7 +385,7 @@ func Test_Explorer_GetClass_WithSort(t *testing.T) {
 
 					if td.expectedError == nil {
 						search.
-							On("VectorSearch", mock.Anything).
+							On("VectorSearch", mock.Anything, mock.Anything).
 							Return(searchResults, nil)
 						res, err := explorer.GetClass(context.Background(), params)
 						assert.Nil(t, err)

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -106,9 +106,9 @@ func (f *fakeVectorSearcher) Aggregate(ctx context.Context,
 }
 
 func (f *fakeVectorSearcher) VectorSearch(ctx context.Context,
-	params dto.GetParams,
+	params dto.GetParams, targetVector string, searchVector []float32,
 ) ([]search.Result, error) {
-	args := f.Called(params)
+	args := f.Called(params, searchVector)
 	return args.Get(0).([]search.Result), args.Error(1)
 }
 


### PR DESCRIPTION
### What's being changed:

The dto.GetParams struct contains the user input for the query - however there are two exceptions: targetVector and searchVector are added later. For example: User does a nearText search for a givent target vector, then the respective module computes the searchVector and adds it to the struct.

This does not work anymore for concurrent searches, as each search has its own target+searchvector requirering error-prone copying of the struct. This PR removes those two entries and adds them as separate paramters.

Not: 90% of the change is moving parameters in the test around

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
