### PR TITLE
offload: delete class will check for frozen tenant before cloud deletion

### DIFF
--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -170,7 +170,7 @@ func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
 	})
 
 	t.Run("delete class", func(t *testing.T) {
-		require.Nil(t, migrator.DropClass(context.Background(), class.Class))
+		require.Nil(t, migrator.DropClass(context.Background(), class.Class, false))
 		for _, idx := range migrator.db.indices {
 			idx.ForEachShard(func(name string, shd ShardLike) error {
 				require.Nil(t, shd.Store().Bucket("property__creationTimeUnix"))

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -150,17 +150,18 @@ func (m *Migrator) DropClass(ctx context.Context, className string) error {
 	m.classLocks.Lock(indexID)
 	defer m.classLocks.Unlock(indexID)
 
+	// get shards before deletion for cloud deletion after local schema
+	shards, err := m.db.schemaGetter.TenantsShards(className)
+	if err != nil {
+		return err
+	}
+
 	if err := m.db.DeleteIndex(schema.ClassName(className)); err != nil {
 		return err
 	}
 
 	if m.cloud == nil {
 		return nil
-	}
-
-	shards, err := m.db.schemaGetter.TenantsShards(className)
-	if err != nil {
-		return err
 	}
 
 	for _, status := range shards {

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -470,7 +470,7 @@ func Test_DimensionTrackingMetrics(t *testing.T) {
 	})
 
 	t.Run("delete class", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "HNSW")
+		err := migrator.DropClass(context.Background(), "HNSW", false)
 		require.Nil(t, err)
 		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("HNSW", shardName)
 		require.Nil(t, err)
@@ -528,7 +528,7 @@ func Test_DimensionTrackingMetrics(t *testing.T) {
 	})
 
 	t.Run("delete class type=BQ", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "BQ")
+		err := migrator.DropClass(context.Background(), "BQ", false)
 		require.Nil(t, err)
 		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("BQ", shardName)
 		require.Nil(t, err)
@@ -592,7 +592,7 @@ func Test_DimensionTrackingMetrics(t *testing.T) {
 	})
 
 	t.Run("delete class type=PQ", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "PQ")
+		err := migrator.DropClass(context.Background(), "PQ", false)
 		require.Nil(t, err)
 		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("PQ", shardName)
 		require.Nil(t, err)

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -226,7 +226,7 @@ func (s *SchemaManager) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool) 
 	var hasFrozen bool
 	tenants, err := s.schema.getTenants(cmd.Class, nil)
 	if err != nil {
-		return err
+		hasFrozen = false
 	}
 
 	for _, t := range tenants {

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -31,7 +31,7 @@ type (
 type Indexer interface {
 	AddClass(api.AddClassRequest) error
 	UpdateClass(api.UpdateClassRequest) error
-	DeleteClass(string) error
+	DeleteClass(className string, hasFrozen bool) error
 	AddProperty(class string, req api.AddPropertyRequest) error
 	AddTenants(class string, req *api.AddTenantsRequest) error
 	UpdateTenants(class string, req *api.UpdateTenantsRequest) error

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -52,7 +52,7 @@ func (m *MockSchemaExecutor) ReloadLocalDB(ctx context.Context, all []api.Update
 	return nil
 }
 
-func (m *MockSchemaExecutor) DeleteClass(name string) error {
+func (m *MockSchemaExecutor) DeleteClass(name string, hasFrozen bool) error {
 	args := m.Called(name)
 	return args.Error(0)
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -120,9 +120,9 @@ func (e *executor) UpdateIndex(req api.UpdateClassRequest) error {
 	return nil
 }
 
-func (e *executor) DeleteClass(cls string) error {
+func (e *executor) DeleteClass(cls string, hasFrozen bool) error {
 	ctx := context.Background()
-	if err := e.migrator.DropClass(ctx, cls); err != nil {
+	if err := e.migrator.DropClass(ctx, cls, hasFrozen); err != nil {
 		e.logger.WithFields(logrus.Fields{
 			"action": "delete_class",
 			"class":  cls,

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -76,13 +76,13 @@ func TestExecutor(t *testing.T) {
 		migrator := &fakeMigrator{}
 		migrator.On("DropClass", Anything, Anything).Return(nil)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.DeleteClass("A"))
+		assert.Nil(t, x.DeleteClass("A", false))
 	})
 	t.Run("DropClassWithError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		migrator.On("DropClass", Anything, Anything).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.DeleteClass("A"))
+		assert.Nil(t, x.DeleteClass("A", false))
 	})
 
 	t.Run("UpdateIndex", func(t *testing.T) {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -99,7 +99,7 @@ func (f *fakeDB) ReloadLocalDB(ctx context.Context, all []command.UpdateClassReq
 	return nil
 }
 
-func (f *fakeDB) DeleteClass(class string) error {
+func (f *fakeDB) DeleteClass(class string, hasFrozen bool) error {
 	return nil
 }
 

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -268,7 +268,7 @@ func (f *fakeMigrator) AddClass(ctx context.Context, cls *models.Class, ss *shar
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) DropClass(ctx context.Context, className string) error {
+func (f *fakeMigrator) DropClass(ctx context.Context, className string, hasFrozen bool) error {
 	args := f.Called(ctx, className)
 	return args.Error(0)
 }

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -35,7 +35,7 @@ type UpdateTenantPayload struct {
 // Migrator represents both the input and output interface of the Composer
 type Migrator interface {
 	AddClass(ctx context.Context, class *models.Class, shardingState *sharding.State) error
-	DropClass(ctx context.Context, className string) error
+	DropClass(ctx context.Context, className string, hasFrozen bool) error
 	// UpdateClass(ctx context.Context, className string,newClassName *string) error
 	GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error)
 


### PR DESCRIPTION
### What's being changed:
to avoid any misleading error and save an extra call 
e.g.
```
ERROR "rm s3://raft-poc-tenant-offload-20240705225613863300000001/ttl/*": no object found
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
