### PR TITLE
change index reload routine to avoid one failure blocking rest of loading

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -264,16 +264,15 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 		invertedIndexConfig:    invertedIndexConfig,
 		stopwords:              sd,
 		replicator:             repl,
-		remote: sharding.NewRemoteIndex(cfg.ClassName.String(), sg,
-			nodeResolver, remoteClient),
-		metrics:             NewMetrics(logger, promMetrics, cfg.ClassName.String(), "n/a"),
-		centralJobQueue:     jobQueueCh,
-		partitioningEnabled: shardState.PartitioningEnabled,
-		backupMutex:         backupMutex{log: logger, retryDuration: mutexRetryDuration, notifyDuration: mutexNotifyDuration},
-		indexCheckpoints:    indexCheckpoints,
-		allocChecker:        allocChecker,
-		shardCreateLocks:    esync.NewKeyLocker(),
-		shardInUseLocks:     esync.NewKeyRWLocker(),
+		remote:                 sharding.NewRemoteIndex(cfg.ClassName.String(), sg, nodeResolver, remoteClient),
+		metrics:                NewMetrics(logger, promMetrics, cfg.ClassName.String(), "n/a"),
+		centralJobQueue:        jobQueueCh,
+		partitioningEnabled:    shardState.PartitioningEnabled,
+		backupMutex:            backupMutex{log: logger, retryDuration: mutexRetryDuration, notifyDuration: mutexNotifyDuration},
+		indexCheckpoints:       indexCheckpoints,
+		allocChecker:           allocChecker,
+		shardCreateLocks:       esync.NewKeyLocker(),
+		shardInUseLocks:        esync.NewKeyRWLocker(),
 	}
 	index.closingCtx, index.closingCancel = context.WithCancel(context.Background())
 
@@ -451,34 +450,6 @@ func (i *Index) addProperty(ctx context.Context, props ...*models.Property) erro
 		return errors.Wrapf(err, "extend idx '%s' with properties '%v", i.ID(), props)
 	}
 	return nil
-}
-
-func (i *Index) addUUIDProperty(ctx context.Context) error {
-	return i.ForEachShard(func(name string, shard ShardLike) error {
-		err := shard.addIDProperty(ctx)
-		if err != nil {
-			return errors.Wrapf(err, "add id property to shard %q", name)
-		}
-		return nil
-	})
-}
-
-func (i *Index) addDimensionsProperty(ctx context.Context) error {
-	return i.ForEachShard(func(name string, shard ShardLike) error {
-		if err := shard.addDimensionsProperty(ctx); err != nil {
-			return errors.Wrapf(err, "add dimensions property to shard %q", name)
-		}
-		return nil
-	})
-}
-
-func (i *Index) addTimestampProperties(ctx context.Context) error {
-	return i.ForEachShard(func(name string, shard ShardLike) error {
-		if err := shard.addTimestampProperties(ctx); err != nil {
-			return errors.Wrapf(err, "add timestamp properties to shard %q", name)
-		}
-		return nil
-	})
 }
 
 func (i *Index) updateVectorIndexConfig(ctx context.Context,

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -122,9 +122,6 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		{"name": "two"},
 	}
 
-	err = index.addUUIDProperty(context.TODO())
-	require.Nil(t, err)
-
 	err = index.addProperty(context.TODO(), &models.Property{
 		Name:         "name",
 		DataType:     schema.DataTypeText.PropString(),
@@ -174,8 +171,6 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		}, nil, logger, nil, nil, nil, nil, class, nil, nil, nil)
 	require.Nil(t, err)
 
-	err = index.addUUIDProperty(context.TODO())
-	require.Nil(t, err)
 	err = index.addProperty(context.TODO(), &models.Property{
 		Name:         "name",
 		DataType:     schema.DataTypeText.PropString(),
@@ -293,9 +288,6 @@ func TestIndex_DropReadOnlyIndexWithData(t *testing.T) {
 		{"name": "one"},
 		{"name": "two"},
 	}
-
-	err = index.addUUIDProperty(ctx)
-	require.Nil(t, err)
 
 	err = index.addProperty(ctx, &models.Property{
 		Name:         "name",

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -84,24 +84,6 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 		return errors.Wrap(err, "create index")
 	}
 
-	err = idx.addUUIDProperty(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "extend idx '%s' with uuid property", idx.ID())
-	}
-
-	if class.InvertedIndexConfig.IndexTimestamps {
-		err = idx.addTimestampProperties(ctx)
-		if err != nil {
-			return errors.Wrapf(err, "extend idx '%s' with timestamp properties", idx.ID())
-		}
-	}
-
-	if m.db.config.TrackVectorDimensions {
-		if err := idx.addDimensionsProperty(context.TODO()); err != nil {
-			return errors.Wrap(err, "init id property")
-		}
-	}
-
 	m.db.indexLock.Lock()
 	m.db.indices[idx.ID()] = idx
 	idx.notifyReady()

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -96,9 +96,6 @@ type ShardLike interface {
 	MultiObjectByID(ctx context.Context, query []multi.Identifier) ([]*storobj.Object, error)
 	ID() string // Get the shard id
 	drop() error
-	addIDProperty(ctx context.Context) error
-	addDimensionsProperty(ctx context.Context) error
-	addTimestampProperties(ctx context.Context) error
 	createPropertyIndex(ctx context.Context, eg *enterrors.ErrorGroupWrapper, props ...*models.Property) error
 	BeginBackup(ctx context.Context) error
 	ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor) error

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -322,27 +322,6 @@ func (l *LazyLoadShard) drop() error {
 	return l.shard.drop()
 }
 
-func (l *LazyLoadShard) addIDProperty(ctx context.Context) error {
-	if err := l.Load(ctx); err != nil {
-		return err
-	}
-	return l.shard.addIDProperty(ctx)
-}
-
-func (l *LazyLoadShard) addDimensionsProperty(ctx context.Context) error {
-	if err := l.Load(ctx); err != nil {
-		return err
-	}
-	return l.shard.addDimensionsProperty(ctx)
-}
-
-func (l *LazyLoadShard) addTimestampProperties(ctx context.Context) error {
-	if err := l.Load(ctx); err != nil {
-		return err
-	}
-	return l.shard.addTimestampProperties(ctx)
-}
-
 func (l *LazyLoadShard) createPropertyIndex(ctx context.Context, eg *enterrors.ErrorGroupWrapper, props ...*models.Property) error {
 	l.mustLoad()
 	return l.shard.createPropertyIndex(ctx, eg, props...)


### PR DESCRIPTION
### What's being changed:

Change the reload DB routine used by RAFT to ensure that the DB is in-sync with classes in schema to continue on failing to load an index to ensure that all possible indexes are loaded.

Remove the routines to add specific properties to shard. These routines would trigger a shard load on lazy loading shard and their specific buckets initialization is covered in `initLSMStore` when we load/start a shard.

Change the behaviour to log error and return a joined list of error in the end instead of stopping on a single failure.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9757005988
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
