### PR TITLE
Fix flaky test with aggregation

### DIFF
--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1218,7 +1218,12 @@ func localMetaWithObjectLimit(t *testing.T) {
 			require.Len(t, res, 1)
 			meta := res[0].(map[string]interface{})["meta"]
 			count := meta.(map[string]interface{})["count"]
-			assert.Equal(t, json.Number("500"), count)
+
+			// hnsw is not perfect
+			countParsed, err := count.(json.Number).Int64()
+			require.Nil(t, err)
+			assert.LessOrEqual(t, countParsed, int64(500))
+			assert.GreaterOrEqual(t, countParsed, int64(495))
 		})
 	})
 
@@ -1245,7 +1250,11 @@ func localMetaWithObjectLimit(t *testing.T) {
 			require.Len(t, res, 1)
 			meta := res[0].(map[string]interface{})["meta"]
 			count := meta.(map[string]interface{})["count"]
-			assert.Equal(t, json.Number("500"), count)
+			// hnsw is not perfect
+			countParsed, err := count.(json.Number).Int64()
+			require.Nil(t, err)
+			assert.LessOrEqual(t, countParsed, int64(500))
+			assert.GreaterOrEqual(t, countParsed, int64(495))
 		})
 	})
 

--- a/test/acceptance/graphql_resolvers/local_get_with_unlimited_vector_search_test.go
+++ b/test/acceptance/graphql_resolvers/local_get_with_unlimited_vector_search_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func gettingObjectsWithNearFields(t *testing.T) {
-	defaultLimit := 100
+	defaultLimit := 50
 
 	// nearVector
 


### PR DESCRIPTION
### What's being changed:

We lowered the default max_connections which makes a test flaky

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
