### PR TITLE
tenant-offload: delete frozen tenants in cloud on tenant or class deletion

### DIFF
--- a/entities/modulecapabilities/offload.go
+++ b/entities/modulecapabilities/offload.go
@@ -26,8 +26,7 @@ type OffloadCloud interface {
 	Download(ctx context.Context, className, shardName, nodeName string) error
 	// Delete deletes content of a shard assigned to specific node in
 	// cloud provider (S3, Azure Blob storage, Google cloud storage)
-	// Careful: if shardName and nodeName is passed empty it will delete all shards
-	// in th cloud
+	// Careful: if shardName and nodeName is passed empty it will delete all class frozen shards in cloud storage
 	// {cloud_provider}://{configured_bucket}/{className}/{shardName}/{nodeName}/{shard content}
 	Delete(ctx context.Context, className, shardName, nodeName string) error
 }

--- a/entities/modulecapabilities/offload.go
+++ b/entities/modulecapabilities/offload.go
@@ -26,6 +26,8 @@ type OffloadCloud interface {
 	Download(ctx context.Context, className, shardName, nodeName string) error
 	// Delete deletes content of a shard assigned to specific node in
 	// cloud provider (S3, Azure Blob storage, Google cloud storage)
+	// Careful: if shardName and nodeName is passed empty it will delete all shards
+	// in th cloud
 	// {cloud_provider}://{configured_bucket}/{className}/{shardName}/{nodeName}/{shard content}
 	Delete(ctx context.Context, className, shardName, nodeName string) error
 }

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -233,6 +233,10 @@ func (m *Module) create(ctx context.Context) error {
 // cloud provider (S3, Azure Blob storage, Google cloud storage)
 // {cloud_provider}://{configured_bucket}/{className}/{shardName}/{nodeName}/{shard content}
 func (m *Module) Upload(ctx context.Context, className, shardName, nodeName string) error {
+	if err := validate(className, shardName, nodeName); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
@@ -263,6 +267,10 @@ func (m *Module) Upload(ctx context.Context, className, shardName, nodeName stri
 // cloud provider (S3, Azure Blob storage, Google cloud storage)
 // {dataPath}/{className}/{shardName}/{content}
 func (m *Module) Download(ctx context.Context, className, shardName, nodeName string) error {
+	if err := validate(className, shardName, nodeName); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 
@@ -294,16 +302,44 @@ func (m *Module) Download(ctx context.Context, className, shardName, nodeName st
 
 // Delete deletes content of a shard assigned to specific node in
 // cloud provider (S3, Azure Blob storage, Google cloud storage)
+// Careful: if shardName and nodeName is passed empty it will delete all shards
+// in th cloud
 // {cloud_provider}://{configured_bucket}/{className}/{shardName}/{nodeName}/{shard content}
 func (m *Module) Delete(ctx context.Context, className, shardName, nodeName string) error {
+	if className == "" {
+		return fmt.Errorf("can't pass empty class name")
+	}
+
+	if shardName == "" && nodeName != "" {
+		return fmt.Errorf("can't pass empty shard name")
+	}
+
+	if nodeName == "" && shardName != "" {
+		return fmt.Errorf("can't pass empty node name")
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
+
+	cloudPath := fmt.Sprintf("s3://%s/%s/%s/%s/*", m.Bucket, strings.ToLower(className), shardName, nodeName)
+
+	if shardName == "" && nodeName == "" {
+		cloudPath = fmt.Sprintf("s3://%s/%s/*", m.Bucket, strings.ToLower(className))
+	}
+
 	cmd := []string{
 		fmt.Sprintf("--endpoint-url=%s", m.Endpoint),
 		"rm",
-		fmt.Sprintf("s3://%s/%s/%s/%s/*", m.Bucket, strings.ToLower(className), shardName, nodeName),
+		cloudPath,
 	}
-	err := m.app.RunContext(ctx, cmd)
+
+	metric, err := monitoring.GetMetrics().TenantCloudDeleteDurations.GetMetricWithLabelValues("s3", className, shardName, nodeName)
+	if err == nil {
+		timer := prometheus.NewTimer(metric)
+		defer timer.ObserveDuration()
+	}
+
+	err = m.app.RunContext(ctx, cmd)
 	if err != nil && !strings.Contains(err.Error(), "no object found") {
 		return err
 	}
@@ -322,4 +358,20 @@ func dirSize(path string) (int64, error) {
 		return err
 	})
 	return size, err
+}
+
+func validate(className, shardName, nodeName string) error {
+	if className == "" {
+		return fmt.Errorf("can't pass empty class name")
+	}
+
+	if shardName == "" {
+		return fmt.Errorf("can't pass empty tenant name")
+	}
+
+	if nodeName == "" {
+		return fmt.Errorf("can't pass empty node name")
+	}
+
+	return nil
 }

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -302,8 +302,7 @@ func (m *Module) Download(ctx context.Context, className, shardName, nodeName st
 
 // Delete deletes content of a shard assigned to specific node in
 // cloud provider (S3, Azure Blob storage, Google cloud storage)
-// Careful: if shardName and nodeName is passed empty it will delete all shards
-// in th cloud
+// Careful: if shardName and nodeName is passed empty it will delete all class frozen shards in cloud storage
 // {cloud_provider}://{configured_bucket}/{className}/{shardName}/{nodeName}/{shard content}
 func (m *Module) Delete(ctx context.Context, className, shardName, nodeName string) error {
 	if className == "" {

--- a/test/modules/offload-s3/offlad_delete_test.go
+++ b/test/modules/offload-s3/offlad_delete_test.go
@@ -14,12 +14,14 @@ package test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -27,8 +29,170 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-func Test_UploadS3Journey(t *testing.T) {
-	t.Run("happy path with RF 2 upload to s3 provider", func(t *testing.T) {
+func Test_DeleteClassS3Journey(t *testing.T) {
+
+	t.Run("delete class, deleting frozen tenants", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
+
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+
+		compose, err := docker.New().
+			WithOffloadS3("offloading").
+			WithText2VecContextionary().
+			With3NodeCluster().
+			Start(ctx)
+		require.Nil(t, err)
+
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminate test containers: %s", err.Error())
+			}
+		}()
+
+		helper.SetupClient(compose.GetWeaviate().URI())
+
+		className := "MultiTenantClass"
+		testClass := models.Class{
+			Class:             className,
+			ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+			MultiTenancyConfig: &models.MultiTenancyConfig{
+				Enabled: true,
+			},
+			Properties: []*models.Property{
+				{
+					Name:     "name",
+					DataType: schema.DataTypeText.PropString(),
+				},
+			},
+		}
+		t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+			helper.CreateClass(t, &testClass)
+		})
+
+		tenantNames := []string{
+			"Tenant1", "Tenant2", "Tenant3",
+		}
+		t.Run("create tenants", func(t *testing.T) {
+			tenants := make([]*models.Tenant, len(tenantNames))
+			for i := range tenants {
+				tenants[i] = &models.Tenant{Name: tenantNames[i]}
+			}
+			helper.CreateTenants(t, className, tenants)
+		})
+
+		tenantObjects := []*models.Object{
+			{
+				ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
+				Class: className,
+				Properties: map[string]interface{}{
+					"name": tenantNames[0],
+				},
+				Tenant: tenantNames[0],
+			},
+			{
+				ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
+				Class: className,
+				Properties: map[string]interface{}{
+					"name": tenantNames[0],
+				},
+				Tenant: tenantNames[0],
+			},
+			{
+				ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
+				Class: className,
+				Properties: map[string]interface{}{
+					"name": tenantNames[0],
+				},
+				Tenant: tenantNames[0],
+			},
+		}
+
+		t.Run("add tenant objects", func(t *testing.T) {
+			for _, obj := range tenantObjects {
+				assert.Nil(t, helper.CreateObject(t, obj))
+			}
+		})
+
+		t.Run("verify object creation", func(t *testing.T) {
+			for _, obj := range tenantObjects {
+				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[0])
+				require.Nil(t, err)
+				assert.Equal(t, obj.Class, resp.Class)
+				assert.Equal(t, obj.Properties, resp.Properties)
+			}
+		})
+
+		t.Run("verify created objects length", func(t *testing.T) {
+			resp, err := helper.TenantListObjects(t, className, tenantNames[0])
+			require.Nil(t, err)
+			assert.Equal(t, len(tenantObjects), len(resp.Objects))
+		})
+
+		t.Run("updating tenant status", func(t *testing.T) {
+			helper.UpdateTenants(t, className, []*models.Tenant{
+				{
+					Name:           tenantNames[0],
+					ActivityStatus: models.TenantActivityStatusFROZEN,
+				},
+			})
+		})
+
+		t.Run("verify tenant status FREEZING", func(t *testing.T) {
+			resp, err := helper.GetTenants(t, className)
+			require.Nil(t, err)
+			for _, tn := range resp.Payload {
+				if tn.Name == tenantNames[0] {
+					require.Equal(t, types.TenantActivityStatusFREEZING, tn.ActivityStatus)
+					break
+				}
+			}
+		})
+
+		t.Run("verify tenant does not exists", func(t *testing.T) {
+			_, err = helper.TenantObject(t, tenantObjects[0].Class, tenantObjects[0].ID, tenantNames[0])
+			require.NotNil(t, err)
+		})
+
+		t.Run("verify tenant status", func(t *testing.T) {
+			assert.EventuallyWithT(t, func(at *assert.CollectT) {
+				resp, err := helper.GetTenants(t, className)
+				require.Nil(t, err)
+				for _, tn := range resp.Payload {
+					if tn.Name == tenantNames[0] {
+						assert.Equal(at, models.TenantActivityStatusFROZEN, tn.ActivityStatus)
+						break
+					}
+				}
+			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusFROZEN))
+		})
+
+		t.Run("verify deleting class", func(t *testing.T) {
+			helper.DeleteClass(t, className)
+		})
+
+		t.Run("verify frozen tenants deleted from cloud", func(t *testing.T) {
+			client, err := minio.New(compose.GetMinIO().URI(), &minio.Options{
+				Creds:  credentials.NewEnvAWS(),
+				Secure: false,
+			})
+			require.Nil(t, err)
+
+			count := 0
+			for obj := range client.ListObjects(ctx, "offloading", minio.ListObjectsOptions{Prefix: strings.ToLower(className)}) {
+				count++
+				t.Log(obj.Key)
+			}
+			require.Nil(t, err)
+			require.Zero(t, count)
+		})
+	})
+}
+
+func Test_DeleteAndRecreateS3Journey(t *testing.T) {
+	t.Run("create tenant, freeze, delete, re-create", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 		t.Log("pre-instance env setup")
@@ -92,17 +256,17 @@ func Test_UploadS3Journey(t *testing.T) {
 				ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
 				Class: className,
 				Properties: map[string]interface{}{
-					"name": tenantNames[1],
+					"name": tenantNames[0],
 				},
-				Tenant: tenantNames[1],
+				Tenant: tenantNames[0],
 			},
 			{
 				ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
 				Class: className,
 				Properties: map[string]interface{}{
-					"name": tenantNames[2],
+					"name": tenantNames[0],
 				},
-				Tenant: tenantNames[2],
+				Tenant: tenantNames[0],
 			},
 		}
 
@@ -117,12 +281,18 @@ func Test_UploadS3Journey(t *testing.T) {
 		})
 
 		t.Run("verify object creation", func(t *testing.T) {
-			for i, obj := range tenantObjects {
-				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[i])
+			for _, obj := range tenantObjects {
+				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[0])
 				require.Nil(t, err)
 				assert.Equal(t, obj.Class, resp.Class)
 				assert.Equal(t, obj.Properties, resp.Properties)
 			}
+		})
+
+		t.Run("verify created objects length", func(t *testing.T) {
+			resp, err := helper.TenantListObjects(t, className, tenantNames[0])
+			require.Nil(t, err)
+			assert.Equal(t, len(tenantObjects), len(resp.Objects))
 		})
 
 		t.Run("updating tenant status", func(t *testing.T) {
@@ -163,135 +333,24 @@ func Test_UploadS3Journey(t *testing.T) {
 			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusFROZEN))
 		})
 
-		t.Run("add objects to frozen tenant shall fail", func(t *testing.T) {
-			t.Run("add frozen tenant objects", func(t *testing.T) {
-				for _, obj := range tenantObjects {
-					obj.Tenant = tenantNames[0]
-					params := objects.NewObjectsCreateParams().WithBody(obj)
-					_, err := helper.Client(t).Objects.ObjectsCreate(params, nil)
-					require.NotNil(t, err)
-				}
-			})
-
-			tenantRefs := []*models.Object{
-				{
-					ID:    "169b62a7-ef1c-481d-8fb0-27f11716bde7",
-					Class: className,
-					Properties: map[string]interface{}{
-						"name":        tenantNames[0],
-						"mutableProp": "ref#0",
-					},
-					Tenant: tenantNames[0],
-				},
-			}
-
-			t.Run("add frozen tenant object references", func(t *testing.T) {
-				for i, obj := range tenantObjects {
-					ref := &models.SingleRef{Beacon: helper.NewBeacon(className, tenantRefs[0].ID)}
-					params := objects.NewObjectsClassReferencesCreateParams().
-						WithClassName(className).WithID(obj.ID).WithBody(ref).WithPropertyName("refProp").WithTenant(&tenantNames[i])
-					_, err := helper.Client(t).Objects.ObjectsClassReferencesCreate(params, nil)
-					require.NotNil(t, err)
-				}
-			})
-		})
-	})
-
-	t.Run("node is down while RF is 3, one weaviate node is down", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
-		t.Log("pre-instance env setup")
-		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
-		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
-
-		compose, err := docker.New().
-			WithOffloadS3("weaviate-offload").
-			WithText2VecContextionary().
-			With3NodeCluster().
-			Start(ctx)
-		require.Nil(t, err)
-
-		defer func() {
-			if err := compose.Terminate(ctx); err != nil {
-				t.Fatalf("failed to terminate test containers: %s", err.Error())
-			}
-		}()
-
-		helper.SetupClient(compose.GetWeaviate().URI())
-
-		className := "MultiTenantClass"
-		testClass := models.Class{
-			Class:             className,
-			ReplicationConfig: &models.ReplicationConfig{Factor: 3},
-			MultiTenancyConfig: &models.MultiTenancyConfig{
-				Enabled: true,
-			},
-			Properties: []*models.Property{
-				{
-					Name:     "name",
-					DataType: schema.DataTypeText.PropString(),
-				},
-			},
-		}
-		t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
-			helper.CreateClass(t, &testClass)
+		t.Run("delete tenant", func(t *testing.T) {
+			err := helper.DeleteTenants(t, className, []string{tenantNames[0]})
+			require.Nil(t, err)
 		})
 
-		tenantNames := []string{
-			"Tenant1", "Tenant2", "Tenant3",
-		}
-		t.Run("create tenants", func(t *testing.T) {
-			tenants := make([]*models.Tenant, len(tenantNames))
-			for i := range tenants {
-				tenants[i] = &models.Tenant{Name: tenantNames[i]}
-			}
-			helper.CreateTenants(t, className, tenants)
+		t.Run("create tenant", func(t *testing.T) {
+			helper.CreateTenants(t, className, []*models.Tenant{{Name: tenantNames[0]}})
 		})
 
-		tenantObjects := []*models.Object{
-			{
-				ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
-				Class: className,
-				Properties: map[string]interface{}{
-					"name": tenantNames[0],
-				},
-				Tenant: tenantNames[0],
-			},
-			{
-				ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
-				Class: className,
-				Properties: map[string]interface{}{
-					"name": tenantNames[1],
-				},
-				Tenant: tenantNames[1],
-			},
-			{
-				ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
-				Class: className,
-				Properties: map[string]interface{}{
-					"name": tenantNames[2],
-				},
-				Tenant: tenantNames[2],
-			},
-		}
-
-		t.Run("add tenant objects", func(t *testing.T) {
-			for _, obj := range tenantObjects {
-				assert.Nil(t, helper.CreateObject(t, obj))
-			}
+		t.Run("add tenant 1 object", func(t *testing.T) {
+			assert.Nil(t, helper.CreateObject(t, tenantObjects[0]))
 		})
 
 		t.Run("verify object creation", func(t *testing.T) {
-			for i, obj := range tenantObjects {
-				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[i])
-				require.Nil(t, err)
-				assert.Equal(t, obj.Class, resp.Class)
-				assert.Equal(t, obj.Properties, resp.Properties)
-			}
-		})
-
-		t.Run("StopNode-2", func(t *testing.T) {
-			require.Nil(t, compose.Stop(ctx, compose.GetWeaviateNode2().Name(), nil))
+			resp, err := helper.TenantObject(t, tenantObjects[0].Class, tenantObjects[0].ID, tenantNames[0])
+			require.Nil(t, err)
+			assert.Equal(t, tenantObjects[0].Class, resp.Class)
+			assert.Equal(t, tenantObjects[0].Properties, resp.Properties)
 		})
 
 		t.Run("updating tenant status", func(t *testing.T) {
@@ -303,28 +362,7 @@ func Test_UploadS3Journey(t *testing.T) {
 			})
 		})
 
-		t.Run("verify tenant status FREEZING", func(t *testing.T) {
-			resp, err := helper.GetTenants(t, className)
-			require.Nil(t, err)
-
-			for _, tn := range resp.Payload {
-				if tn.Name == tenantNames[0] {
-					require.Equal(t, types.TenantActivityStatusFREEZING, tn.ActivityStatus)
-					break
-				}
-			}
-		})
-
-		t.Run("StartNode-2", func(t *testing.T) {
-			require.Nil(t, compose.Start(ctx, compose.GetWeaviateNode2().Name()))
-		})
-
-		t.Run("verify tenant does not exists", func(t *testing.T) {
-			_, err = helper.TenantObject(t, tenantObjects[0].Class, tenantObjects[0].ID, tenantNames[0])
-			require.NotNil(t, err)
-		})
-
-		t.Run("verify tenant status", func(t *testing.T) {
+		t.Run("verify tenant status is FROZEN", func(t *testing.T) {
 			assert.EventuallyWithT(t, func(at *assert.CollectT) {
 				resp, err := helper.GetTenants(t, className)
 				require.Nil(t, err)
@@ -336,133 +374,20 @@ func Test_UploadS3Journey(t *testing.T) {
 				}
 			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusFROZEN))
 		})
-	})
-
-	t.Run("unhappy path with RF 3, cloud provider is down", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
-
-		t.Log("pre-instance env setup")
-		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
-		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
-
-		compose, err := docker.New().
-			WithOffloadS3("offloading").
-			WithWeaviateEnv("OFFLOAD_TIMEOUT", "2").
-			WithText2VecContextionary().
-			With3NodeCluster().
-			Start(ctx)
-		require.Nil(t, err)
-
-		defer func() {
-			if err := compose.Terminate(ctx); err != nil {
-				t.Fatalf("failed to terminate test containers: %s", err.Error())
-			}
-		}()
-
-		helper.SetupClient(compose.GetWeaviate().URI())
-
-		className := "MultiTenantClass"
-		testClass := models.Class{
-			Class:             className,
-			ReplicationConfig: &models.ReplicationConfig{Factor: 3},
-			MultiTenancyConfig: &models.MultiTenancyConfig{
-				Enabled: true,
-			},
-			Properties: []*models.Property{
-				{
-					Name:     "name",
-					DataType: schema.DataTypeText.PropString(),
-				},
-			},
-		}
-		t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
-			helper.CreateClass(t, &testClass)
-		})
-
-		tenantNames := []string{
-			"Tenant1", "Tenant2", "Tenant3",
-		}
-		t.Run("create tenants", func(t *testing.T) {
-			tenants := make([]*models.Tenant, len(tenantNames))
-			for i := range tenants {
-				tenants[i] = &models.Tenant{Name: tenantNames[i]}
-			}
-			helper.CreateTenants(t, className, tenants)
-		})
-
-		tenantObjects := []*models.Object{
-			{
-				ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
-				Class: className,
-				Properties: map[string]interface{}{
-					"name": tenantNames[0],
-				},
-				Tenant: tenantNames[0],
-			},
-			{
-				ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
-				Class: className,
-				Properties: map[string]interface{}{
-					"name": tenantNames[1],
-				},
-				Tenant: tenantNames[1],
-			},
-			{
-				ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
-				Class: className,
-				Properties: map[string]interface{}{
-					"name": tenantNames[2],
-				},
-				Tenant: tenantNames[2],
-			},
-		}
-
-		t.Run("add tenant objects", func(t *testing.T) {
-			for _, obj := range tenantObjects {
-				assert.Nil(t, helper.CreateObject(t, obj))
-			}
-		})
-
-		t.Run("verify object creation", func(t *testing.T) {
-			for i, obj := range tenantObjects {
-				resp, err := helper.TenantObject(t, obj.Class, obj.ID, tenantNames[i])
-				require.Nil(t, err)
-				assert.Equal(t, obj.Class, resp.Class)
-				assert.Equal(t, obj.Properties, resp.Properties)
-			}
-		})
-
-		t.Run("terminate Minio", func(t *testing.T) {
-			require.Nil(t, compose.TerminateContainer(ctx, docker.MinIO))
-		})
 
 		t.Run("updating tenant status", func(t *testing.T) {
 			helper.UpdateTenants(t, className, []*models.Tenant{
 				{
 					Name:           tenantNames[0],
-					ActivityStatus: models.TenantActivityStatusFROZEN,
+					ActivityStatus: models.TenantActivityStatusHOT,
 				},
 			})
 		})
 
-		t.Run("verify tenant status FREEZING", func(t *testing.T) {
-			resp, err := helper.GetTenants(t, className)
-			require.Nil(t, err)
-
-			for _, tn := range resp.Payload {
-				if tn.Name == tenantNames[0] {
-					require.Equal(t, types.TenantActivityStatusFREEZING, tn.ActivityStatus)
-					break
-				}
-			}
-		})
-
-		t.Run("verify tenant status HOT", func(xt *testing.T) {
+		t.Run("verify tenant status is HOT", func(t *testing.T) {
 			assert.EventuallyWithT(t, func(at *assert.CollectT) {
-				resp, err := helper.GetTenants(xt, className)
+				resp, err := helper.GetTenants(t, className)
 				require.Nil(t, err)
-
 				for _, tn := range resp.Payload {
 					if tn.Name == tenantNames[0] {
 						assert.Equal(at, models.TenantActivityStatusHOT, tn.ActivityStatus)
@@ -470,6 +395,14 @@ func Test_UploadS3Journey(t *testing.T) {
 					}
 				}
 			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusHOT))
+		})
+
+		t.Run("verify created object", func(t *testing.T) {
+			resp, err := helper.TenantListObjects(t, className, tenantNames[0])
+			require.Nil(t, err)
+			assert.Equal(t, 1, len(resp.Objects))
+			assert.Equal(t, tenantObjects[0].Class, resp.Objects[0].Class)
+			assert.Equal(t, tenantObjects[0].Properties, resp.Objects[0].Properties)
 		})
 	})
 }

--- a/test/modules/offload-s3/offlad_delete_test.go
+++ b/test/modules/offload-s3/offlad_delete_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func Test_DeleteClassS3Journey(t *testing.T) {
-
 	t.Run("delete class, deleting frozen tenants", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -57,6 +57,7 @@ type PrometheusMetrics struct {
 	// offload metric
 	TenantCloudOffloadDurations       *prometheus.SummaryVec
 	TenantCloudLoadDurations          *prometheus.SummaryVec
+	TenantCloudDeleteDurations        *prometheus.SummaryVec
 	TenantCloudOffloadDataTransferred *prometheus.CounterVec
 	TenantCloudLoadDataTransferred    *prometheus.CounterVec
 
@@ -191,6 +192,7 @@ func (pm *PrometheusMetrics) DeleteClass(className string) error {
 	// delete offload metric
 	pm.TenantCloudOffloadDurations.DeletePartialMatch(labels)
 	pm.TenantCloudLoadDurations.DeletePartialMatch(labels)
+	pm.TenantCloudDeleteDurations.DeletePartialMatch(labels)
 	pm.TenantCloudOffloadDataTransferred.DeletePartialMatch(labels)
 	pm.TenantCloudLoadDataTransferred.DeletePartialMatch(labels)
 
@@ -447,6 +449,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		}, []string{"backend_name", "class_name", "tenant_name", "node_name"}),
 		TenantCloudLoadDurations: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "tenant_offload_down_durations_ms",
+			Help: "tenant onload durations",
+		}, []string{"backend_name", "class_name", "tenant_name", "node_name"}),
+		TenantCloudDeleteDurations: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "tenant_offload_delete_durations_ms",
 			Help: "tenant onload durations",
 		}, []string{"backend_name", "class_name", "tenant_name", "node_name"}),
 		TenantCloudOffloadDataTransferred: promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
### What's being changed:
with this PR change in case of `tenant` or `class` deletion request and the offload module is enabled it will delete the frozen tenants 

this PR adds
-  functionality 
- metric for deletion 
- acceptance test

### Links 
 - https://github.com/weaviate/weaviate-issues/issues/22
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
