### PR TITLE
add cluster id and cluster owner info to sentry

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -179,6 +179,12 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		}
 
 		sentry.ConfigureScope(func(scope *sentry.Scope) {
+			// Set cluster ID and cluster owner using sentry user feature to distinguish multiple clusters in the UI
+			scope.SetUser(sentry.User{
+				ID:       appState.ServerConfig.Config.Sentry.ClusterId,
+				Username: appState.ServerConfig.Config.Sentry.ClusterOwner,
+			})
+			// Set any tags defined
 			for key, value := range appState.ServerConfig.Config.Sentry.Tags {
 				scope.SetTag(key, value)
 			}

--- a/entities/sentry/config.go
+++ b/entities/sentry/config.go
@@ -36,6 +36,8 @@ type ConfigOpts struct {
 	ErrorSampleRate   float64           `json:"error_sample_rate" yaml:"error_sample_rate"`
 	TracesSampleRate  float64           `json:"traces_sample_rate" yaml:"traces_sample_rate"`
 	ProfileSampleRate float64           `json:"profile_sample_rate" yaml:"profile_sample_rate"`
+	ClusterId         string            `json:"cluster_id" yaml:"cluster_id"`
+	ClusterOwner      string            `json:"cluster_owner" yaml:"cluster_owner"`
 }
 
 // Config Global Singleton that can be accessed from anywhere in the app. This
@@ -64,6 +66,9 @@ func InitSentryConfig() (*ConfigOpts, error) {
 	if Config.Environment == "" {
 		Config.Environment = "unknown"
 	}
+
+	Config.ClusterOwner = os.Getenv("SENTRY_CLUSTER_OWNER")
+	Config.ClusterId = os.Getenv("SENTRY_CLUSTER_ID")
 
 	// Configure error sampling
 	if errorSampleRate, err := strconv.ParseFloat(os.Getenv("SENTRY_ERROR_SAMPLE_RATE"), 64); err == nil && errorSampleRate <= 1.0 && errorSampleRate >= 0.0 {

--- a/entities/sentry/config_test.go
+++ b/entities/sentry/config_test.go
@@ -66,10 +66,12 @@ func TestSentryConfig(t *testing.T) {
 		{
 			name: "enabled, everything set",
 			vars: map[string]string{
-				"SENTRY_ENABLED":   "true",
-				"SENTRY_DSN":       "http://dsn",
-				"SENTRY_DEBUG":     "true",
-				"SENTRY_TAG_hello": "world",
+				"SENTRY_ENABLED":       "true",
+				"SENTRY_DSN":           "http://dsn",
+				"SENTRY_DEBUG":         "true",
+				"SENTRY_TAG_hello":     "world",
+				"SENTRY_CLUSTER_OWNER": "im_the_owner",
+				"SENTRY_CLUSTER_ID":    "id123",
 			},
 			expectErr: false,
 			expectedConfig: ConfigOpts{
@@ -81,6 +83,8 @@ func TestSentryConfig(t *testing.T) {
 				ErrorSampleRate:   1.0,
 				TracesSampleRate:  0.1,
 				ProfileSampleRate: 1.0,
+				ClusterId:         "id123",
+				ClusterOwner:      "im_the_owner",
 				Tags: map[string]string{
 					"hello": "world",
 				},


### PR DESCRIPTION
### What's being changed:

Add cluster id and cluster owner env variable and propagate the information into sentry tracing using their user tag feature

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
