### PR TITLE
fix TestRaftEndpoints flakiness

### DIFF
--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -185,7 +185,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, version))
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
-	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastIndex()+1), types.ErrDeadlineExceeded)
+	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastAppliedIndex.Load()), types.ErrDeadlineExceeded)
 
 	// DeleteClass
 	_, err = srv.DeleteClass(ctx, "X")

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -185,7 +185,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, version))
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
-	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastAppliedIndex.Load()), types.ErrDeadlineExceeded)
+	assert.ErrorIs(t, srv.store.WaitForAppliedIndex(ctx, time.Millisecond*10, srv.store.lastAppliedIndex.Load()+1), types.ErrDeadlineExceeded)
 
 	// DeleteClass
 	_, err = srv.DeleteClass(ctx, "X")


### PR DESCRIPTION
### What's being changed:
depend on `lastAppliedIndex()` to handle flakiness 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
