### PR TITLE
Fix rate limiting when using Azure OpenAI

### DIFF
--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -40,7 +40,7 @@ func GetRateLimitsFromHeader(header http.Header) *modulecomponents.RateLimits {
 		limitTokens = dummyLimit
 	}
 	if limitRequests == 0 && remainingRequests > 0 {
-		limitTokens = dummyLimit
+		limitRequests = dummyLimit
 	}
 	return &modulecomponents.RateLimits{
 		LimitRequests:     limitRequests,


### PR DESCRIPTION
### What's being changed:
I noticed that 1.25 is barely usable here when using Azure OpenAI, when doing a batch import there is only request sent to OpenAI every 30 seconds. Before this change, `limitRequests` is being set to zero as no `x-ratelimit-limit-requests` header gets returned in the Azure OpenAI response. Setting `limitRequests` to the dummy limit as is being done to `limitTokens` above should fix this issue (looks like a copy/paste error @dirkkul https://github.com/weaviate/weaviate/commit/c640550dd0276da353942eef3a654569efe0383a)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
