### PR TITLE
hnsw: set default max connections to 32

### DIFF
--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -22,7 +22,7 @@ import (
 const (
 	// Set these defaults if the user leaves them blank
 	DefaultCleanupIntervalSeconds = 5 * 60
-	DefaultMaxConnections         = 64
+	DefaultMaxConnections         = 32
 	DefaultEFConstruction         = 128
 	DefaultEF                     = -1 // indicates "let Weaviate pick"
 	DefaultDynamicEFMin           = 100


### PR DESCRIPTION
### What's being changed:

Fixes #4363 

![output](https://github.com/weaviate/weaviate/assets/2102036/a02deee4-b4a5-4589-aff7-1b74f6207f62)

- orange: 64
- blue: 32

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
