### PR TITLE
✍🏼 add build info to all log lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH go build $EXTRA_BUILD_ARGS \
       -ldflags '-w -extldflags "-static" \
       -X github.com/weaviate/weaviate/usecases/config.GitHash='"$GITHASH"' \
-      -X github.com/weaviate/weaviate/usecases/config.DockerImageTag='"$DOCKER_IMAGE_TAG"'' \
+      -X github.com/weaviate/weaviate/usecases/config.ImageTag='"$DOCKER_IMAGE_TAG"'' \
       -o /weaviate-server ./cmd/weaviate-server
 
 ###############################################################################

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -648,10 +648,22 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 // Defaults to log level info and json format
 func logger() *logrus.Logger {
 	logger := logrus.New()
-	logger.SetFormatter(&WeaviateTextFormatter{&logrus.TextFormatter{}})
+	logger.SetFormatter(&WeaviateTextFormatter{
+		config.GitHash,
+		config.ImageTag,
+		config.ServerVersion,
+		goruntime.Version(),
+		&logrus.TextFormatter{},
+	})
 
 	if os.Getenv("LOG_FORMAT") != "text" {
-		logger.SetFormatter(&WeaviateJSONFormatter{&logrus.JSONFormatter{}})
+		logger.SetFormatter(&WeaviateJSONFormatter{
+			config.GitHash,
+			config.ImageTag,
+			config.ServerVersion,
+			goruntime.Version(),
+			&logrus.JSONFormatter{},
+		})
 	}
 	switch os.Getenv("LOG_LEVEL") {
 	case "panic":

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -150,7 +150,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			// Setup related config
 			Dsn:         appState.ServerConfig.Config.Sentry.DSN,
 			Debug:       appState.ServerConfig.Config.Sentry.Debug,
-			Release:     "weaviate-core@" + config.DockerImageTag,
+			Release:     "weaviate-core@" + config.ImageTag,
 			Environment: appState.ServerConfig.Config.Sentry.Environment,
 			// Enable tracing if requested
 			EnableTracing:    !appState.ServerConfig.Config.Sentry.TracingDisabled,
@@ -464,7 +464,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	appState.Logger.WithFields(logrus.Fields{
 		"server_version":   config.ServerVersion,
-		"docker_image_tag": config.DockerImageTag,
+		"docker_image_tag": config.ImageTag,
 	}).Infof("configured versions")
 
 	api.ServeError = openapierrors.ServeError
@@ -476,7 +476,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.APIKey, appState.OIDC)
 
 	api.Logger = func(msg string, args ...interface{}) {
-		appState.Logger.WithFields(logrus.Fields{"action": "restapi_management", "docker_image_tag": config.DockerImageTag}).Infof(msg, args...)
+		appState.Logger.WithFields(logrus.Fields{"action": "restapi_management", "docker_image_tag": config.ImageTag}).Infof(msg, args...)
 	}
 
 	classifier := classification.New(appState.SchemaManager, appState.ClassificationRepo, appState.DB, // the DB is the vectorrepo
@@ -648,8 +648,10 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 // Defaults to log level info and json format
 func logger() *logrus.Logger {
 	logger := logrus.New()
+	logger.SetFormatter(&WeaviateTextFormatter{&logrus.TextFormatter{}})
+
 	if os.Getenv("LOG_FORMAT") != "text" {
-		logger.SetFormatter(&logrus.JSONFormatter{})
+		logger.SetFormatter(&WeaviateJSONFormatter{&logrus.JSONFormatter{}})
 	}
 	switch os.Getenv("LOG_LEVEL") {
 	case "panic":

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	goruntime "runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+type WeaviateJSONFormatter struct {
+	*logrus.JSONFormatter
+}
+
+func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	e.Data["git_commit"] = config.GitHash
+	e.Data["wv_version"] = config.ImageTag
+	e.Data["go_version"] = goruntime.Version()
+	return wf.JSONFormatter.Format(e)
+}
+
+type WeaviateTextFormatter struct {
+	*logrus.TextFormatter
+}
+
+func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	e.Data["git_commit"] = config.GitHash
+	e.Data["wv_version"] = config.ImageTag
+	e.Data["go_version"] = goruntime.Version()
+	return wf.TextFormatter.Format(e)
+}

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -25,6 +25,7 @@ type WeaviateJSONFormatter struct {
 func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Data["build_git_commit"] = config.GitHash
 	e.Data["build_image_tag"] = config.ImageTag
+	e.Data["build_wv_version"] = config.ServerVersion
 	e.Data["build_go_version"] = goruntime.Version()
 	return wf.JSONFormatter.Format(e)
 }
@@ -36,6 +37,7 @@ type WeaviateTextFormatter struct {
 func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Data["build_git_commit"] = config.GitHash
 	e.Data["build_image_tag"] = config.ImageTag
+	e.Data["build_wv_version"] = config.ServerVersion
 	e.Data["build_go_version"] = goruntime.Version()
 	return wf.TextFormatter.Format(e)
 }

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -24,7 +24,7 @@ type WeaviateJSONFormatter struct {
 
 func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Data["build_git_commit"] = config.GitHash
-	e.Data["build_wv_version"] = config.ImageTag
+	e.Data["build_image_tag"] = config.ImageTag
 	e.Data["build_go_version"] = goruntime.Version()
 	return wf.JSONFormatter.Format(e)
 }
@@ -35,7 +35,7 @@ type WeaviateTextFormatter struct {
 
 func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Data["build_git_commit"] = config.GitHash
-	e.Data["build_wv_version"] = config.ImageTag
+	e.Data["build_image_tag"] = config.ImageTag
 	e.Data["build_go_version"] = goruntime.Version()
 	return wf.TextFormatter.Format(e)
 }

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -23,9 +23,9 @@ type WeaviateJSONFormatter struct {
 }
 
 func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	e.Data["git_commit"] = config.GitHash
-	e.Data["wv_version"] = config.ImageTag
-	e.Data["go_version"] = goruntime.Version()
+	e.Data["build_git_commit"] = config.GitHash
+	e.Data["build_wv_version"] = config.ImageTag
+	e.Data["build_go_version"] = goruntime.Version()
 	return wf.JSONFormatter.Format(e)
 }
 
