### PR TITLE
Optimize vector cache prefilling

### DIFF
--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -23,6 +23,10 @@ import (
 //  3. It will never return duplicates, to make sure all parallel cursors
 //     return unique values.
 func (b *Bucket) QuantileKeys(q int) [][]byte {
+	if q <= 0 {
+		return nil
+	}
+
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 

--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -1,0 +1,41 @@
+package lsmkv
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+func (b *Bucket) QuantileKeys(q int) [][]byte {
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	fmt.Printf("before disk.quantileKeys\n")
+	keys := b.disk.quantileKeys(q)
+	fmt.Printf("after disk.quantileKeys\n")
+	return keys
+}
+
+func (sg *SegmentGroup) quantileKeys(q int) [][]byte {
+	sg.maintenanceLock.RLock()
+	defer sg.maintenanceLock.RUnlock()
+
+	var keys [][]byte
+
+	for _, s := range sg.segments {
+		keys = append(keys, s.quantileKeys(q)...)
+	}
+
+	// re-sort keys
+	sort.Slice(keys, func(i, j int) bool {
+		return bytes.Compare(keys[i], keys[j]) < 0
+	})
+
+	// TODO: re-pick keys to make sure they are evenly distributed
+
+	return keys
+}
+
+func (s *segment) quantileKeys(q int) [][]byte {
+	return s.index.QuantileKeys(q)
+}

--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -2,7 +2,6 @@ package lsmkv
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 )
 
@@ -10,9 +9,7 @@ func (b *Bucket) QuantileKeys(q int) [][]byte {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
-	fmt.Printf("before disk.quantileKeys\n")
 	keys := b.disk.quantileKeys(q)
-	fmt.Printf("after disk.quantileKeys\n")
 	return keys
 }
 
@@ -31,9 +28,12 @@ func (sg *SegmentGroup) quantileKeys(q int) [][]byte {
 		return bytes.Compare(keys[i], keys[j]) < 0
 	})
 
-	// TODO: re-pick keys to make sure they are evenly distributed
+	finalKeys := make([][]byte, q)
+	for i := range finalKeys {
+		finalKeys[i] = keys[len(keys)/q*i]
+	}
 
