### PR TITLE
Fix multi target search for BQ without cache

### DIFF
--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -248,3 +248,53 @@ func Test_NoRaceFlatIndex(t *testing.T) {
 		fmt.Println(err)
 	}
 }
+
+func TestFlat_QueryVectorDistancer(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	cases := []struct {
+		pq    bool
+		cache bool
+		bq    bool
+	}{
+		{pq: false, cache: false, bq: false},
+		{pq: true, cache: false, bq: false},
+		{pq: true, cache: true, bq: false},
+		{pq: false, cache: false, bq: true},
+		{pq: false, cache: true, bq: true},
+	}
+	for _, tt := range cases {
+		t.Run("tt.name", func(t *testing.T) {
+			dirName := t.TempDir()
+
+			pq := flatent.CompressionUserConfig{
+				Enabled: tt.pq, Cache: tt.cache,
+			}
+			bq := flatent.CompressionUserConfig{
+				Enabled: tt.bq, Cache: tt.cache, RescoreLimit: 10,
+			}
+			store, err := lsmkv.New(dirName, dirName, logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+			require.Nil(t, err)
+
+			distancr := distancer.NewCosineDistanceProvider()
+
+			index, err := New(Config{
+				ID:               "id",
+				DistanceProvider: distancr,
+			}, flatent.UserConfig{
+				PQ: pq,
+				BQ: bq,
+			}, store)
+			require.Nil(t, err)
+
+			index.Add(uint64(0), []float32{-1, 0})
+
+			dist := index.QueryVectorDistancer([]float32{0, 0})
+			require.NotNil(t, dist)
+			distance, err := dist.DistanceToNode(0)
+			require.Nil(t, err)
+			require.Equal(t, distance, float32(1.))
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Don't access BQ-cache if not available

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
