### PR TITLE
Optimize allocations in bq cache

### DIFF
--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
@@ -61,9 +61,9 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 	// 2. Read from checkpoint n to checkpoint n+1
 	// 3. Read from last checkpoint to end
 
-	extract := func(k, v []byte) BQVecAndID {
+	extract := func(k, v []byte, vecBuf []uint64) BQVecAndID {
 		id := binary.BigEndian.Uint64(k)
-		vec := uint64SliceFromByteSlice(v, make([]uint64, len(v)/8))
+		vec := uint64SliceFromByteSlice(v, vecBuf)
 		return BQVecAndID{id: id, vec: vec}
 	}
 
@@ -75,8 +75,15 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 		defer c.Close()
 		defer wg.Done()
 
+		var vecBuffer []uint64
 		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
-			localResults = append(localResults, extract(k, v))
+			length := len(v) / 8
+			if vecBuffer == nil || len(vecBuffer) < length {
+				vecBuffer = make([]uint64, length*1000)
+			}
+
+			localResults = append(localResults, extract(k, v, vecBuffer[:length]))
+			vecBuffer = vecBuffer[length:]
 		}
 
 		out <- localResults
@@ -94,8 +101,15 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 			c := cpi.bucket.Cursor()
 			defer c.Close()
 
+			var vecBuffer []uint64
 			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
-				localResults = append(localResults, extract(k, v))
+				length := len(v) / 8
+				if vecBuffer == nil || len(vecBuffer) < length {
+					vecBuffer = make([]uint64, length*1000)
+				}
+
+				localResults = append(localResults, extract(k, v, vecBuffer[:length]))
+				vecBuffer = vecBuffer[length:]
 			}
 
 			out <- localResults
@@ -110,8 +124,15 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 		defer wg.Done()
 		localResults := make([]BQVecAndID, 0, 10_000)
 
+		var vecBuffer []uint64
 		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
-			localResults = append(localResults, extract(k, v))
+			length := len(v) / 8
+			if vecBuffer == nil || len(vecBuffer) < length {
+				vecBuffer = make([]uint64, length*1000)
+			}
+
+			localResults = append(localResults, extract(k, v, vecBuffer[:length]))
+			vecBuffer = vecBuffer[length:]
 		}
 
 		out <- localResults

--- a/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
+++ b/adapters/repos/db/vector/flat/compressed_parallel_iterator.go
@@ -78,7 +78,7 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 		var vecBuffer []uint64
 		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
 			length := len(v) / 8
-			if vecBuffer == nil || len(vecBuffer) < length {
+			if len(vecBuffer) < length {
 				vecBuffer = make([]uint64, length*1000)
 			}
 
@@ -104,7 +104,7 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 			var vecBuffer []uint64
 			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
 				length := len(v) / 8
-				if vecBuffer == nil || len(vecBuffer) < length {
+				if len(vecBuffer) < length {
 					vecBuffer = make([]uint64, length*1000)
 				}
 
@@ -127,7 +127,7 @@ func (cpi *compressedParallelIterator) IterateAll() chan []BQVecAndID {
 		var vecBuffer []uint64
 		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
 			length := len(v) / 8
-			if vecBuffer == nil || len(vecBuffer) < length {
+			if len(vecBuffer) < length {
 				vecBuffer = make([]uint64, length*1000)
 			}
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -708,8 +708,6 @@ func (index *flat) PostStartup() {
 	if !index.isBQCached() {
 		return
 	}
-	cursor := index.store.Bucket(index.getCompressedBucketName()).Cursor()
-	defer cursor.Close()
 
 	// The idea here is to first read everything from disk in one go, then grow
 	// the cache just once before inserting all vectors. A previous iteration


### PR DESCRIPTION
### What's being changed:

Instead of doing one allocation per vector, allocate more at once and then split it up

Benchmarking with private dataset (tenant load, near_vector, tenant unload) with hot and cold page cache

```
Stable/v1.25
COLD 
4.698778867721558
4.699492692947388
5.634742975234985
HOT
2.191330671310425
2.178175687789917
2.2417850494384766

speed_up_allocs
COLD
4.646845579147339
4.708731412887573
5.134345293045044

HOT
1.8141391277313232
1.851912498474121
1.836291790008545
```

mainly noticable for HOT tenants as disk IO is dominating for COLD

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
