### PR TITLE
Remove duplicate callback unregistration

### DIFF
--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -105,16 +105,6 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		}
 	}
 
-	// unregister all callbacks at once, in parallel
-	if err = cyclemanager.NewCombinedCallbackCtrl(0, s.index.logger,
-		s.cycleCallbacks.compactionCallbacksCtrl,
-		s.cycleCallbacks.flushCallbacksCtrl,
-		s.cycleCallbacks.vectorCombinedCallbacksCtrl,
-		s.cycleCallbacks.geoPropsCombinedCallbacksCtrl,
-	).Unregister(ctx); err != nil {
-		return err
-	}
-
 	if s.store != nil {
 		// store would be nil if loading the objects bucket failed, as we would
 		// only return the store on success from s.initLSMStore()


### PR DESCRIPTION
Originally this code block was supposed to be moved, not copied: https://github.com/weaviate/weaviate/commit/1caececece6592148c5b53efffcfe3ea0d0572ec#diff-f5ceda6e94dc8658eea9558fa308aa70db8835f5a0d07762a7cc8ea445777034L988-L997

Looks like during merging sth. went wrong, adding back the code in its original location and that way duplicating it: https://github.com/weaviate/weaviate/commit/47f2b68af1ac596418d50e206cf3f878553c7b25#diff-f5ceda6e94dc8658eea9558fa308aa70db8835f5a0d07762a7cc8ea445777034R1073-R1081

### What's being changed:
This deletes the accidentally duplicated code again.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
