### PR TITLE
Metrics for `text2vec` model base (shared across providers)

### DIFF
--- a/modules/text2vec-cohere/vectorizer/objects.go
+++ b/modules/text2vec-cohere/vectorizer/objects.go
@@ -52,7 +52,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 	}
 	// there does not seem to be a limit
 	maxTokensPerBatch := func(cfg moduletools.ClassConfig) int { return 500000 }
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger, "cohere"), batchTokenizer)
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-huggingface/vectorizer/objects.go
+++ b/modules/text2vec-huggingface/vectorizer/objects.go
@@ -51,5 +51,5 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 	}
 	// there does not seem to be a limit
 	maxTokensPerBatch := func(cfg moduletools.ClassConfig) int { return 500000 }
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger, "huggingface"), batchTokenizer)
 }

--- a/modules/text2vec-jinaai/vectorizer/objects.go
+++ b/modules/text2vec-jinaai/vectorizer/objects.go
@@ -51,7 +51,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 	// There is a limit of 8192 tokens per batch, however we cannot easily precompute how many tokens an object will.
 	// Therefore, we use a dummy value and let the jina API fail in case of a too large input object.
 	maxTokensPerBatch := func(cfg moduletools.ClassConfig) int { return 500000 }
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger, "jinaai"), batchTokenizer)
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-mistral/vectorizer/objects.go
+++ b/modules/text2vec-mistral/vectorizer/objects.go
@@ -63,7 +63,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 	// there does not seem to be a limit
 	maxTokensPerBatch := func(cfg moduletools.ClassConfig) int { return MaxTokensPerBatch }
 
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger, "mistral"), batchTokenizer)
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-octoai/vectorizer/objects.go
+++ b/modules/text2vec-octoai/vectorizer/objects.go
@@ -51,7 +51,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 	// There is a limit of 8192 tokens per batch, however we cannot easily precompute how many tokens an object will.
 	// Therefore, we use a dummy value and let the octo API fail in case of a too large input object.
 	maxTokensPerBatch := func(cfg moduletools.ClassConfig) int { return 500000 }
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, MaxTimePerBatch, logger, "octoai"), batchTokenizer)
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -63,7 +63,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 	// there does not seem to be a limit
 	maxTokensPerBatch := func(cfg moduletools.ClassConfig) int { return 500000 }
 
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, OpenAIMaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, OpenAIMaxTimePerBatch, logger, "openai"), batchTokenizer)
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/modules/text2vec-voyageai/vectorizer/objects.go
+++ b/modules/text2vec-voyageai/vectorizer/objects.go
@@ -71,7 +71,7 @@ func New(client text2vecbase.BatchClient, logger logrus.FieldLogger) *text2vecba
 		return 120000 // unknown model, use the smallest limit
 	}
 
-	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, OpenAIMaxTimePerBatch, logger), batchTokenizer)
+	return text2vecbase.New(client, batch.NewBatchVectorizer(client, 50*time.Second, MaxObjectsPerBatch, maxTokensPerBatch, OpenAIMaxTimePerBatch, logger, "voyageai"), batchTokenizer)
 }
 
 // IndexCheck returns whether a property of a class should be indexed

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 
 	"github.com/pkg/errors"
 	objectsvectorizer "github.com/weaviate/weaviate/usecases/modulecomponents/vectorizer"
@@ -71,7 +72,7 @@ type BatchClient interface {
 	GetApiKeyHash(ctx context.Context, config moduletools.ClassConfig) [32]byte
 }
 
