### PR TITLE
Add vector generator function for BQ and SQ

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_quantization_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_quantization_test.go
@@ -31,7 +31,7 @@ var logger, _ = test.NewNullLogger()
 func TestBinaryQuantizerRecall(t *testing.T) {
 	k := 10
 	distanceProvider := distancer.NewCosineDistanceProvider()
-	vectors, queryVecs := testinghelpers.RandomVecs(10_000, 100, 1536)
+	vectors, queryVecs := testinghelpers.RandomVecsFixedSeed(10_000, 100, 1536)
 	compressionhelpers.Concurrently(logger, uint64(len(vectors)), func(i uint64) {
 		vectors[i] = distancer.Normalize(vectors[i])
 	})

--- a/adapters/repos/db/vector/compressionhelpers/scalar_quantization_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/scalar_quantization_test.go
@@ -131,7 +131,7 @@ func Test_NoRaceRandomSQDistanceByteToByte(t *testing.T) {
 	qSize := 10
 	dims := 150
 	k := 10
-	data, queries := testinghelpers.RandomVecs(vSize, qSize, dims)
+	data, queries := testinghelpers.RandomVecsFixedSeed(vSize, qSize, dims)
 	testinghelpers.Normalize(data)
 	testinghelpers.Normalize(queries)
 	for _, distancer := range distancers {

--- a/adapters/repos/db/vector/testinghelpers/helpers.go
+++ b/adapters/repos/db/vector/testinghelpers/helpers.go
@@ -40,6 +40,11 @@ func getRandomSeed() *rand.Rand {
 	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
+func getFixedSeed() *rand.Rand {
+	seed := int64(425812)
+	return rand.New(rand.NewSource(seed))
+}
+
 func int32FromBytes(bytes []byte) int {
 	return int(binary.LittleEndian.Uint32(bytes))
 }
@@ -111,6 +116,20 @@ func ReadSiftVecsFrom(path string, size int, dimensions int) [][]float32 {
 func RandomVecs(size int, queriesSize int, dimensions int) ([][]float32, [][]float32) {
 	fmt.Printf("generating %d vectors...\n", size+queriesSize)
 	r := getRandomSeed()
+	vectors := make([][]float32, 0, size)
+	queries := make([][]float32, 0, queriesSize)
+	for i := 0; i < size; i++ {
+		vectors = append(vectors, genVector(r, dimensions))
+	}
+	for i := 0; i < queriesSize; i++ {
+		queries = append(queries, genVector(r, dimensions))
+	}
+	return vectors, queries
+}
+
+func RandomVecsFixedSeed(size int, queriesSize int, dimensions int) ([][]float32, [][]float32) {
+	fmt.Printf("generating %d vectors...\n", size+queriesSize)
+	r := getFixedSeed()
 	vectors := make([][]float32, 0, size)
 	queries := make([][]float32, 0, queriesSize)
 	for i := 0; i < size; i++ {


### PR DESCRIPTION
### What's being changed:
Add a new function generating vectors to avoid flaky tests for Binary Quantization and Scalar Quantization. This new function uses a fixed seed for random numbers generation.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
