### PR TITLE
fix: RAFT: reloadDBFromSchema() reload db only if there was change Apply()

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -169,6 +169,9 @@ type Store struct {
 	schemaManager *schema.SchemaManager
 	// lastAppliedIndexToDB represents the index of the last applied command when the store is opened.
 	lastAppliedIndexToDB atomic.Uint64
+
+	//dbReloadOnce is used to reload db once caught up on startup
+	dbReloadOnce sync.Once
 }
 
 func NewFSM(cfg Config) Store {
@@ -624,7 +627,7 @@ func (st *Store) reloadDBFromSchema() {
 	// in this path it means it was called from Apply()
 	// or forced Restore()
 	if st.raft != nil {
-		st.lastAppliedIndexToDB.Store(st.raft.LastIndex())
+		st.lastAppliedIndexToDB.Store(st.raft.AppliedIndex())
 		return
 	}
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -615,10 +615,7 @@ func (st *Store) openDatabase(ctx context.Context) {
 // then later will call Apply() on any new committed log
 func (st *Store) reloadDBFromSchema() {
 	if !st.cfg.MetadataOnlyVoters {
-		// to avoid any not needed db reloads
-		if st.raft != nil && st.lastAppliedIndexToDB.Load() != st.raft.LastIndex() {
-			st.schemaManager.ReloadDBFromSchema()
-		}
+		st.schemaManager.ReloadDBFromSchema()
 	} else {
 		st.log.Info("skipping reload DB from schema as the node is metadata only")
 	}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -196,7 +196,7 @@ func (st *Store) ID() string    { return st.cfg.NodeID }
 // by checking either raft or max(snapshot, log store) instead the db will catchup
 func (st *Store) lastIndex() uint64 {
 	if st.raft != nil {
-		return st.raft.LastIndex()
+		return st.raft.AppliedIndex()
 	}
 
 	l, err := st.LastAppliedCommand()

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -170,7 +170,7 @@ type Store struct {
 	// lastAppliedIndexToDB represents the index of the last applied command when the store is opened.
 	lastAppliedIndexToDB atomic.Uint64
 
-	//dbReloadOnce is used to reload db once caught up on startup
+	// dbReloadOnce is used to reload db once caught up on startup
 	dbReloadOnce sync.Once
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -615,7 +615,10 @@ func (st *Store) openDatabase(ctx context.Context) {
 // then later will call Apply() on any new committed log
 func (st *Store) reloadDBFromSchema() {
 	if !st.cfg.MetadataOnlyVoters {
-		st.schemaManager.ReloadDBFromSchema()
+		// to avoid any not needed db reloads
+		if st.raft != nil && st.lastAppliedIndexToDB.Load() != st.raft.LastIndex() {
+			st.schemaManager.ReloadDBFromSchema()
+		}
 	} else {
 		st.log.Info("skipping reload DB from schema as the node is metadata only")
 	}

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -98,20 +98,16 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
-		// to avoid any not needed db reloads we will call it only if the db need to catchup
-		triggerDBReload := st.raft != nil && // st.raft != nil to make sure it's not a restore request
-			l.Index != 0 && // not 1st log
-			st.lastAppliedIndexToDB.Load() <= st.raft.AppliedIndex() && // what applied to db is less than or eq in RAFT
-			l.Index == st.lastAppliedIndexToDB.Load() // we arrived to the point of reload
-
-		if triggerDBReload {
-			st.log.WithFields(logrus.Fields{
-				"log_type":                     l.Type,
-				"log_name":                     l.Type.String(),
-				"log_index":                    l.Index,
-				"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
-			}).Debug("reloading local DB as RAFT and local DB are now caught up")
-			st.reloadDBFromSchema()
+		if l.Index != 0 && l.Index == st.lastAppliedIndexToDB.Load() {
+			st.dbReloadOnce.Do(func() {
+				st.log.WithFields(logrus.Fields{
+					"log_type":                     l.Type,
+					"log_name":                     l.Type.String(),
+					"log_index":                    l.Index,
+					"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
+				}).Debug("reloading local DB as RAFT and local DB are now caught up")
+				st.reloadDBFromSchema()
+			})
 		}
 
 		if ret.Error != nil {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -101,7 +101,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		// to avoid any not needed db reloads we will call it only if the db need to catchup
 		triggerDBReload := st.raft != nil && // st.raft != nil to make sure it's not a restore request
 			l.Index != 0 && // not 1st log
-			st.lastAppliedIndexToDB.Load() <= st.raft.LastIndex() && // what applied to db is less than or eq in RAFT
+			st.lastAppliedIndexToDB.Load() <= st.raft.AppliedIndex() && // what applied to db is less than or eq in RAFT
 			l.Index == st.lastAppliedIndexToDB.Load() // we arrived to the point of reload
 
 		if triggerDBReload {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -99,7 +99,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
 		// to avoid any not needed db reloads we will call it only if the db need to catchup
-		triggerDBReload := st.raft != nil && //st.raft != nil to make sure it's not a restore request
+		triggerDBReload := st.raft != nil && // st.raft != nil to make sure it's not a restore request
 			l.Index != 0 && // not 1st log
 			st.lastAppliedIndexToDB.Load() <= st.raft.LastIndex() && // what applied to db is less than or eq in RAFT
 			l.Index == st.lastAppliedIndexToDB.Load() // we arrived to the point of reload


### PR DESCRIPTION
this PR avoid any reloads to the db if there was no changes on Apply()

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10368381106/job/28701857996
- [x] e2e run https://github.com/weaviate/weaviate-e2e-tests/actions/runs/10368376962
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
