### PR TITLE
Reuse bm25 memory

### DIFF
--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -131,7 +131,7 @@ func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.
 
 	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, fa.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, fa.classSearcher,
-		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,
+		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion, nil,
 	).BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw, additional.Properties{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -54,7 +54,7 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, a.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, a.classSearcher,
-		a.GetPropertyLengthTracker(), a.logger, a.shardVersion,
+		a.GetPropertyLengthTracker(), a.logger, a.shardVersion, nil,
 	).BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw, additional.Properties{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2117,9 +2117,7 @@ func (i *Index) Shutdown(ctx context.Context) error {
 
 	i.closed = true
 
-	if i.bm25Pool != nil {
-		i.bm25Pool.Close()
-	}
+	i.bm25Pool.Close()
 
 	i.closingCancel()
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2117,7 +2117,9 @@ func (i *Index) Shutdown(ctx context.Context) error {
 
 	i.closed = true
 
-	i.bm25Pool.Close()
+	if i.bm25Pool != nil {
+		i.bm25Pool.Close()
+	}
 
 	i.closingCancel()
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -271,7 +271,7 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 		indexCheckpoints:       indexCheckpoints,
 		allocChecker:           allocChecker,
 		shardCreateLocks:       esync.NewKeyLocker(),
-		bm25Pool:               &inverted.Bm25Pool{},
+		bm25Pool:               inverted.NewBm25Pool(),
 	}
 	index.closingCtx, index.closingCancel = context.WithCancel(context.Background())
 
@@ -2116,6 +2116,8 @@ func (i *Index) Shutdown(ctx context.Context) error {
 	}
 
 	i.closed = true
+
+	i.bm25Pool.Close()
 
 	i.closingCancel()
 

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -246,9 +246,14 @@ func (b *BM25Searcher) wand(
 }
 
 func (b *BM25Searcher) returnToPool(results terms, indices []map[uint64]int) {
-	for i := range results {
-		b.pools.Return(results[i].data, indices[i])
-	}
+	enterrors.GoWrapper(
+		func() {
+			for i := range results {
+				b.pools.Return(results[i].data, indices[i])
+			}
+		},
+		b.logger,
+	)
 }
 
 func (b *BM25Searcher) removeStopwordsFromQueryTerms(queryTerms []string,

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -46,6 +46,10 @@ type Bm25Pool struct {
 	init     bool
 }
 
+func NewBm25Pool() *Bm25Pool {
+	return &Bm25Pool{init: false}
+}
+
 func (b *Bm25Pool) Init(size int) {
 	if b.init {
 		return
@@ -53,6 +57,15 @@ func (b *Bm25Pool) Init(size int) {
 	b.init = true
 	b.ListPool = make(chan *[]docPointerWithScore, size)
 	b.MapPool = make(chan *map[uint64]int, size)
+}
+
+func (b *Bm25Pool) Close() {
+	if !b.init {
+		return
+	}
+	b.init = false
+	close(b.ListPool)
+	close(b.MapPool)
 }
 
 type BM25Searcher struct {

--- a/adapters/repos/db/inverted/bm25_searcher_pool.go
+++ b/adapters/repos/db/inverted/bm25_searcher_pool.go
@@ -1,0 +1,137 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+)
+
+type Bm25Pool struct {
+	ListPool           chan *[]docPointerWithScore
+	MapPool            chan *map[uint64]int
+	init               bool
+	lock               sync.Mutex
+	sizeQueueList      *priorityqueue.Queue[time.Time]
+	sizeQueueListCount uint64
+	sizeQueueMap       *priorityqueue.Queue[time.Time]
+	sizeQueueMapCount  uint64
+	minSizeToKeep      int
+	decayTime          time.Duration
+}
+
+func NewBm25Pool() *Bm25Pool {
+	return &Bm25Pool{
+		init:          false,
+		sizeQueueList: priorityqueue.NewMax[time.Time](50),
+		sizeQueueMap:  priorityqueue.NewMax[time.Time](50),
+		decayTime:     time.Minute,
+	}
+}
+
+func (b *Bm25Pool) Init(size, minSizeToKeep int) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if b.init {
+		return
+	}
+	b.init = true
+	b.minSizeToKeep = minSizeToKeep
+	b.ListPool = make(chan *[]docPointerWithScore, size)
+	b.MapPool = make(chan *map[uint64]int, size)
+}
+
+func (b *Bm25Pool) Return(list []docPointerWithScore, m map[uint64]int) {
+	b.lock.Lock() // prevent races in the decay calculations
+	defer b.lock.Unlock()
+
+	// the size of the returned items can be very large, so we keep track of the sizes and remove items that are too large
+	// This is done in several steps:
+	//   - the size of the returned items is added to a priority queue
+	//   - items that are older than a minute are removed from the queue
+	// => the largest requests in the last minute is the maximum capacity of any item in the pool
+	b.sizeQueueList.InsertWithValue(b.sizeQueueListCount, float32(max(len(list), b.minSizeToKeep)), time.Now())
+	b.sizeQueueListCount++
+
+	for {
+		if b.sizeQueueList.Len() == 0 {
+			break
+		}
+		entry := b.sizeQueueList.Top()
+		if time.Since(entry.Value) > b.decayTime {
+			b.sizeQueueList.Pop()
+		} else {
+			break
+		}
+	}
+	dist := float32(b.minSizeToKeep)
+	if b.sizeQueueList.Len() > 0 {
+		entry := b.sizeQueueList.Top()
+		dist = entry.Dist
+	}
+
+	if cap(list) <= int(dist) {
+		list = list[:0]
+		select {
+		case b.ListPool <- &list:
+		default:
+		}
+	}
+
+	// for maps we do not have a way to determine the capacity, so we keep track of the maximum size a given map has
+	// ever had and use that as the capacity. This is stored in the map itself, with the key math.MaxUint64 which is
+	// never used as a docID
+	b.sizeQueueMap.InsertWithValue(b.sizeQueueMapCount, float32(max(len(m), b.minSizeToKeep)), time.Now())
+	b.sizeQueueMapCount++
+
+	for {
+		if b.sizeQueueMap.Len() == 0 {
+			break
+		}
+
+		entryMap := b.sizeQueueMap.Top()
+		if time.Since(entryMap.Value) > b.decayTime {
+			b.sizeQueueMap.Pop()
+		} else {
+			break
+		}
+	}
+	length := float32(b.minSizeToKeep)
+	if b.sizeQueueMap.Len() > 0 {
+		entry := b.sizeQueueMap.Top()
+		length = entry.Dist
+	}
+	if m[math.MaxUint64] <= int(length) && m != nil {
+		capM := max(len(m), m[math.MaxUint64])
+		clear(m)
+		m[math.MaxUint64] = capM
+		select {
+		case b.MapPool <- &m:
+		default:
+		}
+	}
+}
+
+func (b *Bm25Pool) Close() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if !b.init {
+		return
+	}
+	b.init = false
+	close(b.ListPool)
+	close(b.MapPool)
+}

--- a/adapters/repos/db/inverted/bm25_searcher_pool.go
+++ b/adapters/repos/db/inverted/bm25_searcher_pool.go
@@ -16,14 +16,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 )
 
 type Bm25Pool struct {
 	ListPool           chan *[]docPointerWithScore
+	ListPoolReturn     chan *[]docPointerWithScore
 	MapPool            chan *map[uint64]int
+	MapPoolReturn      chan *map[uint64]int
 	init               bool
-	lock               sync.Mutex
+	lockList           sync.Mutex
+	lockMap            sync.Mutex
 	sizeQueueList      *priorityqueue.Queue[time.Time]
 	sizeQueueListCount uint64
 	sizeQueueMap       *priorityqueue.Queue[time.Time]
@@ -41,92 +47,111 @@ func NewBm25Pool() *Bm25Pool {
 	}
 }
 
-func (b *Bm25Pool) Init(size, minSizeToKeep int) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
+func (b *Bm25Pool) Init(size, minSizeToKeep int, logger logrus.FieldLogger) {
+	b.lockList.Lock()
+	defer b.lockList.Unlock()
 	if b.init {
 		return
 	}
 	b.init = true
 	b.minSizeToKeep = minSizeToKeep
-	b.ListPool = make(chan *[]docPointerWithScore, size)
-	b.MapPool = make(chan *map[uint64]int, size)
+	if size > 0 {
+		b.ListPool = make(chan *[]docPointerWithScore, size)
+		b.ListPoolReturn = make(chan *[]docPointerWithScore, size)
+		b.MapPool = make(chan *map[uint64]int, size)
+		enterrors.GoWrapper(b.returnListWorker, logger)
+		enterrors.GoWrapper(b.returnMapWorker, logger)
+	}
 }
 
-func (b *Bm25Pool) Return(list []docPointerWithScore, m map[uint64]int) {
-	b.lock.Lock() // prevent races in the decay calculations
-	defer b.lock.Unlock()
+func (b *Bm25Pool) returnListWorker() {
+	for listPointer := range b.ListPoolReturn {
+		list := *listPointer
+		b.sizeQueueList.InsertWithValue(b.sizeQueueListCount, float32(max(len(list), b.minSizeToKeep)), time.Now())
+		b.sizeQueueListCount++
 
-	// the size of the returned items can be very large, so we keep track of the sizes and remove items that are too large
-	// This is done in several steps:
-	//   - the size of the returned items is added to a priority queue
-	//   - items that are older than a minute are removed from the queue
-	// => the largest requests in the last minute is the maximum capacity of any item in the pool
-	b.sizeQueueList.InsertWithValue(b.sizeQueueListCount, float32(max(len(list), b.minSizeToKeep)), time.Now())
-	b.sizeQueueListCount++
-
-	for {
-		if b.sizeQueueList.Len() == 0 {
-			break
+		for {
+			if b.sizeQueueList.Len() == 0 {
+				break
+			}
+			entry := b.sizeQueueList.Top()
+			if time.Since(entry.Value) > b.decayTime {
+				b.sizeQueueList.Pop()
+			} else {
+				break
+			}
 		}
-		entry := b.sizeQueueList.Top()
-		if time.Since(entry.Value) > b.decayTime {
-			b.sizeQueueList.Pop()
-		} else {
-			break
-		}
-	}
-	dist := float32(b.minSizeToKeep)
-	if b.sizeQueueList.Len() > 0 {
-		entry := b.sizeQueueList.Top()
-		dist = entry.Dist
-	}
-
-	if cap(list) <= int(dist) {
-		list = list[:0]
-		select {
-		case b.ListPool <- &list:
-		default:
-		}
-	}
-
-	// for maps we do not have a way to determine the capacity, so we keep track of the maximum size a given map has
-	// ever had and use that as the capacity. This is stored in the map itself, with the key math.MaxUint64 which is
-	// never used as a docID
-	b.sizeQueueMap.InsertWithValue(b.sizeQueueMapCount, float32(max(len(m), b.minSizeToKeep)), time.Now())
-	b.sizeQueueMapCount++
-
-	for {
-		if b.sizeQueueMap.Len() == 0 {
-			break
+		dist := float32(b.minSizeToKeep)
+		if b.sizeQueueList.Len() > 0 {
+			entry := b.sizeQueueList.Top()
+			dist = entry.Dist
 		}
 
-		entryMap := b.sizeQueueMap.Top()
-		if time.Since(entryMap.Value) > b.decayTime {
-			b.sizeQueueMap.Pop()
-		} else {
-			break
+		if cap(list) <= int(dist) {
+			list = list[:0]
+			select {
+			case b.ListPool <- &list:
+			default:
+			}
 		}
 	}
-	length := float32(b.minSizeToKeep)
-	if b.sizeQueueMap.Len() > 0 {
-		entry := b.sizeQueueMap.Top()
-		length = entry.Dist
-	}
-	if m[math.MaxUint64] <= int(length) && m != nil {
-		capM := max(len(m), m[math.MaxUint64])
-		clear(m)
-		m[math.MaxUint64] = capM
-		select {
-		case b.MapPool <- &m:
-		default:
+}
+
+func (b *Bm25Pool) returnMapWorker() {
+	for mapPointer := range b.MapPoolReturn {
+		m := *mapPointer
+		b.sizeQueueMap.InsertWithValue(b.sizeQueueMapCount, float32(max(len(m), b.minSizeToKeep)), time.Now())
+		b.sizeQueueMapCount++
+
+		for {
+			if b.sizeQueueMap.Len() == 0 {
+				break
+			}
+
+			entryMap := b.sizeQueueMap.Top()
+			if time.Since(entryMap.Value) > b.decayTime {
+				b.sizeQueueMap.Pop()
+			} else {
+				break
+			}
+		}
+		length := float32(b.minSizeToKeep)
+		if b.sizeQueueMap.Len() > 0 {
+			entry := b.sizeQueueMap.Top()
+			length = entry.Dist
+		}
+		if m[math.MaxUint64] <= int(length) && m != nil {
+			capM := max(len(m), m[math.MaxUint64])
+			clear(m)
+			m[math.MaxUint64] = capM
+			select {
+			case b.MapPool <- &m:
+			default:
+			}
 		}
 	}
+}
+
+// the size of the returned items can be very large, so we keep track of the sizes and remove items that are too large
+// This is done in several steps:
+//   - the size of the returned items is added to a priority queue
+//   - items that are older than a minute are removed from the queue
+// => the largest requests in the last minute is the maximum capacity of any item in the pool
+
+func (b *Bm25Pool) ReturnList(list []docPointerWithScore) {
+	b.ListPoolReturn <- &list
+}
+
+// for maps we do not have a way to determine the capacity, so we keep track of the maximum size a given map has
+// ever had and use that as the capacity. This is stored in the map itself, with the key math.MaxUint64 which is
+// never used as a docID
+func (b *Bm25Pool) ReturnMap(m map[uint64]int) {
+	b.MapPoolReturn <- &m
 }
 
 func (b *Bm25Pool) Close() {
-	b.lock.Lock()
-	defer b.lock.Unlock()
+	b.lockList.Lock()
+	defer b.lockList.Unlock()
 
 	if !b.init {
 		return

--- a/adapters/repos/db/inverted/bm25_searcher_pool_test.go
+++ b/adapters/repos/db/inverted/bm25_searcher_pool_test.go
@@ -1,0 +1,197 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolGettingItems(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+
+	var docMapPairs []docPointerWithScore
+	select {
+	case val := <-pool.ListPool:
+		docMapPairs = *val
+	default: // docMapPairs stays nil and will be created in the next step
+	}
+
+	// no entry yet
+	require.Nil(t, docMapPairs)
+
+	// add a new entry and get it again
+	docMapPairs = make([]docPointerWithScore, 10)
+	pool.Return(docMapPairs, make(map[uint64]int))
+	val := <-pool.ListPool
+	require.Equal(t, cap(*val), 10)
+	require.Len(t, *val, 0) // has been cleared upon return
+}
+
+func TestPoolSize(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+
+	// add more entries than the pool has
+	for i := 0; i < 20; i++ {
+		pool.Return(make([]docPointerWithScore, 10), nil)
+	}
+
+	for i := 0; i < 20; i++ {
+		var docMapPairs []docPointerWithScore
+		select {
+		case val := <-pool.ListPool:
+			docMapPairs = *val
+		default: // docMapPairs stays nil and will be created in the next step
+		}
+
+		if i < 10 {
+			require.Equal(t, cap(docMapPairs), 10)
+		} else {
+			require.Equal(t, cap(docMapPairs), 0)
+		}
+	}
+}
+
+func TestPoolSizeDecay(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+	pool.decayTime = time.Second
+
+	// add item above min size and get it again
+	pool.Return(make([]docPointerWithScore, 10), nil)
+	returned := *<-pool.ListPool
+
+	// wait for decay to be over
+	time.Sleep(time.Second)
+
+	// return item, it is now above the min size and will be discarded
+	returned = returned[:5]
+	pool.Return(returned, nil)
+
+	var docMapPairs []docPointerWithScore
+	select {
+	case val := <-pool.ListPool:
+		docMapPairs = *val
+	default: // docMapPairs stays nil and will be created in the next step
+	}
+	require.Equal(t, cap(docMapPairs), 0)
+}
+
+func TestPoolSizeDecayMaps(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+	pool.decayTime = time.Second
+
+	dummyList := make([]docPointerWithScore, 10)
+
+	map1 := make(map[uint64]int, 10)
+	for i := 0; i < 10; i++ {
+		map1[uint64(i)] = i
+	}
+	pool.Return(dummyList, map1)
+	map1 = *<-pool.MapPool // return and discard
+
+	// wait for decay to be over
+	time.Sleep(time.Second)
+
+	// get map back, but only add 6 entries => still over min size to keep
+	for i := 0; i < 6; i++ {
+		map1[uint64(i)] = i
+	}
+
+	pool.Return(dummyList, map1)
+
+	var maps map[uint64]int
+	select {
+	case val := <-pool.MapPool:
+		maps = *val
+	default: // docMapPairs stays nil and will be created in the next step
+	}
+
+	// new map without any entries
+	require.Equal(t, len(maps), 0)
+}
+
+func TestPoolMinSize(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+
+	// below min size, does not
+	pool.Return(make([]docPointerWithScore, 4), nil)
+
+	var docMapPairs []docPointerWithScore
+	select {
+	case val := <-pool.ListPool:
+		docMapPairs = *val
+	default: // docMapPairs stays nil and will be created in the next step
+	}
+	require.Equal(t, cap(docMapPairs), 0)
+}
+
+func TestPoolConcurencyReturn(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			pool.Return(make([]docPointerWithScore, 10), nil)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	for i := 0; i < 10; i++ {
+		returnedList := *<-pool.ListPool
+		require.Equal(t, cap(returnedList), 10)
+	}
+
+	// empty afterwards
+	var docMapPairs []docPointerWithScore
+	select {
+	case val := <-pool.ListPool:
+		docMapPairs = *val
+	default: // docMapPairs stays nil and will be created in the next step
+	}
+	require.Equal(t, cap(docMapPairs), 0)
+}
+
+func TestPoolConcurencyReturnAndGet(t *testing.T) {
+	pool := NewBm25Pool()
+	pool.Init(10, 5)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func() {
+			pool.Return(make([]docPointerWithScore, 10), nil)
+			wg.Done()
+		}()
+		go func() {
+			docMapPairs := []docPointerWithScore{}
+			select {
+			case val := <-pool.ListPool:
+				docMapPairs = *val
+			default: // docMapPairs stays nil and will be created in the next step
+			}
+			require.NotNil(t, docMapPairs)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -210,6 +210,7 @@ type Shard struct {
 	inUseCounter atomic.Int64
 	// allows concurrent shut read/write
 	shutdownLock *sync.RWMutex
+	bm25Pool     *inverted.Bm25Pool
 }
 
 func (s *Shard) ID() string {

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -32,7 +34,7 @@ import (
 
 func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	shardName string, index *Index, class *models.Class, jobQueueCh chan job,
-	indexCheckpoints *indexcheckpoint.Checkpoints,
+	indexCheckpoints *indexcheckpoint.Checkpoints, bm25Pool *inverted.Bm25Pool,
 ) (_ *Shard, err error) {
 	before := time.Now()
 
@@ -57,7 +59,8 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		shut:         false,
 		shutdownLock: new(sync.RWMutex),
 
-		status: storagestate.StatusLoading,
+		status:   storagestate.StatusLoading,
+		bm25Pool: bm25Pool,
 	}
 
 	defer func() {

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -244,7 +244,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		logger := s.index.logger.WithFields(logrus.Fields{"class": s.index.Config.ClassName, "shard": s.name})
 		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store,
 			s.index.getSchema.ReadOnlyClass, s.propertyIndices, s.index.classSearcher,
-			s.GetPropertyLengthTracker(), logger, s.versioner.Version())
+			s.GetPropertyLengthTracker(), logger, s.versioner.Version(), s.bm25Pool)
 		bm25objs, bm25count, err = bm25searcher.BM25F(ctx, filterDocIds, className, limit, *keywordRanking, additional)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
### What's being changed:

Currently we are allocating quite a bit of memory in teh bm25 searcher on each request and then throw it away afterwards. Instead add a pool to reuse allocated obejcts

The pool is currently located on the index level, so all shards/tenants can share it.  We could also move it to the DB level, so all collections would share one pool. The pool will only be initialized/filled when queries are happening, if you don't use BM25 it will stay empty

old: took 244s
New took 234s

saved ~20Gb in allocs for 50000 queries

with script: https://gist.github.com/dirkkul/2d77f28f2d3cf39d8f15d6826c9f7d2b

Old: ![profile001](https://github.com/user-attachments/assets/2013c495-bd14-4545-815b-39b3bd208666)
New: ![profile002](https://github.com/user-attachments/assets/bdabe3e5-c7a3-4468-901e-cf95add9df37)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
