### PR TITLE
allow over 100 on tenants creation

### DIFF
--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -48,7 +48,7 @@ func (h *Handler) AddTenants(ctx context.Context,
 		return 0, err
 	}
 
-	validated, err := validateTenants(tenants)
+	validated, err := validateTenants(tenants, true)
 	if err != nil {
 		return 0, err
 	}
@@ -71,8 +71,8 @@ func (h *Handler) AddTenants(ctx context.Context,
 	return h.schemaManager.AddTenants(class, &request)
 }
 
-func validateTenants(tenants []*models.Tenant) (validated []*models.Tenant, err error) {
-	if len(tenants) > 100 {
+func validateTenants(tenants []*models.Tenant, allowOverHundred bool) (validated []*models.Tenant, err error) {
+	if !allowOverHundred && len(tenants) > 100 {
 		err = uco.NewErrInvalidUserInput(ErrMsgMaxAllowedTenants)
 		return
 	}
@@ -153,7 +153,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 		"tenants": tenants,
 	}).Debug("update tenants status")
 
-	validated, err := validateTenants(tenants)
+	validated, err := validateTenants(tenants, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:
previously on `1.26` limitation was added that users can add/update only 100 tenant on a single batch, this amend that limitation on creation 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
