### PR TITLE
index: add Iterate method

### DIFF
--- a/adapters/repos/db/vector/flat/iterate_test.go
+++ b/adapters/repos/db/vector/flat/iterate_test.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+)
+
+func createTestIndex(t *testing.T) *flat {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	distancer := distancer.NewCosineDistanceProvider()
+
+	store, err := lsmkv.New(dirName, dirName, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+
+	index, err := New(Config{
+		ID:               uuid.New().String(),
+		DistanceProvider: distancer,
+	}, flatent.UserConfig{
+		PQ: flatent.CompressionUserConfig{
+			Enabled: false,
+		},
+		BQ: flatent.CompressionUserConfig{
+			Enabled: false,
+		},
+	}, store)
+	require.NoError(t, err)
+
+	return index
+}
+
+func createTestVectors(n int) [][]float32 {
+	dimensions := 256
+	vectors, _ := testinghelpers.RandomVecs(n, 0, dimensions)
+	testinghelpers.Normalize(vectors)
+
+	return vectors
+}
+
+func TestFlatIndexIterate(t *testing.T) {
+	t.Run("should not run callback on empty index", func(t *testing.T) {
+		index := createTestIndex(t)
+		index.Iterate(func(id uint64) bool {
+			t.Fatalf("callback should not be called on empty index")
+			return true
+		})
+	})
+
+	t.Run("should iterate over all nodes", func(t *testing.T) {
+		testVectors := createTestVectors(10)
+		index := createTestIndex(t)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			return true
+		})
+		for i, v := range visited {
+			require.True(t, v, "node %d was not visited", i)
+		}
+	})
+
+	t.Run("should stop iteration when callback returns false", func(t *testing.T) {
+		testVectors := createTestVectors(10)
+		index := createTestIndex(t)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			return id < 5
+		})
+		for i, v := range visited {
+			if i <= 5 {
+				require.True(t, v, "node %d was not visited", i)
+			} else {
+				require.False(t, v, "node %d was visited", i)
+			}
+		}
+	})
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -677,6 +677,31 @@ func (h *hnsw) ContainsNode(id uint64) bool {
 	return len(h.nodes) > int(id) && h.nodes[id] != nil
 }
 
