### PR TITLE
Add metrics for batch sizes

### DIFF
--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -89,6 +89,9 @@ func (db *DB) BatchPutObjects(ctx context.Context, objs objects.BatchObjects,
 	for class, index := range indexByClass {
 		queue := objectByClass[class]
 		errs := index.putObjectBatch(ctx, queue.objects, repl, schemaVersion)
+		index.metrics.BatchCount(len(queue.objects))
+		index.metrics.BatchCountBytes(estimateStorBatchMemory(queue.objects))
+
 		// remove index from map to skip releasing its lock in defer
 		indexByClass[class] = nil
 		index.dropIndex.RUnlock()
@@ -215,6 +218,15 @@ func estimateBatchMemory(objs objects.BatchObjects) int64 {
 	var sum int64
 	for _, item := range objs {
 		sum += memwatch.EstimateObjectMemory(item.Object)
+	}
+
+	return sum
+}
+
+func estimateStorBatchMemory(objs []*storobj.Object) int64 {
+	var sum int64
+	for _, item := range objs {
+		sum += memwatch.EstimateStorObjectMemory(item)
 	}
 
 	return sum

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -24,6 +24,8 @@ type Metrics struct {
 	monitoring            bool
 	batchTime             prometheus.ObserverVec
 	batchDeleteTime       prometheus.ObserverVec
+	batchCount            prometheus.Counter
+	batchCountBytes       prometheus.Counter
 	objectTime            prometheus.ObserverVec
 	startupDurations      prometheus.ObserverVec
 	filteredVectorFilter  prometheus.Observer
@@ -60,6 +62,14 @@ func NewMetrics(
 		"shard_name": shardName,
 	})
 	m.batchDeleteTime = prom.BatchDeleteTime.MustCurryWith(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+	m.batchCount = prom.BatchCount.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+	m.batchCountBytes = prom.BatchCountBytes.With(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
 	})
@@ -267,6 +277,22 @@ func (m *Metrics) BatchDelete(start time.Time, op string) {
 	m.batchDeleteTime.With(prometheus.Labels{
 		"operation": op,
 	}).Observe(float64(took) / float64(time.Millisecond))
+}
+
+func (m *Metrics) BatchCount(size int) {
+	if !m.monitoring {
+		return
+	}
+
+	m.batchCount.Add(float64(size))
+}
+
+func (m *Metrics) BatchCountBytes(size int64) {
+	if !m.monitoring {
+		return
+	}
+
+	m.batchCountBytes.Add(float64(size))
 }
 
 func (m *Metrics) FilteredVectorFilter(dur time.Duration) {

--- a/tools/dev/grafana/dashboards/importing.json
+++ b/tools/dev/grafana/dashboards/importing.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -35,6 +38,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -46,6 +52,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -92,10 +99,13 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -126,6 +136,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -137,6 +150,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -182,10 +196,13 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -241,6 +258,8 @@
       },
       "id": 11,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -250,9 +269,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "11.0.1",
       "targets": [
         {
           "datasource": {
@@ -280,6 +300,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -291,6 +314,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -337,10 +361,13 @@
         "legend": {
           "calcs": [],
           "displayMode": "table",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -382,6 +409,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -393,6 +423,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -437,10 +468,13 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -494,6 +528,8 @@
       },
       "id": 15,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -503,9 +539,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "11.0.1",
       "targets": [
         {
           "datasource": {
@@ -565,9 +602,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "11.0.1",
       "targets": [
         {
           "datasource": {
@@ -589,13 +628,16 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "Count of active segments across all classes and shards, shown by type.",
+      "description": "Rate of the number of objects processed in a batch",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -607,6 +649,108 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(batch_objects_processed_total[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Rate Batch Objects Processed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Count of active segments across all classes and shards, shown by type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -655,10 +799,13 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -743,9 +890,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.3.3",
+      "pluginVersion": "11.0.1",
       "targets": [
         {
           "datasource": {
@@ -798,6 +947,9 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -809,6 +961,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -854,10 +1007,13 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -875,11 +1031,112 @@
       ],
       "title": "Heap in use (bytes)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Rate of the number of bytes processed in a batch",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(batch_objects_processed_bytes[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Rate Batch Objects Processed Bytes",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 34,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": []
@@ -888,6 +1145,7 @@
     "from": "now-15m",
     "to": "now"
   },
+  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "",
   "title": "Importing Data into Weaviate",

--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -313,7 +313,12 @@ func EstimateObjectMemory(object *models.Object) int64 {
 }
 
 func EstimateStorObjectMemory(object *storobj.Object) int64 {
-	return int64(len(object.Vector)*4 + 49)
+	// Note: The estimation is not super accurate. It assumes that the
+	// memory is mostly used by the vector of float32 + the fixed
+	// overhead. It assumes a fixed overhead of 46 Bytes per object
+	// (30 Bytes from the data field models.Object + 16 Bytes from
+	// remaining data fields of storobj.Object).
+	return int64(len(object.Vector)*4 + 46)
 }
 
 func EstimateObjectDeleteMemory() int64 {

--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 const (
@@ -309,6 +310,10 @@ func EstimateObjectMemory(object *models.Object) int64 {
 	// prevent OOM crashes. Given the fuzziness and async style of the
 	// memtracking somewhat decent estimate should be good enough.
 	return int64(len(object.Vector)*4 + 30)
+}
+
+func EstimateStorObjectMemory(object *storobj.Object) int64 {
+	return int64(len(object.Vector)*4 + 49)
 }
 
 func EstimateObjectDeleteMemory() int64 {

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -28,6 +28,8 @@ type Config struct {
 type PrometheusMetrics struct {
 	BatchTime                         *prometheus.HistogramVec
 	BatchDeleteTime                   *prometheus.SummaryVec
+	BatchCount                        *prometheus.CounterVec
+	BatchCountBytes                   *prometheus.CounterVec
 	ObjectsTime                       *prometheus.SummaryVec
 	LSMBloomFilters                   *prometheus.SummaryVec
 	AsyncOperations                   *prometheus.GaugeVec
@@ -227,6 +229,16 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "batch_delete_durations_ms",
 			Help: "Duration in ms of a single delete batch",
 		}, []string{"operation", "class_name", "shard_name"}),
+
+		BatchCount: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "batch_objects_processed_total",
+			Help: "Number of objects processed in a batch",
+		}, []string{"class_name", "shard_name"}),
+
+		BatchCountBytes: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "batch_objects_processed_bytes",
+			Help: "Number of bytes processed in a batch",
+		}, []string{"class_name", "shard_name"}),
 
 		ObjectsTime: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "objects_durations_ms",


### PR DESCRIPTION
### What's being changed:
Add two new metrics (counters) `batch_objects_processed_total` and `batch_objects_processed_bytes` that allow to see the number of objects in a batch and their total size in bytes.

Add visualization panels in Grafana dashboard `Importing Data into Weaviate`.

Why:
This PR adds feature request: #5219 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
