### PR TITLE
Migrate existing class properties so IndexRangeFilters won't be nil

### DIFF
--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -19,14 +19,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-	"github.com/weaviate/weaviate/entities/tenantactivity"
-
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/entities/diskio"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/tenantactivity"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/replica"
 	migratefs "github.com/weaviate/weaviate/usecases/schema/migrate/fs"
@@ -136,7 +136,7 @@ func (db *DB) LocalTenantActivity() tenantactivity.ByCollection {
 
 func (db *DB) migrateFileStructureIfNecessary() error {
 	fsMigrationPath := path.Join(db.config.RootPath, "migration1.22.fs.hierarchy")
-	exists, err := fileExists(fsMigrationPath)
+	exists, err := diskio.FileExists(fsMigrationPath)
 	if err != nil {
 		return err
 	}
@@ -160,17 +160,6 @@ func (db *DB) migrateToHierarchicalFS() error {
 	db.logger.WithField("action", "hierarchical_fs_migration").
 		Debugf("fs migration took %s\n", time.Since(before))
 	return nil
-}
-
-func fileExists(file string) (bool, error) {
-	_, err := os.Stat(file)
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
 }
 
 func NewAtomicInt64(val int64) *atomic.Int64 {

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -178,7 +178,8 @@ func NewFSM(cfg Config) Store {
 			IsLocalHost:       cfg.IsLocalHost,
 			NodeNameToPortMap: cfg.NodeNameToPortMap,
 		}),
-		schemaManager: schema.NewSchemaManager(cfg.NodeID, cfg.DB, cfg.Parser, cfg.Logger),
+		schemaManager: schema.NewSchemaManager(
+			cfg.NodeID, cfg.DB, cfg.Parser, cfg.Logger, cfg.WorkDir),
 	}
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -179,7 +179,7 @@ func NewFSM(cfg Config) Store {
 			NodeNameToPortMap: cfg.NodeNameToPortMap,
 		}),
 		schemaManager: schema.NewSchemaManager(
-			cfg.NodeID, cfg.DB, cfg.Parser, cfg.Logger, cfg.WorkDir),
+			cfg.NodeID, cfg.DB, cfg.Parser, cfg.Logger),
 	}
 }
 

--- a/entities/diskio/files.go
+++ b/entities/diskio/files.go
@@ -1,0 +1,25 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package diskio
+
+import "os"
+
+func FileExists(file string) (bool, error) {
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
### What's being changed:

Checks to see if any data which existed prior to 1.26 has been properly updated to reflect the new IndexRangeFilters property field which was introduced in that version. Any data which existed prior to 1.26 will have a value of `nil` for this field after upgrading to ≥ 1.26.

The PR takes a migrate-on-read approach, rather than making any OS calls to store state in the file system

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
