### PR TITLE
Disable certainty for multi vector search

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -14,6 +14,7 @@ package v1
 import (
 	"fmt"
 
+	"github.com/weaviate/weaviate/entities/schema/configvalidation"
 	"github.com/weaviate/weaviate/usecases/config"
 
 	"github.com/go-openapi/strfmt"
@@ -25,11 +26,9 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
-	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/byteops"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate"
@@ -804,6 +803,12 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 		Vectors:            prop.Vectors,
 	}
 
+	if vectorSearch && configvalidation.CheckCertaintyCompatibility(class, targetVectors) != nil {
+		props.Certainty = false
+	} else {
+		props.Certainty = prop.Certainty
+	}
+
 	// return all named vectors if vector is true
 	if prop.Vector && len(class.VectorConfig) > 0 {
 		props.Vectors = make([]string, 0, len(class.VectorConfig))
@@ -811,24 +816,6 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 			props.Vectors = append(props.Vectors, vectorName)
 		}
 
-	}
-
-	if vectorSearch {
-		vectorIndex, err := schemaConfig.TypeAssertVectorIndex(class, targetVectors)
-		if err != nil {
-			return props, errors.Wrap(err, "get vector index config from class")
-		}
-
-		certainty := false
-		for _, conf := range vectorIndex {
-			if conf.DistanceName() == common.DistanceCosine && prop.Certainty {
-				certainty = true
-			} else {
-				certainty = false
-				break // all vector indexes must be cosine for certainty
-			}
-		}
-		props.Certainty = certainty
 	}
 
 	return props, nil

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -138,17 +138,17 @@ func TestGRPCRequest(t *testing.T) {
 					VectorConfig: map[string]models.VectorConfig{
 						"custom": {
 							VectorIndexType:   "hnsw",
-							VectorIndexConfig: hnsw.UserConfig{},
+							VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine},
 							Vectorizer:        map[string]interface{}{"none": map[string]interface{}{}},
 						},
 						"first": {
 							VectorIndexType:   "flat",
-							VectorIndexConfig: flat.UserConfig{},
+							VectorIndexConfig: flat.UserConfig{Distance: vectorIndex.DistanceCosine},
 							Vectorizer:        map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
 						},
 						"second": {
 							VectorIndexType:   "flat",
-							VectorIndexConfig: flat.UserConfig{},
+							VectorIndexConfig: flat.UserConfig{Distance: vectorIndex.DistanceCosine},
 							Vectorizer:        map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
 						},
 					},
@@ -161,7 +161,7 @@ func TestGRPCRequest(t *testing.T) {
 					VectorConfig: map[string]models.VectorConfig{
 						"default": {
 							VectorIndexType:   "hnsw",
-							VectorIndexConfig: hnsw.UserConfig{},
+							VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine},
 							Vectorizer:        map[string]interface{}{"none": map[string]interface{}{}},
 						},
 					},
@@ -1666,6 +1666,46 @@ func TestGRPCRequest(t *testing.T) {
 					NoProps: false,
 				},
 				NearVector: &searchparams.NearVector{VectorPerTarget: map[string][]float32{"default": {1, 2, 3}}, TargetVectors: []string{"default"}},
+			},
+			error: false,
+		},
+		{
+			name: "Dont disable certainty for compatible parameters",
+			req: &pb.SearchRequest{
+				Collection: singleNamedVecClass,
+				NearVector: &pb.NearVector{
+					VectorBytes: byteVector([]float32{1, 2, 3}),
+				},
+				Metadata: &pb.MetadataRequest{Certainty: true},
+			},
+			out: dto.GetParams{
+				ClassName: singleNamedVecClass, Pagination: defaultPagination,
+				Properties: defaultNamedVecProps,
+				AdditionalProperties: additional.Properties{
+					NoProps: false, Certainty: true,
+				},
+				NearVector: &searchparams.NearVector{VectorPerTarget: map[string][]float32{"default": {1, 2, 3}}, TargetVectors: []string{"default"}},
+			},
+			error: false,
+		},
+		{
+			name: "Disable certainty for incompatible parameters",
+			req: &pb.SearchRequest{
+				Collection: multiVecClass,
+				NearVector: &pb.NearVector{
+					Targets:         &pb.Targets{TargetVectors: []string{"first", "second"}},
+					VectorPerTarget: map[string][]byte{"first": byteVector([]float32{1, 2, 3}), "second": byteVector([]float32{1, 2, 3, 4})},
+				},
+				Metadata: &pb.MetadataRequest{Certainty: true},
+			},
+			out: dto.GetParams{
+				ClassName: multiVecClass, Pagination: defaultPagination,
+				Properties: defaultNamedVecProps,
+				AdditionalProperties: additional.Properties{
+					NoProps: false, Certainty: false,
+				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: make(map[string]float32)},
+				NearVector:              &searchparams.NearVector{VectorPerTarget: map[string][]float32{"first": {1, 2, 3}, "second": {1, 2, 3, 4}}, TargetVectors: []string{"first", "second"}},
 			},
 			error: false,
 		},

