### PR TITLE
Fix targets for near vector GQL subsearch

### DIFF
--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -98,7 +98,7 @@ func hybridOperands(classObject *graphql.Object,
 									graphql.InputObjectConfig{
 										Name:        fmt.Sprintf("%sNearVectorInpObj", prefixName),
 										Description: "Near vector search",
-										Fields:      common_filters.NearVectorFields(prefixName, false),
+										Fields:      common_filters.NearVectorFields(prefixName, true),
 									},
 								),
 							},

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client==4.7.0-rc.0
+weaviate-client==4.7.0-rc.2
 
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1


### PR DESCRIPTION
### What's being changed:

Adds targets (needed for vector per target vector search) to the nearVector subsearch of hybrid

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
