### PR TITLE
offload:module: log level error only for default

### DIFF
--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -96,12 +96,10 @@ func New() *Module {
 			Before: func(c *cli.Context) error {
 				retryCount := c.Int("retry-count")
 				workerCount := c.Int("numworkers")
-				printJSON := c.Bool("json")
-				logLevel := c.String("log")
 				isStat := c.Bool("stat")
 				endpointURL := c.String("endpoint-url")
 
-				log.Init(logLevel, printJSON)
+				log.Init("error", false) // print level error only
 				parallel.Init(workerCount)
 
 				if retryCount < 0 {


### PR DESCRIPTION
### What's being changed:
we will print s5cmd logs on error only to decrease the noise

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
