### PR TITLE
Add a korean tokenizer

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4578,7 +4578,8 @@ func init() {
             "whitespace",
             "field",
             "trigram",
-            "gse"
+            "gse",
+            "kagome_kr"
           ]
         }
       }
@@ -10128,7 +10129,8 @@ func init() {
             "whitespace",
             "field",
             "trigram",
-            "gse"
+            "gse",
+            "kagome_kr"
           ]
         }
       }

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -162,6 +162,8 @@ func tokenizeGSE(in string) []string {
 	return append(terms, alpha...)
 }
 
+// TODO - add a Korean tokenizer here
+
 // tokenizeWordWithWildcards splits on any non-alphanumerical except wildcard-symbols and
 // lowercases the words
 func tokenizeWordWithWildcards(in string) []string {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -39,6 +39,7 @@ var Tokenizations []string = []string{
 	models.PropertyTokenizationField,
 	models.PropertyTokenizationTrigram,
 	models.PropertyTokenizationGse,
+	models.PropertyTokenizationKagomeKr,
 }
 
 func init() {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/weaviate/weaviate/usecases/configbase"
+
 	"github.com/go-ego/gse"
 	koDict "github.com/ikawaha/kagome-dict-ko"
 	kagomeTokenizer "github.com/ikawaha/kagome/v2/tokenizer"
@@ -41,10 +43,10 @@ var Tokenizations []string = []string{
 }
 
 func init() {
-	if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
+	if configbase.Enabled(os.Getenv("USE_GSE")) || configbase.Enabled(os.Getenv("ENABLE_TOKENIZER_GSE")) {
 		Tokenizations = append(Tokenizations, models.PropertyTokenizationGse)
 	}
-	if os.Getenv("ENABLE_TOKENIZER_KAGOME_KR") == "true" {
+	if configbase.Enabled(os.Getenv("ENABLE_TOKENIZER_KAGOME_KR")) {
 		Tokenizations = append(Tokenizations, models.PropertyTokenizationKagomeKr)
 	}
 	init_gse()
@@ -52,7 +54,7 @@ func init() {
 }
 
 func init_gse() {
-	if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
+	if configbase.Enabled(os.Getenv("USE_GSE")) || configbase.Enabled(os.Getenv("ENABLE_TOKENIZER_GSE")) {
 		UseGse = true
 	}
 	if UseGse {
@@ -195,7 +197,7 @@ func initializeKagomeTokenizerKr() error {
 	kagomeInitLock.Lock()
 	defer kagomeInitLock.Unlock()
 
-	if os.Getenv("ENABLE_TOKENIZER_KAGOME_KR") == "true" {
+	if configbase.Enabled(os.Getenv("ENABLE_TOKENIZER_KAGOME_KR")) {
 		if tokenizers.Korean != nil {
 			return nil
 		}
@@ -209,9 +211,9 @@ func initializeKagomeTokenizerKr() error {
 		tokenizers.Korean = tokenizer
 		KagomeKrEnabled = true
 		return nil
-	} else {
-		return nil
 	}
+
+	return nil
 }
 
 func tokenizeKagomeKr(in string) []string {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -29,7 +29,7 @@ var (
 	gseTokenizer     *gse.Segmenter
 	gseTokenizerLock = &sync.Mutex{}
 	UseGse           = false
-	KagomeEnabled    = true
+	KagomeEnabled    = false
 )
 
 var Tokenizations []string = []string{
@@ -104,6 +104,16 @@ func TokenizeWithWildcards(tokenization string, in string) []string {
 	}
 }
 
+func removeEmptyStrings(terms []string) []string {
+	for i := 0; i < len(terms); i++ {
+		if terms[i] == "" || terms[i] == " " {
+			terms = append(terms[:i], terms[i+1:]...)
+			i--
+		}
+	}
+	return terms
+}
+
 // tokenizeField trims white spaces
 // (former DataTypeString/Field)
 func tokenizeField(in string) []string {
@@ -159,13 +169,7 @@ func tokenizeGSE(in string) []string {
 	defer gseTokenizerLock.Unlock()
 	terms := gseTokenizer.CutAll(in)
 
-	// Remove empty strings from terms
-	for i := 0; i < len(terms); i++ {
-		if terms[i] == "" || terms[i] == " " {
-			terms = append(terms[:i], terms[i+1:]...)
-			i--
-		}
-	}
+	terms = removeEmptyStrings(terms)
 
 	alpha := tokenizeWord(in)
 	return append(terms, alpha...)
@@ -218,13 +222,7 @@ func tokenizeWithKagome(in string, t *kagomeTokenizer.Tokenizer) []string {
 		}
 	}
 
-	// Remove empty strings from terms
-	for i := 0; i < len(terms); i++ {
-		if terms[i] == "" || terms[i] == " " {
-			terms = append(terms[:i], terms[i+1:]...)
-			i--
-		}
-	}
+	terms = removeEmptyStrings(terms)
 
 	return terms
 }

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/go-ego/gse"
 	koDict "github.com/ikawaha/kagome-dict-ko"
 	kagomeTokenizer "github.com/ikawaha/kagome/v2/tokenizer"
@@ -30,7 +28,6 @@ var (
 	gseTokenizerLock = &sync.Mutex{}
 	UseGse           = false
 	KagomeKrEnabled  = false
-	log              logrus.FieldLogger
 )
 
 var Tokenizations []string = []string{
@@ -43,15 +40,7 @@ var Tokenizations []string = []string{
 	models.PropertyTokenizationKagomeKr,
 }
 
-func InitLogger(logger logrus.FieldLogger) {
-	log = logger
-}
-
 func init() {
-	logger := logrus.New()
-	logger.SetFormatter(&logrus.JSONFormatter{})
-	logger.SetLevel(logrus.InfoLevel)
-	InitLogger(logger)
 	init_gse()
 	_ = initializeKagomeTokenizerKr()
 }
@@ -208,16 +197,13 @@ func initializeKagomeTokenizerKr() error {
 		dictInstance := koDict.Dict()
 		tokenizer, err := kagomeTokenizer.New(dictInstance)
 		if err != nil {
-			log.WithField("action", "initialize_kagome_kr_tokenizer").WithError(err).Error("failed to create Korean tokenizer")
 			return err
 		}
 
 		tokenizers.Korean = tokenizer
 		KagomeKrEnabled = true
-		log.WithField("action", "initialize_kagome_kr_tokenizer").Info("successfully created Korean tokenizer")
 		return nil
 	} else {
-		log.WithField("action", "initialize_kagome_kr_tokenizer").Warn("Korean tokenizer not enabled; enable by setting ENABLE_KOREAN_TOKENIZER env variable to true")
 		return nil
 	}
 }
@@ -225,7 +211,6 @@ func initializeKagomeTokenizerKr() error {
 func tokenizeKagomeKr(in string) []string {
 	tokenizer := tokenizers.Korean
 	if tokenizer == nil || !KagomeKrEnabled {
-		log.WithField("action", "tokenizer_with_kagome_kr").Warn("Korean tokenizer has not been initialized")
 		return []string{}
 	}
 

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -206,8 +206,8 @@ func InitializeKagomeTokenizerKr() error {
 }
 
 func tokenizeWithKagome(in string, tokenizer *KagomeTokenizer) []string {
-	tokenizer.mutex.RLock()
-	defer tokenizer.mutex.RUnlock()
+	tokenizer.mutex.Lock()
+	defer tokenizer.mutex.Unlock()
 
 	if tokenizer.tokenizer == nil {
 		return []string{}

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -28,7 +28,6 @@ var (
 	gseTokenizer     *gse.Segmenter
 	gseTokenizerLock = &sync.Mutex{}
 	UseGse           = false
-	KagomeEnabled    = false // Disable Kagome tokenizer by default to reduce resource usage until needed
 )
 
 var Tokenizations []string = []string{
@@ -184,10 +183,6 @@ var tokenizers KagomeTokenizers
 func InitializeKagomeTokenizerKr() bool {
 	if tokenizers.Korean != nil {
 		return true
-	}
-
-	if os.Getenv("USE_KOREAN_TOKENIZER") != "true" {
-		return false
 	}
 
 	dictInstance := koDict.Dict()

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -42,6 +42,7 @@ var Tokenizations []string = []string{
 
 func init() {
 	init_gse()
+	_ = InitializeKagomeTokenizerKr()
 }
 
 func init_gse() {
@@ -179,14 +180,14 @@ type KagomeTokenizers struct {
 }
 
 var (
-	tokenizers KagomeTokenizers
-	initMutex  sync.Mutex
+	tokenizers     KagomeTokenizers
+	kagomeInitLock sync.Mutex
 )
 
 func InitializeKagomeTokenizerKr() error {
 	// Acquire lock to prevent initialization race
-	initMutex.Lock()
-	defer initMutex.Unlock()
+	kagomeInitLock.Lock()
+	defer kagomeInitLock.Unlock()
 
 	if tokenizers.Korean != nil {
 		return nil

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -12,15 +12,12 @@
 package helpers
 
 import (
-	"log"
 	"os"
 	"strings"
 	"sync"
 	"unicode"
 
 	"github.com/go-ego/gse"
-	koDict "github.com/ikawaha/kagome-dict-ko"
-	kagomeDict "github.com/ikawaha/kagome-dict/dict"
 	kagomeTokenizer "github.com/ikawaha/kagome/v2/tokenizer"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -183,34 +180,38 @@ var (
 	kagomeInitErr       error
 )
 
-func initializeKagomeTokenizer(dictInstance *kagomeDict.Dict, tokenizerInstance **kagomeTokenizer.Tokenizer, once *sync.Once) bool {
-	// If already initialized successfully
-	if KagomeEnabled {
-		return true
-	}
-
-	// If already initialized with an error
-	if kagomeInitErr != nil {
-		return false
-	}
-
-	// Otherwise, initialize the tokenizer
-	once.Do(func() {
-		var err error
-		*tokenizerInstance, err = kagomeTokenizer.New(dictInstance)
-		if err != nil {
-			kagomeInitErr = err
-			log.Printf("failed to create tokenizer: %v", err)
-		} else {
-			KagomeEnabled = true
-		}
-	})
-
-	return true
-}
+//func initializeKagomeTokenizer(dictInstance *kagomeDict.Dict, tokenizerInstance **kagomeTokenizer.Tokenizer, once *sync.Once) bool {
+//	// If already initialized successfully
+//	if KagomeEnabled {
+//		return true
+//	}
+//
+//	// If already initialized with an error
+//	if kagomeInitErr != nil {
+//		return false
+//	}
+//
+//	// Otherwise, initialize the tokenizer
+//	once.Do(func() {
+//		start := time.Now()
+//		var err error
+//		*tokenizerInstance, err = kagomeTokenizer.New(dictInstance)
+//		duration := time.Since(start)
+//		if err != nil {
+//			kagomeInitErr = err
+//			log.Printf("failed to create tokenizer: %v", err)
+//		} else {
+//			KagomeEnabled = true
+//			log.Printf("successfully created tokenizer (took %v)", duration)
+//		}
+//	})
+//
+//	return true
+//}
 
 func InitializeKagomeTokenizerKr() bool {
-	return initializeKagomeTokenizer(koDict.Dict(), &koTokenizerInstance, &koOnce)
+	// return initializeKagomeTokenizer(koDict.Dict(), &koTokenizerInstance, &koOnce)
+	return false
 }
 
 func tokenizeWithKagome(in string, t *kagomeTokenizer.Tokenizer) []string {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -39,7 +39,7 @@ var Tokenizations []string = []string{
 	models.PropertyTokenizationField,
 	models.PropertyTokenizationTrigram,
 	models.PropertyTokenizationGse,
-	// models.PropertyTokenizationKagomeKr,
+	models.PropertyTokenizationKagomeKr,
 }
 
 func init() {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -210,11 +210,6 @@ func InitializeKagomeTokenizerKr() error {
 }
 
 func tokenizeKagomeKr(in string) []string {
-	if err := InitializeKagomeTokenizerKr(); err != nil {
-		log.Printf("Tokenizer not available: %v", err)
-		return []string{}
-	}
-
 	tokenizer := tokenizers.Korean.Load()
 	if tokenizer == nil {
 		log.Printf("Tokenizer not initialized")

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -225,9 +225,15 @@ func tokenizeWithKagome(in string, tokenizer *KagomeTokenizer) []string {
 	return removeEmptyStrings(terms)
 }
 
+var initKoreanTokenizerOnce sync.Once
+
 func tokenizeKagomeKr(in string) []string {
-	if err := InitializeKagomeTokenizerKr(); err != nil {
-		log.Printf("Korean tokenizer not available: %v", err)
+	var initErr error
+	initKoreanTokenizerOnce.Do(func() {
+		initErr = InitializeKagomeTokenizerKr()
+	})
+	if initErr != nil {
+		log.Printf("Korean tokenizer not available: %v", initErr)
 		return []string{}
 	}
 	return tokenizeWithKagome(in, &koreanTokenizer)

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -214,7 +214,7 @@ func InitializeKagomeTokenizerKr() error {
 
 func tokenizeKagomeKr(in string) []string {
 	tokenizer := tokenizers.Korean
-	if tokenizer == nil || KagomeKrEnabled == false {
+	if tokenizer == nil || !KagomeKrEnabled {
 		log.Printf("Tokenizer not initialized")
 		return []string{}
 	}

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -180,9 +180,7 @@ type KagomeTokenizer struct {
 	mutex     sync.RWMutex
 }
 
-var (
-	koreanTokenizer KagomeTokenizer
-)
+var koreanTokenizer KagomeTokenizer
 
 func initializeKagomeTokenizer(dictInstance *kagomeDict.Dict, tokenizer *KagomeTokenizer, language string) error {
 	tokenizer.mutex.Lock()

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -29,7 +29,7 @@ var (
 	gseTokenizer     *gse.Segmenter
 	gseTokenizerLock = &sync.Mutex{}
 	UseGse           = false
-	EnableKagome     = true
+	EnableKagome     = true // To later have an option of disabling this by default
 )
 
 var Tokenizations []string = []string{

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -29,7 +29,7 @@ var (
 	gseTokenizer     *gse.Segmenter
 	gseTokenizerLock = &sync.Mutex{}
 	UseGse           = false
-	KagomeEnabled    = false
+	KagomeEnabled    = false // Disable Kagome tokenizer by default to reduce resource usage until needed
 )
 
 var Tokenizations []string = []string{

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -31,7 +31,7 @@ var (
 )
 
 // Optional tokenizers can be enabled with an environment variable like:
-// 'ENABLE_TOKENIZER_XXX', e.g. 'ENABLE_TOKENIZER_GSE', 'ENABLE_TOKENIZER_KOREAN'
+// 'ENABLE_TOKENIZER_XXX', e.g. 'ENABLE_TOKENIZER_GSE', 'ENABLE_TOKENIZER_KAGOME_KR'
 var Tokenizations []string = []string{
 	models.PropertyTokenizationWord,
 	models.PropertyTokenizationLowercase,
@@ -44,7 +44,7 @@ func init() {
 	if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
 		Tokenizations = append(Tokenizations, models.PropertyTokenizationGse)
 	}
-	if os.Getenv("ENABLE_TOKENIZER_KOREAN") == "true" {
+	if os.Getenv("ENABLE_TOKENIZER_KAGOME_KR") == "true" {
 		Tokenizations = append(Tokenizations, models.PropertyTokenizationKagomeKr)
 	}
 	init_gse()
@@ -195,7 +195,7 @@ func initializeKagomeTokenizerKr() error {
 	kagomeInitLock.Lock()
 	defer kagomeInitLock.Unlock()
 
-	if os.Getenv("ENABLE_TOKENIZER_KOREAN") == "true" {
+	if os.Getenv("ENABLE_TOKENIZER_KAGOME_KR") == "true" {
 		if tokenizers.Korean != nil {
 			return nil
 		}

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -44,6 +44,7 @@ var Tokenizations []string = []string{
 
 func init() {
 	init_gse()
+	InitializeKagomeTokenizerKr()
 }
 
 func init_gse() {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -39,7 +39,7 @@ var Tokenizations []string = []string{
 	models.PropertyTokenizationField,
 	models.PropertyTokenizationTrigram,
 	models.PropertyTokenizationGse,
-	models.PropertyTokenizationKagomeKr,
+	// models.PropertyTokenizationKagomeKr,
 }
 
 func init() {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -44,7 +44,6 @@ var Tokenizations []string = []string{
 
 func init() {
 	init_gse()
-	InitializeKagomeTokenizerKr()
 }
 
 func init_gse() {

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -45,8 +45,10 @@ func init() {
 	_ = initializeKagomeTokenizerKr()
 }
 
+// Optional tokenizers can be enabled with an environment variable like:
+// 'ENABLE_TOKENIZER_XXX', e.g. 'ENABLE_TOKENIZER_GSE', 'ENABLE_TOKENIZER_KOREAN'
 func init_gse() {
-	if os.Getenv("USE_GSE") == "true" {
+	if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
 		UseGse = true
 	}
 	if UseGse {
@@ -189,7 +191,7 @@ func initializeKagomeTokenizerKr() error {
 	kagomeInitLock.Lock()
 	defer kagomeInitLock.Unlock()
 
-	if os.Getenv("ENABLE_KOREAN_TOKENIZER") == "true" {
+	if os.Getenv("ENABLE_TOKENIZER_KOREAN") == "true" {
 		if tokenizers.Korean != nil {
 			return nil
 		}

--- a/adapters/repos/db/helpers/tokenizer.go
+++ b/adapters/repos/db/helpers/tokenizer.go
@@ -30,23 +30,27 @@ var (
 	KagomeKrEnabled  = false
 )
 
+// Optional tokenizers can be enabled with an environment variable like:
+// 'ENABLE_TOKENIZER_XXX', e.g. 'ENABLE_TOKENIZER_GSE', 'ENABLE_TOKENIZER_KOREAN'
 var Tokenizations []string = []string{
 	models.PropertyTokenizationWord,
 	models.PropertyTokenizationLowercase,
 	models.PropertyTokenizationWhitespace,
 	models.PropertyTokenizationField,
 	models.PropertyTokenizationTrigram,
-	models.PropertyTokenizationGse,
-	models.PropertyTokenizationKagomeKr,
 }
 
 func init() {
+	if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
+		Tokenizations = append(Tokenizations, models.PropertyTokenizationGse)
+	}
+	if os.Getenv("ENABLE_TOKENIZER_KOREAN") == "true" {
+		Tokenizations = append(Tokenizations, models.PropertyTokenizationKagomeKr)
+	}
 	init_gse()
 	_ = initializeKagomeTokenizerKr()
 }
 
-// Optional tokenizers can be enabled with an environment variable like:
-// 'ENABLE_TOKENIZER_XXX', e.g. 'ENABLE_TOKENIZER_GSE', 'ENABLE_TOKENIZER_KOREAN'
 func init_gse() {
 	if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
 		UseGse = true

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -91,6 +91,12 @@ func TestTokenise(t *testing.T) {
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
 	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
+
+	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "false")
+	if envSetErr != nil {
+		// Handle error if setting the environment variable fails
+		panic(envSetErr)
+	}
 }
 
 func TestTokenize(t *testing.T) {
@@ -239,5 +245,11 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 				assert.Equal(t, tc.expected[terms[i]], dups[i])
 			}
 		})
+	}
+
+	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "false")
+	if envSetErr != nil {
+		// Handle error if setting the environment variable fails
+		panic(envSetErr)
 	}
 }

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -68,10 +68,6 @@ func TestTokenise(t *testing.T) {
 	// Should be disabled by default & return empty tokens
 	koreanText := "아버지가방에들어가신다"
 
-	// Enable & Initialize Kagome tokenizer
-	EnableKagome = true
-	InitializeKagomeTokenizerKr()
-
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, koreanText)
 	expectedKorean := []string{"아버지", "가", "방", "에", "들어가", "신다"}
 	assert.Equal(t, expectedKorean, tokens)

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -63,6 +63,20 @@ func TestTokenise(t *testing.T) {
 
 	tokens = Tokenize(models.PropertyTokenizationGse, "The quick brown fox jumps over the lazy dog")
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
+
+	// Kagome tokenizer for Korean and Japanese
+	// Should be disabled by default & return empty tokens
+	koreanText := "아버지가방에들어가신다"
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, koreanText)
+	assert.Equal(t, []string{}, tokens)
+
+	// Enable & Initialize Kagome tokenizer
+	EnableKagome = true
+	InitializeKagomeTokenizerKr()
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, koreanText)
+	expectedKorean := []string{"아버지", "가", "방", "에", "들어가", "신다"}
+	assert.Equal(t, expectedKorean, tokens)
 }
 
 func TestTokenize(t *testing.T) {

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -143,21 +143,24 @@ func TestTokenize(t *testing.T) {
 }
 
 func TestTokenizeAndCountDuplicates(t *testing.T) {
-	input := "Hello You Beautiful World! hello you beautiful world!"
+	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
 	type testCase struct {
+		input        string
 		tokenization string
 		expected     map[string]int
 	}
 
 	testCases := []testCase{
 		{
+			input:        alphaInput,
 			tokenization: models.PropertyTokenizationField,
 			expected: map[string]int{
 				"Hello You Beautiful World! hello you beautiful world!": 1,
 			},
 		},
 		{
+			input:        alphaInput,
 			tokenization: models.PropertyTokenizationWhitespace,
 			expected: map[string]int{
 				"Hello":     1,
@@ -171,6 +174,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 			},
 		},
 		{
+			input:        alphaInput,
 			tokenization: models.PropertyTokenizationLowercase,
 			expected: map[string]int{
 				"hello":     2,
@@ -180,6 +184,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 			},
 		},
 		{
+			input:        alphaInput,
 			tokenization: models.PropertyTokenizationWord,
 			expected: map[string]int{
 				"hello":     2,
@@ -188,11 +193,24 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 				"world":     2,
 			},
 		},
+		{
+			input:        "한국어를 처리하는 예시입니다 한국어를 처리하는 예시입니다",
+			tokenization: models.PropertyTokenizationKagomeKr,
+			expected: map[string]int{
+				"한국어": 2,
+				"를":   2,
+				"처리":  2,
+				"하":   2,
+				"는":   2,
+				"예시":  2,
+				"입니다": 2,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.tokenization, func(t *testing.T) {
-			terms, dups := TokenizeAndCountDuplicates(tc.tokenization, input)
+			terms, dups := TokenizeAndCountDuplicates(tc.tokenization, tc.input)
 
 			assert.Len(t, terms, len(tc.expected))
 			assert.Len(t, dups, len(tc.expected))

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,7 +65,7 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	_ = InitializeKagomeTokenizerKr()
+	_ = InitializeKoreanTokenizer()
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
@@ -153,7 +153,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
-	_ = InitializeKagomeTokenizerKr()
+	_ = InitializeKoreanTokenizer()
 
 	testCases := []testCase{
 		{

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -66,7 +66,7 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	_ = os.Setenv("ENABLE_TOKENIZER_KOREAN", "true")
+	_ = os.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
 	_ = initializeKagomeTokenizerKr()
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
@@ -153,7 +153,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 		expected     map[string]int
 	}
 
-	_ = os.Setenv("ENABLE_TOKENIZER_KOREAN", "true")
+	_ = os.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
 	_ = initializeKagomeTokenizerKr()
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -64,13 +64,21 @@ func TestTokenise(t *testing.T) {
 	tokens = Tokenize(models.PropertyTokenizationGse, "The quick brown fox jumps over the lazy dog")
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
-	// Kagome tokenizer for Korean and Japanese
-	// Should be disabled by default & return empty tokens
-	koreanText := "아버지가방에들어가신다"
+	// Kagome tokenizer for Korean
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
+	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, koreanText)
-	expectedKorean := []string{"아버지", "가", "방", "에", "들어가", "신다"}
-	assert.Equal(t, expectedKorean, tokens)
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가 방에 들어가신다")
+	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "결정하겠다")
+	assert.Equal(t, []string{"결정", "하", "겠", "다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를처리하는예시입니다")
+	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
+	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
 }
 
 func TestTokenize(t *testing.T) {

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,6 +65,8 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
+	_ = InitializeKagomeTokenizerKr()
+
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 
@@ -150,6 +152,8 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 	}
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
+
+	_ = InitializeKagomeTokenizerKr()
 
 	testCases := []testCase{
 		{

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,6 +65,8 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
+	_ = InitializeKagomeTokenizerKr()
+
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 
@@ -151,7 +153,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
-	InitializeKagomeTokenizerKr()
+	_ = InitializeKagomeTokenizerKr()
 
 	testCases := []testCase{
 		{

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -143,7 +143,6 @@ func TestTokenize(t *testing.T) {
 }
 
 func TestTokenizeAndCountDuplicates(t *testing.T) {
-
 	type testCase struct {
 		input        string
 		tokenization string

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -143,13 +143,14 @@ func TestTokenize(t *testing.T) {
 }
 
 func TestTokenizeAndCountDuplicates(t *testing.T) {
-	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
 	type testCase struct {
 		input        string
 		tokenization string
 		expected     map[string]int
 	}
+
+	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
 	testCases := []testCase{
 		{

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -12,6 +12,7 @@
 package helpers
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,9 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
+	_ = os.Setenv("ENABLE_KOREAN_TOKENIZER", "true")
+	_ = InitializeKagomeTokenizerKr()
+
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 
@@ -148,6 +152,9 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 		tokenization string
 		expected     map[string]int
 	}
+
+	_ = os.Setenv("ENABLE_KOREAN_TOKENIZER", "true")
+	_ = InitializeKagomeTokenizerKr()
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -66,7 +66,7 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	_ = os.Setenv("ENABLE_KOREAN_TOKENIZER", "true")
+	_ = os.Setenv("ENABLE_TOKENIZER_KOREAN", "true")
 	_ = initializeKagomeTokenizerKr()
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
@@ -153,7 +153,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 		expected     map[string]int
 	}
 
-	_ = os.Setenv("ENABLE_KOREAN_TOKENIZER", "true")
+	_ = os.Setenv("ENABLE_TOKENIZER_KOREAN", "true")
 	_ = initializeKagomeTokenizerKr()
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -67,7 +67,7 @@ func TestTokenise(t *testing.T) {
 
 	// Kagome tokenizer for Korean
 	_ = os.Setenv("ENABLE_KOREAN_TOKENIZER", "true")
-	_ = InitializeKagomeTokenizerKr()
+	_ = initializeKagomeTokenizerKr()
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
@@ -154,7 +154,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 	}
 
 	_ = os.Setenv("ENABLE_KOREAN_TOKENIZER", "true")
-	_ = InitializeKagomeTokenizerKr()
+	_ = initializeKagomeTokenizerKr()
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -12,7 +12,6 @@
 package helpers
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,17 +65,6 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	// Should be disabled by default & return the whole string
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
-	assert.Equal(t, []string{}, tokens)
-
-	// Enable Korean tokenizer via env var
-	envSetErr := os.Setenv("USE_KOREAN_TOKENIZER", "true")
-	if envSetErr != nil {
-		// Handle error if setting the environment variable fails
-		panic(envSetErr)
-	}
-
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 
@@ -91,12 +79,6 @@ func TestTokenise(t *testing.T) {
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
 	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
-
-	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "false")
-	if envSetErr != nil {
-		// Handle error if setting the environment variable fails
-		panic(envSetErr)
-	}
 }
 
 func TestTokenize(t *testing.T) {
@@ -169,12 +151,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
-	// Enable Korean tokenizer via env var
-	envSetErr := os.Setenv("USE_KOREAN_TOKENIZER", "true")
-	if envSetErr != nil {
-		// Handle error if setting the environment variable fails
-		panic(envSetErr)
-	}
+	InitializeKagomeTokenizerKr()
 
 	testCases := []testCase{
 		{
@@ -245,11 +222,5 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 				assert.Equal(t, tc.expected[terms[i]], dups[i])
 			}
 		})
-	}
-
-	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "false")
-	if envSetErr != nil {
-		// Handle error if setting the environment variable fails
-		panic(envSetErr)
 	}
 }

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,20 +65,20 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
-	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
-
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가 방에 들어가신다")
-	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
-
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "결정하겠다")
-	assert.Equal(t, []string{"결정", "하", "겠", "다"}, tokens)
-
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를처리하는예시입니다")
-	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
-
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
-	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
+	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
+	//assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
+	//
+	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가 방에 들어가신다")
+	//assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
+	//
+	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "결정하겠다")
+	//assert.Equal(t, []string{"결정", "하", "겠", "다"}, tokens)
+	//
+	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를처리하는예시입니다")
+	//assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
+	//
+	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
+	//assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
 }
 
 func TestTokenize(t *testing.T) {
@@ -193,19 +193,19 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 				"world":     2,
 			},
 		},
-		{
-			input:        "한국어를 처리하는 예시입니다 한국어를 처리하는 예시입니다",
-			tokenization: models.PropertyTokenizationKagomeKr,
-			expected: map[string]int{
-				"한국어": 2,
-				"를":   2,
-				"처리":  2,
-				"하":   2,
-				"는":   2,
-				"예시":  2,
-				"입니다": 2,
-			},
-		},
+		//{
+		//	input:        "한국어를 처리하는 예시입니다 한국어를 처리하는 예시입니다",
+		//	tokenization: models.PropertyTokenizationKagomeKr,
+		//	expected: map[string]int{
+		//		"한국어": 2,
+		//		"를":   2,
+		//		"처리":  2,
+		//		"하":   2,
+		//		"는":   2,
+		//		"예시":  2,
+		//		"입니다": 2,
+		//	},
+		//},
 	}
 
 	for _, tc := range testCases {

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -71,8 +71,7 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"아버지가방에들어가신다"}, tokens)
 
 	// Enable Korean tokenizer via env var
-	var envSetErr error
-	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "true")
+	envSetErr := os.Setenv("USE_KOREAN_TOKENIZER", "true")
 	if envSetErr != nil {
 		// Handle error if setting the environment variable fails
 		panic(envSetErr)
@@ -165,8 +164,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
 	// Enable Korean tokenizer via env var
-	var envSetErr error
-	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "true")
+	envSetErr := os.Setenv("USE_KOREAN_TOKENIZER", "true")
 	if envSetErr != nil {
 		// Handle error if setting the environment variable fails
 		panic(envSetErr)

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -12,6 +12,7 @@
 package helpers
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,24 +66,32 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	// Should be disabled by default & return empty tokens
+	// Should be disabled by default & return the whole string
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지가방에들어가신다"}, tokens)
 
-	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
-	//assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
-	//
-	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가 방에 들어가신다")
-	//assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
-	//
-	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "결정하겠다")
-	//assert.Equal(t, []string{"결정", "하", "겠", "다"}, tokens)
-	//
-	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를처리하는예시입니다")
-	//assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
-	//
-	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
-	//assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
+	// Enable Korean tokenizer via env var
+	var envSetErr error
+	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "true")
+	if envSetErr != nil {
+		// Handle error if setting the environment variable fails
+		panic(envSetErr)
+	}
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
+	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가 방에 들어가신다")
+	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "결정하겠다")
+	assert.Equal(t, []string{"결정", "하", "겠", "다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를처리하는예시입니다")
+	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
+
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "한국어를 처리하는 예시입니다")
+	assert.Equal(t, []string{"한국어", "를", "처리", "하", "는", "예시", "입니다"}, tokens)
 }
 
 func TestTokenize(t *testing.T) {
@@ -155,6 +164,14 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
+	// Enable Korean tokenizer via env var
+	var envSetErr error
+	envSetErr = os.Setenv("USE_KOREAN_TOKENIZER", "true")
+	if envSetErr != nil {
+		// Handle error if setting the environment variable fails
+		panic(envSetErr)
+	}
+
 	testCases := []testCase{
 		{
 			input:        alphaInput,
@@ -197,19 +214,19 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 				"world":     2,
 			},
 		},
-		//{
-		//	input:        "한국어를 처리하는 예시입니다 한국어를 처리하는 예시입니다",
-		//	tokenization: models.PropertyTokenizationKagomeKr,
-		//	expected: map[string]int{
-		//		"한국어": 2,
-		//		"를":   2,
-		//		"처리":  2,
-		//		"하":   2,
-		//		"는":   2,
-		//		"예시":  2,
-		//		"입니다": 2,
-		//	},
-		//},
+		{
+			input:        "한국어를 처리하는 예시입니다 한국어를 처리하는 예시입니다",
+			tokenization: models.PropertyTokenizationKagomeKr,
+			expected: map[string]int{
+				"한국어": 2,
+				"를":   2,
+				"처리":  2,
+				"하":   2,
+				"는":   2,
+				"예시":  2,
+				"입니다": 2,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -68,7 +68,7 @@ func TestTokenise(t *testing.T) {
 	// Kagome tokenizer for Korean
 	// Should be disabled by default & return the whole string
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
-	assert.Equal(t, []string{"아버지가방에들어가신다"}, tokens)
+	assert.Equal(t, []string{}, tokens)
 
 	// Enable Korean tokenizer via env var
 	envSetErr := os.Setenv("USE_KOREAN_TOKENIZER", "true")

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -12,7 +12,6 @@
 package helpers
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +65,7 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	_ = os.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
+	t.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
 	_ = initializeKagomeTokenizerKr()
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
@@ -153,7 +152,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 		expected     map[string]int
 	}
 
-	_ = os.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
+	t.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
 	_ = initializeKagomeTokenizerKr()
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -67,8 +67,6 @@ func TestTokenise(t *testing.T) {
 	// Kagome tokenizer for Korean and Japanese
 	// Should be disabled by default & return empty tokens
 	koreanText := "아버지가방에들어가신다"
-	tokens = Tokenize(models.PropertyTokenizationKagomeKr, koreanText)
-	assert.Equal(t, []string{}, tokens)
 
 	// Enable & Initialize Kagome tokenizer
 	EnableKagome = true

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,8 +65,6 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	_ = InitializeKagomeTokenizerKr()
-
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 
@@ -152,8 +150,6 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 	}
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
-
-	_ = InitializeKagomeTokenizerKr()
 
 	testCases := []testCase{
 		{

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,7 +65,7 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
-	_ = InitializeKoreanTokenizer()
+	_ = InitializeKagomeTokenizerKr()
 
 	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
@@ -153,7 +153,7 @@ func TestTokenizeAndCountDuplicates(t *testing.T) {
 
 	alphaInput := "Hello You Beautiful World! hello you beautiful world!"
 
-	_ = InitializeKoreanTokenizer()
+	_ = InitializeKagomeTokenizerKr()
 
 	testCases := []testCase{
 		{

--- a/adapters/repos/db/helpers/tokenizer_test.go
+++ b/adapters/repos/db/helpers/tokenizer_test.go
@@ -65,6 +65,10 @@ func TestTokenise(t *testing.T) {
 	assert.Equal(t, []string{"t", "h", "e", "q", "u", "i", "c", "k", "b", "r", "o", "w", "n", "f", "o", "x", "j", "u", "m", "p", "s", "o", "v", "e", "r", "t", "h", "e", "l", "a", "z", "y", "d", "o", "g", "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"}, tokens)
 
 	// Kagome tokenizer for Korean
+	// Should be disabled by default & return empty tokens
+	tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
+	assert.Equal(t, []string{"아버지가방에들어가신다"}, tokens)
+
 	//tokens = Tokenize(models.PropertyTokenizationKagomeKr, "아버지가방에들어가신다")
 	//assert.Equal(t, []string{"아버지", "가", "방", "에", "들어가", "신다"}, tokens)
 	//

--- a/entities/models/property.go
+++ b/entities/models/property.go
@@ -57,7 +57,7 @@ type Property struct {
 	NestedProperties []*NestedProperty `json:"nestedProperties,omitempty"`
 
 	// Determines tokenization of the property as separate words or whole field. Optional. Applies to text and text[] data types. Allowed values are `word` (default; splits on any non-alphanumerical, lowercases), `lowercase` (splits on white spaces, lowercases), `whitespace` (splits on white spaces), `field` (trims). Not supported for remaining data types
-	// Enum: [word lowercase whitespace field trigram gse]
+	// Enum: [word lowercase whitespace field trigram gse kagome_kr]
 	Tokenization string `json:"tokenization,omitempty"`
 }
 
@@ -109,7 +109,7 @@ var propertyTypeTokenizationPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["word","lowercase","whitespace","field","trigram","gse"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["word","lowercase","whitespace","field","trigram","gse","kagome_kr"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -136,6 +136,9 @@ const (
 
 	// PropertyTokenizationGse captures enum value "gse"
 	PropertyTokenizationGse string = "gse"
+
+	// PropertyTokenizationKagomeKr captures enum value "kagome_kr"
+	PropertyTokenizationKagomeKr string = "kagome_kr"
 )
 
 // prop value enum

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2
 	github.com/ikawaha/kagome-dict v1.1.0
 	github.com/ikawaha/kagome-dict-ko v0.2.1
+	github.com/ikawaha/kagome-dict/ipa v1.2.0
 	github.com/ikawaha/kagome/v2 v2.9.11
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/tailor-inc/graphql v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/raft v1.5.0
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2
+	github.com/ikawaha/kagome-dict v1.1.0
 	github.com/ikawaha/kagome-dict-ko v0.2.1
 	github.com/ikawaha/kagome/v2 v2.9.11
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
@@ -135,7 +136,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/ikawaha/kagome-dict v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2
 	github.com/ikawaha/kagome-dict v1.1.0
 	github.com/ikawaha/kagome-dict-ko v0.2.1
-	github.com/ikawaha/kagome-dict/ipa v1.2.0
 	github.com/ikawaha/kagome/v2 v2.9.11
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/tailor-inc/graphql v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,8 @@ require (
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/raft v1.5.0
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2
+	github.com/ikawaha/kagome-dict-ko v0.2.1
+	github.com/ikawaha/kagome/v2 v2.9.11
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/tailor-inc/graphql v0.2.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
@@ -133,6 +135,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/ikawaha/kagome-dict v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,17 @@ github.com/hashicorp/raft-boltdb v0.0.0-20210409134258-03c10cc3d4ea/go.mod h1:qR
 github.com/hashicorp/raft-boltdb/v2 v2.2.2 h1:rlkPtOllgIcKLxVT4nutqlTH2NRFn+tO1wwZk/4Dxqw=
 github.com/hashicorp/raft-boltdb/v2 v2.2.2/go.mod h1:N8YgaZgNJLpZC+h+by7vDu5rzsRgONThTEeUS3zWbfY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/ikawaha/kagome-dict v1.0.0/go.mod h1:pbeH4qwp/LVWKNePhU4Mh11w/l8uUSXKxfvNwRkj3NY=
+github.com/ikawaha/kagome-dict v1.0.3/go.mod h1:8Ma5E21J2kyaak6KumYLWGLKxm1kaAkCCWKWnrc5o/o=
+github.com/ikawaha/kagome-dict v1.1.0 h1:ePU16KkyonhYLo4YDf/UExmZJBhY/6C946T1SOg1TI4=
+github.com/ikawaha/kagome-dict v1.1.0/go.mod h1:tcbTxQQll5voEBnJqGYt2zJuCouUL6buAOrpSxzo9Fg=
+github.com/ikawaha/kagome-dict-ko v0.2.1/go.mod h1:37IdqtbE77c8xxVmsxtS4MIT5f78KZRDhiBOFfJ1wvw=
+github.com/ikawaha/kagome-dict-ko v1.1.0 h1:UdzDIiMODp4/7TjV/zXBU+nrqaust0qDydEiCm3al9I=
+github.com/ikawaha/kagome-dict-ko v1.1.0/go.mod h1:04XLdBZi1Q3ygXVrMZIb9+LIGLCaK/0trwqZttPRILg=
+github.com/ikawaha/kagome-dict/ipa v1.2.0 h1:lgehXOf2USDkBwGPEBD9sbbOBk3WlkhZ2zejPSLjIJA=
+github.com/ikawaha/kagome-dict/ipa v1.2.0/go.mod h1:LRtB3BXipG3Iu4V+KI/E1E7r9GMa79WgAH6IAW4wy6A=
+github.com/ikawaha/kagome/v2 v2.9.11 h1:5655Mj9t1KSwYyLercB7V9VvlI+uXdvQpaRUeUzHFp4=
+github.com/ikawaha/kagome/v2 v2.9.11/go.mod h1:IEyFbC0oCkMMaIvTAU3O4IrM5mK0AyWJwM41Tb4u77U=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -326,13 +326,11 @@ github.com/hashicorp/raft-boltdb v0.0.0-20210409134258-03c10cc3d4ea/go.mod h1:qR
 github.com/hashicorp/raft-boltdb/v2 v2.2.2 h1:rlkPtOllgIcKLxVT4nutqlTH2NRFn+tO1wwZk/4Dxqw=
 github.com/hashicorp/raft-boltdb/v2 v2.2.2/go.mod h1:N8YgaZgNJLpZC+h+by7vDu5rzsRgONThTEeUS3zWbfY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/ikawaha/kagome-dict v1.0.0/go.mod h1:pbeH4qwp/LVWKNePhU4Mh11w/l8uUSXKxfvNwRkj3NY=
 github.com/ikawaha/kagome-dict v1.0.3/go.mod h1:8Ma5E21J2kyaak6KumYLWGLKxm1kaAkCCWKWnrc5o/o=
 github.com/ikawaha/kagome-dict v1.1.0 h1:ePU16KkyonhYLo4YDf/UExmZJBhY/6C946T1SOg1TI4=
 github.com/ikawaha/kagome-dict v1.1.0/go.mod h1:tcbTxQQll5voEBnJqGYt2zJuCouUL6buAOrpSxzo9Fg=
+github.com/ikawaha/kagome-dict-ko v0.2.1 h1:4vBxs9FhnrtCnCpM5J4niQIF8Ys2/p4xpy1pRKW1Iow=
 github.com/ikawaha/kagome-dict-ko v0.2.1/go.mod h1:37IdqtbE77c8xxVmsxtS4MIT5f78KZRDhiBOFfJ1wvw=
-github.com/ikawaha/kagome-dict-ko v1.1.0 h1:UdzDIiMODp4/7TjV/zXBU+nrqaust0qDydEiCm3al9I=
-github.com/ikawaha/kagome-dict-ko v1.1.0/go.mod h1:04XLdBZi1Q3ygXVrMZIb9+LIGLCaK/0trwqZttPRILg=
 github.com/ikawaha/kagome-dict/ipa v1.2.0 h1:lgehXOf2USDkBwGPEBD9sbbOBk3WlkhZ2zejPSLjIJA=
 github.com/ikawaha/kagome-dict/ipa v1.2.0/go.mod h1:LRtB3BXipG3Iu4V+KI/E1E7r9GMa79WgAH6IAW4wy6A=
 github.com/ikawaha/kagome/v2 v2.9.11 h1:5655Mj9t1KSwYyLercB7V9VvlI+uXdvQpaRUeUzHFp4=

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -742,7 +742,8 @@
             "whitespace",
             "field",
             "trigram",
-            "gse"
+            "gse",
+            "kagome_kr"
           ]
         },
         "nestedProperties": {

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -115,7 +115,6 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 			if newProperties := schema.DedupProperties(schemaClass.Properties, properties); len(newProperties) > 0 {
 				schemaClass, schemaVersion, err = m.schemaManager.AddClassProperty(ctx,
 					principal, schemaClass, true, newProperties...)
-
 				if err != nil {
 					return 0, err
 				}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -586,7 +586,7 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
 				return nil
 			case models.PropertyTokenizationKagomeKr:
-				_ = helpers.InitializeKoreanTokenizer()
+				_ = helpers.InitializeKagomeTokenizerKr()
 				return nil
 			}
 		default:

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -581,7 +581,8 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 		case schema.DataTypeText, schema.DataTypeTextArray:
 			switch tokenization {
 			case models.PropertyTokenizationField, models.PropertyTokenizationWord,
-				models.PropertyTokenizationWhitespace, models.PropertyTokenizationLowercase, models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
+				models.PropertyTokenizationWhitespace, models.PropertyTokenizationLowercase,
+				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse, models.PropertyTokenizationKagomeKr:
 				return nil
 			}
 		default:

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/classcache"
@@ -582,7 +583,10 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 			switch tokenization {
 			case models.PropertyTokenizationField, models.PropertyTokenizationWord,
 				models.PropertyTokenizationWhitespace, models.PropertyTokenizationLowercase,
-				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse, models.PropertyTokenizationKagomeKr:
+				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
+				return nil
+			case models.PropertyTokenizationKagomeKr:
+				helpers.InitializeKagomeTokenizerKr()
 				return nil
 			}
 		default:

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -586,7 +586,7 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
 				return nil
 			case models.PropertyTokenizationKagomeKr:
-				helpers.InitializeKagomeTokenizerKr()
+				_ = helpers.InitializeKagomeTokenizerKr()
 				return nil
 			}
 		default:

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/classcache"
@@ -586,7 +585,6 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
 				return nil
 			case models.PropertyTokenizationKagomeKr:
-				_ = helpers.InitializeKagomeTokenizerKr()
 				return nil
 			}
 		default:

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -582,10 +582,20 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 			switch tokenization {
 			case models.PropertyTokenizationField, models.PropertyTokenizationWord,
 				models.PropertyTokenizationWhitespace, models.PropertyTokenizationLowercase,
-				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
+				models.PropertyTokenizationTrigram:
 				return nil
+			case models.PropertyTokenizationGse:
+				if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
+					return fmt.Errorf("the GSE tokenizer is not enabled; set 'ENABLE_TOKENIZER_GSE' to 'true' to enable")
+				} else {
+					return nil
+				}
 			case models.PropertyTokenizationKagomeKr:
-				return nil
+				if os.Getenv("ENABLE_TOKENIZER_KOREAN") != "true" {
+					return fmt.Errorf("the Korean tokenizer is not enabled; set 'ENABLE_TOKENIZER_KOREAN' to 'true' to enable")
+				} else {
+					return nil
+				}
 			}
 		default:
 			if tokenization == "" {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/weaviate/weaviate/usecases/configbase"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -585,17 +587,15 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 				models.PropertyTokenizationTrigram:
 				return nil
 			case models.PropertyTokenizationGse:
-				if os.Getenv("USE_GSE") == "true" || os.Getenv("ENABLE_TOKENIZER_GSE") == "true" {
+				if !configbase.Enabled(os.Getenv("USE_GSE")) && !configbase.Enabled(os.Getenv("ENABLE_TOKENIZER_GSE")) {
 					return fmt.Errorf("the GSE tokenizer is not enabled; set 'ENABLE_TOKENIZER_GSE' to 'true' to enable")
-				} else {
-					return nil
 				}
+				return nil
 			case models.PropertyTokenizationKagomeKr:
-				if os.Getenv("ENABLE_TOKENIZER_KAGOME_KR") != "true" {
+				if !configbase.Enabled(os.Getenv("ENABLE_TOKENIZER_KAGOME_KR")) {
 					return fmt.Errorf("the Korean tokenizer is not enabled; set 'ENABLE_TOKENIZER_KAGOME_KR' to 'true' to enable")
-				} else {
-					return nil
 				}
+				return nil
 			}
 		default:
 			if tokenization == "" {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -586,7 +586,7 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 				models.PropertyTokenizationTrigram, models.PropertyTokenizationGse:
 				return nil
 			case models.PropertyTokenizationKagomeKr:
-				_ = helpers.InitializeKagomeTokenizerKr()
+				_ = helpers.InitializeKoreanTokenizer()
 				return nil
 			}
 		default:

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -591,8 +591,8 @@ func (h *Handler) validatePropertyTokenization(tokenization string, propertyData
 					return nil
 				}
 			case models.PropertyTokenizationKagomeKr:
-				if os.Getenv("ENABLE_TOKENIZER_KOREAN") != "true" {
-					return fmt.Errorf("the Korean tokenizer is not enabled; set 'ENABLE_TOKENIZER_KOREAN' to 'true' to enable")
+				if os.Getenv("ENABLE_TOKENIZER_KAGOME_KR") != "true" {
+					return fmt.Errorf("the Korean tokenizer is not enabled; set 'ENABLE_TOKENIZER_KAGOME_KR' to 'true' to enable")
 				} else {
 					return nil
 				}


### PR DESCRIPTION
### What's being changed:

- Add a Korean tokenizer using the [kagome](https://github.com/ikawaha/kagome) package.
    - Tokenizer instantiation occurs on instantiation if `ENABLE_TOKENIZER_KOREAN` env var is set to "true"
    - Uses the MeCab-ko dictionary (https://github.com/ikawaha/kagome-dict-ko) similar to what SpaCy uses https://spacy.io/usage/models
- Add `ENABLE_TOKENIZER_GSE` env var for enabling GSE (for Chinese)
    -  Kept `USE_GSE` for backwards compatibility
- Refactor `helpers.Tokenizations` so GSE & Kagome tokenizers are only added if the correct env var is set
- Add a few unit tests
- Minor refactors to related tokenizer code & tests

Tested with the following Python code. Note: editable install of the Python client used, as it required `KAGOME_KR = "kagome_kr"` to be added to `weaviate/collections/classes/config.py` to prevent it throwing a validation error on search.

```python
import weaviate
import os
from weaviate.classes.config import Configure, DataType, Property
from weaviate.classes.query import MetadataQuery
import requests

client = weaviate.connect_to_local(
    headers={
        "X-Cohere-Api-Key": os.environ["COHERE_API_KEY"],
    }
)

client.collections.delete("TextChunk")

url = "http://localhost:8080/v1/schema"

payload = {
    "class": "TextChunk",
    "properties": [
        {
            "name": "chunk",
            "dataType": ["text"],
            "tokenization": "kagome_kr"
        },
        {
            "name": "chunk_number",
            "dataType": ["int"],
        },
    ],
    "vectorizer": "text2vec-cohere",
    "moduleConfig": {
        "generative-cohere": {}
    }
}

response = requests.post(url, json=payload)

temp_coll = client.collections.get("TextChunk")

src_text = """
거북선 또는 귀선(龜船, Geobukseon, turtle ship)은 조선 시대의 군함이다. 거북선은 판옥선을 기본으로 하여 판옥선의 갑판 위 외형 전체에 뚜껑을 씌운 뒤 나무판[1]으로 덮은 배다. 주로 나무판이 아니라 철갑이라고 생각하는 사람이 많지만 비용적인 문제나 바닷물에 녹슬기 쉬운 것을 감안할 경우 나무판이라는 것이 훨씬 설득력 있고, 임진왜란 당시 일본배는 매우 얇아 삼나무 목재선을 사용하여도 전투에 문제가 없었다. 또한 이 나무판에는 적병이 못 뛰어오르도록 무수한 송곳과 칼을 꽂았었다. 선수부에는 용머리 모양의 충각 겸 포문을 만들어 그 곳에서 전면부로 화포를 쏘게 했고 선미부에는 거북이 꼬리를 세우고 역시 화포를 쏘았다. 결국 거북선은 완전 무장으로 승조원을 보호한 채 안전한 곳에서 앞뒤와 선체 측면의 포문으로 전후좌우 각각 6개씩 화포를 발사할 수 있었다.[2]

조선 수군의 지휘관 이순신이 임진왜란 직전에 건조하여 임진왜란 중 사천 해전에서 첫 출전한 이래 칠천량 해전에서 패배하기 전까지 일본 수군과의 16전에서 16승을 하는데 크게 기여하여 일본 수군의 공포의 대명사가 되었다. 조선왕조실록 등에서는 거북선을 한자로 귀선(龜船)으로 표기하고 있다.[3] 임진왜란 이후 일본인들에게는 샤치호코(鯱, 상상의 동물)와 닮은 보쿠카이센 혹은 깃카이센, 기카이센(亀甲船)으로 불렸다는 설이 있다.[4] 1597년 음력 7월 16일 새벽 칠천량 해전에서 일본군에 의해 모두 침몰되었다. 임진왜란 이후에도 만들어졌으나, 임진왜란 당시와 비교해서 모양과 크기가 조금씩 변형되었다.

1973년 9월 대한민국에서는 500원권 지폐의 앞면에 이순신과 거북선을, 뒷면에는 현충사를 도안으로 만들어 쓰기도 하였다. 1966년 이후로 발행된 5원 동전 앞면에도 거북선이 도안되었다.[5] 옥포대첩에는 나가지 않았다.
"""

chunk_len = 50
chunks = [src_text[i*chunk_len:(i+1)*chunk_len] for i in range(len(src_text)//chunk_len+1)]

with temp_coll.batch.dynamic() as batch:
    for i, chunk in enumerate(chunks):
        batch.add_object(
            properties={
                "chunk": chunk,
                "chunk_number": i,
            }
        )

for q in ["거북선", "거북", "귀선", "배", "일본", "수군", "일본수군"]:
    response = temp_coll.query.bm25(
        query=q,
        return_metadata=MetadataQuery(score=True, explain_score=True),
        limit=3
    )
    print("\n" + "=" * 50)
    print(f"Query: {q}")
    for o in response.objects:
        print(o.properties["chunk"])
        print(f"ID: {o.properties['chunk_number']}, Score: {o.metadata.score}, Explain: {o.metadata.explain_score}")

client.close()
```

Outputs:

```text
==================================================
Query: 거북선

거북선 또는 귀선(龜船, Geobukseon, turtle ship)은 조선 시대의 군함
ID: 0, Score: 0.5433447957038879, Explain: , BM25F_거북선_frequency:1, BM25F_거북선_propLength:20
이다. 거북선은 판옥선을 기본으로 하여 판옥선의 갑판 위 외형 전체에 뚜껑을 씌운 뒤 나무
ID: 1, Score: 0.5334352254867554, Explain: , BM25F_거북선_frequency:1, BM25F_거북선_propLength:21
 역시 화포를 쏘았다. 결국 거북선은 완전 무장으로 승조원을 보호한 채 안전한 곳에서 앞뒤
ID: 7, Score: 0.523880660533905, Explain: , BM25F_거북선_frequency:1, BM25F_거북선_propLength:22

==================================================
Query: 거북
각 겸 포문을 만들어 그 곳에서 전면부로 화포를 쏘게 했고 선미부에는 거북이 꼬리를 세우고
ID: 6, Score: 1.126643419265747, Explain: , BM25F_거북_frequency:1, BM25F_거북_propLength:26

==================================================
Query: 귀선

거북선 또는 귀선(龜船, Geobukseon, turtle ship)은 조선 시대의 군함
ID: 0, Score: 1.0052704811096191, Explain: , BM25F_귀선_frequency:1, BM25F_귀선_propLength:20
 수군의 공포의 대명사가 되었다. 조선왕조실록 등에서는 거북선을 한자로 귀선(龜船)으로 표
ID: 11, Score: 0.9357381463050842, Explain: , BM25F_귀선_frequency:1, BM25F_귀선_propLength:24

==================================================
Query: 배
판[1]으로 덮은 배다. 주로 나무판이 아니라 철갑이라고 생각하는 사람이 많지만 비용적인 
ID: 2, Score: 0.9044584631919861, Explain: , BM25F_배_frequency:1, BM25F_배_propLength:26
란 당시 일본배는 매우 얇아 삼나무 목재선을 사용하여도 전투에 문제가 없었다. 또한 이 나
ID: 4, Score: 0.8895899653434753, Explain: , BM25F_배_frequency:1, BM25F_배_propLength:27

==================================================
Query: 일본
천량 해전에서 패배하기 전까지 일본 수군과의 16전에서 16승을 하는데 크게 기여하여 일본
ID: 10, Score: 1.121975064277649, Explain: , BM25F_일본_frequency:2, BM25F_일본_propLength:21
 16일 새벽 칠천량 해전에서 일본군에 의해 모두 침몰되었다. 임진왜란 이후에도 만들어졌으
ID: 14, Score: 0.7843273878097534, Explain: , BM25F_일본_frequency:1, BM25F_일본_propLength:24
란 당시 일본배는 매우 얇아 삼나무 목재선을 사용하여도 전투에 문제가 없었다. 또한 이 나
ID: 4, Score: 0.7456463575363159, Explain: , BM25F_일본_frequency:1, BM25F_일본_propLength:27

==================================================
Query: 수군
천량 해전에서 패배하기 전까지 일본 수군과의 16전에서 16승을 하는데 크게 기여하여 일본
ID: 10, Score: 0.8272411823272705, Explain: , BM25F_수군_frequency:1, BM25F_수군_propLength:21
 수군의 공포의 대명사가 되었다. 조선왕조실록 등에서는 거북선을 한자로 귀선(龜船)으로 표
ID: 11, Score: 0.7843273878097534, Explain: , BM25F_수군_frequency:1, BM25F_수군_propLength:24
와 선체 측면의 포문으로 전후좌우 각각 6개씩 화포를 발사할 수 있었다.[2]

조선 수군
ID: 8, Score: 0.7581090331077576, Explain: , BM25F_수군_frequency:1, BM25F_수군_propLength:26

==================================================
Query: 일본수군
천량 해전에서 패배하기 전까지 일본 수군과의 16전에서 16승을 하는데 크게 기여하여 일본
ID: 10, Score: 1.9492162466049194, Explain: , BM25F_일본_frequency:2, BM25F_일본_propLength:21, BM25F_수군_frequency:1, BM25F_수군_propLength:21
 16일 새벽 칠천량 해전에서 일본군에 의해 모두 침몰되었다. 임진왜란 이후에도 만들어졌으
ID: 14, Score: 0.7843273878097534, Explain: , BM25F_일본_frequency:1, BM25F_일본_propLength:24
 수군의 공포의 대명사가 되었다. 조선왕조실록 등에서는 거북선을 한자로 귀선(龜船)으로 표
ID: 11, Score: 0.7843273878097534, Explain: , BM25F_수군_propLength:24, BM25F_수군_frequency:1
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
