### PR TITLE
fix: panic by add missing wrapper func in RAFT apply and offload grpc client tests

### DIFF
--- a/adapters/handlers/grpc/v1/tenants.go
+++ b/adapters/handlers/grpc/v1/tenants.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/entities/models"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
@@ -60,24 +59,13 @@ func (s *Service) tenantsGet(ctx context.Context, principal *models.Principal, r
 }
 
 func tenantToGRPC(tenant *models.Tenant) (*pb.Tenant, error) {
-	var status pb.TenantActivityStatus
-	if tenant.ActivityStatus == models.TenantActivityStatusHOT {
-		status = pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_HOT
-	} else if tenant.ActivityStatus == models.TenantActivityStatusCOLD {
-		status = pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_COLD
-	} else if tenant.ActivityStatus == models.TenantActivityStatusFROZEN {
-		status = pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_FROZEN
-	} else if tenant.ActivityStatus == types.TenantActivityStatusFREEZING {
-		status = pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_FREEZING
-	} else if tenant.ActivityStatus == types.TenantActivityStatusUNFREEZING {
-		status = pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_UNFREEZING
-	} else if tenant.ActivityStatus == types.TenantActivityStatusUNFROZEN {
-		status = pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_UNFROZEN
-	} else {
+	status, ok := pb.TenantActivityStatus_value[fmt.Sprintf("TENANT_ACTIVITY_STATUS_%s", tenant.ActivityStatus)]
+	if !ok {
 		return nil, fmt.Errorf("unknown tenant activity status %s", tenant.ActivityStatus)
 	}
+
 	return &pb.Tenant{
 		Name:           tenant.Name,
-		ActivityStatus: status,
+		ActivityStatus: pb.TenantActivityStatus(status),
 	}, nil
 }

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -228,10 +228,10 @@ func (s *schema) multiTenancyEnabled(class string) (bool, *metaClass, ClassInfo,
 	s.RLock()
 	defer s.RUnlock()
 	meta := s.Classes[class]
-	info := s.Classes[class].ClassInfo()
 	if meta == nil {
 		return false, nil, ClassInfo{}, ErrClassNotFound
 	}
+	info := s.Classes[class].ClassInfo()
 	if !info.MultiTenancy.Enabled {
 		return false, nil, ClassInfo{}, fmt.Errorf("multi-tenancy is not enabled for class %q", class)
 	}

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -131,7 +131,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		"cmd_schema_only": schemaOnly,
 	}).Debug("server.apply")
 
-	var f = func() {}
+	f := func() {}
 
 	switch cmd.Type {
 

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -131,7 +131,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		"cmd_schema_only": schemaOnly,
 	}).Debug("server.apply")
 
-	var f func()
+	var f = func() {}
 
 	switch cmd.Type {
 
@@ -181,7 +181,9 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		}
 
 	case api.ApplyRequest_TYPE_TENANT_PROCESS:
