### PR TITLE
fix: gql dependancy on RAFT schema

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -343,18 +343,12 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	updateSchemaCallback := makeUpdateSchemaCall(appState)
 	executor.RegisterSchemaUpdateCallback(updateSchemaCallback)
 
-	enterrors.GoWrapper(func() {
-		if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
-			appState.Logger.
-				WithField("action", "startup").
-				WithError(err).
-				Fatal("could not open cloud meta store")
-		}
-	}, appState.Logger)
-
-	// TODO-RAFT: refactor remove this sleep
-	// this sleep was used to block GraphQL and give time to RAFT to start.
-	time.Sleep(2 * time.Second)
+	if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
+		appState.Logger.
+			WithField("action", "startup").
+			WithError(err).
+			Fatal("could not open cloud meta store")
+	}
 
 	batchManager := objects.NewBatchManager(vectorRepo, appState.Modules,
 		appState.Locks, schemaManager, appState.ServerConfig, appState.Logger,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -343,12 +343,31 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	updateSchemaCallback := makeUpdateSchemaCall(appState)
 	executor.RegisterSchemaUpdateCallback(updateSchemaCallback)
 
-	if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
+	// while we accept an overall longer startup, e.g. due to a recovery, we
+	// still want to limit the module startup context, as that's mostly service
+	// discovery / dependency checking
+	moduleCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
+	err = initModules(moduleCtx, appState)
+	if err != nil {
 		appState.Logger.
-			WithField("action", "startup").
-			WithError(err).
-			Fatal("could not open cloud meta store")
+			WithField("action", "startup").WithError(err).
+			Fatal("modules didn't initialize")
 	}
+
+	enterrors.GoWrapper(func() {
+		if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
+			appState.Logger.
+				WithField("action", "startup").
+				WithError(err).
+				Fatal("could not open cloud meta store")
+		}
+	}, appState.Logger)
+
+	// TODO-RAFT: refactor remove this sleep
+	// this sleep was used to block GraphQL and give time to RAFT to start.
+	time.Sleep(2 * time.Second)
 
 	batchManager := objects.NewBatchManager(vectorRepo, appState.Modules,
 		appState.Locks, schemaManager, appState.ServerConfig, appState.Logger,
@@ -388,19 +407,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	}
 
 	configureServer = makeConfigureServer(appState)
