### PR TITLE
RAFT: retry leader not found and refact the retry policy

### DIFF
--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -38,13 +38,12 @@ const serviceConfig = `
 				"MaxAttempts": 5,
 				"BackoffMultiplier": 2,
 				"InitialBackoff": "0.5s",
-				"MaxBackoff": "5s",
+				"MaxBackoff": "15s",
 				"RetryableStatusCodes": [
 					"ABORTED",
 					"RESOURCE_EXHAUSTED",
 					"INTERNAL",
-					"UNAVAILABLE",
-					"NOT_FOUND"
+					"UNAVAILABLE"					
 				]
 			}
 		}

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -160,8 +160,8 @@ func toRPCError(err error) error {
 
 	var ec codes.Code
 	switch {
-	case errors.Is(err, types.ErrNotLeader):
-		ec = codes.NotFound
+	case errors.Is(err, types.ErrNotLeader), errors.Is(err, types.ErrLeaderNotFound):
+		ec = codes.ResourceExhausted
 	case errors.Is(err, types.ErrNotOpen):
 		ec = codes.Unavailable
 	default:

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -74,7 +74,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				assert.NotNil(t, err)
 				st, ok := status.FromError(err)
 				assert.True(t, ok)
-				assert.Equal(t, st.Code(), codes.Internal)
+				assert.Equal(t, st.Code(), codes.ResourceExhausted)
 				assert.ErrorContains(t, st.Err(), types.ErrLeaderNotFound.Error())
 			},
 		},
@@ -154,7 +154,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				assert.NotNil(t, err)
 				st, ok := status.FromError(err)
 				assert.True(t, ok)
-				assert.Equal(t, st.Code(), codes.NotFound)
+				assert.Equal(t, st.Code(), codes.ResourceExhausted)
 				assert.ErrorContains(t, st.Err(), types.ErrNotLeader.Error())
 			},
 		},

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -253,7 +253,7 @@ func TestQueryEndpoint(t *testing.T) {
 				assert.NotNil(t, err)
 				st, ok := status.FromError(err)
 				assert.True(t, ok)
-				assert.Equal(t, st.Code(), codes.Internal)
+				assert.Equal(t, st.Code(), codes.ResourceExhausted)
 				assert.ErrorContains(t, st.Err(), types.ErrLeaderNotFound.Error())
 			},
 		},
@@ -302,7 +302,7 @@ func TestApply(t *testing.T) {
 				assert.NotNil(t, err)
 				st, ok := status.FromError(err)
 				assert.True(t, ok)
-				assert.Equal(t, st.Code(), codes.Internal)
+				assert.Equal(t, st.Code(), codes.ResourceExhausted)
 				assert.ErrorContains(t, st.Err(), types.ErrLeaderNotFound.Error())
 			},
 		},


### PR DESCRIPTION
### What's being changed:
[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10039206151)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
