### PR TITLE
Fix reranker module e2e tests

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -101,7 +101,6 @@ jobs:
           "--only-module-img2vec-neural",
           "--only-module-many-modules",
           "--only-module-ref2vec-centroid",
-          "--only-module-reranker-transformers",
           "--only-module-text2vec-contextionary",
           "--only-module-text2vec-transformers"
         ]
@@ -123,7 +122,8 @@ jobs:
         test: [
           "--only-module-qna-transformers",
           "--only-module-sum-transformers",
-          "--only-module-multi2vec-clip"
+          "--only-module-multi2vec-clip",
+          "--only-module-reranker-transformers"
         ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### What's being changed:

Fix reranker module e2e tests, those tests now need bigger gh runners bc the docker image also got bigger.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
