### PR TITLE
Add generative dummy module and tests

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -53,6 +53,7 @@ import (
 	modgenerativeanyscale "github.com/weaviate/weaviate/modules/generative-anyscale"
 	modgenerativeaws "github.com/weaviate/weaviate/modules/generative-aws"
 	modgenerativecohere "github.com/weaviate/weaviate/modules/generative-cohere"
+	modgenerativedummy "github.com/weaviate/weaviate/modules/generative-dummy"
 	modgenerativeopenai "github.com/weaviate/weaviate/modules/generative-openai"
 	modgenerativepalm "github.com/weaviate/weaviate/modules/generative-palm"
 	modimage "github.com/weaviate/weaviate/modules/img2vec-neural"
@@ -689,6 +690,14 @@ func registerModules(appState *state.State) error {
 		appState.Logger.
 			WithField("action", "startup").
 			WithField("module", modgenerativeopenai.Name).
+			Debug("enabled module")
+	}
+
+	if _, ok := enabledModules[modgenerativedummy.Name]; ok {
+		appState.Modules.Register(modgenerativedummy.New())
+		appState.Logger.
+			WithField("action", "startup").
+			WithField("module", modgenerativedummy.Name).
 			Debug("enabled module")
 	}
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,7 +20,7 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: "./data"
       DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
-      ENABLE_MODULES: text2vec-contextionary,backup-filesystem
+      ENABLE_MODULES: text2vec-contextionary,backup-filesystem,generative-dummy
       BACKUP_FILESYSTEM_PATH: "/var/lib/backups" 
       PROMETHEUS_MONITORING_ENABLED: 'true'
       PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'

--- a/modules/generative-dummy/clients/openai.go
+++ b/modules/generative-dummy/clients/openai.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	generativemodels "github.com/weaviate/weaviate/usecases/modulecomponents/additional/models"
+)
+
+var compile, _ = regexp.Compile(`{([\w\s]*?)}`)
+
+type dummy struct {
+	logger logrus.FieldLogger
+}
+
+func New(logger logrus.FieldLogger) *dummy {
+	return &dummy{
+		logger: logger,
+	}
+}
+
+func (v *dummy) GenerateSingleResult(ctx context.Context, textProperties map[string]string, prompt string, cfg moduletools.ClassConfig) (*generativemodels.GenerateResponse, error) {
+	forPrompt, err := v.generateForPrompt(textProperties, prompt)
+	if err != nil {
+		return nil, err
+	}
+	return v.Generate(ctx, cfg, forPrompt)
+}
+
+func (v *dummy) GenerateAllResults(ctx context.Context, textProperties []map[string]string, task string, cfg moduletools.ClassConfig) (*generativemodels.GenerateResponse, error) {
+	forTask, err := v.generatePromptForTask(textProperties, task)
+	if err != nil {
+		return nil, err
+	}
+	return v.Generate(ctx, cfg, forTask)
+}
+
+func (v *dummy) Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string) (*generativemodels.GenerateResponse, error) {
+	result := "You want me to generate something based on the following prompt: " + prompt + ". I'm sorry, I'm just a dummy and can't generate anything."
+	return &generativemodels.GenerateResponse{
+		Result: &result,
+	}, nil
+}
+
+func (v *dummy) generatePromptForTask(textProperties []map[string]string, task string) (string, error) {
+	marshal, err := json.Marshal(textProperties)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`'%v:
+%v`, task, string(marshal)), nil
+}
+
+func (v *dummy) generateForPrompt(textProperties map[string]string, prompt string) (string, error) {
+	all := compile.FindAll([]byte(prompt), -1)
+	for _, match := range all {
+		originalProperty := string(match)
+		replacedProperty := compile.FindStringSubmatch(originalProperty)[1]
+		replacedProperty = strings.TrimSpace(replacedProperty)
+		value := textProperties[replacedProperty]
+		if value == "" {
+			return "", errors.Errorf("Following property has empty value: '%v'. Make sure you spell the property name correctly, verify that the property exists and has a value", replacedProperty)
+		}
+		prompt = strings.ReplaceAll(prompt, originalProperty, value)
+	}
+	return prompt, nil
+}

