### PR TITLE
test: use only odd nodes count cluster for testing

### DIFF
--- a/test/acceptance/replication/graphql_test.go
+++ b/test/acceptance/replication/graphql_test.go
@@ -31,7 +31,7 @@ func graphqlSearch(t *testing.T) {
 	defer cancel()
 
 	compose, err := docker.New().
-		With2NodeCluster().
+		WithWeaviateCluster().
 		WithText2VecContextionary().
 		Start(ctx)
 	require.Nil(t, err)

--- a/test/acceptance/schema/get_class_consistency_test.go
+++ b/test/acceptance/schema/get_class_consistency_test.go
@@ -30,7 +30,7 @@ func TestGetClassWithConsistency(t *testing.T) {
 	defer cancel()
 
 	// 3 Node cluster so that we can verify that the proxy to leader feature work
-	compose, err := docker.New().With2NodeCluster().
+	compose, err := docker.New().WithWeaviateCluster().
 		WithText2VecContextionary().
 		Start(ctx)
 	require.Nil(t, err)

--- a/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
@@ -224,16 +224,16 @@ func TestActivationDeactivation_Restarts(t *testing.T) {
 
 			restartFn = func(t *testing.T, ctx context.Context) *wvt.Client {
 				eg := errgroup.Group{}
-				require.Nil(t, compose.StopAt(ctx, 0, nil))
+				require.Nil(t, compose.StopAt(ctx, 1, nil))
 				eg.Go(func() error {
-					require.Nil(t, compose.StartAt(ctx, 0))
+					require.Nil(t, compose.StartAt(ctx, 1))
 					return nil
 				})
 
-				require.Nil(t, compose.StopAt(ctx, 1, nil))
+				require.Nil(t, compose.StopAt(ctx, 2, nil))
 				eg.Go(func() error {
 					time.Sleep(4 * time.Second) // wait for member list initialization
-					require.Nil(t, compose.StartAt(ctx, 1))
+					require.Nil(t, compose.StartAt(ctx, 2))
 					return nil
 				})
 

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -349,18 +349,12 @@ func (d *Compose) WithWeaviateWithGRPC() *Compose {
 	return d
 }
 
-func (d *Compose) WithSecondWeaviate() *Compose {
-	d.With1NodeCluster()
-	d.withSecondWeaviate = true // TODO: create a second 1 node cluster
-	return d
-}
-
 func (d *Compose) WithWeaviateCluster() *Compose {
-	return d.With2NodeCluster()
+	return d.With3NodeCluster()
 }
 
 func (d *Compose) WithWeaviateClusterWithGRPC() *Compose {
-	d.With2NodeCluster()
+	d.With3NodeCluster()
 	d.withWeaviateExposeGRPCPort = true
 	return d
 }
@@ -591,12 +585,6 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 func (d *Compose) With1NodeCluster() *Compose {
 	d.withWeaviateCluster = true
 	d.size = 1
-	return d
-}
-
-func (d *Compose) With2NodeCluster() *Compose {
-	d.withWeaviateCluster = true
-	d.size = 2
 	return d
 }
 

--- a/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
+++ b/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
@@ -12,6 +12,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -63,15 +64,12 @@ func Test_WeaviateCluster_NodesAPI(t *testing.T) {
 
 				assert.Equal(t, "node1", nodes[0].Name)
 				assert.Equal(t, "node2", nodes[1].Name)
+				assert.Equal(t, "node3", nodes[2].Name)
 
 				for i, nodeStatus := range nodes {
 					require.NotNil(t, nodeStatus)
 					assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
-					if i == 0 {
-						assert.Equal(t, "node1", nodeStatus.Name)
-					} else {
-						assert.Equal(t, "node2", nodeStatus.Name)
-					}
+					assert.Equal(t, fmt.Sprintf("node%d", i+1), nodeStatus.Name)
 					assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
 					assert.Len(t, nodeStatus.Shards, 2)
 					var objectCount int64

--- a/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
+++ b/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
@@ -59,7 +59,7 @@ func Test_WeaviateCluster_NodesAPI(t *testing.T) {
 
 				nodes := nodeStatusResp.Nodes
 				require.NotNil(t, nodes)
-				require.Len(t, nodes, 2)
+				require.Len(t, nodes, 3)
 
 				assert.Equal(t, "node1", nodes[0].Name)
 				assert.Equal(t, "node2", nodes[1].Name)

--- a/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
+++ b/test/modules/text2vec-contextionary/cluster_nodes_api_test.go
@@ -47,7 +47,7 @@ func Test_WeaviateCluster_NodesAPI(t *testing.T) {
 	})
 
 	t.Run("check nodes api", func(t *testing.T) {
-		for _, endpoint := range []string{weaviateNode1Endpoint, weaviateNode2Endpoint} {
+		for _, endpoint := range []string{weaviateNode1Endpoint, weaviateNode2Endpoint, weaviateNode3Endpoint} {
 			t.Run(endpoint, func(t *testing.T) {
 				helper.SetupClient(os.Getenv(endpoint))
 				verbose := verbosity.OutputVerbose
@@ -71,7 +71,8 @@ func Test_WeaviateCluster_NodesAPI(t *testing.T) {
 					assert.Equal(t, models.NodeStatusStatusHEALTHY, *nodeStatus.Status)
 					assert.Equal(t, fmt.Sprintf("node%d", i+1), nodeStatus.Name)
 					assert.True(t, nodeStatus.GitHash != "" && nodeStatus.GitHash != "unknown")
-					assert.Len(t, nodeStatus.Shards, 2)
+					// 2 shards for multishard class and 1 for book class
+					assert.True(t, len(nodeStatus.Shards) == 1 || len(nodeStatus.Shards) == 2, fmt.Sprintf("shard count should be either 1 or 2, got %d", len(nodeStatus.Shards)))
 					var objectCount int64
 					var shardCount int64
 					for _, shard := range nodeStatus.Shards {

--- a/test/modules/text2vec-contextionary/setup_test.go
+++ b/test/modules/text2vec-contextionary/setup_test.go
@@ -36,8 +36,8 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Setenv(weaviateNode1Endpoint, compose.GetWeaviate().URI())
-	os.Setenv(weaviateNode2Endpoint, compose.GetWeaviateNode(2).URI())
-	os.Setenv(weaviateNode3Endpoint, compose.GetWeaviateNode(3).URI())
+	os.Setenv(weaviateNode2Endpoint, compose.GetWeaviateNode2().URI())
+	os.Setenv(weaviateNode3Endpoint, compose.GetWeaviateNode3().URI())
 	code := m.Run()
 
 	if err := compose.Terminate(ctx); err != nil {

--- a/test/modules/text2vec-contextionary/setup_test.go
+++ b/test/modules/text2vec-contextionary/setup_test.go
@@ -23,6 +23,7 @@ import (
 const (
 	weaviateNode1Endpoint = "WEAVIATE1_ENDPOINT"
 	weaviateNode2Endpoint = "WEAVIATE2_ENDPOINT"
+	weaviateNode3Endpoint = "WEAVIATE3_ENDPOINT"
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +36,8 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Setenv(weaviateNode1Endpoint, compose.GetWeaviate().URI())
-	os.Setenv(weaviateNode2Endpoint, compose.GetWeaviateNode2().URI())
+	os.Setenv(weaviateNode2Endpoint, compose.GetWeaviateNode(2).URI())
+	os.Setenv(weaviateNode3Endpoint, compose.GetWeaviateNode(3).URI())
 	code := m.Run()
 
 	if err := compose.Terminate(ctx); err != nil {


### PR DESCRIPTION
### What's being changed:
since 1.25 (RAFT) we have to have odd number of nodes in order to have majority of nodes agreeing (QUORUM) in case of one is down, this PR  force that for all tests cases 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
