### PR TITLE
refact: make offload bucket auto creation configurable

### DIFF
--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/configbase"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -172,15 +173,6 @@ func (m *Module) Init(ctx context.Context,
 		m.Bucket = bucket
 	}
 
-	var autoCreateBucket bool
-	if autoCreateBucketStr := os.Getenv(s3BucketAutoCreate); autoCreateBucketStr != "" {
-		v, err := strconv.ParseBool(autoCreateBucketStr)
-		if err != nil {
-			return err
-		}
-		autoCreateBucket = v
-	}
-
 	if endpoint := os.Getenv(s3Endpoint); endpoint != "" {
 		m.Endpoint = endpoint
 	}
@@ -201,7 +193,7 @@ func (m *Module) Init(ctx context.Context,
 		m.Concurrency = conccN
 	}
 
-	if autoCreateBucket {
+	if configbase.Enabled(os.Getenv(s3BucketAutoCreate)) {
 		if err := m.create(ctx); err != nil && !strings.Contains(err.Error(), "BucketAlreadyOwnedByYou") {
 			return fmt.Errorf("can't create offload bucket: %s at endpoint %s %w", m.Bucket, m.Endpoint, err)
 		}

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -28,10 +28,10 @@ import (
 	"github.com/weaviate/s5cmd/v2/log"
 	"github.com/weaviate/s5cmd/v2/log/stat"
 	"github.com/weaviate/s5cmd/v2/parallel"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/usecases/config"
-	"github.com/weaviate/weaviate/usecases/configbase"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -193,7 +193,7 @@ func (m *Module) Init(ctx context.Context,
 		m.Concurrency = conccN
 	}
 
-	if configbase.Enabled(os.Getenv(s3BucketAutoCreate)) {
+	if entcfg.Enabled(os.Getenv(s3BucketAutoCreate)) {
 		if err := m.create(ctx); err != nil && !strings.Contains(err.Error(), "BucketAlreadyOwnedByYou") {
 			return fmt.Errorf("can't create offload bucket: %s at endpoint %s %w", m.Bucket, m.Endpoint, err)
 		}

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -127,9 +127,10 @@ func (d *Compose) WithMinIO() *Compose {
 }
 
 func (d *Compose) WithMinIOBucket(bucket string) *Compose {
-	c := d.WithMinIO()
-	c.withMinIOBucketName = bucket
-	return c
+	d.withMinIO = true
+	d.enableModules = append(d.enableModules, modstgs3.Name, modsloads3.Name)
+	d.withMinIOBucketName = bucket
+	return d
 }
 
 func (d *Compose) WithGCS() *Compose {

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -630,10 +630,10 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 		delete(secondWeaviateSettings, "RAFT_INTERNAL_PORT")
 		delete(secondWeaviateSettings, "RAFT_JOIN")
 		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort)
+		containers = append(containers, container)
 		if err != nil {
 			return &DockerCompose{network, containers}, errors.Wrapf(err, "start %s", hostname)
 		}
-		containers = append(containers, container)
 	}
 
 	return &DockerCompose{network, containers}, nil

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -631,7 +631,7 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 		delete(secondWeaviateSettings, "RAFT_JOIN")
 		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort)
 		if err != nil {
-			return nil, errors.Wrapf(err, "start %s", hostname)
+			return &DockerCompose{network, containers}, errors.Wrapf(err, "start %s", hostname)
 		}
 		containers = append(containers, container)
 	}

--- a/test/modules/offload-s3/offload_bucket_test.go
+++ b/test/modules/offload-s3/offload_bucket_test.go
@@ -30,28 +30,29 @@ import (
 )
 
 func Test_OffloadBucketNotAutoCreate(t *testing.T) {
-	t.Run("shall fail because bucket doesn't exists", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
-		t.Log("pre-instance env setup")
-		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
-		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+	t.Log("pre-instance env setup")
+	t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+	t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
 
-		compose, err := docker.New().
-			WithOffloadS3("offloading").
-			WithText2VecContextionary().
-			WithWeaviateEnv("OFFLOAD_TIMEOUT", "2").
-			WithWeaviateEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "false").
-			With3NodeCluster().
-			Start(ctx)
-		require.NotNil(t, err)
+	compose, err := docker.New().
+		WithOffloadS3("offloading").
+		WithText2VecContextionary().
+		WithWeaviateEnv("OFFLOAD_TIMEOUT", "2").
+		WithWeaviateEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "false").
+		WithWeaviate().
+		Start(ctx)
+	require.NotNil(t, err)
 
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	})
+	if err := compose.Terminate(ctx); err != nil {
+		t.Fatalf("failed to terminate test containers: %s", err.Error())
+	}
+}
 
