### PR TITLE
fix: TestActivationDeactivation flakiness restart nodes sequentially

### DIFF
--- a/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
@@ -223,20 +223,12 @@ func TestActivationDeactivation_Restarts(t *testing.T) {
 			}
 
 			restartFn = func(t *testing.T, ctx context.Context) *wvt.Client {
-				eg := errgroup.Group{}
 				require.Nil(t, compose.StopAt(ctx, 1, nil))
-				eg.Go(func() error {
-					require.Nil(t, compose.StartAt(ctx, 1))
-					return nil
-				})
+				require.Nil(t, compose.StartAt(ctx, 1))
 
 				require.Nil(t, compose.StopAt(ctx, 2, nil))
-				eg.Go(func() error {
-					require.Nil(t, compose.StartAt(ctx, 2))
-					return nil
-				})
+				require.Nil(t, compose.StartAt(ctx, 2))
 
-				eg.Wait()
 				client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: compose.ContainerURI(0)})
 				require.Nil(t, err)
 				return client


### PR DESCRIPTION
### What's being changed:
given that we have just 3 nodes , we can't have 2 nodes down at the same time because that will lose quorum, so this change convert the test to restart sequentially to avoid any flakiness could happen from 2 nodes down at the same time 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