-	return keys
+	return finalKeys
 }
 
 func (s *segment) quantileKeys(q int) [][]byte {

--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -2,9 +2,26 @@ package lsmkv
 
 import (
 	"bytes"
+	"math"
 	"sort"
 )
 
+// QuantileKeys returns an approximation of the keys that make up the specified
+// quantiles. This can be used to start parallel cursors at fairly evenly
+// distributed positions in the segment.
+//
+// To understand the approximation, checkout
+// [lsmkv.segmentindex.DiskTree.QuantileKeys] that runs on each segment.
+//
+// Some things to keep in mind:
+//
+//  1. It may return fewer keys than requested (including 0) if the segment
+//     contains fewer entries
+//  2. It may return keys that do not exist, for example because they are
+//     tombstoned. This is acceptable, as a key does not have to exist to be used
+//     as part of .Seek() in a cursor.
+//  3. It will never return duplicates, to make sure all parallel cursors
+//     return unique values.
 func (b *Bucket) QuantileKeys(q int) [][]byte {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -32,14 +49,45 @@ func (sg *SegmentGroup) quantileKeys(q int) [][]byte {
 		return bytes.Compare(keys[i], keys[j]) < 0
 	})
 
-	finalKeys := make([][]byte, q)
-	for i := range finalKeys {
-		finalKeys[i] = keys[len(keys)/q*i]
+	// There could be duplicates if a key was modified in multiple segments, we
+	// need to remove them. Since the list is sorted at this, this is fairly easy
+	// to do:
+	uniqueKeys := make([][]byte, 0, len(keys))
+	for i := range keys {
+		if i == 0 || !bytes.Equal(keys[i], keys[i-1]) {
+			uniqueKeys = append(uniqueKeys, keys[i])
+		}
 	}
 
-	return finalKeys
+	return pickEvenlyDistributedKeys(uniqueKeys, q)
 }
 
 func (s *segment) quantileKeys(q int) [][]byte {
 	return s.index.QuantileKeys(q)
+}
+
+// pickEvenlyDistributedKeys picks q keys from the input keys, trying to keep
+// the distribution as even as possible. The input keys are assumed to be
+// sorted. It never returns duplicates, see the unit test proving this.
+func pickEvenlyDistributedKeys(uniqueKeys [][]byte, q int) [][]byte {
+	if q >= len(uniqueKeys) {
+		// impossible to pick, simply return the input
+		return uniqueKeys
+	}
+
+	// we know have the guarantee that q > len(uniqueKeys), which means it is
+	// possible to pick q keys without overlap while keeping the distribution as
+	// even as possible
+	finalKeys := make([][]byte, q)
+	stepSize := float64(len(uniqueKeys)) / float64(q)
+	for i := range finalKeys {
+		pos := int(math.Round(float64(i)*stepSize + 0.5*stepSize))
+		if pos >= len(uniqueKeys) {
+			pos = len(uniqueKeys) - 1
+		}
+
+		finalKeys[i] = uniqueKeys[pos]
+	}
+
+	return finalKeys
 }

--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -19,6 +19,10 @@ func (sg *SegmentGroup) quantileKeys(q int) [][]byte {
 
 	var keys [][]byte
 
+	if len(sg.segments) == 0 {
+		return keys
+	}
+
 	for _, s := range sg.segments {
 		keys = append(keys, s.quantileKeys(q)...)
 	}

--- a/adapters/repos/db/lsmkv/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/quantile_keys_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/lsmkv/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/quantile_keys_test.go
@@ -1,0 +1,145 @@
+package lsmkv
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestQuantileKeysSingleSegment(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(
+		ctx, dir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+
+	importConsecutiveKeys(t, b, 0, 1000)
+
+	// all cyclemmanagers are noops, so we need to explicitly flush if we want a
+	// segment to be built
+	require.Nil(t, b.FlushAndSwitch())
+
+	quantiles := b.QuantileKeys(10)
+
+	asNumbers := make([]uint64, len(quantiles))
+	for i, q := range quantiles {
+		asNumbers[i] = binary.BigEndian.Uint64(q)
+	}
+
+	// validate there are no duplicates, and each key is strictly greater than
+	// the last
+	for i, n := range asNumbers {
+		if i == 0 {
+			continue
+		}
+
+		prev := asNumbers[i-1]
+		assert.Greater(t, n, prev)
+	}
+
+	// assert on distribution
+	idealStepSize := float64(1000) / float64(len(asNumbers)+1)
+	for i, n := range asNumbers {
+		actualStepSize := float64(n) / float64(i+1)
+		assert.InEpsilon(t, idealStepSize, actualStepSize, 0.1)
+	}
+}
+
+func TestQuantileKeysMultipleSegmentsUniqueEntries(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(
+		ctx, dir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+
+	importConsecutiveKeys(t, b, 0, 1000)
+
+	// all cyclemmanagers are noops, so we need to explicitly flush if we want a
+	// segment to be built
+	require.Nil(t, b.FlushAndSwitch())
+
+	importConsecutiveKeys(t, b, 1000, 2000)
+
+	// all cyclemmanagers are noops, so we need to explicitly flush if we want a
+	// segment to be built
+	require.Nil(t, b.FlushAndSwitch())
+
+	quantiles := b.QuantileKeys(10)
+
+	asNumbers := make([]uint64, len(quantiles))
+	for i, q := range quantiles {
+		asNumbers[i] = binary.BigEndian.Uint64(q)
+	}
+
+	// validate there are no duplicates, and each key is strictly greater than
+	// the last
+	for i, n := range asNumbers {
+		if i == 0 {
+			continue
+		}
+
+		prev := asNumbers[i-1]
+		assert.Greater(t, n, prev)
+	}
+}
+
+func importConsecutiveKeys(t *testing.T, b *Bucket, start, end uint64) {
+	for i := start; i < end; i++ {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, i)
+		err := b.Put(key, key)
+		require.Nil(t, err)
+	}
+}
+
+func TestPickEvenlyDistributedKeys(t *testing.T) {
+	for input := 0; input < 100; input++ {
+		for q := 1; q < 100; q++ {
+			t.Run(fmt.Sprintf("input=%d, q=%d", input, q), func(t *testing.T) {
+				keys := make([][]byte, input)
+				for i := 0; i < input; i++ {
+					key := make([]byte, 8)
+					binary.BigEndian.PutUint64(key, uint64(i))
+					keys[i] = key
+				}
+
+				picked := pickEvenlyDistributedKeys(keys, q)
+
+				// make sure there are never more results than q
+				require.LessOrEqual(t, len(picked), q)
+
+				// make sure that we get q results if there are at least q keys
+				if input >= q {
+					require.Equal(t, q, len(picked))
+				} else {
+					// if there are fewer keys than q, we should get all of them
+					require.Equal(t, input, len(picked))
+				}
+
+				// make sure there are no duplicates
+				for i, key := range picked {
+					if i == 0 {
+						continue
+					}
+
+					prev := binary.BigEndian.Uint64(picked[i-1])
+					curr := binary.BigEndian.Uint64(key)
+
+					require.Greater(t, curr, prev, "found duplicate picks")
+				}
+			})
+		}
+	}
+}

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -69,6 +69,8 @@ type diskIndex interface {
 
 	// Size of the index in bytes
 	Size() int
+
+	QuantileKeys(q int) [][]byte
 }
 
 func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package segmentindex
 
 import (

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
@@ -31,7 +31,7 @@ import (
 // returns more keys. This is because in a real-life application you would
 // likely aggregate across multiple segments. Similarly keys are not returned
 // in any specific order, as the assumption is that post-processing will be
-// done when keys are aggregated accross multiple segments.
+// done when keys are aggregated across multiple segments.
 //
 // The two guarantees you get are:
 //

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
@@ -1,0 +1,70 @@
+package segmentindex
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+func (t *DiskTree) QuantileKeys(q int) [][]byte {
+	bfs := parallelBFS{
+		dt:             t,
+		maxDepth:       8,
+		keysDiscovered: make(chan []byte),
+	}
+
+	return bfs.run()
+}
+
+type parallelBFS struct {
+	dt             *DiskTree
+	maxDepth       int
+	keysDiscovered chan []byte
+	wg             sync.WaitGroup
+}
+
+func (bfs *parallelBFS) run() [][]byte {
+	bfs.wg.Add(1)
+	go bfs.parse(0, 0)
+
+	var keys [][]byte
+	go func() {
+		for key := range bfs.keysDiscovered {
+			keys = append(keys, key)
+			bfs.wg.Done()
+		}
+	}()
+	bfs.wg.Wait()
+
+	close(bfs.keysDiscovered)
+
+	return keys
+}
+
+func (bfs *parallelBFS) parse(offset uint64, level int) {
+	// TODO: check exit condition (when have we reached the end of the tree)
+	fmt.Printf("offset=%d, max=%d level=%d\n", offset, len(bfs.dt.data), level)
+	rw := byteops.NewReadWriter(bfs.dt.data)
+	rw.Position = offset
+	keyLen := rw.ReadUint32()
+	nodeKeyBuffer := make([]byte, int(keyLen))
+	_, err := rw.CopyBytesFromBuffer(uint64(keyLen), nodeKeyBuffer)
+	if err != nil {
+		// TODO: handle error
+		panic(fmt.Errorf("copy node key: %w", err).Error())
+	}
+	bfs.keysDiscovered <- nodeKeyBuffer
+
+	if level+1 >= bfs.maxDepth {
+		return
+	}
+
+	rw.MoveBufferPositionForward(2 * 8) // jump over start+end position
+	leftChildPos := rw.ReadUint64()     // left child
+	rightChildPos := rw.ReadUint64()    // left child
+
+	bfs.wg.Add(2)
+	bfs.parse(leftChildPos, level+1)
+	bfs.parse(rightChildPos, level+1)
+}

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
@@ -28,6 +28,10 @@ import (
 //     most likely more
 //  2. If there are less than q keys in the tree, you will get all keys.
 func (t *DiskTree) QuantileKeys(q int) [][]byte {
+	if q <= 0 {
+		return nil
+	}
+
 	// we will overfetch a bit because we will have q keys at level n, but in
 	// addition we can use all keys discovered on the way to get to level n. This
 	// will help us to get a more even distribution of keys – especially when

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
@@ -7,6 +7,26 @@ import (
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
+// QuantileKeys returns a list of keys that roughly represent the quantiles of
+// the tree. This can be very useful to bootstrap parallel cursors over the
+// segment that are more or less evenly distributed.
+//
+// This method uses the natural shape of the tree to determine the
+// distribution of the keys. This is a performance-accuracy trade-off. It does
+// not guarantee perfect distribution, but it is fairly cheap to obtain as most
+// runs will only need to go a few levels deep – even on massive trees.
+//
+// The number of keys returned is not guaranteed to be exactly q, in most cases
+// returns more keys. This is because in a real-life application you would
+// likely aggregate across multiple segments. Similarly keys are not returned
+// in any specific order, as the assumption is that post-processing will be
+// done when keys are aggregated accross multiple segments.
+//
+// The two guarantees you get are:
+//
+//  1. If there are at least q keys in the tree, you will get at least q keys,
+//     most likely more
+//  2. If there are less than q keys in the tree, you will get all keys.
 func (t *DiskTree) QuantileKeys(q int) [][]byte {
 	// we will overfetch a bit because we will have q keys at level n, but in
 	// addition we can use all keys discovered on the way to get to level n. This

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package segmentindex
 
 import (

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
@@ -26,6 +26,18 @@ func TestQuantileKeys(t *testing.T) {
 			expectedMinimumOutput: 10,
 		},
 		{
+			name:                  "single entry, no quantiles",
+			objects:               1,
+			inputQuantiles:        0,
+			expectedMinimumOutput: 0,
+		},
+		{
+			name:                  "negative quanitles",
+			objects:               50,
+			inputQuantiles:        -100,
+			expectedMinimumOutput: 0,
+		},
+		{
 			name:                  "single entry, single quantile",
 			objects:               1,
 			inputQuantiles:        1,

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
@@ -1,0 +1,108 @@
+package segmentindex
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuantileKeys(t *testing.T) {
+	type test struct {
+		name                  string
+		objects               int
+		inputQuantiles        int
+		expectedMinimumOutput int
+	}
+
+	tests := []test{
+		{
+			name:                  "many entries, few quantiles",
+			objects:               1000,
+			inputQuantiles:        10,
+			expectedMinimumOutput: 10,
+		},
+		{
+			name:                  "single entry, single quantile",
+			objects:               1,
+			inputQuantiles:        1,
+			expectedMinimumOutput: 1,
+		},
+		{
+			name:                  "single entry, many quantiles",
+			objects:               1,
+			inputQuantiles:        100,
+			expectedMinimumOutput: 1,
+		},
+		{
+			name:                  "few entries, many quantiles",
+			objects:               17,
+			inputQuantiles:        100,
+			expectedMinimumOutput: 17,
+		},
+		{
+			name:                  "same number of entries and quantiles",
+			objects:               31,
+			inputQuantiles:        31,
+			expectedMinimumOutput: 31,
+		},
+		{
+			name:                  "no entries",
+			objects:               0,
+			inputQuantiles:        31,
+			expectedMinimumOutput: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dt := buildSampleDiskTree(t, test.objects)
+			keys := dt.QuantileKeys(test.inputQuantiles)
+
+			require.GreaterOrEqual(t, len(keys), test.expectedMinimumOutput)
+		})
+	}
+}
+
+func TestQuantileKeysDistribution(t *testing.T) {
+	dt := buildSampleDiskTree(t, 1000)
+	keys := dt.QuantileKeys(8)
+	sort.Slice(keys, func(a, b int) bool {
+		return bytes.Compare(keys[a], keys[b]) < 0
+	})
+
+	asNumbers := make([]uint64, 0, len(keys))
+	for _, key := range keys {
+		asNumbers = append(asNumbers, binary.BigEndian.Uint64(key))
+	}
+
+	idealStepSize := float64(1000) / float64(len(asNumbers)+1)
+	for i, n := range asNumbers {
+		actualStepSize := float64(n) / float64(i+1)
+		assert.InEpsilon(t, idealStepSize, actualStepSize, 0.1)
+	}
+}
+
+func buildSampleDiskTree(t *testing.T, n int) *DiskTree {
+	nodes := make([]Node, 0, n)
+	for i := 0; i < n; i++ {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i))
+		// the index positions do not matter for this test
+		start, end := uint64(0), uint64(0)
+		nodes = append(nodes, Node{Key: key, Start: start, End: end})
+	}
+
+	sort.Slice(nodes, func(a, b int) bool {
+		return bytes.Compare(nodes[a].Key, nodes[b].Key) < 0
+	})
+
+	balanced := NewBalanced(nodes)
+	dt, err := balanced.MarshalBinary()
+	require.Nil(t, err)
+
+	return NewDiskTree(dt)
+}

--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -25,6 +25,8 @@ type Cache[T any] interface {
 	CountVectors() int64
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vec []T)
+	PreloadNoLock(id uint64, vec []T)
+	SetSizeNoLock(id uint64)
 	Prefetch(id uint64)
 	Grow(size uint64)
 	Drop()

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -227,6 +227,14 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 	s.cache[id] = vec
 }
 
+func (s *shardedLockCache[T]) PreloadNoLock(id uint64, vec []T) {
+	s.cache[id] = vec
+}
+
+func (s *shardedLockCache[T]) SetSizeNoLock(size uint64) {
+	atomic.StoreInt64(&s.count, int64(size))
+}
+
 func (s *shardedLockCache[T]) Grow(node uint64) {
 	s.maintenanceLock.RLock()
 	if node < uint64(len(s.cache)) {

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -408,7 +408,7 @@ func (pq *ProductQuantizer) Fit(data [][]float32) error {
 				errorResult = err
 			}
 			mutex.Unlock()
-		})
+		}, 0)
 		if errorResult != nil {
 			return errorResult
 		}

--- a/adapters/repos/db/vector/compressionhelpers/utils.go
+++ b/adapters/repos/db/vector/compressionhelpers/utils.go
@@ -22,9 +22,11 @@ import (
 
 type Action func(taskIndex uint64)
 
-func Concurrently(log logrus.FieldLogger, n uint64, action Action) {
+func Concurrently(log logrus.FieldLogger, n uint64, action Action, workerCount int) {
 	n64 := float64(n)
-	workerCount := runtime.GOMAXPROCS(0)
+	if workerCount == 0 {
+		workerCount = runtime.GOMAXPROCS(0)
+	}
 	wg := &sync.WaitGroup{}
 	split := uint64(math.Ceil(n64 / float64(workerCount)))
 	for worker := uint64(0); worker < uint64(workerCount); worker++ {

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -51,7 +51,7 @@ func TestDynamic(t *testing.T) {
 	truths := make([][]uint64, queries_size)
 	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
 		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, distanceWrapper(distancer))
-	})
+	}, 0)
 	noopCallback := cyclemanager.NewCallbackGroupNoop()
 	fuc := flatent.UserConfig{}
 	fuc.SetDefaults()
@@ -87,7 +87,7 @@ func TestDynamic(t *testing.T) {
 
 	compressionhelpers.Concurrently(logger, uint64(vectors_size), func(i uint64) {
 		dynamic.Add(i, vectors[i])
-	})
+	}, 0)
 	shouldUpgrade, at := dynamic.ShouldUpgrade()
 	assert.True(t, shouldUpgrade)
 	assert.Equal(t, vectors_size, at)
@@ -155,7 +155,7 @@ func recallAndLatency(queries [][]float32, k int, index dynamic.VectorIndex, tru
 		querying += ellapsed
 		relevant += hits
 		mutex.Unlock()
-	})
+	}, 0)
 
 	recall := float32(relevant) / float32(retrieved)
 	latency := float32(querying.Microseconds()) / float32(len(queries))

--- a/adapters/repos/db/vector/dynamic/restore_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_integration_test.go
@@ -47,7 +47,7 @@ func TestBackup_Integration(t *testing.T) {
 	distancer := distancer.NewL2SquaredProvider()
 	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
 		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, distanceWrapper(distancer))
-	})
+	}, 0)
 	logger, _ := test.NewNullLogger()
 
 	dirName := t.TempDir()
