### PR TITLE
Compaction optimizations

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -13,7 +13,6 @@ package lsmkv
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,75 +25,143 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-func (sg *SegmentGroup) bestCompactionCandidatePair() []int {
-	sg.maintenanceLock.RLock()
-	defer sg.maintenanceLock.RUnlock()
-
+// findCompactionCandidates looks for pair of segments eligible for compaction
+// into single segment.
+// Segments use level property to mark how many times they were compacted.
+//
+// By default pair of segments with lowest matching levels is searched. If there are more
+// than 2 segments of the same level, the oldest ones are picked.
+// Behaviour of the method can be changed with 2 segment group settings:
+// - maxSegmentSize (prevents segments being compacted into single segment of too large size)
+// - compactLeftOverSegments (allows picking for compaction segments of not equal levels)
+// Regardless of compaction settings, following constraints have to be met:
+// - only consecutive segments can be merged to keep order of creations/updates/deletions of data stored
+// - newer segments have levels lower or equal than levels of older segments (descendent order is kept)
+//
+// E.g. out of segments: s1(4), s2(3), s3(3), s4(2), s5(2), s6(2), s7(1), s8(0), s4+s5 will be
+// selected for compaction first producing single segment s4s5(3), then s2+s3 producing s2s3(4),
+// then s1+s2s3 producing s1s2s3(5). Until new segment s9(0) will be added to segment group,
+// no next pair will be returned, as all segments will have different levels.
+//
+// If maxSegmentSize is set, estimated total size of compacted segment must not exceed given limit.
+// Only pair of segments having sum of sizes <= maxSegmentSize can be returned by the method. If there
+// exist older segments with same lavel as level of selected pair, level of compacted segment will
+// not be changed to ensure no new segment have higher level than older ones. If there is no segment
+// having same level as selected pair, new segment's level will be incremented.
+// E.g. out of segments: s1(4), s2(3), s3(3), s4(2), s5(2), s6(2), s7(1), s8(0),
+// when s4.size+s5.size > maxSegmentSize, but s5.size+s6.size <= maxSegmentSize, s5+s6 will be selected
+// first for compaction producing segment s5s6(2) (note same level, due to older s2(2)).
+// If s2.size+s3.size <= maxSegmentSize, then s2+s3 producing s2s3(4) (note incremented level,
+// due to no older segment of level 3). If s1.size+s2s3.size <= maxSegmentSize s1s2s3(5) will be produced,
+// if not, no other pair will be returned until new segments will be added to segment group.
+//
+// If compactLeftOverSegments is set, pair of segments of lowest levels, though similar in sizes
+// can be returned if no pair of matching levels will be found. Segment sizes need to be close to each
+// other to prevent merging large segments (GiB) with tiny one (KiB). Level of newly produced segment
+// will be the same as level of larger(left) segment.
+// maxSegmentSize ise respected for pair of leftover segments.
+func (sg *SegmentGroup) findCompactionCandidates() (pair []int, level uint16) {
 	// if true, the parent shard has indicated that it has
 	// entered an immutable state. During this time, the
 	// SegmentGroup should refrain from flushing until its
 	// shard indicates otherwise
 	if sg.isReadyOnly() {
-		return nil
+		return nil, 0
 	}
+
+	sg.maintenanceLock.RLock()
+	defer sg.maintenanceLock.RUnlock()
 
 	// Nothing to compact
 	if len(sg.segments) < 2 {
-		return nil
+		return nil, 0
 	}
 
-	// first determine the lowest level with candidates
-	levels := map[uint16]int{}
-	lowestPairLevel := uint16(math.MaxUint16)
-	lowestLevel := uint16(math.MaxUint16)
-	lowestIndex := -1
-	secondLowestIndex := -1
-	pairExists := false
+	matchingPairFound := false
+	leftoverPairFound := false
+	var matchingLeftId, leftoverLeftId int
+	var matchingLevel, leftoverLevel uint16
 
-	for ind, seg := range sg.segments {
-		levels[seg.level]++
-		val := levels[seg.level]
-		if val > 1 {
-			if seg.level < lowestPairLevel {
-				lowestPairLevel = seg.level
-				pairExists = true
+	// as newest segments are prioritized, loop in reverse order
+	for leftId := len(sg.segments) - 2; leftId >= 0; leftId-- {
+		left, right := sg.segments[leftId], sg.segments[leftId+1]
+
+		if left.level == right.level {
+			if sg.compactionFitsSizeLimit(left, right) {
+				// max size not exceeded
+				matchingPairFound = true
+				matchingLeftId = leftId
+				matchingLevel = left.level + 1
+			} else if matchingPairFound {
+				// older segment of same level as pair's level exist.
+				// keep unchanged level
+				matchingLevel = left.level
 			}
-		}
-
-		if seg.level < lowestLevel {
-			secondLowestIndex = lowestIndex
-			lowestLevel = seg.level
-			lowestIndex = ind
-		}
-	}
-
-	if pairExists {
-		// now pick any two segments which match the level
-		var res []int
-
-		for i, segment := range sg.segments {
-			if len(res) >= 2 {
+		} else {
+			if matchingPairFound {
+				// moving to segments of higher level, but matching pair is already found.
+				// stop further search
 				break
 			}
-
-			if segment.level == lowestPairLevel {
-				res = append(res, i)
+			if sg.compactLeftOverSegments && !leftoverPairFound {
+				// eftover segments enabled, none leftover pair found yet
+				if sg.compactionFitsSizeLimit(left, right) && isSimilarSegmentSizes(left.size, right.size) {
+					// max size not exceeded, segment sizes similar despite different levels
+					leftoverPairFound = true
+					leftoverLeftId = leftId
+					leftoverLevel = left.level
+				}
 			}
 		}
-
-		return res
-	} else {
-		if sg.compactLeftOverSegments {
-			// Some segments exist, but none are of the same level
-			// Merge the two lowest segments
-
-			return []int{secondLowestIndex, lowestIndex}
-		} else {
-			// No segments of the same level exist, and we are not allowed to merge the lowest segments
-			// This means we cannot compact.  Set COMPACT_LEFTOVER_SEGMENTS to true to compact the remaining segments
-			return nil
-		}
 	}
+
+	if matchingPairFound {
+		return []int{matchingLeftId, matchingLeftId + 1}, matchingLevel
+	}
+	if leftoverPairFound {
+		return []int{leftoverLeftId, leftoverLeftId + 1}, leftoverLevel
+	}
+	return nil, 0
+}
+
+func isSimilarSegmentSizes(leftSize, rightSize int64) bool {
+	MiB := int64(1024 * 1024)
+	GiB := 1024 * MiB
+
+	threshold1 := 10 * MiB
+	threshold2 := 100 * MiB
+	threshold3 := GiB
+	threshold4 := 10 * GiB
+
+	factor2 := int64(10)
+	factor3 := int64(5)
+	factor4 := int64(3)
+	factorDef := int64(2)
+
+	// if both sizes less then 10 MiB
+	if leftSize <= threshold1 && rightSize <= threshold1 {
+		return true
+	}
+
+	lowerSize, higherSize := leftSize, rightSize
+	if leftSize > rightSize {
+		lowerSize, higherSize = rightSize, leftSize
+	}
+
+	// if higher size less than 100 MiB and not 10x bigger than lower
+	if higherSize <= threshold2 && lowerSize*factor2 >= higherSize {
+		return true
+	}
+	// if higher size less than 1 GiB and not 5x bigger than lower
+	if higherSize <= threshold3 && lowerSize*factor3 >= higherSize {
+		return true
+	}
+	// if higher size less than 10 GiB and not 3x bigger than lower
+	if higherSize <= threshold4 && lowerSize*factor4 >= higherSize {
+		return true
+	}
+	// if higher size not 2x bigger than lower
+	return lowerSize*factorDef >= higherSize
 }
 
 // segmentAtPos retrieves the segment for the given position using a read-lock
@@ -117,7 +184,8 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 	// that the array contents stay stable over the duration of an entire
 	// compaction. We do however need to protect against a read-while-write (race
 	// condition) on the array. Thus any read from sg.segments need to protected
-	pair := sg.bestCompactionCandidatePair()
+
+	pair, level := sg.findCompactionCandidates()
 	if pair == nil {
 		// nothing to do
 		return false, nil
@@ -146,12 +214,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 	leftSegment := sg.segmentAtPos(pair[0])
 	rightSegment := sg.segmentAtPos(pair[1])
 
-	if !sg.compactionFitsSizeLimit(leftSegment, rightSegment) {
-		// nothing to do this round, let's wait for the next round in the hopes
-		// that we'll find smaller (lower-level) segments that can still fit.
-		return false, nil
-	}
-
 	path := filepath.Join(sg.dir, "segment-"+segmentID(leftSegment.path)+"_"+segmentID(rightSegment.path)+".db.tmp")
 
 	f, err := os.Create(path)
@@ -161,15 +223,8 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 
 	scratchSpacePath := rightSegment.path + "compaction.scratch.d"
 
-	// the assumption is that the first element is older, and/or a higher level
-	level := leftSegment.level
-	secondaryIndices := leftSegment.secondaryIndexCount
-
-	if level == rightSegment.level {
-		level = level + 1
-	}
-
 	strategy := leftSegment.strategy
+	secondaryIndices := leftSegment.secondaryIndexCount
 	cleanupTombstones := !sg.keepTombstones && pair[0] == 0
 
 	pathLabel := "n/a"

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -12,9 +12,17 @@
 package lsmkv
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	KiB = int64(1024)
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
 )
 
 func TestSegmentGroup_BestCompactionPair(t *testing.T) {
@@ -70,9 +78,10 @@ func TestSegmentGroup_BestCompactionPair(t *testing.T) {
 				segments:       test.segments,
 				maxSegmentSize: maxSegmentSize,
 			}
-			pair := sg.bestCompactionCandidatePair()
+			pair, level := sg.findCompactionCandidates()
 			if test.expectedPair == nil {
 				assert.Nil(t, pair)
+				assert.Equal(t, uint16(0), level)
 			} else {
 				leftPath := test.segments[pair[0]].path
 				rightPath := test.segments[pair[1]].path
@@ -98,4 +107,2510 @@ func TestSegmenGroup_CompactionLargerThanMaxSize(t *testing.T) {
 	ok, err := sg.compactOnce()
 	assert.False(t, ok, "segments are too large to run")
 	assert.Nil(t, err)
+}
+
+func TestSegmentGroup_CompactionCandidates(t *testing.T) {
+	compactionResizeFactor := float32(1)
+	sg := &SegmentGroup{
+		segments: createSegments(),
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 14,
+				controlPath:   "seg_02+seg_03",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 14,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 14,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 14,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 14,
+				controlPath:   "seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 14,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 14,
+				controlPath:   "seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 14,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 14,
+				controlPath:   "seg_32+seg_33+seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 14,
+				controlPath:   "seg_36+seg_37+seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{0, 1},
+				expectedLevel: 15,
+				controlPath:   "seg_01+seg_02+seg_03",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 15,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07+seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 15,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 15,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23+seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 15,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31+seg_32+seg_33+seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{0, 1},
+				expectedLevel: 16,
+				controlPath:   "seg_01+seg_02+seg_03+seg_04+seg_05+seg_06+seg_07+seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 16,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19+seg_20+seg_21+seg_22+seg_23+seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{0, 1},
+				expectedLevel: 17,
+				controlPath:   "seg_01+seg_02+seg_03+seg_04+seg_05+seg_06+seg_07+seg_08+seg_09+seg_10+seg_11+seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19+seg_20+seg_21+seg_22+seg_23+seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 1,
+				controlPath:   "seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 2,
+				controlPath:   "seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 3,
+				controlPath:   "seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 4,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 5,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize300_Resize08(t *testing.T) {
+	compactionResizeFactor := float32(.8)
+	sg := &SegmentGroup{
+		segments:       createSegments(),
+		maxSegmentSize: 300 * GiB,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 12,
+				controlPath:   "seg_05+seg_06",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 12,
+				controlPath:   "seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10+seg_11+seg_12",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 12,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 12,
+				controlPath:   "seg_14+seg_15+seg_16",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 12,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 12,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 12,
+				controlPath:   "seg_18+seg_19+seg_20",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 12,
+				controlPath:   "seg_21+seg_22",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 12,
+				controlPath:   "seg_23+seg_24",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 12,
+				controlPath:   "seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27+seg_28",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 12,
+				controlPath:   "seg_31+seg_32",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 12,
+				controlPath:   "seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 12,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 12,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 12,
+				controlPath:   "seg_36+seg_37+seg_38",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 12,
+				controlPath:   "seg_39+seg_40",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 12,
+				controlPath:   "seg_39+seg_40+seg_41",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{23, 24},
+				expectedLevel: 1,
+				controlPath:   "seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{22, 23},
+				expectedLevel: 2,
+				controlPath:   "seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 3,
+				controlPath:   "seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 4,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 5,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize400_Resize09(t *testing.T) {
+	compactionResizeFactor := float32(.9)
+	sg := &SegmentGroup{
+		segments:       createSegments(),
+		maxSegmentSize: 400 * GiB,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19+seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35+seg_36+seg_37",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 1,
+				controlPath:   "seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 2,
+				controlPath:   "seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 3,
+				controlPath:   "seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 4,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 5,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize500_Resize08(t *testing.T) {
+	compactionResizeFactor := float32(.8)
+	sg := &SegmentGroup{
+		segments:       createSegments(),
+		maxSegmentSize: 500 * GiB,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 13,
+				controlPath:   "seg_03+seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 13,
+				controlPath:   "seg_03+seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30+seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35+seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39+seg_40+seg_41",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 1,
+				controlPath:   "seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 2,
+				controlPath:   "seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 3,
+				controlPath:   "seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 4,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 5,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize600_Resize09(t *testing.T) {
+	compactionResizeFactor := float32(.9)
+	sg := &SegmentGroup{
+		segments:       createSegments(),
+		maxSegmentSize: 600 * GiB,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 14,
+				controlPath:   "seg_02+seg_03",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 14,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 14,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 14,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 14,
+				controlPath:   "seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 14,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 14,
+				controlPath:   "seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 14,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 14,
+				controlPath:   "seg_32+seg_33+seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 14,
+				controlPath:   "seg_36+seg_37+seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 14,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 1,
+				controlPath:   "seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 2,
+				controlPath:   "seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 3,
+				controlPath:   "seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 4,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 5,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49+seg_50",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize300To600_Resize08(t *testing.T) {
+	compactionResizeFactor := float32(.8)
+	sg := &SegmentGroup{
+		segments:       createSegments(),
+		maxSegmentSize: 300 * GiB,
+	}
+
+	t.Run("compact with 300 GiB limit", func(t *testing.T) {
+		for pair, level := sg.findCompactionCandidates(); pair != nil; pair, level = sg.findCompactionCandidates() {
+			compactSegments(sg, pair, level, compactionResizeFactor)
+		}
+	})
+
+	t.Run("compact again with 600 GiB limit", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17+seg_18+seg_19+seg_20",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_21+seg_22+seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30+seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35+seg_36+seg_37+seg_38",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_39+seg_40+seg_41+seg_42",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 14,
+				controlPath:   "seg_02+seg_03",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.maxSegmentSize = 600 * GiB
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_Leftover(t *testing.T) {
+	compactionResizeFactor := float32(1)
+	sg := &SegmentGroup{
+		segments:                createSegments(),
+		compactLeftOverSegments: true,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 14,
+				controlPath:   "seg_02+seg_03",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 14,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 14,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 14,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 14,
+				controlPath:   "seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 14,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 14,
+				controlPath:   "seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 14,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 14,
+				controlPath:   "seg_32+seg_33+seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 14,
+				controlPath:   "seg_36+seg_37+seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{0, 1},
+				expectedLevel: 15,
+				controlPath:   "seg_01+seg_02+seg_03",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 15,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07+seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 15,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 15,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23+seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 15,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31+seg_32+seg_33+seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{0, 1},
+				expectedLevel: 16,
+				controlPath:   "seg_01+seg_02+seg_03+seg_04+seg_05+seg_06+seg_07+seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 16,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19+seg_20+seg_21+seg_22+seg_23+seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{0, 1},
+				expectedLevel: 17,
+				controlPath:   "seg_01+seg_02+seg_03+seg_04+seg_05+seg_06+seg_07+seg_08+seg_09+seg_10+seg_11+seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19+seg_20+seg_21+seg_22+seg_23+seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 1,
+				controlPath:   "seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 2,
+				controlPath:   "seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 3,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 4,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 8,
+				controlPath:   "seg_43+seg_44",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 14,
+				controlPath:   "seg_36+seg_37+seg_38+seg_39+seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 15,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31+seg_32+seg_33+seg_34+seg_35+seg_36+seg_37+seg_38+seg_39+seg_40+seg_41",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize300_Resize08_Leftover(t *testing.T) {
+	compactionResizeFactor := float32(.8)
+	sg := &SegmentGroup{
+		segments:                createSegments(),
+		maxSegmentSize:          300 * GiB,
+		compactLeftOverSegments: true,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 12,
+				controlPath:   "seg_05+seg_06",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 12,
+				controlPath:   "seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10+seg_11+seg_12",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 12,
+				controlPath:   "seg_09+seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 12,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 12,
+				controlPath:   "seg_14+seg_15+seg_16",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 12,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 12,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 12,
+				controlPath:   "seg_18+seg_19+seg_20",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 12,
+				controlPath:   "seg_21+seg_22",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 12,
+				controlPath:   "seg_23+seg_24",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 12,
+				controlPath:   "seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27+seg_28",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 12,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 12,
+				controlPath:   "seg_31+seg_32",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 12,
+				controlPath:   "seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 12,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 12,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 12,
+				controlPath:   "seg_36+seg_37+seg_38",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 12,
+				controlPath:   "seg_39+seg_40",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 12,
+				controlPath:   "seg_39+seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{22, 23},
+				expectedLevel: 1,
+				controlPath:   "seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 2,
+				controlPath:   "seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 3,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 4,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 8,
+				controlPath:   "seg_43+seg_44",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize400_Resize09_Leftover(t *testing.T) {
+	compactionResizeFactor := float32(.9)
+	sg := &SegmentGroup{
+		segments:                createSegments(),
+		maxSegmentSize:          400 * GiB,
+		compactLeftOverSegments: true,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19+seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35+seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 1,
+				controlPath:   "seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 2,
+				controlPath:   "seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 3,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 4,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 8,
+				controlPath:   "seg_43+seg_44",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41+seg_42",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize500_Resize08_Leftover(t *testing.T) {
+	compactionResizeFactor := float32(.8)
+	sg := &SegmentGroup{
+		segments:                createSegments(),
+		maxSegmentSize:          500 * GiB,
+		compactLeftOverSegments: true,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 13,
+				controlPath:   "seg_03+seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 13,
+				controlPath:   "seg_03+seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30+seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35+seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39+seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 1,
+				controlPath:   "seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 2,
+				controlPath:   "seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 3,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 4,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 8,
+				controlPath:   "seg_43+seg_44",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize600_Resize09_Leftover(t *testing.T) {
+	compactionResizeFactor := float32(.9)
+	sg := &SegmentGroup{
+		segments:                createSegments(),
+		maxSegmentSize:          600 * GiB,
+		compactLeftOverSegments: true,
+	}
+
+	t.Run("existing segments", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_16+seg_17",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{11, 12},
+				expectedLevel: 13,
+				controlPath:   "seg_20+seg_21",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 13,
+				controlPath:   "seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{13, 14},
+				expectedLevel: 13,
+				controlPath:   "seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 13,
+				controlPath:   "seg_28+seg_29",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 13,
+				controlPath:   "seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 13,
+				controlPath:   "seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{18, 19},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{19, 20},
+				expectedLevel: 13,
+				controlPath:   "seg_36+seg_37",
+			},
+			{
+				expectedPair:  []int{20, 21},
+				expectedLevel: 13,
+				controlPath:   "seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{21, 22},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 14,
+				controlPath:   "seg_02+seg_03",
+			},
+			{
+				expectedPair:  []int{2, 3},
+				expectedLevel: 14,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 14,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 14,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 14,
+				controlPath:   "seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 14,
+				controlPath:   "seg_20+seg_21+seg_22+seg_23",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 14,
+				controlPath:   "seg_24+seg_25+seg_26+seg_27",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 14,
+				controlPath:   "seg_28+seg_29+seg_30+seg_31",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 14,
+				controlPath:   "seg_32+seg_33+seg_34+seg_35",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 14,
+				controlPath:   "seg_36+seg_37+seg_38+seg_39",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 14,
+				controlPath:   "seg_12+seg_13+seg_14+seg_15+seg_16+seg_17+seg_18+seg_19",
+			},
+			{
+				expectedPair:  []int{17, 18},
+				expectedLevel: 1,
+				controlPath:   "seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{16, 17},
+				expectedLevel: 2,
+				controlPath:   "seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{15, 16},
+				expectedLevel: 3,
+				controlPath:   "seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{14, 15},
+				expectedLevel: 4,
+				controlPath:   "seg_45+seg_46+seg_47+seg_48+seg_49",
+			},
+			{
+				expectedPair:  []int{12, 13},
+				expectedLevel: 8,
+				controlPath:   "seg_43+seg_44",
+			},
+			{
+				expectedPair:  []int{10, 11},
+				expectedLevel: 13,
+				controlPath:   "seg_40+seg_41+seg_42",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+
+	t.Run("new segment", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.segments = append(sg.segments, &segment{path: "seg_50", level: 0, size: 20 * MiB})
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+func TestSegmentGroup_CompactionCandidates_MaxSize300To600_Resize08_Leftover(t *testing.T) {
+	compactionResizeFactor := float32(.8)
+	sg := &SegmentGroup{
+		segments:                createSegments(),
+		maxSegmentSize:          300 * GiB,
+		compactLeftOverSegments: true,
+	}
+
+	t.Run("compact with 300 GiB limit", func(t *testing.T) {
+		for pair, level := sg.findCompactionCandidates(); pair != nil; pair, level = sg.findCompactionCandidates() {
+			compactSegments(sg, pair, level, compactionResizeFactor)
+		}
+	})
+
+	t.Run("compact again with 600 GiB limit", func(t *testing.T) {
+		testCases := []testCaseCompactionCandidates{
+			{
+				expectedPair:  []int{3, 4},
+				expectedLevel: 13,
+				controlPath:   "seg_04+seg_05+seg_06+seg_07",
+			},
+			{
+				expectedPair:  []int{4, 5},
+				expectedLevel: 13,
+				controlPath:   "seg_08+seg_09+seg_10+seg_11+seg_12+seg_13",
+			},
+			{
+				expectedPair:  []int{5, 6},
+				expectedLevel: 13,
+				controlPath:   "seg_14+seg_15+seg_16+seg_17+seg_18+seg_19+seg_20",
+			},
+			{
+				expectedPair:  []int{6, 7},
+				expectedLevel: 13,
+				controlPath:   "seg_21+seg_22+seg_23+seg_24+seg_25",
+			},
+			{
+				expectedPair:  []int{7, 8},
+				expectedLevel: 13,
+				controlPath:   "seg_26+seg_27+seg_28+seg_29+seg_30+seg_31+seg_32+seg_33",
+			},
+			{
+				expectedPair:  []int{8, 9},
+				expectedLevel: 13,
+				controlPath:   "seg_34+seg_35+seg_36+seg_37+seg_38",
+			},
+			{
+				expectedPair:  []int{9, 10},
+				expectedLevel: 13,
+				controlPath:   "seg_39+seg_40+seg_41+seg_42",
+			},
+			{
+				expectedPair:  []int{1, 2},
+				expectedLevel: 14,
+				controlPath:   "seg_02+seg_03",
+			},
+			{
+				expectedPair:  nil,
+				expectedLevel: 0,
+			},
+		}
+
+		sg.maxSegmentSize = 600 * GiB
+		runCompactionCandidatesTestCases(t, testCases, sg, compactionResizeFactor)
+	})
+}
+
+type testCaseCompactionCandidates struct {
+	expectedPair  []int
+	expectedLevel uint16
+	controlPath   string
+}
+
+func runCompactionCandidatesTestCases(t *testing.T, testCases []testCaseCompactionCandidates,
+	sg *SegmentGroup, compactionResizeFactor float32,
+) {
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("find candidates %s", tc.controlPath), func(t *testing.T) {
+			pair, level := sg.findCompactionCandidates()
+			require.ElementsMatch(t, tc.expectedPair, pair)
+			require.Equal(t, tc.expectedLevel, level)
+
+			if pair != nil {
+				t.Run("compact", func(t *testing.T) {
+					compactSegments(sg, pair, tc.expectedLevel, compactionResizeFactor)
+					assert.Equal(t, tc.controlPath, sg.segments[pair[0]].path)
+				})
+			}
+		})
+
+		for i, seg := range sg.segments {
+			fmt.Printf("[%d]: path [%s] level [%d] size [%d]\n", i, seg.path, seg.level, seg.size)
+		}
+		fmt.Println()
+	}
+}
+
+func compactSegments(sg *SegmentGroup, pair []int, newLevel uint16, resizeFactor float32) {
+	leftId, rightId := pair[0], pair[1]
+	left, right := sg.segments[leftId], sg.segments[rightId]
+
+	seg := &segment{
+		path:  left.path + "+" + right.path,
+		size:  int64(float32(left.size+right.size) * resizeFactor),
+		level: newLevel,
+	}
+
+	sg.segments[leftId] = seg
+	sg.segments = append(sg.segments[:rightId], sg.segments[rightId+1:]...)
+}
+
+func createSegments() []*segment {
+	return []*segment{
+		{path: "seg_01", level: 14, size: 836263427894},
+		{path: "seg_02", level: 13, size: 374869132170},
+		{path: "seg_03", level: 13, size: 208332808374},
+		{path: "seg_04", level: 12, size: 239015897301},
+		{path: "seg_05", level: 12, size: 106610102545},
+		{path: "seg_06", level: 12, size: 23426179335},
+		{path: "seg_07", level: 12, size: 87965523667},
+		{path: "seg_08", level: 12, size: 191582236181},
+		{path: "seg_09", level: 12, size: 210767274757},
+		{path: "seg_10", level: 12, size: 59578965712},
+		{path: "seg_11", level: 12, size: 64190979390},
+		{path: "seg_12", level: 12, size: 82209515753},
+		{path: "seg_13", level: 12, size: 75902833663},
+		{path: "seg_14", level: 12, size: 118868567716},
+		{path: "seg_15", level: 12, size: 127672461922},
+		{path: "seg_16", level: 12, size: 98975345366},
+		{path: "seg_17", level: 12, size: 68258824385},
+		{path: "seg_18", level: 12, size: 100849005187},
+		{path: "seg_19", level: 12, size: 102541173132},
+		{path: "seg_20", level: 12, size: 95981553544},
+		{path: "seg_21", level: 12, size: 159801966562},
+		{path: "seg_22", level: 12, size: 124441347108},
+		{path: "seg_23", level: 12, size: 134382829443},
+		{path: "seg_24", level: 12, size: 120928049419},
+		{path: "seg_25", level: 12, size: 96456793734},
+		{path: "seg_26", level: 12, size: 83607439705},
+		{path: "seg_27", level: 12, size: 96770548809},
+		{path: "seg_28", level: 12, size: 75610476308},
+		{path: "seg_29", level: 12, size: 90640520486},
+		{path: "seg_30", level: 12, size: 70865888540},
+		{path: "seg_31", level: 12, size: 210224834736},
+		{path: "seg_32", level: 12, size: 73153660353},
+		{path: "seg_33", level: 12, size: 76174252244},
+		{path: "seg_34", level: 12, size: 151728889040},
+		{path: "seg_35", level: 12, size: 128444521806},
+		{path: "seg_36", level: 12, size: 117679144581},
+		{path: "seg_37", level: 12, size: 75389068382},
+		{path: "seg_38", level: 12, size: 166442398845},
+		{path: "seg_39", level: 12, size: 131302230624},
+		{path: "seg_40", level: 12, size: 161545213956},
+		{path: "seg_41", level: 12, size: 85106406717},
+		{path: "seg_42", level: 12, size: 121845832221},
+		{path: "seg_43", level: 8, size: 7567704640},
+		{path: "seg_44", level: 7, size: 3025167714},
+		{path: "seg_45", level: 4, size: 372239668},
+		{path: "seg_46", level: 3, size: 176198587},
+		{path: "seg_47", level: 2, size: 92733242},
+		{path: "seg_48", level: 1, size: 45556463},
+		{path: "seg_49", level: 0, size: 24278171},
+	}
+}
+
+func Test_IsSimilarSegmentSizes(t *testing.T) {
+	type testCase struct {
+		leftSize, rightSize int64
+		expected            bool
+	}
+
+	testCases := []testCase{
+		{
+			leftSize:  10 * KiB,
+			rightSize: 999 * KiB,
+			expected:  true,
+		},
+		{
+			leftSize:  2 * KiB,
+			rightSize: 9 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  88 * KiB,
+			rightSize: 99 * KiB,
+			expected:  true,
+		},
+		{
+			leftSize:  2 * MiB,
+			rightSize: 3 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  1 * KiB,
+			rightSize: 10 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  1 * KiB,
+			rightSize: 11 * MiB,
+			expected:  false,
+		},
+		{
+			leftSize:  1 * MiB,
+			rightSize: 11 * MiB,
+			expected:  false,
+		},
+		{
+			leftSize:  2 * MiB,
+			rightSize: 11 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  2 * MiB,
+			rightSize: 21 * MiB,
+			expected:  false,
+		},
+		{
+			leftSize:  15 * MiB,
+			rightSize: 29 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  9 * MiB,
+			rightSize: 90 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  9 * MiB,
+			rightSize: 91 * MiB,
+			expected:  false,
+		},
+		{
+			leftSize:  10 * MiB,
+			rightSize: 100 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  11 * MiB,
+			rightSize: 110 * MiB,
+			expected:  false,
+		},
+		{
+			leftSize:  22 * MiB,
+			rightSize: 110 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  199 * MiB,
+			rightSize: 999 * MiB,
+			expected:  false,
+		},
+		{
+			leftSize:  200 * MiB,
+			rightSize: 999 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  777 * MiB,
+			rightSize: 888 * MiB,
+			expected:  true,
+		},
+		{
+			leftSize:  500 * MiB,
+			rightSize: 2 * GiB,
+			expected:  false,
+		},
+		{
+			leftSize:  700 * MiB,
+			rightSize: 2 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  2 * GiB,
+			rightSize: 7 * GiB,
+			expected:  false,
+		},
+		{
+			leftSize:  3 * GiB,
+			rightSize: 7 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  5 * GiB,
+			rightSize: 6 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  4 * GiB,
+			rightSize: 10 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  4 * GiB,
+			rightSize: 11 * GiB,
+			expected:  false,
+		},
+		{
+			leftSize:  5 * GiB,
+			rightSize: 11 * GiB,
+			expected:  false,
+		},
+		{
+			leftSize:  6 * GiB,
+			rightSize: 11 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  24 * GiB,
+			rightSize: 50 * GiB,
+			expected:  false,
+		},
+		{
+			leftSize:  25 * GiB,
+			rightSize: 50 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  111 * GiB,
+			rightSize: 234 * GiB,
+			expected:  false,
+		},
+		{
+			leftSize:  123 * GiB,
+			rightSize: 234 * GiB,
+			expected:  true,
+		},
+		{
+			leftSize:  666 * GiB,
+			rightSize: 777 * GiB,
+			expected:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d + %d", tc.leftSize, tc.rightSize), func(t *testing.T) {
+			if tc.expected {
+				assert.True(t, isSimilarSegmentSizes(tc.leftSize, tc.rightSize))
+				assert.True(t, isSimilarSegmentSizes(tc.rightSize, tc.leftSize))
+			} else {
+				assert.False(t, isSimilarSegmentSizes(tc.leftSize, tc.rightSize))
+				assert.False(t, isSimilarSegmentSizes(tc.rightSize, tc.leftSize))
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:
Improves the way compaction candidates segments are picked and new levels are assigned.
- if `SegmentGroup::maxSegmentSize` is applied and estimated total size of candidates exceeds the limit, other candidates with the same level can be suggested (if below the limit). Previously only candidates with lower level could be returned, which could lead to segments of particular level not being compacted despite being eligible to do so.
- if `SegmentGroup::compactLeftOverSegments` is set, candidates are suggested only if similar in size, regardless of their levels. Previously any 2 candidates were returned, resulting in frequent compaction of huge segments with tiny ones (e.g. 500 GiB with 100 KiB)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/10592392572
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
