### PR TITLE
Fix PQ rescoring when vectors missing

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -571,8 +571,8 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 		}
 		res.Reset()
 		for _, id := range ids {
-			dist, _, err := h.distanceFromBytesToFloatNode(compressorDistancer, id)
-			if err != nil {
+			dist, found, err := h.distanceFromBytesToFloatNode(compressorDistancer, id)
+			if found && err == nil {
 				res.Insert(id, dist)
 				if res.Len() > ef {
 					res.Pop()

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -571,10 +571,16 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 		}
 		res.Reset()
 		for _, id := range ids {
-			dist, _, _ := h.distanceFromBytesToFloatNode(compressorDistancer, id)
-			res.Insert(id, dist)
-			if res.Len() > ef {
-				res.Pop()
+			dist, _, err := h.distanceFromBytesToFloatNode(compressorDistancer, id)
+			if err != nil {
+				res.Insert(id, dist)
+				if res.Len() > ef {
+					res.Pop()
+				}
+			} else {
+				h.logger.
+					WithField("action", "rescore").
+					Warnf("could not rescore node %d", id)
 			}
 		}
 

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -580,6 +580,7 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 			} else {
 				h.logger.
 					WithField("action", "rescore").
+					WithError(err).
 					Warnf("could not rescore node %d", id)
 			}
 		}


### PR DESCRIPTION
### What's being changed:
- PQ rescores vectors with original vectors
- In certain cases the vector may no longer be available
- This manifests in an unexpected distance of 0

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
