### PR TITLE
gh-5491: take 2 fix single node upgrade recovery 

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -181,11 +181,11 @@ func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, s
 	)
 }
 
-// UpdateStatesNodeName it update the node name inside sharding states.
+// ReplaceStatesNodeName it update the node name inside sharding states.
 // WARNING: this shall be used in one node cluster environments only.
 // because it update the shard node name if the node name got update.
-func (s *SchemaManager) UpdateStatesNodeName(nodeName string) {
-	s.schema.updateStatesNodeName(nodeName)
+func (s *SchemaManager) ReplaceStatesNodeName(old, new string) {
+	s.schema.replaceStatesNodeName(old, new)
 }
 
 // UpdateClass modifies the vectors and inverted indexes associated with a class

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -181,6 +181,13 @@ func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, s
 	)
 }
 
+// UpdateStatesNodeName it update the node name inside sharding states.
+// WARNING: this shall be used in one node cluster environments only.
+// because it update the shard node name if the node name got update.
+func (s *SchemaManager) UpdateStatesNodeName(nodeName string) {
+	s.schema.updateStatesNodeName(nodeName)
+}
+
 // UpdateClass modifies the vectors and inverted indexes associated with a class
 // Other class properties are handled by separate functions
 func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -183,9 +183,10 @@ func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, s
 
 // ReplaceStatesNodeName it update the node name inside sharding states.
 // WARNING: this shall be used in one node cluster environments only.
