### PR TITLE
Add global bucket registry as a safety net in `lsmkv`

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -170,7 +170,6 @@ func bucketReadsIntoMemory(ctx context.Context, t *testing.T, opts []BucketOptio
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -184,6 +183,7 @@ func bucketReadsIntoMemory(ctx context.Context, t *testing.T, opts []BucketOptio
 
 	_, ok = findFileWithExt(files, "secondary.0.bloom")
 	assert.True(t, ok)
+	b.Shutdown(ctx)
 
 	b2, err := NewBucketCreator().NewBucket(ctx, b.dir, "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)

--- a/adapters/repos/db/lsmkv/global_bucket_registry.go
+++ b/adapters/repos/db/lsmkv/global_bucket_registry.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/lsmkv/global_bucket_registry.go
+++ b/adapters/repos/db/lsmkv/global_bucket_registry.go
@@ -1,0 +1,41 @@
+package lsmkv
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type globalBucketRegistry struct {
+	buckets map[string]struct{}
+	mu      sync.Mutex
+}
+
+func newGlobalBucketRegistry() *globalBucketRegistry {
+	return &globalBucketRegistry{
+		buckets: make(map[string]struct{}),
+	}
+}
+
+var GlobalBucketRegistry = newGlobalBucketRegistry()
+
+var ErrBucketAlreadyRegistered = errors.New("bucket already registered")
+
+func (r *globalBucketRegistry) TryAdd(absoluteBucketPath string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.buckets[absoluteBucketPath]; ok {
+		return fmt.Errorf("bucket %q: %w", absoluteBucketPath, ErrBucketAlreadyRegistered)
+	}
+
+	r.buckets[absoluteBucketPath] = struct{}{}
+	return nil
+}
+
+func (r *globalBucketRegistry) Remove(absoluteBucketPath string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.buckets, absoluteBucketPath)
+}

--- a/adapters/repos/db/lsmkv/global_bucket_registry.go
+++ b/adapters/repos/db/lsmkv/global_bucket_registry.go
@@ -28,7 +28,11 @@ func newGlobalBucketRegistry() *globalBucketRegistry {
 	}
 }
 
-var GlobalBucketRegistry = newGlobalBucketRegistry()
+var GlobalBucketRegistry *globalBucketRegistry
+
+func init() {
+	GlobalBucketRegistry = newGlobalBucketRegistry()
+}
 
 var ErrBucketAlreadyRegistered = errors.New("bucket already registered")
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -162,7 +162,6 @@ func TestRepairTooShortBloomOnInit(t *testing.T) {
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
 	require.Nil(t, b.FlushMemtable())
@@ -171,6 +170,7 @@ func TestRepairTooShortBloomOnInit(t *testing.T) {
 	require.Nil(t, err)
 	fname, ok := findFileWithExt(files, ".bloom")
 	require.True(t, ok)
+	b.Shutdown(ctx)
 
 	// now corrupt the bloom filter by randomly overriding data
 	require.Nil(t, corruptBloomFileByTruncatingIt(path.Join(dirName, fname)))
@@ -248,7 +248,6 @@ func TestRepairCorruptedBloomSecondaryOnInitIntoMemory(t *testing.T) {
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -258,6 +257,8 @@ func TestRepairCorruptedBloomSecondaryOnInitIntoMemory(t *testing.T) {
 	require.Nil(t, err)
 	fname, ok := findFileWithExt(files, "secondary.0.bloom")
 	require.True(t, ok)
+
+	b.Shutdown(ctx)
 
 	// now corrupt the file by replacing the count value without adapting the checksum
 	require.Nil(t, corruptBloomFile(path.Join(dirName, fname)))
@@ -285,7 +286,6 @@ func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
-	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -296,6 +296,7 @@ func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
 	fname, ok := findFileWithExt(files, "secondary.0.bloom")
 	require.True(t, ok)
 
+	b.Shutdown(ctx)
 	// now corrupt the file by replacing the count value without adapting the checksum
 	require.Nil(t, corruptBloomFileByTruncatingIt(path.Join(dirName, fname)))
 

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -60,6 +60,8 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -149,6 +151,8 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -243,6 +247,8 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -340,6 +346,8 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -445,6 +453,8 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -538,6 +548,8 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -640,6 +652,8 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -747,6 +761,8 @@ func mapCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -68,6 +68,8 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -132,6 +134,8 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -208,6 +212,8 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -278,6 +284,8 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -362,6 +370,8 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -454,6 +464,8 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -512,6 +524,8 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -582,6 +596,8 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -657,6 +673,8 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -710,6 +728,8 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -768,6 +788,8 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -832,6 +854,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -1066,6 +1090,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -1157,6 +1183,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -1446,6 +1474,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)

--- a/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaring_set_integration_test.go
@@ -45,6 +45,8 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -119,6 +121,8 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -60,6 +60,8 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 
+		defer b.Shutdown(ctx)
+
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
 
@@ -118,6 +120,8 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -181,6 +185,8 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -246,6 +252,8 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -335,6 +343,8 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -431,6 +441,8 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -531,6 +543,8 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -641,6 +655,8 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 			require.Nil(t, err)
 
+			defer b.Shutdown(ctx)
+
 			// so big it effectively never triggers as part of this test
 			b.SetMemtableThreshold(1e9)
 
@@ -715,6 +731,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
@@ -842,6 +860,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
+
+		defer b.Shutdown(ctx)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -87,7 +87,10 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 		pool:              newPools(),
 		store:             store,
 	}
-	index.initBuckets(context.Background())
+	if err := index.initBuckets(context.Background()); err != nil {
+		return nil, fmt.Errorf("init flat index buckets: %w", err)
+	}
+
 	if uc.BQ.Enabled && uc.BQ.Cache {
 		index.bqCache = cache.NewShardedUInt64LockCache(
 			index.getBQVector, uc.VectorCacheMaxObjects, cfg.Logger, 0, cfg.AllocChecker)

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -14,6 +14,7 @@
 package flat
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -59,6 +60,8 @@ func run(dirName string, logger *logrus.Logger, compression string, vectorCache 
 	if err != nil {
 		return 0, 0, err
 	}
+
+	defer store.Shutdown(context.Background())
 
 	pq := flatent.CompressionUserConfig{
 		Enabled: false,


### PR DESCRIPTION
### What's being changed:

- If you try to register the same bucket path twice, it will now error. This prevents corruptions
- There is likely still a root cause that leads to buckets being loaded twice. **This root cause is not addressed by this PR**. This PR simply makes the failure explicit and prevents the silent corruption
- As this failure is now explicit a lot of tests that leaked buckets had to be adjusted to make sure they clean up properly now
- As part of this, we also spotted an issue in the flat index where bucket initialization could fail silently. A fix is also provided.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