@@ -98,7 +98,7 @@ func TestBackup_Integration(t *testing.T) {
 
 	compressionhelpers.Concurrently(logger, uint64(vectors_size), func(i uint64) {
 		idx.Add(i, vectors[i])
-	})
+	}, 0)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
@@ -1,0 +1,131 @@
+package flat
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sync"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+)
+
+type compressedParallelIterator struct {
+	bucket   *lsmkv.Bucket
+	parallel int
+}
+
+func NewCompressedParallelIterator(bucket *lsmkv.Bucket, parallel int) *compressedParallelIterator {
+	return &compressedParallelIterator{
+		bucket:   bucket,
+		parallel: parallel,
+	}
+}
+
+func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
+	if cpi.parallel <= 1 {
+		// caller explicitly wants no parallelism, fallback to regular cursor
+		return cpi.iterateAllNoConcurrency()
+	}
+
+	// We need one fewer seed than our desired parallel factor, that is because
+	// we will add one routine that starts with cursor.First() and reads to the
+	// first checkpoint, therefore we will have len(checkpoints) + 1 routines in
+	// total.
+	seedCount := cpi.parallel - 1
+	seeds := cpi.bucket.QuantileKeys(seedCount)
+	if len(seeds) == 0 {
+		return nil
+	}
+
+	wg := sync.WaitGroup{}
+	out := make(chan []BQVecAndID)
+
+	// There are three scenarios:
+	// 1. Read from beginning to first checkpoint
+	// 2. Read from checkpoint n to checkpoint n+1
+	// 3. Read from last checkpoint to end
+
+	extract := func(k, v []byte) BQVecAndID {
+		id := binary.BigEndian.Uint64(k)
+		vec := uint64SliceFromByteSlice(v, make([]uint64, len(v)/8))
+		return BQVecAndID{id: id, vec: vec}
+	}
+
+	// S1: Read from beginning to first checkpoint:
+	wg.Add(1)
+	go func() {
+		c := cpi.bucket.Cursor()
+		localResults := make([]BQVecAndID, 0, 10_000)
+		defer c.Close()
+		defer wg.Done()
+
+		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
+			localResults = append(localResults, extract(k, v))
+		}
+
+		out <- localResults
+	}()
+
+	// S2: Read from checkpoint n to checkpoint n+1, stop at last checkpoint:
+	for i := 0; i < len(seeds)-1; i++ {
+		wg.Add(1)
+		go func(start, end []byte) {
+			defer wg.Done()
+			localResults := make([]BQVecAndID, 0, 10_000)
+			c := cpi.bucket.Cursor()
+			defer c.Close()
+
+			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
+				localResults = append(localResults, extract(k, v))
+			}
+
+			out <- localResults
+		}(seeds[i], seeds[i+1])
+	}
+
+	// S3: Read from last checkpoint to end:
+	wg.Add(1)
+	go func() {
+		c := cpi.bucket.Cursor()
+		defer c.Close()
+		defer wg.Done()
+		localResults := make([]BQVecAndID, 0, 10_000)
+
+		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
+			localResults = append(localResults, extract(k, v))
+		}
+
+		out <- localResults
+	}()
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}
+
+func (cpi *compressedParallelIterator) iterateAllNoConcurrency() chan []BQVecAndID {
+	out := make(chan []BQVecAndID)
+	go func() {
+		defer close(out)
+		c := cpi.bucket.Cursor()
+		defer c.Close()
+
+		localResults := make([]BQVecAndID, 0, 10_000)
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			id := binary.BigEndian.Uint64(k)
+			vec := uint64SliceFromByteSlice(v, make([]uint64, len(v)/8))
+			localResults = append(localResults, BQVecAndID{id: id, vec: vec})
+		}
+
+		out <- localResults
+	}()
+
+	return out
+}
+
+type BQVecAndID struct {
+	id  uint64
+	vec []uint64
+}

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
@@ -117,17 +117,17 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 		out <- localResults
 	}, cpi.logger)
 