--- a/modules/generative-dummy/clients/openai_meta.go
+++ b/modules/generative-dummy/clients/openai_meta.go
@@ -1,0 +1,18 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+func (v *dummy) MetaInfo() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"name": "Generative Search - Dummy",
+	}, nil
+}

--- a/modules/generative-dummy/config.go
+++ b/modules/generative-dummy/config.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modgenerativedummy
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func (m *GenerativeDummyModule) ClassConfigDefaults() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *GenerativeDummyModule) PropertyConfigDefaults(
+	dt *schema.DataType,
+) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *GenerativeDummyModule) ValidateClass(ctx context.Context,
+	class *models.Class, cfg moduletools.ClassConfig,
+) error {
+	return nil
+}
+
+var _ = modulecapabilities.ClassConfigurator(New())

--- a/modules/generative-dummy/module.go
+++ b/modules/generative-dummy/module.go
@@ -1,0 +1,94 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modgenerativedummy
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/generative-dummy/clients"
+	additionalprovider "github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	generativemodels "github.com/weaviate/weaviate/usecases/modulecomponents/additional/models"
+)
+
+const Name = "generative-dummy"
+
+func New() *GenerativeDummyModule {
+	return &GenerativeDummyModule{}
+}
+
+type GenerativeDummyModule struct {
+	generative                   generativeClient
+	additionalPropertiesProvider modulecapabilities.AdditionalProperties
+}
+
+type generativeClient interface {
+	GenerateSingleResult(ctx context.Context, textProperties map[string]string, prompt string, cfg moduletools.ClassConfig) (*generativemodels.GenerateResponse, error)
+	GenerateAllResults(ctx context.Context, textProperties []map[string]string, task string, cfg moduletools.ClassConfig) (*generativemodels.GenerateResponse, error)
+	Generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string) (*generativemodels.GenerateResponse, error)
+	MetaInfo() (map[string]interface{}, error)
+}
+
+func (m *GenerativeDummyModule) Name() string {
+	return Name
+}
+
+func (m *GenerativeDummyModule) Type() modulecapabilities.ModuleType {
+	return modulecapabilities.Text2TextGenerative
+}
+
+func (m *GenerativeDummyModule) Init(ctx context.Context,
+	params moduletools.ModuleInitParams,
+) error {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
+		return errors.Wrap(err, "init q/a")
+	}
+
+	return nil
+}
+
+func (m *GenerativeDummyModule) initAdditional(ctx context.Context, timeout time.Duration,
+	logger logrus.FieldLogger,
+) error {
+	client := clients.New(logger)
+
+	m.generative = client
+
+	m.additionalPropertiesProvider = additionalprovider.NewGenerativeProvider(m.generative)
+
+	return nil
+}
+
+func (m *GenerativeDummyModule) MetaInfo() (map[string]interface{}, error) {
+	return m.generative.MetaInfo()
+}
+
+func (m *GenerativeDummyModule) RootHandler() http.Handler {
+	// TODO: remove once this is a capability interface
+	return nil
+}
+
+func (m *GenerativeDummyModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {
+	return m.additionalPropertiesProvider.AdditionalProperties()
+}
+
+// verify we implement the modules.Module interface
+var (
+	_ = modulecapabilities.Module(New())
+	_ = modulecapabilities.AdditionalProperties(New())
+	_ = modulecapabilities.MetaProvider(New())
+)

--- a/test/acceptance_with_go_client/generative_test.go
+++ b/test/acceptance_with_go_client/generative_test.go
@@ -1,0 +1,93 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestGenerative(t *testing.T) {
+	ctx := context.Background()
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: "localhost:8080"})
+	require.Nil(t, err)
+
+	className := "BigScaryMonsterDog"
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	classCreator := c.Schema().ClassCreator()
+	class := models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "first",
+				DataType: []string{string(schema.DataTypeText)},
+			},
+			{
+				Name:     "second",
+				DataType: []string{string(schema.DataTypeText)},
+			},
+		},
+		ModuleConfig: map[string]interface{}{
+			"generative-dummy": map[string]interface{}{},
+		},
+	}
+	require.Nil(t, classCreator.WithClass(&class).Do(ctx))
+
+	_, err = c.Data().Creator().WithClassName(className).WithProperties(
+		map[string]interface{}{"first": "one", "second": "two"},
+	).WithID(uuid.New().String()).Do(ctx)
+	require.Nil(t, err)
+
+	_, err = c.Data().Creator().WithClassName(className).WithProperties(
+		map[string]interface{}{"first": "three", "second": "four"},
+	).WithID(uuid.New().String()).Do(ctx)
+	require.Nil(t, err)
+
+	t.Run("single result", func(t *testing.T) {
+		gs := graphql.NewGenerativeSearch().SingleResult("Input: {first} and {second}")
+
+		result, err := c.GraphQL().Get().WithClassName(className).WithGenerativeSearch(gs).Do(ctx)
+		require.Nil(t, err)
+
+		expected := []string{"Input: one and two", "Input: three and four"}
+		for i := 0; i < 2; i++ {
+			returnString := result.Data["Get"].(map[string]interface{})[className].([]interface{})[i].(map[string]interface{})["_additional"].(map[string]interface{})["generate"].(map[string]interface{})["singleResult"].(string)
+			require.NotNil(t, returnString)
+			require.True(t, strings.Contains(returnString, expected[i]))
+		}
+	})
+
+	t.Run("grouped result", func(t *testing.T) {
+		gs := graphql.NewGenerativeSearch().GroupedResult("Input: {first} and {second}")
+
+		result, err := c.GraphQL().Get().WithClassName(className).WithGenerativeSearch(gs).Do(ctx)
+		require.Nil(t, err)
+
+		returnString := result.Data["Get"].(map[string]interface{})[className].([]interface{})[0].(map[string]interface{})["_additional"].(map[string]interface{})["generate"].(map[string]interface{})["groupedResult"].(string)
+		require.NotNil(t, returnString)
+		require.True(t, strings.Contains(returnString, "Input: {first} and {second}:"))
+
+		// order is not guaranteed
+		require.True(t, strings.Contains(returnString, "{\"first\":\"one\",\"second\":\"two\"}"))
+		require.True(t, strings.Contains(returnString, "{\"first\":\"three\",\"second\":\"four\"}"))
+	})
+}

