### PR TITLE
Add Generative Anthropic e2e tests

### DIFF
--- a/modules/generative-anthropic/clients/anthropic.go
+++ b/modules/generative-anthropic/clients/anthropic.go
@@ -151,20 +151,19 @@ func (a *anthropic) getParameters(cfg moduletools.ClassConfig, options interface
 	}
 
 	if params.Model == "" {
-		model := settings.Model()
-		params.Model = model
+		params.Model = settings.Model()
 	}
 	if params.Temperature == nil {
 		temperature := settings.Temperature()
 		params.Temperature = &temperature
 	}
 	if params.TopK == nil {
-		k := settings.K()
-		params.TopK = &k
+		topK := settings.TopK()
+		params.TopK = &topK
 	}
 	if params.TopP == nil {
-		p := settings.P()
-		params.TopP = &p
+		topP := settings.TopP()
+		params.TopP = &topP
 	}
 	if len(params.StopSequences) == 0 {
 		params.StopSequences = settings.StopSequences()

--- a/modules/generative-anthropic/config/class_settings.go
+++ b/modules/generative-anthropic/config/class_settings.go
@@ -24,16 +24,9 @@ const (
 	maxTokensProperty     = "maxTokens"
 	stopSequencesProperty = "stopSequences"
 	temperatureProperty   = "temperature"
-	topKProperty          = "k"
-	topPProperty          = "p"
+	topKProperty          = "topK"
+	topPProperty          = "topP"
 )
-
-var availableAnthropicModels = []string{
-	"claude-3-5-sonnet-20240620",
-	"claude-3-opus-20240229",
-	"claude-3-sonnet-20240229",
-	"claude-3-haiku-20240307",
-}
 
 // todo: anthropic make a distinction between input and output tokens
 // so have a context window and a max output tokens, while the max
@@ -52,8 +45,8 @@ var (
 	DefaultAnthropicTemperature = 1.0
 	// DefaultAnthropicMaxTokens - 4096 is the max output tokens, input tokens are typically much larger
 	DefaultAnthropicMaxTokens     = 4096
-	DefaultAnthropicK             = 0
-	DefaultAnthropicP             = 0.0
+	DefaultAnthropicTopK          = 0
+	DefaultAnthropicTopP          = 0.0
 	DefaultAnthropicStopSequences = []string{}
 )
 
@@ -72,12 +65,6 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		// we would receive a nil-config on cross-class requests, such as Explore{}
 		return errors.New("empty config")
 	}
-	model := ic.Model()
-
-	if !basesettings.ValidateSetting[string](model, availableAnthropicModels) {
-		return errors.Errorf("wrong Anthropic model name, available model names are: %v", availableAnthropicModels)
-	}
-
 	return nil
 }
 
@@ -134,12 +121,12 @@ func (ic *classSettings) Temperature() float64 {
 	return *ic.getFloatProperty(temperatureProperty, &DefaultAnthropicTemperature)
 }
 
