### PR TITLE
Sort posting lists from multi-prop BM25 search

### DIFF
--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -998,7 +998,6 @@ func MultiPropClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGetter
 }
 
 func TestBM25F_SortMultiProp(t *testing.T) {
-	t.Skip("Currently failing")
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -16,6 +16,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -1040,5 +1041,27 @@ func TestBM25F_SortMultiProp(t *testing.T) {
 		// Document 1 is a result for both terms
 		require.Len(t, res, 1)
 		require.Equal(t, uint64(1), res[0].DocID())
+	})
+
+	t.Run("two docs to test additional explanations", func(t *testing.T) {
+		kwr := &searchparams.KeywordRanking{Type: "bm25", Query: "pepper banana", AdditionalExplanations: true}
+		res, _, err := idx.objectSearch(context.TODO(), 2, nil, kwr, nil, nil, addit, nil, "", 0)
+		require.Nil(t, err)
+
+		// Print results
+		t.Log("--- Start results for boosted search ---")
+		for _, r := range res {
+			t.Logf("Result id: %v, score: %v, additional: %v\n", r.DocID(), r.Score(), r.Object.Additional)
+		}
+
+		// We have two results, one that matches both terms and one that matches only one
+		require.Len(t, res, 2)
+		require.Equal(t, uint64(1), res[0].DocID())
+		// these assertions failed if we didn't swap the positions of the additional explanations, as we would be getting the explanations from the second doc
+		explanationString := fmt.Sprintf("%f", res[0].Object.Additional["explainScore"])
+		require.True(t, strings.Contains(explanationString, "BM25F_pepper_frequency:1"))
+		require.True(t, strings.Contains(explanationString, "BM25F_pepper_propLength:1"))
+		require.True(t, strings.Contains(explanationString, "BM25F_banana_frequency:1"))
+		require.True(t, strings.Contains(explanationString, "BM25F_banana_propLength:1"))
 	})
 }

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -467,6 +467,11 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 		termResult.exhausted = true
 		return termResult, docMapPairsIndices, nil
 	}
+
+	if len(allMsAndProps) > 1 {
+		sort.Sort(ById(docMapPairs))
+	}
+
 	termResult.data = docMapPairs
 
 	n := float64(len(docMapPairs))

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -470,8 +470,8 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 
 	if len(allMsAndProps) > 1 {
 		sort.Sort(ById{
-			DocMapPairs:        docMapPairs,
-			DocMapPairsIndices: docMapPairsIndices,
+			docMapPairs:        docMapPairs,
+			docMapPairsIndices: docMapPairsIndices,
 		})
 	}
 

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -469,7 +469,10 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 	}
 
 	if len(allMsAndProps) > 1 {
-		sort.Sort(ById(docMapPairs))
+		sort.Sort(ById{
+			DocMapPairs:        docMapPairs,
+			DocMapPairsIndices: docMapPairsIndices,
+		})
 	}
 
 	termResult.data = docMapPairs

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -470,8 +470,9 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 
 	if len(allMsAndProps) > 1 {
 		sort.Sort(ById{
-			docMapPairs:        docMapPairs,
-			docMapPairsIndices: docMapPairsIndices,
+			docMapPairs:            docMapPairs,
+			docMapPairsIndices:     docMapPairsIndices,
+			additionalExplanations: additionalExplanations,
 		})
 	}
 

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -881,3 +881,9 @@ type docPointerWithScore struct {
 	frequency  float32
 	propLength float32
 }
+
+type ById []docPointerWithScore
+
+func (a ById) Len() int           { return len(a) }
+func (a ById) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ById) Less(i, j int) bool { return a[i].id < a[j].id }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -882,8 +882,15 @@ type docPointerWithScore struct {
 	propLength float32
 }
 
-type ById []docPointerWithScore
+type ById struct {
+	DocMapPairs        []docPointerWithScore
+	DocMapPairsIndices map[uint64]int
+}
 
-func (a ById) Len() int           { return len(a) }
-func (a ById) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ById) Less(i, j int) bool { return a[i].id < a[j].id }
+func (a ById) Len() int { return len(a.DocMapPairs) }
+func (a ById) Swap(i, j int) {
+	a.DocMapPairs[i], a.DocMapPairs[j] = a.DocMapPairs[j], a.DocMapPairs[i]
+	a.DocMapPairsIndices[a.DocMapPairs[i].id] = i
+	a.DocMapPairsIndices[a.DocMapPairs[j].id] = j
+}
+func (a ById) Less(i, j int) bool { return a.DocMapPairs[i].id < a.DocMapPairs[j].id }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -883,14 +883,15 @@ type docPointerWithScore struct {
 }
 
 type ById struct {
-	DocMapPairs        []docPointerWithScore
-	DocMapPairsIndices map[uint64]int
+	docMapPairs        []docPointerWithScore
+	docMapPairsIndices map[uint64]int
 }
 
-func (a ById) Len() int { return len(a.DocMapPairs) }
+func (a ById) Len() int { return len(a.docMapPairs) }
 func (a ById) Swap(i, j int) {
-	a.DocMapPairs[i], a.DocMapPairs[j] = a.DocMapPairs[j], a.DocMapPairs[i]
-	a.DocMapPairsIndices[a.DocMapPairs[i].id] = i
-	a.DocMapPairsIndices[a.DocMapPairs[j].id] = j
+	a.docMapPairs[i], a.docMapPairs[j] = a.docMapPairs[j], a.docMapPairs[i]
+	// also swap term positions for additional explanations
+	a.docMapPairsIndices[a.docMapPairs[i].id] = i
+	a.docMapPairsIndices[a.docMapPairs[j].id] = j
 }
-func (a ById) Less(i, j int) bool { return a.DocMapPairs[i].id < a.DocMapPairs[j].id }
+func (a ById) Less(i, j int) bool { return a.docMapPairs[i].id < a.docMapPairs[j].id }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -883,15 +883,18 @@ type docPointerWithScore struct {
 }
 
 type ById struct {
-	docMapPairs        []docPointerWithScore
-	docMapPairsIndices map[uint64]int
+	docMapPairs            []docPointerWithScore
+	docMapPairsIndices     map[uint64]int
+	additionalExplanations bool
 }
 
 func (a ById) Len() int { return len(a.docMapPairs) }
 func (a ById) Swap(i, j int) {
 	a.docMapPairs[i], a.docMapPairs[j] = a.docMapPairs[j], a.docMapPairs[i]
 	// also swap term positions for additional explanations
-	a.docMapPairsIndices[a.docMapPairs[i].id] = i
-	a.docMapPairsIndices[a.docMapPairs[j].id] = j
+	if a.additionalExplanations {
+		a.docMapPairsIndices[a.docMapPairs[i].id] = i
+		a.docMapPairsIndices[a.docMapPairs[j].id] = j
+	}
 }
 func (a ById) Less(i, j int) bool { return a.docMapPairs[i].id < a.docMapPairs[j].id }


### PR DESCRIPTION
### What's being changed:

Fix edge case that could make some property results not be inspected by WAND on multi-prop BM25 search.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
