### PR TITLE
refact:distance: handle deleted nodes from caller only

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -467,11 +467,6 @@ func (h *hnsw) distBetweenNodes(a, b uint64) (float32, error) {
 	if h.compressed.Load() {
 		dist, err := h.compressor.DistanceBetweenCompressedVectorsFromIDs(context.Background(), a, b)
 		if err != nil {
-			var e storobj.ErrNotFound
-			if errors.As(err, &e) {
-				h.handleDeletedNode(e.DocID)
-				return 0, nil
-			}
 			return 0, err
 		}
 
@@ -519,11 +514,6 @@ func (h *hnsw) distBetweenNodeAndVec(node uint64, vecB []float32) (float32, erro
 	if h.compressed.Load() {
 		dist, err := h.compressor.DistanceBetweenCompressedAndUncompressedVectorsFromID(context.Background(), node, vecB)
 		if err != nil {
-			var e storobj.ErrNotFound
-			if errors.As(err, &e) {
-				h.handleDeletedNode(e.DocID)
-				return 0, nil
-			}
 			return 0, err
 		}
 

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -346,7 +346,7 @@ func (n *neighborFinderConnector) connectNeighborAtLevel(neighborID uint64,
 			dist, err := n.graph.distBetweenNodes(existingConnection, neighborID)
 			var e storobj.ErrNotFound
 			if errors.As(err, &e) {
-				n.graph.handleDeletedNode(neighborID)
+				n.graph.handleDeletedNode(e.DocID)
 				// was deleted in the meantime
 				continue
 			}
@@ -506,6 +506,7 @@ func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error)
 	}
 	var e storobj.ErrNotFound
 	if errors.As(err, &e) {
+		n.graph.handleDeletedNode(e.DocID)
 		return false, nil
 	}
 	if err != nil {

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -102,6 +102,7 @@ func (n *neighborFinderConnector) processNode(id uint64) (float32, error) {
 
 	var e storobj.ErrNotFound
 	if errors.As(err, &e) {
+		n.graph.handleDeletedNode(e.DocID)
 		return math.MaxFloat32, nil
 	}
 	if err != nil {
@@ -329,6 +330,7 @@ func (n *neighborFinderConnector) connectNeighborAtLevel(neighborID uint64,
 		dist, err := n.graph.distBetweenNodes(n.node.id, neighborID)
 		var e storobj.ErrNotFound
 		if err != nil && errors.As(err, &e) {
+			n.graph.handleDeletedNode(e.DocID)
 			// it seems either the node or the neighbor were deleted in the meantime,
 			// there is nothing we can do now
 			return nil
@@ -344,6 +346,7 @@ func (n *neighborFinderConnector) connectNeighborAtLevel(neighborID uint64,
 			dist, err := n.graph.distBetweenNodes(existingConnection, neighborID)
 			var e storobj.ErrNotFound
 			if errors.As(err, &e) {
+				n.graph.handleDeletedNode(neighborID)
 				// was deleted in the meantime
 				continue
 			}

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist.go
@@ -27,6 +27,7 @@ func (h *hnsw) KnnSearchByVectorMaxDist(searchVec []float32, dist float32,
 	entryPointDistance, err := h.distBetweenNodeAndVec(entryPointID, searchVec)
 	var e storobj.ErrNotFound
 	if err != nil && errors.As(err, &e) {
+		h.handleDeletedNode(e.DocID)
 		return nil, fmt.Errorf("entrypoint was deleted in the object store, " +
 			"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
 	}


### PR DESCRIPTION
### What's being changed:
a follow up for https://github.com/weaviate/weaviate/pull/5474 to make sure the deleted nodes handled by the caller methods of `distBetweenNodes ()` and `distBetweenNodeAndVec()`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10161026082
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
