### PR TITLE
[HNSW] Fix concurrent tombstone test

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -251,10 +251,9 @@ func (h *hnsw) CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 }
 
 func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (bool, error) {
-	if h.tombstoneCleanupRunning.Load() {
+	if !h.tombstoneCleanupRunning.CompareAndSwap(false, true) {
 		return false, errors.New("tombstone cleanup already running")
 	}
-	h.tombstoneCleanupRunning.Store(true)
 	defer h.tombstoneCleanupRunning.Store(false)
 
 	h.compressActionLock.RLock()

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -303,18 +303,49 @@ func TestDelete_WithCleaningUpTombstonesTwiceConcurrently(t *testing.T) {
 		}
 	})
 
-	t.Run("running two cleanups should start only once", func(t *testing.T) {
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			wg.Done()
-			err := vectorIndex.CleanUpTombstonedNodes(neverStop)
-			require.Nil(t, err)
-		}()
+	t.Run("running two cleanups concurrently", func(t *testing.T) {
+		var wg sync.WaitGroup
+		results := make(chan error, 2)
+
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := vectorIndex.CleanUpTombstonedNodes(neverStop)
+				results <- err
+			}()
+		}
+
 		wg.Wait()
-		err := vectorIndex.CleanUpTombstonedNodes(neverStop)
-		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "tombstone cleanup already running")
+		close(results)
+
+		var errors []error
+		for err := range results {
+			errors = append(errors, err)
+		}
+
+		require.Len(t, errors, 2, "Expected exactly two results")
+
+		successCount := 0
+		alreadyRunningCount := 0
+		for _, err := range errors {
+			if err == nil {
+				successCount++
+			} else if err.Error() == "tombstone cleanup already running" {
+				alreadyRunningCount++
+			} else {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		}
+
+		// There is a possibility the first cleanup completes before the second one starts
+		assert.GreaterOrEqual(t, successCount, 1, "Expected at least one successful cleanup")
+		assert.LessOrEqual(t, alreadyRunningCount, 1, "Expected at most one 'already running' error")
+		stats, err := vectorIndex.Stats()
+		require.Nil(t, err)
+		hnswStats, ok := stats.(*HnswStats)
+		require.True(t, ok)
+		assert.Equal(t, 0, hnswStats.NumTombstones, "Expected no tombstones after cleanup")
 	})
 
 	t.Run("destroy the index", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

- The `TestDelete_WithCleaningUpTombstonesTwiceConcurrently` test was [flaky](https://github.com/weaviate/weaviate/actions/runs/10529659620/job/29177927767?pr=5643) because it had `wg.Done()` before the first tombstone cleanup process started but then assumed the first tombstone cleanup process would finish first.
- The new test runs two cleanups at the same time and doesn't assume any ordering. It doesn't require an error with `tombstone cleanup already running` because there is a chance the first cleanup completes successfully before the second cleanup starts.
- Have also changed `tombstoneCleanupRunning` to use `CompareAndSwap` vs `Load` then `Store`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
