### PR TITLE
Fix timeout when trying to insert object while Azure OpenAI is out of tokens

### DIFF
--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -28,7 +28,8 @@ func GetRateLimitsFromHeader(header http.Header) *modulecomponents.RateLimits {
 	}
 	tokensReset, err := time.ParseDuration(header.Get("x-ratelimit-reset-tokens"))
 	if err != nil {
-		tokensReset = 0
+		// azure doesn't include the x-ratelimit-reset-tokens header, fallback to default
+		tokensReset = time.Duration(1) * time.Minute
 	}
 	limitRequests := getHeaderInt(header, "x-ratelimit-limit-requests")
 	limitTokens := getHeaderInt(header, "x-ratelimit-limit-tokens")

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -36,10 +36,10 @@ func GetRateLimitsFromHeader(header http.Header) *modulecomponents.RateLimits {
 	remainingTokens := getHeaderInt(header, "x-ratelimit-remaining-tokens")
 
 	// azure returns 0 as limit, make sure this does not block anything by setting a high value
-	if limitTokens == 0 && remainingTokens > 0 {
+	if limitTokens == 0 {
 		limitTokens = dummyLimit
 	}
-	if limitRequests == 0 && remainingRequests > 0 {
+	if limitRequests == 0 {
 		limitRequests = dummyLimit
 	}
 	return &modulecomponents.RateLimits{

--- a/modules/text2vec-openai/vectorizer/batch_test.go
+++ b/modules/text2vec-openai/vectorizer/batch_test.go
@@ -82,12 +82,13 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "has error again"}},
 		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{3: fmt.Errorf("context deadline exceeded or cancelled"), 5: fmt.Errorf("context deadline exceeded or cancelled")}},
 		{name: "azure limit without total Limit", objects: []*models.Object{
-			{Class: "Car", Properties: map[string]interface{}{"test": "azure_tokens 15"}}, // set azure limit without total Limit
+			{Class: "Car", Properties: map[string]interface{}{"test": "azure_tokens 20"}}, // set azure limit without total Limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long"}},
+			{Class: "Car", Properties: map[string]interface{}{"test": "azure_tokens 0"}}, // simulate token limit hit
 			{Class: "Car", Properties: map[string]interface{}{"test": "something"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "all works"}},
-		}, skip: []bool{false, false, false, true, false}},
+		}, skip: []bool{false, false, false, false, true, false}},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -36,7 +36,9 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 	if c.defaultResetRate == 0 {
 		c.defaultResetRate = 60
 	}
-
+	if len(text) == 0 {
+		panic("Vectorize() called with empty text array")
+	}
 	vectors := make([][]float32, len(text))
 	errors := make([]error, len(text))
 	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -247,7 +247,7 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 	maxTokensPerBatch := b.maxTokensPerBatch(job.cfg)
 	tokensInCurrentBatch := 0
 	numRequests := 0
-	numSendObjets := 0
+	numSendObjects := 0
 
 	texts := make([]string, 0, 100)
 	origIndex := make([]int, 0, 100)
@@ -311,7 +311,7 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 			timePerToken = batchTookInS / float64(tokensInCurrentBatch)
 		}
 		numRequests += 1
-		numSendObjets += len(texts)
+		numSendObjects += len(texts)
 
 		// in case of low rate limits we should not send the next batch immediately but sleep a bit
 		batchesPerMinute := 61.0 / batchTookInS
@@ -327,7 +327,7 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 			time.Sleep(time.Duration(sleepFor * float64(time.Second)))
 		}
 
-		// not all request limits are included in "RemainingRequests" and "ResetRequests". For example, in the OPenAI
+		// not all request limits are included in "RemainingRequests" and "ResetRequests". For example, in the OpenAI
 		// free tier only the RPD limits are shown but not RPM
 		if rateLimit.RemainingRequests <= 0 && time.Until(rateLimit.ResetRequests) > 0 {
 			// if we need to wait more than MaxBatchTime for a reset we need to stop the batch to not produce timeouts
@@ -355,7 +355,7 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 	}
 	objectsPerRequest := 0
 	if numRequests > 0 {
-		objectsPerRequest = numSendObjets / numRequests
+		objectsPerRequest = numSendObjects / numRequests
 	}
 	b.endOfBatchChannel <- endOfBatchJob{
 		timePerToken:      timePerToken,


### PR DESCRIPTION
### What's being changed:
Best first merge https://github.com/weaviate/weaviate/pull/5657 as this builds on top.

This fixes what happens when `x-ratelimit-remaining-tokens` is too low for inserting the next object. In the old code, this lead to the whole batch import to fail with a timeout, because Azure OpenAI does not provide a value for the `x-ratelimit-reset-tokens` header value at least for successful vectorization requests. Not having a value for that header value leads to `rateLimit.ResetTokens ` to be set to `time.Now()` here: https://github.com/weaviate/weaviate/blob/aba0017951205e2b078d364299d1a9e61776e84a/modules/text2vec-openai/ent/vectorization_result.go#L51
Therefore when checking `rateLimit.ResetTokens` later (https://github.com/weaviate/weaviate/blob/aba0017951205e2b078d364299d1a9e61776e84a/usecases/modulecomponents/batch/batch.go#L294), the `ResetTokens` time is in the past and not in the future, leading to a skip over that if clause and repeated calls to `makeRequest()` with an empty `texts` array, which is invalid and results in an error response from Azure OpenAI.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