+func (h *hnsw) Iterate(fn func(id uint64) bool) {
+	var id uint64
+
+	for {
+		h.RLock()
+		h.shardedNodeLocks.RLock(id)
+		stop := int(id) >= len(h.nodes)
+		exists := !stop && h.nodes[id] != nil
+		h.shardedNodeLocks.RUnlock(id)
+		h.RUnlock()
+
+		if stop {
+			return
+		}
+
+		if exists {
+			if !fn(id) {
+				return
+			}
+		}
+
+		id++
+	}
+}
+
 func (h *hnsw) DistancerProvider() distancer.Provider {
 	return h.distancerProvider
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -681,6 +681,13 @@ func (h *hnsw) Iterate(fn func(id uint64) bool) {
 	var id uint64
 
 	for {
+		if h.shutdownCtx.Err() != nil {
+			return
+		}
+		if h.resetCtx.Err() != nil {
+			return
+		}
+
 		h.RLock()
 		h.shardedNodeLocks.RLock(id)
 		stop := int(id) >= len(h.nodes)

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -700,8 +700,14 @@ func (h *hnsw) Iterate(fn func(id uint64) bool) {
 		}
 
 		if exists {
-			if !fn(id) {
-				return
+			h.tombstoneLock.RLock()
+			_, tombstoned := h.tombstones[id]
+			h.tombstoneLock.RUnlock()
+
+			if !tombstoned {
+				if !fn(id) {
+					return
+				}
 			}
 		}
 

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -264,4 +264,31 @@ func TestHnswIndexIterate(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("should skip deleted nodes", func(t *testing.T) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+			return testVectors[id], nil
+		}
+		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		err := index.Delete(uint64(5))
+		require.Nil(t, err)
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			return true
+		})
+		for i, v := range visited {
+			if i == 5 {
+				assert.False(t, v, "node %d was visited", i)
+			} else {
+				assert.True(t, v, "node %d was not visited", i)
+			}
+		}
+	})
 }

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -152,3 +152,116 @@ func createEmptyHnswIndexForTests(t testing.TB, vecForIDFn common.VectorForID[fl
 	require.Nil(t, err)
 	return index
 }
+
+func TestHnswIndexIterate(t *testing.T) {
+	t.Run("should not run callback on empty index", func(t *testing.T) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+			t.Fatalf("vecForID should not be called on empty index")
+			return nil, nil
+		}
+		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		index.Iterate(func(id uint64) bool {
+			t.Fatalf("callback should not be called on empty index")
+			return true
+		})
+	})
+
+	t.Run("should iterate over all nodes", func(t *testing.T) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+			return testVectors[id], nil
+		}
+		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			return true
+		})
+		for i, v := range visited {
+			assert.True(t, v, "node %d was not visited", i)
+		}
+	})
+
+	t.Run("should stop iteration when callback returns false", func(t *testing.T) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+			return testVectors[id], nil
+		}
+		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			return id < 5
+		})
+		for i, v := range visited {
+			if i <= 5 {
+				assert.True(t, v, "node %d was not visited", i)
+			} else {
+				assert.False(t, v, "node %d was visited", i)
+			}
+		}
+	})
+
+	t.Run("should stop iteration when shutdownCtx is canceled", func(t *testing.T) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+			return testVectors[id], nil
+		}
+		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			if id == 5 {
+				err := index.Shutdown(context.Background())
+				require.NoError(t, err)
+			}
+			return true
+		})
+		for i, v := range visited {
+			if i <= 5 {
+				assert.True(t, v, "node %d was not visited", i)
+			} else {
+				assert.False(t, v, "node %d was visited", i)
+			}
+		}
+	})
+
+	t.Run("should stop iteration when resetCtx is canceled", func(t *testing.T) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+			return testVectors[id], nil
+		}
+		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		for i, vec := range testVectors {
+			err := index.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		visited := make([]bool, len(testVectors))
+		index.Iterate(func(id uint64) bool {
+			visited[id] = true
+			if id == 5 {
+				index.resetCtxCancel()
+			}
+			return true
+		})
+		for i, v := range visited {
+			if i <= 5 {
+				assert.True(t, v, "node %d was not visited", i)
+			} else {
+				assert.False(t, v, "node %d was visited", i)
+			}
+		}
+	})
+}

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -108,6 +108,8 @@ func (i *Index) ContainsNode(id uint64) bool {
 	return false
 }
 
+func (i *Index) Iterate(fn func(id uint64) bool) {}
+
 func (i *Index) DistancerProvider() distancer.Provider {
 	return nil
 }

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -41,7 +41,8 @@ type VectorIndex interface {
 	DistanceBetweenVectors(x, y []float32) (float32, error)
 	ContainsNode(id uint64) bool
 	// Iterate over all nodes in the index.
-	// Order and consistency is not guaranteed.
+	// Consistency is not guaranteed, as the
+	// index may be concurrently modified.
 	// If the callback returns false, the iteration will stop.
 	Iterate(fn func(id uint64) bool)
 	DistancerProvider() distancer.Provider

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -40,5 +40,9 @@ type VectorIndex interface {
 	ValidateBeforeInsert(vector []float32) error
 	DistanceBetweenVectors(x, y []float32) (float32, error)
 	ContainsNode(id uint64) bool
+	// Iterate over all nodes in the index.
+	// Order and consistency is not guaranteed.
+	// If the callback returns false, the iteration will stop.
+	Iterate(fn func(id uint64) bool)
 	DistancerProvider() distancer.Provider
 }


### PR DESCRIPTION
### What's being changed:

This adds a thread-safe method for iterating on the nodes of vector indexes.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
