### PR TITLE
prevent checkpoint file deletion when the shard is dropped

### DIFF
--- a/adapters/repos/db/indexcheckpoint/checkpoint.go
+++ b/adapters/repos/db/indexcheckpoint/checkpoint.go
@@ -154,15 +154,16 @@ func (c *Checkpoints) DeleteShard(shardID string) error {
 		b := tx.Bucket(checkpointBucket)
 
 		c := b.Cursor()
+		sID := []byte(shardID)
 		var toDelete [][]byte
 
-		for k, _ := c.Seek([]byte(shardID)); k != nil; k, _ = c.Next() {
-			if !bytes.HasPrefix(k, []byte(shardID)) {
+		for k, _ := c.Seek(sID); k != nil; k, _ = c.Next() {
+			if !bytes.HasPrefix(k, sID) {
 				break
 			}
 
 			// ensure the key is either the shardID or shardID_vector
-			if !bytes.Equal(k, []byte(shardID)) && k[len(shardID)] != '_' {
+			if !bytes.Equal(k, sID) && k[len(sID)] != '_' {
 				continue
 			}
 

--- a/adapters/repos/db/indexcheckpoint/checkpoint.go
+++ b/adapters/repos/db/indexcheckpoint/checkpoint.go
@@ -12,6 +12,7 @@
 package indexcheckpoint
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -141,6 +142,43 @@ func (c *Checkpoints) Delete(shardID, targetVector string) error {
 	})
 	if err != nil {
 		return errors.Wrap(err, "delete checkpoint")
+	}
+
+	return nil
+}
+
+// DeleteShard removes all checkpoints for a shard.
+// It works for both single and multi vector shards.
+func (c *Checkpoints) DeleteShard(shardID string) error {
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(checkpointBucket)
+
+		c := b.Cursor()
+		var toDelete [][]byte
+
+		for k, _ := c.Seek([]byte(shardID)); k != nil; k, _ = c.Next() {
+			if !bytes.HasPrefix(k, []byte(shardID)) {
+				break
+			}
+
+			// ensure the key is either the shardID or shardID_vector
+			if !bytes.Equal(k, []byte(shardID)) && k[len(shardID)] != '_' {
+				continue
+			}
+
+			toDelete = append(toDelete, k)
+		}
+
+		for _, k := range toDelete {
+			if err := b.Delete(k); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "delete shard checkpoints")
 	}
 
 	return nil

--- a/adapters/repos/db/indexcheckpoint/checkpoint_test.go
+++ b/adapters/repos/db/indexcheckpoint/checkpoint_test.go
@@ -87,6 +87,43 @@ func TestCheckpoint(t *testing.T) {
 		require.Zero(t, v)
 	})
 
+	t.Run("deleteShard: named vectors", func(t *testing.T) {
+		err = c.Update("vector_wKFB6FDP7hdS", "a", 1)
+		require.NoError(t, err)
+
+		err = c.Update("vector_wKFB6FDP7hdS", "b", 2)
+		require.NoError(t, err)
+
+		// ensure it doesn't delete other shards
+		err = c.Update("vector_wKFB6FDP7hdS2", "", 3)
+		require.NoError(t, err)
+		err = c.Update("vector_wKFB6FDP7hd_", "a", 4)
+		require.NoError(t, err)
+
+		err := c.DeleteShard("vector_wKFB6FDP7hdS")
+		require.NoError(t, err)
+
+		v, ok, err := c.Get("vector_wKFB6FDP7hdS", "a")
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Zero(t, v)
+
+		v, ok, err = c.Get("vector_wKFB6FDP7hdS", "b")
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Zero(t, v)
+
+		v, ok, err = c.Get("vector_wKFB6FDP7hdS2", "")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.EqualValues(t, 3, v)
+
+		v, ok, err = c.Get("vector_wKFB6FDP7hd_", "a")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.EqualValues(t, 4, v)
+	})
+
 	t.Run("drop", func(t *testing.T) {
 		c, err := New(t.TempDir(), l)
 		require.NoError(t, err)

--- a/adapters/repos/db/indexcheckpoint/checkpoint_test.go
+++ b/adapters/repos/db/indexcheckpoint/checkpoint_test.go
@@ -74,6 +74,19 @@ func TestCheckpoint(t *testing.T) {
 		require.Zero(t, v)
 	})
 
+	t.Run("deleteShard: single vector", func(t *testing.T) {
+		err = c.Update("shard1", "", 123)
+		require.NoError(t, err)
+
+		err := c.DeleteShard("shard1")
+		require.NoError(t, err)
+
+		v, ok, err := c.Get("shard1", "")
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Zero(t, v)
+	})
+
 	t.Run("drop", func(t *testing.T) {
 		c, err := New(t.TempDir(), l)
 		require.NoError(t, err)

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -308,13 +308,6 @@ func (l *LazyLoadShard) drop() error {
 				idx.vectorIndexUserConfig, idx.vectorIndexUserConfigs)
 		}
 
-		// cleanup queue
-		if l.shardOpts.indexCheckpoints != nil {
-			if err := l.shardOpts.indexCheckpoints.Drop(); err != nil {
-				return fmt.Errorf("delete checkpoint: %w", err)
-			}
-		}
-
 		// remove shard dir
 		if err := os.RemoveAll(shardPath(idx.path(), shardName)); err != nil {
 			return fmt.Errorf("delete shard dir: %w", err)

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -308,6 +308,13 @@ func (l *LazyLoadShard) drop() error {
 				idx.vectorIndexUserConfig, idx.vectorIndexUserConfigs)
 		}
 
+		// cleanup index checkpoints
+		if l.shardOpts.indexCheckpoints != nil {
+			if err := l.shardOpts.index.indexCheckpoints.DeleteShard(l.ID()); err != nil {
+				return fmt.Errorf("delete shard index checkpoints: %w", err)
+			}
+		}
+
 		// remove shard dir
 		if err := os.RemoveAll(shardPath(idx.path(), shardName)); err != nil {
 			return fmt.Errorf("delete shard dir: %w", err)


### PR DESCRIPTION
### What's being changed:

LazyLoadedShard Drop logic was deleting the shared checkpoint file, which potentially created orphaned vectors upon restarting the node.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
