### PR TITLE
raft:GRPC: propagate ctx to client connections and warn on close error instead of error propagation  

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -179,7 +179,7 @@ func (f *fakeSchemaManager) ShardReplicas(class, shard string) ([]string, error)
 	return x.BelongsToNodes, nil
 }
 
-func (f *fakeSchemaManager) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaManager) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, t := range tenants {
 		res[t] = models.TenantActivityStatusHOT

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -187,7 +187,7 @@ func (f *fakeSchemaManager) TenantsShards(class string, tenants ...string) (map[
 	return res, nil
 }
 
-func (f *fakeSchemaManager) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaManager) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -2330,7 +2330,7 @@ func TestOverwriteObjects(t *testing.T) {
 		}
 
 		idx := repo.GetIndex(schema.ClassName(class.Class))
-		shd, err := idx.determineObjectShard(fresh.ID, "")
+		shd, err := idx.determineObjectShard(context.Background(), fresh.ID, "")
 		require.Nil(t, err)
 
 		received, err := idx.OverwriteObjects(context.Background(), shd, input)
@@ -2425,7 +2425,7 @@ func TestIndexDigestObjects(t *testing.T) {
 
 	t.Run("get digest object", func(t *testing.T) {
 		idx := repo.GetIndex(schema.ClassName(class.Class))
-		shd, err := idx.determineObjectShard(obj1.ID, "")
+		shd, err := idx.determineObjectShard(context.Background(), obj1.ID, "")
 		require.Nil(t, err)
 
 		input := []strfmt.UUID{obj1.ID, obj2.ID}

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -81,7 +81,7 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -73,7 +73,7 @@ func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) 
 	return x.BelongsToNodes, nil
 }
 
-func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, t := range tenants {
 		res[t] = models.TenantActivityStatusHOT

--- a/adapters/repos/db/file_structure_migration_test.go
+++ b/adapters/repos/db/file_structure_migration_test.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -304,7 +305,7 @@ func (sg *fakeMigrationSchemaGetter) TenantsShards(class string, tenants ...stri
 	return nil, nil
 }
 
-func (f *fakeMigrationSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeMigrationSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/adapters/repos/db/file_structure_migration_test.go
+++ b/adapters/repos/db/file_structure_migration_test.go
@@ -301,7 +301,7 @@ func (sg *fakeMigrationSchemaGetter) ShardOwner(class, shard string) (string, er
 	return "", nil
 }
 
-func (sg *fakeMigrationSchemaGetter) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (sg *fakeMigrationSchemaGetter) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1226,7 +1226,7 @@ func (i *Index) objectSearch(ctx context.Context, limit int, filters *filters.Lo
 		return nil, nil, err
 	}
 
-	shardNames, err := i.targetShardNames(tenant)
+	shardNames, err := i.targetShardNames(ctx, tenant)
 	if err != nil || len(shardNames) == 0 {
 		return nil, nil, err
 	}
@@ -1484,7 +1484,7 @@ func (i *Index) singleLocalShardObjectVectorSearch(ctx context.Context, searchVe
 }
 
 // to be called after validating multi-tenancy
-func (i *Index) targetShardNames(tenant string) ([]string, error) {
+func (i *Index) targetShardNames(ctx context.Context, tenant string) ([]string, error) {
 	className := i.Config.ClassName.String()
 	if !i.partitioningEnabled {
 		return i.getSchema.CopyShardingState(className).AllPhysicalShards(), nil
@@ -1494,7 +1494,7 @@ func (i *Index) targetShardNames(tenant string) ([]string, error) {
 		return []string{}, objects.NewErrMultiTenancy(fmt.Errorf("tenant name is empty"))
 	}
 
-	tenantShards, err := i.getSchema.OptimisticTenantStatus(className, tenant)
+	tenantShards, err := i.getSchema.OptimisticTenantStatus(ctx, className, tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -1517,7 +1517,7 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVector []float32,
 	if err := i.validateMultiTenancy(tenant); err != nil {
 		return nil, nil, err
 	}
-	shardNames, err := i.targetShardNames(tenant)
+	shardNames, err := i.targetShardNames(ctx, tenant)
 	if err != nil || len(shardNames) == 0 {
 		return nil, nil, err
 	}
@@ -1958,7 +1958,7 @@ func (i *Index) aggregate(ctx context.Context,
 		return nil, err
 	}
 
-	shardNames, err := i.targetShardNames(params.Tenant)
+	shardNames, err := i.targetShardNames(ctx, params.Tenant)
 	if err != nil || len(shardNames) == 0 {
 		return nil, err
 	}
@@ -2306,7 +2306,7 @@ func (i *Index) findUUIDs(ctx context.Context,
 
 	className := i.Config.ClassName.String()
 
-	shardNames, err := i.targetShardNames(tenant)
+	shardNames, err := i.targetShardNames(ctx, tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -575,11 +575,11 @@ func indexID(class schema.ClassName) string {
 	return strings.ToLower(string(class))
 }
 
-func (i *Index) determineObjectShard(id strfmt.UUID, tenant string) (string, error) {
-	return i.determineObjectShardByStatus(id, tenant, nil)
+func (i *Index) determineObjectShard(ctx context.Context, id strfmt.UUID, tenant string) (string, error) {
+	return i.determineObjectShardByStatus(ctx, id, tenant, nil)
 }
 
-func (i *Index) determineObjectShardByStatus(id strfmt.UUID, tenant string, shardsStatus map[string]string) (string, error) {
+func (i *Index) determineObjectShardByStatus(ctx context.Context, id strfmt.UUID, tenant string, shardsStatus map[string]string) (string, error) {
 	if tenant == "" {
 		uuid, err := uuid.Parse(id.String())
 		if err != nil {
@@ -595,7 +595,7 @@ func (i *Index) determineObjectShardByStatus(id strfmt.UUID, tenant string, shar
 
 	var err error
 	if len(shardsStatus) == 0 {
-		shardsStatus, err = i.getSchema.TenantsShards(i.Config.ClassName.String(), tenant)
+		shardsStatus, err = i.getSchema.TenantsShards(ctx, i.Config.ClassName.String(), tenant)
 		if err != nil {
 			return "", err
 		}
@@ -627,7 +627,7 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object,
 			object.Class(), i.Config.ClassName)
 	}
 
-	shardName, err := i.determineObjectShard(object.ID(), object.Object.Tenant)
+	shardName, err := i.determineObjectShard(ctx, object.ID(), object.Object.Tenant)
 	if err != nil {
 		return objects.NewErrInvalidUserInput("determine shard: %v", err)
 	}
@@ -807,7 +807,7 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 	}
 
 	if len(tenants) > 0 {
-		tenantsStatus, err = i.getSchema.TenantsShards(i.Config.ClassName.String(), tenants...)
+		tenantsStatus, err = i.getSchema.TenantsShards(ctx, i.Config.ClassName.String(), tenants...)
 		if err != nil {
 			return []error{err}
 		}
@@ -818,7 +818,7 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 			out[pos] = err
 			continue
 		}
-		shardName, err := i.determineObjectShardByStatus(obj.ID(), obj.Object.Tenant, tenantsStatus)
+		shardName, err := i.determineObjectShardByStatus(ctx, obj.ID(), obj.Object.Tenant, tenantsStatus)
 		if err != nil {
 			out[pos] = err
 			continue
@@ -938,7 +938,7 @@ func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchRefere
 			out[pos] = err
 			continue
 		}
-		shardName, err := i.determineObjectShard(ref.From.TargetID, ref.Tenant)
+		shardName, err := i.determineObjectShard(ctx, ref.From.TargetID, ref.Tenant)
 		if err != nil {
 			out[pos] = err
 			continue
@@ -1001,7 +1001,7 @@ func (i *Index) objectByID(ctx context.Context, id strfmt.UUID,
 		return nil, err
 	}
 
-	shardName, err := i.determineObjectShard(id, tenant)
+	shardName, err := i.determineObjectShard(ctx, id, tenant)
 	if err != nil {
 		switch err.(type) {
 		case objects.ErrMultiTenancy:
@@ -1092,7 +1092,7 @@ func (i *Index) multiObjectByID(ctx context.Context,
 
 	byShard := map[string]idsAndPos{}
 	for pos, id := range query {
-		shardName, err := i.determineObjectShard(strfmt.UUID(id.ID), tenant)
+		shardName, err := i.determineObjectShard(ctx, strfmt.UUID(id.ID), tenant)
 		if err != nil {
 			return nil, objects.NewErrInvalidUserInput("determine shard: %v", err)
 		}
@@ -1161,7 +1161,7 @@ func (i *Index) exists(ctx context.Context, id strfmt.UUID,
 		return false, err
 	}
 
-	shardName, err := i.determineObjectShard(id, tenant)
+	shardName, err := i.determineObjectShard(ctx, id, tenant)
 	if err != nil {
 		switch err.(type) {
 		case objects.ErrMultiTenancy:
@@ -1718,7 +1718,7 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 		return err
 	}
 
-	shardName, err := i.determineObjectShard(id, tenant)
+	shardName, err := i.determineObjectShard(ctx, id, tenant)
 	if err != nil {
 		return objects.NewErrInvalidUserInput("determine shard: %v", err)
 	}
@@ -1896,7 +1896,7 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 		return err
 	}
 
-	shardName, err := i.determineObjectShard(merge.ID, tenant)
+	shardName, err := i.determineObjectShard(ctx, merge.ID, tenant)
 	if err != nil {
 		return objects.NewErrInvalidUserInput("determine shard: %v", err)
 	}

--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -31,7 +31,7 @@ type Raft struct {
 
 // client to communicate with remote services
 type client interface {
-	Apply(leaderAddr string, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error)
+	Apply(ctx context.Context, leaderAddr string, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error)
 	Query(ctx context.Context, leaderAddr string, req *cmd.QueryRequest) (*cmd.QueryResponse, error)
 	Remove(ctx context.Context, leaderAddress string, req *cmd.RemovePeerRequest) (*cmd.RemovePeerResponse, error)
 	Join(ctx context.Context, leaderAddr string, req *cmd.JoinPeerRequest) (*cmd.JoinPeerResponse, error)

--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -12,6 +12,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -25,7 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func (s *Raft) AddClass(cls *models.Class, ss *sharding.State) (uint64, error) {
+func (s *Raft) AddClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
 	if cls == nil || cls.Class == "" {
 		return 0, fmt.Errorf("nil class or empty class name : %w", schema.ErrBadRequest)
 	}
@@ -40,10 +41,10 @@ func (s *Raft) AddClass(cls *models.Class, ss *sharding.State) (uint64, error) {
 		Class:      cls.Class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) UpdateClass(cls *models.Class, ss *sharding.State) (uint64, error) {
+func (s *Raft) UpdateClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
 	if cls == nil || cls.Class == "" {
 		return 0, fmt.Errorf("nil class or empty class name : %w", schema.ErrBadRequest)
 	}
@@ -57,18 +58,18 @@ func (s *Raft) UpdateClass(cls *models.Class, ss *sharding.State) (uint64, error
 		Class:      cls.Class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) DeleteClass(name string) (uint64, error) {
+func (s *Raft) DeleteClass(ctx context.Context, name string) (uint64, error) {
 	command := &cmd.ApplyRequest{
 		Type:  cmd.ApplyRequest_TYPE_DELETE_CLASS,
 		Class: name,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) RestoreClass(cls *models.Class, ss *sharding.State) (uint64, error) {
+func (s *Raft) RestoreClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
 	if cls == nil || cls.Class == "" {
 		return 0, fmt.Errorf("nil class or empty class name : %w", schema.ErrBadRequest)
 	}
@@ -82,10 +83,10 @@ func (s *Raft) RestoreClass(cls *models.Class, ss *sharding.State) (uint64, erro
 		Class:      cls.Class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) AddProperty(class string, props ...*models.Property) (uint64, error) {
+func (s *Raft) AddProperty(ctx context.Context, class string, props ...*models.Property) (uint64, error) {
 	for _, p := range props {
 		if p == nil || p.Name == "" || class == "" {
 			return 0, fmt.Errorf("empty property or empty class name : %w", schema.ErrBadRequest)
@@ -101,10 +102,10 @@ func (s *Raft) AddProperty(class string, props ...*models.Property) (uint64, err
 		Class:      class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) UpdateShardStatus(class, shard, status string) (uint64, error) {
+func (s *Raft) UpdateShardStatus(ctx context.Context, class, shard, status string) (uint64, error) {
 	if class == "" || shard == "" {
 		return 0, fmt.Errorf("empty class or shard : %w", schema.ErrBadRequest)
 	}
@@ -118,10 +119,10 @@ func (s *Raft) UpdateShardStatus(class, shard, status string) (uint64, error) {
 		Class:      req.Class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) AddTenants(class string, req *cmd.AddTenantsRequest) (uint64, error) {
+func (s *Raft) AddTenants(ctx context.Context, class string, req *cmd.AddTenantsRequest) (uint64, error) {
 	if class == "" || req == nil {
 		return 0, fmt.Errorf("empty class name or nil request : %w", schema.ErrBadRequest)
 	}
@@ -134,10 +135,10 @@ func (s *Raft) AddTenants(class string, req *cmd.AddTenantsRequest) (uint64, err
 		Class:      class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) UpdateTenants(class string, req *cmd.UpdateTenantsRequest) (uint64, error) {
+func (s *Raft) UpdateTenants(ctx context.Context, class string, req *cmd.UpdateTenantsRequest) (uint64, error) {
 	if class == "" || req == nil {
 		return 0, fmt.Errorf("empty class name or nil request : %w", schema.ErrBadRequest)
 	}
@@ -150,10 +151,10 @@ func (s *Raft) UpdateTenants(class string, req *cmd.UpdateTenantsRequest) (uint6
 		Class:      class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
-func (s *Raft) DeleteTenants(class string, req *cmd.DeleteTenantsRequest) (uint64, error) {
+func (s *Raft) DeleteTenants(ctx context.Context, class string, req *cmd.DeleteTenantsRequest) (uint64, error) {
 	if class == "" || req == nil {
 		return 0, fmt.Errorf("empty class name or nil request : %w", schema.ErrBadRequest)
 	}
@@ -166,18 +167,18 @@ func (s *Raft) DeleteTenants(class string, req *cmd.DeleteTenantsRequest) (uint6
 		Class:      class,
 		SubCommand: subCommand,
 	}
-	return s.Execute(command)
+	return s.Execute(ctx, command)
 }
 
 func (s *Raft) StoreSchemaV1() error {
 	command := &cmd.ApplyRequest{
 		Type: cmd.ApplyRequest_TYPE_STORE_SCHEMA_V1,
 	}
-	_, err := s.Execute(command)
+	_, err := s.Execute(context.Background(), command)
 	return err
 }
 
-func (s *Raft) Execute(req *cmd.ApplyRequest) (uint64, error) {
+func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, error) {
 	t := prometheus.NewTimer(
 		monitoring.GetMetrics().SchemaWrites.WithLabelValues(
 			req.Type.String(),
@@ -195,7 +196,7 @@ func (s *Raft) Execute(req *cmd.ApplyRequest) (uint64, error) {
 	if leader == "" {
 		return 0, s.leaderErr()
 	}
-	resp, err := s.cl.Apply(leader, req)
+	resp, err := s.cl.Apply(ctx, leader, req)
 	if err != nil {
 		return 0, err
 	}

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -49,7 +49,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	// DeleteClass
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 	m.indexer.On("DeleteClass", Anything).Return(nil)
-	_, err := srv.DeleteClass("C")
+	_, err := srv.DeleteClass(ctx, "C")
 	assert.Nil(t, err)
 
 	// Add a class C with a tenant T0 with state S0
@@ -62,7 +62,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	// Get a shema reader to verify our schema operation are working
 	schemaReader := srv.SchemaReader()
 	ss := &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0", Status: "S0"}}}
-	_, err = srv.AddClass(cls, ss)
+	_, err = srv.AddClass(ctx, cls, ss)
 	assert.Nil(t, err)
 	assert.Equal(t, schemaReader.ClassEqual(cls.Class), cls.Class)
 	assert.Equal(t, "S0", schemaReader.CopyShardingState(cls.Class).Physical["T0"].Status)
@@ -73,12 +73,12 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 
 	m.indexer.On("DeleteTenants", Anything, Anything).Return(nil)
 	// Now let's drop the tenant T0 (this will be a log entry and not included in the snapshot)
-	_, err = srv.DeleteTenants(cls.Class, &api.DeleteTenantsRequest{Tenants: []string{"T0"}})
+	_, err = srv.DeleteTenants(ctx, cls.Class, &api.DeleteTenantsRequest{Tenants: []string{"T0"}})
 	require.NoError(t, err)
 
 	// Now re-add the tenant T0 with state S1
 	m.indexer.On("AddTenants", Anything, Anything).Return(nil)
-	_, err = srv.AddTenants(cls.Class, &api.AddTenantsRequest{
+	_, err = srv.AddTenants(ctx, cls.Class, &api.AddTenantsRequest{
 		ClusterNodes: []string{"Node-1"},
 		Tenants:      []*api.Tenant{{Name: "T0", Status: "S1"}},
 	})

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -53,7 +53,7 @@ func TestRaftEndpoints(t *testing.T) {
 	srv := NewRaft(m.store, nil)
 
 	// LeaderNotFound
-	_, err := srv.Execute(&command.ApplyRequest{})
+	_, err := srv.Execute(ctx, &command.ApplyRequest{})
 	assert.ErrorIs(t, err, types.ErrLeaderNotFound)
 	assert.ErrorIs(t, srv.Join(ctx, m.store.cfg.NodeID, addr, true), types.ErrLeaderNotFound)
 	assert.ErrorIs(t, srv.Remove(ctx, m.store.cfg.NodeID), types.ErrLeaderNotFound)
@@ -84,7 +84,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Equal(t, schemaReader.Len(), 0)
 
 	// AddClass
-	_, err = srv.AddClass(nil, nil)
+	_, err = srv.AddClass(ctx, nil, nil)
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
 	assert.Equal(t, schemaReader.ClassEqual("C"), "")
 
@@ -93,17 +93,17 @@ func TestRaftEndpoints(t *testing.T) {
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	}
 	ss := &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0"}}}
-	version0, err := srv.AddClass(cls, ss)
+	version0, err := srv.AddClass(ctx, cls, ss)
 	assert.Nil(t, err)
 	assert.Equal(t, schemaReader.ClassEqual("C"), "C")
 
 	// Add same class again
-	_, err = srv.AddClass(cls, ss)
+	_, err = srv.AddClass(ctx, cls, ss)
 	assert.Error(t, err)
 	assert.Equal(t, "class name C already exists", err.Error())
 
 	// Add similar class
-	_, err = srv.AddClass(&models.Class{Class: "c"}, ss)
+	_, err = srv.AddClass(ctx, &models.Class{Class: "c"}, ss)
 	assert.ErrorIs(t, err, schema.ErrClassExists)
 
 	// QueryReadOnlyClass
@@ -155,14 +155,14 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// QueryShardOwner
-	srv.UpdateClass(cls, &sharding.State{Physical: map[string]sharding.Physical{"T0": {BelongsToNodes: []string{"N0"}}}})
+	srv.UpdateClass(ctx, cls, &sharding.State{Physical: map[string]sharding.Physical{"T0": {BelongsToNodes: []string{"N0"}}}})
 	getShardOwner, _, err := srv.QueryShardOwner(cls.Class, "T0")
 	assert.Nil(t, err)
 	assert.Equal(t, "N0", getShardOwner)
 
 	// QueryShardingState
 	shardingState := &sharding.State{Physical: map[string]sharding.Physical{"T0": {BelongsToNodes: []string{"N0"}}}}
-	srv.UpdateClass(cls, shardingState)
+	srv.UpdateClass(ctx, cls, shardingState)
 	getShardingState, _, err := srv.QueryShardingState(cls.Class)
 	assert.Nil(t, err)
 	assert.Equal(t, shardingState, getShardingState)
@@ -174,12 +174,12 @@ func TestRaftEndpoints(t *testing.T) {
 		ReplicationFactor: 1,
 		Tenants:           1,
 	}
-	_, err = srv.UpdateClass(nil, nil)
+	_, err = srv.UpdateClass(ctx, nil, nil)
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
 	cls.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
 	cls.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
 	ss.Physical = map[string]sharding.Physical{"T0": {Name: "T0"}}
-	version, err := srv.UpdateClass(cls, nil)
+	version, err := srv.UpdateClass(ctx, cls, nil)
 	info.ClassVersion = version
 	info.ShardVersion = version0
 	assert.Nil(t, err)
@@ -188,44 +188,44 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastIndex()+1), types.ErrDeadlineExceeded)
 
 	// DeleteClass
-	_, err = srv.DeleteClass("X")
+	_, err = srv.DeleteClass(ctx, "X")
 	assert.Nil(t, err)
-	_, err = srv.DeleteClass("C")
+	_, err = srv.DeleteClass(ctx, "C")
 	assert.Nil(t, err)
 	assert.Equal(t, schema.ClassInfo{}, schemaReader.ClassInfo("C"))
 
 	// RestoreClass
-	_, err = srv.RestoreClass(nil, nil)
+	_, err = srv.RestoreClass(ctx, nil, nil)
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	version, err = srv.RestoreClass(cls, ss)
+	version, err = srv.RestoreClass(ctx, cls, ss)
 	assert.Nil(t, err)
 	info.ClassVersion = version
 	info.ShardVersion = version
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
 
 	// AddProperty
-	_, err = srv.AddProperty("C", nil)
+	_, err = srv.AddProperty(ctx, "C", nil)
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	_, err = srv.AddProperty("", &models.Property{Name: "P1"})
+	_, err = srv.AddProperty(ctx, "", &models.Property{Name: "P1"})
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	version, err = srv.AddProperty("C", &models.Property{Name: "P1"})
+	version, err = srv.AddProperty(ctx, "C", &models.Property{Name: "P1"})
 	assert.Nil(t, err)
 	info.ClassVersion = version
 	info.Properties = 1
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
 
 	// UpdateStatus
-	_, err = srv.UpdateShardStatus("", "A", "ACTIVE")
+	_, err = srv.UpdateShardStatus(ctx, "", "A", "ACTIVE")
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	_, err = srv.UpdateShardStatus("C", "", "ACTIVE")
+	_, err = srv.UpdateShardStatus(ctx, "C", "", "ACTIVE")
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	_, err = srv.UpdateShardStatus("C", "A", "ACTIVE")
+	_, err = srv.UpdateShardStatus(ctx, "C", "A", "ACTIVE")
 	assert.Nil(t, err)
 
 	// AddTenants
-	_, err = srv.AddTenants("", &command.AddTenantsRequest{})
+	_, err = srv.AddTenants(ctx, "", &command.AddTenantsRequest{})
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	version, err = srv.AddTenants("C", &command.AddTenantsRequest{
+	version, err = srv.AddTenants(ctx, "C", &command.AddTenantsRequest{
 		ClusterNodes: []string{"Node-1"},
 		Tenants:      []*command.Tenant{nil, {Name: "T2", Status: "S1"}, nil},
 	})
@@ -235,15 +235,15 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
 
 	// UpdateTenants
-	_, err = srv.UpdateTenants("", &command.UpdateTenantsRequest{})
+	_, err = srv.UpdateTenants(ctx, "", &command.UpdateTenantsRequest{})
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	_, err = srv.UpdateTenants("C", &command.UpdateTenantsRequest{Tenants: []*command.Tenant{{Name: "T2", Status: "S2"}}})
+	_, err = srv.UpdateTenants(ctx, "C", &command.UpdateTenantsRequest{Tenants: []*command.Tenant{{Name: "T2", Status: "S2"}}})
 	assert.Nil(t, err)
 
 	// DeleteTenants
-	_, err = srv.DeleteTenants("", &command.DeleteTenantsRequest{})
+	_, err = srv.DeleteTenants(ctx, "", &command.DeleteTenantsRequest{})
 	assert.ErrorIs(t, err, schema.ErrBadRequest)
-	version, err = srv.DeleteTenants("C", &command.DeleteTenantsRequest{Tenants: []string{"T0", "Tn"}})
+	version, err = srv.DeleteTenants(ctx, "C", &command.DeleteTenantsRequest{Tenants: []string{"T0", "Tn"}})
 	assert.Nil(t, err)
 	info.Tenants -= 1
 	info.ShardVersion = version

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -197,8 +197,9 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 		if err := cl.leaderRpcConn.Close(); err != nil {
 			cl.logger.WithFields(
 				logrus.Fields{
-					"error":       err,
-					"leader_addr": leaderRaftAddr,
+					"error":                  err,
+					"closing_on_leader_addr": cl.leaderRaftAddr,
+					"new_leader_addr":        leaderRaftAddr,
 				},
 			).Warn("error closing the leader gRPC connection")
 		}

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -140,8 +140,6 @@ func (cl *Client) Remove(ctx context.Context, leaderRaftAddr string, req *cmd.Re
 }
 
 // Apply will contact the node at leaderRaftAddr and send req to be applied in the RAFT store
-// It does not take a context and will instead use a background context to ensure that request
-// applied the change in the leader node.
 // Returns the server response to the apply request
 // Returns an error if an RPC connection to leaderRaftAddr can't be established
 // Returns an error if the apply command fails

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
@@ -142,10 +141,7 @@ func (cl *Client) Remove(ctx context.Context, leaderRaftAddr string, req *cmd.Re
 // Returns the server response to the apply request
 // Returns an error if an RPC connection to leaderRaftAddr can't be established
 // Returns an error if the apply command fails
-func (cl *Client) Apply(leaderRaftAddr string, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+func (cl *Client) Apply(ctx context.Context, leaderRaftAddr string, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error) {
 	conn, err := cl.getConn(ctx, leaderRaftAddr)
 	if err != nil {
 		return nil, err

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -166,18 +166,20 @@ func (cl *Client) Query(ctx context.Context, leaderRaftAddr string, req *cmd.Que
 }
 
 // Close the client and allocated resources
-func (cl *Client) Close() error {
-	if cl.leaderRpcConn != nil {
-		if err := cl.leaderRpcConn.Close(); err != nil {
-			cl.logger.WithFields(
-				logrus.Fields{
-					"error":       err,
-					"leader_addr": cl.leaderRaftAddr,
-				},
-			).Warn("error closing the leader gRPC connection")
-		}
+func (cl *Client) Close() {
+	if cl.leaderRpcConn == nil {
+		return
 	}
-	return nil
+
+	if err := cl.leaderRpcConn.Close(); err != nil {
+		cl.logger.WithFields(
+			logrus.Fields{
+				"error":       err,
+				"leader_addr": cl.leaderRaftAddr,
+			},
+		).Warn("error closing the leader gRPC connection")
+	}
+
 }
 
 // getConn either returns the cached connection in the client to the leader or will instantiate a new one towards

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -199,7 +199,7 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 		return nil, fmt.Errorf("resolve address: %w", err)
 	}
 
-	var options = []grpc.DialOption{
+	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(serviceConfig),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(cl.rpcMessageMaxSize)),

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -179,7 +179,6 @@ func (cl *Client) Close() {
 			},
 		).Warn("error closing the leader gRPC connection")
 	}
-
 }
 
 // getConn either returns the cached connection in the client to the leader or will instantiate a new one towards

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -43,7 +43,7 @@ func TestClient(t *testing.T) {
 		require.ErrorIs(t, err, ErrAny)
 		require.ErrorContains(t, err, "resolve")
 
-		_, err = c.Apply(addr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
+		_, err = c.Apply(context.TODO(), addr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
 		require.ErrorIs(t, err, ErrAny)
 		require.ErrorContains(t, err, "resolve")
 
@@ -66,7 +66,7 @@ func TestClient(t *testing.T) {
 		_, err = c.Remove(ctx, badAddr, &cmd.RemovePeerRequest{Id: "Node1"})
 		require.ErrorContains(t, err, "dial")
 
-		_, err = c.Apply(badAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
+		_, err = c.Apply(context.TODO(), badAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
 		require.ErrorContains(t, err, "dial")
 
 		_, err = c.Query(ctx, badAddr, &cmd.QueryRequest{Type: cmd.QueryRequest_TYPE_GET_CLASSES})

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/fakes"
@@ -30,7 +31,7 @@ func TestClient(t *testing.T) {
 
 	t.Run("Verify error on invalid raft address", func(t *testing.T) {
 		addr := fmt.Sprintf("localhost:%v", 8013)
-		c := NewClient(fakes.NewFakeRPCAddressResolver(addr, ErrAny), 1024*1024*1024, false)
+		c := NewClient(fakes.NewFakeRPCAddressResolver(addr, ErrAny), 1024*1024*1024, false, logrus.StandardLogger())
 		_, err := c.Join(ctx, addr, &cmd.JoinPeerRequest{Id: "Node1", Address: addr, Voter: false})
 		require.ErrorIs(t, err, ErrAny)
 		require.ErrorContains(t, err, "resolve")
@@ -55,7 +56,7 @@ func TestClient(t *testing.T) {
 	t.Run("Verify error on invalid address dial", func(t *testing.T) {
 		// invalid control character in URL
 		badAddr := string(byte(0))
-		c := NewClient(fakes.NewFakeRPCAddressResolver(badAddr, nil), 1024*1024*1024, false)
+		c := NewClient(fakes.NewFakeRPCAddressResolver(badAddr, nil), 1024*1024*1024, false, logrus.StandardLogger())
 
 		_, err := c.Join(ctx, badAddr, &cmd.JoinPeerRequest{Id: "Node1", Address: "abc", Voter: false})
 		require.ErrorContains(t, err, "dial")

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -37,7 +37,7 @@ type raftPeers interface {
 }
 
 type raftFSM interface {
-	Execute(cmd *cmd.ApplyRequest) (uint64, error)
+	Execute(ctx context.Context, cmd *cmd.ApplyRequest) (uint64, error)
 	Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResponse, error)
 }
 
@@ -96,8 +96,8 @@ func (s *Server) NotifyPeer(_ context.Context, req *cmd.NotifyPeerRequest) (*cmd
 // Apply will update the RAFT FSM representation to apply req.
 // Returns the FSM version of that change.
 // Returns an error and the current raft leader if applying fails.
-func (s *Server) Apply(_ context.Context, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error) {
-	v, err := s.raftFSM.Execute(req)
+func (s *Server) Apply(ctx context.Context, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error) {
+	v, err := s.raftFSM.Execute(ctx, req)
 	if err != nil {
 		return &cmd.ApplyResponse{Leader: s.raftPeers.Leader()}, toRPCError(err)
 	}

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -298,7 +298,7 @@ func TestApply(t *testing.T) {
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
 				defer client.Close()
 
-				_, err := client.Apply(leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
+				_, err := client.Apply(context.TODO(), leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
 				assert.NotNil(t, err)
 				st, ok := status.FromError(err)
 				assert.True(t, ok)
@@ -328,7 +328,7 @@ func TestApply(t *testing.T) {
 					return nil
 				}
 
-				_, err := client.Apply(leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
+				_, err := client.Apply(context.TODO(), leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
 				assert.Nil(t, err)
 				assert.Greater(t, n, 1)
 			},
@@ -346,7 +346,7 @@ func TestApply(t *testing.T) {
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
 				defer client.Close()
 
-				_, err := client.Apply(leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
+				_, err := client.Apply(context.TODO(), leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
 				assert.Nil(t, err)
 			},
 		},
@@ -389,7 +389,7 @@ type MockExecutor struct {
 	qf func(*cmd.QueryRequest) (*cmd.QueryResponse, error)
 }
 
-func (m *MockExecutor) Execute(cmd *cmd.ApplyRequest) (uint64, error) {
+func (m *MockExecutor) Execute(_ context.Context, cmd *cmd.ApplyRequest) (uint64, error) {
 	if m.ef != nil {
 		return 0, m.ef()
 	}

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
@@ -67,7 +68,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Join(ctx, leaderAddr, &cmd.JoinPeerRequest{Id: "Node1", Address: leaderAddr, Voter: false})
@@ -89,7 +90,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Join(ctx, leaderAddr, &cmd.JoinPeerRequest{Id: "Node1", Address: leaderAddr, Voter: false})
@@ -107,7 +108,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Notify(ctx, leaderAddr, &cmd.NotifyPeerRequest{Id: "Node1", Address: leaderAddr})
@@ -129,7 +130,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Notify(ctx, leaderAddr, &cmd.NotifyPeerRequest{Id: "Node1", Address: leaderAddr})
@@ -147,7 +148,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Remove(ctx, leaderAddr, &cmd.RemovePeerRequest{Id: "node1"})
@@ -169,7 +170,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Remove(ctx, leaderAddr, &cmd.RemovePeerRequest{Id: "node1"})
@@ -201,7 +202,7 @@ func TestQueryEndpoint(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Query(ctx, leaderAddr, &cmd.QueryRequest{Type: cmd.QueryRequest_TYPE_GET_CLASSES})
@@ -217,7 +218,7 @@ func TestQueryEndpoint(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				n := 0
@@ -243,7 +244,7 @@ func TestQueryEndpoint(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				executor.qf = func(*cmd.QueryRequest) (*cmd.QueryResponse, error) {
@@ -295,7 +296,7 @@ func TestApply(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Apply(context.TODO(), leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})
@@ -316,7 +317,7 @@ func TestApply(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				n := 0
@@ -343,7 +344,7 @@ func TestApply(t *testing.T) {
 				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
 				assert.Nil(t, server.Open())
 				defer server.Close()
-				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false)
+				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
 				defer client.Close()
 
 				_, err := client.Apply(context.TODO(), leaderAddr, &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_DELETE_CLASS, Class: "C"})

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -46,7 +46,7 @@ type Service struct {
 // Raft store will be initialized and ready to be started. To start the service call Open().
 func New(cfg Config) *Service {
 	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.RPCPort)
-	cl := rpc.NewClient(resolver.NewRpc(cfg.IsLocalHost, cfg.RPCPort), cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled)
+	cl := rpc.NewClient(resolver.NewRpc(cfg.IsLocalHost, cfg.RPCPort), cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled, cfg.Logger)
 	fsm := NewFSM(cfg)
 	raft := NewRaft(&fsm, cl)
 	return &Service{

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -112,9 +112,7 @@ func (c *Service) Close(ctx context.Context) error {
 	}
 
 	c.logger.Info("closing raft-rpc client ...")
-	if err := c.rpcClient.Close(); err != nil {
-		return err
-	}
+	c.rpcClient.Close()
 
 	c.logger.Info("closing raft-rpc server ...")
 	c.rpcServer.Close()

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -58,7 +58,7 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -50,7 +50,7 @@ func (f *fakeSchemaGetter) CopyShardingState(class string) *sharding.State {
 func (f *fakeSchemaGetter) ShardOwner(class, shard string) (string, error)      { return "", nil }
 func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) { return nil, nil }
 
-func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, t := range tenants {
 		res[t] = models.TenantActivityStatusHOT

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -64,7 +64,7 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -56,7 +56,7 @@ func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) 
 	return []string{shard}, nil
 }
 
-func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, t := range tenants {
 		res[t] = models.TenantActivityStatusHOT

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -84,7 +84,7 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -76,7 +76,7 @@ func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) 
 	return x.BelongsToNodes, nil
 }
 
-func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, t := range tenants {
 		res[t] = models.TenantActivityStatusHOT

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -135,7 +135,7 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	if err != nil {
 		return nil, 0, fmt.Errorf("init sharding state: %w", err)
 	}
-	version, err := h.schemaManager.AddClass(cls, shardState)
+	version, err := h.schemaManager.AddClass(ctx, cls, shardState)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -184,7 +184,7 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 
 	shardingState.MigrateFromOldFormat()
 	shardingState.ApplyNodeMapping(m)
-	_, err = h.schemaManager.RestoreClass(class, &shardingState)
+	_, err = h.schemaManager.RestoreClass(ctx, class, &shardingState)
 	return err
 }
 
@@ -195,7 +195,7 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 		return err
 	}
 
-	_, err = h.schemaManager.DeleteClass(class)
+	_, err = h.schemaManager.DeleteClass(ctx, class)
 	return err
 }
 
@@ -245,7 +245,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 		}
 	}
 
-	_, err = h.schemaManager.UpdateClass(updated, shardingState)
+	_, err = h.schemaManager.UpdateClass(ctx, updated, shardingState)
 	return err
 }
 

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -30,47 +30,47 @@ type fakeSchemaManager struct {
 	countClassEqual bool
 }
 
-func (f *fakeSchemaManager) AddClass(cls *models.Class, ss *sharding.State) (uint64, error) {
+func (f *fakeSchemaManager) AddClass(_ context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
 	args := f.Called(cls, ss)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) RestoreClass(cls *models.Class, ss *sharding.State) (uint64, error) {
+func (f *fakeSchemaManager) RestoreClass(_ context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
 	args := f.Called(cls, ss)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) UpdateClass(cls *models.Class, ss *sharding.State) (uint64, error) {
+func (f *fakeSchemaManager) UpdateClass(_ context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
 	args := f.Called(cls, ss)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) DeleteClass(name string) (uint64, error) {
+func (f *fakeSchemaManager) DeleteClass(_ context.Context, name string) (uint64, error) {
 	args := f.Called(name)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) AddProperty(class string, p ...*models.Property) (uint64, error) {
+func (f *fakeSchemaManager) AddProperty(_ context.Context, class string, p ...*models.Property) (uint64, error) {
 	args := f.Called(class, p)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) UpdateShardStatus(class, shard, status string) (uint64, error) {
+func (f *fakeSchemaManager) UpdateShardStatus(c_ context.Context, class, shard, status string) (uint64, error) {
 	args := f.Called(class, shard, status)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) AddTenants(class string, req *command.AddTenantsRequest) (uint64, error) {
+func (f *fakeSchemaManager) AddTenants(_ context.Context, class string, req *command.AddTenantsRequest) (uint64, error) {
 	args := f.Called(class, req)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) UpdateTenants(class string, req *command.UpdateTenantsRequest) (uint64, error) {
+func (f *fakeSchemaManager) UpdateTenants(_ context.Context, class string, req *command.UpdateTenantsRequest) (uint64, error) {
 	args := f.Called(class, req)
 	return 0, args.Error(0)
 }
 
-func (f *fakeSchemaManager) DeleteTenants(class string, req *command.DeleteTenantsRequest) (uint64, error) {
+func (f *fakeSchemaManager) DeleteTenants(_ context.Context, class string, req *command.DeleteTenantsRequest) (uint64, error) {
 	args := f.Called(class, req)
 	return 0, args.Error(0)
 }

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -37,15 +37,15 @@ var ErrNotFound = errors.New("not found")
 // For local schema lookup where eventual consistency is acceptable, see [SchemaReader].
 type SchemaManager interface {
 	// Schema writes operation.
-	AddClass(cls *models.Class, ss *sharding.State) (uint64, error)
-	RestoreClass(cls *models.Class, ss *sharding.State) (uint64, error)
-	UpdateClass(cls *models.Class, ss *sharding.State) (uint64, error)
-	DeleteClass(name string) (uint64, error)
-	AddProperty(class string, p ...*models.Property) (uint64, error)
-	UpdateShardStatus(class, shard, status string) (uint64, error)
-	AddTenants(class string, req *command.AddTenantsRequest) (uint64, error)
-	UpdateTenants(class string, req *command.UpdateTenantsRequest) (uint64, error)
-	DeleteTenants(class string, req *command.DeleteTenantsRequest) (uint64, error)
+	AddClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error)
+	RestoreClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error)
+	UpdateClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error)
+	DeleteClass(ctx context.Context, name string) (uint64, error)
+	AddProperty(ctx context.Context, class string, p ...*models.Property) (uint64, error)
+	UpdateShardStatus(ctx context.Context, class, shard, status string) (uint64, error)
+	AddTenants(ctx context.Context, class string, req *command.AddTenantsRequest) (uint64, error)
+	UpdateTenants(ctx context.Context, class string, req *command.UpdateTenantsRequest) (uint64, error)
+	DeleteTenants(ctx context.Context, class string, req *command.DeleteTenantsRequest) (uint64, error)
 
 	// Cluster related operations
 	Join(_ context.Context, nodeID, raftAddr string, voter bool) error
@@ -215,7 +215,7 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 		return 0, err
 	}
 
-	return h.schemaManager.UpdateShardStatus(class, shard, status)
+	return h.schemaManager.UpdateShardStatus(ctx, class, shard, status)
 }
 
 func (h *Handler) ShardsStatus(ctx context.Context,

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -64,7 +64,7 @@ type SchemaGetter interface {
 	CopyShardingState(class string) *sharding.State
 	ShardOwner(class, shard string) (string, error)
 	TenantsShards(class string, tenants ...string) (map[string]string, error)
-	OptimisticTenantStatus(class string, tenants string) (map[string]string, error)
+	OptimisticTenantStatus(ctx context.Context, class string, tenants string) (map[string]string, error)
 	ShardFromUUID(class string, uuid []byte) string
 	ShardReplicas(class, shard string) ([]string, error)
 }

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -348,7 +348,7 @@ func (m *Manager) ResolveParentNodes(class, shardName string) (map[string]string
 	return name2Addr, nil
 }
 
-func (m *Manager) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (m *Manager) TenantsShards(ctx context.Context, class string, tenants ...string) (map[string]string, error) {
 	slices.Sort(tenants)
 	tenants = slices.Compact(tenants)
 	status, _, err := m.schemaManager.QueryTenantsShards(class, tenants...)
@@ -356,7 +356,7 @@ func (m *Manager) TenantsShards(class string, tenants ...string) (map[string]str
 		return status, err
 	}
 
-	return m.activateTenantIfInactive(class, status)
+	return m.activateTenantIfInactive(ctx, class, status)
 }
 
 // OptimisticTenantStatus tries to query the local state first. It is
@@ -383,7 +383,7 @@ func (m *Manager) TenantsShards(class string, tenants ...string) (map[string]str
 // Overall, we keep the (very common) happy path, free from expensive
 // leader-lookups and only fall back to the leader if the local result implies
 // an unhappy path.
-func (m *Manager) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tenant string) (map[string]string, error) {
 	var foundTenant bool
 	var status string
 	err := m.schemaReader.Read(class, func(_ *models.Class, ss *sharding.State) error {
@@ -403,7 +403,7 @@ func (m *Manager) OptimisticTenantStatus(class string, tenant string) (map[strin
 	if !foundTenant || status != models.TenantActivityStatusHOT {
 		// either no state at all or state does not imply happy path -> delegate to
 		// leader
-		return m.TenantsShards(class, tenant)
+		return m.TenantsShards(ctx, class, tenant)
 	}
 
 	return map[string]string{
@@ -411,7 +411,7 @@ func (m *Manager) OptimisticTenantStatus(class string, tenant string) (map[strin
 	}, nil
 }
 
-func (m *Manager) activateTenantIfInactive(class string,
+func (m *Manager) activateTenantIfInactive(ctx context.Context, class string,
 	status map[string]string,
 ) (map[string]string, error) {
 	req := &api.UpdateTenantsRequest{
@@ -430,7 +430,7 @@ func (m *Manager) activateTenantIfInactive(class string,
 		return status, nil
 	}
 
-	_, err := m.schemaManager.UpdateTenants(class, req)
+	_, err := m.schemaManager.UpdateTenants(ctx, class, req)
 	if err != nil {
 		names := make([]string, len(req.Tenants))
 		for i, t := range req.Tenants {

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -63,7 +63,7 @@ type SchemaGetter interface {
 
 	CopyShardingState(class string) *sharding.State
 	ShardOwner(class, shard string) (string, error)
-	TenantsShards(class string, tenants ...string) (map[string]string, error)
+	TenantsShards(ctx context.Context, class string, tenants ...string) (map[string]string, error)
 	OptimisticTenantStatus(ctx context.Context, class string, tenants string) (map[string]string, error)
 	ShardFromUUID(class string, uuid []byte) string
 	ShardReplicas(class, shard string) ([]string, error)

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -75,7 +75,7 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 	migratePropertySettings(props...)
 
 	class.Properties = clusterSchema.MergeProps(class.Properties, props)
-	version, err := h.schemaManager.AddProperty(class.Class, props...)
+	version, err := h.schemaManager.AddProperty(ctx, class.Class, props...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -62,7 +62,7 @@ func (h *Handler) AddTenants(ctx context.Context,
 		})
 	}
 
-	return h.schemaManager.AddTenants(class, &request)
+	return h.schemaManager.AddTenants(ctx, class, &request)
 }
 
 func validateTenants(tenants []*models.Tenant) (validated []*models.Tenant, err error) {
@@ -141,7 +141,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 	for i, tenant := range tenants {
 		req.Tenants[i] = &api.Tenant{Name: tenant.Name, Status: tenant.ActivityStatus}
 	}
-	_, err = h.schemaManager.UpdateTenants(class, &req)
+	_, err = h.schemaManager.UpdateTenants(ctx, class, &req)
 	return err
 }
 
@@ -162,7 +162,7 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 		Tenants: tenants,
 	}
 
-	_, err := h.schemaManager.DeleteTenants(class, &req)
+	_, err := h.schemaManager.DeleteTenants(ctx, class, &req)
 	return err
 }
 

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -244,7 +244,7 @@ func (f *fakeSchemaGetter) ShardReplicas(class, shard string) ([]string, error) 
 	return []string{shard}, nil
 }
 
-func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	res := map[string]string{}
 	for _, t := range tenants {
 		res[t] = models.TenantActivityStatusHOT

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -252,7 +252,7 @@ func (f *fakeSchemaGetter) TenantsShards(class string, tenants ...string) (map[s
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/traverser/hybrid/fakes_for_test.go
+++ b/usecases/traverser/hybrid/fakes_for_test.go
@@ -93,7 +93,7 @@ func (f *fakeSchemaManager) TenantsShards(class string, tenants ...string) (map[
 	return nil, nil
 }
 
-func (f *fakeSchemaManager) OptimisticTenantStatus(class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaManager) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/traverser/hybrid/fakes_for_test.go
+++ b/usecases/traverser/hybrid/fakes_for_test.go
@@ -89,7 +89,7 @@ func (f *fakeSchemaManager) ShardFromUUID(class string, uuid []byte) string {
 	return ""
 }
 
-func (f *fakeSchemaManager) TenantsShards(class string, tenants ...string) (map[string]string, error) {
+func (f *fakeSchemaManager) TenantsShards(_ context.Context, class string, tenants ...string) (map[string]string, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
### What's being changed:
this PR 
- propgate the ctx from parent calls to grpc client calls to avoid any leaks
- on closing() `warn` instead of returning an error to avoid any transit errors 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10401512653
- [x] e2e tests https://github.com/weaviate/weaviate-e2e-tests/actions/runs/10401519522
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
