### PR TITLE
Make tombstoneDeletionConcurrency() not return 0 if GOMAXPROCS is set to 1

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -391,7 +391,11 @@ func tombstoneDeletionConcurrency() int {
 			return asInt
 		}
 	}
-	return runtime.GOMAXPROCS(0) / 2
+	concurrency := runtime.GOMAXPROCS(0) / 2
+	if concurrency == 0 {
+		return 1
+	}
+	return concurrency
 }
 
 func (h *hnsw) reassignNeighborsOf(deleteList helpers.AllowList, breakCleanUpTombstonedNodes breakCleanUpTombstonedNodesFunc) (ok bool, err error) {


### PR DESCRIPTION
### What's being changed:
If GOMAXPROCS is set to 1 (e.g. due to https://github.com/weaviate/weaviate/issues/5537), without this, `tombstoneDeletionConcurrency()` returns 0 which leads to no actual tombstone deletion taking place and the code here to wait forever: https://github.com/weaviate/weaviate/blob/main/adapters/repos/db/vector/hnsw/delete.go#L448

Related to https://github.com/weaviate/weaviate/issues/5214.

I have already contributed before and agree with the CLA.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
