### PR TITLE
bucket range reader: improved panic handling

### DIFF
--- a/entities/errors/go_wrapper.go
+++ b/entities/errors/go_wrapper.go
@@ -35,8 +35,8 @@ func GoWrapper(f func(), logger logrus.FieldLogger) {
 	}()
 }
 
-func GoWrapperWithBlock(f func(), logger logrus.FieldLogger) error {
-	errChan := make(chan error)
+func GoWrapperWithErrorCh(f func(), logger logrus.FieldLogger) chan error {
+	errChan := make(chan error, 1)
 	go func() {
 		defer func() {
 			if !configbase.Enabled(os.Getenv("DISABLE_RECOVERY_ON_PANIC")) {
@@ -50,5 +50,9 @@ func GoWrapperWithBlock(f func(), logger logrus.FieldLogger) error {
 		f()
 		errChan <- nil
 	}()
-	return <-errChan
+	return errChan
+}
+
+func GoWrapperWithBlock(f func(), logger logrus.FieldLogger) error {
+	return <-GoWrapperWithErrorCh(f, logger)
 }

--- a/entities/errors/go_wrapper_test.go
+++ b/entities/errors/go_wrapper_test.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,6 +90,47 @@ func TestGoWrapperWithBlock(t *testing.T) {
 			// in the function we pass to the wrapper has been called and we have no way to block until it is done.
 			// Note that this does not matter in normal operation as we do not depend on the log being written to
 			time.Sleep(100 * time.Millisecond)
+			log.SetOutput(os.Stderr)
+			assert.Contains(t, buf.String(), "Recovered from panic")
+			assert.Contains(t, buf.String(), "test panic")
+		})
+	}
+}
+
+func TestGoWrapperWithErrorCh(t *testing.T) {
+	cases := []struct {
+		env string
+		set bool
+	}{
+		{env: "something", set: true},
+		{env: "something", set: false},
+		{env: "", set: true},
+		{env: "false", set: true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.env, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := logrus.New()
+			log.SetOutput(&buf)
+
+			if tt.set {
+				t.Setenv("DISABLE_RECOVERY_ON_PANIC", tt.env)
+			}
+
+			var a atomic.Bool
+			a.Store(true)
+
+			errCh := GoWrapperWithErrorCh(func() {
+				time.Sleep(50 * time.Millisecond)
+				a.Store(false)
+				panic("test panic")
+			}, log)
+
+			assert.True(t, a.Load())
+			assert.NotNil(t, errCh)
+			assert.NotNil(t, <-errCh)
+			assert.False(t, a.Load())
+
 			log.SetOutput(os.Stderr)
 			assert.Contains(t, buf.String(), "Recovered from panic")
 			assert.Contains(t, buf.String(), "test panic")

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/tailor-inc/graphql v0.2.1
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/vmihailenco/msgpack/v5 v5.4.1
-	github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d
+	github.com/weaviate/sroar v0.0.1
 	github.com/weaviate/tiktoken-go v0.0.2
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/text v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/weaviate/contextionary v1.2.1 h1:mmxHVc1mWpqivLHEA/ITHUiAOZziIDluYfKysIgEmnM=
 github.com/weaviate/contextionary v1.2.1/go.mod h1:nIEM3Gq1BzTZLuY+Pl7t8hD3eR6VAU43fRdZTEZ9LRY=
-github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d h1:bULMGmIS786YSmm/SssAmwu86y4saMoHhvuL0u7pWLc=
-github.com/weaviate/sroar v0.0.0-20230210105426-26108af5465d/go.mod h1:bJUcu8a/7XKOeaCWZtSjuBogUGReUiwJTyGSvcAjDzQ=
+github.com/weaviate/sroar v0.0.1 h1:a39wT/IcoOog7ZkA1rnzIo6gLEtfm+xpiXfR+augdXA=
+github.com/weaviate/sroar v0.0.1/go.mod h1:bJUcu8a/7XKOeaCWZtSjuBogUGReUiwJTyGSvcAjDzQ=
 github.com/weaviate/tiktoken-go v0.0.2 h1:lkwTMEoXSFSXxYvw1c44/xz3OOAh27L3+3vvNN/TSSg=
 github.com/weaviate/tiktoken-go v0.0.2/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=


### PR DESCRIPTION
### What's being changed:

Improves panic handling within goroutine. If goroutine reading from channel panics, parent goroutine could get stuck on pushing data to full channel. Now errors are returned.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
