### PR TITLE
Restore 1.24 replication timeouts from before coordinator pull fallback changes

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -55,7 +55,7 @@ func (c *replicationClient) FetchObject(ctx context.Context, host, index,
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
-	err = c.doCustomUnmarshal(c.timeoutUnit*10, req, nil, resp.UnmarshalBinary, numRetries)
+	err = c.doCustomUnmarshal(c.timeoutUnit*20, req, nil, resp.UnmarshalBinary, numRetries)
 	return resp, err
 }
 
@@ -91,7 +91,7 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
-	err = c.do(c.timeoutUnit*60, req, body, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, body, &resp, 9)
 	return resp, err
 }
 
@@ -112,7 +112,7 @@ func (c *replicationClient) FetchObjects(ctx context.Context, host,
 	}
 
 	req.URL.RawQuery = url.Values{"ids": []string{idsEncoded}}.Encode()
-	err = c.doCustomUnmarshal(c.timeoutUnit*60, req, nil, resp.UnmarshalBinary, 9)
+	err = c.doCustomUnmarshal(c.timeoutUnit*90, req, nil, resp.UnmarshalBinary, 9)
 	return resp, err
 }
 
@@ -131,7 +131,7 @@ func (c *replicationClient) PutObject(ctx context.Context, host, index,
 	}
 
 	clusterapi.IndicesPayloads.SingleObject.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*20, req, body, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, body, &resp, 9)
 	return resp, err
 }
 
@@ -144,7 +144,7 @@ func (c *replicationClient) DeleteObject(ctx context.Context, host, index,
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
-	err = c.do(c.timeoutUnit*10, req, nil, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, nil, &resp, 9)
 	return resp, err
 }
 
@@ -162,7 +162,7 @@ func (c *replicationClient) PutObjects(ctx context.Context, host, index,
 	}
 
 	clusterapi.IndicesPayloads.ObjectList.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*60, req, body, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, body, &resp, 9)
 	return resp, err
 }
 
@@ -182,7 +182,7 @@ func (c *replicationClient) MergeObject(ctx context.Context, host, index, shard,
 	}
 
 	clusterapi.IndicesPayloads.MergeDoc.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*10, req, body, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, body, &resp, 9)
 	return resp, err
 }
 
@@ -201,7 +201,7 @@ func (c *replicationClient) AddReferences(ctx context.Context, host, index,
 	}
 
 	clusterapi.IndicesPayloads.ReferenceList.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*60, req, body, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, body, &resp, 9)
 	return resp, err
 }
 
@@ -218,7 +218,7 @@ func (c *replicationClient) DeleteObjects(ctx context.Context, host, index, shar
 	}
 
 	clusterapi.IndicesPayloads.BatchDeleteParams.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*20, req, body, &resp, 9)
+	err = c.do(c.timeoutUnit*90, req, body, &resp, 9)
 	return resp, err
 }
 
@@ -277,7 +277,7 @@ func (c *replicationClient) Commit(ctx context.Context, host, index, shard strin
 		return fmt.Errorf("create http request: %w", err)
 	}
 
-	return c.do(c.timeoutUnit*20, req, nil, resp, 9)
+	return c.do(c.timeoutUnit*90, req, nil, resp, 9)
 }
 
 func (c *replicationClient) Abort(ctx context.Context, host, index, shard, requestID string) (


### PR DESCRIPTION
### What's being changed:

[This recent PR](https://github.com/weaviate/weaviate/pull/5472), inadvertently included changes to the timeouts for a number of methods in `adapters/clients/replication.go`. These timeout changes were accidentally included because that PR was originally branched off main, but then rebased onto 1.24 and it was not noticed during review that the modified lines included changes to numRetries and the leading number of the timeout seconds. Note that these timeout values were those which are currently on main, which are presumably reasonable and unlikely to cause issues, but to be safe we should revert 1.24 back to it's original timeout values

This PR reverts the timeouts back to what they were.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
