### PR TITLE
chore: wait for ready on restarting nodes

### DIFF
--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 type DockerCompose struct {
@@ -116,6 +117,15 @@ func (d *DockerCompose) StartAt(ctx context.Context, nodeIndex int) error {
 			return fmt.Errorf("failed to get new uri for container %q: %w", c.name, err)
 		}
 		endPoints[name] = endpoint{e.port, newURI}
+
+		// wait until node is ready
+		if name != HTTP {
+			continue
+		}
+		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port))
+		if err := waitStrategy.WaitUntilReady(ctx, c.container); err != nil {
+			return err
+		}
 	}
 	c.endpoints = endPoints
 	return nil


### PR DESCRIPTION
### What's being changed:
in other branches [we sleep to wait for memberlist](https://github.com/weaviate/weaviate/blob/stable/v1.25/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go#L235) to make sure it got initialized, and we have in 1.26 `TestActivationDeactivation_Restarts` flakey, there fore instead of sleeping. just having that mechanism to wait for the node to report ready instead 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
