### PR TITLE
Concurrent lsm lookup

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -393,10 +393,10 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 					m = preM
 				}
 				if len(m) == 0 {
-					return nil
+					allMsAndProps[i] = MapPairsAndPropName{MapPairs: nil, propBoost: propertyBoosts[propName]}
+				} else {
+					allMsAndProps[i] = MapPairsAndPropName{MapPairs: m, propBoost: propertyBoosts[propName]}
 				}
-
-				allMsAndProps[i] = MapPairsAndPropName{MapPairs: m, propBoost: propertyBoosts[propName]}
 				return nil
 			},
 		)
@@ -408,7 +408,11 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 	// remove gaps
 	for i := range allMsAndProps {
 		if len(allMsAndProps[i].MapPairs) == 0 {
-			allMsAndProps = append(allMsAndProps[:i], allMsAndProps[i+1:]...)
+			if i == len(allMsAndProps)-1 {
+				allMsAndProps = allMsAndProps[:i]
+			} else {
+				allMsAndProps = append(allMsAndProps[:i], allMsAndProps[i+1:]...)
+			}
 		}
 	}
 

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -358,7 +358,7 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 ) (term, map[uint64]int, error) {
 	termResult := term{queryTerm: query}
 	filteredDocIDs := sroar.NewBitmap() // to build the global n if there is a filter
-
+	filterLock := sync.Mutex{}
 	eg := enterrors.NewErrorGroupWrapper(b.logger)
 	eg.SetLimit(_NUMCPU)
 
@@ -386,7 +386,9 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 						if filterDocIds.Contains(docID) {
 							m = append(m, val)
 						} else {
+							filterLock.Lock()
 							filteredDocIDs.Set(docID)
+							filterLock.Unlock()
 						}
 					}
 				} else {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -407,6 +407,9 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 
 	// remove gaps
 	for i := range allMsAndProps {
+		if i >= len(allMsAndProps) {
+			break // in case the length of allMsAndProps changed during the loop
+		}
 		if len(allMsAndProps[i].MapPairs) == 0 {
 			if i == len(allMsAndProps)-1 {
 				allMsAndProps = allMsAndProps[:i]


### PR DESCRIPTION
### What's being changed:

We were doing the LSM lookups sequentially - it is much faster if done concurrently.

For an expensive query with cold page cache:
Old ~1.5s 
New: ~1.1

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
