### PR TITLE
refactor bootstrap and add FQDN resolver

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -369,6 +369,8 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		IsLocalHost:            appState.ServerConfig.Config.Cluster.Localhost,
 		LoadLegacySchema:       schemaRepo.LoadLegacySchema,
 		SaveLegacySchema:       schemaRepo.SaveLegacySchema,
+		EnableFQDNResolver:     appState.ServerConfig.Config.Raft.EnableFQDNResolver,
+		FQDNResolverTLD:        appState.ServerConfig.Config.Raft.FQDNResolverTLD,
 		SentryEnabled:          appState.ServerConfig.Config.Sentry.Enabled,
 	}
 	for _, name := range appState.ServerConfig.Config.Raft.Join[:rConfig.BootstrapExpect] {

--- a/cluster/bootstrap/bootstrap.go
+++ b/cluster/bootstrap/bootstrap.go
@@ -22,43 +22,45 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/resolver"
 	entSentry "github.com/weaviate/weaviate/entities/sentry"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"golang.org/x/exp/slices"
 )
 
-type joiner interface {
+// PeerJoiner is the interface we expect to be able to talk to the other peers to either Join or Notify them
+type PeerJoiner interface {
 	Join(_ context.Context, leaderAddr string, _ *cmd.JoinPeerRequest) (*cmd.JoinPeerResponse, error)
 	Notify(_ context.Context, leaderAddr string, _ *cmd.NotifyPeerRequest) (*cmd.NotifyPeerResponse, error)
 }
 
 // Bootstrapper is used to bootstrap this node by attempting to join it to a RAFT cluster.
 type Bootstrapper struct {
-	joiner       joiner
+	peerJoiner   PeerJoiner
 	addrResolver resolver.NodeToAddress
 	isStoreReady func() bool
 
 	localRaftAddr string
 	localNodeID   string
+	voter         bool
 
 	retryPeriod time.Duration
 	jitter      time.Duration
 }
 
 // NewBootstrapper constructs a new bootsrapper
-func NewBootstrapper(joiner joiner, raftID, raftAddr string, r resolver.NodeToAddress, isStoreReady func() bool) *Bootstrapper {
+func NewBootstrapper(peerJoiner PeerJoiner, raftID string, raftAddr string, voter bool, r resolver.NodeToAddress, isStoreReady func() bool) *Bootstrapper {
 	return &Bootstrapper{
-		joiner:        joiner,
+		peerJoiner:    peerJoiner,
 		addrResolver:  r,
 		retryPeriod:   time.Second,
 		jitter:        time.Second,
 		localNodeID:   raftID,
 		localRaftAddr: raftAddr,
 		isStoreReady:  isStoreReady,
+		voter:         voter,
 	}
 }
 
 // Do iterates over a list of servers in an attempt to join this node to a cluster.
-func (b *Bootstrapper) Do(ctx context.Context, serverPortMap map[string]int, lg *logrus.Logger, voter bool, close chan struct{}) error {
+func (b *Bootstrapper) Do(ctx context.Context, serverPortMap map[string]int, lg *logrus.Logger, stop chan struct{}) error {
 	if entSentry.Enabled() {
 		transaction := sentry.StartTransaction(ctx, "raft.bootstrap",
 			sentry.WithOpName("init"),
@@ -68,33 +70,34 @@ func (b *Bootstrapper) Do(ctx context.Context, serverPortMap map[string]int, lg 
 		defer transaction.Finish()
 	}
 	ticker := time.NewTicker(jitter(b.retryPeriod, b.jitter))
-	servers := make([]string, 0, len(serverPortMap))
 	defer ticker.Stop()
 	for {
-		servers = b.servers(servers, serverPortMap)
 		select {
-		case <-close:
+		case <-stop:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
 			if b.isStoreReady() {
-				lg.WithField("action", "bootstrap").Info("node reporting ready, node has probably recovered cluster from raft config. Exiting bootstrap process")
+				lg.WithField("action", "bootstrap").Info("node reporting ready, exiting bootstrap process")
 				return nil
 			}
 
-			// If we have found no other server, there is nobody to contact
-			if len(servers) == 0 {
+			remoteNodes := ResolveRemoteNodes(b.addrResolver, serverPortMap)
+			// We were not able to resolve any nodes to an address
+			if len(remoteNodes) == 0 {
+				lg.WithField("action", "bootstrap").WithField("join_list", serverPortMap).Warn("unable to resolve any node address to join")
 				continue
 			}
 
-			// try to join an existing cluster
-			if leader, err := b.join(ctx, servers, voter); err != nil {
+			// Always try to join an existing cluster first
+			joiner := NewJoiner(b.peerJoiner, b.localNodeID, b.localRaftAddr, b.voter)
+			if leader, err := joiner.Do(ctx, lg, remoteNodes); err != nil {
 				lg.WithFields(logrus.Fields{
-					"servers": servers,
 					"action":  "bootstrap",
-					"voter":   voter,
-				}).WithError(err).Warning("failed to join cluster, will notify next if voter")
+					"servers": remoteNodes,
+					"voter":   b.voter,
+				}).WithError(err).Warning("failed to join cluster")
 			} else {
 				lg.WithFields(logrus.Fields{
 					"action": "bootstrap",
@@ -103,73 +106,42 @@ func (b *Bootstrapper) Do(ctx context.Context, serverPortMap map[string]int, lg 
 				return nil
 			}
 
-			if voter {
+			// We are a voter, we resolve other peers but we're unable to join them. We're in the situation where we are
+			// bootstrapping a new cluster and now we want to notify the other nodes.
+			// Each node on notify will build a list of notified node. Once bootstrap expect is reached the nodes will
+			// bootstrap together.
+			if b.voter {
 				// notify other servers about readiness of this node to be joined
-				if err := b.notify(ctx, servers); err != nil {
+				if err := b.notify(ctx, remoteNodes); err != nil {
 					lg.WithFields(logrus.Fields{
 						"action":  "bootstrap",
-						"servers": servers,
-					}).WithError(err).Error("notify all peers")
+						"servers": remoteNodes,
+					}).WithError(err).Error("failed to notify peers")
 					continue
 				}
 				lg.WithFields(logrus.Fields{
 					"action":  "bootstrap",
-					"servers": servers,
+					"servers": remoteNodes,
 				}).Info("notified peers this node is ready to join as voter")
 			}
 		}
 	}
 }
 
-// join attempts to join an existing leader
-func (b *Bootstrapper) join(ctx context.Context, servers []string, voter bool) (leader string, err error) {
-	if entSentry.Enabled() {
-		span := sentry.StartSpan(ctx, "raft.bootstrap.join",
-			sentry.WithOpName("join"),
-			sentry.WithDescription("Attempt to join an existing cluster"),
-		)
-		ctx = span.Context()
-		span.SetData("servers", servers)
-		defer span.Finish()
-	}
-
-	var resp *cmd.JoinPeerResponse
-	req := &cmd.JoinPeerRequest{Id: b.localNodeID, Address: b.localRaftAddr, Voter: voter}
-	// For each server, try to join.
-	// If we have no error then we have a leader
-	// If we have an error check for err == NOT_FOUND and leader != "" -> we contacted a non-leader node part of the
-	// cluster, let's join the leader.
-	// If no server allows us to join a cluster, return an error
-	for _, addr := range servers {
-		resp, err = b.joiner.Join(ctx, addr, req)
-		if err == nil {
-			return addr, nil
-		}
-		st := status.Convert(err)
-		if leader = resp.GetLeader(); st.Code() == codes.NotFound && leader != "" {
-			_, err = b.joiner.Join(ctx, leader, req)
-			if err == nil {
-				return leader, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("could not join a cluster from %v", servers)
-}
-
-// notify notifies another server of my presence
-func (b *Bootstrapper) notify(ctx context.Context, servers []string) (err error) {
+// notify attempts to notify all nodes in remoteNodes that this server is ready to bootstrap
+func (b *Bootstrapper) notify(ctx context.Context, remoteNodes []string) (err error) {
 	if entSentry.Enabled() {
 		span := sentry.StartSpan(ctx, "raft.bootstrap.notify",
 			sentry.WithOpName("notify"),
 			sentry.WithDescription("Attempt to notify existing node(s) to join a cluster"),
 		)
 		ctx = span.Context()
-		span.SetData("servers", servers)
+		span.SetData("servers", remoteNodes)
 		defer span.Finish()
 	}
-	for _, addr := range servers {
+	for _, addr := range remoteNodes {
 		req := &cmd.NotifyPeerRequest{Id: b.localNodeID, Address: b.localRaftAddr}
-		_, err = b.joiner.Notify(ctx, addr, req)
+		_, err = b.peerJoiner.Notify(ctx, addr, req)
 		if err != nil {
 			return err
 		}
@@ -177,14 +149,16 @@ func (b *Bootstrapper) notify(ctx context.Context, servers []string) (err error)
 	return
 }
 
-// servers retrieves a list of server addresses based on their names and ports.
-func (b *Bootstrapper) servers(candidates []string, serverPortMap map[string]int) []string {
-	candidates = candidates[:0]
+// ResolveRemoteNodes returns a list of remoteNodes addresses resolved using addrResolver. The nodes id used are
+// taken from serverPortMap keys and ports from the values
+func ResolveRemoteNodes(addrResolver resolver.NodeToAddress, serverPortMap map[string]int) []string {
+	candidates := make([]string, 0, len(serverPortMap))
 	for name, raftPort := range serverPortMap {
-		if addr := b.addrResolver.NodeAddress(name); addr != "" {
+		if addr := addrResolver.NodeAddress(name); addr != "" {
 			candidates = append(candidates, fmt.Sprintf("%s:%d", addr, raftPort))
 		}
 	}
+	slices.Sort(candidates)
 	return candidates
 }
 

--- a/cluster/bootstrap/bootstrap_test.go
+++ b/cluster/bootstrap/bootstrap_test.go
@@ -27,44 +27,42 @@ import (
 
 var errAny = errors.New("any error")
 
-func TestBootStrapper(t *testing.T) {
+func TestBootstrapper(t *testing.T) {
 	ctx := context.Background()
 	anything := mock.Anything
-	servers := map[string]int{"S1": 1, "S2": 2}
+	nodes := map[string]int{"S1": 1, "S2": 2}
 
 	tests := []struct {
 		name     string
 		voter    bool
-		servers  map[string]int
-		doBefore func(*MockJoiner)
+		nodes    map[string]int
+		doBefore func(*MockNodeClient)
 		isReady  func() bool
 		success  bool
 	}{
 		{
-			name:    "empty server list",
-			voter:   true,
-			servers: nil,
-			doBefore: func(m *MockJoiner) {
-				m.On("Join", anything, anything, anything).Return(&cmd.JoinPeerResponse{}, nil)
-			},
-			isReady: func() bool { return false },
-			success: false,
+			name:     "empty server list",
+			voter:    true,
+			nodes:    nil,
+			doBefore: func(m *MockNodeClient) {},
+			isReady:  func() bool { return false },
+			success:  false,
 		},
 		{
-			name:    "leader exist",
-			voter:   true,
-			servers: servers,
-			doBefore: func(m *MockJoiner) {
+			name:  "leader exist",
+			voter: true,
+			nodes: nodes,
+			doBefore: func(m *MockNodeClient) {
 				m.On("Join", anything, anything, anything).Return(&cmd.JoinPeerResponse{}, nil)
 			},
 			isReady: func() bool { return false },
 			success: true,
 		},
 		{
-			name:    "servers not available",
-			voter:   true,
-			servers: servers,
-			doBefore: func(m *MockJoiner) {
+			name:  "nodes not available",
+			voter: true,
+			nodes: nodes,
+			doBefore: func(m *MockNodeClient) {
 				m.On("Join", anything, "S1:1", anything).Return(&cmd.JoinPeerResponse{}, errAny)
 				m.On("Join", anything, "S2:2", anything).Return(&cmd.JoinPeerResponse{}, errAny)
 
@@ -75,10 +73,10 @@ func TestBootStrapper(t *testing.T) {
 			success: false,
 		},
 		{
-			name:    "follow the leader",
-			voter:   true,
-			servers: servers,
-			doBefore: func(m *MockJoiner) {
+			name:  "follow the leader",
+			voter: true,
+			nodes: nodes,
+			doBefore: func(m *MockNodeClient) {
 				err := status.Error(codes.NotFound, "follow the leader")
 				m.On("Join", anything, "S1:1", anything).Return(&cmd.JoinPeerResponse{}, errAny)
 				m.On("Join", anything, "S2:2", anything).Return(&cmd.JoinPeerResponse{Leader: "S3"}, err)
@@ -90,8 +88,8 @@ func TestBootStrapper(t *testing.T) {
 		{
 			name:     "exit early on cluster ready",
 			voter:    true,
-			servers:  servers,
-			doBefore: func(m *MockJoiner) {},
+			nodes:    nodes,
+			doBefore: func(m *MockNodeClient) {},
 			isReady:  func() bool { return true },
 			success:  true,
 		},
@@ -99,34 +97,42 @@ func TestBootStrapper(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			m := &MockJoiner{}
-			b := NewBootstrapper(m, "RID", "ADDR", fakes.NewMockAddressResolver(func(id string) string { return id }), test.isReady)
+			// Ensure the mocks are setup
+			m := &MockNodeClient{}
+			test.doBefore(m)
+
+			// Configure the bootstrapper
+			b := NewBootstrapper(m, "RID", "ADDR", test.voter, fakes.NewMockAddressResolver(func(id string) string { return id }), test.isReady)
 			b.retryPeriod = time.Millisecond
 			b.jitter = time.Millisecond
-			test.doBefore(m)
 			ctx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
 			logger, _ := logrustest.NewNullLogger()
-			err := b.Do(ctx, test.servers, logger, test.voter, make(chan struct{}))
+
+			// Do the bootstrap
+			err := b.Do(ctx, test.nodes, logger, make(chan struct{}))
 			cancel()
+
+			// Check all assertions
 			if test.success && err != nil {
 				t.Errorf("%s: %v", test.name, err)
 			} else if !test.success && err == nil {
 				t.Errorf("%s: test must fail", test.name)
 			}
+			m.AssertExpectations(t)
 		})
 	}
 }
 
-type MockJoiner struct {
+type MockNodeClient struct {
 	mock.Mock
 }
 
-func (m *MockJoiner) Join(ctx context.Context, leaderAddr string, req *cmd.JoinPeerRequest) (*cmd.JoinPeerResponse, error) {
+func (m *MockNodeClient) Join(ctx context.Context, leaderAddr string, req *cmd.JoinPeerRequest) (*cmd.JoinPeerResponse, error) {
 	args := m.Called(ctx, leaderAddr, req)
 	return args.Get(0).(*cmd.JoinPeerResponse), args.Error(1)
 }
 
-func (m *MockJoiner) Notify(ctx context.Context, leaderAddr string, req *cmd.NotifyPeerRequest) (*cmd.NotifyPeerResponse, error) {
+func (m *MockNodeClient) Notify(ctx context.Context, leaderAddr string, req *cmd.NotifyPeerRequest) (*cmd.NotifyPeerResponse, error) {
 	args := m.Called(ctx, leaderAddr, req)
 	return args.Get(0).(*cmd.NotifyPeerResponse), args.Error(1)
 }

--- a/cluster/bootstrap/joiner.go
+++ b/cluster/bootstrap/joiner.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/sirupsen/logrus"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	entSentry "github.com/weaviate/weaviate/entities/sentry"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type Joiner struct {
+	localRaftAddr string
+	localNodeID   string
+	voter         bool
+	peerJoiner    PeerJoiner
+}
+
+// NewJoiner returns a *Joiner configured with localNodeID, localRaftAddr and voter.
+func NewJoiner(peerJoiner PeerJoiner, localNodeID string, localRaftAddr string, voter bool) *Joiner {
+	return &Joiner{
+		peerJoiner:    peerJoiner,
+		localNodeID:   localNodeID,
+		localRaftAddr: localRaftAddr,
+		voter:         voter,
+	}
+}
+
+// Do will attempt to send to any nodes in remoteNodes a JoinPeerRequest for j.localNodeID with the address j.localRaftAddr.
+// Will join as voter if j.voter is true, non voter otherwise.
+// Returns the leader address if a cluster was joined or an error otherwise.
+func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes []string) (string, error) {
+	if entSentry.Enabled() {
+		span := sentry.StartSpan(ctx, "raft.bootstrap.join",
+			sentry.WithOpName("join"),
+			sentry.WithDescription("Attempt to join an existing cluster"),
+		)
+		ctx = span.Context()
+		span.SetData("servers", remoteNodes)
+		defer span.Finish()
+	}
+
+	var resp *cmd.JoinPeerResponse
+	var err error
+	req := &cmd.JoinPeerRequest{Id: j.localNodeID, Address: j.localRaftAddr, Voter: j.voter}
+	lg.WithField("remoteNodes", remoteNodes).Info("attempting to join")
+
+	// For each server, try to join.
+	// If we have no error then we have a leader
+	// If we have an error check for err == NOT_FOUND and leader != "" -> we contacted a non-leader node part of the
+	// cluster, let's join the leader.
+	// If no server allows us to join a cluster, return an error
+	for _, addr := range remoteNodes {
+		resp, err = j.peerJoiner.Join(ctx, addr, req)
+		if err == nil {
+			return addr, nil
+		}
+		st := status.Convert(err)
+		lg.WithField("remoteNode", addr).WithField("status", st.Code()).Info("attempted to join and failed")
+		// Get the leader from response and if not empty try to join it
+		if leader := resp.GetLeader(); st.Code() == codes.NotFound && leader != "" {
+			_, err = j.peerJoiner.Join(ctx, leader, req)
+			if err == nil {
+				return leader, nil
+			}
+			lg.WithField("leader", leader).WithError(err).Info("attempted to follow to leader and failed")
+		}
+	}
+	return "", fmt.Errorf("could not join a cluster from %v", remoteNodes)
+}

--- a/cluster/resolver/fqdn.go
+++ b/cluster/resolver/fqdn.go
@@ -22,17 +22,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/log"
 )
 
-const (
-	// RaftTcpMaxPool controls how many connections raft transport will pool
-	raftTcpMaxPool = 3
-	// RaftTcpTimeout is used to apply I/O deadlines.
-	raftTcpTimeout = 10 * time.Second
-)
-
-type raft struct {
-	// NodeToAddress allows the raft to also be used to resolve node-ids to ip addresses.
-	NodeToAddress
-
+type fqdn struct {
 	// RaftPort is the configured RAFT port in the cluster that the resolver will append to the node id.
 	RaftPort int
 	// IsLocalCluster is the cluster running on a single host machine. This is necessary to ensure that we don't use the
@@ -41,14 +31,18 @@ type raft struct {
 	// NodeNameToPortMap maps a given node name ot a given port. This is useful when running locally so that we can
 	// keep in memory which node uses which port.
 	NodeNameToPortMap map[string]int
+	// TLD is a string that if set well be appended to the node-id using the format <node-id>.<TLD>. This allows
+	// weaviate to resolve node id to name in a namespaces environment where node id don't directly translate to an ip
+	// at the DNS layer.
+	TLD string
 
 	nodesLock        sync.Mutex
 	notResolvedNodes map[raftImpl.ServerID]struct{}
 }
 
-func NewRaft(cfg RaftConfig) *raft {
-	return &raft{
-		NodeToAddress:     cfg.NodeToAddress,
+func NewFQDN(cfg FQDNConfig) *fqdn {
+	return &fqdn{
+		TLD:               cfg.TLD,
 		RaftPort:          cfg.RaftPort,
 		IsLocalCluster:    cfg.IsLocalHost,
 		NodeNameToPortMap: cfg.NodeNameToPortMap,
@@ -56,32 +50,48 @@ func NewRaft(cfg RaftConfig) *raft {
 	}
 }
 
-// ServerAddr resolves server ID to a RAFT address
-func (a *raft) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) {
-	// Get the address from the node id
-	addr := a.NodeToAddress.NodeAddress(string(id))
+// NodeAddress resolves a node id to an IP address, returns empty string if host is not found.
+// This is useful to implement as it is the same interface implemented by cluster state to do memberlist based lookups
+func (r *fqdn) NodeAddress(id string) string {
+	fqdn := string(id)
+	if r.TLD != "" {
+		fqdn += "." + r.TLD
+	}
+	addr, err := net.LookupIP(fqdn)
+	if err != nil || len(addr) < 1 {
+		return ""
+	}
+	return addr[0].String()
+}
 
-	// Update the internal notResolvedNodes if the addr if empty, otherwise delete it from the map
-	a.nodesLock.Lock()
-	defer a.nodesLock.Unlock()
-	if addr == "" {
-		a.notResolvedNodes[id] = struct{}{}
+// ServerAddr resolves server ID to a RAFT address
+func (r *fqdn) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) {
+	// Get the address from the node id
+	fqdn := string(id)
+	if r.TLD != "" {
+		fqdn += "." + r.TLD
+	}
+	addr, err := net.LookupIP(fqdn)
+	r.nodesLock.Lock()
+	defer r.nodesLock.Unlock()
+	if err != nil || len(addr) < 1 {
+		r.notResolvedNodes[id] = struct{}{}
 		return raftImpl.ServerAddress(invalidAddr), nil
 	}
-	delete(a.notResolvedNodes, id)
+	delete(r.notResolvedNodes, id)
 
 	// If we are not running a local cluster we can immediately return, otherwise we need to lookup the port of the node
 	// as we can't use the default raft port locally.
-	if !a.IsLocalCluster {
-		return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr, a.RaftPort)), nil
+	if !r.IsLocalCluster {
+		return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr[0], r.RaftPort)), nil
 	}
-	return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr, a.NodeNameToPortMap[string(id)])), nil
+	return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr[0], r.NodeNameToPortMap[string(id)])), nil
 }
 
-// NewTCPTransport returns a new raft.NetworkTransportConfig that utilizes
+// NewTCPTransport returns a new fqdn.NetworkTransportConfig that utilizes
 // this resolver to resolve addresses based on server IDs.
 // This is particularly crucial as K8s assigns new IPs on each node restart.
-func (a *raft) NewTCPTransport(
+func (r *fqdn) NewTCPTransport(
 	bindAddr string,
 	advertise net.Addr,
 	maxPool int,
@@ -89,7 +99,7 @@ func (a *raft) NewTCPTransport(
 	logger *logrus.Logger,
 ) (*raftImpl.NetworkTransport, error) {
 	cfg := &raftImpl.NetworkTransportConfig{
-		ServerAddressProvider: a,
+		ServerAddressProvider: r,
 		MaxPool:               raftTcpMaxPool,
 		Timeout:               raftTcpTimeout,
 		Logger:                log.NewHCLogrusLogger("raft-net", logger),
@@ -97,6 +107,6 @@ func (a *raft) NewTCPTransport(
 	return raftImpl.NewTCPTransportWithConfig(bindAddr, advertise, cfg)
 }
 
-func (a *raft) NotResolvedNodes() map[raftImpl.ServerID]struct{} {
-	return a.notResolvedNodes
+func (r *fqdn) NotResolvedNodes() map[raftImpl.ServerID]struct{} {
+	return r.notResolvedNodes
 }

--- a/cluster/resolver/rpc.go
+++ b/cluster/resolver/rpc.go
@@ -31,7 +31,7 @@ func NewRpc(isLocalHost bool, rpcPort int) *Rpc {
 	return &Rpc{isLocalCluster: isLocalHost, rpcPort: rpcPort}
 }
 
-// rpcAddressFromRAFT returns the FQDN raft address (rpcAddr:rpcPort) based on raftAddr (raftAddr:raftPort).
+// rpcAddressFromRAFT returns the rpc address (rpcAddr:rpcPort) based on raftAddr (raftAddr:raftPort).
 // In a real cluster, the RPC port is the same for all nodes. In a local environment, the RPC ports need to be
 // different. Specifically, we calculate the RPC port as the RAFT port + 1.
 // Returns an error if raftAddr is not parseable.

--- a/cluster/resolver/types.go
+++ b/cluster/resolver/types.go
@@ -11,6 +11,10 @@
 
 package resolver
 
+const (
+	invalidAddr = "256.256.256.256:99999999"
+)
+
 // NodeToAddress allows the resolver to compute node-id to ip addresses.
 type NodeToAddress interface {
 	// NodeAddress resolves node id into an ip address without the port.
@@ -22,4 +26,11 @@ type RaftConfig struct {
 	RaftPort          int
 	IsLocalHost       bool
 	NodeNameToPortMap map[string]int
+}
+
+type FQDNConfig struct {
+	RaftPort          int
+	IsLocalHost       bool
+	NodeNameToPortMap map[string]int
+	TLD               string
 }

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/bootstrap"
 	"github.com/weaviate/weaviate/cluster/resolver"
@@ -46,16 +48,33 @@ type Service struct {
 // nodes.
 // Raft store will be initialized and ready to be started. To start the service call Open().
 func New(selector cluster.NodeSelector, cfg Config) *Service {
-	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.RPCPort)
+	rpcListenAddress := fmt.Sprintf("%s:%d", cfg.Host, cfg.RPCPort)
+	// When using FQDN lookup we might want to advertise a different IP than the one we'll be listening on.
+	// This address is then sent to raft peers as the address this node listen on.
+	// This address needs to proxy/forward to that node (think static ip for a service)
+	// This is necessary to ensure that the FQDN ip will be stored in the raft logs.
+	raftAdvertisedAddress := fmt.Sprintf("%s:%d", cfg.Host, cfg.RaftPort)
+	if cfg.EnableFQDNResolver {
+		addr := resolver.NewFQDN(resolver.FQDNConfig{
+			// We don't need to specify more config as we are only using that resolver to resolve a node id to an IP
+			// overriding the default resolver using memberlist.
+			TLD: cfg.FQDNResolverTLD,
+		}).NodeAddress(cfg.NodeID)
+		if addr != "" {
+			raftAdvertisedAddress = addr
+		} else {
+			cfg.Logger.Warnf("raft fqdn lookup configured but unable to resolve node %s to an IP, fallbacking to %s", cfg.NodeID, raftAdvertisedAddress)
+		}
+	}
 	cl := rpc.NewClient(resolver.NewRpc(cfg.IsLocalHost, cfg.RPCPort), cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled, cfg.Logger)
 	fsm := NewFSM(cfg)
 	raft := NewRaft(selector, &fsm, cl)
 	return &Service{
 		Raft:              raft,
-		raftAddr:          fmt.Sprintf("%s:%d", cfg.Host, cfg.RaftPort),
+		raftAddr:          raftAdvertisedAddress,
 		config:            &cfg,
 		rpcClient:         cl,
-		rpcServer:         rpc.NewServer(&fsm, raft, addr, cfg.Logger, cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled),
+		rpcServer:         rpc.NewServer(&fsm, raft, rpcListenAddress, cfg.Logger, cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled),
 		logger:            cfg.Logger,
 		closeBootstrapper: make(chan struct{}),
 		closeWaitForDB:    make(chan struct{}),
@@ -74,22 +93,54 @@ func (c *Service) Open(ctx context.Context, db schema.Indexer) error {
 		return fmt.Errorf("open raft store: %w", err)
 	}
 
-	bs := bootstrap.NewBootstrapper(
-		c.rpcClient,
-		c.config.NodeID,
-		c.raftAddr,
-		c.config.NodeToAddressResolver,
-		c.Raft.Ready,
-	)
+	// If FQDN resolver is enabled make sure we're also using it for the bootstrapping process
+	nodeToAddressResolver := c.config.NodeToAddressResolver
+	if c.config.EnableFQDNResolver {
+		nodeToAddressResolver = resolver.NewFQDN(resolver.FQDNConfig{
+			// We don't need to specify more config as we are only using that resolver to resolve a node id to an IP
+			// overriding the default resolver using memberlist.
+			TLD: c.config.FQDNResolverTLD,
+		})
+	}
 
-	bCtx, bCancel := context.WithTimeout(ctx, c.config.BootstrapTimeout)
+	hasState, err := raft.HasExistingState(c.Raft.store.logCache, c.Raft.store.logStore, c.Raft.store.snapshotStore)
+	if err != nil {
+		return err
+	}
+	c.log.WithField("hasState", hasState).Info("raft init")
+
+	// If we have a state in raft, we only want to re-join the nodes in raft_join list to ensure that we update the
+	// configuration with our current ip.
+	// If we have no state, we want to do the bootstrap procedure where we will try to join a cluster or notify other
+	// peers that we are ready to form a new cluster.
+	bootstrapCtx, bCancel := context.WithTimeout(ctx, c.config.BootstrapTimeout)
 	defer bCancel()
-	if err := bs.Do(
-		bCtx,
-		c.config.NodeNameToPortMap,
-		c.logger,
-		c.config.Voter, c.closeBootstrapper); err != nil {
-		return fmt.Errorf("bootstrap: %w", err)
+	if hasState {
+		joiner := bootstrap.NewJoiner(c.rpcClient, c.config.NodeID, c.raftAddr, c.config.Voter)
+		err = backoff.Retry(func() error {
+			joinNodes := bootstrap.ResolveRemoteNodes(nodeToAddressResolver, c.config.NodeNameToPortMap)
+			_, err := joiner.Do(bootstrapCtx, c.logger, joinNodes)
+			return err
+		}, backoff.WithContext(backoff.NewConstantBackOff(1*time.Second), bootstrapCtx))
+		if err != nil {
+			return fmt.Errorf("could not join raft join list: %w", err)
+		}
+	} else {
+		bs := bootstrap.NewBootstrapper(
+			c.rpcClient,
+			c.config.NodeID,
+			c.raftAddr,
+			c.config.Voter,
+			nodeToAddressResolver,
+			c.Raft.Ready,
+		)
+		if err := bs.Do(
+			bootstrapCtx,
+			c.config.NodeNameToPortMap,
+			c.logger,
+			c.closeBootstrapper); err != nil {
+			return fmt.Errorf("bootstrap: %w", err)
+		}
 	}
 
 	if err := c.WaitUntilDBRestored(ctx, 10*time.Second, c.closeWaitForDB); err != nil {

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -130,6 +130,9 @@ type Config struct {
 	// committed wrong peer configuration entry that makes it unable to obtain a quorum to start.
 	// WARNING: This should be run on *actual* one node cluster only.
 	ForceOneNodeRecovery bool
+
+	EnableFQDNResolver bool
+	FQDNResolverTLD    string
 }
 
 // Store is the implementation of RAFT on this local node. It will handle the local schema and RAFT operations (startup,
@@ -179,17 +182,30 @@ type Store struct {
 }
 
 func NewFSM(cfg Config) Store {
-	return Store{
-		cfg:          cfg,
-		log:          cfg.Logger,
-		candidates:   make(map[string]string, cfg.BootstrapExpect),
-		applyTimeout: time.Second * 20,
-		raftResolver: resolver.NewRaft(resolver.RaftConfig{
-			NodeToAddress:     cfg.NodeToAddressResolver,
+	// We have different resolver in raft so that depending on the environment we can resolve a node-id to an IP using
+	// different methods.
+	var raftResolver types.RaftResolver
+	raftResolver = resolver.NewRaft(resolver.RaftConfig{
+		NodeToAddress:     cfg.NodeToAddressResolver,
+		RaftPort:          cfg.RaftPort,
+		IsLocalHost:       cfg.IsLocalHost,
+		NodeNameToPortMap: cfg.NodeNameToPortMap,
+	})
+	if cfg.EnableFQDNResolver {
+		raftResolver = resolver.NewFQDN(resolver.FQDNConfig{
+			TLD:               cfg.FQDNResolverTLD,
 			RaftPort:          cfg.RaftPort,
 			IsLocalHost:       cfg.IsLocalHost,
 			NodeNameToPortMap: cfg.NodeNameToPortMap,
-		}),
+		})
+	}
+
+	return Store{
+		cfg:           cfg,
+		log:           cfg.Logger,
+		candidates:    make(map[string]string, cfg.BootstrapExpect),
+		applyTimeout:  time.Second * 20,
+		raftResolver:  raftResolver,
 		schemaManager: schema.NewSchemaManager(cfg.NodeID, cfg.DB, cfg.Parser, cfg.Logger),
 	}
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -324,6 +324,9 @@ type Raft struct {
 	MetadataOnlyVoters bool
 
 	ForceOneNodeRecovery bool
+
+	EnableFQDNResolver bool
+	FQDNResolverTLD    string
 }
 
 func (r *Raft) Validate() error {
@@ -383,6 +386,7 @@ func (r *Raft) Validate() error {
 	if r.ConsistencyWaitTimeout <= 0 {
 		return fmt.Errorf("raft.bootstrap.consistency_wait_timeout must be more than 0")
 	}
+
 	return nil
 }
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -508,6 +508,14 @@ func parseRAFTConfig(hostname string) (Raft, error) {
 
 	cfg.ForceOneNodeRecovery = entcfg.Enabled(os.Getenv("RAFT_FORCE_ONE_NODE_RECOVERY"))
 
+	// For FQDN related config, we need to have 2 different one because TLD might be unset/empty when running inside
+	// docker without a TLD available. However is running in k8s for example you have a TLD available.
+	if entcfg.Enabled(os.Getenv("RAFT_ENABLE_FQDN_RESOLVER")) {
+		cfg.EnableFQDNResolver = true
+	}
+
+	cfg.FQDNResolverTLD = os.Getenv("RAFT_FQDN_RESOLVER_TLD")
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
### What's being changed:

Add a new FQDN based node resolver to bypass memberlist in raft. This will impact both the bootstrapping process node resolving and the raft resolution when communicating inside the cluster.
Add related config using env variables
* `RAFT_ENABLE_FQDN_RESOLVER` to enable or not that resolver (default is false and use memberlist)
* `RAFT_FQDN_RESOLVER_TLD` to add a TLD to the node ids when resolving their hostnames

Change the behaviour of the default raft resolver to return an invalid address `256.256.256.256:999999` when a node is not found in memberlist. This is necessary to ensure that RAFT will not try to talk to the last IP it has registered in it's log entries, as this IP might me re-allocated to a different cluster if running multiple weaviate in the same subnet.

Change the behaviour of bootstrap process to always `join` on starting up with a state. This will make the node tell the cluster leader to `AddVoter` or `AddNonVoter` with the node-id + node-ip couple and it will update the IP stored in raft configuration.



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