--- a/test/acceptance_with_go_client/generative_test.go
+++ b/test/acceptance_with_go_client/generative_test.go
@@ -72,7 +72,7 @@ func TestGenerative(t *testing.T) {
 		for i := 0; i < 2; i++ {
 			returnString := result.Data["Get"].(map[string]interface{})[className].([]interface{})[i].(map[string]interface{})["_additional"].(map[string]interface{})["generate"].(map[string]interface{})["singleResult"].(string)
 			require.NotNil(t, returnString)
-			require.True(t, strings.Contains(returnString, expected[i]))
+			require.True(t, strings.Contains(returnString, expected[i]), "expected %s to contain %s", returnString, expected[i])
 		}
 	})
 
@@ -84,10 +84,11 @@ func TestGenerative(t *testing.T) {
 
 		returnString := result.Data["Get"].(map[string]interface{})[className].([]interface{})[0].(map[string]interface{})["_additional"].(map[string]interface{})["generate"].(map[string]interface{})["groupedResult"].(string)
 		require.NotNil(t, returnString)
-		require.True(t, strings.Contains(returnString, "Input: {first} and {second}:"))
+		expected := "Input: {first} and {second}:"
+		require.True(t, strings.Contains(returnString, expected), "expected %s to contain %s", returnString, expected)
 
 		// order is not guaranteed
-		require.True(t, strings.Contains(returnString, "{\"first\":\"one\",\"second\":\"two\"}"))
-		require.True(t, strings.Contains(returnString, "{\"first\":\"three\",\"second\":\"four\"}"))
+		require.True(t, strings.Contains(returnString, "{\"first\":\"one\",\"second\":\"two\"}"), "got &v", returnString)
+		require.True(t, strings.Contains(returnString, "{\"first\":\"three\",\"second\":\"four\"}"), "got &v", returnString)
 	})
 }


### PR DESCRIPTION
### What's being changed:

Adds a generative dummy module to enable tests of this feature that do not require API keys or huge local models. Targeted 1.23 because this is the oldest version we test in the python client and this would help to make our tests better.

Came out of https://github.com/weaviate/weaviate/pull/5213 and needed to add tests for some edge cases there

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
