### PR TITLE
Fix Azure OpenAI batch test

### DIFF
--- a/modules/text2vec-openai/vectorizer/batch_test.go
+++ b/modules/text2vec-openai/vectorizer/batch_test.go
@@ -82,7 +82,7 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "has error again"}},
 		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{3: fmt.Errorf("context deadline exceeded or cancelled"), 5: fmt.Errorf("context deadline exceeded or cancelled")}},
 		{name: "azure limit without total Limit", objects: []*models.Object{
-			{Class: "Car", Properties: map[string]interface{}{"test": "azureTokens 15"}}, // set azure limit without total Limit
+			{Class: "Car", Properties: map[string]interface{}{"test": "azure_tokens 15"}}, // set azure limit without total Limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "something"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -14,9 +14,12 @@ package vectorizer
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/weaviate/weaviate/modules/text2vec-openai/ent"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 
@@ -50,11 +53,12 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 			rateLimit.LimitTokens = 2 * rate
 		}
 
-		azureTok := len("azureTokens ")
-		if len(text[i]) >= azureTok && text[i][:azureTok] == "azureTokens " {
-			rate, _ := strconv.Atoi(text[i][tok:])
-			rateLimit.RemainingTokens = rate
-			rateLimit.LimitTokens = 0
+		azureTok := len("azure_tokens ")
+		if len(text[i]) >= azureTok && text[i][:azureTok] == "azure_tokens " {
+			rate, _ := strconv.Atoi(text[i][azureTok:])
+			header := make(http.Header)
+			header.Add("x-ratelimit-remaining-tokens", strconv.Itoa(rate))
+			rateLimit = ent.GetRateLimitsFromHeader(header)
 		}
 
 		req := len("requests ")


### PR DESCRIPTION
### What's being changed:
This fixes multiple issues with the Azure OpenAI batch test:
- The instruction `azureTokens` was not working as intended, because it gets converted to lowercase before it is sent to the vectorizer. In this PR this is fixed by using `azure_tokens` instead.
- The rate limit was not read correctly due to a copy paste error. Solved in this PR by `rate, _ := strconv.Atoi(text[i][tok:])` &rarr; `rate, _ := strconv.Atoi(text[i][azureTok:])`.
- Setting `rateLimit.LimitTokens = 0` in the fake vectorizer is not correct. What happens in practice is that the header `x-ratelimit-limit-tokens` is not set in case of Azure OpenAI and `rateLimit.LimitTokens` gets set to a dummy value in `GetRateLimitsFromHeader()`. This PR fixes this by using the rate limits as returned by `GetRateLimitsFromHeader()`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
