### PR TITLE
Prevent tenant freezing when offload module not available

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -421,9 +421,9 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 			hot = append(hot, tName.Name)
 		case models.TenantActivityStatusCOLD:
 			cold = append(cold, tName.Name)
-
-		case models.TenantActivityStatusFROZEN: // never arrives from user
+		case models.TenantActivityStatusFROZEN:
 			frozen = append(frozen, tName.Name)
+
 		case types.TenantActivityStatusFREEZING: // never arrives from user
 			freezing = append(freezing, tName.Name)
 		case types.TenantActivityStatusUNFREEZING: // never arrives from user

--- a/test/modules/offload-s3/offload_not_enabled_test.go
+++ b/test/modules/offload-s3/offload_not_enabled_test.go
@@ -1,0 +1,116 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func Test_Offload_When_Not_Enabled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	compose, err := docker.New().
+		WithText2VecContextionary().
+		With3NodeCluster().
+		Start(ctx)
+	require.Nil(t, err)
+
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	className := "MultiTenantClass"
+	testClass := models.Class{
+		Class:             className,
+		ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: schema.DataTypeText.PropString(),
+			},
+		},
+	}
+	t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+		helper.CreateClass(t, &testClass)
+	})
+
+	tenantNames := []string{
+		"Tenant1", "Tenant2", "Tenant3",
+	}
+	tenants := make([]*models.Tenant, len(tenantNames))
+
+	t.Run("create tenants", func(t *testing.T) {
+		for i := range tenants {
+			tenants[i] = &models.Tenant{Name: tenantNames[i]}
+		}
+		helper.CreateTenants(t, className, tenants)
+	})
+
+	tenantObjects := make([]*models.Object, len(tenantNames))
+	for i := range tenantObjects {
+		tenantObjects[i] = &models.Object{
+			Class: className,
+			Properties: map[string]interface{}{
+				"name": tenantNames[0],
+			},
+			Tenant: tenantNames[0],
+		}
+	}
+
+	defer func() {
+		helper.DeleteClass(t, className)
+	}()
+
+	t.Run("add tenant objects", func(t *testing.T) {
+		for _, obj := range tenantObjects {
+			assert.Nil(t, helper.CreateObject(t, obj))
+		}
+	})
+
+	t.Run("updating tenant status", func(t *testing.T) {
+		t.Helper()
+		for i := range tenants {
+			tenants[i].ActivityStatus = "FROZEN"
+		}
+		params := client.NewTenantsUpdateParams().
+			WithClassName(className).WithBody(tenants)
+		_, err := helper.Client(t).Schema.TenantsUpdate(params, nil)
+		require.NotNil(t, err)
+
+		tenantErr := &client.TenantsUpdateUnprocessableEntity{}
+		if !errors.As(err, &tenantErr) {
+			t.Fatalf("expected %T, got: %T", tenantErr, err)
+		}
+		require.NotNil(t, tenantErr.Payload)
+		require.Len(t, tenantErr.Payload.Error, 1)
+		msg := tenantErr.Payload.Error[0].Message
+		assert.Equal(t, "can't offload tenants, because offload-s3 module is not enabled", msg)
+	})
+}

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -22,6 +22,7 @@ import (
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -213,6 +214,10 @@ func (f *fakeModuleConfig) SetSinglePropertyDefaults(class *models.Class,
 }
 
 func (f *fakeModuleConfig) ValidateClass(ctx context.Context, class *models.Class) error {
+	return nil
+}
+
+func (f *fakeModuleConfig) GetByName(name string) modulecapabilities.Module {
 	return nil
 }
 

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -77,6 +78,7 @@ type ModuleConfig interface {
 	SetClassDefaults(class *models.Class)
 	SetSinglePropertyDefaults(class *models.Class, props ...*models.Property)
 	ValidateClass(ctx context.Context, class *models.Class) error
+	GetByName(name string) modulecapabilities.Module
 }
 
 // State is a cached copy of the schema that can also be saved into a remote


### PR DESCRIPTION
### What's being changed:

Prior to this change, tenants are stuck in `FREEZING` status when an offload attempt fails due to offload module not being enabled. 

This PR prevents this bad internal state by failing immediately when attempting a tenant offload when the offload module is not available.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
