### PR TITLE
Fix classification properties to return

### DIFF
--- a/adapters/repos/db/classification.go
+++ b/adapters/repos/db/classification.go
@@ -32,10 +32,11 @@ import (
 // TODO: why is this logic in the persistence package? This is business-logic,
 // move out of here!
 func (db *DB) GetUnclassified(ctx context.Context, className string,
-	properties []string, filter *libfilters.LocalFilter,
+	properties []string, propsToReturn []string, filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
-	props := make(search.SelectProperties, len(properties))
-	for i, prop := range properties {
+	propsToReturnTmp := append(properties, propsToReturn...)
+	props := make(search.SelectProperties, len(propsToReturnTmp))
+	for i, prop := range propsToReturnTmp {
 		props[i] = search.SelectProperty{Name: prop}
 	}
 	mergedFilter := mergeUserFilterWithRefCountFilter(filter, className, properties,
@@ -65,6 +66,11 @@ func (db *DB) ZeroShotSearch(ctx context.Context, vector []float32,
 	class string, properties []string,
 	filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
+	props := make(search.SelectProperties, len(properties))
+	for i, prop := range properties {
+		props[i] = search.SelectProperty{Name: prop}
+	}
+
 	res, err := db.VectorSearch(ctx, dto.GetParams{
 		ClassName: class,
 		Pagination: &filters.Pagination{
@@ -74,6 +80,7 @@ func (db *DB) ZeroShotSearch(ctx context.Context, vector []float32,
 		AdditionalProperties: additional.Properties{
 			Vector: true,
 		},
+		Properties: props,
 	}, []string{""}, [][]float32{vector})
 
 	return res, err

--- a/adapters/repos/db/classification_integration_test.go
+++ b/adapters/repos/db/classification_integration_test.go
@@ -79,7 +79,7 @@ func TestClassifications(t *testing.T) {
 
 	t.Run("finding all unclassified (no filters)", func(t *testing.T) {
 		res, err := repo.GetUnclassified(context.Background(),
-			"Article", []string{"exactCategory", "mainCategory"}, nil)
+			"Article", []string{"exactCategory", "mainCategory"}, nil, nil)
 		require.Nil(t, err)
 		require.Len(t, res, 6)
 	})
@@ -99,7 +99,7 @@ func TestClassifications(t *testing.T) {
 		}
 
 		res, err := repo.GetUnclassified(context.Background(),
-			"Article", []string{"exactCategory", "mainCategory"}, filter)
+			"Article", []string{"exactCategory", "mainCategory"}, nil, filter)
 		require.Nil(t, err)
 		require.Len(t, res, 1)
 		assert.Equal(t, strfmt.UUID("a2bbcbdc-76e1-477d-9e72-a6d2cfb50109"), res[0].ID)

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -138,7 +138,7 @@ type fakeVectorRepoKNN struct {
 }
 
 func (f *fakeVectorRepoKNN) GetUnclassified(ctx context.Context,
-	class string, properties []string,
+	class string, properties []string, propsToReturn []string,
 	filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
 	f.Lock()
@@ -267,7 +267,7 @@ func (f *fakeVectorRepoContextual) get(id strfmt.UUID) (*models.Object, bool) {
 }
 
 func (f *fakeVectorRepoContextual) GetUnclassified(ctx context.Context,
-	class string, properties []string,
+	class string, properties []string, propsToReturn []string,
 	filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
 	return f.unclassified, nil

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -101,7 +101,7 @@ type Repo interface {
 
 type VectorRepo interface {
 	GetUnclassified(ctx context.Context, class string,
-		properties []string, filter *libfilters.LocalFilter) ([]search.Result, error)
+		properties []string, propertiesToReturn []string, filter *libfilters.LocalFilter) ([]search.Result, error)
 	AggregateNeighbors(ctx context.Context, vector []float32,
 		class string, properties []string, k int,
 		filter *libfilters.LocalFilter) ([]NeighborRef, error)

--- a/usecases/classification/classifier_run.go
+++ b/usecases/classification/classifier_run.go
@@ -40,7 +40,7 @@ func (c *Classifier) run(params models.Classification,
 
 	c.logBegin(params, filters)
 	unclassifiedItems, err := c.vectorRepo.GetUnclassified(ctx,
-		params.Class, params.ClassifyProperties, filters.Source())
+		params.Class, params.ClassifyProperties, params.BasedOnProperties, filters.Source())
 	if err != nil {
 		c.failRunWithError(params, errors.Wrap(err, "retrieve to-be-classifieds"))
 		return

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -144,7 +144,7 @@ type fakeVectorRepoKNN struct {
 }
 
 func (f *fakeVectorRepoKNN) GetUnclassified(ctx context.Context,
-	class string, properties []string,
+	class string, properties []string, propsToReturn []string,
 	filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
 	f.Lock()
@@ -273,7 +273,7 @@ func (f *fakeVectorRepoContextual) get(id strfmt.UUID) (*models.Object, bool) {
 }
 
 func (f *fakeVectorRepoContextual) GetUnclassified(ctx context.Context,
-	class string, properties []string,
+	class string, properties []string, propsToReturn []string,
 	filter *libfilters.LocalFilter,
 ) ([]search.Result, error) {
 	return f.unclassified, nil


### PR DESCRIPTION
### What's being changed:

With the current main properties have to be explicitly provided to be unmarshalled. This was missing for some classification case

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