-	go func() {
+	enterrors.GoWrapper(func() {
 		wg.Wait()
 		close(out)
-	}()
+	}, cpi.logger)
 
 	return out
 }
 
 func (cpi *compressedParallelIterator) iterateAllNoConcurrency() chan []BQVecAndID {
 	out := make(chan []BQVecAndID)
-	go func() {
+	enterrors.GoWrapper(func() {
 		defer close(out)
 		c := cpi.bucket.Cursor()
 		defer c.Close()
@@ -140,7 +140,7 @@ func (cpi *compressedParallelIterator) iterateAllNoConcurrency() chan []BQVecAnd
 		}
 
 		out <- localResults
-	}()
+	}, cpi.logger)
 
 	return out
 }

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package flat
 
 import (

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
@@ -27,49 +27,49 @@ func TestCompressedParallelIterator(t *testing.T) {
 	type test struct {
 		name      string
 		totalVecs int
-		paralell  int
+		parallel  int
 	}
 
 	tests := []test{
 		{
 			name:      "single vector, many parallel routines",
 			totalVecs: 1,
-			paralell:  16,
+			parallel:  16,
 		},
 		{
 			name:      "two vectors, many parallel routines",
 			totalVecs: 2,
-			paralell:  16,
+			parallel:  16,
 		},
 		{
 			name:      "three vectors, many parallel routines",
 			totalVecs: 3,
-			paralell:  16,
+			parallel:  16,
 		},
 		{
 			name:      "many vectors, many parallel routines",
 			totalVecs: 1000,
-			paralell:  16,
+			parallel:  16,
 		},
 		{
 			name:      "many vectors, single routine",
 			totalVecs: 1000,
-			paralell:  1,
+			parallel:  1,
 		},
 		{
 			name:      "one fewer vectors than routines",
 			totalVecs: 5,
-			paralell:  6,
+			parallel:  6,
 		},
 		{
 			name:      "matching vectors and routines",
 			totalVecs: 6,
-			paralell:  6,
+			parallel:  6,
 		},
 		{
 			name:      "one more vector than routines",
 			totalVecs: 7,
-			paralell:  6,
+			parallel:  6,
 		},
 	}
 
@@ -78,7 +78,7 @@ func TestCompressedParallelIterator(t *testing.T) {
 			bucket := buildCompressedBucketForTest(t, test.totalVecs)
 			defer bucket.Shutdown(context.Background())
 			logger, _ := logrustest.NewNullLogger()
-			cpi := NewCompressedParallelIterator(bucket, test.paralell, logger)
+			cpi := NewCompressedParallelIterator(bucket, test.parallel, logger)
 			require.NotNil(t, cpi)
 
 			ch := cpi.IterateAll()

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
@@ -1,0 +1,107 @@
+package flat
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestCompressedParallelIterator(t *testing.T) {
+	type test struct {
+		name      string
+		totalVecs int
+		paralell  int
+	}
+
+	tests := []test{
+		{
+			name:      "single vector, many parallel routines",
+			totalVecs: 1,
+			paralell:  16,
+		},
+		{
+			name:      "two vectors, many parallel routines",
+			totalVecs: 2,
+			paralell:  16,
+		},
+		{
+			name:      "three vectors, many parallel routines",
+			totalVecs: 3,
+			paralell:  16,
+		},
+		{
+			name:      "many vectors, many parallel routines",
+			totalVecs: 1000,
+			paralell:  16,
+		},
+		{
+			name:      "many vectors, single routine",
+			totalVecs: 1000,
+			paralell:  1,
+		},
+		{
+			name:      "one fewer vectors than routines",
+			totalVecs: 5,
+			paralell:  6,
+		},
+		{
+			name:      "matching vectors and routines",
+			totalVecs: 6,
+			paralell:  6,
+		},
+		{
+			name:      "one more vector than routines",
+			totalVecs: 7,
+			paralell:  6,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bucket := buildCompressedBucketForTest(t, test.totalVecs)
+			defer bucket.Shutdown(context.Background())
+			cpi := NewCompressedParallelIterator(bucket, test.paralell)
+			require.NotNil(t, cpi)
+
+			ch := cpi.IterateAll()
+			idsFound := make(map[uint64]struct{})
+			for vecs := range ch {
+				for _, vec := range vecs {
+					if _, ok := idsFound[vec.id]; ok {
+						t.Errorf("id %d found more than once", vec.id)
+					}
+					idsFound[vec.id] = struct{}{}
+				}
+			}
+
+			// assert all ids are found
+			// we already know that the ids are unique, so we can just check the
+			// length
+			require.Len(t, idsFound, test.totalVecs)
+		})
+	}
+}
+
+func buildCompressedBucketForTest(t *testing.T, totalVecs int) *lsmkv.Bucket {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+
+	for i := 0; i < totalVecs; i++ {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i))
+		// actual vector does not matter for this test, we can keep it blank
+		err := bucket.Put(key, make([]byte, 8))
+		require.Nil(t, err)
+	}
+
+	require.Nil(t, bucket.FlushAndSwitch())
+
+	return bucket
+}

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -65,7 +66,8 @@ func TestCompressedParallelIterator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			bucket := buildCompressedBucketForTest(t, test.totalVecs)
 			defer bucket.Shutdown(context.Background())