-
-	// while we accept an overall longer startup, e.g. due to a recovery, we
-	// still want to limit the module startup context, as that's mostly service
-	// discovery / dependency checking
-	moduleCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
-	defer cancel()
-
-	err = initModules(moduleCtx, appState)
-	if err != nil {
-		appState.Logger.
-			WithField("action", "startup").WithError(err).
-			Fatal("modules didn't initialize")
-	}
 
 	// Add dimensions to all the objects in the database, if requested by the user
 	if appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup {

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -335,6 +335,14 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	explorer.SetSchemaGetter(schemaManager)
 	appState.Modules.SetSchemaGetter(schemaManager)
 
+	appState.Traverser = traverser.NewTraverser(appState.ServerConfig, appState.Locks,
+		appState.Logger, appState.Authorizer, vectorRepo, explorer, schemaManager,
+		appState.Modules, traverser.NewMetrics(appState.Metrics),
+		appState.ServerConfig.Config.MaximumConcurrentGetRequests)
+
+	updateSchemaCallback := makeUpdateSchemaCall(appState)
+	executor.RegisterSchemaUpdateCallback(updateSchemaCallback)
+
 	enterrors.GoWrapper(func() {
 		if err := appState.ClusterService.Open(context.Background(), executor); err != nil {
 			appState.Logger.
@@ -352,14 +360,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		appState.Locks, schemaManager, appState.ServerConfig, appState.Logger,
 		appState.Authorizer, appState.Metrics)
 	appState.BatchManager = batchManager
-	objectsTraverser := traverser.NewTraverser(appState.ServerConfig, appState.Locks,
-		appState.Logger, appState.Authorizer, vectorRepo, explorer, schemaManager,
-		appState.Modules, traverser.NewMetrics(appState.Metrics),
-		appState.ServerConfig.Config.MaximumConcurrentGetRequests)
-	appState.Traverser = objectsTraverser
-
-	updateSchemaCallback := makeUpdateSchemaCall(appState.Logger, appState, objectsTraverser)
-	executor.RegisterSchemaUpdateCallback(updateSchemaCallback)
 
 	err = migrator.AdjustFilterablePropSettings(ctx)
 	if err != nil {
@@ -407,10 +407,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			WithField("action", "startup").WithError(err).
 			Fatal("modules didn't initialize")
 	}
-
-	// manually update schema once
-	schema := schemaManager.GetSchemaSkipAuth()
-	updateSchemaCallback(schema)
 
 	// Add dimensions to all the objects in the database, if requested by the user
 	if appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup {

--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -40,7 +40,7 @@ import (
 // are only available within there
 var configureServer func(*http.Server, string, string)
 
-func makeUpdateSchemaCall(logger logrus.FieldLogger, appState *state.State, traverser *traverser.Traverser) func(schema.Schema) {
+func makeUpdateSchemaCall(appState *state.State) func(schema.Schema) {
 	return func(updatedSchema schema.Schema) {
 		if appState.ServerConfig.Config.DisableGraphQL {
 			return
@@ -51,13 +51,13 @@ func makeUpdateSchemaCall(logger logrus.FieldLogger, appState *state.State, trav
 
 		gql, err := rebuildGraphQL(
 			updatedSchema,
-			logger,
+			appState.Logger,
 			appState.ServerConfig.Config,
-			traverser,
+			appState.Traverser,
 			appState.Modules,
 		)
 		if err != nil && err != utils.ErrEmptySchema {
-			logger.WithField("action", "graphql_rebuild").
+			appState.Logger.WithField("action", "graphql_rebuild").
 				WithError(err).Error("could not (re)build graphql provider")
 		}
 		appState.SetGraphQL(gql)


### PR DESCRIPTION
### What's being changed:
this PR moves the modules init and registering the callbacks for GQL before RAFT init to avoid any panics and races between raft and GQL, because raft shall trigger rebuilding the GQL schema and it was initiated before initiating the modules 

[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/9795740893)
```
github.com/weaviate/weaviate/modules/text2vec-transformers.(*TransformersModule).Arguments(0x14003decb78?)
	/Users/jfrancoa/repos/weaviate/modules/text2vec-transformers/nearText.go:26 +0x20
github.com/weaviate/weaviate/usecases/modules.(*Provider).GetArguments(0x14003b546c0, 0x14002fca420)
	/Users/jfrancoa/repos/weaviate/usecases/modules/modules.go:367 +0x1b0
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.buildGetClassField(0x101ed7260?, 0x14002fca420, {0x10225e190?, 0x14003b546c0}, 0x129fe1e28?)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/local/get/class_builder_fields.go:242 +0x730
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.(*classBuilder).classField(0x140031e3d00, 0x14002fca420, 0x14003a40240?)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/local/get/class_builder.go:103 +0xb4
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.(*classBuilder).kinds(0x14002e12268?, 0x1400384a9c0)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/local/get/class_builder.go:84 +0x1b8
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.(*classBuilder).objects(...)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/local/get/class_builder.go:65
github.com/weaviate/weaviate/adapters/handlers/graphql/local/get.Build(0x14002e12268, {0x10226e728?, 0x14003cb4e00?}, {0x10225e190?, 0x14003b546c0?})
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/local/get/get.go:48 +0x64
github.com/weaviate/weaviate/adapters/handlers/graphql/local.Build(_, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, 0x186a0, {{0x0, ...}}, ...}, ...)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/local/local.go:29 +0x40
github.com/weaviate/weaviate/adapters/handlers/graphql.buildGraphqlSchema(_, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, 0x186a0, {{0x0, ...}}, ...}, ...)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/schema.go:87 +0x68
github.com/weaviate/weaviate/adapters/handlers/graphql.Build(_, {_, _}, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, ...}, ...)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/graphql/schema.go:57 +0x178
github.com/weaviate/weaviate/adapters/handlers/rest.rebuildGraphQL({_}, {_, _}, {{0x0, 0x0}, 0x0, {0x14}, 0x2710, 0x186a0, {{0x0, ...}}, ...}, ...)
	/Users/jfrancoa/repos/weaviate/adapters/handlers/rest/configure_server.go:70 +0xb0
github.com/weaviate/weaviate/adapters/handlers/rest.MakeAppState.makeUpdateSchemaCall.func6({0x14002c25b40?})
	/Users/jfrancoa/repos/weaviate/adapters/handlers/rest/configure_server.go:52 +0x9c
github.com/weaviate/weaviate/usecases/schema.(*executor).TriggerSchemaUpdateCallbacks(0x14002836770)
	/Users/jfrancoa/repos/weaviate/usecases/schema/executor.go:269 +0x158
github.com/weaviate/weaviate/usecases/schema.(*executor).ReloadLocalDB(0x14002836770, {0x102257fd8, 0x104990940}, {0x14002bbf100, 0x1, 0x1400311a8c0?})
	/Users/jfrancoa/repos/weaviate/usecases/schema/executor.go:66 +0x3c8
github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).ReloadDBFromSchema(0x14002828ab0)
	/Users/jfrancoa/repos/weaviate/cluster/schema/manager.go:124 +0x184
github.com/weaviate/weaviate/cluster.(*Store).reloadDBFromSchema(0x14003e042c0)
	/Users/jfrancoa/repos/weaviate/cluster/store.go:616 +0x30
github.com/weaviate/weaviate/cluster.(*Store).Apply.func1()
	/Users/jfrancoa/repos/weaviate/cluster/store_apply.go:107 +0x27c
github.com/weaviate/weaviate/cluster.(*Store).Apply(0x14003e042c0, 0x14003f00f60)
	/Users/jfrancoa/repos/weaviate/cluster/store_apply.go:216 +0xce0
github.com/hashicorp/raft.(*Raft).runFSM.func1(0x14002acf1e0)
	/Users/jfrancoa/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/fsm.go:101 +0x1cc
github.com/hashicorp/raft.(*Raft).runFSM.func2({0x1400326a400, 0x4, 0x4?})
	/Users/jfrancoa/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/fsm.go:124 +0x3ac
github.com/hashicorp/raft.(*Raft).runFSM(0x14003a9a000)
	/Users/jfrancoa/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/fsm.go:240 +0x2d0
github.com/hashicorp/raft.(*raftState).goFunc.func1()
	/Users/jfrancoa/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/state.go:149 +0x5c
created by github.com/hashicorp/raft.(*raftState).goFunc in goroutine 170
	/Users/jfrancoa/go/pkg/mod/github.com/hashicorp/raft@v1.5.0/state.go:147 +0x84
exit status 2
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