-func (ic *classSettings) K() int {
-	return *ic.getIntProperty(topKProperty, &DefaultAnthropicK)
+func (ic *classSettings) TopK() int {
+	return *ic.getIntProperty(topKProperty, &DefaultAnthropicTopK)
 }
 
-func (ic *classSettings) P() float64 {
-	return *ic.getFloatProperty(topPProperty, &DefaultAnthropicP)
+func (ic *classSettings) TopP() float64 {
+	return *ic.getFloatProperty(topPProperty, &DefaultAnthropicTopP)
 }
 
 func (ic *classSettings) StopSequences() []string {

--- a/modules/generative-anthropic/config/class_settings_test.go
+++ b/modules/generative-anthropic/config/class_settings_test.go
@@ -14,7 +14,6 @@ package config
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/moduletools"
 )
@@ -26,8 +25,8 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantModel         string
 		wantMaxTokens     int
 		wantTemperature   float64
-		wantK             int
-		wantP             float64
+		wantTopK          int
+		wantTopP          float64
 		wantStopSequences []string
 		wantBaseURL       string
 		wantErr           error
@@ -40,8 +39,8 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantModel:         "claude-3-5-sonnet-20240620",
 			wantMaxTokens:     4096,
 			wantTemperature:   1.0,
-			wantK:             0,
-			wantP:             0.0,
+			wantTopK:          0,
+			wantTopP:          0.0,
 			wantStopSequences: []string{},
 			wantBaseURL:       "https://api.anthropic.com",
 			wantErr:           nil,
@@ -53,8 +52,8 @@ func Test_classSettings_Validate(t *testing.T) {
 					"model":         "claude-3-opus-20240229",
 					"maxTokens":     3000,
 					"temperature":   0.7,
-					"k":             5,
-					"p":             0.9,
+					"topK":          5,
+					"topP":          0.9,
 					"stopSequences": []string{"stop1", "stop2"},
 					"baseURL":       "https://custom.anthropic.api",
 				},
@@ -62,21 +61,27 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantModel:         "claude-3-opus-20240229",
 			wantMaxTokens:     3000,
 			wantTemperature:   0.7,
-			wantK:             5,
-			wantP:             0.9,
+			wantTopK:          5,
+			wantTopP:          0.9,
 			wantStopSequences: []string{"stop1", "stop2"},
 			wantBaseURL:       "https://custom.anthropic.api",
 			wantErr:           nil,
 		},
 		{
-			name: "wrong model configured",
+			name: "new model name configured",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"model": "wrong-model",
+					"model": "some-new-model-name",
 				},
 			},
-			wantErr: errors.Errorf("wrong Anthropic model name, available model names are: " +
-				"[claude-3-5-sonnet-20240620 claude-3-opus-20240229 claude-3-sonnet-20240229 claude-3-haiku-20240307]"),
+			wantModel:         "some-new-model-name",
+			wantMaxTokens:     4096,
+			wantTemperature:   1.0,
+			wantTopK:          0,
+			wantTopP:          0.0,
+			wantStopSequences: []string{},
+			wantBaseURL:       "https://api.anthropic.com",
+			wantErr:           nil,
 		},
 		{
 			name: "default settings with claude-3-haiku-20240307",
@@ -88,8 +93,8 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantModel:         "claude-3-haiku-20240307",
 			wantMaxTokens:     4096,
 			wantTemperature:   1.0,
-			wantK:             0,
-			wantP:             0.0,
+			wantTopK:          0,
+			wantTopP:          0.0,
 			wantStopSequences: []string{},
 			wantBaseURL:       "https://api.anthropic.com",
 			wantErr:           nil,
@@ -105,8 +110,8 @@ func Test_classSettings_Validate(t *testing.T) {
 				assert.Equal(t, tt.wantModel, ic.Model())
 				assert.Equal(t, tt.wantMaxTokens, ic.MaxTokens())
 				assert.Equal(t, tt.wantTemperature, ic.Temperature())
-				assert.Equal(t, tt.wantK, ic.K())
-				assert.Equal(t, tt.wantP, ic.P())
+				assert.Equal(t, tt.wantTopK, ic.TopK())
+				assert.Equal(t, tt.wantTopP, ic.TopP())
 				assert.Equal(t, tt.wantStopSequences, ic.StopSequences())
 				assert.Equal(t, tt.wantBaseURL, ic.BaseURL())
 			}

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -326,7 +326,8 @@ func (d *Compose) WithGenerativeOctoAI(apiKey string) *Compose {
 	return d
 }
 
-func (d *Compose) WithGenerativeAnthropic() *Compose {
+func (d *Compose) WithGenerativeAnthropic(apiKey string) *Compose {
+	d.weaviateEnvs["ANTHROPIC_APIKEY"] = apiKey
 	d.enableModules = append(d.enableModules, modgenerativeanthropic.Name)
 	return d
 }

--- a/test/modules/generative-anthropic/generative_anthropic_test.go
+++ b/test/modules/generative-anthropic/generative_anthropic_test.go
@@ -1,0 +1,100 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/planets"
+)
+
+func testGenerativeAnthropic(host string) func(t *testing.T) {
+	return func(t *testing.T) {
+		helper.SetupClient(host)
+		// Data
+		data := planets.Planets
+		// Define class
+		class := planets.BaseClass("PlanetsGenerativeTest")
+		class.VectorConfig = map[string]models.VectorConfig{
+			"description": {
+				Vectorizer: map[string]interface{}{
+					"text2vec-transformers": map[string]interface{}{
+						"properties":         []interface{}{"description"},
+						"vectorizeClassName": false,
+					},
+				},
+				VectorIndexType: "flat",
+			},
+		}
+		tests := []struct {
+			name            string
+			generativeModel string
+		}{
+			{
+				name:            "claude-3-5-sonnet-20240620",
+				generativeModel: "claude-3-5-sonnet-20240620",
+			},
+			{
+				name:            "claude-3-opus-20240229",
+				generativeModel: "claude-3-opus-20240229",
+			},
+			{
+				name:            "claude-3-sonnet-20240229",
+				generativeModel: "claude-3-sonnet-20240229",
+			},
+			{
+				name:            "claude-3-haiku-20240307",
+				generativeModel: "claude-3-haiku-20240307",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				class.ModuleConfig = map[string]interface{}{
+					"generative-anthropic": map[string]interface{}{
+						"model": tt.generativeModel,
+					},
+				}
+				// create schema
+				helper.CreateClass(t, class)
+				defer helper.DeleteClass(t, class.Class)
+				// create objects
+				t.Run("create objects", func(t *testing.T) {
+					planets.InsertObjects(t, class.Class)
+				})
+				t.Run("check objects existence", func(t *testing.T) {
+					for _, planet := range data {
+						t.Run(planet.ID.String(), func(t *testing.T) {
+							obj, err := helper.GetObject(t, class.Class, planet.ID, "vector")
+							require.NoError(t, err)
+							require.NotNil(t, obj)
+							require.Len(t, obj.Vectors, 1)
+							assert.True(t, len(obj.Vectors["description"]) > 0)
+						})
+					}
+				})
+				// generative task
+				t.Run("create a tweet", func(t *testing.T) {
+					planets.CreateTweetTest(t, class.Class)
+				})
+				t.Run("create a tweet with params", func(t *testing.T) {
+					params := fmt.Sprintf("anthropic:{topP:0.9 topK:90 model:%q}", tt.generativeModel)
+					planets.CreateTweetTestWithParams(t, class.Class, params)
+				})
+			})
+		}
+	}
+}

