### PR TITLE
Improve Batch Metrics

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -111,6 +111,7 @@ func makeMetricsInterceptor(logger logrus.FieldLogger, metrics *monitoring.Prome
 		// Metric uses non-standard base unit ms, use ms for backwards compatibility
 		metrics.BatchTime.WithLabelValues("total_api_level_grpc", "n/a", "n/a").
 			Observe(float64(duration.Milliseconds()))
+		metrics.BatchSizeBytes.WithLabelValues("grpc").Observe(reqSizeBytes)
 
 		return resp, err
 	})

--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -12,19 +12,24 @@
 package grpc
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	pbv0 "github.com/weaviate/weaviate/grpc/generated/protocol/v0"
 	pbv1 "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/composer"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // Install the gzip compressor
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/proto"
 
 	v0 "github.com/weaviate/weaviate/adapters/handlers/grpc/v0"
 	v1 "github.com/weaviate/weaviate/adapters/handlers/grpc/v1"
@@ -56,6 +61,10 @@ func CreateGRPCServer(state *state.State) *GRPCServer {
 		)))
 	}
 
+	if state.Metrics != nil {
+		o = append(o, makeMetricsInterceptor(state.Logger, state.Metrics))
+	}
+
 	s := grpc.NewServer(o...)
 	weaviateV0 := v0.NewService()
 	weaviateV1 := v1.NewService(
@@ -74,6 +83,37 @@ func CreateGRPCServer(state *state.State) *GRPCServer {
 	grpc_health_v1.RegisterHealthServer(s, weaviateV1)
 
 	return &GRPCServer{s}
+}
+
+func makeMetricsInterceptor(logger logrus.FieldLogger, metrics *monitoring.PrometheusMetrics) grpc.ServerOption {
+	return grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if info.FullMethod != "/weaviate.v1.Weaviate/BatchObjects" {
+			return handler(ctx, req)
+		}
+
+		// For now only Batch has specific metrics (in line with http API)
+		startTime := time.Now()
+		reqSizeBytes := float64(proto.Size(req.(proto.Message)))
+		reqSizeMB := float64(reqSizeBytes) / (1024 * 1024)
+		// Invoke the handler to process the request
+		resp, err := handler(ctx, req)
+
+		// Measure duration
+		duration := time.Since(startTime)
+
+		logger.WithFields(logrus.Fields{
+			"action":             "grpc_batch_objects",
+			"method":             info.FullMethod,
+			"request_size_bytes": reqSizeBytes,
+			"duration":           duration,
+		}).Debugf("grpc BatchObjects request (%fMB) took %s", reqSizeMB, duration)
+
+		// Metric uses non-standard base unit ms, use ms for backwards compatibility
+		metrics.BatchTime.WithLabelValues("total_api_level_grpc", "n/a", "n/a").
+			Observe(float64(duration.Milliseconds()))
+
+		return resp, err
+	})
 }
 
 func StartAndListen(s *GRPCServer, state *state.State) error {

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -170,6 +170,8 @@ func makeAddMonitoring(metrics *monitoring.PrometheusMetrics) func(http.Handler)
 					"shard_name": "n/a",
 				}).
 					Observe(float64(time.Since(before) / time.Millisecond))
+
+				metrics.BatchSizeBytes.WithLabelValues("rest").Observe(float64(r.ContentLength))
 			}
 		})
 	}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -27,6 +27,9 @@ type Config struct {
 
 type PrometheusMetrics struct {
 	BatchTime                         *prometheus.HistogramVec
+	BatchSizeBytes                    *prometheus.SummaryVec
+	BatchSizeObjects                  prometheus.Summary
+	BatchSizeTenants                  prometheus.Summary
 	BatchDeleteTime                   *prometheus.SummaryVec
 	ObjectsTime                       *prometheus.SummaryVec
 	LSMBloomFilters                   *prometheus.SummaryVec
@@ -186,7 +189,7 @@ func (pm *PrometheusMetrics) DeleteClass(className string) error {
 }
 
 var (
-	msBuckets                    = []float64{10, 50, 100, 500, 1000, 5000}
+	msBuckets                    = []float64{10, 50, 100, 500, 1000, 5000, 10000, 60000, 300000}
 	metrics   *PrometheusMetrics = nil
 )
 
@@ -209,6 +212,19 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Help:    "Duration in ms of a single batch",
 			Buckets: msBuckets,
 		}, []string{"operation", "class_name", "shard_name"}),
