### PR TITLE
Add webistouche2000 dataset to bm25 benchmark

### DIFF
--- a/test/benchmark_bm25/convert_json_to_jsonl.sh
+++ b/test/benchmark_bm25/convert_json_to_jsonl.sh
@@ -1,0 +1,18 @@
+if [ -z "$1" ]; then
+  echo "Usage: $0 input.json"
+  exit 1
+fi
+
+input_file="$1"
+output_file="${input_file%.json}.jsonl"
+
+# Convert JSON to JSONL using jq
+jq -c '.[]' "$input_file" > "$output_file"
+
+# Check if the output file was created and is not empty
+if [ -s "$output_file" ]; then
+  echo "Conversion complete. Output saved to $output_file"
+else
+  echo "Conversion failed. Please check the input file format."
+fi
+

--- a/test/benchmark_bm25/datasets_default.yml
+++ b/test/benchmark_bm25/datasets_default.yml
@@ -45,7 +45,10 @@ datasets:
     corpus:
       indexed_properties:
         - text
+        - title
       unindexed_properties:
-        - _id 
+        - __id
     queries:
-      property: text
+      property: query
+      matching_results: matchingIDs
+      property_with_id: __id

--- a/test/benchmark_bm25/lib/dataset_corpus.go
+++ b/test/benchmark_bm25/lib/dataset_corpus.go
@@ -73,8 +73,7 @@ func ParseCorpi(ds Dataset, multiply int) (Corpi, error) {
 		for _, prop := range ds.Corpus.UnindexedProperties {
 			propStr, ok := obj[prop].(string)
 			if !ok {
-				return nil, fmt.Errorf("unindexed property %s is not a string: %T",
-					prop, obj[prop])
+				propStr = fmt.Sprintf("%v", obj[prop])
 			}
 
 			corp[SanitizePropName(prop)] = propStr


### PR DESCRIPTION
### What's being changed:

Adds config for search in webis-touche2000 dataset for bm25 searcher:

Query Latencies
--------------------
Min:    4.058166ms
Mean:    9.49407ms
Max:   26.037542ms
p50:    9.015625ms
p90:   13.255542ms
p99:   26.037542ms

nDCG score: 0.1617, hits at 1: 17, hits at 5: 67

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
