### PR TITLE
RAFT:snapshot edge case use latest applied index

### DIFF
--- a/cluster/log.go
+++ b/cluster/log.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/raft"
 )
 
-func (st *Store) LastAppliedCommand() (uint64, error) {
+func (st *Store) LastLogStoreAppliedCommand() (uint64, error) {
 	if st.logStore == nil {
 		return 0, fmt.Errorf("log store can't be nil")
 	}
@@ -45,4 +45,10 @@ func (st *Store) LastAppliedCommand() (uint64, error) {
 		}
 	}
 	return 0, nil
+}
+
+func (st *Store) LastAppliedCommand() (uint64, error) {
+	lastLog, err := st.LastLogStoreAppliedCommand()
+	lastSnapshot := lastSnapshotIndex(st.snapshotStore)
+	return max(lastSnapshot, lastLog), err
 }

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -596,32 +596,6 @@ func (st *Store) openDatabase(ctx context.Context) {
 	st.log.WithField("n", st.schemaManager.NewSchemaReader().Len()).Info("schema manager loaded")
 }
 
-// reloadDBFromSnapshot reloads the node's local db. If the db is already loaded, it will be reloaded.
-// If a snapshot exists and its is up to date with the log, it will be loaded.
-// Otherwise, the database will be loaded when the node synchronizes its state with the leader.
-//
-// In specific scenarios where the follower's state is too far behind the leader's log,
-// the leader may decide to send a snapshot. Consequently, the follower must update its state accordingly.
-func (st *Store) reloadDBFromSnapshot() (success bool) {
-	defer func() {
-		if success && !st.cfg.MetadataOnlyVoters {
-			st.reloadDBFromSchema()
-		}
-	}()
-
-	if !st.dbLoaded.CompareAndSwap(true, false) {
-		// the snapshot already includes the state from the raft log
-		snapIndex := lastSnapshotIndex(st.snapshotStore)
-		st.log.WithFields(logrus.Fields{
-			"last_applied_index":           st.lastAppliedIndex.Load(),
-			"last_store_log_applied_index": st.lastAppliedIndexOnStart.Load(),
-			"last_snapshot_index":          snapIndex,
-		}).Info("load local db from snapshot")
-		return st.lastAppliedIndexOnStart.Load() <= snapIndex
-	}
-	return true
-}
-
 func (st *Store) reloadDBFromSchema() {
 	if !st.cfg.MetadataOnlyVoters {
 		st.schemaManager.ReloadDBFromSchema()
@@ -629,7 +603,14 @@ func (st *Store) reloadDBFromSchema() {
 		st.log.Info("skipping reload DB from schema as the node is metadata only")
 	}
 	st.dbLoaded.Store(true)
-	st.lastAppliedIndexOnStart.Store(0)
+	if st.raft != nil {
+		st.lastAppliedIndexOnStart.Store(st.raft.LastIndex())
+		return
+	}
+
+	// restore requests from snapshots
+	lastApplied, _ := st.LastAppliedCommand()
+	st.lastAppliedIndexOnStart.Store(lastApplied)
 }
 
 type Response struct {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -93,11 +93,11 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	// schemaOnly is necessary so that on restart when we are re-applying RAFT log entries to our in-memory schema we
 	// don't update the database. This can lead to data loss for example if we drop then re-add a class.
 	// If we don't have any last applied index on start, schema only is always false.
-	schemaOnly := st.lastAppliedIndexOnStart.Load() != 0 && l.Index <= st.lastAppliedIndexOnStart.Load() || st.cfg.MetadataOnlyVoters
+	schemaOnly := l.Index != 0 && l.Index <= st.lastAppliedIndexOnStart.Load() || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
-		if st.lastAppliedIndexOnStart.Load() != 0 && l.Index == st.lastAppliedIndexOnStart.Load() {
+		if l.Index != 0 && l.Index == st.lastAppliedIndexOnStart.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,
 				"log_name":                     l.Type.String(),

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -55,10 +55,10 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 		}
 		st.log.Info("successfully restored schema from snapshot")
 
-		if st.reloadDBFromSnapshot() {
-			st.log.WithField("n", st.schemaManager.NewSchemaReader().Len()).
-				Info("successfully reloaded indexes from snapshot")
-		}
+		st.reloadDBFromSchema()
+
+		st.log.WithField("n", st.schemaManager.NewSchemaReader().Len()).
+			Info("successfully reloaded indexes from snapshot")
 
 		if st.raft != nil {
 			st.lastAppliedIndex.Store(st.raft.AppliedIndex())


### PR DESCRIPTION
### What's being changed:
to catch situations if there was a freshly created snapshot and empty log store 

situation:
```
Logstore  0 
Snapshot 1 
```





### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
