### PR TITLE
fix replication pulls for CL one and one node is down blocks

### DIFF
--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -273,7 +273,7 @@ func (c *coordinator[T]) Pull(ctx context.Context,
 
 					timer := time.NewTimer(nextBackOff)
 					select {
-					case <-ctx.Done():
+					case <-workerCtx.Done():
 						timer.Stop()
 						replyCh <- _Result[T]{resp, err}
 						return

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -346,7 +346,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		}, nil
 	}
 
-	replyCh, state, err := coord.Pull(ctx, One, op, "", 0)
+	replyCh, state, err := coord.Pull(ctx, One, op, "", 20*time.Second)
 	if err != nil {
 		return nil, nil, fmt.Errorf("pull shard: %w", err)
 	}


### PR DESCRIPTION
### What's being changed:
this PR adjust the replication logic to handle an edge case happens in replication, when we have requests with CL=One  and one node completely down. 
this PR fixes that, we discovered that in `1.26` [merge](https://github.com/weaviate/weaviate/actions/runs/10455904382/job/28951988023?pr=5562) because there is a test does that for async replication 
changes :
- add timeouts was missing because that could block for ever
- select on the `workerCtx`  not the parent `ctx`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
