### PR TITLE
offload: abort on any shard error

### DIFF
--- a/adapters/repos/db/migrator_shard_status_ops.go
+++ b/adapters/repos/db/migrator_shard_status_ops.go
@@ -138,7 +138,6 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 						"name":   class,
 						"tenant": name,
 					}).Error("HaltForTransfer")
-					ec.Add(err)
 					cmd.TenantsProcesses[uidx] = &command.TenantsProcess{
 						Tenant: &command.Tenant{
 							Name:   name,
@@ -146,6 +145,7 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 						},
 						Op: command.TenantsProcess_OP_ABORT,
 					}
+					ec.Add(err)
 					return fmt.Errorf("attempt to mark begin offloading: %w", err)
 				}
 			}
@@ -252,8 +252,7 @@ func (m *Migrator) unfreeze(ctx context.Context, idx *Index, class string, unfre
 			idx.shardCreateLocks.Lock(name)
 			defer idx.shardCreateLocks.Unlock(name)
 
-			err := m.cloud.Download(ctx, class, name, nodeID)
-			if err != nil {
+			if err := m.cloud.Download(ctx, class, name, nodeID); err != nil {
 				m.logger.WithFields(logrus.Fields{
 					"action": "download_tenant_from_cloud",
 					"error":  err,

--- a/adapters/repos/db/migrator_shard_status_ops.go
+++ b/adapters/repos/db/migrator_shard_status_ops.go
@@ -130,8 +130,7 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 				}
 			}
 
-			err = m.cloud.Upload(ctx, class, name, m.nodeId)
-			if err != nil {
+			if err := m.cloud.Upload(ctx, class, name, m.nodeId); err != nil {
 				m.logger.WithFields(logrus.Fields{
 					"action": "upload_tenant_from_cloud",
 					"error":  err,

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -337,6 +337,11 @@ func (s *SchemaManager) UpdateTenantsProcess(cmd *command.ApplyRequest, schemaOn
 	if err := gproto.Unmarshal(cmd.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
+	s.log.WithFields(logrus.Fields{
+		"action":  "updateTenantsProcess",
+		"node":    req.Node,
+		"request": req.TenantsProcesses,
+	}).Debug("updateTenantsProcess")
 
 	return s.apply(
 		applyOp{

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -337,11 +337,6 @@ func (s *SchemaManager) UpdateTenantsProcess(cmd *command.ApplyRequest, schemaOn
 	if err := gproto.Unmarshal(cmd.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
-	s.log.WithFields(logrus.Fields{
-		"action":  "updateTenantsProcess",
-		"node":    req.Node,
-		"request": req.TenantsProcesses,
-	}).Debug("updateTenantsProcess")
 
 	return s.apply(
 		applyOp{

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -249,7 +249,7 @@ func (m *metaClass) UpdateTenantsProcess(nodeID string, req *command.TenantProce
 	defer m.Unlock()
 
 	for idx := range req.TenantsProcesses {
-		if req.TenantsProcesses[idx] == nil {
+		if req.TenantsProcesses[idx] == nil || req.TenantsProcesses[idx].Tenant == nil {
 			continue
 		}
 		name := req.TenantsProcesses[idx].Tenant.Name

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -249,9 +249,6 @@ func (m *metaClass) UpdateTenantsProcess(nodeID string, req *command.TenantProce
 	defer m.Unlock()
 
 	for idx := range req.TenantsProcesses {
-		if req.TenantsProcesses[idx] == nil || req.TenantsProcesses[idx].Tenant == nil {
-			continue
-		}
 		name := req.TenantsProcesses[idx].Tenant.Name
 		shard, ok := m.Sharding.Physical[name]
 		if !ok {

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -249,6 +249,9 @@ func (m *metaClass) UpdateTenantsProcess(nodeID string, req *command.TenantProce
 	defer m.Unlock()
 
 	for idx := range req.TenantsProcesses {
+		if req.TenantsProcesses[idx] == nil {
+			continue
+		}
 		name := req.TenantsProcesses[idx].Tenant.Name
 		shard, ok := m.Sharding.Physical[name]
 		if !ok {

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -310,7 +310,9 @@ func (s State) GetPartitions(nodes []string, shards []string, replFactor int64) 
 	partitions := make(map[string][]string, len(shards))
 	nodeSet := make(map[string]bool)
 	for _, name := range shards {
-		if existedShard, alreadyExists := s.Physical[name]; alreadyExists && existedShard.Status != models.TenantActivityStatusFROZEN {
+		if existedShard, exists := s.Physical[name]; exists &&
+			existedShard.Status != models.TenantActivityStatusFROZEN &&
+			existedShard.Status != models.TenantActivityStatusFREEZING {
 			continue
 		}
 		owners := make([]string, 0, replFactor)


### PR DESCRIPTION
### What's being changed:
- in case of any error on the shard level like `HaltForTransfer()` or `TenantShutdown()` will send an `UpdateTenantProcess()` msg to abort the operation `off/on-load` 
- refactor some parts inside RAFT for offloading

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