--- a/test/modules/generative-anthropic/setup_test.go
+++ b/test/modules/generative-anthropic/setup_test.go
@@ -1,0 +1,53 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+func TestGenerativeAnthropic_SingleNode(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_APIKEY")
+	if apiKey == "" {
+		t.Skip("skipping, ANTHROPIC_APIKEY environment variable not present")
+	}
+	ctx := context.Background()
+	compose, err := createSingleNodeEnvironment(ctx, apiKey)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+	endpoint := compose.GetWeaviate().URI()
+
+	t.Run("tests", testGenerativeAnthropic(endpoint))
+}
+
+func createSingleNodeEnvironment(ctx context.Context, apiKey string,
+) (compose *docker.DockerCompose, err error) {
+	compose, err = composeModules(apiKey).
+		WithWeaviate().
+		WithWeaviateEnv("EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		Start(ctx)
+	return
+}
+
+func composeModules(apiKey string) (composeModules *docker.Compose) {
+	composeModules = docker.New().
+		WithText2VecTransformers().
+		WithGenerativeAnthropic(apiKey)
+	return
+}

--- a/test/modules/many-modules/setup_test.go
+++ b/test/modules/many-modules/setup_test.go
@@ -92,7 +92,7 @@ func composeModules() (composeModules *docker.Compose) {
 		WithGenerativePaLM(os.Getenv("PALM_APIKEY")).
 		WithGenerativeAWS(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN")).
 		WithGenerativeAnyscale().
-		WithGenerativeAnthropic().
+		WithGenerativeAnthropic(os.Getenv("ANTHROPIC_APIKEY")).
 		WithQnAOpenAI().
 		WithRerankerCohere().
 		WithRerankerVoyageAI()


### PR DESCRIPTION
### What's being changed:

This PR adds generative-anthropic e2e tests:
- removes the model name validation
- unifies the names of the `topP` and `topK` settings (renamed from `K` to `topK` and `P` to `topP`)
- adds e2e generative-anthropic e2e tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
