### PR TITLE
chore: log ctx's with timeout DEBUG LEVEL

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1817,7 +1817,7 @@ func (i *Index) drop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	i.logger.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "drop_index",
 		"duration": 60 * time.Second,
 	}).Debug("context.WithTimeout")
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1816,6 +1816,10 @@ func (i *Index) drop() error {
 	// need to stop the cycle managers that those shards used to register with.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	i.logger.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": 60 * time.Second,
+	}).Debug("context.WithTimeout")
 
 	if err := i.stopCycleManagers(ctx, "drop"); err != nil {
 		return err

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -258,7 +258,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 			s.index.logger.WithFields(logrus.Fields{
-				"action":   "ctx_with_timeout",
+				"action":   "new_shard",
 				"duration": 120 * time.Second,
 			}).Debug("context.WithTimeout")
 
@@ -624,7 +624,7 @@ func (s *Shard) drop() error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 	defer cancel()
 	s.index.logger.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "drop_shard",
 		"duration": 5 * time.Second,
 	}).Debug("context.WithTimeout")
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -257,6 +257,10 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 			// up the partial init
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
+			s.index.logger.WithFields(logrus.Fields{
+				"action":   "ctx_with_timeout",
+				"duration": 120 * time.Second,
+			}).Debug("context.WithTimeout")
 
 			s.cleanupPartialInit(ctx)
 		}