@@ -34,8 +34,8 @@ type WeaviateTextFormatter struct {
 }
 
 func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	e.Data["git_commit"] = config.GitHash
-	e.Data["wv_version"] = config.ImageTag
-	e.Data["go_version"] = goruntime.Version()
+	e.Data["build_git_commit"] = config.GitHash
+	e.Data["build_wv_version"] = config.ImageTag
+	e.Data["build_go_version"] = goruntime.Version()
 	return wf.TextFormatter.Format(e)
 }

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -12,32 +12,31 @@
 package rest
 
 import (
-	goruntime "runtime"
-
 	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/usecases/config"
 )
 
 type WeaviateJSONFormatter struct {
+	gitHash, imageTag, serverVersion, goVersion string
 	*logrus.JSONFormatter
 }
 
 func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	e.Data["build_git_commit"] = config.GitHash
-	e.Data["build_image_tag"] = config.ImageTag
-	e.Data["build_wv_version"] = config.ServerVersion
-	e.Data["build_go_version"] = goruntime.Version()
+	e.Data["build_git_commit"] = wf.gitHash
+	e.Data["build_image_tag"] = wf.imageTag
+	e.Data["build_wv_version"] = wf.serverVersion
+	e.Data["build_go_version"] = wf.goVersion
 	return wf.JSONFormatter.Format(e)
 }
 
 type WeaviateTextFormatter struct {
+	gitHash, imageTag, serverVersion, goVersion string
 	*logrus.TextFormatter
 }
 
 func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
-	e.Data["build_git_commit"] = config.GitHash
-	e.Data["build_image_tag"] = config.ImageTag
-	e.Data["build_wv_version"] = config.ServerVersion
-	e.Data["build_go_version"] = goruntime.Version()
+	e.Data["build_git_commit"] = wf.gitHash
+	e.Data["build_image_tag"] = wf.imageTag
+	e.Data["build_wv_version"] = wf.serverVersion
+	e.Data["build_go_version"] = wf.goVersion
 	return wf.TextFormatter.Format(e)
 }

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -21,8 +21,9 @@ export DISABLE_TELEMETRY=true # disable telemetry for local development
 
 function go_run() {
   GIT_HASH=$(git rev-parse --short HEAD)
-  go run -ldflags "-X github.com/weaviate/weaviate/usecases/config.GitHash=$GIT_HASH" "$@"
-  go run -ldflags "-X github.com/weaviate/weaviate/usecases/config.IMAGE_TAG=localhost"
+   go run -ldflags "-X github.com/weaviate/weaviate/usecases/config.GitHash=$GIT_HASH \
+   -X github.com/weaviate/weaviate/usecases/config.IMAGE_TAG=localhost" \
+   "$@"
 }
 
 case $CONFIG in

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -22,6 +22,7 @@ export DISABLE_TELEMETRY=true # disable telemetry for local development
 function go_run() {
   GIT_HASH=$(git rev-parse --short HEAD)
   go run -ldflags "-X github.com/weaviate/weaviate/usecases/config.GitHash=$GIT_HASH" "$@"
+  go run -ldflags "-X github.com/weaviate/weaviate/usecases/config.IMAGE_TAG=localhost"
 }
 
 case $CONFIG in

