### PR TITLE
gh-5491: fix single node upgrade recovery

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -659,7 +659,7 @@ func lastSnapshotIndex(ss *raft.FileSnapshotStore) uint64 {
 
 // recoverSingleNode is used to manually force a new configuration in order to
 // recover from a loss of quorum where the current configuration cannot be
-// WARNING! This operation implicilty commits all entries in the Raft log, so
+// WARNING! This operation impliciimplicitlylty commits all entries in the Raft log, so
 // in general this is an extremely unsafe operation and that's why it's made to be
 // used in a single cluster node.
 // for more details see : https://github.com/hashicorp/raft/blob/main/api.go#L279

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -659,7 +659,7 @@ func lastSnapshotIndex(ss *raft.FileSnapshotStore) uint64 {
 
 // recoverSingleNode is used to manually force a new configuration in order to
 // recover from a loss of quorum where the current configuration cannot be
-// WARNING! This operation impliciimplicitlylty commits all entries in the Raft log, so
+// WARNING! This operation implicitly commits all entries in the Raft log, so
 // in general this is an extremely unsafe operation and that's why it's made to be
 // used in a single cluster node.
 // for more details see : https://github.com/hashicorp/raft/blob/main/api.go#L279
@@ -667,7 +667,12 @@ func (st *Store) recoverSingleNode() error {
 	if st.cfg.BootstrapExpect > 1 {
 		return fmt.Errorf("bootstrap expect is more than 1, can't perform auto recovery in multi node cluster")
 	}
-	exNode := st.raft.GetConfiguration().Configuration().Servers[0]
+	servers := st.raft.GetConfiguration().Configuration().Servers
+	if len(servers) == 0 {
+		return nil
+	}
+
+	exNode := servers[0]
 	newNode := raft.Server{
 		ID:       raft.ServerID(st.cfg.NodeID),
 		Address:  raft.ServerAddress(fmt.Sprintf("%s:%d", st.cfg.Host, st.cfg.RPCPort)),


### PR DESCRIPTION
### What's being changed:
if we have a one node setup cluster without specified identified `CLUSTER_HOSTNAME`  in the env vars and perform upgrade that results that node name change after the upgrade and given the fact the node was already onboarded into raft and there was an old raft configuration, so raft will stuck in the state of trying to the old node configuration until gives up bootstrapping with error  context deadline exceeded. 

in case of multi node the IP discovery logic will handle ip changes. The issue appears because of node ID/name change and it happens in one node cluster without a deterministic name but with multiple nodes RAFT_JOIN is already required which force node name to be deterministic

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: 
 - [failure before this change](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10177404882/job/2814895305510177404882/job/28148953055)
 - [success after this change](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10177503039/job/28149149375) 
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

Links:
https://github.com/weaviate/weaviate/issues/5491