-		ret.Error = st.schemaManager.UpdateTenantsProcess(&cmd, schemaOnly)
+		f = func() {
+			ret.Error = st.schemaManager.UpdateTenantsProcess(&cmd, schemaOnly)
+		}
 
 	case api.ApplyRequest_TYPE_STORE_SCHEMA_V1:
 		f = func() {

--- a/grpc/generated/protocol/v0/batch.pb.go
+++ b/grpc/generated/protocol/v0/batch.pb.go
@@ -3,11 +3,10 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v0/search_get.pb.go
+++ b/grpc/generated/protocol/v0/search_get.pb.go
@@ -3,11 +3,10 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v0/weaviate.pb.go
+++ b/grpc/generated/protocol/v0/weaviate.pb.go
@@ -3,10 +3,9 @@
 package protocol
 
 import (
-	reflect "reflect"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
 )
 
 const (

--- a/grpc/generated/protocol/v0/weaviate_grpc.pb.go
+++ b/grpc/generated/protocol/v0/weaviate_grpc.pb.go
@@ -4,7 +4,6 @@ package protocol
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -14,6 +13,11 @@ import (
 // is compatible with the grpc package it is being compiled against.
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
+
+const (
+	Weaviate_Search_FullMethodName       = "/weaviategrpc.Weaviate/Search"
+	Weaviate_BatchObjects_FullMethodName = "/weaviategrpc.Weaviate/BatchObjects"
+)
 
 // WeaviateClient is the client API for Weaviate service.
 //
@@ -33,7 +37,7 @@ func NewWeaviateClient(cc grpc.ClientConnInterface) WeaviateClient {
 
 func (c *weaviateClient) Search(ctx context.Context, in *SearchRequest, opts ...grpc.CallOption) (*SearchReply, error) {
 	out := new(SearchReply)
-	err := c.cc.Invoke(ctx, "/weaviategrpc.Weaviate/Search", in, out, opts...)
+	err := c.cc.Invoke(ctx, Weaviate_Search_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +46,7 @@ func (c *weaviateClient) Search(ctx context.Context, in *SearchRequest, opts ...
 
 func (c *weaviateClient) BatchObjects(ctx context.Context, in *BatchObjectsRequest, opts ...grpc.CallOption) (*BatchObjectsReply, error) {
 	out := new(BatchObjectsReply)
-	err := c.cc.Invoke(ctx, "/weaviategrpc.Weaviate/BatchObjects", in, out, opts...)
+	err := c.cc.Invoke(ctx, Weaviate_BatchObjects_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +95,7 @@ func _Weaviate_Search_Handler(srv interface{}, ctx context.Context, dec func(int
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/weaviategrpc.Weaviate/Search",
+		FullMethod: Weaviate_Search_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WeaviateServer).Search(ctx, req.(*SearchRequest))
@@ -109,7 +113,7 @@ func _Weaviate_BatchObjects_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/weaviategrpc.Weaviate/BatchObjects",
+		FullMethod: Weaviate_BatchObjects_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WeaviateServer).BatchObjects(ctx, req.(*BatchObjectsRequest))

--- a/grpc/generated/protocol/v1/base.pb.go
+++ b/grpc/generated/protocol/v1/base.pb.go
@@ -3,12 +3,11 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v1/batch.pb.go
+++ b/grpc/generated/protocol/v1/batch.pb.go
@@ -3,12 +3,11 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v1/batch_delete.pb.go
+++ b/grpc/generated/protocol/v1/batch_delete.pb.go
@@ -3,11 +3,10 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v1/properties.pb.go
+++ b/grpc/generated/protocol/v1/properties.pb.go
@@ -3,12 +3,11 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -3,12 +3,11 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v1/tenants.pb.go
+++ b/grpc/generated/protocol/v1/tenants.pb.go
@@ -3,11 +3,10 @@
 package protocol
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/grpc/generated/protocol/v1/weaviate.pb.go
+++ b/grpc/generated/protocol/v1/weaviate.pb.go
@@ -3,10 +3,9 @@
 package protocol
 
 import (
-	reflect "reflect"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
 )
 
 const (

--- a/grpc/generated/protocol/v1/weaviate_grpc.pb.go
+++ b/grpc/generated/protocol/v1/weaviate_grpc.pb.go
@@ -4,7 +4,6 @@ package protocol
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -14,6 +13,13 @@ import (
 // is compatible with the grpc package it is being compiled against.
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
+
+const (
+	Weaviate_Search_FullMethodName       = "/weaviate.v1.Weaviate/Search"
+	Weaviate_BatchObjects_FullMethodName = "/weaviate.v1.Weaviate/BatchObjects"
+	Weaviate_BatchDelete_FullMethodName  = "/weaviate.v1.Weaviate/BatchDelete"
+	Weaviate_TenantsGet_FullMethodName   = "/weaviate.v1.Weaviate/TenantsGet"
+)
 
 // WeaviateClient is the client API for Weaviate service.
 //
@@ -35,7 +41,7 @@ func NewWeaviateClient(cc grpc.ClientConnInterface) WeaviateClient {
 
 func (c *weaviateClient) Search(ctx context.Context, in *SearchRequest, opts ...grpc.CallOption) (*SearchReply, error) {
 	out := new(SearchReply)
-	err := c.cc.Invoke(ctx, "/weaviate.v1.Weaviate/Search", in, out, opts...)
+	err := c.cc.Invoke(ctx, Weaviate_Search_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +50,7 @@ func (c *weaviateClient) Search(ctx context.Context, in *SearchRequest, opts ...
 
 func (c *weaviateClient) BatchObjects(ctx context.Context, in *BatchObjectsRequest, opts ...grpc.CallOption) (*BatchObjectsReply, error) {
 	out := new(BatchObjectsReply)
-	err := c.cc.Invoke(ctx, "/weaviate.v1.Weaviate/BatchObjects", in, out, opts...)
+	err := c.cc.Invoke(ctx, Weaviate_BatchObjects_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +59,7 @@ func (c *weaviateClient) BatchObjects(ctx context.Context, in *BatchObjectsReque
 
 func (c *weaviateClient) BatchDelete(ctx context.Context, in *BatchDeleteRequest, opts ...grpc.CallOption) (*BatchDeleteReply, error) {
 	out := new(BatchDeleteReply)
-	err := c.cc.Invoke(ctx, "/weaviate.v1.Weaviate/BatchDelete", in, out, opts...)
+	err := c.cc.Invoke(ctx, Weaviate_BatchDelete_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +68,7 @@ func (c *weaviateClient) BatchDelete(ctx context.Context, in *BatchDeleteRequest
 
 func (c *weaviateClient) TenantsGet(ctx context.Context, in *TenantsGetRequest, opts ...grpc.CallOption) (*TenantsGetReply, error) {
 	out := new(TenantsGetReply)
-	err := c.cc.Invoke(ctx, "/weaviate.v1.Weaviate/TenantsGet", in, out, opts...)
+	err := c.cc.Invoke(ctx, Weaviate_TenantsGet_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +125,7 @@ func _Weaviate_Search_Handler(srv interface{}, ctx context.Context, dec func(int
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/weaviate.v1.Weaviate/Search",
+		FullMethod: Weaviate_Search_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WeaviateServer).Search(ctx, req.(*SearchRequest))
@@ -137,7 +143,7 @@ func _Weaviate_BatchObjects_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/weaviate.v1.Weaviate/BatchObjects",
+		FullMethod: Weaviate_BatchObjects_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WeaviateServer).BatchObjects(ctx, req.(*BatchObjectsRequest))
@@ -155,7 +161,7 @@ func _Weaviate_BatchDelete_Handler(srv interface{}, ctx context.Context, dec fun
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/weaviate.v1.Weaviate/BatchDelete",
+		FullMethod: Weaviate_BatchDelete_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WeaviateServer).BatchDelete(ctx, req.(*BatchDeleteRequest))
@@ -173,7 +179,7 @@ func _Weaviate_TenantsGet_Handler(srv interface{}, ctx context.Context, dec func
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/weaviate.v1.Weaviate/TenantsGet",
+		FullMethod: Weaviate_TenantsGet_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WeaviateServer).TenantsGet(ctx, req.(*TenantsGetRequest))

--- a/test/docker/container.go
+++ b/test/docker/container.go
@@ -43,6 +43,10 @@ func (d *DockerContainer) URI() string {
 	return d.GetEndpoint(HTTP)
 }
 
+func (d *DockerContainer) GrpcURI() string {
+	return d.GetEndpoint(GRPC)
+}
+
 func (d *DockerContainer) GetEndpoint(name EndpointName) string {
 	if endpoint, ok := d.endpoints[name]; ok {
 		return endpoint.uri

--- a/test/helper/client.go
+++ b/test/helper/client.go
@@ -72,8 +72,8 @@ func CreateAuth(apiKey strfmt.UUID, apiToken string) runtime.ClientAuthInfoWrite
 	return authWriter
 }
 
-func ClientGRPC(t *testing.T) pb.WeaviateClient {
-	conn, err := CreateGrpcConnectionClient(":50051")
+func ClientGRPC(t *testing.T, uri string) pb.WeaviateClient {
+	conn, err := CreateGrpcConnectionClient(uri)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	grpcClient := CreateGrpcWeaviateClient(conn)

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -28,6 +28,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/replica"
 )
 
+var grpcClient pb.WeaviateClient
+
 func SetupClient(uri string) {
 	host, port := "", ""
 	res := strings.Split(uri, ":")
@@ -36,6 +38,10 @@ func SetupClient(uri string) {
 	}
 	ServerHost = host
 	ServerPort = port
+}
+
+func SetupGRPCClient(t *testing.T, uri string) {
+	grpcClient = ClientGRPC(t, uri)
 }
 
 func CreateClass(t *testing.T, class *models.Class) {
@@ -299,7 +305,7 @@ func GetTenants(t *testing.T, class string) (*schema.TenantsGetOK, error) {
 
 func GetTenantsGRPC(t *testing.T, class string) (*pb.TenantsGetReply, error) {
 	t.Helper()
-	return ClientGRPC(t).TenantsGet(context.TODO(), &pb.TenantsGetRequest{Collection: class})
+	return grpcClient.TenantsGet(context.TODO(), &pb.TenantsGetRequest{Collection: class})
 }
 
 func TenantExists(t *testing.T, class string, tenant string) (*schema.TenantExistsOK, error) {

--- a/test/modules/offload-s3/offload_download_test.go
+++ b/test/modules/offload-s3/offload_download_test.go
@@ -38,6 +38,7 @@ func Test_DownloadS3Journey(t *testing.T) {
 			WithOffloadS3("offloading").
 			WithText2VecContextionary().
 			With3NodeCluster().
+			WithWeaviateGRPC().
 			Start(ctx)
 		require.Nil(t, err)
 
@@ -48,6 +49,7 @@ func Test_DownloadS3Journey(t *testing.T) {
 		}()
 
 		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupGRPCClient(t, compose.GetWeaviate().GrpcURI())
 
 		className := "MultiTenantClass"
 		testClass := models.Class{
@@ -205,6 +207,7 @@ func Test_DownloadS3Journey(t *testing.T) {
 			WithOffloadS3("offloading").
 			WithText2VecContextionary().
 			With3NodeCluster().
+			WithWeaviateGRPC().
 			Start(ctx)
 		require.Nil(t, err)
 
@@ -215,6 +218,7 @@ func Test_DownloadS3Journey(t *testing.T) {
 		}()
 
 		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupGRPCClient(t, compose.GetWeaviate().GrpcURI())
 
 		className := "MultiTenantClass"
 		testClass := models.Class{


### PR DESCRIPTION
### What's being changed:
this PR includes fixes for implementation and acceptance tests of tenant offload

- handle missing wrapper function on RAFT Apply to handle panics like this.
<img width="1337" alt="Screenshot 2024-07-01 at 13 37 49" src="https://github.com/weaviate/weaviate/assets/2805614/c7274398-2258-4b79-88ce-7f345a4c9d81">

- refact the `tenantsToGrpc` method to make it more abstract and avoid the need to extend when adding new status 
- fix the grpc client passed to tests to use the correct docker grpc 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
