### PR TITLE
Add more tests for search_dedup

### DIFF
--- a/adapters/repos/db/search_deduplication.go
+++ b/adapters/repos/db/search_deduplication.go
@@ -28,7 +28,7 @@ func searchResultDedup(out []*storobj.Object, dists []float32) ([]*storobj.Objec
 	filteredScores := make([]float32, 0, len(dists))
 
 	i := 0
-	// Iterate over all the objects, the corresponding score is always dists[i] for object at index i
+	// Iterate over all the objects, the corresponding score is always dists[j] for object at index j
 	for j, obj := range out {
 		// If we have encountered the object before lookup the score of the current object vs the previous one. If
 		// the score is better then we keep this one by replacing it in filtered arrays in place, if not we ignore


### PR DESCRIPTION
Rewrite existing tests as table-driven and add more test scenarios. This was done in the hopes of finding a bug in the dedup logic, but according to the tests it behaves exactly as it should

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
