### PR TITLE
force a single tombstone cleanup running at a time

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -251,6 +251,12 @@ func (h *hnsw) CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 }
 
 func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (bool, error) {
+	if h.tombstoneCleanupRunning.Load() {
+		return false, errors.New("tombstone cleanup already running")
+	}
+	h.tombstoneCleanupRunning.Store(true)
+	defer h.tombstoneCleanupRunning.Store(false)
+
 	h.compressActionLock.RLock()
 	defer h.compressActionLock.RUnlock()
 	defer func() {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -171,6 +171,8 @@ type hnsw struct {
 	store              *lsmkv.Store
 
 	allocChecker memwatch.AllocChecker
+
+	tombstoneCleanupRunning atomic.Bool
 }
 
 type CommitLogger interface {


### PR DESCRIPTION
### What's being changed:

The cleanup logic uses thread safe internal management but it is suppose to run as a single instance at a time. This PR enforces a single run at the time.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
