### PR TITLE
Add gpt-4o as available OpenAI model

### DIFF
--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -43,6 +43,7 @@ var availableOpenAIModels = []string{
 	"gpt-4",
 	"gpt-4-32k",
 	"gpt-4-1106-preview",
+	"gpt-4o",
 }
 
 var (


### PR DESCRIPTION
### What's being changed:
In [this PR](https://github.com/weaviate/weaviate/pull/5470) I had added support for GPT-4o but I forgot to add it as **available OpenAI models**. This PR is doing that missing piece.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
