### PR TITLE
5257 avoid loading lazy shard when unecessary

### DIFF
--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -16,6 +16,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -356,6 +357,9 @@ func getIndexFilenames(rootDir, indexName string) ([]string, error) {
 			return filenames, nil
 		}
 		return nil, err
+	}
+	if len(indexRoot) == 0 {
+		return nil, fmt.Errorf("index root length is 0")
 	}
 	shardFiles, err := os.ReadDir(path.Join(rootDir, indexName, indexRoot[0].Name()))
 	if err != nil {


### PR DESCRIPTION
### What's being changed:

When updating properties (triggered by a DB reload when the schema in raft might have changed) we currently update all shards. This forces all lazy loaded shards to be loaded in order to instantiate buckets. However by iterating on loaded shards only we can avoid force loading lazy shards and instead their buckets for new properties will be instantiated on their initialization/loading.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9761660430
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
