### PR TITLE
fix:RAFT-EC: use AppliedIndex()  and local log index for WaitForAppliedIndex()

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -196,7 +196,7 @@ func (st *Store) ID() string    { return st.cfg.NodeID }
 // by checking either raft or max(snapshot, log store) instead the db will catchup
 func (st *Store) lastIndex() uint64 {
 	if st.raft != nil {
-		return st.raft.LastIndex()
+		return st.raft.AppliedIndex()
 	}
 
 	l, err := st.LastAppliedCommand()
@@ -624,7 +624,7 @@ func (st *Store) reloadDBFromSchema() {
 	// in this path it means it was called from Apply()
 	// or forced Restore()
 	if st.raft != nil {
-		st.lastAppliedIndexToDB.Store(st.raft.LastIndex())
+		st.lastAppliedIndexToDB.Store(st.raft.AppliedIndex())
 		return
 	}
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -431,7 +431,7 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 
 // WaitForAppliedIndex waits until the update with the given version is propagated to this follower node
 func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, version uint64) error {
-	if idx := st.lastIndex(); idx >= version {
+	if idx := st.raft.AppliedIndex(); idx >= version {
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(ctx, st.cfg.ConsistencyWaitTimeout)
@@ -444,7 +444,7 @@ func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, 
 		case <-ctx.Done():
 			return fmt.Errorf("%w: version got=%d  want=%d", types.ErrDeadlineExceeded, idx, version)
 		case <-ticker.C:
-			if idx = st.lastIndex(); idx >= version {
+			if idx = st.raft.AppliedIndex(); idx >= version {
 				return nil
 			} else {
 				st.log.WithFields(logrus.Fields{

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -198,7 +198,7 @@ func (st *Store) ID() string    { return st.cfg.NodeID }
 // by checking either raft or max(snapshot, log store) instead the db will catchup
 func (st *Store) lastIndex() uint64 {
 	if st.raft != nil {
-		return st.raft.LastIndex()
+		return st.raft.AppliedIndex()
 	}
 
 	l, err := st.LastAppliedCommand()
@@ -628,6 +628,7 @@ func (st *Store) reloadDBFromSchema() {
 	// in this path it means it was called from Apply()
 	// or forced Restore()
 	if st.raft != nil {
+		st.lastAppliedIndexToDB.Store(st.raft.AppliedIndex())
 		return
 	}
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -169,6 +169,8 @@ type Store struct {
 	schemaManager *schema.SchemaManager
 	// lastAppliedIndexToDB represents the index of the last applied command when the store is opened.
 	lastAppliedIndexToDB atomic.Uint64
+	// / lastAppliedIndex index of latest update to the store
+	lastAppliedIndex atomic.Uint64
 }
 
 func NewFSM(cfg Config) Store {
@@ -244,6 +246,8 @@ func (st *Store) Open(ctx context.Context) (err error) {
 		// if empty node report ready
 		st.dbLoaded.Store(true)
 	}
+
+	st.lastAppliedIndex.Store(st.raft.AppliedIndex())
 
 	st.log.WithFields(logrus.Fields{
 		"raft_applied_index":                st.raft.AppliedIndex(),
@@ -431,7 +435,7 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 
 // WaitForAppliedIndex waits until the update with the given version is propagated to this follower node
 func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, version uint64) error {
-	if idx := st.raft.AppliedIndex(); idx >= version {
+	if idx := st.lastAppliedIndex.Load(); idx >= version {
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(ctx, st.cfg.ConsistencyWaitTimeout)
@@ -444,7 +448,7 @@ func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, 
 		case <-ctx.Done():
 			return fmt.Errorf("%w: version got=%d  want=%d", types.ErrDeadlineExceeded, idx, version)
 		case <-ticker.C:
-			if idx = st.raft.AppliedIndex(); idx >= version {
+			if idx = st.lastAppliedIndex.Load(); idx >= version {
 				return nil
 			} else {
 				st.log.WithFields(logrus.Fields{

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -196,7 +196,7 @@ func (st *Store) ID() string    { return st.cfg.NodeID }
 // by checking either raft or max(snapshot, log store) instead the db will catchup
 func (st *Store) lastIndex() uint64 {
 	if st.raft != nil {
-		return st.raft.AppliedIndex()
+		return st.raft.LastIndex()
 	}
 
 	l, err := st.LastAppliedCommand()

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -624,7 +624,6 @@ func (st *Store) reloadDBFromSchema() {
 	// in this path it means it was called from Apply()
 	// or forced Restore()
 	if st.raft != nil {
-		st.lastAppliedIndexToDB.Store(st.raft.AppliedIndex())
 		return
 	}
 

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -108,6 +108,8 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 			st.reloadDBFromSchema()
 		}
 
+		st.lastAppliedIndex.Store(l.Index)
+
 		if ret.Error != nil {
 			st.log.WithFields(logrus.Fields{
 				"log_type":      l.Type,


### PR DESCRIPTION
### What's being changed:
in this [Refactor PR ](https://github.com/weaviate/weaviate/pull/5527), removed the local `appliedIndex()` and instead used raft applied index, it turns out that caused EC issue. however this PR bring back the last applied index to be decided by the local node to avoid the EC issue 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10394407793
- [x] e2e tests https://github.com/weaviate/weaviate-e2e-tests/actions/runs/10394300627/job/28783785659
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
