### PR TITLE
RAFT: don't update lastAppliedIndexToDB on non restore in reloadDBFromSchema

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -628,7 +628,7 @@ func (st *Store) reloadDBFromSchema() {
 	// in this path it means it was called from Apply()
 	// or forced Restore()
 	if st.raft != nil {
-		st.lastAppliedIndexToDB.Store(st.raft.AppliedIndex())
+		// we don't update lastAppliedIndexToDB if not a restore
 		return
 	}
 


### PR DESCRIPTION
### What's being changed:
finding out of merging `stable/1.26` updating `lastAppliedIndexToDB` affects `schemaOnly` flag, there for we will just update it if it was the call from restore  


It affects tenants offload on restarting nodes, where log shall be applied to the db if the node was down while there was a change on the tenant

https://github.com/weaviate/weaviate/pull/5562

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
