### PR TITLE
Correct reference to text2vec-contextionary in text2vec-transformers

### DIFF
--- a/modules/text2vec-transformers/config.go
+++ b/modules/text2vec-transformers/config.go
@@ -148,7 +148,7 @@ func (cv *ConfigValidator) checkForPossibilityOfDuplicateVectors(
 
 	cv.logger.WithField("module", "text2vec-transformers").
 		WithField("class", class.Class).
-		Warnf("text2vec-contextionary: Class %q does not have any properties "+
+		Warnf("text2vec-transformers: Class %q does not have any properties "+
 			"indexed (or only non text-properties indexed) and the vector position is "+
 			"only determined by the class name. Each object will end up with the same "+
 			"vector which leads to a severe performance penalty on imports. Consider "+


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