-			cpi := NewCompressedParallelIterator(bucket, test.paralell)
+			logger, _ := logrustest.NewNullLogger()
+			cpi := NewCompressedParallelIterator(bucket, test.paralell, logger)
 			require.NotNil(t, cpi)
 
 			ch := cpi.IterateAll()

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package flat
 
 import (

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -12,7 +12,6 @@
 package flat
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -696,7 +695,12 @@ func (index *flat) PostStartup() {
 	maxID := uint64(0)
 
 	before := time.Now()
-	channel := index.iterateCompressedBucketInParallel()
+	bucket := index.store.Bucket(index.getCompressedBucketName())
+	// we expect to be IO-bound, so more goroutines than CPUs is fine, we do
+	// however want some kind of relationship to the machine size, so
+	// 2*GOMAXPROCS seems like a good default.
+	it := NewCompressedParallelIterator(bucket, 2*runtime.GOMAXPROCS(0))
+	channel := it.IterateAll()
 	if channel == nil {
 		return // nothing to do
 	}
@@ -719,90 +723,6 @@ func (index *flat) PostStartup() {
 		index.bqCache.Preload(vec.id, vec.vec)
 	}
 	fmt.Printf("pre-loaded %d vectors in %s\n", count, time.Since(before))
-}
-
-type BQVecAndID struct {
-	id  uint64
-	vec []uint64
-}
-
-func (index *flat) iterateCompressedBucketInParallel() chan []BQVecAndID {
-	// we expect to be IO-bound, so more goroutines than CPUs is fine, we do
-	// however want some kind of relationship to the machine size, so
-	// 2*GOMAXPROCS seems like a good default.
-	parallel := 2 * runtime.GOMAXPROCS(0)
-	bucket := index.store.Bucket(index.getCompressedBucketName())
-	// subtract one because the first routine is going to use cursor.First()
-	seeds := bucket.QuantileKeys(parallel - 1)
-	if len(seeds) == 0 {
-		return nil
-	}
-
-	wg := sync.WaitGroup{}
-	out := make(chan []BQVecAndID)
-
-	// There are three scenarios:
-	// 1. Read from beginning to first checkpoint
-	// 2. Read from checkpoint n to checkpoint n+1
-	// 3. Read from last checkpoint to end
-
-	extract := func(k, v []byte) BQVecAndID {
-		id := binary.BigEndian.Uint64(k)
-		vec := uint64SliceFromByteSlice(v, make([]uint64, len(v)/8))
-		return BQVecAndID{id: id, vec: vec}
-	}
-
-	// S1: Read from beginning to first checkpoint:
-	wg.Add(1)
-	go func() {
-		c := bucket.Cursor()
-		localResults := make([]BQVecAndID, 0, 10_000)
-		defer c.Close()
-		defer wg.Done()
-
-		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) <= 0; k, v = c.Next() {
-			localResults = append(localResults, extract(k, v))
-		}
-
-		out <- localResults
-	}()
-
-	// S2: Read from checkpoint n to checkpoint n+1, stop at last checkpoint:
-	for i := 0; i < len(seeds)-1; i++ {
-		wg.Add(1)
-		go func(start, end []byte) {
-			defer wg.Done()
-			localResults := make([]BQVecAndID, 0, 10_000)
-			c := bucket.Cursor()
-			defer c.Close()
-
-			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) <= 0; k, v = c.Next() {
-				localResults = append(localResults, extract(k, v))
-			}
-			out <- localResults
-		}(seeds[i], seeds[i+1])
-	}
-
-	// S3: Read from last checkpoint to end:
-	wg.Add(1)
-	go func() {
-		c := bucket.Cursor()
-		defer c.Close()
-		defer wg.Done()
-		localResults := make([]BQVecAndID, 0, 10_000)
-
-		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
-			localResults = append(localResults, extract(k, v))
-		}
-		out <- localResults
-	}()
-
-	go func() {
-		wg.Wait()
-		close(out)
-	}()
-
-	return out
 }
 
 func (index *flat) Dump(labels ...string) {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -743,9 +743,10 @@ func (index *flat) PostStartup() {
 
 	// Grow cache just once
 	index.bqCache.Grow(maxID)
+	index.bqCache.SetSizeNoLock(maxID)
 
 	for _, vec := range vecs {
-		index.bqCache.Preload(vec.id, vec.vec)
+		index.bqCache.PreloadNoLock(vec.id, vec.vec)
 	}
 	fmt.Printf("pre-loaded %d vectors in %s\n", count, time.Since(before))
 }

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -699,7 +699,7 @@ func (index *flat) PostStartup() {
 	// we expect to be IO-bound, so more goroutines than CPUs is fine, we do
 	// however want some kind of relationship to the machine size, so
 	// 2*GOMAXPROCS seems like a good default.
-	it := NewCompressedParallelIterator(bucket, 2*runtime.GOMAXPROCS(0))
+	it := NewCompressedParallelIterator(bucket, 2*runtime.GOMAXPROCS(0), index.logger)
 	channel := it.IterateAll()
 	if channel == nil {
 		return // nothing to do

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -49,7 +50,7 @@ func distanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
 func run(dirName string, logger *logrus.Logger, compression string, vectorCache bool,
 	vectors [][]float32, queries [][]float32, k int, truths [][]uint64,
 	extraVectorsForDelete [][]float32, allowIds []uint64,
-	distancer distancer.Provider,
+	distancer distancer.Provider, concurrentCacheReads int,
 ) (float32, float32, error) {
 	vectors_size := len(vectors)
 	queries_size := len(queries)
@@ -88,6 +89,10 @@ func run(dirName string, logger *logrus.Logger, compression string, vectorCache 
 	}, store)
 	if err != nil {
 		return 0, 0, err
+	}
+
+	if concurrentCacheReads != 0 {
+		index.concurrentCacheReads = concurrentCacheReads
 	}
 
 	compressionhelpers.ConcurrentlyWithError(logger, uint64(vectors_size), func(id uint64) error {
@@ -182,7 +187,7 @@ func Test_NoRaceFlatIndex(t *testing.T) {
 						targetRecall = 0.8
 					}
 					t.Run("recall", func(t *testing.T) {
-						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, nil, nil, distancer)
+						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, nil, nil, distancer, 0)
 						require.Nil(t, err)
 
 						fmt.Println(recall, latency)
@@ -191,7 +196,7 @@ func Test_NoRaceFlatIndex(t *testing.T) {
 					})
 
 					t.Run("recall with deletes", func(t *testing.T) {
-						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, extraVectorsForDelete, nil, distancer)
+						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, extraVectorsForDelete, nil, distancer, 0)
 						require.Nil(t, err)
 
 						fmt.Println(recall, latency)
@@ -222,7 +227,7 @@ func Test_NoRaceFlatIndex(t *testing.T) {
 					}
 
 					t.Run("recall on filtered", func(t *testing.T) {
-						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, nil, allowIds, distancer)
+						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, nil, allowIds, distancer, 0)
 						require.Nil(t, err)
 
 						fmt.Println(recall, latency)
@@ -231,7 +236,7 @@ func Test_NoRaceFlatIndex(t *testing.T) {
 					})
 
 					t.Run("recall on filtered with deletes", func(t *testing.T) {
-						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, extraVectorsForDelete, allowIds, distancer)
+						recall, latency, err := run(dirName, logger, compression, cache, vectors, queries, k, truths, extraVectorsForDelete, allowIds, distancer, 0)
 						require.Nil(t, err)
 
 						fmt.Println(recall, latency)
@@ -246,5 +251,40 @@ func Test_NoRaceFlatIndex(t *testing.T) {
 	err := os.RemoveAll(dirName)
 	if err != nil {
 		fmt.Println(err)
+	}
+}
+
+func TestConcurrentReads(t *testing.T) {
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	dimensions := 256
+	vectors_size := 12000
+	queries_size := 100
+	k := 10
+	vectors, queries := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
+	testinghelpers.Normalize(vectors)
+	testinghelpers.Normalize(queries)
+	distancer := distancer.NewCosineDistanceProvider()
+
+	truths := make([][]uint64, queries_size)
+	for i := range queries {
+		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, distanceWrapper(distancer))
+	}
+
+	cores := runtime.GOMAXPROCS(0) * 2
+
+	concurrentReads := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, cores - 1, cores, cores + 1}
+	for i := range concurrentReads {
+		t.Run("concurrent reads: "+strconv.Itoa(concurrentReads[i]), func(t *testing.T) {
+			targetRecall := float32(0.8)
+			recall, latency, err := run(dirName, logger, compressionBQ, true, vectors, queries, k, truths, nil, nil, distancer, concurrentReads[i])
+			require.Nil(t, err)
+
+			fmt.Println(recall, latency)
+			assert.Greater(t, recall, targetRecall)
+			assert.Less(t, latency, float32(1_000_000))
+		})
 	}
 }

--- a/adapters/repos/db/vector/hnsw/benchmark_test.go
+++ b/adapters/repos/db/vector/hnsw/benchmark_test.go
@@ -108,12 +108,12 @@ Ex: go test -v -benchmem -bench ^BenchmarkHnswNeurips23$ -download`, step.Datase
 								compressionhelpers.Concurrently(logger, uint64(op.End-op.Start), func(i uint64) {
 									err := index.Add(uint64(op.Start+int(i)), vectors[op.Start+int(i)])
 									require.NoError(b, err)
-								})
+								}, 0)
 							case "delete":
 								compressionhelpers.Concurrently(logger, uint64(op.End-op.Start), func(i uint64) {
 									err := index.Delete(uint64(op.Start + int(i)))
 									require.NoError(b, err)
-								})
+								}, 0)
 							case "search":
 								if len(queryVectors) == 0 {
 									file, ok := queries[step.Dataset]
@@ -127,7 +127,7 @@ Ex: go test -v -benchmem -bench ^BenchmarkHnswNeurips23$ -download`, step.Datase
 								compressionhelpers.Concurrently(logger, uint64(len(queryVectors)), func(i uint64) {
 									_, _, err := index.SearchByVector(queryVectors[i], 0, nil)
 									require.NoError(b, err)
-								})
+								}, 0)
 							default:
 								b.Errorf("Unknown operation %s", op.Operation)
 							}

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -101,7 +101,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 				return
 			}
 			h.compressor.Preload(index, data[index])
