### PR TITLE
Fix batch updates of empty arrays

### DIFF
--- a/test/acceptance_with_python/test_batch.py
+++ b/test/acceptance_with_python/test_batch.py
@@ -1,0 +1,20 @@
+import weaviate
+import weaviate.classes as wvc
+
+from conftest import CollectionFactory
+
+
+def test_batch_update_empty_list(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[
+            wvc.config.Property(name="array", data_type=wvc.config.DataType.TEXT_ARRAY),
+        ],
+        vectorizer_config=wvc.config.Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+
+    uuid1 = collection.data.insert({"array": []})
+    collection.data.insert_many(
+        [wvc.data.DataObject(properties={"array": ["one", "two"]}, uuid=uuid1)]
+    )

--- a/usecases/modules/compare.go
+++ b/usecases/modules/compare.go
@@ -123,6 +123,11 @@ func reVectorize(ctx context.Context, cfg moduletools.ClassConfig, mod modulecap
 		}
 
 		if propStruct.IsArray {
+			// empty strings do not have type information saved with them
+			if _, ok := valOld.([]interface{}); ok && len(valOld.([]interface{})) == 0 {
+				valOld = []string{}
+			}
+
 			if len(valOld.([]string)) != len(valNew.([]string)) {
 				return true, nil, nil
 			}


### PR DESCRIPTION
### What's being changed:

empty lists are read as []interface, but the code was assuming it is []string, because we only vectorize string arrays

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
