### PR TITLE
Forbid loading the local DB if the node is a metadata only node

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -577,13 +577,18 @@ func (st *Store) openDatabase(ctx context.Context) {
 		return
 	}
 
-	st.log.Info("loading local db")
-	if err := st.schemaManager.Load(ctx, st.cfg.NodeID); err != nil {
-		st.log.WithError(err).Error("cannot restore database")
-		panic("error restoring database")
+	if st.cfg.MetadataOnlyVoters {
+		st.log.Info("Not loading local DB as the node is metadata only")
+	} else {
+		st.log.Info("loading local db")
+		if err := st.schemaManager.Load(ctx, st.cfg.NodeID); err != nil {
+			st.log.WithError(err).Error("cannot restore database")
+			panic("error restoring database")
+		}
+		st.log.Info("local DB successfully loaded")
 	}
 
-	st.log.WithField("n", st.schemaManager.NewSchemaReader().Len()).Info("database has been successfully loaded")
+	st.log.WithField("n", st.schemaManager.NewSchemaReader().Len()).Info("schema manager loaded")
 }
 
 // reloadDBFromSnapshot reloads the node's local db. If the db is already loaded, it will be reloaded.

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -93,7 +93,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	// schemaOnly is necessary so that on restart when we are re-applying RAFT log entries to our in-memory schema we
 	// don't update the database. This can lead to data loss for example if we drop then re-add a class.
 	// If we don't have any last applied index on start, schema only is always false.
-	schemaOnly := st.lastAppliedIndexOnStart.Load() != 0 && l.Index <= st.lastAppliedIndexOnStart.Load()
+	schemaOnly := st.lastAppliedIndexOnStart.Load() != 0 && l.Index <= st.lastAppliedIndexOnStart.Load() || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.


### PR DESCRIPTION
### What's being changed:

* Forbid metadata only nodes to even load the database into memory

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
