### PR TITLE
experimental: repair index endpoint

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2301,3 +2301,21 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 
 	return nil
 }
+
+func (i *Index) DebugRepairIndex(ctx context.Context, shardName, targetVector string) error {
+	shard := i.GetShard(shardName)
+	if shard == nil {
+		return errors.New("shard not found")
+	}
+
+	// Repair in the background
+	enterrors.GoWrapper(func() {
+		err := shard.RepairIndex(context.Background(), targetVector)
+		if err != nil {
+			i.logger.WithField("shard", shardName).WithError(err).Error("failed to repair vector index")
+			return
+		}
+	}, i.logger)
+
+	return nil
+}

--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -177,6 +177,9 @@ func NewIndexQueue(
 	if opts.StaleTimeout == 0 {
 		opts.StaleTimeout = 5 * time.Second
 	}
+	if v, _ := time.ParseDuration(os.Getenv("ASYNC_STALE_TIMEOUT")); v > 0 {
+		opts.StaleTimeout = v
+	}
 
 	if opts.MaxChunksPerTick == 0 {
 		opts.MaxChunksPerTick = runtime.GOMAXPROCS(0) - 1
@@ -473,6 +476,8 @@ func (q *IndexQueue) pushToWorkers(max int, wait bool) int64 {
 			}
 		}
 
+		q.queue.ResetDeleted(deleted...)
+
 		if len(ids) == 0 {
 			q.Logger.Debug("all vectors in the chunk are deleted. skipping")
 			continue
@@ -493,7 +498,6 @@ func (q *IndexQueue) pushToWorkers(max int, wait bool) int64 {
 			vectors: vectors,
 			done:    q.processingJobs.Decr,
 		}:
-			q.queue.ResetDeleted(deleted...)
 		}
 	}
 
@@ -874,9 +878,9 @@ func (q *vectorQueue) persistCheckpoint(minID uint64) {
 		checkpoint = 0
 	}
 
-	err := q.IndexQueue.Checkpoints.Update(q.IndexQueue.shardID, q.IndexQueue.targetVector, checkpoint)
+	err := q.IndexQueue.Checkpoints.UpdateIfNewer(q.IndexQueue.shardID, q.IndexQueue.targetVector, checkpoint)
 	if err != nil {
-		q.IndexQueue.Logger.WithError(err).Error("update checkpoint")
+		q.IndexQueue.Logger.WithError(err).Warn("checkpoint not updated")
 	}
 }
 

