### PR TITLE
refact: Distance methods

### DIFF
--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -1206,7 +1206,7 @@ func bruteForceMaxDist(inputs []*models.Object, query []float32, maxDist float32
 		coord := elem.Properties.(map[string]interface{})["location"].(*models.GeoCoordinates)
 		vec := []float32{*coord.Latitude, *coord.Longitude}
 
-		dist, _, _ := distancer.Distance(vec)
+		dist, _ := distancer.Distance(vec)
 		distances[i] = distanceAndIndex{
 			index:    i,
 			distance: dist,

--- a/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
@@ -261,7 +261,7 @@ func bruteForceObjectsByQuery(objs []*models.Object,
 	distances := make([]distanceAndObj, len(objs))
 
 	for i := range objs {
-		dist, _, _ := distProv.SingleDist(normalize(query), normalize(objs[i].Vector))
+		dist, _ := distProv.SingleDist(normalize(query), normalize(objs[i].Vector))
 		distances[i] = distanceAndObj{
 			distance: dist,
 			obj:      objs[i],

--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -117,7 +117,7 @@ type batchIndexer interface {
 	SearchByVector(vector []float32, k int, allowList helpers.AllowList) ([]uint64, []float32, error)
 	SearchByVectorDistance(vector []float32, dist float32,
 		maxLimit int64, allow helpers.AllowList) ([]uint64, []float32, error)
-	DistanceBetweenVectors(x, y []float32) (float32, bool, error)
+	DistanceBetweenVectors(x, y []float32) (float32, error)
 	ContainsNode(id uint64) bool
 	Delete(id ...uint64) error
 	DistancerProvider() distancer.Provider
@@ -746,7 +746,7 @@ func (q *IndexQueue) bruteForce(vector []float32, snapshot []vectorDescriptor, k
 			v = distancer.Normalize(v)
 		}
 
-		dist, _, err := q.Index.DistanceBetweenVectors(vector, v)
+		dist, err := q.Index.DistanceBetweenVectors(vector, v)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -1023,7 +1023,7 @@ func (m *mockBatchIndexer) SearchByVector(vector []float32, k int, allowList hel
 			v = distancer.Normalize(v)
 		}
 
-		dist, _, err := m.DistanceBetweenVectors(vector, v)
+		dist, err := m.DistanceBetweenVectors(vector, v)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1070,7 +1070,7 @@ func (m *mockBatchIndexer) SearchByVectorDistance(vector []float32, maxDistance 
 			v = distancer.Normalize(v)
 		}
 
-		dist, _, err := m.DistanceBetweenVectors(vector, v)
+		dist, err := m.DistanceBetweenVectors(vector, v)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1101,13 +1101,13 @@ func (m *mockBatchIndexer) SearchByVectorDistance(vector []float32, maxDistance 
 	return ids, distances, nil
 }
 
-func (m *mockBatchIndexer) DistanceBetweenVectors(x, y []float32) (float32, bool, error) {
+func (m *mockBatchIndexer) DistanceBetweenVectors(x, y []float32) (float32, error) {
 	res := float32(0)
 	for i := range x {
 		diff := x[i] - y[i]
 		res += diff * diff
 	}
-	return res, true, nil
+	return res, nil
 }
 
 func (m *mockBatchIndexer) ContainsNode(id uint64) bool {

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -824,7 +824,7 @@ func bruteForceObjectsByQuery(objs []*models.Object,
 	distances := make([]distanceAndObj, len(objs))
 
 	for i := range objs {
-		dist, _, _ := distProv.SingleDist(normalize(query), normalize(objs[i].Vector))
+		dist, _ := distProv.SingleDist(normalize(query), normalize(objs[i].Vector))
 		distances[i] = distanceAndObj{
 			distance: dist,
 			obj:      objs[i],

--- a/adapters/repos/db/vector/compressionhelpers/binary_quantization_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_quantization_test.go
@@ -43,7 +43,7 @@ func TestBinaryQuantizerRecall(t *testing.T) {
 	neighbors := make([][]uint64, len(queryVecs))
 	compressionhelpers.Concurrently(uint64(len(queryVecs)), func(i uint64) {
 		neighbors[i], _ = testinghelpers.BruteForce(vectors, queryVecs[i], k, func(f1, f2 []float32) float32 {
-			d, _, _ := distanceProvider.SingleDist(f1, f2)
+			d, _ := distanceProvider.SingleDist(f1, f2)
 			return d
 		})
 	})

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -29,8 +29,8 @@ import (
 )
 
 type CompressorDistancer interface {
-	DistanceToNode(id uint64) (float32, bool, error)
-	DistanceToFloat(vec []float32) (float32, bool, error)
+	DistanceToNode(id uint64) (float32, error)
+	DistanceToFloat(vec []float32) (float32, error)
 }
 
 type ReturnDistancerFn func()
@@ -361,18 +361,18 @@ type quantizedCompressorDistancer[T byte | uint64] struct {
 	distancer  quantizerDistancer[T]
 }
 
-func (distancer *quantizedCompressorDistancer[T]) DistanceToNode(id uint64) (float32, bool, error) {
+func (distancer *quantizedCompressorDistancer[T]) DistanceToNode(id uint64) (float32, error) {
 	compressedVector, err := distancer.compressor.cache.Get(context.Background(), id)
 	if err != nil {
-		return 0, false, err
+		return 0, err
 	}
 	if len(compressedVector) == 0 {
-		return 0, false, fmt.Errorf(
+		return 0, fmt.Errorf(
 			"got a nil or zero-length vector at docID %d", id)
 	}
 	return distancer.distancer.Distance(compressedVector)
 }
 
-func (distancer *quantizedCompressorDistancer[T]) DistanceToFloat(vector []float32) (float32, bool, error) {
+func (distancer *quantizedCompressorDistancer[T]) DistanceToFloat(vector []float32) (float32, error) {
 	return distancer.distancer.DistanceToFloat(vector)
 }

--- a/adapters/repos/db/vector/compressionhelpers/compression_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_test.go
@@ -69,19 +69,19 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 		distancer, returnFn := compressor.NewDistancer([]float32{0.1, -0.2})
 		defer returnFn()
 
-		d, _, err := distancer.DistanceToNode(1)
+		d, err := distancer.DistanceToNode(1)
 		assert.Nil(t, err)
 		assert.Equal(t, float32(2), d)
 
-		d, _, err = distancer.DistanceToNode(2)
+		d, err = distancer.DistanceToNode(2)
 		assert.Nil(t, err)
 		assert.Equal(t, float32(1), d)
 
-		d, _, err = distancer.DistanceToNode(3)
+		d, err = distancer.DistanceToNode(3)
 		assert.Nil(t, err)
 		assert.Equal(t, float32(1), d)
 
-		d, _, err = distancer.DistanceToFloat([]float32{0.8, -0.2})
+		d, err = distancer.DistanceToFloat([]float32{0.8, -0.2})
 		assert.Nil(t, err)
 		assert.Equal(t, float32(0.88), d)
 	})
@@ -96,19 +96,19 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 
 		assert.Nil(t, err)
 
-		d, _, err := distancer.DistanceToNode(1)
+		d, err := distancer.DistanceToNode(1)
 		assert.Nil(t, err)
 		assert.Equal(t, float32(0), d)
 
-		d, _, err = distancer.DistanceToNode(2)
+		d, err = distancer.DistanceToNode(2)
 		assert.Nil(t, err)
 		assert.Equal(t, float32(1), d)
 
-		d, _, err = distancer.DistanceToNode(3)
+		d, err = distancer.DistanceToNode(3)
 		assert.Nil(t, err)
 		assert.Equal(t, float32(1), d)
 
-		d, _, err = distancer.DistanceToFloat([]float32{0.8, -0.2})
+		d, err = distancer.DistanceToFloat([]float32{0.8, -0.2})
 		assert.Nil(t, err)
 		assert.Equal(t, float32(2), d)
 	})

--- a/adapters/repos/db/vector/compressionhelpers/kmeans.go
+++ b/adapters/repos/db/vector/compressionhelpers/kmeans.go
@@ -117,7 +117,7 @@ func (m *KMeans) nNearest(point []float32, n int) ([]uint64, []float32) {
 	}
 	filteredPoint := point[m.segment*m.dimensions : (m.segment+1)*m.dimensions]
 	for i, c := range m.centers {
-		distance, _, _ := m.Distance.SingleDist(filteredPoint, c)
+		distance, _ := m.Distance.SingleDist(filteredPoint, c)
 		j := 0
 		for (j < n) && minD[j] < distance {
 			j++

--- a/adapters/repos/db/vector/compressionhelpers/kmeans_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/kmeans_test.go
@@ -44,9 +44,9 @@ func Test_NoRaceKMeansNNearest(t *testing.T) {
 		centers[i] = byte(kmeans.Nearest(vectors[i]))
 	}
 	for v := range vectors {
-		min, _, _ := distanceProvider.SingleDist(vectors[v], kmeans.Centroid(centers[v]))
+		min, _ := distanceProvider.SingleDist(vectors[v], kmeans.Centroid(centers[v]))
 		for c := range centers {
-			dist, _, _ := distanceProvider.SingleDist(vectors[v], kmeans.Centroid(centers[c]))
+			dist, _ := distanceProvider.SingleDist(vectors[v], kmeans.Centroid(centers[c]))
 			assert.True(t, dist >= min)
 		}
 	}

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -360,8 +360,7 @@ func (d *PQDistancer) DistanceToFloat(x []float32) (float32, error) {
 		return d.pq.distance.SingleDist(x, d.lut.flatCenter)
 	}
 	xComp := d.pq.Encode(x)
-	dist, err := d.pq.DistanceBetweenCompressedVectors(d.compressed, xComp)
-	return dist, err
+	return d.pq.DistanceBetweenCompressedVectors(d.compressed, xComp)
 }
 
 func (pq *ProductQuantizer) Fit(data [][]float32) error {

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -345,24 +345,23 @@ func (pq *ProductQuantizer) ReturnDistancer(d *PQDistancer) {
 	pq.dlutPool.Return(d.lut)
 }
 
-func (d *PQDistancer) Distance(x []byte) (float32, bool, error) {
+func (d *PQDistancer) Distance(x []byte) (float32, error) {
 	if d.lut == nil {
-		dist, err := d.pq.DistanceBetweenCompressedVectors(d.compressed, x)
-		return dist, err == nil, err
+		return d.pq.DistanceBetweenCompressedVectors(d.compressed, x)
 	}
 	if len(x) != d.pq.m {
-		return 0, false, fmt.Errorf("inconsistent compressed vector length")
+		return 0, fmt.Errorf("inconsistent compressed vector length")
 	}
-	return d.pq.Distance(x, d.lut), true, nil
+	return d.pq.Distance(x, d.lut), nil
 }
 
-func (d *PQDistancer) DistanceToFloat(x []float32) (float32, bool, error) {
+func (d *PQDistancer) DistanceToFloat(x []float32) (float32, error) {
 	if d.lut != nil {
 		return d.pq.distance.SingleDist(x, d.lut.flatCenter)
 	}
 	xComp := d.pq.Encode(x)
 	dist, err := d.pq.DistanceBetweenCompressedVectors(d.compressed, xComp)
-	return dist, err == nil, err
+	return dist, err
 }
 
 func (pq *ProductQuantizer) Fit(data [][]float32) error {

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization_test.go
@@ -33,7 +33,7 @@ type IndexAndDistance struct {
 
 func distance(dp distancer.Provider) func(x, y []float32) float32 {
 	return func(x, y []float32) float32 {
-		dist, _, _ := dp.SingleDist(x, y)
+		dist, _ := dp.SingleDist(x, y)
 		return dist
 	}
 }
@@ -95,7 +95,7 @@ func Test_NoRacePQKMeans(t *testing.T) {
 
 		distancer := pq.NewDistancer(query)
 		for v := range vectors {
-			d, _, _ := distancer.Distance(encoded[v])
+			d, _ := distancer.Distance(encoded[v])
 			distances[v] = IndexAndDistance{index: uint64(v), distance: d}
 		}
 		sort.Slice(distances, func(a, b int) bool {

--- a/adapters/repos/db/vector/compressionhelpers/quantizer.go
+++ b/adapters/repos/db/vector/compressionhelpers/quantizer.go
@@ -14,8 +14,8 @@ package compressionhelpers
 import "encoding/binary"
 
 type quantizerDistancer[T byte | uint64] interface {
-	Distance(x []T) (float32, bool, error)
-	DistanceToFloat(x []float32) (float32, bool, error)
+	Distance(x []T) (float32, error)
+	DistanceToFloat(x []float32) (float32, error)
 }
 
 type quantizer[T byte | uint64] interface {
@@ -102,18 +102,17 @@ func (bq *BinaryQuantizer) NewCompressedQuantizerDistancer(a []uint64) quantizer
 	}
 }
 
-func (d *BQDistancer) Distance(x []uint64) (float32, bool, error) {
-	dist, err := d.bq.DistanceBetweenCompressedVectors(d.compressed, x)
-	return dist, err == nil, err
+func (d *BQDistancer) Distance(x []uint64) (float32, error) {
+	return d.bq.DistanceBetweenCompressedVectors(d.compressed, x)
 }
 
-func (d *BQDistancer) DistanceToFloat(x []float32) (float32, bool, error) {
+func (d *BQDistancer) DistanceToFloat(x []float32) (float32, error) {
 	if len(d.x) > 0 {
 		return d.bq.distancer.SingleDist(d.x, x)
 	}
 	xComp := d.bq.Encode(x)
 	dist, err := d.bq.DistanceBetweenCompressedVectors(d.compressed, xComp)
-	return dist, err == nil, err
+	return dist, err
 }
 
 func (bq *BinaryQuantizer) NewQuantizerDistancer(vec []float32) quantizerDistancer[uint64] {

--- a/adapters/repos/db/vector/compressionhelpers/quantizer.go
+++ b/adapters/repos/db/vector/compressionhelpers/quantizer.go
@@ -111,8 +111,7 @@ func (d *BQDistancer) DistanceToFloat(x []float32) (float32, error) {
 		return d.bq.distancer.SingleDist(d.x, x)
 	}
 	xComp := d.bq.Encode(x)
-	dist, err := d.bq.DistanceBetweenCompressedVectors(d.compressed, xComp)
-	return dist, err
+	return d.bq.DistanceBetweenCompressedVectors(d.compressed, xComp)
 }
 
 func (bq *BinaryQuantizer) NewQuantizerDistancer(vec []float32) quantizerDistancer[uint64] {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -336,7 +336,7 @@ func (index *flat) createDistanceCalc(vector []float32) distanceCalc {
 		defer index.pool.float32SlicePool.Put(vecSlice)
 
 		candidate := float32SliceFromByteSlice(vecAsBytes, vecSlice.slice)
-		distance, _, err := index.distancerProvider.SingleDist(vector, candidate)
+		distance, err := index.distancerProvider.SingleDist(vector, candidate)
 		return distance, err
 	}
 }
@@ -658,7 +658,7 @@ func (index *flat) Dump(labels ...string) {
 	fmt.Printf("--------------------------------------------------\n")
 }
 
-func (index *flat) DistanceBetweenVectors(x, y []float32) (float32, bool, error) {
+func (index *flat) DistanceBetweenVectors(x, y []float32) (float32, error) {
 	return index.distancerProvider.SingleDist(x, y)
 }
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -336,8 +336,7 @@ func (index *flat) createDistanceCalc(vector []float32) distanceCalc {
 		defer index.pool.float32SlicePool.Put(vecSlice)
 
 		candidate := float32SliceFromByteSlice(vecAsBytes, vecSlice.slice)
-		distance, err := index.distancerProvider.SingleDist(vector, candidate)
-		return distance, err
+		return index.distancerProvider.SingleDist(vector, candidate)
 	}
 }
 

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -40,7 +40,7 @@ import (
 
 func distanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
 	return func(x, y []float32) float32 {
-		dist, _, _ := provider.SingleDist(x, y)
+		dist, _ := provider.SingleDist(x, y)
 		return dist
 	}
 }

--- a/adapters/repos/db/vector/hnsw/compress_recall_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_recall_test.go
@@ -34,7 +34,7 @@ import (
 
 func distanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
 	return func(x, y []float32) float32 {
-		dist, _, _ := provider.SingleDist(x, y)
+		dist, _ := provider.SingleDist(x, y)
 		return dist
 	}
 }

--- a/adapters/repos/db/vector/hnsw/compress_sift_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_sift_test.go
@@ -40,7 +40,7 @@ import (
 
 func distanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
 	return func(x, y []float32) float32 {
-		dist, _, _ := provider.SingleDist(x, y)
+		dist, _ := provider.SingleDist(x, y)
 		return dist
 	}
 }

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -1335,7 +1335,7 @@ func bruteForceCosine(vectors [][]float32, query []float32, k int) []uint64 {
 
 	d := distancer.NewCosineDistanceProvider().New(distancer.Normalize(query))
 	for i, vec := range vectors {
-		dist, _, _ := d.Distance(distancer.Normalize(vec))
+		dist, _ := d.Distance(distancer.Normalize(vec))
 		distances[i] = distanceAndIndex{
 			index:    uint64(i),
 			distance: dist,

--- a/adapters/repos/db/vector/hnsw/distancer/cosine_dist.go
+++ b/adapters/repos/db/vector/hnsw/distancer/cosine_dist.go
@@ -19,14 +19,14 @@ type CosineDistance struct {
 	a []float32
 }
 
-func (d *CosineDistance) Distance(b []float32) (float32, bool, error) {
+func (d *CosineDistance) Distance(b []float32) (float32, error) {
 	if len(d.a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(d.a), len(b))
 	}
 
 	dist := 1 - dotProductImplementation(d.a, b)
-	return dist, true, nil
+	return dist, nil
 }
 
 type CosineDistanceProvider struct{}
@@ -35,15 +35,15 @@ func NewCosineDistanceProvider() CosineDistanceProvider {
 	return CosineDistanceProvider{}
 }
 
-func (d CosineDistanceProvider) SingleDist(a, b []float32) (float32, bool, error) {
+func (d CosineDistanceProvider) SingleDist(a, b []float32) (float32, error) {
 	if len(a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(a), len(b))
 	}
 
 	prod := 1 - dotProductImplementation(a, b)
 
-	return prod, true, nil
+	return prod, nil
 }
 
 func (d CosineDistanceProvider) Type() string {

--- a/adapters/repos/db/vector/hnsw/distancer/cosine_dist_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/cosine_dist_test.go
@@ -24,11 +24,10 @@ func TestCosineDistancer(t *testing.T) {
 		vec2 := Normalize([]float32{0.1, 0.3, 0.7})
 		expectedDistance := float32(0.0)
 
-		dist, ok, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
+		dist, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -39,11 +38,10 @@ func TestCosineDistancer(t *testing.T) {
 		vec2 := Normalize([]float32{0.2, 0.6, 1.4})
 		expectedDistance := float32(0.0)
 
-		dist, ok, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
+		dist, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -54,11 +52,10 @@ func TestCosineDistancer(t *testing.T) {
 		vec2 := Normalize([]float32{0.2, 0.2, 0.2})
 		expectedDistance := float32(0.173)
 
-		dist, ok, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
+		dist, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.InDelta(t, expectedDistance, dist, 0.01)
@@ -70,11 +67,10 @@ func TestCosineDistancer(t *testing.T) {
 		vec2 := Normalize([]float32{-0.1, -0.3, -0.7})
 		expectedDistance := float32(2)
 
-		dist, ok, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
+		dist, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewCosineDistanceProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.InDelta(t, expectedDistance, dist, 0.01)
@@ -86,9 +82,8 @@ func TestCosineDistancerStepbyStep(t *testing.T) {
 		vec1 := Normalize([]float32{3, 4, 5})
 		vec2 := Normalize([]float32{-3, -4, -5})
 
-		expectedDistance, ok, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
+		expectedDistance, err := NewCosineDistanceProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
 
 		distanceProvider := NewCosineDistanceProvider()
 		sum := float32(0.0)

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product.go
@@ -33,14 +33,14 @@ type DotProduct struct {
 	a []float32
 }
 
-func (d *DotProduct) Distance(b []float32) (float32, bool, error) {
+func (d *DotProduct) Distance(b []float32) (float32, error) {
 	if len(d.a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(d.a), len(b))
 	}
 
 	dist := -dotProductImplementation(d.a, b)
-	return dist, true, nil
+	return dist, nil
 }
 
 type DotProductProvider struct{}
@@ -58,15 +58,15 @@ func DotProductGo(a, b []float32) float32 {
 	return -sum
 }
 
-func (d DotProductProvider) SingleDist(a, b []float32) (float32, bool, error) {
+func (d DotProductProvider) SingleDist(a, b []float32) (float32, error) {
 	if len(a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(a), len(b))
 	}
 
 	prod := -dotProductImplementation(a, b)
 
-	return prod, true, nil
+	return prod, nil
 }
 
 func (d DotProductProvider) Type() string {

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product_test.go
@@ -24,11 +24,10 @@ func TestDotDistancer(t *testing.T) {
 		vec2 := []float32{3, 4, 5}
 		expectedDistance := float32(-50)
 
-		dist, ok, err := NewDotProductProvider().New(vec1).Distance(vec2)
+		dist, err := NewDotProductProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewDotProductProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewDotProductProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -39,11 +38,10 @@ func TestDotDistancer(t *testing.T) {
 		vec2 := []float32{1, 0, 2, 0, 3, 0}
 		expectedDistance := float32(0)
 
-		dist, ok, err := NewDotProductProvider().New(vec1).Distance(vec2)
+		dist, err := NewDotProductProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewDotProductProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewDotProductProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -54,11 +52,10 @@ func TestDotDistancer(t *testing.T) {
 		vec2 := []float32{-3, -4, -5}
 		expectedDistance := float32(+50)
 
-		dist, ok, err := NewDotProductProvider().New(vec1).Distance(vec2)
+		dist, err := NewDotProductProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewDotProductProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewDotProductProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -70,9 +67,8 @@ func TestDotDistancerStepbyStep(t *testing.T) {
 		vec1 := []float32{3, 4, 5}
 		vec2 := []float32{-3, -4, -5}
 
-		expectedDistance, ok, err := NewDotProductProvider().New(vec1).Distance(vec2)
+		expectedDistance, err := NewDotProductProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
 
 		distanceProvider := NewDotProductProvider()
 		sum := float32(0.0)

--- a/adapters/repos/db/vector/hnsw/distancer/geo_spatial.go
+++ b/adapters/repos/db/vector/hnsw/distancer/geo_spatial.go
@@ -16,9 +16,9 @@ import (
 	"math"
 )
 
-func geoDist(a, b []float32) (float32, bool, error) {
+func geoDist(a, b []float32) (float32, error) {
 	if len(a) != 2 || len(b) != 2 {
-		return 0, false, fmt.Errorf("distance vectors must have len 2")
+		return 0, fmt.Errorf("distance vectors must have len 2")
 	}
 
 	latA := a[0]
@@ -37,14 +37,14 @@ func geoDist(a, b []float32) (float32, bool, error) {
 
 	C := 2 * math.Atan2(math.Sqrt(A), math.Sqrt(1-A))
 
-	return float32(R * C), true, nil
+	return float32(R * C), nil
 }
 
 type GeoDistancer struct {
 	a []float32
 }
 
-func (g GeoDistancer) Distance(b []float32) (float32, bool, error) {
+func (g GeoDistancer) Distance(b []float32) (float32, error) {
 	return geoDist(g.a, b)
 }
 
@@ -54,7 +54,7 @@ func (gp GeoProvider) New(vec []float32) Distancer {
 	return GeoDistancer{a: vec}
 }
 
-func (gp GeoProvider) SingleDist(vec1, vec2 []float32) (float32, bool, error) {
+func (gp GeoProvider) SingleDist(vec1, vec2 []float32) (float32, error) {
 	return geoDist(vec1, vec2)
 }
 

--- a/adapters/repos/db/vector/hnsw/distancer/geo_spatial_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/geo_spatial_test.go
@@ -23,9 +23,8 @@ func TestGeoSpatialDistance(t *testing.T) {
 		munich := []float32{48.137154, 11.576124}
 		stuttgart := []float32{48.783333, 9.183333}
 
-		dist, ok, err := NewGeoProvider().New(munich).Distance(stuttgart)
+		dist, err := NewGeoProvider().New(munich).Distance(stuttgart)
 		require.Nil(t, err)
-		require.True(t, ok)
 		assert.InDelta(t, 190000, dist, 1000)
 	})
 }

--- a/adapters/repos/db/vector/hnsw/distancer/hamming.go
+++ b/adapters/repos/db/vector/hnsw/distancer/hamming.go
@@ -31,13 +31,13 @@ type Hamming struct {
 	a []float32
 }
 
-func (l Hamming) Distance(b []float32) (float32, bool, error) {
+func (l Hamming) Distance(b []float32) (float32, error) {
 	if len(l.a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(l.a), len(b))
 	}
 
-	return hammingImpl(l.a, b), true, nil
+	return hammingImpl(l.a, b), nil
 }
 
 type HammingProvider struct{}
@@ -46,13 +46,13 @@ func NewHammingProvider() HammingProvider {
 	return HammingProvider{}
 }
 
-func (l HammingProvider) SingleDist(a, b []float32) (float32, bool, error) {
+func (l HammingProvider) SingleDist(a, b []float32) (float32, error) {
 	if len(a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(a), len(b))
 	}
 
-	return hammingImpl(a, b), true, nil
+	return hammingImpl(a, b), nil
 }
 
 func (l HammingProvider) Type() string {

--- a/adapters/repos/db/vector/hnsw/distancer/hamming_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/hamming_test.go
@@ -24,11 +24,10 @@ func TestHammingDistancer(t *testing.T) {
 		vec2 := []float32{3, 4, 5}
 		expectedDistance := float32(0)
 
-		dist, ok, err := NewHammingProvider().New(vec1).Distance(vec2)
+		dist, err := NewHammingProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewHammingProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewHammingProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -39,11 +38,11 @@ func TestHammingDistancer(t *testing.T) {
 		vec2 := []float32{1.5, 2, 2.5}
 		expectedDistance := float32(3) // all three positions are different
 
-		dist, ok, err := NewHammingProvider().New(vec1).Distance(vec2)
+		dist, err := NewHammingProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewHammingProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewHammingProvider().SingleDist(vec1, vec2)
+
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -54,11 +53,10 @@ func TestHammingDistancer(t *testing.T) {
 		vec2 := []float32{10, 15}
 		expectedDistance := float32(1)
 
-		dist, ok, err := NewHammingProvider().New(vec1).Distance(vec2)
+		dist, err := NewHammingProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewHammingProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewHammingProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -69,11 +67,10 @@ func TestHammingDistancer(t *testing.T) {
 		vec2 := []float32{10, 15, 16, 25, 30}
 		expectedDistance := float32(3)
 
-		dist, ok, err := NewHammingProvider().New(vec1).Distance(vec2)
+		dist, err := NewHammingProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewHammingProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewHammingProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -85,9 +82,8 @@ func TestHammingDistancerStepbyStep(t *testing.T) {
 		vec1 := []float32{10, 11, 15, 25, 31}
 		vec2 := []float32{10, 15, 16, 25, 30}
 
-		expectedDistance, ok, err := NewHammingProvider().New(vec1).Distance(vec2)
+		expectedDistance, err := NewHammingProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
 
 		distanceProvider := NewHammingProvider()
 		sum := float32(0.0)

--- a/adapters/repos/db/vector/hnsw/distancer/l2.go
+++ b/adapters/repos/db/vector/hnsw/distancer/l2.go
@@ -28,13 +28,13 @@ type L2Squared struct {
 	a []float32
 }
 
-func (l L2Squared) Distance(b []float32) (float32, bool, error) {
+func (l L2Squared) Distance(b []float32) (float32, error) {
 	if len(l.a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(l.a), len(b))
 	}
 
-	return l2SquaredImpl(l.a, b), true, nil
+	return l2SquaredImpl(l.a, b), nil
 }
 
 type L2SquaredProvider struct{}
@@ -43,13 +43,13 @@ func NewL2SquaredProvider() L2SquaredProvider {
 	return L2SquaredProvider{}
 }
 
-func (l L2SquaredProvider) SingleDist(a, b []float32) (float32, bool, error) {
+func (l L2SquaredProvider) SingleDist(a, b []float32) (float32, error) {
 	if len(a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(a), len(b))
 	}
 
-	return l2SquaredImpl(a, b), true, nil
+	return l2SquaredImpl(a, b), nil
 }
 
 func (l L2SquaredProvider) Type() string {

--- a/adapters/repos/db/vector/hnsw/distancer/l2_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/l2_test.go
@@ -24,11 +24,9 @@ func TestL2Distancer(t *testing.T) {
 		vec2 := []float32{3, 4, 5}
 		expectedDistance := float32(0)
 
-		dist, ok, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
+		dist, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewL2SquaredProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+		control, err := NewL2SquaredProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -39,11 +37,10 @@ func TestL2Distancer(t *testing.T) {
 		vec2 := []float32{1.5, 2, 2.5}
 		expectedDistance := float32(12.5)
 
-		dist, ok, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
+		dist, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewL2SquaredProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewL2SquaredProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -54,11 +51,9 @@ func TestL2Distancer(t *testing.T) {
 		vec2 := []float32{13, 15}
 		expectedDistance := float32(25)
 
-		dist, ok, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
+		dist, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewL2SquaredProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+		control, err := NewL2SquaredProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -70,9 +65,8 @@ func TestL2DistancerStepbyStep(t *testing.T) {
 		vec1 := []float32{3, 4, 5}
 		vec2 := []float32{1.5, 2, 2.5}
 
-		expectedDistance, ok, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
+		expectedDistance, err := NewL2SquaredProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
 
 		distanceProvider := NewL2SquaredProvider()
 		sum := float32(0.0)

--- a/adapters/repos/db/vector/hnsw/distancer/manhattan.go
+++ b/adapters/repos/db/vector/hnsw/distancer/manhattan.go
@@ -33,13 +33,12 @@ type Manhattan struct {
 	a []float32
 }
 
-func (l Manhattan) Distance(b []float32) (float32, bool, error) {
+func (l Manhattan) Distance(b []float32) (float32, error) {
 	if len(l.a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
-			len(l.a), len(b))
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d", len(l.a), len(b))
 	}
 
-	return manhattanImpl(l.a, b), true, nil
+	return manhattanImpl(l.a, b), nil
 }
 
 type ManhattanProvider struct{}
@@ -48,13 +47,13 @@ func NewManhattanProvider() ManhattanProvider {
 	return ManhattanProvider{}
 }
 
-func (l ManhattanProvider) SingleDist(a, b []float32) (float32, bool, error) {
+func (l ManhattanProvider) SingleDist(a, b []float32) (float32, error) {
 	if len(a) != len(b) {
-		return 0, false, errors.Errorf("vector lengths don't match: %d vs %d",
+		return 0, errors.Errorf("vector lengths don't match: %d vs %d",
 			len(a), len(b))
 	}
 
-	return manhattanImpl(a, b), true, nil
+	return manhattanImpl(a, b), nil
 }
 
 func (l ManhattanProvider) Type() string {

--- a/adapters/repos/db/vector/hnsw/distancer/manhattan_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/manhattan_test.go
@@ -24,11 +24,10 @@ func TestManhattanDistancer(t *testing.T) {
 		vec2 := []float32{3, 4, 5}
 		expectedDistance := float32(0)
 
-		dist, ok, err := NewManhattanProvider().New(vec1).Distance(vec2)
+		dist, err := NewManhattanProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewManhattanProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewManhattanProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -40,11 +39,10 @@ func TestManhattanDistancer(t *testing.T) {
 		// distance will be abs(3-1.5) + abs(4-2) + abs(5-2.5) = 1.5 + 2 + 2.5 = 6
 		expectedDistance := float32(6)
 
-		dist, ok, err := NewManhattanProvider().New(vec1).Distance(vec2)
+		dist, err := NewManhattanProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewManhattanProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewManhattanProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -56,11 +54,10 @@ func TestManhattanDistancer(t *testing.T) {
 		// distance will be calculated as abs(10-13) + abs(11-15) = 3 + 4 = 7
 		expectedDistance := float32(7)
 
-		dist, ok, err := NewManhattanProvider().New(vec1).Distance(vec2)
+		dist, err := NewManhattanProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
-		control, ok, err := NewManhattanProvider().SingleDist(vec1, vec2)
-		require.True(t, ok)
+
+		control, err := NewManhattanProvider().SingleDist(vec1, vec2)
 		require.Nil(t, err)
 		assert.Equal(t, control, dist)
 		assert.Equal(t, expectedDistance, dist)
@@ -72,9 +69,8 @@ func TestManhattanDistancerStepbyStep(t *testing.T) {
 		vec1 := []float32{3, 4, 5}
 		vec2 := []float32{1.5, 2, 2.5}
 
-		expectedDistance, ok, err := NewManhattanProvider().New(vec1).Distance(vec2)
+		expectedDistance, err := NewManhattanProvider().New(vec1).Distance(vec2)
 		require.Nil(t, err)
-		require.True(t, ok)
 
 		distanceProvider := NewManhattanProvider()
 		sum := float32(0.0)

--- a/adapters/repos/db/vector/hnsw/distancer/provider.go
+++ b/adapters/repos/db/vector/hnsw/distancer/provider.go
@@ -13,12 +13,12 @@ package distancer
 
 type Provider interface {
 	New(vec []float32) Distancer
-	SingleDist(vec1, vec2 []float32) (float32, bool, error)
+	SingleDist(vec1, vec2 []float32) (float32, error)
 	Step(x, y []float32) float32
 	Wrap(x float32) float32
 	Type() string
 }
 
 type Distancer interface {
-	Distance(vec []float32) (float32, bool, error)
+	Distance(vec []float32) (float32, error)
 }

--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -49,14 +49,9 @@ func (h *hnsw) flatSearch(queryVector []float32, k, limit int,
 			continue
 		}
 		h.RUnlock()
-		dist, ok, err := h.distBetweenNodeAndVec(candidate, queryVector)
+		dist, err := h.distBetweenNodeAndVec(candidate, queryVector)
 		if err != nil {
 			return nil, nil, err
-		}
-
-		if !ok {
-			// deleted node, ignore
-			continue
 		}
 
 		if results.Len() < limit {

--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -12,8 +12,10 @@
 package hnsw
 
 import (
+	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (h *hnsw) flatSearch(queryVector []float32, k, limit int,
@@ -50,6 +52,11 @@ func (h *hnsw) flatSearch(queryVector []float32, k, limit int,
 		}
 		h.RUnlock()
 		dist, err := h.distBetweenNodeAndVec(candidate, queryVector)
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) {
+			h.handleDeletedNode(e.DocID)
+			continue
+		}
 		if err != nil {
 			return nil, nil, err
 		}

--- a/adapters/repos/db/vector/hnsw/flat_search_test.go
+++ b/adapters/repos/db/vector/hnsw/flat_search_test.go
@@ -134,7 +134,7 @@ func Test_NoRaceCompressionRecall(t *testing.T) {
 
 func distanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
 	return func(x, y []float32) float32 {
-		dist, _, _ := provider.SingleDist(x, y)
+		dist, _ := provider.SingleDist(x, y)
 		return dist
 	}
 }

--- a/adapters/repos/db/vector/hnsw/generate_recall_datasets.go
+++ b/adapters/repos/db/vector/hnsw/generate_recall_datasets.go
@@ -94,7 +94,7 @@ func bruteForce(vectors [][]float32, query []float32, k int) []uint64 {
 	distances := make([]distanceAndIndex, len(vectors))
 
 	for i, vec := range vectors {
-		dist, _, _ := distancer.NewCosineDistanceProvider().SingleDist(query, vec)
+		dist, _ := distancer.NewCosineDistanceProvider().SingleDist(query, vec)
 		distances[i] = distanceAndIndex{
 			index:    uint64(i),
 			distance: dist,

--- a/adapters/repos/db/vector/hnsw/heuristic.go
+++ b/adapters/repos/db/vector/hnsw/heuristic.go
@@ -103,7 +103,7 @@ func (h *hnsw) selectNeighborsHeuristic(input *priorityqueue.Queue[any],
 			}
 			good := true
 			for _, item := range returnList {
-				peerDist, _, _ := h.distancerProvider.SingleDist(currVec,
+				peerDist, _ := h.distancerProvider.SingleDist(currVec,
 					vecs[item.Value])
 
 				if peerDist < distToQuery {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -419,11 +419,6 @@ func (h *hnsw) findBestEntrypointForNode(currentMaxLevel, targetLevel int,
 		var err error
 		if h.compressed.Load() {
 			dist, err = distancer.DistanceToNode(entryPointID)
-			var e storobj.ErrNotFound
-			if errors.As(err, &e) {
-				h.handleDeletedNode(e.DocID)
-				continue
-			}
 		} else {
 			dist, err = h.distBetweenNodeAndVec(entryPointID, nodeVec)
 		}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -427,6 +427,12 @@ func (h *hnsw) findBestEntrypointForNode(currentMaxLevel, targetLevel int,
 		} else {
 			dist, err = h.distBetweenNodeAndVec(entryPointID, nodeVec)
 		}
+
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) {
+			h.handleDeletedNode(e.DocID)
+			continue
+		}
 		if err != nil {
 			return 0, errors.Wrapf(err,
 				"calculate distance between insert node and entry point at level %d", level)

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -416,24 +416,20 @@ func (h *hnsw) findBestEntrypointForNode(currentMaxLevel, targetLevel int,
 	for level := currentMaxLevel; level > targetLevel; level-- {
 		eps := priorityqueue.NewMin[any](1)
 		var dist float32
-		var ok bool
 		var err error
 		if h.compressed.Load() {
-			dist, ok, err = distancer.DistanceToNode(entryPointID)
+			dist, err = distancer.DistanceToNode(entryPointID)
 			var e storobj.ErrNotFound
 			if errors.As(err, &e) {
 				h.handleDeletedNode(e.DocID)
 				continue
 			}
 		} else {
-			dist, ok, err = h.distBetweenNodeAndVec(entryPointID, nodeVec)
+			dist, err = h.distBetweenNodeAndVec(entryPointID, nodeVec)
 		}
 		if err != nil {
 			return 0, errors.Wrapf(err,
 				"calculate distance between insert node and entry point at level %d", level)
-		}
-		if !ok {
-			continue
 		}
 
 		eps.Insert(entryPointID, dist)
@@ -466,20 +462,19 @@ func min(a, b int) int {
 	return b
 }
 
-func (h *hnsw) distBetweenNodes(a, b uint64) (float32, bool, error) {
+func (h *hnsw) distBetweenNodes(a, b uint64) (float32, error) {
 	if h.compressed.Load() {
 		dist, err := h.compressor.DistanceBetweenCompressedVectorsFromIDs(context.Background(), a, b)
 		if err != nil {
 			var e storobj.ErrNotFound
 			if errors.As(err, &e) {
 				h.handleDeletedNode(e.DocID)
-				return 0, false, nil
-			} else {
-				return 0, false, err
+				return 0, nil
 			}
+			return 0, err
 		}
 
-		return dist, true, nil
+		return dist, nil
 	}
 
 	// TODO: introduce single search/transaction context instead of spawning new
@@ -489,16 +484,15 @@ func (h *hnsw) distBetweenNodes(a, b uint64) (float32, bool, error) {
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
 			h.handleDeletedNode(e.DocID)
-			return 0, false, nil
-		} else {
-			// not a typed error, we can recover from, return with err
-			return 0, false, errors.Wrapf(err,
-				"could not get vector of object at docID %d", a)
+			return 0, nil
 		}
+		// not a typed error, we can recover from, return with err
+		return 0, errors.Wrapf(err,
+			"could not get vector of object at docID %d", a)
 	}
 
 	if len(vecA) == 0 {
-		return 0, false, fmt.Errorf("got a nil or zero-length vector at docID %d", a)
+		return 0, fmt.Errorf("got a nil or zero-length vector at docID %d", a)
 	}
 
 	vecB, err := h.vectorForID(context.Background(), b)
@@ -506,35 +500,33 @@ func (h *hnsw) distBetweenNodes(a, b uint64) (float32, bool, error) {
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
 			h.handleDeletedNode(e.DocID)
-			return 0, false, nil
-		} else {
-			// not a typed error, we can recover from, return with err
-			return 0, false, errors.Wrapf(err,
-				"could not get vector of object at docID %d", b)
+			return 0, nil
 		}
+		// not a typed error, we can recover from, return with err
+		return 0, errors.Wrapf(err,
+			"could not get vector of object at docID %d", b)
 	}
 
 	if len(vecB) == 0 {
-		return 0, false, fmt.Errorf("got a nil or zero-length vector at docID %d", b)
+		return 0, fmt.Errorf("got a nil or zero-length vector at docID %d", b)
 	}
 
 	return h.distancerProvider.SingleDist(vecA, vecB)
 }
 
-func (h *hnsw) distBetweenNodeAndVec(node uint64, vecB []float32) (float32, bool, error) {
+func (h *hnsw) distBetweenNodeAndVec(node uint64, vecB []float32) (float32, error) {
 	if h.compressed.Load() {
 		dist, err := h.compressor.DistanceBetweenCompressedAndUncompressedVectorsFromID(context.Background(), node, vecB)
 		if err != nil {
 			var e storobj.ErrNotFound
 			if errors.As(err, &e) {
 				h.handleDeletedNode(e.DocID)
-				return 0, false, nil
-			} else {
-				return 0, false, err
+				return 0, nil
 			}
+			return 0, err
 		}
 
-		return dist, true, nil
+		return dist, nil
 	}
 
 	// TODO: introduce single search/transaction context instead of spawning new
@@ -544,21 +536,20 @@ func (h *hnsw) distBetweenNodeAndVec(node uint64, vecB []float32) (float32, bool
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
 			h.handleDeletedNode(e.DocID)
-			return 0, false, nil
-		} else {
-			// not a typed error, we can recover from, return with err
-			return 0, false, errors.Wrapf(err,
-				"could not get vector of object at docID %d", node)
+			return 0, nil
 		}
+		// not a typed error, we can recover from, return with err
+		return 0, errors.Wrapf(err,
+			"could not get vector of object at docID %d", node)
 	}
 
 	if len(vecA) == 0 {
-		return 0, false, fmt.Errorf(
+		return 0, fmt.Errorf(
 			"got a nil or zero-length vector at docID %d", node)
 	}
 
 	if len(vecB) == 0 {
-		return 0, false, fmt.Errorf(
+		return 0, fmt.Errorf(
 			"got a nil or zero-length vector as search vector")
 	}
 
@@ -682,7 +673,7 @@ func (h *hnsw) Entrypoint() uint64 {
 	return h.entryPointID
 }
 
-func (h *hnsw) DistanceBetweenVectors(x, y []float32) (float32, bool, error) {
+func (h *hnsw) DistanceBetweenVectors(x, y []float32) (float32, error) {
 	return h.distancerProvider.SingleDist(x, y)
 }
 

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -328,7 +328,7 @@ func (n *neighborFinderConnector) connectNeighborAtLevel(neighborID uint64,
 
 		dist, err := n.graph.distBetweenNodes(n.node.id, neighborID)
 		var e storobj.ErrNotFound
-		if errors.As(err, &e) {
+		if err != nil && errors.As(err, &e) {
 			// it seems either the node or the neighbor were deleted in the meantime,
 			// there is nothing we can do now
 			return nil

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -92,20 +92,16 @@ func (n *neighborFinderConnector) Do() error {
 
 func (n *neighborFinderConnector) processNode(id uint64) (float32, error) {
 	var dist float32
-	var ok bool
 	var err error
 
 	if n.distancer == nil {
-		dist, ok, err = n.graph.distBetweenNodeAndVec(id, n.nodeVec)
+		dist, err = n.graph.distBetweenNodeAndVec(id, n.nodeVec)
 	} else {
-		dist, ok, err = n.distancer.DistanceToNode(id)
+		dist, err = n.distancer.DistanceToNode(id)
 	}
 	if err != nil {
 		return math.MaxFloat32, fmt.Errorf(
 			"calculate distance between insert node and entrypoint: %w", err)
-	}
-	if !ok {
-		return math.MaxFloat32, nil
 	}
 	return dist, nil
 }
@@ -325,29 +321,18 @@ func (n *neighborFinderConnector) connectNeighborAtLevel(neighborID uint64,
 	} else {
 		// we need to run the heuristic
 
-		dist, ok, err := n.graph.distBetweenNodes(n.node.id, neighborID)
+		dist, err := n.graph.distBetweenNodes(n.node.id, neighborID)
 		if err != nil {
 			return errors.Wrapf(err, "dist between %d and %d", n.node.id, neighborID)
-		}
-
-		if !ok {
-			// it seems either the node or the neighbor were deleted in the meantime,
-			// there is nothing we can do now
-			return nil
 		}
 
 		candidates := priorityqueue.NewMax[any](len(currentConnections) + 1)
 		candidates.Insert(n.node.id, dist)
 
 		for _, existingConnection := range currentConnections {
-			dist, ok, err := n.graph.distBetweenNodes(existingConnection, neighborID)
+			dist, err := n.graph.distBetweenNodes(existingConnection, neighborID)
 			if err != nil {
 				return errors.Wrapf(err, "dist between %d and %d", existingConnection, neighborID)
-			}
-
-			if !ok {
-				// was deleted in the meantime
-				continue
 			}
 
 			candidates.Insert(existingConnection, dist)
@@ -494,18 +479,14 @@ func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error)
 	}
 
 	var dist float32
-	var ok bool
 	var err error
 	if n.distancer == nil {
-		dist, ok, err = n.graph.distBetweenNodeAndVec(candidate, n.nodeVec)
+		dist, err = n.graph.distBetweenNodeAndVec(candidate, n.nodeVec)
 	} else {
-		dist, ok, err = n.distancer.DistanceToNode(candidate)
+		dist, err = n.distancer.DistanceToNode(candidate)
 	}
 	if err != nil {
 		return false, fmt.Errorf("calculate distance between insert node and entrypoint: %w", err)
-	}
-	if !ok {
-		return false, nil
 	}
 
 	// we were able to calculate a distance, we're good

--- a/adapters/repos/db/vector/hnsw/recall_geo_spatial_test.go
+++ b/adapters/repos/db/vector/hnsw/recall_geo_spatial_test.go
@@ -207,7 +207,7 @@ func bruteForce(vectors [][]float32, query []float32, k int) []uint64 {
 
 	distancer := distancer.NewGeoProvider().New(query)
 	for i, vec := range vectors {
-		dist, _, _ := distancer.Distance(vec)
+		dist, _ := distancer.Distance(vec)
 		distances[i] = distanceAndIndex{
 			index:    uint64(i),
 			distance: dist,
@@ -240,7 +240,7 @@ func bruteForceMaxDist(vectors [][]float32, query []float32, maxDist float32) []
 
 	distancer := distancer.NewGeoProvider().New(query)
 	for i, vec := range vectors {
-		dist, _, _ := distancer.Distance(vec)
+		dist, _ := distancer.Distance(vec)
 		distances[i] = distanceAndIndex{
 			index:    uint64(i),
 			distance: dist,

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -268,31 +268,22 @@ func (h *hnsw) searchLayerByVectorWithDistancer(queryVector []float32,
 			// make sure we never visit this neighbor again
 			visited.Visit(neighborID)
 			var distance float32
-			var ok bool
 			var err error
 			if h.compressed.Load() {
-				distance, ok, err = compressorDistancer.DistanceToNode(neighborID)
+				distance, err = compressorDistancer.DistanceToNode(neighborID)
 			} else {
-				distance, ok, err = h.distanceToFloatNode(floatDistancer, neighborID)
+				distance, err = h.distanceToFloatNode(floatDistancer, neighborID)
 			}
 			if err != nil {
 				var e storobj.ErrNotFound
 				if errors.As(err, &e) {
 					h.handleDeletedNode(e.DocID)
 					continue
-				} else {
-					if err != nil {
-						h.pools.visitedListsLock.RLock()
-						h.pools.visitedLists.Return(visited)
-						h.pools.visitedListsLock.RUnlock()
-						return nil, errors.Wrap(err, "calculate distance between candidate and query")
-					}
 				}
-			}
-
-			if !ok {
-				// node was deleted in the underlying object store
-				continue
+				h.pools.visitedListsLock.RLock()
+				h.pools.visitedLists.Return(visited)
+				h.pools.visitedListsLock.RUnlock()
+				return nil, errors.Wrap(err, "calculate distance between candidate and query")
 			}
 
 			if distance < worstResultDistance || results.Len() < ef {
@@ -372,21 +363,16 @@ func (h *hnsw) currentWorstResultDistanceToFloat(results *priorityqueue.Queue[an
 	if results.Len() > 0 {
 		id := results.Top().ID
 
-		d, ok, err := h.distanceToFloatNode(distancer, id)
+		d, err := h.distanceToFloatNode(distancer, id)
 		if err != nil {
 			var e storobj.ErrNotFound
 			if errors.As(err, &e) {
 				h.handleDeletedNode(e.DocID)
 			} else {
-				if err != nil {
-					return 0, errors.Wrap(err, "calculated distance between worst result and query")
-				}
+				return 0, errors.Wrap(err, "calculated distance between worst result and query")
 			}
 		}
 
-		if !ok {
-			return math.MaxFloat32, nil
-		}
 		return d, nil
 	} else {
 		// if the entrypoint (which we received from a higher layer doesn't match
@@ -406,15 +392,12 @@ func (h *hnsw) currentWorstResultDistanceToByte(results *priorityqueue.Queue[any
 			return item.Dist, nil
 		}
 		id := item.ID
-		d, ok, err := distancer.DistanceToNode(id)
+		d, err := distancer.DistanceToNode(id)
 		if err != nil {
 			return 0, errors.Wrap(err,
 				"calculated distance between worst result and query")
 		}
 
-		if !ok {
-			return math.MaxFloat32, nil
-		}
 		return d, nil
 	} else {
 		// if the entrypoint (which we received from a higher layer doesn't match
@@ -425,7 +408,7 @@ func (h *hnsw) currentWorstResultDistanceToByte(results *priorityqueue.Queue[any
 	}
 }
 
-func (h *hnsw) distanceFromBytesToFloatNode(concreteDistancer compressionhelpers.CompressorDistancer, nodeID uint64) (float32, bool, error) {
+func (h *hnsw) distanceFromBytesToFloatNode(concreteDistancer compressionhelpers.CompressorDistancer, nodeID uint64) (float32, error) {
 	slice := h.pools.tempVectors.Get(int(h.dims))
 	defer h.pools.tempVectors.Put(slice)
 	vec, err := h.TempVectorForIDThunk(context.Background(), nodeID, slice)
@@ -433,30 +416,28 @@ func (h *hnsw) distanceFromBytesToFloatNode(concreteDistancer compressionhelpers
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
 			h.handleDeletedNode(e.DocID)
-			return 0, false, nil
+			return 0, nil
 		} else {
 			// not a typed error, we can recover from, return with err
-			return 0, false, errors.Wrapf(err, "get vector of docID %d", nodeID)
+			return 0, errors.Wrapf(err, "get vector of docID %d", nodeID)
 		}
 	}
 	vec = h.normalizeVec(vec)
 	return concreteDistancer.DistanceToFloat(vec)
 }
 
-func (h *hnsw) distanceToFloatNode(distancer distancer.Distancer,
-	nodeID uint64,
-) (float32, bool, error) {
+func (h *hnsw) distanceToFloatNode(distancer distancer.Distancer, nodeID uint64) (float32, error) {
 	candidateVec, err := h.vectorForID(context.Background(), nodeID)
 	if err != nil {
-		return 0, false, err
+		return 0, err
 	}
 
-	dist, _, err := distancer.Distance(candidateVec)
+	dist, err := distancer.Distance(candidateVec)
 	if err != nil {
-		return 0, false, errors.Wrap(err, "calculate distance between candidate and query")
+		return 0, errors.Wrap(err, "calculate distance between candidate and query")
 	}
 
-	return dist, true, nil
+	return dist, nil
 }
 
 // the underlying object seems to have been deleted, to recover from
@@ -492,14 +473,9 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 	maxLayer := h.currentMaximumLayer
 	h.RUnlock()
 
-	entryPointDistance, ok, err := h.distBetweenNodeAndVec(entryPointID, searchVec)
+	entryPointDistance, err := h.distBetweenNodeAndVec(entryPointID, searchVec)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
-	}
-
-	if !ok {
-		return nil, nil, fmt.Errorf("entrypoint was deleted in the object store, " +
-			"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
 	}
 
 	var compressorDistancer compressionhelpers.CompressorDistancer
@@ -595,8 +571,8 @@ func (h *hnsw) rescore(res *priorityqueue.Queue[any], k int, compressorDistancer
 	}
 	res.Reset()
 	for _, id := range ids {
-		dist, found, err := h.distanceFromBytesToFloatNode(compressorDistancer, id)
-		if found && err == nil {
+		dist, err := h.distanceFromBytesToFloatNode(compressorDistancer, id)
+		if err == nil {
 			res.Insert(id, dist)
 			if res.Len() > k {
 				res.Pop()

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist.go
@@ -12,9 +12,12 @@
 package hnsw
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (h *hnsw) KnnSearchByVectorMaxDist(searchVec []float32, dist float32,
@@ -22,6 +25,11 @@ func (h *hnsw) KnnSearchByVectorMaxDist(searchVec []float32, dist float32,
 ) ([]uint64, error) {
 	entryPointID := h.entryPointID
 	entryPointDistance, err := h.distBetweenNodeAndVec(entryPointID, searchVec)
+	var e storobj.ErrNotFound
+	if err != nil && errors.As(err, &e) {
+		return nil, fmt.Errorf("entrypoint was deleted in the object store, " +
+			"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
 	}

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist.go
@@ -12,8 +12,6 @@
 package hnsw
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
@@ -23,14 +21,9 @@ func (h *hnsw) KnnSearchByVectorMaxDist(searchVec []float32, dist float32,
 	ef int, allowList helpers.AllowList,
 ) ([]uint64, error) {
 	entryPointID := h.entryPointID
-	entryPointDistance, ok, err := h.distBetweenNodeAndVec(entryPointID, searchVec)
+	entryPointDistance, err := h.distBetweenNodeAndVec(entryPointID, searchVec)
 	if err != nil {
 		return nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
-	}
-
-	if !ok {
-		return nil, fmt.Errorf("entrypoint was deleted in the object store, " +
-			"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
 	}
 
 	// stop at layer 1, not 0!

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -100,8 +100,8 @@ func (i *Index) PostStartup() {
 func (i *Index) Dump(labels ...string) {
 }
 
-func (i *Index) DistanceBetweenVectors(x, y []float32) (float32, bool, error) {
-	return 0, true, nil
+func (i *Index) DistanceBetweenVectors(x, y []float32) (float32, error) {
+	return 0, nil
 }
 
 func (i *Index) ContainsNode(id uint64) bool {

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -38,7 +38,7 @@ type VectorIndex interface {
 	PostStartup()
 	Compressed() bool
 	ValidateBeforeInsert(vector []float32) error
-	DistanceBetweenVectors(x, y []float32) (float32, bool, error)
+	DistanceBetweenVectors(x, y []float32) (float32, error)
 	ContainsNode(id uint64) bool
 	DistancerProvider() distancer.Provider
 }


### PR DESCRIPTION
### What's being changed:
this PR 
- get rid off all `found` bool in the interface of `Distance*()` methods. 
- makes sure any deleted node are handled on returned error and having a consistent behaviour to all `Distance*()` methods. 

*Note* `distBetweenNodes()` ignores error and return nil in case of the node was deleted 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
