### PR TITLE
Fix GraphQL schema error when class name is a GraphQL primitive type name

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -106,7 +106,7 @@ func (b *classBuilder) classField(class *models.Class, fusionEnum *graphql.Enum)
 
 func (b *classBuilder) classObject(class *models.Class) *graphql.Object {
 	return graphql.NewObject(graphql.ObjectConfig{
-		Name: class.Class,
+		Name: b.getClassObjectName(class.Class),
 		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
 			classProperties := graphql.Fields{}
 			for _, property := range class.Properties {
@@ -147,6 +147,21 @@ func (b *classBuilder) classObject(class *models.Class) *graphql.Object {
 		}),
 		Description: class.Description,
 	})
+}
+
+func (b *classBuilder) getClassObjectName(name string) string {
+	switch name {
+	// GraphQL scalars have graphql names assigned the same as the name of the scalar.
+	// In order to avoid name clash we must override those class names. We are prepending
+	// underscore character before the class name as it is safe to do so
+	// because class names starting with "_" are not valid Weaviate class names,
+	// so it is safe to override such a class name with "_" prefix and use it as GraphQL name.
+	case graphql.String.Name(), graphql.DateTime.Name(), graphql.Int.Name(), graphql.Float.Name(),
+		graphql.Boolean.Name(), graphql.ID.Name(), graphql.FieldSet.Name():
+		return fmt.Sprintf("_%s", name)
+	default:
+		return name
+	}
 }
 
 func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *models.Class) {

--- a/entities/schema/validation_test.go
+++ b/entities/schema/validation_test.go
@@ -44,6 +44,13 @@ func TestFailValidateBadClassName(t *testing.T) {
 		"fooBar",
 		"_foo",
 		"ThisClassNameHasMoreThan255Characters_MaximumAllowed____________________qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890_qwertyuiopasdfghjklzxcvbnm1234567890",
+		"_String", "string",
+		"_DateTime", "dateTime", "datetime",
+		"_Int", "int",
+		"_Float", "float",
+		"_Boolean", "boolean",
+		"_ID", "id",
+		"_FieldSet", "fieldSet", "fieldset",
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := ValidateClassName(name)

--- a/test/acceptance_with_go_client/schema_class_names_test.go
+++ b/test/acceptance_with_go_client/schema_class_names_test.go
@@ -1,0 +1,156 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tailor-inc/graphql"
+	client "github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/grpc"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestSchemaClassNames(t *testing.T) {
+	ctx := context.Background()
+	config := client.Config{
+		Scheme: "http", Host: "localhost:8080",
+		GrpcConfig: &grpc.Config{Host: "localhost:50051", Secured: false},
+	}
+	client, err := client.NewClient(config)
+	require.Nil(t, err)
+
+	// clean DB
+	err = client.Schema().AllDeleter().Do(ctx)
+	require.NoError(t, err)
+
+	tests := []struct {
+		className string
+	}{
+		{
+			className: graphql.String.Name(),
+		},
+		{
+			className: graphql.Float.Name(),
+		},
+		{
+			className: graphql.Boolean.Name(),
+		},
+		{
+			className: graphql.Int.Name(),
+		},
+		{
+			className: graphql.DateTime.Name(),
+		},
+		{
+			className: graphql.ID.Name(),
+		},
+		{
+			className: graphql.FieldSet.Name(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.className, func(t *testing.T) {
+			id1 := "00000000-0000-0000-0000-000000000001"
+			className := tt.className
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name:     "description",
+						DataType: []string{schema.DataTypeText.String()},
+					},
+					{
+						Name:     "number",
+						DataType: []string{schema.DataTypeInt.String()},
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					"description": {
+						Vectorizer: map[string]interface{}{
+							"text2vec-contextionary": map[string]interface{}{
+								"properties":         []interface{}{"description"},
+								"vectorizeClassName": false,
+							},
+						},
+						VectorIndexType: "hnsw",
+					},
+				},
+			}
+			t.Run("create class", func(t *testing.T) {
+				err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+				require.NoError(t, err)
+			})
+			t.Run("batch import object", func(t *testing.T) {
+				objects := []*models.Object{
+					{
+						ID:    strfmt.UUID(id1),
+						Class: className,
+						Properties: map[string]interface{}{
+							"description": "some text property",
+							"number":      1,
+						},
+					},
+				}
+				resp, err := client.Batch().ObjectsBatcher().WithObjects(objects...).Do(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Len(t, resp, 1)
+				require.NotNil(t, resp[0].Result)
+				assert.Nil(t, resp[0].Result.Errors)
+			})
+			t.Run("check existence", func(t *testing.T) {
+				objs, err := client.Data().ObjectsGetter().WithClassName(className).WithID(id1).Do(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, objs)
+				require.Len(t, objs, 1)
+				assert.Equal(t, className, objs[0].Class)
+				props, ok := objs[0].Properties.(map[string]interface{})
+				require.True(t, ok)
+				require.Equal(t, 2, len(props))
+			})
+			t.Run("graphql check", func(t *testing.T) {
+				query := fmt.Sprintf("{ Get { %s { description number _additional { id } } } }", className)
+				resp, err := client.GraphQL().Raw().WithQuery(query).Do(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+
+				classMap, ok := resp.Data["Get"].(map[string]interface{})
+				require.True(t, ok)
+
+				classResult, ok := classMap[className].([]interface{})
+				require.True(t, ok)
+				for i := range classResult {
+					resultMap, ok := classResult[i].(map[string]interface{})
+					require.True(t, ok)
+					description, ok := resultMap["description"].(string)
+					require.True(t, ok)
+					require.NotEmpty(t, description)
+					number, ok := resultMap["number"].(float64)
+					require.True(t, ok)
+					require.Equal(t, float64(1), number)
+					additional, ok := resultMap["_additional"].(map[string]interface{})
+					require.True(t, ok)
+					id, ok := additional["id"].(string)
+					require.True(t, ok)
+					require.NotEmpty(t, id)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

This PR fixes a situation where a class gets one of GraphQL's primitive names (such as String or Float) which was causing GraphQL schema error preventing it from being properly rebuilt.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
