### PR TITLE
chore(grpc): Make `BatchFromProto` public.

### DIFF
--- a/adapters/handlers/grpc/v1/batch_parse_request.go
+++ b/adapters/handlers/grpc/v1/batch_parse_request.go
@@ -33,7 +33,7 @@ func sliceToInterface[T any](values []T) []interface{} {
 	return tmpArray
 }
 
-func batchFromProto(req *pb.BatchObjectsRequest, getClass func(string) *models.Class) ([]*models.Object, map[int]int, map[int]error) {
+func BatchFromProto(req *pb.BatchObjectsRequest, getClass func(string) *models.Class) ([]*models.Object, map[int]int, map[int]error) {
 	objectsBatch := req.Objects
 	objs := make([]*models.Object, 0, len(objectsBatch))
 	objOriginalIndex := make(map[int]int)

--- a/adapters/handlers/grpc/v1/batch_parse_request_test.go
+++ b/adapters/handlers/grpc/v1/batch_parse_request_test.go
@@ -311,7 +311,7 @@ func TestGRPCBatchRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, origIndex, batchErrors := batchFromProto(&pb.BatchObjectsRequest{Objects: tt.req}, scheme.GetClass)
+			out, origIndex, batchErrors := BatchFromProto(&pb.BatchObjectsRequest{Objects: tt.req}, scheme.GetClass)
 			if len(tt.outError) > 0 {
 				require.NotNil(t, batchErrors)
 				if len(tt.out) > 0 {

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -142,7 +142,7 @@ func (s *Service) batchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
-	objs, objOriginalIndex, objectParsingErrors := batchFromProto(req, s.schemaManager.ReadOnlyClass)
+	objs, objOriginalIndex, objectParsingErrors := BatchFromProto(req, s.schemaManager.ReadOnlyClass)
 
 	var objErrors []*pb.BatchObjectsReply_BatchError
 	for i, err := range objectParsingErrors {


### PR DESCRIPTION

### What's being changed:
This makes is easy to consume protobuf request and parse into `models.BatchObject`. Which then make it possible to reuse helpers

Shouldn't change any functionalities.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
