### PR TITLE
Fix compressor logger for scalar quantization

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -350,6 +350,7 @@ func NewHNSWSQCompressor(
 		compressedStore: store,
 		storeId:         binary.BigEndian.PutUint64,
 		loadId:          binary.BigEndian.Uint64,
+		logger:          logger,
 	}
 	sqVectorsCompressor.initCompressedStore()
 	sqVectorsCompressor.cache = cache.NewShardedByteLockCache(
@@ -377,6 +378,7 @@ func RestoreHNSWSQCompressor(
 		compressedStore: store,
 		storeId:         binary.BigEndian.PutUint64,
 		loadId:          binary.BigEndian.Uint64,
+		logger:          logger,
 	}
 	sqVectorsCompressor.initCompressedStore()
 	sqVectorsCompressor.cache = cache.NewShardedByteLockCache(


### PR DESCRIPTION
### What's being changed:
- https://github.com/weaviate/weaviate/pull/5162 added additional logging to the quantizers
- When scalar quantization was merged this was not included
- Fixes a recoverable panic as the logger is otherwise nil

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
