### PR TITLE
refact: update tenants validation

### DIFF
--- a/usecases/schema/tenant_test.go
+++ b/usecases/schema/tenant_test.go
@@ -111,7 +111,7 @@ func TestAddTenants(t *testing.T) {
 			tenants: []*models.Tenant{
 				{Name: "Aaaa", ActivityStatus: "DOES_NOT_EXIST_1"},
 				{Name: "Bbbb", ActivityStatus: "DOES_NOT_EXIST_2"},
-				{Name: "Bbbb", ActivityStatus: "WARM"},
+				{Name: "Bbbb2", ActivityStatus: "WARM"},
 			},
 			errMsgs: []string{
 				"invalid activity status",


### PR DESCRIPTION
### What's being changed:
tenants now can be added to max 100 at 1 request. 
if tenants to be updated or added has duplication it will report an error 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
