### PR TITLE
refact:raft: last applied index (guard db "FSM") from any re-apply

### DIFF
--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -185,7 +185,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, version))
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
-	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastAppliedIndex.Load()+1), types.ErrDeadlineExceeded)
+	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastIndex()+1), types.ErrDeadlineExceeded)
 
 	// DeleteClass
 	_, err = srv.DeleteClass("X")

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -623,7 +623,10 @@ func (st *Store) reloadDBFromSchema() {
 	}
 
 	// restore requests from snapshots before init new RAFT node
-	lastLogApplied, _ := st.LastAppliedCommand()
+	lastLogApplied, err := st.LastAppliedCommand()
+	if err != nil {
+		st.log.WithField("error", err).Warn("can't detect the last applied command, setting the lastLogApplied to 0")
+	}
 	st.lastAppliedIndexToDB.Store(max(lastSnapshotIndex(st.snapshotStore), lastLogApplied))
 }
 

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -93,11 +93,11 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	// schemaOnly is necessary so that on restart when we are re-applying RAFT log entries to our in-memory schema we
 	// don't update the database. This can lead to data loss for example if we drop then re-add a class.
 	// If we don't have any last applied index on start, schema only is always false.
-	schemaOnly := st.lastAppliedIndexOnStart.Load() != 0 && l.Index <= st.lastAppliedIndexOnStart.Load() || st.cfg.MetadataOnlyVoters
+	schemaOnly := l.Index != 0 && l.Index <= st.lastAppliedIndexOnStart.Load() || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
-		if st.lastAppliedIndexOnStart.Load() != 0 && l.Index == st.lastAppliedIndexOnStart.Load() {
+		if l.Index != 0 && l.Index == st.lastAppliedIndexOnStart.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,
 				"log_name":                     l.Type.String(),

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -106,7 +106,6 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 			}).Debug("reloading local DB as RAFT and local DB are now caught up")
 			st.reloadDBFromSchema()
 		}
-		st.lastAppliedIndex.Store(l.Index)
 
 		if ret.Error != nil {
 			st.log.WithFields(logrus.Fields{

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -93,16 +93,16 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	// schemaOnly is necessary so that on restart when we are re-applying RAFT log entries to our in-memory schema we
 	// don't update the database. This can lead to data loss for example if we drop then re-add a class.
 	// If we don't have any last applied index on start, schema only is always false.
-	schemaOnly := l.Index != 0 && l.Index <= st.lastAppliedIndexOnStart.Load() || st.cfg.MetadataOnlyVoters
+	schemaOnly := l.Index != 0 && l.Index <= st.lastAppliedIndexToDB.Load() || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
-		if l.Index != 0 && l.Index == st.lastAppliedIndexOnStart.Load() {
+		if l.Index != 0 && l.Index == st.lastAppliedIndexToDB.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,
 				"log_name":                     l.Type.String(),
 				"log_index":                    l.Index,
-				"last_store_log_applied_index": st.lastAppliedIndexOnStart.Load(),
+				"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
 			}).Debug("reloading local DB as RAFT and local DB are now caught up")
 			st.reloadDBFromSchema()
 		}

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -93,6 +93,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	// schemaOnly is necessary so that on restart when we are re-applying RAFT log entries to our in-memory schema we
 	// don't update the database. This can lead to data loss for example if we drop then re-add a class.
 	// If we don't have any last applied index on start, schema only is always false.
+	// we check for index !=0 to force apply of the 1st index in both db and schema
 	schemaOnly := l.Index != 0 && l.Index <= st.lastAppliedIndexToDB.Load() || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -65,14 +65,14 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 		}
 
 		snapIndex := lastSnapshotIndex(st.snapshotStore)
-		if st.lastAppliedIndexOnStart.Load() <= snapIndex {
+		if st.lastAppliedIndexToDB.Load() <= snapIndex {
 			// db shall reload after snapshot applied to schema
 			st.reloadDBFromSchema()
 		}
 
 		st.log.WithFields(logrus.Fields{
 			"last_applied_index":           st.lastAppliedIndex.Load(),
-			"last_store_log_applied_index": st.lastAppliedIndexOnStart.Load(),
+			"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
 			"last_snapshot_index":          snapIndex,
 			"n":                            st.schemaManager.NewSchemaReader().Len(),
 		}).Info("successfully reloaded indexes from snapshot")

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -56,10 +56,6 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 		}
 		st.log.Info("successfully restored schema from snapshot")
 
-		if st.raft != nil {
-			st.lastAppliedIndex.Store(st.raft.AppliedIndex())
-		}
-
 		if st.cfg.MetadataOnlyVoters {
 			return nil
 		}
@@ -71,7 +67,7 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 		}
 
 		st.log.WithFields(logrus.Fields{
-			"last_applied_index":           st.lastAppliedIndex.Load(),
+			"last_applied_index":           st.lastIndex(),
 			"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
 			"last_snapshot_index":          snapIndex,
 			"n":                            st.schemaManager.NewSchemaReader().Len(),


### PR DESCRIPTION
### What's being changed:
this PR gates the db from any re-apply
- simplify the db needs to be reloaded after snapshot logic
- rename `lastAppliedIndexOnStart` to `lastAppliedIndexToDB` to reflect the need for this attr.
- remove `reloadDBFromSnapshot()` given it's not needed and directly do the logic inside `Restore()` 
- stop setting `st.lastAppliedIndexOnStart.Store(0)` given that the `index` will grow only and instead depend either on last applied on RAFT or detect from the log store before starting new node 
- remove `lastAppliedIndex` attr. which is not need and was adding confusion given that `raft` offers [LastIndex](https://github.com/hashicorp/raft/blob/main/api.go#L1213), so there is no reason to have an extra filed from our side. 
- introduce  `lastIndex()` this work as a gate which will alway get the max applied either by Raft or `max(snapshot,logstore)`


for simpler review, please review based on commits: 
- https://github.com/weaviate/weaviate/pull/5527/commits/84f59270e5c044a32bcf69e26aeca9aa75afb130
- https://github.com/weaviate/weaviate/pull/5527/commits/b5f24d047e72b6656588117143c5f77149b83b4e
- https://github.com/weaviate/weaviate/pull/5527/commits/ec8980d177f761ff3c11d3eeb26ea544cdcf6045

 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10252086179
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
