### PR TITLE
fix: use immutable copy of sharding state when reloading db from latest schema

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -116,7 +116,9 @@ func (s *SchemaManager) ReloadDBFromSchema() {
 	cs := make([]command.UpdateClassRequest, len(classes))
 	i := 0
 	for _, v := range classes {
-		cs[i] = command.UpdateClassRequest{Class: &v.Class, State: &v.Sharding}
+		// an immutable copy of the sharding state has to be used to avoid conflicts
+		shardingState, _ := v.CopyShardingState()
+		cs[i] = command.UpdateClassRequest{Class: &v.Class, State: shardingState}
 		i++
 	}
 


### PR DESCRIPTION
…st schema

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
