### PR TITLE
Enable recover Roaring as list WAL from 1.26

### DIFF
--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -63,6 +63,9 @@ const (
 	// only appends in a collection strategy
 	CommitTypeCollection
 	CommitTypeRoaringSet
+	// new version of roaringset that stores data as a list of uint64 values,
+	// instead of a roaring bitmap
+	CommitTypeRoaringSetList
 )
 
 func (ct CommitType) String() string {
@@ -73,6 +76,8 @@ func (ct CommitType) String() string {
 		return "collection"
 	case CommitTypeRoaringSet:
 		return "roaringset"
+	case CommitTypeRoaringSetList:
+		return "roaringsetlist"
 	default:
 		return "unknown"
 	}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -118,6 +118,13 @@ func (m *Memtable) roaringSetAddRemoveBitmaps(key []byte, additions *sroar.Bitma
 	return nil
 }
 
+func (m *Memtable) roaringSetAddRemoveLists(key []byte, additions []uint64, deletions []uint64) error {
+	additionsBM := roaringset.NewBitmap(additions...)
+	deletionsBM := roaringset.NewBitmap(deletions...)
+
+	return m.roaringSetAddRemoveBitmaps(key, additionsBM, deletionsBM)
+}
+
 func (m *Memtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
 	if err := checkStrategyRoaringSet(m.strategy); err != nil {
 		return roaringset.BitmapLayer{}, err

--- a/adapters/repos/db/roaringset/serialization_test.go
+++ b/adapters/repos/db/roaringset/serialization_test.go
@@ -14,6 +14,7 @@ package roaringset
 import (
 	"bytes"
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,5 +112,93 @@ func TestSerialization_KeyIndexAndWriteTo(t *testing.T) {
 	newDeletions := newSN.Deletions()
 	assert.False(t, newDeletions.Contains(4))
 	assert.True(t, newDeletions.Contains(5))
+	assert.Equal(t, []byte("my-key"), newSN.PrimaryKey())
+}
+
+func TestSerializationList_HappyPath(t *testing.T) {
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7}
+	key := []byte("my-key")
+
+	sn, err := NewSegmentNodeList(key, additions, deletions)
+	require.Nil(t, err)
+
+	buf := sn.ToBuffer()
+	assert.Equal(t, sn.Len(), uint64(len(buf)))
+
+	newSN := NewSegmentNodeListFromBuffer(buf)
+	assert.Equal(t, newSN.Len(), uint64(len(buf)))
+
+	// without copying
+	newAdditions := newSN.Additions()
+
+	assert.True(t, slices.Index(newAdditions, 4) != -1)
+	assert.False(t, slices.Index(newAdditions, 5) != -1)
+	newDeletions := newSN.Deletions()
+	assert.False(t, slices.Index(newDeletions, 4) != -1)
+	assert.True(t, slices.Index(newDeletions, 5) != -1)
+	assert.True(t, slices.Index(newDeletions, 7) != -1)
+	assert.Equal(t, []byte("my-key"), newSN.PrimaryKey())
+}
+
+func TestSerializationList_InitializingFromBufferTooLarge(t *testing.T) {
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7}
+	key := []byte("my-key")
+
+	sn, err := NewSegmentNodeList(key, additions, deletions)
+	require.Nil(t, err)
+
+	buf := sn.ToBuffer()
+	assert.Equal(t, sn.Len(), uint64(len(buf)))
+
+	bufTooLarge := make([]byte, 3*len(buf))
+	copy(bufTooLarge, buf)
+
+	newSN := NewSegmentNodeListFromBuffer(bufTooLarge)
+	// assert that the buffer self reports the useful length, not the length of
+	// the initialization buffer
+	assert.Equal(t, newSN.Len(), uint64(len(buf)))
+	// assert that ToBuffer() returns a buffer that is no longer than the useful
+	// length
+	assert.Equal(t, len(buf), len(newSN.ToBuffer()))
+}
+
+func TestSerializationList_UnhappyPath(t *testing.T) {
+	t.Run("with primary key that's too long", func(t *testing.T) {
+		key := make([]byte, math.MaxUint32+3)
+		_, err := NewSegmentNodeList(key, nil, nil)
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "key too long")
+	})
+}
+
+func TestSerializationList_KeyIndexAndWriteTo(t *testing.T) {
+	buf := &bytes.Buffer{}
+	offset := 7
+	// write some dummy data, so we have an offset
+	buf.Write(make([]byte, offset))
+
+	additions := []uint64{1, 2, 3, 4, 6}
+	deletions := []uint64{5, 7}
+	key := []byte("my-key")
+
+	sn, err := NewSegmentNodeList(key, additions, deletions)
+	require.Nil(t, err)
+
+	keyIndex, err := sn.KeyIndexAndWriteTo(buf, offset)
+	require.Nil(t, err)
+
+	res := buf.Bytes()
+	assert.Equal(t, keyIndex.ValueEnd, len(res))
+
+	newSN := NewSegmentNodeListFromBuffer(res[keyIndex.ValueStart:keyIndex.ValueEnd])
+	newAdditions := newSN.Additions()
+	assert.True(t, slices.Index(newAdditions, 4) != -1)
+	assert.False(t, slices.Index(newAdditions, 5) != -1)
+	newDeletions := newSN.Deletions()
+	assert.False(t, slices.Index(newDeletions, 4) != -1)
+	assert.True(t, slices.Index(newDeletions, 5) != -1)
 	assert.Equal(t, []byte("my-key"), newSN.PrimaryKey())
 }


### PR DESCRIPTION
### What's being changed:

Enable recovering from roaring WALs created on 1.26
https://github.com/weaviate/weaviate/pull/4358

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
