### PR TITLE
Add dummy rerank module

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -64,6 +64,7 @@ import (
 	modqna "github.com/weaviate/weaviate/modules/qna-transformers"
 	modcentroid "github.com/weaviate/weaviate/modules/ref2vec-centroid"
 	modrerankercohere "github.com/weaviate/weaviate/modules/reranker-cohere"
+	modrerankerdummy "github.com/weaviate/weaviate/modules/reranker-dummy"
 	modrerankertransformers "github.com/weaviate/weaviate/modules/reranker-transformers"
 	modsum "github.com/weaviate/weaviate/modules/sum-transformers"
 	modspellcheck "github.com/weaviate/weaviate/modules/text-spellcheck"
@@ -610,6 +611,14 @@ func registerModules(appState *state.State) error {
 		appState.Logger.
 			WithField("action", "startup").
 			WithField("module", modrerankercohere.Name).
+			Debug("enabled module")
+	}
+
+	if _, ok := enabledModules[modrerankerdummy.Name]; ok {
+		appState.Modules.Register(modrerankerdummy.New())
+		appState.Logger.
+			WithField("action", "startup").
+			WithField("module", modrerankerdummy.Name).
 			Debug("enabled module")
 	}
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,7 +20,7 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: "./data"
       DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
-      ENABLE_MODULES: text2vec-contextionary,backup-filesystem,generative-dummy
+      ENABLE_MODULES: text2vec-contextionary,backup-filesystem,generative-dummy,rerank-dummy
       BACKUP_FILESYSTEM_PATH: "/var/lib/backups" 
       PROMETHEUS_MONITORING_ENABLED: 'true'
       PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,7 +20,7 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: "./data"
       DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
-      ENABLE_MODULES: text2vec-contextionary,backup-filesystem,generative-dummy,rerank-dummy
+      ENABLE_MODULES: text2vec-contextionary,backup-filesystem,generative-dummy,reranker-dummy
       BACKUP_FILESYSTEM_PATH: "/var/lib/backups" 
       PROMETHEUS_MONITORING_ENABLED: 'true'
       PROMETHEUS_MONITORING_GROUP_CLASSES: 'true'

--- a/modules/multi2vec-dummy/clients/meta.go
+++ b/modules/multi2vec-dummy/clients/meta.go
@@ -1,0 +1,20 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+type MetaClient struct{}
+
+func (v MetaClient) MetaInfo() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"name": "Dummy module for tests",
+	}, nil
+}

--- a/modules/multi2vec-dummy/ent/vectorization_config.go
+++ b/modules/multi2vec-dummy/ent/vectorization_config.go
@@ -1,0 +1,20 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package ent
+
+type VectorizationConfig struct {
+	Location             string
+	ProjectID            string
+	Model                string
+	Dimensions           int64
+	VideoIntervalSeconds int64
+}

--- a/modules/multi2vec-dummy/ent/vectorization_result.go
+++ b/modules/multi2vec-dummy/ent/vectorization_result.go
@@ -1,0 +1,22 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package ent
+
+type VectorizationResult struct {
+	TextVectors    [][]float32
+	ImageVectors   [][]float32
+	AudioVectors   [][]float32
+	VideoVectors   [][]float32
+	IMUVectors     [][]float32
+	ThermalVectors [][]float32
+	DepthVectors   [][]float32
+}

--- a/modules/reranker-dummy/clients/ranker.go
+++ b/modules/reranker-dummy/clients/ranker.go
@@ -1,0 +1,51 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/ent"
+)
+
+type client struct {
+	logger logrus.FieldLogger
+}
+
+type documentScore struct {
+	Document string
+	Length   int
+}
+
+func New(logger logrus.FieldLogger) *client {
+	return &client{
+		logger: logger,
+	}
+}
+
+func (c *client) Rank(ctx context.Context, query string, documents []string,
+	cfg moduletools.ClassConfig,
+) (*ent.RankResult, error) {
+	documentScores := make([]ent.DocumentScore, 0, len(documents))
+	for _, doc := range documents {
+		documentScores = append(documentScores, ent.DocumentScore{
+			Document: doc,
+			Score:    float64(len(doc)),
+		})
+	}
+
+	return &ent.RankResult{
+		Query: query, DocumentScores: documentScores,
+	}, nil
+}

--- a/modules/reranker-dummy/clients/ranker.go
+++ b/modules/reranker-dummy/clients/ranker.go
@@ -23,11 +23,6 @@ type client struct {
 	logger logrus.FieldLogger
 }
 
-type documentScore struct {
-	Document string
-	Length   int
-}
-
 func New(logger logrus.FieldLogger) *client {
 	return &client{
 		logger: logger,

--- a/modules/reranker-dummy/clients/ranker_meta.go
+++ b/modules/reranker-dummy/clients/ranker_meta.go
@@ -1,0 +1,18 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+func (s *client) MetaInfo() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"name": "Reranker - Dummy",
+	}, nil
+}