+		BatchSizeBytes: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "batch_size_bytes",
+			Help: "Size of a raw batch request batch in bytes",
+		}, []string{"api"}),
+		BatchSizeObjects: promauto.NewSummary(prometheus.SummaryOpts{
+			Name: "batch_size_objects",
+			Help: "Number of objects in a batch",
+		}),
+		BatchSizeTenants: promauto.NewSummary(prometheus.SummaryOpts{
+			Name: "batch_size_tenants",
+			Help: "Number of unique tenants referenced in a batch",
+		}),
+
 		BatchDeleteTime: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "batch_delete_durations_ms",
 			Help: "Duration in ms of a single delete batch",

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -67,7 +67,7 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}
 
-	if _, err = m.autoSchemaManager.autoTenants(ctx, principal, []*models.Object{object}); err != nil {
+	if _, _, err = m.autoSchemaManager.autoTenants(ctx, principal, []*models.Object{object}); err != nil {
 		return nil, NewErrInternal(err.Error())
 	}
 

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -54,7 +54,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 
 	var maxSchemaVersion uint64
 	batchObjects, maxSchemaVersion := b.validateAndGetVector(ctx, principal, objects, repl)
-	schemaVersion, err := b.autoSchemaManager.autoTenants(ctx, principal, objects)
+	schemaVersion, tenantCount, err := b.autoSchemaManager.autoTenants(ctx, principal, objects)
 	if err != nil {
 		return nil, fmt.Errorf("auto create tenants: %w", err)
 	}
@@ -62,6 +62,8 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 		maxSchemaVersion = schemaVersion
 	}
 
+	b.metrics.BatchTenants(tenantCount)
+	b.metrics.BatchObjects(len(objects))
 	b.metrics.BatchOp("total_preprocessing", beforePreProcessing.UnixNano())
 
 	var res BatchObjects

--- a/usecases/objects/metrics.go
+++ b/usecases/objects/metrics.go
@@ -24,6 +24,8 @@ type Metrics struct {
 	dimensions         *prometheus.CounterVec
 	dimensionsCombined prometheus.Counter
 	groupClasses       bool
+	batchTenants       prometheus.Summary
+	batchObjects       prometheus.Summary
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -37,6 +39,8 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 		dimensions:         prom.QueryDimensions,
 		dimensionsCombined: prom.QueryDimensionsCombined,
 		groupClasses:       prom.Group,
+		batchTenants:       prom.BatchSizeTenants,
+		batchObjects:       prom.BatchSizeObjects,
 	}
 }
 
@@ -170,6 +174,22 @@ func (m *Metrics) BatchOp(op string, startNs int64) {
 		"class_name": "n/a",
 		"shard_name": "n/a",
 	}).Observe(float64(took))
+}
+
+func (m *Metrics) BatchTenants(tenants int) {
+	if m == nil {
+		return
+	}
+
+	m.batchTenants.Observe(float64(tenants))
+}
+
+func (m *Metrics) BatchObjects(objects int) {
+	if m == nil {
+		return
+	}
+
+	m.batchObjects.Observe(float64(objects))
 }
 
 func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dims int) {


### PR DESCRIPTION
### What's being changed:
* adds an equivalent to rest `total_api_level` in the form of `total_api_level_grpc` for the grpc API
* observes batch size in bytes (for both grpc and REST)
* observes number of objects and number of tenants per batch
* closes #5673

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