--- a/entities/schema/configvalidation/config_validation.go
+++ b/entities/schema/configvalidation/config_validation.go
@@ -1,0 +1,44 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package configvalidation
+
+import (
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+)
+
+func CheckCertaintyCompatibility(class *models.Class, targetVectors []string) error {
+	if class == nil {
+		return errors.Errorf("no class provided to check certainty compatibility")
+	}
+	if len(targetVectors) > 1 {
+		return errors.Errorf("multiple target vectors are not supported with certainty")
+	}
+
+	vectorConfigs, err := config.TypeAssertVectorIndex(class, targetVectors)
+	if err != nil {
+		return err
+	}
+	if dn := vectorConfigs[0].DistanceName(); dn != common.DistanceCosine {
+		return certaintyUnsupportedError(dn)
+	}
+
+	return nil
+}
+
+func certaintyUnsupportedError(distType string) error {
+	return errors.Errorf(
+		"can't compute and return certainty when vector index is configured with %s distance",
+		distType)
+}

--- a/entities/schema/configvalidation/config_validation_test.go
+++ b/entities/schema/configvalidation/config_validation_test.go
@@ -1,0 +1,61 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package configvalidation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	vectorIndex "github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+func TestCertainty(t *testing.T) {
+	cases := []struct {
+		name          string
+		targetVectors []string
+		class         *models.Class
+		fail          bool
+	}{
+		{name: "no vectorizer", targetVectors: nil, class: &models.Class{}, fail: true},
+		{name: "cosine", targetVectors: nil, class: &models.Class{VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}}, fail: false},
+		{name: "dot", targetVectors: nil, class: &models.Class{VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceDot}}, fail: true},
+		{name: "single target vector", targetVectors: []string{"named"}, class: &models.Class{VectorConfig: map[string]models.VectorConfig{
+			"named":  {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}},
+			"named2": {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}},
+		}}, fail: false},
+		{name: "multi target vector", targetVectors: []string{"named", "named2"}, class: &models.Class{VectorConfig: map[string]models.VectorConfig{
+			"named":  {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}},
+			"named2": {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}},
+		}}, fail: true},
+		{name: "single target vector and dot", targetVectors: []string{"named"}, class: &models.Class{VectorConfig: map[string]models.VectorConfig{
+			"named":  {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceDot}},
+			"named2": {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}},
+		}}, fail: true},
+		{name: "single target vector and dot for non selected", targetVectors: []string{"named2"}, class: &models.Class{VectorConfig: map[string]models.VectorConfig{
+			"named":  {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceDot}},
+			"named2": {VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DistanceCosine}},
+		}}, fail: false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckCertaintyCompatibility(tt.class, tt.targetVectors)
+			if tt.fail {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/usecases/traverser/traverser_validate_distance_metrics.go
+++ b/usecases/traverser/traverser_validate_distance_metrics.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaviate/weaviate/entities/schema/configvalidation"
+
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/dto"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -107,15 +109,8 @@ func (t *Traverser) validateGetDistanceParams(params dto.GetParams) error {
 	}
 
 	targetVectors := t.targetVectorParamHelper.GetTargetVectorsFromParams(params)
-	vectorConfig, err := schemaConfig.TypeAssertVectorIndex(class, targetVectors)
-	if err != nil {
+	if err := configvalidation.CheckCertaintyCompatibility(class, targetVectors); err != nil {
 		return err
-	}
-
-	for _, conf := range vectorConfig {
-		if dn := conf.DistanceName(); dn != common.DistanceCosine {
-			return certaintyUnsupportedError(dn)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:

Certainty is confusing in general and does not make too much sense with all combinations of multi target search => disable

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
