### PR TITLE
rename env variables

### DIFF
--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -92,10 +92,10 @@ func FromEnv(config *Config) error {
 		config.Monitoring.Port = asInt
 	}
 
-	if v := os.Getenv("PROFILING_PORT"); v != "" {
+	if v := os.Getenv("GO_PROFILING_PORT"); v != "" {
 		asInt, err := strconv.Atoi(v)
 		if err != nil {
-			return fmt.Errorf("parse PROFILING_PORT as int: %w", err)
+			return fmt.Errorf("parse GO_PROFILING_PORT as int: %w", err)
 		}
 
 		config.Profiling.Port = asInt
@@ -171,7 +171,7 @@ func FromEnv(config *Config) error {
 		}
 	}
 
-	config.Profiling.Disabled = configbase.Enabled(os.Getenv("DISABLE_GO_PROFILING"))
+	config.Profiling.Disabled = configbase.Enabled(os.Getenv("GO_PROFILING_DISABLE"))
 
 	if !config.Authentication.AnyAuthMethodSelected() {
 		config.Authentication = DefaultAuthentication


### PR DESCRIPTION
### What's being changed:
There are two new go-releated environment variables:

DISABLE_GO_PROFILING
PROFILING_PORT

Older go-related variables use this naming convention:

GODEBUG
GOMAXPROCS
GOMEMLIMIT

This PR renames the new variables to put Go first for consistency:

GO_PROFILING_DISABLE
GO_PROFILING_PORT

For readability, the PR also retains the underscores which most non-go variables use.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
