### PR TITLE
Adjust pipelines for larger github runners

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -93,7 +93,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--only-module-backup-azure", "--only-module-backup-filesystem", "--only-module-backup-gcs", "--only-module-backup-s3", "--only-module-img2vec-neural", "--only-module-many-modules", "--only-module-multi2vec-clip", "--only-module-ref2vec-centroid", "--only-module-reranker-transformers", "--only-module-text2vec-contextionary", "--only-module-text2vec-transformers"]
+        test: [
+          "--only-module-backup-azure",
+          "--only-module-backup-filesystem",
+          "--only-module-backup-gcs",
+          "--only-module-backup-s3",
+          "--only-module-img2vec-neural",
+          "--only-module-many-modules",
+          "--only-module-ref2vec-centroid",
+          "--only-module-reranker-transformers",
+          "--only-module-text2vec-contextionary",
+          "--only-module-text2vec-transformers"
+        ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -109,7 +120,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--only-module-qna-transformers", "--only-module-sum-transformers"]
+        test: [
+          "--only-module-qna-transformers",
+          "--only-module-sum-transformers",
+          "--only-module-multi2vec-clip"
+        ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -214,7 +229,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--acceptance-only-fast", "--acceptance-only-graphql", "--acceptance-only-replication", "--acceptance-only-python"]
+        test: [
+          "--acceptance-only-fast",
+          "--acceptance-only-graphql",
+          "--acceptance-only-replication",
+          "--acceptance-only-python"
+        ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
### What's being changed:

Adjust pipelines for larger github runners, `multi2vec-clip` pipeline needs a larger gh runner to run with

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