--- a/modules/reranker-dummy/config.go
+++ b/modules/reranker-dummy/config.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modrerankerdummy
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func (m *ReRankerDummyModule) ClassConfigDefaults() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *ReRankerDummyModule) PropertyConfigDefaults(
+	dt *schema.DataType,
+) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (m *ReRankerDummyModule) ValidateClass(ctx context.Context,
+	class *models.Class, cfg moduletools.ClassConfig,
+) error {
+	return nil
+}
+
+var _ = modulecapabilities.ClassConfigurator(New())

--- a/modules/reranker-dummy/module.go
+++ b/modules/reranker-dummy/module.go
@@ -1,0 +1,89 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modrerankerdummy
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/reranker-dummy/clients"
+	rerankeradditional "github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/ent"
+)
+
+const Name = "reranker-dummy"
+
+func New() *ReRankerDummyModule {
+	return &ReRankerDummyModule{}
+}
+
+type ReRankerDummyModule struct {
+	reranker                     ReRankerDummyClient
+	additionalPropertiesProvider modulecapabilities.AdditionalProperties
+}
+
+type ReRankerDummyClient interface {
+	Rank(ctx context.Context, query string, documents []string, cfg moduletools.ClassConfig) (*ent.RankResult, error)
+	MetaInfo() (map[string]interface{}, error)
+}
+
+func (m *ReRankerDummyModule) Name() string {
+	return Name
+}
+
+func (m *ReRankerDummyModule) Type() modulecapabilities.ModuleType {
+	return modulecapabilities.Text2TextReranker
+}
+
+func (m *ReRankerDummyModule) Init(ctx context.Context,
+	params moduletools.ModuleInitParams,
+) error {
+	if err := m.initAdditional(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
+		return errors.Wrap(err, "init cross encoder")
+	}
+
+	return nil
+}
+
+func (m *ReRankerDummyModule) initAdditional(ctx context.Context, timeout time.Duration,
+	logger logrus.FieldLogger,
+) error {
+	client := clients.New(logger)
+	m.reranker = client
+	m.additionalPropertiesProvider = rerankeradditional.NewRankerProvider(m.reranker)
+	return nil
+}
+
+func (m *ReRankerDummyModule) MetaInfo() (map[string]interface{}, error) {
+	return m.reranker.MetaInfo()
+}
+
+func (m *ReRankerDummyModule) RootHandler() http.Handler {
+	// TODO: remove once this is a capability interface
+	return nil
+}
+
+func (m *ReRankerDummyModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {
+	return m.additionalPropertiesProvider.AdditionalProperties()
+}
+
+// verify we implement the modules.Module interface
+var (
+	_ = modulecapabilities.Module(New())
+	_ = modulecapabilities.AdditionalProperties(New())
+	_ = modulecapabilities.MetaProvider(New())
+)

--- a/test/acceptance_with_go_client/reranker_test.go
+++ b/test/acceptance_with_go_client/reranker_test.go
@@ -1,0 +1,77 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestReRanker(t *testing.T) {
+	ctx := context.Background()
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: "localhost:8080"})
+	require.Nil(t, err)
+
+	className := "BigFurryMonsterDog"
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	classCreator := c.Schema().ClassCreator()
+	class := models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "first",
+				DataType: []string{string(schema.DataTypeText)},
+			},
+			{
+				Name:     "second",
+				DataType: []string{string(schema.DataTypeText)},
+			},
+		},
+		ModuleConfig: map[string]interface{}{
+			"reranker-dummy": map[string]interface{}{},
+		},
+	}
+	require.Nil(t, classCreator.WithClass(&class).Do(ctx))
+	uids := []string{uuid.New().String(), uuid.New().String()}
+	_, err = c.Data().Creator().WithClassName(className).WithProperties(
+		map[string]interface{}{"first": "apple", "second": "longlong"},
+	).WithID(uids[0]).Do(ctx)
+	require.Nil(t, err)
+
+	_, err = c.Data().Creator().WithClassName(className).WithProperties(
+		map[string]interface{}{"first": "apple", "second": "longlonglong"},
+	).WithID(uids[1]).Do(ctx)
+	require.Nil(t, err)
+
+	t.Run("Rerank", func(t *testing.T) {
+		fields := []graphql.Field{
+			{Name: "_additional{id}"},
+			{Name: "_additional{rerank(property: \"second\",query: \"apple\" ){score}}"},
+		}
+		result, err := c.GraphQL().Get().WithClassName(className).WithFields(fields...).Do(ctx)
+		require.Nil(t, err)
+
+		expected := []float64{12, 8}
+		for i := 0; i < 2; i++ {
+			rerankScore := result.Data["Get"].(map[string]interface{})[className].([]interface{})[i].(map[string]interface{})["_additional"].(map[string]interface{})["rerank"].([]interface{})[0].(map[string]interface{})["score"].(float64)
+			require.Equal(t, rerankScore, expected[i])
+		}
+	})
+}


### PR DESCRIPTION
### What's being changed:

Adds a dummy reranker module. I need this to test some edge cases in [this PR](https://github.com/weaviate/weaviate/pull/5213), but it is targeted for 1.23 because this would be useful for our python client tests, which still target 1.23

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
