### PR TITLE
Replace `if targetVectors != nil` with `if vectorSearch` when extracting `metadata.certainty`

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -815,23 +815,21 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 
 	}
 
-	if targetVectors != nil {
-		vectorIndex, err := schemaConfig.TypeAssertVectorIndex(class, targetVectors)
-		if err != nil {
-			return props, errors.Wrap(err, "get vector index config from class")
-		}
-
-		certainty := false
-		for _, conf := range vectorIndex {
-			if conf.DistanceName() == common.DistanceCosine && prop.Certainty {
-				certainty = true
-			} else {
-				certainty = false
-				break // all vector indexes must be cosine for certainty
-			}
-		}
-		props.Certainty = certainty
+	vectorIndex, err := schemaConfig.TypeAssertVectorIndex(class, targetVectors)
+	if err != nil {
+		return props, errors.Wrap(err, "get vector index config from class")
 	}
+
+	certainty := false
+	for _, conf := range vectorIndex {
+		if conf.DistanceName() == common.DistanceCosine && prop.Certainty {
+			certainty = true
+		} else {
+			certainty = false
+			break // all vector indexes must be cosine for certainty
+		}
+	}
+	props.Certainty = certainty
 
 	return props, nil
 }

--- a/test/acceptance_with_python/test_grpc_search.py
+++ b/test/acceptance_with_python/test_grpc_search.py
@@ -1,0 +1,62 @@
+from weaviate.classes.config import Configure, DataType, Property
+from weaviate.classes.query import MetadataQuery
+
+from .conftest import CollectionFactory
+
+
+def test_near_object_search(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana = collection.data.insert({"Name": "Banana"})
+    collection.data.insert({"Name": "Fruit"})
+    collection.data.insert({"Name": "car"})
+    collection.data.insert({"Name": "Mountain"})
+
+    full_objects = collection.query.near_object(
+        uuid_banana, return_metadata=MetadataQuery(distance=True, certainty=True)
+    ).objects
+    assert len(full_objects) == 4
+
+    objects_distance = collection.query.near_object(
+        uuid_banana, distance=full_objects[2].metadata.distance
+    ).objects
+    assert len(objects_distance) == 3
+
+    objects_certainty = collection.query.near_object(
+        uuid_banana, certainty=full_objects[2].metadata.certainty
+    ).objects
+    assert len(objects_certainty) == 3
+
+
+def test_near_vector_search(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana = collection.data.insert({"Name": "Banana"})
+    collection.data.insert({"Name": "Fruit"})
+    collection.data.insert({"Name": "car"})
+    collection.data.insert({"Name": "Mountain"})
+
+    banana = collection.query.fetch_object_by_id(uuid_banana, include_vector=True)
+
+    full_objects = collection.query.near_vector(
+        banana.vector["default"], return_metadata=MetadataQuery(distance=True, certainty=True)
+    ).objects
+    assert len(full_objects) == 4
+
+    objects_distance = collection.query.near_vector(
+        banana.vector["default"], distance=full_objects[2].metadata.distance
+    ).objects
+    assert len(objects_distance) == 3
+
+    objects_distance = collection.query.near_vector(
+        banana.vector["default"], certainty=full_objects[2].metadata.certainty
+    ).objects
+    assert len(objects_distance) == 3

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -249,7 +249,7 @@ func (e *Explorer) searchForTargets(ctx context.Context, params dto.GetParams, t
 				searchVectorParam = searchVectorParams[i]
 			}
 
-			searchVectors[i], err = e.vectorFromParamsForTaget(ctx, searchVectorParam, params.NearObject, params.ModuleParams, params.ClassName, params.Tenant, targetVectors[i])
+			searchVectors[i], err = e.vectorFromParamsForTarget(ctx, searchVectorParam, params.NearObject, params.ModuleParams, params.ClassName, params.Tenant, targetVectors[i])
 			if err != nil {
 				return errors.Errorf("explorer: get class: vectorize search vector: %v", err)
 			}
@@ -679,7 +679,7 @@ func (e *Explorer) targetFromParams(ctx context.Context,
 		params.NearObject, params.ModuleParams, params.ClassName, params.Tenant)
 }
 
-func (e *Explorer) vectorFromParamsForTaget(ctx context.Context,
+func (e *Explorer) vectorFromParamsForTarget(ctx context.Context,
 	nv *searchparams.NearVector, no *searchparams.NearObject, moduleParams map[string]interface{}, className, tenant, target string,
 ) ([]float32, error) {
 	return e.nearParamsVector.vectorFromParams(ctx, nv, no, moduleParams, className, tenant, target)
@@ -788,6 +788,19 @@ func ExtractDistanceFromParams(params dto.GetParams) (distance float64, withDist
 		distance = params.NearObject.Distance
 		withDistance = params.NearObject.WithDistance
 		return
+	}
+
+	if params.HybridSearch != nil {
+		if params.HybridSearch.NearTextParams != nil {
+			distance = params.HybridSearch.NearTextParams.Distance
+			withDistance = params.HybridSearch.NearTextParams.WithDistance
+			return
+		}
+		if params.HybridSearch.NearVectorParams != nil {
+			distance = params.HybridSearch.NearVectorParams.Distance
+			withDistance = params.HybridSearch.NearVectorParams.WithDistance
+			return
+		}
 	}
 
 	if len(params.ModuleParams) == 1 {


### PR DESCRIPTION
### What's being changed:

Logic is required to differentiate between a search with and without vectors. Previously, this was accomplished using the `nil` value of `targetVectors *[]string` but now that `targetVectors` has type `[]string` this is no longer possible. Instead, the `vectorSearch` parameter is used to define this differentiation and thus maintain the previous behaviour.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
