### PR TITLE
Fix updating object with empty list

### DIFF
--- a/test/acceptance_with_python/test_updates.py
+++ b/test/acceptance_with_python/test_updates.py
@@ -1,0 +1,23 @@
+import weaviate.classes as wvc
+
+from .conftest import CollectionFactory
+
+
+def test_batch_update_empty_list2(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[
+            wvc.config.Property(name="tags", data_type=wvc.config.DataType.TEXT_ARRAY),
+            wvc.config.Property(name="title", data_type=wvc.config.DataType.TEXT),
+            wvc.config.Property(name="authorized", data_type=wvc.config.DataType.BOOL),
+        ],
+        vectorizer_config=[
+            wvc.config.Configure.NamedVectors.text2vec_contextionary(
+                name="title_vector", vectorize_collection_name=False
+            ),
+        ],
+    )
+
+    uuid1 = collection.data.insert({"tags": [], "authorized": False})
+
+    # update without the empty array
+    collection.data.update(properties={"authorized": True}, uuid=uuid1)

--- a/usecases/modules/compare.go
+++ b/usecases/modules/compare.go
@@ -123,9 +123,13 @@ func reVectorize(ctx context.Context, cfg moduletools.ClassConfig, mod modulecap
 		}
 
 		if propStruct.IsArray {
-			// empty strings do not have type information saved with them
+			// empty strings do not have type information saved with them - the new value can also come from disk if
+			// an update happens
 			if _, ok := valOld.([]interface{}); ok && len(valOld.([]interface{})) == 0 {
 				valOld = []string{}
+			}
+			if _, ok := valNew.([]interface{}); ok && len(valNew.([]interface{})) == 0 {
+				valNew = []string{}
 			}
 
 			if len(valOld.([]string)) != len(valNew.([]string)) {


### PR DESCRIPTION
### What's being changed:

When updating an object that has an empty list as an property this prop is loaded from disk without any type information (as []interface).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
