### PR TITLE
Parallelize object store retrieval

### DIFF
--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -75,7 +75,7 @@ func (a *Aggregator) objectVectorSearch(searchVector []float32,
 	}
 
 	bucket := a.store.Bucket(helpers.ObjectsBucketLSM)
-	objs, err := storobj.ObjectsByDocID(bucket, ids, additional.Properties{})
+	objs, err := storobj.ObjectsByDocID(bucket, ids, additional.Properties{}, a.logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get objects by doc id: %w", err)
 	}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -370,7 +370,7 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVector []float32, 
 	beforeObjects := time.Now()
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
-	objs, err := storobj.ObjectsByDocID(bucket, ids, additional)
+	objs, err := storobj.ObjectsByDocID(bucket, ids, additional, s.index.logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -390,7 +390,7 @@ func (s *Shard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, 
 			return nil, err
 		}
 		bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
-		return storobj.ObjectsByDocID(bucket, docIDs, additional)
+		return storobj.ObjectsByDocID(bucket, docIDs, additional, s.index.logger)
 	}
 
 	if cursor == nil {

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -245,12 +245,10 @@ type bucket interface {
 func ObjectsByDocID(bucket bucket, ids []uint64,
 	additional additional.Properties, logger logrus.FieldLogger,
 ) ([]*Object, error) {
-	if len(ids) == 1 {
-		// fairly small result set, not worth parallelizing
+	if len(ids) == 1 { // no need to try to run concurrently if there is just one result anyway
 		return objectsByDocIDSequential(bucket, ids, additional)
 	}
 
-	// larger results set, may benefit from parallelization
 	return objectsByDocIDParallel(bucket, ids, additional, logger)
 }
 

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -261,7 +261,7 @@ func objectsByDocIDParallel(bucket bucket, ids []uint64,
 
 	out := make([]*Object, len(ids))
 
-	chunkSize := max(len(ids)/parallel, 1)
+	chunkSize := max(int(math.Ceil(float64(len(ids))/float64(parallel))), 1)
 
 	eg := errwrap.NewErrorGroupWrapper(logger)
 

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -774,26 +774,34 @@ func TestObjectsByDocID(t *testing.T) {
 		// exactly to the doc ID.
 	}{
 		{
+			name:     "1 object - sequential code path",
+			inputIDs: []uint64{0},
+		},
+		{
+			name:     "2 objects - concurrent code path",
+			inputIDs: []uint64{0, 1},
+		},
+		{
 			name:     "10 objects - consecutive from beginning",
 			inputIDs: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		},
 		{
-			name: "30 objects - consecutive from beginning, should be enough to force parallelization",
+			name: "30 objects - consecutive from beginning",
 			inputIDs: []uint64{
 				0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
 				17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 			},
 		},
 		{
-			name:     "100 objects - random - should perfectly match the chunk size",
+			name:     "100 objects - random - should perfectly match to divide into groups",
 			inputIDs: pickRandomIDsBetween(0, 1000, 100),
 		},
 		{
-			name:     "99 objects - random - slightly below ideal chunk size",
+			name:     "99 objects - random - uneven groups slightly below perfect chunk size",
 			inputIDs: pickRandomIDsBetween(0, 1000, 99),
 		},
 		{
-			name:     "101 objects - random - slightly above ideal chunk size",
+			name:     "101 objects - random - uneven groups slightly above perfect chunk size",
 			inputIDs: pickRandomIDsBetween(0, 1000, 101),
 		},
 		{

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -813,7 +813,7 @@ func TestObjectsByDocID(t *testing.T) {
 			for i, obj := range res {
 				expectedDocID := test.inputIDs[i]
 				assert.Equal(t, expectedDocID, uint64(obj.Properties().(map[string]any)["i"].(float64)))
-				expectedUUID := strfmt.UUID(fmt.Sprintf("73f2eb5f-5abf-447a-81ca-74b1dd168%03d", expectedDocID))
+				expectedUUID := strfmt.UUID(fmt.Sprintf("73f2eb5f-5abf-447a-81ca-74b1dd16%04d", expectedDocID))
 				assert.Equal(t, expectedUUID, obj.ID())
 			}
 		})


### PR DESCRIPTION
### What's being changed:

Get objects from disk concurrently to speed up object retrieval. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
