### PR TITLE
chore: further divide acceptance with go client e2e tests

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -260,7 +260,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--acceptance-only-fast", "--acceptance-go-client", "--acceptance-only-graphql", "--acceptance-only-replication", "--acceptance-only-python"]
+        test: [
+          "--acceptance-only-fast",
+          "--acceptance-only-graphql",
+          "--acceptance-only-replication",
+          "--acceptance-go-client-only-fast",
+          "--acceptance-go-client-named-vectors",
+          "--acceptance-only-python"
+        ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
### What's being changed:

Named vectors package tests are taking quite a lot of time so it makes sense to run them separately in our github actions pipelines, so that the whole building process takes less time.

<img width="585" alt="go_e2e_times" src="https://github.com/user-attachments/assets/21db0e92-bb96-4941-b7ac-c1dba7154511">



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
