### PR TITLE
Fix nil nodes in unreachability function

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -766,11 +766,13 @@ func (h *hnsw) calculateUnreachablePoints() []uint64 {
 			visitedPairs[currentNode] = true
 			h.shardedNodeLocks.RLock(currentNode.nodeId)
 			node := h.nodes[currentNode.nodeId]
-			node.Lock()
-			neighbors := node.connectionsAtLowerLevelsNoLock(currentNode.level, visitedPairs)
-			node.Unlock()
+			if node != nil {
+				node.Lock()
+				neighbors := node.connectionsAtLowerLevelsNoLock(currentNode.level, visitedPairs)
+				node.Unlock()
+				candidateList = append(candidateList, neighbors...)
+			}
 			h.shardedNodeLocks.RUnlock(currentNode.nodeId)
-			candidateList = append(candidateList, neighbors...)
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:
This PR fix the function `calculateUnreachablePoints` which was not able to manage `nil` nodes. (A `nil` node can be caused from deletions and deletes in the hnsw graph.)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
