### PR TITLE
offload: adjust the wal recovery log to include on offloaded

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -72,7 +72,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 
 		b.logger.WithField("action", "lsm_recover_from_active_wal").
 			WithField("path", path).
-			Warning("active write-ahead-log found. Did weaviate crash prior to this? Trying to recover...")
+			Warning("active write-ahead-log found. Did weaviate crash prior to this or the tenant on/loaded from the cloud? Trying to recover...")
 
 		meteredReader := diskio.NewMeteredReader(bufio.NewReader(cl.file), b.metrics.TrackStartupReadWALDiskIO)
 

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -65,6 +65,18 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		cl.pause()
 		defer cl.unpause()
 
+		stat, err := cl.file.Stat()
+		if err != nil {
+			return errors.Wrap(err, "stat commit log")
+		}
+
+		if stat.Size() == 0 {
+			b.logger.WithField("action", "lsm_recover_from_active_wal").
+				WithField("path", path).
+				Warning("empty write-ahead-log found. Did weaviate crash prior to this or the tenant on/loaded from the cloud? Nothing to recover from this file.")
+			continue
+		}
+
 		mt, err := newMemtable(path, b.strategy, b.secondaryIndices, cl, b.metrics, b.logger)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What's being changed:
sometimes on tenants onload that log appear in order to make it less confusing that the users won't think there was a crash , this PR adjusting the log  

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