-		})
+		}, 0)
 
 	h.compressed.Store(true)
 	h.cache.Drop()

--- a/adapters/repos/db/vector/hnsw/compress_deletes_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_deletes_test.go
@@ -154,7 +154,7 @@ func TestHnswPqNilVectors(t *testing.T) {
 
 		err := index.Add(uint64(id), vectors[id])
 		require.Nil(t, err)
-	})
+	}, 0)
 
 	userConfig.PQ = ent.PQConfig{
 		Enabled: true,
@@ -182,5 +182,5 @@ func TestHnswPqNilVectors(t *testing.T) {
 
 		err = index.Add(uint64(id)+start, vectors[id+start])
 		require.Nil(t, err)
-	})
+	}, 0)
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -100,11 +100,19 @@ func (f *fakeCache) Preload(id uint64, vec []float32) {
 	panic("not implemented")
 }
 
+func (f *fakeCache) PreloadNoLock(id uint64, vec []float32) {
+	panic("not implemented")
+}
+
 func (f *fakeCache) Prefetch(id uint64) {
 	panic("not implemented")
 }
 
 func (f *fakeCache) Grow(id uint64) {
+	panic("not implemented")
+}
+
+func (f *fakeCache) SetSizeNoLock(id uint64) {
 	panic("not implemented")
 }
 

--- a/adapters/repos/db/vector/testinghelpers/helpers.go
+++ b/adapters/repos/db/vector/testinghelpers/helpers.go
@@ -172,7 +172,7 @@ func BruteForce(logger logrus.FieldLogger, vectors [][]float32, query []float32,
 			index:    uint64(i),
 			distance: dist,
 		}
-	})
+	}, 0)
 
 	sort.Slice(distances, func(a, b int) bool {
 		return distances[a].distance < distances[b].distance
@@ -206,7 +206,7 @@ func BuildTruths(logger logrus.FieldLogger, queriesSize int, vectorsSize int, qu
 
 	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
 		truths[i], _ = BruteForce(logger, vectors, queries[i], k, distance)
-	})
+	}, 0)
 
 	f, err := os.Create(fileName)
 	if err != nil {


### PR DESCRIPTION
### What's being changed:

In the original implementation each call would (un)lock the cache and increase an atomic counter. This shaves off ~30ms when loading a tenant in our private dataset

Depends on:
- https://github.com/weaviate/weaviate/pull/5477
- https://github.com/weaviate/weaviate/pull/5468

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