-// because it will replace the shard node name if it did find matched old name.
-func (s *SchemaManager) ReplaceStatesNodeName(old, new string) {
-	s.schema.replaceStatesNodeName(old, new)
+// because it will replace the shard node name if the node name got updated
+// only if the replication factor is 1, otherwise it's no-op
+func (s *SchemaManager) ReplaceStatesNodeName(new string) {
+	s.schema.replaceStatesNodeName(new)
 }
 
 // UpdateClass modifies the vectors and inverted indexes associated with a class

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -183,7 +183,7 @@ func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, s
 
 // ReplaceStatesNodeName it update the node name inside sharding states.
 // WARNING: this shall be used in one node cluster environments only.
-// because it update the shard node name if the node name got update.
+// because it will replace the shard node name if it did find matched old name.
 func (s *SchemaManager) ReplaceStatesNodeName(old, new string) {
 	s.schema.replaceStatesNodeName(old, new)
 }

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -262,6 +262,26 @@ func (s *schema) updateClass(name string, f func(*metaClass) error) error {
 	return meta.LockGuard(f)
 }
 
+// updateStatesNodeName it update the node name inside sharding states.
+// WARNING: this shall be used in one node cluster environments only.
+// because it update the shard node name if the node name got update.
+func (s *schema) updateStatesNodeName(nodeName string) {
+	s.Lock()
+	defer s.Unlock()
+
+	for _, meta := range s.Classes {
+		meta.LockGuard(func(mc *metaClass) error {
+			for k, v := range meta.Sharding.Physical {
+				v = v.DeepCopy()
+				v.BelongsToNodes = []string{nodeName}
+				meta.Sharding.Physical[k] = v
+
+			}
+			return nil
+		})
+	}
+}
+
 func (s *schema) deleteClass(name string) {
 	s.Lock()
 	defer s.Unlock()

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -264,20 +264,21 @@ func (s *schema) updateClass(name string, f func(*metaClass) error) error {
 
 // replaceStatesNodeName it update the node name inside sharding states.
 // WARNING: this shall be used in one node cluster environments only.
-// because it will replace the shard node name if it did find matched old name.
-func (s *schema) replaceStatesNodeName(old, new string) {
+// because it will replace the shard node name if the node name got updated
+// only if the replication factor is 1, otherwise it's no-op
+func (s *schema) replaceStatesNodeName(new string) {
 	s.Lock()
 	defer s.Unlock()
 
 	for _, meta := range s.Classes {
 		meta.LockGuard(func(mc *metaClass) error {
+			if meta.Class.ReplicationConfig.Factor > 1 {
+				return nil
+			}
+
 			for idx := range meta.Sharding.Physical {
 				cp := meta.Sharding.Physical[idx].DeepCopy()
-				for i, name := range cp.BelongsToNodes {
-					if name == old {
-						cp.BelongsToNodes[i] = new
-					}
-				}
+				cp.BelongsToNodes = []string{new}
 				meta.Sharding.Physical[idx] = cp
 			}
 			return nil

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -264,23 +264,21 @@ func (s *schema) updateClass(name string, f func(*metaClass) error) error {
 
 // replaceStatesNodeName it update the node name inside sharding states.
 // WARNING: this shall be used in one node cluster environments only.
-// because it update the shard node name if the node name got update.
+// because it will replace the shard node name if it did find matched old name.
 func (s *schema) replaceStatesNodeName(old, new string) {
 	s.Lock()
 	defer s.Unlock()
 
 	for _, meta := range s.Classes {
 		meta.LockGuard(func(mc *metaClass) error {
-			for k, v := range meta.Sharding.Physical {
-				v = v.DeepCopy()
-
-				for idx, name := range v.BelongsToNodes {
+			for idx := range meta.Sharding.Physical {
+				cp := meta.Sharding.Physical[idx].DeepCopy()
+				for i, name := range cp.BelongsToNodes {
 					if name == old {
-						v.BelongsToNodes[idx] = new
+						cp.BelongsToNodes[i] = new
 					}
 				}
-				meta.Sharding.Physical[k] = v
-
+				meta.Sharding.Physical[idx] = cp
 			}
 			return nil
 		})

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -262,10 +262,10 @@ func (s *schema) updateClass(name string, f func(*metaClass) error) error {
 	return meta.LockGuard(f)
 }
 
-// updateStatesNodeName it update the node name inside sharding states.
+// replaceStatesNodeName it update the node name inside sharding states.
 // WARNING: this shall be used in one node cluster environments only.
 // because it update the shard node name if the node name got update.
-func (s *schema) updateStatesNodeName(nodeName string) {
+func (s *schema) replaceStatesNodeName(old, new string) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -273,7 +273,12 @@ func (s *schema) updateStatesNodeName(nodeName string) {
 		meta.LockGuard(func(mc *metaClass) error {
 			for k, v := range meta.Sharding.Physical {
 				v = v.DeepCopy()
-				v.BelongsToNodes = []string{nodeName}
+
+				for idx, name := range v.BelongsToNodes {
+					if name == old {
+						v.BelongsToNodes[idx] = new
+					}
+				}
 				meta.Sharding.Physical[k] = v
 
 			}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -664,7 +664,7 @@ func (st *Store) recoverSingleNode() error {
 	}
 	servers := st.raft.GetConfiguration().Configuration().Servers
 	// nothing to do here, wasn't a single node
-	if len(servers) == 0 || len(servers) > 1 {
+	if len(servers) != 1 {
 		return nil
 	}
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -659,12 +659,16 @@ func lastSnapshotIndex(ss *raft.FileSnapshotStore) uint64 {
 // for more details see : https://github.com/hashicorp/raft/blob/main/api.go#L279
 func (st *Store) recoverSingleNode() error {
 	if st.cfg.BootstrapExpect > 1 || len(st.candidates) > 1 {
-		return fmt.Errorf("bootstrap expect  %v, candidates %v,"+
+		return fmt.Errorf("bootstrap expect %v, candidates %v, "+
 			"can't perform auto recovery in multi node cluster", st.cfg.BootstrapExpect, st.candidates)
 	}
 	servers := st.raft.GetConfiguration().Configuration().Servers
 	// nothing to do here, wasn't a single node
 	if len(servers) != 1 {
+		st.log.WithFields(logrus.Fields{
+			"servers_from_previous_configuration": servers,
+			"candidates":                          st.candidates,
+		}).Warn("didn't perform cluster recovery")
 		return nil
 	}
 


### PR DESCRIPTION
if we have a one node setup cluster without specified identified `CLUSTER_HOSTNAME` in the env vars and perform upgrade that results that node name change after the upgrade and given the fact the node was already onboarded into raft and there was an old raft configuration, so raft will stuck in the state of trying to the old node configuration until gives up bootstrapping with error context deadline exceeded.

in case of multi node the IP discovery logic will handle ip changes. The issue appears because of node ID/name change and it happens in one node cluster without a deterministic name but with multiple nodes RAFT_JOIN is already required which force node name to be deterministic

https://github.com/weaviate/weaviate/pull/5492 originally was reverted but this PR now has additional changes 

chaos test was added to verify that change 
chaos-pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10263192041
Linked PRs https://github.com/weaviate/weaviate/pull/5527