### PR TITLE
offload: increase offload module timeout default to 120s

### DIFF
--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -63,7 +63,7 @@ func New() *Module {
 		Bucket:      "weaviate-offload",
 		Concurrency: 25,
 		DataPath:    config.DefaultPersistenceDataPath,
-		timeout:     10 * time.Second,
+		timeout:     120 * time.Second,
 		// we use custom cli app to avoid some bugs in underlying dependencies
 		// specially with .After implementation.
 		app: &cli.App{


### PR DESCRIPTION
### What's being changed:
https://github.com/weaviate/weaviate-issues/issues/29

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