--- a/adapters/repos/db/indexcheckpoint/checkpoint_test.go
+++ b/adapters/repos/db/indexcheckpoint/checkpoint_test.go
@@ -35,7 +35,7 @@ func TestCheckpoint(t *testing.T) {
 	})
 
 	t.Run("set and get", func(t *testing.T) {
-		err := c.Update("shard1", "a", 123)
+		err := c.UpdateIfNewer("shard1", "a", 123)
 		require.NoError(t, err)
 
 		v, ok, err := c.Get("shard1", "a")
@@ -45,7 +45,7 @@ func TestCheckpoint(t *testing.T) {
 	})
 
 	t.Run("set and get: no target", func(t *testing.T) {
-		err := c.Update("shard1", "", 123)
+		err := c.UpdateIfNewer("shard1", "", 123)
 		require.NoError(t, err)
 
 		v, ok, err := c.Get("shard1", "")
@@ -55,7 +55,7 @@ func TestCheckpoint(t *testing.T) {
 	})
 
 	t.Run("overwrite", func(t *testing.T) {
-		err := c.Update("shard1", "a", 456)
+		err := c.UpdateIfNewer("shard1", "a", 456)
 		require.NoError(t, err)
 
 		v, ok, err := c.Get("shard1", "a")
@@ -85,7 +85,7 @@ func TestCheckpoint(t *testing.T) {
 		_, _, err = c.Get("shard1", "a")
 		require.Error(t, err)
 
-		err = c.Update("shard1", "a", 123)
+		err = c.UpdateIfNewer("shard1", "a", 123)
 		require.Error(t, err)
 
 		err = c.Delete("shard1", "a")

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -161,6 +161,7 @@ type ShardLike interface {
 
 	// Debug methods
 	DebugResetVectorIndex(ctx context.Context, targetVector string) error
+	RepairIndex(ctx context.Context, targetVector string) error
 }
 
 // Shard is the smallest completely-contained index unit. A shard manages

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -152,6 +152,8 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 		return nil
 	}
 
+	start := time.Now()
+
 	vectorIndex := s.getVectorIndex(targetVector)
 	if vectorIndex == nil {
 		s.index.logger.Warn("repair index: vector index not found")
@@ -234,6 +236,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 		WithField("added", added).
 		WithField("deleted", deleted).
 		WithField("shard_id", s.ID()).
+		WithField("took", time.Since(start)).
 		WithField("target_vector", targetVector).
 		Info("repaired vector index")
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -435,6 +435,11 @@ func (l *LazyLoadShard) PreloadQueue(targetVector string) error {
 	return l.shard.PreloadQueue(targetVector)
 }
 
+func (l *LazyLoadShard) RepairIndex(ctx context.Context, targetVector string) error {
+	l.mustLoad()
+	return l.shard.RepairIndex(ctx, targetVector)
+}
+
 func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	if !l.isLoaded() {
 		return nil

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -271,6 +271,9 @@ func (s *Shard) getIndexQueue(targetVector string) (*IndexQueue, error) {
 		}
 		return queue, nil
 	}
+	if targetVector != "" {
+		return nil, fmt.Errorf("index queue: target vector not found: %q", targetVector)
+	}
 	return s.queue, nil
 }
 

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -497,6 +497,9 @@ func TestShard_RepairIndex(t *testing.T) {
 				}
 			}
 
+			// wait for the worker to start the indexing
+			time.Sleep(500 * time.Millisecond)
+
 			// make sure all objects except >= 100 < 300 are back in the vector index
 			for i := 0; i < amount; i++ {
 				if i >= 100 && i < 300 {

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -17,6 +17,7 @@ package db
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,14 +26,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -227,6 +231,7 @@ func TestShard_InvalidVectorBatches(t *testing.T) {
 
 func TestShard_DebugResetVectorIndex(t *testing.T) {
 	t.Setenv("ASYNC_INDEXING", "true")
+	t.Setenv("ASYNC_STALE_TIMEOUT", "200ms")
 
 	ctx := testCtx()
 	className := "TestClass"
@@ -287,6 +292,7 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 
 func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
 	t.Setenv("ASYNC_INDEXING", "true")
+	t.Setenv("ASYNC_STALE_TIMEOUT", "200ms")
 
 	ctx := testCtx()
 	className := "TestClass"
@@ -315,6 +321,9 @@ func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
 	var objs []*storobj.Object
 	for i := 0; i < amount; i++ {
 		obj := testObject(className)
+		obj.Vectors = map[string][]float32{
+			"foo": {1, 2, 3},
+		}
 		objs = append(objs, obj)
 	}
 
@@ -355,4 +364,155 @@ func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
 
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_RepairIndex(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+	t.Setenv("ASYNC_STALE_TIMEOUT", "200ms")
+
+	tests := []struct {
+		name           string
+		targetVector   string
+		cfg            schema.VectorIndexConfig
+		idxOpt         func(*Index)
+		getQueue       func(ShardLike) *IndexQueue
+		getVectorIndex func(ShardLike) VectorIndex
+	}{
+		{
+			"hnsw",
+			"",
+			hnsw.UserConfig{},
+			nil,
+			func(s ShardLike) *IndexQueue {
+				return s.Queue()
+			},
+			func(s ShardLike) VectorIndex {
+				return s.VectorIndex()
+			},
+		},
+		{
+			"hnsw with target vectors",
+			"foo",
+			hnsw.UserConfig{},
+			func(i *Index) {
+				i.vectorIndexUserConfigs = make(map[string]schema.VectorIndexConfig)
+				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{}
+			},
+			func(s ShardLike) *IndexQueue {
+				return s.Queues()["foo"]
+			},
+			func(s ShardLike) VectorIndex {
+				return s.VectorIndexes()["foo"]
+			},
+		},
+		{
+			"flat",
+			"",
+			flat.NewDefaultUserConfig(),
+			nil,
+			func(s ShardLike) *IndexQueue {
+				return s.Queue()
+			},
+			func(s ShardLike) VectorIndex {
+				return s.VectorIndex()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			className := "TestClass"
+			var opts []func(*Index)
+			if test.idxOpt != nil {
+				opts = append(opts, test.idxOpt)
+			}
+			shd, idx := testShardWithSettings(t, ctx, &models.Class{Class: className}, test.cfg, false, true /* withCheckpoints */, opts...)
+
+			amount := 1000
+
+			defer func(path string) {
+				err := os.RemoveAll(path)
+				if err != nil {
+					fmt.Println(err)
+				}
+			}(shd.Index().Config.RootPath)
+
+			var objs []*storobj.Object
+			for i := 0; i < amount; i++ {
+				obj := testObject(className)
+				if test.targetVector != "" {
+					obj.Vectors = map[string][]float32{
+						test.targetVector: {1, 2, 3},
+					}
+				}
+				objs = append(objs, obj)
+			}
+
+			errs := shd.PutObjectBatch(ctx, objs)
+			for _, err := range errs {
+				require.Nil(t, err)
+			}
+
+			vidx := test.getVectorIndex(shd)
+			q := test.getQueue(shd)
+
+			// wait for the queue to be empty
+			for i := 0; i < 20; i++ {
+				time.Sleep(500 * time.Millisecond)
+				if q.Size() == 0 {
+					break
+				}
+			}
+
+			// remove some objects from the vector index
+			for i := 400; i < 600; i++ {
+				err := vidx.Delete(uint64(i))
+				require.NoError(t, err)
+			}
+
+			// remove some objects from the store
+			bucket := shd.Store().Bucket(helpers.ObjectsBucketLSM)
+			buf := make([]byte, 8)
+			for i := 100; i < 300; i++ {
+				binary.LittleEndian.PutUint64(buf, uint64(i))
+				v, err := bucket.GetBySecondary(0, buf)
+				require.NoError(t, err)
+				obj, err := storobj.FromBinary(v)
+				require.NoError(t, err)
+				idBytes, err := uuid.MustParse(obj.ID().String()).MarshalBinary()
+				require.NoError(t, err)
+				err = bucket.Delete(idBytes)
+				require.NoError(t, err)
+			}
+
+			err := shd.RepairIndex(ctx, test.targetVector)
+			require.NoError(t, err)
+
+			// wait for the queue to be empty
+			for i := 0; i < 20; i++ {
+				time.Sleep(500 * time.Millisecond)
+				if q.Size() == 0 {
+					break
+				}
+			}
+
+			// make sure all objects except >= 100 < 300 are back in the vector index
+			for i := 0; i < amount; i++ {
+				if i >= 100 && i < 300 {
+					if vidx.ContainsNode(uint64(i)) {
+						t.Fatalf("node %d should not be in the vector index", i)
+					}
+					continue
+				}
+
+				if !vidx.ContainsNode(uint64(i)) {
+					t.Fatalf("node %d should be in the vector index", i)
+				}
+			}
+
+			require.Nil(t, idx.drop())
+			require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+		})
+	}
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -744,3 +744,15 @@ func IsHNSWIndex(index any) bool {
 	_, ok := index.(*hnsw)
 	return ok
 }
+
+func AsHNSWIndex(index any) Index {
+	h, _ := index.(*hnsw)
+	return h
+}
+
+// This interface exposes public methods of the HNSW index
+// that are not part of the VectorIndex interface.
+// It is a workaround to avoid circular dependencies.
+type Index interface {
+	CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) error
+}


### PR DESCRIPTION
### What's being changed:

This adds a new debug/experimental endpoint to repair indexes.

Usage:

```bash
curl -I -v -X POST http://localhost:6060/debug/index/repair/vector?shard=foo&collection=bar&vector=baz
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