@@ -619,6 +623,10 @@ func (s *Shard) drop() error {
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 	defer cancel()
+	s.index.logger.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": 5 * time.Second,
+	}).Debug("context.WithTimeout")
 
 	// unregister all callbacks at once, in parallel
 	if err := cyclemanager.NewCombinedCallbackCtrl(0, s.index.logger,

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -130,7 +130,7 @@ func (s *Shard) initDimensionTracking() {
 		ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 		defer cancel()
 		s.index.logger.WithFields(logrus.Fields{
-			"action":   "ctx_with_timeout",
+			"action":   "init_dimension_tracking",
 			"duration": 30 * time.Minute,
 		}).Debug("context.WithTimeout")
 
@@ -152,7 +152,7 @@ func (s *Shard) initDimensionTracking() {
 						ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 						defer cancel()
 						s.index.logger.WithFields(logrus.Fields{
-							"action":   "ctx_with_timeout",
+							"action":   "init_dimension_tracking",
 							"duration": 30 * time.Minute,
 						}).Debug("context.WithTimeout")
 						s.publishDimensionMetrics(ctx)

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -128,6 +129,10 @@ func (s *Shard) initDimensionTracking() {
 		// leak. The actual work should be much faster.
 		ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 		defer cancel()
+		s.index.logger.WithFields(logrus.Fields{
+			"action":   "ctx_with_timeout",
+			"duration": 30 * time.Minute,
+		}).Debug("context.WithTimeout")
 
 		// always send vector dimensions at startup if tracking is enabled
 		s.publishDimensionMetrics(ctx)
@@ -146,6 +151,10 @@ func (s *Shard) initDimensionTracking() {
 						// leak. The actual work should be much faster.
 						ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 						defer cancel()
+						s.index.logger.WithFields(logrus.Fields{
+							"action":   "ctx_with_timeout",
+							"duration": 30 * time.Minute,
+						}).Debug("context.WithTimeout")
 						s.publishDimensionMetrics(ctx)
 					}()
 				}

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -445,7 +445,7 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	n.graph.logger.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "pick_entrypoint",
 		"duration": 60 * time.Second,
 	}).Debug("context.WithTimeout")
 

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
@@ -443,6 +444,10 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 	// underlying object store and we cannot retrieve the vector in time, etc.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	n.graph.logger.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": 60 * time.Second,
+	}).Debug("context.WithTimeout")
 
 	for {
 		if err := ctx.Err(); err != nil {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -230,7 +230,7 @@ func (h *hnsw) prefillCache() {
 		defer cancel()
 
 		h.logger.WithFields(logrus.Fields{
-			"action":   "ctx_with_timeout",
+			"action":   "prefill_cache",
 			"duration": 60 * time.Minute,
 		}).Debug("context.WithTimeout")
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -229,6 +229,11 @@ func (h *hnsw) prefillCache() {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
 		defer cancel()
 
+		h.logger.WithFields(logrus.Fields{
+			"action":   "ctx_with_timeout",
+			"duration": 60 * time.Minute,
+		}).Debug("context.WithTimeout")
+
 		var err error
 		if h.compressed.Load() {
 			h.compressor.PrefillCache()

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -263,6 +263,12 @@ func (u *uploader) class(ctx context.Context, id string, desc *backup.ClassDescr
 	}()
 	ctx, cancel := context.WithTimeout(ctx, storeTimeout)
 	defer cancel()
+
+	u.log.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": storeTimeout,
+	}).Debug("context.WithTimeout")
+
 	nShards := len(desc.Shards)
 	if nShards == 0 {
 		return nil

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -265,7 +265,7 @@ func (u *uploader) class(ctx context.Context, id string, desc *backup.ClassDescr
 	defer cancel()
 
 	u.log.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "upload_class",
 		"duration": storeTimeout,
 	}).Debug("context.WithTimeout")
 

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -271,6 +271,11 @@ func (c *coordinator) canCommit(ctx context.Context, req *Request) (map[string]s
 	ctx, cancel := context.WithTimeout(ctx, c.timeoutCanCommit)
 	defer cancel()
 
+	c.log.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": c.timeoutCanCommit,
+	}).Debug("context.WithTimeout")
+
 	type nodeHost struct {
 		node, host string
 	}
@@ -394,6 +399,11 @@ func (c *coordinator) commit(ctx context.Context,
 func (c *coordinator) queryAll(ctx context.Context, req *StatusRequest, nodes map[string]string) int {
 	ctx, cancel := context.WithTimeout(ctx, c.timeoutQueryStatus)
 	defer cancel()
+
+	c.log.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": c.timeoutQueryStatus,
+	}).Debug("context.WithTimeout")
 
 	rs := make([]partialStatus, len(nodes))
 	g, ctx := enterrors.NewErrorGroupWithContextWrapper(c.log, ctx)

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -272,8 +272,11 @@ func (c *coordinator) canCommit(ctx context.Context, req *Request) (map[string]s
 	defer cancel()
 
 	c.log.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "coordinator_can_commit",
 		"duration": c.timeoutCanCommit,
+		"level":    req.Level,
+		"method":   req.Method,
+		"backend":  req.Backend,
 	}).Debug("context.WithTimeout")
 
 	type nodeHost struct {
@@ -401,8 +404,11 @@ func (c *coordinator) queryAll(ctx context.Context, req *StatusRequest, nodes ma
 	defer cancel()
 
 	c.log.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "coordinator_query_all",
 		"duration": c.timeoutQueryStatus,
+		"nodes":    nodes,
+		"method":   req.Method,
+		"backend":  req.Backend,
 	}).Debug("context.WithTimeout")
 
 	rs := make([]partialStatus, len(nodes))

--- a/usecases/cluster/transactions_broadcast.go
+++ b/usecases/cluster/transactions_broadcast.go
@@ -83,6 +83,11 @@ func (t *TxBroadcaster) BroadcastTransaction(rootCtx context.Context, tx *Transa
 			ctx, cancel := context.WithTimeout(rootCtx, 30*time.Second)
 			defer cancel()
 
+			t.logger.WithFields(logrus.Fields{
+				"action":   "ctx_with_timeout",
+				"duration": 30 * time.Second,
+			}).Debug("context.WithTimeout")
+
 			// the client call can mutate the tx, so we need to work with copies to
 			// prevent a race and to be able to keep all individual results, so they
 			// can be passed to the consensus fn
@@ -125,6 +130,11 @@ func (t *TxBroadcaster) BroadcastAbortTransaction(rootCtx context.Context, tx *T
 			ctx, cancel := context.WithTimeout(rootCtx, 30*time.Second)
 			defer cancel()
 
+			t.logger.WithFields(logrus.Fields{
+				"action":   "ctx_with_timeout",
+				"duration": 30 * time.Second,
+			}).Debug("context.WithTimeout")
+
 			if err := t.client.AbortTransaction(ctx, host, tx); err != nil {
 				return errors.Wrapf(err, "host %q", host)
 			}
@@ -149,6 +159,12 @@ func (t *TxBroadcaster) BroadcastCommitTransaction(rootCtx context.Context, tx *
 		// the tx commit attempt failed.
 		ctx, cancel := context.WithTimeout(rootCtx, 30*time.Second)
 		defer cancel()
+
+		t.logger.WithFields(logrus.Fields{
+			"action":   "ctx_with_timeout",
+			"duration": 30 * time.Second,
+		}).Debug("context.WithTimeout")
+
 		host := host // https://golang.org/doc/faq#closures_and_goroutines
 		eg.Go(func() error {
 			if err := t.client.CommitTransaction(ctx, host, tx); err != nil {

--- a/usecases/cluster/transactions_broadcast.go
+++ b/usecases/cluster/transactions_broadcast.go
@@ -84,7 +84,7 @@ func (t *TxBroadcaster) BroadcastTransaction(rootCtx context.Context, tx *Transa
 			defer cancel()
 
 			t.logger.WithFields(logrus.Fields{
-				"action":   "ctx_with_timeout",
+				"action":   "broadcast_transaction",
 				"duration": 30 * time.Second,
 			}).Debug("context.WithTimeout")
 
@@ -131,7 +131,7 @@ func (t *TxBroadcaster) BroadcastAbortTransaction(rootCtx context.Context, tx *T
 			defer cancel()
 
 			t.logger.WithFields(logrus.Fields{
-				"action":   "ctx_with_timeout",
+				"action":   "broadcast_abort_transaction",
 				"duration": 30 * time.Second,
 			}).Debug("context.WithTimeout")
 
@@ -161,7 +161,7 @@ func (t *TxBroadcaster) BroadcastCommitTransaction(rootCtx context.Context, tx *
 		defer cancel()
 
 		t.logger.WithFields(logrus.Fields{
-			"action":   "ctx_with_timeout",
+			"action":   "broadcast_commit_transaction",
 			"duration": 30 * time.Second,
 		}).Debug("context.WithTimeout")
 

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -214,7 +214,7 @@ func (c *TxManager) resetTxExpiry(ttl time.Duration, id string) {
 	} else {
 		ctx, cancel = context.WithTimeout(ctx, ttl)
 		c.logger.WithFields(logrus.Fields{
-			"action":   "ctx_with_timeout",
+			"action":   "reset_tx_expiry",
 			"duration": ttl,
 		}).Debug("context.WithTimeout")
 		c.currentTransactionContext = ctx

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -213,6 +213,10 @@ func (c *TxManager) resetTxExpiry(ttl time.Duration, id string) {
 		c.currentTransactionContext = context.Background()
 	} else {
 		ctx, cancel = context.WithTimeout(ctx, ttl)
+		c.logger.WithFields(logrus.Fields{
+			"action":   "ctx_with_timeout",
+			"duration": ttl,
+		}).Debug("context.WithTimeout")
 		c.currentTransactionContext = ctx
 	}
 

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -168,8 +168,9 @@ func (c *coordinator[T]) Push(ctx context.Context,
 	//nolint:govet // we expressely don't want to cancel that context as the timeout will take care of it
 	ctxWithTimeout, _ := context.WithTimeout(context.Background(), 20*time.Second)
 	c.log.WithFields(logrus.Fields{
-		"action":   "ctx_with_timeout",
+		"action":   "coordinator_push",
 		"duration": 20 * time.Second,
+		"level":    level,
 	}).Debug("context.WithTimeout")
 	nodeCh := c.broadcast(ctxWithTimeout, state.Hosts, ask, level)
 	return c.commitAll(context.Background(), nodeCh, com), level, nil

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -167,6 +167,10 @@ func (c *coordinator[T]) Push(ctx context.Context,
 	level := state.Level
 	//nolint:govet // we expressely don't want to cancel that context as the timeout will take care of it
 	ctxWithTimeout, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	c.log.WithFields(logrus.Fields{
+		"action":   "ctx_with_timeout",
+		"duration": 20 * time.Second,
+	}).Debug("context.WithTimeout")
 	nodeCh := c.broadcast(ctxWithTimeout, state.Hosts, ask, level)
 	return c.commitAll(context.Background(), nodeCh, com), level, nil
 }


### PR DESCRIPTION
### What's being changed:
add some `DEBUG` level info logs for `context.WithTimeout()`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
