### PR TITLE
Optimize vector cache initialization

### DIFF
--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -25,6 +25,8 @@ type Cache[T any] interface {
 	CountVectors() int64
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vec []T)
+	PreloadNoLock(id uint64, vec []T)
+	SetSizeNoLock(id uint64)
 	Prefetch(id uint64)
 	Grow(size uint64)
 	Drop()

--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -26,11 +26,13 @@ type Cache[T any] interface {
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vec []T)
 	PreloadNoLock(id uint64, vec []T)
-	SetSizeNoLock(id uint64)
+	SetSizeAndGrowNoLock(id uint64)
 	Prefetch(id uint64)
 	Grow(size uint64)
 	Drop()
 	UpdateMaxSize(size int64)
 	CopyMaxSize() int64
 	All() [][]T
+	LockAll()
+	UnlockAll()
 }

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -227,6 +227,14 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 	s.cache[id] = vec
 }
 
+func (s *shardedLockCache[T]) PreloadNoLock(id uint64, vec []T) {
+	s.cache[id] = vec
+}
+
+func (s *shardedLockCache[T]) SetSizeNoLock(size uint64) {
+	atomic.StoreInt64(&s.count, int64(size))
+}
+
 func (s *shardedLockCache[T]) Grow(node uint64) {
 	s.maintenanceLock.RLock()
 	if node < uint64(len(s.cache)) {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -742,9 +742,10 @@ func (index *flat) PostStartup() {
 
 	// Grow cache just once
 	index.bqCache.Grow(maxID)
+	index.bqCache.SetSizeNoLock(maxID)
 
 	for _, vec := range vecs {
-		index.bqCache.Preload(vec.id, vec.vec)
+		index.bqCache.PreloadNoLock(vec.id, vec.vec)
 	}
 
 	took := time.Since(before)

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -741,9 +741,10 @@ func (index *flat) PostStartup() {
 	}
 
 	// Grow cache just once
-	index.bqCache.Grow(maxID)
-	index.bqCache.SetSizeNoLock(maxID)
+	index.bqCache.LockAll()
+	defer index.bqCache.UnlockAll()
 
+	index.bqCache.SetSizeAndGrowNoLock(maxID)
 	for _, vec := range vecs {
 		index.bqCache.PreloadNoLock(vec.id, vec.vec)
 	}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -100,11 +100,19 @@ func (f *fakeCache) Preload(id uint64, vec []float32) {
 	panic("not implemented")
 }
 
+func (f *fakeCache) PreloadNoLock(id uint64, vec []float32) {
+	panic("not implemented")
+}
+
 func (f *fakeCache) Prefetch(id uint64) {
 	panic("not implemented")
 }
 
 func (f *fakeCache) Grow(id uint64) {
+	panic("not implemented")
+}
+
+func (f *fakeCache) SetSizeNoLock(id uint64) {
 	panic("not implemented")
 }
 

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -112,9 +112,13 @@ func (f *fakeCache) Grow(id uint64) {
 	panic("not implemented")
 }
 
-func (f *fakeCache) SetSizeNoLock(id uint64) {
+func (f *fakeCache) SetSizeAndGrowNoLock(id uint64) {
 	panic("not implemented")
 }
+
+func (f *fakeCache) LockAll() { panic("not implemented") }
+
+func (f *fakeCache) UnlockAll() { panic("not implemented") }
 
 func (f *fakeCache) UpdateMaxSize(size int64) {
 	panic("not implemented")


### PR DESCRIPTION
### What's being changed:

In the original implementation each call would (un)lock the cache and increase an atomic counter. However, we know that there are no other callers during initialization.

This shaves off ~30ms when loading a tenant in our private dataset

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
