### PR TITLE
[GraphQL] Increase max connections for flaky test

### DIFF
--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1218,7 +1218,9 @@ func localMetaWithObjectLimit(t *testing.T) {
 			require.Len(t, res, 1)
 			meta := res[0].(map[string]interface{})["meta"]
 			count := meta.(map[string]interface{})["count"]
-			assert.Equal(t, json.Number("500"), count)
+			countInt, err := count.(json.Number).Int64()
+			require.Nil(t, err)
+			assert.InDelta(t, 500, countInt, 1)
 		})
 	})
 
@@ -1245,7 +1247,9 @@ func localMetaWithObjectLimit(t *testing.T) {
 			require.Len(t, res, 1)
 			meta := res[0].(map[string]interface{})["meta"]
 			count := meta.(map[string]interface{})["count"]
-			assert.Equal(t, json.Number("500"), count)
+			countInt, err := count.(json.Number).Int64()
+			require.Nil(t, err)
+			assert.InDelta(t, 500, countInt, 1)
 		})
 	})
 

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/multishard"
@@ -520,6 +521,8 @@ func addTestSchema(t *testing.T) {
 		},
 	})
 
+	hnswConfig := enthnsw.NewDefaultUserConfig()
+	hnswConfig.MaxConnections = 64 // RansomNote tests require higher default max connections (reduced in 1.26)
 	createObjectClass(t, &models.Class{
 		Class: "RansomNote",
 		ModuleConfig: map[string]interface{}{
@@ -527,6 +530,7 @@ func addTestSchema(t *testing.T) {
 				"vectorizeClassName": true,
 			},
 		},
+		VectorIndexConfig: hnswConfig,
 		Properties: []*models.Property{
 			{
 				Name:         "contents",


### PR DESCRIPTION
### What's being changed:
- Test has always been slightly flaky due to assumption of 100% recall (though in a relatively small index)
- The recent max connections defaults change 64 -> 32 has made this flakier
- Test now uses 64 connections and allows for a delta of 1

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
