### PR TITLE
fix: Add guard to avoid a panic from results.Top().Dist when results is empty

### DIFF
--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -153,7 +153,7 @@ func (n *neighborFinderConnector) processRecursively(from uint64, results *prior
 				return err
 			}
 		}
-		if results.Len() >= top && dist < results.Top().Dist {
+		if results.Len() >= top && (results.Len() > 0 && dist < results.Top().Dist) {
 			results.Pop()
 			results.Insert(id, dist)
 		} else if results.Len() < top {


### PR DESCRIPTION
### What's being changed:

A panic can occur during tombstone cleanup if `results` is empty. An additional check as been added to the conditional to prevent this.

#### Observed panic from v1.24.20 node

```
2024-07-13 03:18:52.181 BST
runtime/debug.Stack()
2024-07-13 03:18:52.181 BST
	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
2024-07-13 03:18:52.181 BST
runtime/debug.PrintStack()
2024-07-13 03:18:52.181 BST
	/usr/local/go/src/runtime/debug/stack.go:16 +0x13
2024-07-13 03:18:52.181 BST
github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).setDeferFunc.func1({0xc1a7063a90, 0x1, 0x1})
2024-07-13 03:18:52.181 BST
	/go/src/github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:74 +0x145
2024-07-13 03:18:52.181 BST
panic({0x1ac9260?, 0xc171a37440?})
2024-07-13 03:18:52.181 BST
	/usr/local/go/src/runtime/panic.go:914 +0x21f
2024-07-13 03:18:52.181 BST
github.com/weaviate/weaviate/adapters/repos/db/priorityqueue.(*Queue[...]).Top(...)
2024-07-13 03:18:52.181 BST
	/go/src/github.com/weaviate/weaviate/adapters/repos/db/priorityqueue/queue.go:63
2024-07-13 03:18:52.181 BST
github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*neighborFinderConnector).processRecursively(0xc004ddbb38, 0x303bdd, 0xc1a70477c0, {{0xc77c7c2000, 0xd8a350, 0xd8a350}}, 0x0, 0xffffffffffffffab)
2024-07-13 03:18:52.181 BST
	/go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/neighbor_connections.go:156 +0x6f7
2024-07-13 03:18:52.181 BST
github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*neighborFinderConnector).doAtLevel(0xc1aa3a1b38, 0x0)
2024-07-13 03:18:52.181 BST
	/go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/neighbor_connections.go:220 +0xb51
2024-07-13 03:18:52.181 BST
github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*neighborFinderConnector).Do(0xc1aa3a1b38)
2024-07-13 03:18:52.181 BST
	/go/src/github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/neighbor_connections.go:83 +0x47
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