+func Test_OffloadBucketNotAutoCreateMinioManualCreate(t *testing.T) {
 	t.Run("success because created manually in minio", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()

--- a/test/modules/offload-s3/offload_bucket_test.go
+++ b/test/modules/offload-s3/offload_bucket_test.go
@@ -1,0 +1,203 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func Test_OffloadBucketNotAutoCreate(t *testing.T) {
+	t.Run("shall fail because bucket doesn't exists", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+
+		compose, err := docker.New().
+			WithOffloadS3("offloading").
+			WithText2VecContextionary().
+			WithWeaviateEnv("OFFLOAD_TIMEOUT", "2").
+			WithWeaviateEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "false").
+			With3NodeCluster().
+			Start(ctx)
+		require.NotNil(t, err)
+
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	})
+
+	t.Run("success because created manually in minio", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		bucketname := "offloading"
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+
+		compose, err := docker.New().
+			WithOffloadS3(bucketname).
+			WithMinIOBucket(bucketname).
+			WithText2VecContextionary().
+			WithWeaviateEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "false").
+			WithWeaviateEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "false").
+			With3NodeCluster().
+			Start(ctx)
+		require.Nil(t, err)
+
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminate test containers: %s", err.Error())
+			}
+		}()
+
+		helper.SetupClient(compose.GetWeaviate().URI())
+
+		className := "MultiTenantClass"
+		testClass := models.Class{
+			Class:             className,
+			ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+			MultiTenancyConfig: &models.MultiTenancyConfig{
+				Enabled: true,
+			},
+			Properties: []*models.Property{
+				{
+					Name:     "name",
+					DataType: schema.DataTypeText.PropString(),
+				},
+			},
+		}
+		t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+			helper.CreateClass(t, &testClass)
+		})
+
+		tenantNames := []string{
+			"Tenant1", "Tenant2", "Tenant3",
+		}
+		t.Run("create tenants", func(t *testing.T) {
+			tenants := make([]*models.Tenant, len(tenantNames))
+			for i := range tenants {
+				tenants[i] = &models.Tenant{Name: tenantNames[i]}
+			}
+			helper.CreateTenants(t, className, tenants)
+		})
+
+		tenantObjects := []*models.Object{
+			{
+				ID:    "0927a1e0-398e-4e76-91fb-04a7a8f0405c",
+				Class: className,
+				Properties: map[string]interface{}{
+					"name": tenantNames[0],
+				},
+				Tenant: tenantNames[0],
+			},
+			{
+				ID:    "831ae1d0-f441-44b1-bb2a-46548048e26f",
+				Class: className,
+				Properties: map[string]interface{}{
+					"name": tenantNames[0],
+				},
+				Tenant: tenantNames[0],
+			},
+			{
+				ID:    "6f3363e0-c0a0-4618-bf1f-b6cad9cdff59",
+				Class: className,
+				Properties: map[string]interface{}{
+					"name": tenantNames[0],
+				},
+				Tenant: tenantNames[0],
+			},
+		}
+
+		t.Run("add tenant objects", func(t *testing.T) {
+			for _, obj := range tenantObjects {
+				assert.Nil(t, helper.CreateObject(t, obj))
+			}
+		})
+
+		t.Run("updating tenant status", func(t *testing.T) {
+			helper.UpdateTenants(t, className, []*models.Tenant{
+				{
+					Name:           tenantNames[0],
+					ActivityStatus: models.TenantActivityStatusFROZEN,
+				},
+			})
+		})
+
+		t.Run("verify tenant status FREEZING", func(t *testing.T) {
+			resp, err := helper.GetTenants(t, className)
+			require.Nil(t, err)
+			for _, tn := range resp.Payload {
+				if tn.Name == tenantNames[0] {
+					require.Equal(t, types.TenantActivityStatusFREEZING, tn.ActivityStatus)
+					break
+				}
+			}
+		})
+
+		t.Run("verify tenant does not exists", func(t *testing.T) {
+			_, err = helper.TenantObject(t, tenantObjects[0].Class, tenantObjects[0].ID, tenantNames[0])
+			require.NotNil(t, err)
+		})
+
+		t.Run("verify tenant status", func(t *testing.T) {
+			assert.EventuallyWithT(t, func(at *assert.CollectT) {
+				resp, err := helper.GetTenants(t, className)
+				require.Nil(t, err)
+				for _, tn := range resp.Payload {
+					if tn.Name == tenantNames[0] {
+						assert.Equal(at, models.TenantActivityStatusFROZEN, tn.ActivityStatus)
+						break
+					}
+				}
+			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusFROZEN))
+		})
+
+		t.Run("verify deleting class", func(t *testing.T) {
+			helper.DeleteClass(t, className)
+		})
+
+		t.Run("verify frozen tenants deleted from cloud", func(t *testing.T) {
+			client, err := minio.New(compose.GetMinIO().URI(), &minio.Options{
+				Creds:  credentials.NewEnvAWS(),
+				Secure: false,
+			})
+			require.Nil(t, err)
+
+			count := 0
+			for obj := range client.ListObjects(ctx, "offloading", minio.ListObjectsOptions{Prefix: strings.ToLower(className)}) {
+				if obj.Key != "" {
+					count++
+					t.Log(obj.Key)
+				}
+			}
+			require.Nil(t, err)
+			require.Zero(t, count)
+		})
+	})
+}


### PR DESCRIPTION
### What's being changed:

this PR 
- adds `OFFLOAD_S3_BUCKET_AUTO_CREATE` to make the offload bucket auto create configurable, so by default now the bucket won't be created and user has to pass `OFFLOAD_S3_BUCKET_AUTO_CREATE=true` to make sure it's auto created.

- adds tests to confirm change

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
