### PR TITLE
async: move index queue preload logic to shard

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2292,7 +2292,7 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 
 	// Reindex in the background
 	enterrors.GoWrapper(func() {
-		err = shard.PreloadQueue("")
+		err = shard.PreloadQueue(targetVector)
 		if err != nil {
 			i.logger.WithField("shard", shardName).WithError(err).Error("failed to reindex vector index")
 			return

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2292,7 +2292,7 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 
 	// Reindex in the background
 	enterrors.GoWrapper(func() {
-		err = q.PreloadShard(shard)
+		err = shard.PreloadQueue("")
 		if err != nil {
 			i.logger.WithField("shard", shardName).WithError(err).Error("failed to reindex vector index")
 			return

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -682,10 +682,10 @@ func TestIndex_PreloadQueue(t *testing.T) {
 	}
 
 	// reset the queue
-	err := shard.Queue().ResetWith(shard.VectorIndex())
+	q := shard.Queue()
+	err := q.ResetWith(shard.VectorIndex())
 	require.Nil(t, err)
-
-	shard.Queue().ResumeIndexing()
+	q.ResumeIndexing()
 
 	err = shard.PreloadQueue("")
 	require.Nil(t, err)
@@ -693,17 +693,84 @@ func TestIndex_PreloadQueue(t *testing.T) {
 	// wait until the queue is empty
 	for i := 0; i < 200; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.Queue().Size() == 0 {
+		if q.Size() == 0 {
 			break
 		}
 	}
 
 	// wait for the in-flight indexing to finish
-	shard.Queue().Wait()
+	q.Wait()
 
 	// make sure the index contains all the objects
 	for _, obj := range objs {
 		if !shard.VectorIndex().ContainsNode(obj.DocID) {
+			t.Fatalf("node %d should be in the vector index", obj.DocID)
+		}
+	}
+
+	err = index.drop()
+	require.Nil(t, err)
+}
+
+func TestIndex_PreloadQueueTargetVector(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+
+	ctx := context.Background()
+	class := &models.Class{Class: "preloadtest"}
+	shard, index := testShardWithSettings(
+		t,
+		ctx,
+		&models.Class{Class: class.Class},
+		hnsw.UserConfig{},
+		false,
+		true,
+		func(i *Index) {
+			i.vectorIndexUserConfigs = make(map[string]schema.VectorIndexConfig)
+			i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{}
+		},
+	)
+	amount := 1000
+
+	var objs []*storobj.Object
+	for i := 0; i < amount; i++ {
+		obj := testObject("preloadtest")
+		obj.Vectors = map[string][]float32{
+			"foo": {1, 2, 3},
+		}
+		objs = append(objs, obj)
+	}
+
+	errs := shard.PutObjectBatch(ctx, objs)
+	for _, err := range errs {
+		require.Nil(t, err)
+	}
+
+	q := shard.Queues()["foo"]
+	vectorIndex := shard.VectorIndexes()["foo"]
+
+	// reset the queue
+	q.PauseIndexing()
+	err := q.ResetWith(vectorIndex)
+	require.Nil(t, err)
+	q.ResumeIndexing()
+
+	err = shard.PreloadQueue("foo")
+	require.Nil(t, err)
+
+	// wait until the queue is empty
+	for i := 0; i < 200; i++ {
+		time.Sleep(500 * time.Millisecond)
+		if q.Size() == 0 {
+			break
+		}
+	}
+
+	// wait for the in-flight indexing to finish
+	q.Wait()
+
+	// make sure the index contains all the objects
+	for _, obj := range objs {
+		if !vectorIndex.ContainsNode(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -653,3 +653,61 @@ func TestIndex_DebugResetVectorIndexFlat(t *testing.T) {
 	err = index.drop()
 	require.Nil(t, err)
 }
+
+func TestIndex_PreloadQueue(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+
+	ctx := context.Background()
+	class := &models.Class{Class: "preloadtest"}
+	shard, index := testShardWithSettings(
+		t,
+		ctx,
+		&models.Class{Class: class.Class},
+		hnsw.UserConfig{},
+		false,
+		true,
+	)
+	amount := 1000
+
+	var objs []*storobj.Object
+	for i := 0; i < amount; i++ {
+		obj := testObject("preloadtest")
+		obj.Vector = randVector(16)
+		objs = append(objs, obj)
+	}
+
+	errs := shard.PutObjectBatch(ctx, objs)
+	for _, err := range errs {
+		require.Nil(t, err)
+	}
+
+	// reset the queue
+	err := shard.Queue().ResetWith(shard.VectorIndex())
+	require.Nil(t, err)
+
+	shard.Queue().ResumeIndexing()
+
+	err = shard.PreloadQueue("")
+	require.Nil(t, err)
+
+	// wait until the queue is empty
+	for i := 0; i < 200; i++ {
+		time.Sleep(500 * time.Millisecond)
+		if shard.Queue().Size() == 0 {
+			break
+		}
+	}
+
+	// wait for the in-flight indexing to finish
+	shard.Queue().Wait()
+
+	// make sure the index contains all the objects
+	for _, obj := range objs {
+		if !shard.VectorIndex().ContainsNode(obj.DocID) {
+			t.Fatalf("node %d should be in the vector index", obj.DocID)
+		}
+	}
+
+	err = index.drop()
+	require.Nil(t, err)
+}

--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -251,6 +251,7 @@ func (q *IndexQueue) Close() error {
 // - discard any pending vectors
 // - reset the checkpoint to 0
 // Requires the queue to be paused.
+// It does not resume the queue.
 func (q *IndexQueue) ResetWith(v batchIndexer) error {
 	q.indexLock.Lock()
 	defer q.indexLock.Unlock()

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -550,6 +550,13 @@ func (s *Shard) vectorIndexID(targetVector string) string {
 	return "main"
 }
 
+func (s *Shard) getVectorIndex(targetVector string) VectorIndex {
+	if targetVector != "" {
+		return s.vectorIndexes[targetVector]
+	}
+	return s.vectorIndex
+}
+
 func (s *Shard) uuidToIdLockPoolId(idBytes []byte) uint8 {
 	// use the last byte of the uuid to determine which locking-pool a given object should use. The last byte is used
 	// as uuids probably often have some kind of order and the last byte will in general be the one that changes the most

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -1,0 +1,130 @@
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// PreloadShard goes through the LSM store from the last checkpoint
+// and enqueues any unindexed vector.
+func (s *Shard) PreloadShard(targetVector string) error {
+	if !asyncEnabled() {
+		return nil
+	}
+
+	start := time.Now()
+
+	var counter int
+
+	vectorIndex := s.getVectorIndex(targetVector)
+	if vectorIndex == nil {
+		s.index.logger.Warn("preload queue: vector index not found")
+		// shard was never initialized, possibly because of a failed shard
+		// initialization. No op.
+		return nil
+	}
+
+	q, err := s.getIndexQueue(targetVector)
+	if err != nil {
+		s.index.logger.Warn("preload queue: queue not found")
+		// queue was never initialized, possibly because of a failed shard
+		// initialization. No op.
+		return nil
+	}
+
+	// load non-indexed vectors and add them to the queue
+	checkpoint, exists, err := s.indexCheckpoints.Get(s.ID(), targetVector)
+	if err != nil {
+		return errors.Wrap(err, "get last indexed id")
+	}
+	if !exists {
+		return nil
+	}
+
+	defer func() {
+		q.metrics.Preload(start, counter)
+	}()
+
+	ctx := context.Background()
+
+	maxDocID := s.Counter().Get()
+
+	err = s.iterateOnLSMVectors(ctx, checkpoint, targetVector, func(id uint64, vector []float32) error {
+		if vectorIndex.ContainsNode(id) {
+			return nil
+		}
+		if len(vector) == 0 {
+			return nil
+		}
+
+		desc := vectorDescriptor{
+			id:     id,
+			vector: vector,
+		}
+
+		counter++
+		return q.Push(ctx, desc)
+	})
+	if err != nil {
+		return errors.Wrap(err, "iterate on LSM")
+	}
+
+	s.index.logger.
+		WithField("checkpoint", checkpoint).
+		WithField("last_stored_id", maxDocID).
+		WithField("count", counter).
+		WithField("took", time.Since(start)).
+		WithField("shard_id", q.shardID).
+		WithField("target_vector", q.targetVector).
+		Info("enqueued vectors from last indexed checkpoint")
+
+	return nil
+}
+
+func (s *Shard) iterateOnLSMVectors(ctx context.Context, fromID uint64, targetVector string, fn func(id uint64, vector []float32) error) error {
+	maxDocID := s.Counter().Get()
+	bucket := s.Store().Bucket(helpers.ObjectsBucketLSM)
+
+	buf := make([]byte, 8)
+	for i := fromID; i < maxDocID; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		binary.LittleEndian.PutUint64(buf, i)
+
+		v, err := bucket.GetBySecondary(0, buf)
+		if err != nil {
+			return errors.Wrap(err, "get last indexed object")
+		}
+		if v == nil {
+			continue
+		}
+		obj, err := storobj.FromBinary(v)
+		if err != nil {
+			return errors.Wrap(err, "unmarshal last indexed object")
+		}
+		id := obj.DocID
+
+		var vector []float32
+		if targetVector == "" {
+			vector = obj.Vector
+		} else {
+			if len(obj.Vectors) > 0 {
+				vector = obj.Vectors[targetVector]
+			}
+		}
+
+		err = fn(id, vector)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -10,9 +10,9 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-// PreloadShard goes through the LSM store from the last checkpoint
+// PreloadQueue goes through the LSM store from the last checkpoint
 // and enqueues any unindexed vector.
-func (s *Shard) PreloadShard(targetVector string) error {
+func (s *Shard) PreloadQueue(targetVector string) error {
 	if !asyncEnabled() {
 		return nil
 	}
@@ -79,8 +79,8 @@ func (s *Shard) PreloadShard(targetVector string) error {
 		WithField("last_stored_id", maxDocID).
 		WithField("count", counter).
 		WithField("took", time.Since(start)).
-		WithField("shard_id", q.shardID).
-		WithField("target_vector", q.targetVector).
+		WithField("shard_id", s.ID()).
+		WithField("target_vector", targetVector).
 		Info("enqueued vectors from last indexed checkpoint")
 
 	return nil

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -430,6 +430,11 @@ func (l *LazyLoadShard) Queues() map[string]*IndexQueue {
 	return l.shard.Queues()
 }
 
+func (l *LazyLoadShard) PreloadQueue(targetVector string) error {
+	l.mustLoad()
+	return l.shard.PreloadQueue(targetVector)
+}
+
 func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	if !l.isLoaded() {
 		return nil


### PR DESCRIPTION
### What's being changed:

This is a maintenance PR that simply moves the Preload logic of the index queue to the shard, where it should have been in the first place. This simplifies the queue logic, as it was mostly used as a pass through to the shard.
It is preparation work for the upcoming repair PR.

It also adds a few tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