--- a/tools/generate-release-artifacts.sh
+++ b/tools/generate-release-artifacts.sh
@@ -48,7 +48,7 @@ function build_binary() {
   arch_dir="${BUILD_ARTIFACTS_DIR}/${arch}"
 
   echo_green "Building linux/${arch} binary..."
-  GOOS=linux GOARCH=$arch go build -o $BUILD_ARTIFACTS_DIR/$arch/weaviate -ldflags "-w -extldflags \"-static\" -X github.com/weaviate/weaviate/usecases/config.GitHash='${GIT_HASH}'"
+  GOOS=linux GOARCH=$arch go build -o $BUILD_ARTIFACTS_DIR/$arch/weaviate -ldflags "-w -extldflags \"-static\" -X github.com/weaviate/weaviate/usecases/config.GitHash='${GIT_HASH}'  -X github.com/weaviate/weaviate/usecases/config.ImageTag='${VERSION}'
   step_complete
 
   cd $arch_dir

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -40,10 +40,10 @@ import (
 var ServerVersion string
 
 var (
-	// GitHash keeps the current git hash commit information
+	// GitHash keeps the current git hash commit information, value injected to build by the compiler using ldflags -X
 	GitHash = "unknown"
-	// DockerImageTag keeps the docker tag the weaviate binary was built in
-	DockerImageTag = "unknown"
+	// ImageTag keeps the docker tag the weaviate binary was built in, value injected to build by the compiler
+	ImageTag = "unknown"
 )
 
 // DefaultConfigFile is the default file when no config file is provided

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -40,10 +40,10 @@ import (
 var ServerVersion string
 
 var (
-	// GitHash keeps the current git hash commit information, value injected to build by the compiler using ldflags -X
+	// GitHash keeps the current git hash commit information, value injected by the compiler using ldflags -X at build time.
 	GitHash = "unknown"
-	// ImageTag keeps the docker tag the weaviate binary was built in, value injected to build by the compiler
-	ImageTag = "unknown"
+	// ImageTag keeps the docker tag the weaviate binary was built in, value injected by the compiler using ldflags -X at build time.
+	ImageTag = "localhost"
 )
 
 // DefaultConfigFile is the default file when no config file is provided


### PR DESCRIPTION
### What's being changed:
with this change we shouldn't have that question any more (**which version this build from ?**)
it adds build info every log line 
- `git_commit`
- `wv_version`
- `go_version`
- `image_tag`

e.g. 
```
2024-08-09 12:19:48 {"action":"startup","auto_schema_enabled":true,"git_commit":"1ad6514","go_version":"go1.21.13","level":"info","msg":"auto schema enabled setting is set to \"true\"","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
2024-08-09 12:19:48 {"action":"startup","git_commit":"1ad6514","go_version":"go1.21.13","level":"debug","msg":"config loaded","startup_time_left":"59m59.996699417s","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
2024-08-09 12:19:48 {"action":"startup","git_commit":"1ad6514","go_version":"go1.21.13","level":"debug","msg":"configured OIDC and anonymous access client","startup_time_left":"59m59.996685417s","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
2024-08-09 12:19:48 {"action":"startup","git_commit":"1ad6514","go_version":"go1.21.13","level":"debug","msg":"initialized schema","startup_time_left":"59m59.996678292s","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
2024-08-09 12:19:48 {"action":"startup","git_commit":"1ad6514","go_version":"go1.21.13","level":"debug","msg":"startup routine complete","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
2024-08-09 12:19:48 {"git_commit":"1ad6514","go_version":"go1.21.13","level":"info","msg":"No resource limits set, weaviate will use all available memory and CPU. To limit resources, set LIMIT_RESOURCES=true","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
2024-08-09 12:19:48 {"action":"startup","git_commit":"1ad6514","go_version":"go1.21.13","level":"debug","msg":"start registering modules","time":"2024-08-09T10:19:48Z","wv_version":"preview--add-build-info-to-all-log-lines-1ad6514"}
```
*Update* : prefix all the build info by `build_`  because logrus lexicographically sort the keys and we want those info at the beginning of the line 

```
INFO[0001] configured versions                           build_git_commit=8e6424758 build_go_version=go1.22.4 build_image_tag=localhost build_wv_version=1.24.22 docker_image_tag=localhost server_version=1.24.22
INFO[0001] grpc server listening at [::]:50051           action=grpc_startup build_git_commit=8e6424758 build_go_version=go1.22.4 build_image_tag=localhost build_wv_version=1.24.22
INFO[0001] Serving weaviate at http://127.0.0.1:8080     action=restapi_management build_git_commit=8e6424758 build_go_version=go1.22.4 build_image_tag=localhost build_wv_version=1.24.22 docker_image_tag=localhost
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
