### PR TITLE
Fetch gRPC health probe using go sources instead of github releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,9 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 
 ###############################################################################
 # This image gets grpc health check probe
-FROM build_base AS grpc_health_probe_builder
-ARG TARGETARCH
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.27 && \
-      wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
-      chmod +x /bin/grpc_health_probe
+FROM golang:1.22-alpine AS grpc_health_probe_builder
+RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.29
+RUN GOBIN=/go/bin && chmod +x ${GOBIN}/grpc-health-probe && mv ${GOBIN}/grpc-health-probe /bin/grpc_health_probe
 
 ###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)


### PR DESCRIPTION
### What's being changed:

Fetch gRPC health probe using go sources instead of github releases

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
