### PR TITLE
FLAG to enable fast memberlist failure detection

### DIFF
--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -74,7 +74,15 @@ func (d *DockerCompose) StopAt(ctx context.Context, nodeIndex int, timeout *time
 	if nodeIndex >= len(d.containers) {
 		return nil
 	}
-	return d.containers[nodeIndex].container.Stop(ctx, timeout)
+	if err := d.containers[nodeIndex].container.Stop(ctx, timeout); err != nil {
+		return err
+	}
+
+	// sleep to make sure that the off node is detected by memberlist and marked failed
+	// it shall be used with combination of "FAST_FAILURE_DETECTION" env flag
+	time.Sleep(3 * time.Second)
+
+	return nil
 }
 
 func (d *DockerCompose) StartAt(ctx context.Context, nodeIndex int) error {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -79,6 +79,7 @@ func startWeaviate(ctx context.Context,
 		"QUERY_DEFAULTS_LIMIT":      "20",
 		"PERSISTENCE_DATA_PATH":     "./data",
 		"DEFAULT_VECTORIZER_MODULE": "none",
+		"FAST_FAILURE_DETECTION":    "true",
 	}
 	if len(enableModules) > 0 {
 		env["ENABLE_MODULES"] = strings.Join(enableModules, ",")

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -41,6 +41,9 @@ type Config struct {
 	AuthConfig              AuthConfig `json:"auth" yaml:"auth"`
 	AdvertiseAddr           string     `json:"advertiseAddr" yaml:"advertiseAddr"`
 	AdvertisePort           int        `json:"advertisePort" yaml:"advertisePort"`
+	// FastFailureDetection mostly for testing purpose, it will make memberlist sensitive and detect
+	// failures (down nodes) faster.
+	FastFailureDetection bool `json:"fastFailureDetection" yaml:"fastFailureDetection"`
 	// LocalHost flag enables running a multi-node setup with the same localhost and different ports
 	Localhost bool `json:"localhost" yaml:"localhost"`
 }
@@ -87,6 +90,10 @@ func Init(userConfig Config, dataPath string, nonStorageNodes map[string]struct{
 
 	if userConfig.AdvertisePort != 0 {
 		cfg.AdvertisePort = userConfig.AdvertisePort
+	}
+
+	if userConfig.FastFailureDetection {
+		cfg.SuspicionMult = 1
 	}
 
 	if state.list, err = memberlist.Create(cfg); err != nil {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -753,5 +753,7 @@ func parseClusterConfig() (cluster.Config, error) {
 		},
 	}
 
+	cfg.FastFailureDetection = entcfg.Enabled(os.Getenv("FAST_FAILURE_DETECTION"))
+
 	return cfg, nil
 }


### PR DESCRIPTION
### What's being changed:
in our tests we do a lot of node restarts to test how weaviate will behave in multi-node cluster setup, however memberlist doesn't report immediately that the node is failed and remove it from members. this PR makes sure that the node removed from the memberlist once brought down 


We call `docker.stopAt()` to bring node down and they still exists in memberlist and won't be marked failed until quite sometime. 10 sec. for example now. it comes from memberlist default equation`Suspect a node for 4 * log(N+1) * Interval` [source](https://github.com/hashicorp/memberlist/blob/3f82dc10a89f82efe300228752f7077d0d9f87e4/config.go#L314) with this change we make sure that it's around `1 sec`,
### Review checklist


needed for https://github.com/weaviate/weaviate/pull/5571

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