-func NewBatchVectorizer(client BatchClient, maxBatchTime time.Duration, maxObjectsPerBatch int, maxTokensPerBatch func(cfg moduletools.ClassConfig) int, maxTimePerVectorizerBatch float64, logger logrus.FieldLogger) *Batch {
+func NewBatchVectorizer(client BatchClient, maxBatchTime time.Duration, maxObjectsPerBatch int, maxTokensPerBatch func(cfg moduletools.ClassConfig) int, maxTimePerVectorizerBatch float64, logger logrus.FieldLogger, label string) *Batch {
 	batch := Batch{
 		client:                    client,
 		objectVectorizer:          objectsvectorizer.New(),
@@ -82,6 +83,7 @@ func NewBatchVectorizer(client BatchClient, maxBatchTime time.Duration, maxObjec
 		maxTokensPerBatch:         maxTokensPerBatch,
 		concurrentBatches:         atomic.Int32{},
 		logger:                    logger,
+		label:                     label,
 	}
 
 	batch.rateLimitChannel = make(chan rateLimitJob, BatchChannelSize)
@@ -117,6 +119,7 @@ type Batch struct {
 	endOfBatchChannel         chan endOfBatchJob
 	concurrentBatches         atomic.Int32
 	logger                    logrus.FieldLogger
+	label                     string
 }
 
 // batchWorker is a go routine that handles the communication with the vectorizer
@@ -134,6 +137,13 @@ func (b *Batch) batchWorker() {
 
 	// the total batch should not take longer than 60s to avoid timeouts. We will only use 40s here to be safe
 	for job := range b.jobQueueCh {
+		// observe how long the batch was in the queue waiting for processing
+		durWaiting := time.Since(job.startTime).Seconds()
+		monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.label, "waiting_for_processing").
+			Observe(durWaiting)
+
+		startProcessingTime := time.Now()
+
 		// check if we already have rate limits for the current api key and reuse them if possible
 		rateLimit, ok := rateLimitPerApiKey[job.apiKeyHash]
 		if !ok {
@@ -159,6 +169,12 @@ func (b *Batch) batchWorker() {
 			objCounter++
 		}
 
+		stats := monitoring.GetMetrics().T2VRateLimitStats
+		stats.WithLabelValues(b.label, "token_limit").Set(float64(rateLimit.LimitTokens))
+		stats.WithLabelValues(b.label, "token_remaining").Set(float64(rateLimit.RemainingTokens))
+		stats.WithLabelValues(b.label, "request_limit").Set(float64(rateLimit.LimitRequests))
+		stats.WithLabelValues(b.label, "request_remaining").Set(float64(rateLimit.RemainingRequests))
+
 		// if we have a high rate limit we can send multiple batches in parallel.
 		//
 		// If the rate limit is high enough to "fit" the current batch, we send it concurrently. If not, we wait for
@@ -180,6 +196,7 @@ func (b *Batch) batchWorker() {
 			numRequests := 1 + int(1.25*float32(len(job.texts)))/objectsPerBatch // round up to be on the safe side
 			if rateLimit.CanSendFullBatch(numRequests, job.tokenSum) {
 				b.concurrentBatches.Add(1)
+				monitoring.GetMetrics().T2VBatches.WithLabelValues(b.label).Inc()
 				jobCopy := job.copy()
 				rateLimit.ReservedRequests += numRequests
 				rateLimit.ReservedTokens += job.tokenSum
@@ -194,12 +211,16 @@ func (b *Batch) batchWorker() {
 				break
 			} else if b.concurrentBatches.Load() < 1 {
 				b.concurrentBatches.Add(1)
+				monitoring.GetMetrics().T2VBatches.WithLabelValues(b.label).Inc()
 				// block so no concurrent batch can be sent
 				b.sendBatch(job, objCounter, rateLimit, timePerToken, 0, false)
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
+
+		monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.label, "processing").
+			Observe(time.Since(startProcessingTime).Seconds())
 	}
 }
 
@@ -367,9 +388,19 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 	}
 	job.wg.Done()
 	b.concurrentBatches.Add(-1)
+	monitoring.GetMetrics().T2VBatches.WithLabelValues(b.label).Dec()
 }
 
 func (b *Batch) makeRequest(job BatchJob, texts []string, cfg moduletools.ClassConfig, origIndex []int, rateLimit *modulecomponents.RateLimits, tokensInCurrentBatch int) error {
+	beforeRequest := time.Now()
+	defer func() {
+		monitoring.GetMetrics().T2VRequestDuration.WithLabelValues(b.label).
+			Observe(time.Since(beforeRequest).Seconds())
+	}()
+
+	monitoring.GetMetrics().T2VTokensInRequest.WithLabelValues(b.label).
+		Observe(float64(tokensInCurrentBatch))
+
 	res, rateLimitNew, err := b.client.Vectorize(job.ctx, texts, cfg)
 	if err != nil {
 		for j := 0; j < len(texts); j++ {
@@ -410,6 +441,10 @@ func (b *Batch) SubmitBatchAndWait(ctx context.Context, cfg moduletools.ClassCon
 		tokenSum += tokenCounts[i]
 	}
 
+	monitoring.GetMetrics().T2VTokensInBatch.WithLabelValues(b.label).
+		Observe(float64(tokenSum))
+
+	beforeEnqueue := time.Now()
 	b.jobQueueCh <- BatchJob{
 		ctx:        ctx,
 		wg:         &wg,
@@ -424,7 +459,15 @@ func (b *Batch) SubmitBatchAndWait(ctx context.Context, cfg moduletools.ClassCon
 		tokenSum:   tokenSum,
 	}
 
+	// observe enqueue duration
+	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.label, "enqueue").
+		Observe(time.Since(beforeEnqueue).Seconds())
+
 	wg.Wait()
+
+	// observe total duration
+	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.label, "total").
+		Observe(time.Since(beforeEnqueue).Seconds())
 	return vecs, errs
 }
 

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -95,7 +95,7 @@ func TestBatch(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			v := NewBatchVectorizer(client, 1*time.Second, 2000, maxTokensPerBatch, 2000.0, logger) // avoid waiting for rate limit
+			v := NewBatchVectorizer(client, 1*time.Second, 2000, maxTokensPerBatch, 2000.0, logger, "test") // avoid waiting for rate limit
 			deadline := time.Now().Add(10 * time.Second)
 			if tt.deadline != 0 {
 				deadline = time.Now().Add(tt.deadline)
@@ -128,7 +128,7 @@ func TestBatchMultiple(t *testing.T) {
 	cfg := &fakeClassConfig{vectorizePropertyName: false, classConfig: map[string]interface{}{"vectorizeClassName": false}}
 	logger, _ := test.NewNullLogger()
 
-	v := NewBatchVectorizer(client, 40*time.Second, 2000, maxTokensPerBatch, 2000.0, logger) // avoid waiting for rate limit
+	v := NewBatchVectorizer(client, 40*time.Second, 2000, maxTokensPerBatch, 2000.0, logger, "test") // avoid waiting for rate limit
 	res := make(chan int, 3)
 	wg := sync.WaitGroup{}
 	wg.Add(3)
@@ -183,7 +183,7 @@ func TestBatchTimeouts(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(fmt.Sprint("BatchTimeouts", tt.batchTime), func(t *testing.T) {
-			v := NewBatchVectorizer(client, tt.batchTime, 2000, maxTokensPerBatch, 2000.0, logger) // avoid waiting for rate limit
+			v := NewBatchVectorizer(client, tt.batchTime, 2000, maxTokensPerBatch, 2000.0, logger, "test") // avoid waiting for rate limit
 
 			texts, tokenCounts := generateTokens(objs)
 
@@ -216,7 +216,7 @@ func TestBatchRequestLimit(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(fmt.Sprint("Test request limit with", tt.batchTime), func(t *testing.T) {
-			v := NewBatchVectorizer(client, tt.batchTime, 2000, maxTokensPerBatch, 2000.0, logger) // avoid waiting for rate limit
+			v := NewBatchVectorizer(client, tt.batchTime, 2000, maxTokensPerBatch, 2000.0, logger, "test") // avoid waiting for rate limit
 
 			_, errs := v.SubmitBatchAndWait(context.Background(), cfg, skip, tokenCounts, texts)
 			require.Len(t, errs, tt.expectedErrors)
@@ -246,7 +246,7 @@ func TestBatchMaxTokens(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(fmt.Sprint("Max tokens", tt.name), func(t *testing.T) {
-			v := NewBatchVectorizer(client, time.Second, 2000, tt.maxTokens, 2000.0, logger) // avoid waiting for rate limit
+			v := NewBatchVectorizer(client, time.Second, 2000, tt.maxTokens, 2000.0, logger, "test") // avoid waiting for rate limit
 
 			_, errs := v.SubmitBatchAndWait(context.Background(), cfg, skip, tokenCounts, texts)
 			require.Len(t, errs, tt.expectedErrors)

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -108,6 +108,14 @@ type PrometheusMetrics struct {
 	SchemaTxOpened   *prometheus.CounterVec
 	SchemaTxClosed   *prometheus.CounterVec
 	SchemaTxDuration *prometheus.SummaryVec
+
+	// Vectorization
+	T2VBatches            *prometheus.GaugeVec
+	T2VBatchQueueDuration *prometheus.HistogramVec
+	T2VRequestDuration    *prometheus.HistogramVec
+	T2VTokensInBatch      *prometheus.HistogramVec
+	T2VTokensInRequest    *prometheus.HistogramVec
+	T2VRateLimitStats     *prometheus.GaugeVec
 }
 
 // Delete Shard deletes existing label combinations that match both
@@ -190,6 +198,7 @@ func (pm *PrometheusMetrics) DeleteClass(className string) error {
 
 var (
 	msBuckets                    = []float64{10, 50, 100, 500, 1000, 5000, 10000, 60000, 300000}
+	sBuckets                     = []float64{0.01, 0.1, 1, 10, 20, 30, 60, 120, 180, 500}
 	metrics   *PrometheusMetrics = nil
 )
 
@@ -510,6 +519,35 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "tombstone_delete_list_size",
 			Help: "Delete list size of tombstones",
 		}, []string{"class_name", "shard_name"}),
+
+		T2VBatches: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "t2v_concurrent_batches",
+			Help: "Number of batches currently running",
+		}, []string{"vectorizer"}),
+		T2VBatchQueueDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "t2v_batch_queue_duration_seconds",
+			Help:    "Time of a batch spend in specific portions of the queue",
+			Buckets: sBuckets,
+		}, []string{"vectorizer", "operation"}),
+		T2VRequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "t2v_request_duration_seconds",
+			Help:    "Duration of an individual request to the vectorizer",
+			Buckets: sBuckets,
+		}, []string{"vectorizer"}),
+		T2VTokensInBatch: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "t2v_tokens_in_batch",
+			Help:    "Number of tokens in a user-defined batch",
+			Buckets: []float64{1, 10, 100, 1000, 10000, 100000, 1000000},
+		}, []string{"vectorizer"}),
+		T2VTokensInRequest: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "t2v_tokens_in_request",
+			Help:    "Number of tokens in an individual request sent to the vectorizer",
+			Buckets: []float64{1, 10, 100, 1000, 10000, 100000, 1000000},
+		}, []string{"vectorizer"}),
+		T2VRateLimitStats: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "t2v_rate_limit_stats",
+			Help: "Rate limit stats for the vectorizer",
+		}, []string{"vectorizer", "stat"}),
 	}
 }
 

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -116,6 +116,7 @@ type PrometheusMetrics struct {
 	T2VTokensInBatch      *prometheus.HistogramVec
 	T2VTokensInRequest    *prometheus.HistogramVec
 	T2VRateLimitStats     *prometheus.GaugeVec
+	T2VRequestsPerBatch   *prometheus.HistogramVec
 }
 
 // Delete Shard deletes existing label combinations that match both
@@ -548,6 +549,11 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "t2v_rate_limit_stats",
 			Help: "Rate limit stats for the vectorizer",
 		}, []string{"vectorizer", "stat"}),
+		T2VRequestsPerBatch: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "t2v_requests_per_batch",
+			Help:    "Number of requests required to process an entire (user) batch",
+			Buckets: []float64{1, 2, 5, 10, 100, 1000},
+		}, []string{"vectorizer"}),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:
* Observe token count in batch (user batch)
* Observe token count in request to vectorizer (can be smaller than user batch)
* Observe duration of request to vectorizer (as histogram buckets)
* Observe duration of a full batch split into:
   * time spent enqueing
   * time spent waiting in the queue
   * time spent processing
   * total
* Observe general rate limit stats (token limit, remaining tokens, request limit, remaining requests)  


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
