### PR TITLE
fix: hnsw ContainsNode properly handles tombstones

### DIFF
--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -39,6 +39,8 @@ type VectorIndex interface {
 	Compressed() bool
 	ValidateBeforeInsert(vector []float32) error
 	DistanceBetweenVectors(x, y []float32) (float32, error)
+	// ContainsNode returns true if the index contains the node with the given id.
+	// It must return false if the node does not exist, or has a tombstone.
 	ContainsNode(id uint64) bool
 	// Iterate over all nodes in the index.
 	// Consistency is not guaranteed, as the


### PR DESCRIPTION
### What's being changed:

This fixes the `ContainsNode` method to always return false if the node has a tombstone.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
