### PR TITLE
Turn term into interface to prepare support for Inverted format

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -452,7 +452,11 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 
 	if len(nonEmptyMsAndProps) == 1 {
 		termResult.data = allMsAndProps[0]
-		termResult.idf = math.Log(float64(1)+(N-float64(len(termResult.data))+0.5)/(float64(len(termResult.data))+0.5)) * float64(duplicateTextBoost)
+		n := float64(len(termResult.data))
+		if filterDocIds != nil {
+			n += float64(filteredDocIDs.GetCardinality())
+		}
+		termResult.idf = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoost)
 		termResult.posPointer = 0
 		termResult.idPointer = termResult.data[0].Id
 		return termResult, nil

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -568,6 +568,7 @@ func (t *term) ScoreAndAdvance(averagePropLength float64, config schema.BM25Conf
 	t.posPointer++
 	if t.posPointer >= uint64(len(t.data)) {
 		t.exhausted = true
+		t.idPointer = math.MaxUint64 // force them to the end of the term list
 	} else {
 		t.idPointer = t.data[t.posPointer].Id
 	}
@@ -580,6 +581,7 @@ func (t *term) AdvanceAtLeast(minID uint64) {
 		t.posPointer++
 		if t.posPointer >= uint64(len(t.data)) {
 			t.exhausted = true
+			t.idPointer = math.MaxUint64 // force them to the end of the term list
 			return
 		}
 		t.idPointer = t.data[t.posPointer].Id
@@ -611,7 +613,6 @@ func (t *term) Count() int {
 }
 
 type MapPairsAndPropName struct {
-	propname string
 	MapPairs []lsmkv.MapPair
 }
 

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -12,14 +12,13 @@
 package inverted
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
-	"sort"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/weaviate/weaviate/entities/additional"
 
@@ -380,7 +379,8 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 ) (term, error) {
 	termResult := term{queryTerm: query, queryTermIndex: queryTermIndex}
 	filteredDocIDs := sroar.NewBitmap() // to build the global n if there is a filter
-	filterLock := sync.Mutex{}
+	filteredDocIDsThread := make([]*sroar.Bitmap, len(propertyNames))
+
 	eg := enterrors.NewErrorGroupWrapper(b.logger)
 	eg.SetLimit(_NUMCPU)
 
@@ -402,15 +402,16 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 
 				var m []lsmkv.MapPair
 				if filterDocIds != nil {
+					if filteredDocIDsThread[i] == nil {
+						filteredDocIDsThread[i] = sroar.NewBitmap()
+					}
 					m = make([]lsmkv.MapPair, 0, len(preM))
 					for _, val := range preM {
 						docID := binary.BigEndian.Uint64(val.Key)
 						if filterDocIds.Contains(docID) {
 							m = append(m, val)
 						} else {
-							filterLock.Lock()
-							filteredDocIDs.Set(docID)
-							filterLock.Unlock()
+							filteredDocIDsThread[i].Set(docID)
 						}
 					}
 				} else {
@@ -443,89 +444,98 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 		}
 	}
 
-	// sort ascending, this code has two effects
-	// 1) We can skip writing the indices from the last property to the map (see next comment). Therefore, having the
-	//    biggest property at the end will save us most writes on average
-	// 2) For the first property all entries are new, and we can create the map with the respective size. When choosing
-	//    the second-biggest entry as the first property we save additional allocations later
-	sort.Sort(allMsAndProps)
-	if len(allMsAndProps) > 2 {
-		allMsAndProps[len(allMsAndProps)-2], allMsAndProps[0] = allMsAndProps[0], allMsAndProps[len(allMsAndProps)-2]
+	if filterDocIds != nil {
+		for _, docIDs := range filteredDocIDsThread {
+			if docIDs != nil {
+				filteredDocIDs.Or(docIDs)
+			}
+		}
 	}
 
+	indices := make([]int, len(allMsAndProps))
 	var docMapPairs []terms.DocPointerWithScore = nil
-	var docMapPairsIndices map[uint64]int = nil
-	for i, mAndProps := range allMsAndProps {
-		m := mAndProps.MapPairs
 
-		// The indices are needed for two things:
-		// a) combining the results of different properties
-		// b) Retrieve additional information that helps to understand the results when debugging. The retrieval is done
-		//    in a later step, after it is clear which objects are the most relevant
-		//
-		// When b) is not needed the results from the last property do not need to be added to the index-map as there
-		// won't be any follow-up combinations.
-		includeIndicesForLastElement := false
-		if additionalExplanations || i < len(allMsAndProps)-1 {
-			includeIndicesForLastElement = true
+	// The indices are needed to combining the results of different properties
+	// They were previously used to keep track of additional explanations TF and prop len,
+	// but this is now done when adding terms to the heap in the getTopKHeap function
+	var docMapPairsIndices map[uint64]int = nil
+
+	for {
+		i := -1
+		minKey := make([]byte, 8)
+		for ti, mAndProps := range allMsAndProps {
+			if indices[ti] >= len(mAndProps.MapPairs) {
+				continue
+			}
+			ki := mAndProps.MapPairs[indices[ti]].Key
+			if i == -1 || bytes.Compare(ki, minKey) < 0 {
+				i = ti
+				copy(minKey, ki)
+			}
 		}
+
+		if i == -1 {
+			break
+		}
+
+		m := allMsAndProps[i].MapPairs
+		k := indices[i]
+		val := m[indices[i]]
+
+		indices[i]++
+
+		propBoost := propertyBoosts[allMsAndProps[i].propname]
 
 		// only create maps/slices if we know how many entries there are
 		if docMapPairs == nil {
 			docMapPairs = make([]terms.DocPointerWithScore, 0, len(m))
 			docMapPairsIndices = make(map[uint64]int, len(m))
-			for k, val := range m {
-				if len(val.Value) < 8 {
-					b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(val.Value))
+			if len(val.Value) < 8 {
+				b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(val.Value))
+				continue
+			}
+			freqBits := binary.LittleEndian.Uint32(val.Value[0:4])
+			propLenBits := binary.LittleEndian.Uint32(val.Value[4:8])
+			docMapPairs = append(docMapPairs,
+				terms.DocPointerWithScore{
+					Id:         binary.BigEndian.Uint64(val.Key),
+					Frequency:  math.Float32frombits(freqBits) * propBoost,
+					PropLength: math.Float32frombits(propLenBits),
+				})
+			docMapPairsIndices[binary.BigEndian.Uint64(val.Key)] = k
+
+		} else {
+			if len(val.Value) < 8 {
+				b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(val.Value))
+				continue
+			}
+			key := binary.BigEndian.Uint64(val.Key)
+			ind, ok := docMapPairsIndices[key]
+			freqBits := binary.LittleEndian.Uint32(val.Value[0:4])
+			propLenBits := binary.LittleEndian.Uint32(val.Value[4:8])
+			if ok {
+				if ind >= len(docMapPairs) {
+					// the index is not valid anymore, but the key is still in the map
+					b.logger.Warnf("Skipping pair in BM25: Index %d is out of range for key %d, length %d.", ind, key, len(docMapPairs))
 					continue
 				}
-				freqBits := binary.LittleEndian.Uint32(val.Value[0:4])
-				propLenBits := binary.LittleEndian.Uint32(val.Value[4:8])
+				if ind < len(docMapPairs) && docMapPairs[ind].Id != key {
+					b.logger.Warnf("Skipping pair in BM25: id at %d in doc map pairs, %d, differs from current key, %d", ind, docMapPairs[ind].Id, key)
+					continue
+				}
+
+				docMapPairs[ind].PropLength += math.Float32frombits(propLenBits)
+				docMapPairs[ind].Frequency += math.Float32frombits(freqBits) * propBoost
+			} else {
 				docMapPairs = append(docMapPairs,
 					terms.DocPointerWithScore{
 						Id:         binary.BigEndian.Uint64(val.Key),
-						Frequency:  math.Float32frombits(freqBits) * propertyBoosts[mAndProps.propname],
+						Frequency:  math.Float32frombits(freqBits) * propBoost,
 						PropLength: math.Float32frombits(propLenBits),
 					})
-				if includeIndicesForLastElement {
-					docMapPairsIndices[binary.BigEndian.Uint64(val.Key)] = k
-				}
+				docMapPairsIndices[binary.BigEndian.Uint64(val.Key)] = len(docMapPairs) - 1 // current last entry
 			}
-		} else {
-			for _, val := range m {
-				if len(val.Value) < 8 {
-					b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(val.Value))
-					continue
-				}
-				key := binary.BigEndian.Uint64(val.Key)
-				ind, ok := docMapPairsIndices[key]
-				freqBits := binary.LittleEndian.Uint32(val.Value[0:4])
-				propLenBits := binary.LittleEndian.Uint32(val.Value[4:8])
-				if ok {
-					if ind >= len(docMapPairs) {
-						// the index is not valid anymore, but the key is still in the map
-						b.logger.Warnf("Skipping pair in BM25: Index %d is out of range for key %d, length %d.", ind, key, len(docMapPairs))
-						continue
-					}
-					if ind < len(docMapPairs) && docMapPairs[ind].Id != key {
-						b.logger.Warnf("Skipping pair in BM25: id at %d in doc map pairs, %d, differs from current key, %d", ind, docMapPairs[ind].Id, key)
-						continue
-					}
 
-					docMapPairs[ind].PropLength += math.Float32frombits(propLenBits)
-					docMapPairs[ind].Frequency += math.Float32frombits(freqBits) * propertyBoosts[mAndProps.propname]
-				} else {
-					docMapPairs = append(docMapPairs,
-						terms.DocPointerWithScore{
-							Id:         binary.BigEndian.Uint64(val.Key),
-							Frequency:  math.Float32frombits(freqBits) * propertyBoosts[mAndProps.propname],
-							PropLength: math.Float32frombits(propLenBits),
-						})
-					if includeIndicesForLastElement {
-						docMapPairsIndices[binary.BigEndian.Uint64(val.Key)] = len(docMapPairs) - 1 // current last entry
-					}
-				}
-			}
 		}
 	}
 	if docMapPairs == nil {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -433,11 +433,15 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 		}
 	}
 
+	largestN := 0
 	// remove empty results from allMsAndProps
 	nonEmptyMsAndProps := make([][]terms.DocPointerWithScore, 0, len(allMsAndProps))
 	for _, m := range allMsAndProps {
 		if len(m) > 0 {
 			nonEmptyMsAndProps = append(nonEmptyMsAndProps, m)
+		}
+		if len(m) > largestN {
+			largestN = len(m)
 		}
 	}
 	allMsAndProps = nonEmptyMsAndProps
@@ -462,7 +466,6 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 	// They were previously used to keep track of additional explanations TF and prop len,
 	// but this is now done when adding terms to the heap in the getTopKHeap function
 	var docMapPairsIndices map[uint64]int = nil
-
 	for {
 		i := -1
 		minId := uint64(0)
@@ -489,8 +492,8 @@ func (b *BM25Searcher) createTerm(ctx context.Context, N float64, filterDocIds h
 
 		// only create maps/slices if we know how many entries there are
 		if docMapPairs == nil {
-			docMapPairs = make([]terms.DocPointerWithScore, 0, len(m))
-			docMapPairsIndices = make(map[uint64]int, len(m))
+			docMapPairs = make([]terms.DocPointerWithScore, 0, largestN)
+			docMapPairsIndices = make(map[uint64]int, largestN)
 
 			docMapPairs = append(docMapPairs, val)
 			docMapPairsIndices[val.Id] = k

--- a/adapters/repos/db/inverted/terms/bm25_terms.go
+++ b/adapters/repos/db/inverted/terms/bm25_terms.go
@@ -229,6 +229,8 @@ func (t *Terms) Pivot(minScore float64) bool {
 	}
 
 	t.AdvanceAllAtLeast(minID)
+
+	// we don't need to sort the entire list, just the first pivotPoint elements
 	t.PartialSort()
 	return false
 }
@@ -317,19 +319,15 @@ func (t *Terms) FullSort() {
 }
 
 func (t *Terms) PartialSort() {
-	// ensure the first element is the one with the lowest id instead of doing a full sort
-	if len(t.T) < 2 {
-		return
-	}
-	min := t.T[0].IdPointer()
-	minIndex := 0
-	for i := 1; i < len(t.T); i++ {
-		if t.T[i].IdPointer() < min {
+	min := uint64(0)
+	minIndex := -1
+	for i := 0; i < len(t.T); i++ {
+		if minIndex == -1 || (t.T[i].IdPointer() < min && !t.T[i].IsExhausted()) {
 			min = t.T[i].IdPointer()
 			minIndex = i
 		}
 	}
-	if minIndex != 0 {
+	if minIndex > 0 {
 		t.T[0], t.T[minIndex] = t.T[minIndex], t.T[0]
 	}
 }

--- a/adapters/repos/db/inverted/terms/bm25_terms.go
+++ b/adapters/repos/db/inverted/terms/bm25_terms.go
@@ -12,8 +12,12 @@
 package terms
 
 import (
+	"context"
+	"encoding/binary"
+	"math"
 	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
@@ -21,6 +25,159 @@ type DocPointerWithScore struct {
 	Id         uint64
 	Frequency  float32
 	PropLength float32
+}
+
+func (d *DocPointerWithScore) FromBytes(in []byte, boost float32) error {
+	var read uint16
+
+	keyLen := binary.LittleEndian.Uint16(in[:2])
+	read += 2 // uint16 -> 2 bytes
+
+	key := in[read : read+keyLen]
+	read += keyLen
+
+	valueLen := binary.LittleEndian.Uint16(in[read : read+2])
+	read += 2
+
+	if valueLen == 0 {
+		d.Id = binary.BigEndian.Uint64(key)
+		d.Frequency = 0
+		d.PropLength = 0
+		return nil
+	}
+
+	value := in[read : read+valueLen]
+	read += valueLen
+
+	return d.FromKeyVal(key, value, boost)
+}
+
+func (d *DocPointerWithScore) FromKeyVal(key []byte, value []byte, boost float32) error {
+	d.Id = binary.BigEndian.Uint64(key)
+	d.Frequency = math.Float32frombits(binary.LittleEndian.Uint32(value[:4])) * boost
+	d.PropLength = math.Float32frombits(binary.LittleEndian.Uint32(value[4:]))
+	return nil
+}
+
+type SortedDocPointerWithScoreMerger struct {
+	input   [][]DocPointerWithScore
+	output  []DocPointerWithScore
+	offsets []int
+}
+
+func NewSortedDocPointerWithScoreMerger() *SortedDocPointerWithScoreMerger {
+	return &SortedDocPointerWithScoreMerger{}
+}
+
+func (s *SortedDocPointerWithScoreMerger) init(segments [][]DocPointerWithScore) error {
+	s.input = segments
+
+	// all offset pointers initialized at 0 which is where we want to start
+	s.offsets = make([]int, len(segments))
+
+	// The maximum output is the sum of all the input segments if there are only
+	// unique keys and zero tombstones. If there are duplicate keys (i.e.
+	// updates) or tombstones, we will slice off some elements of the output
+	// later, but this way we can be sure each index will always be initialized
+	// correctly
+	maxOutput := 0
+	for _, seg := range segments {
+		maxOutput += len(seg)
+	}
+	s.output = make([]DocPointerWithScore, maxOutput)
+
+	return nil
+}
+
+func (s *SortedDocPointerWithScoreMerger) findSegmentWithLowestKey() (DocPointerWithScore, bool) {
+	bestSeg := -1
+	bestKey := uint64(0)
+
+	for segmentID := 0; segmentID < len(s.input); segmentID++ {
+		// check if a segment is already exhausted, then skip
+		if s.offsets[segmentID] >= len(s.input[segmentID]) {
+			continue
+		}
+
+		currKey := s.input[segmentID][s.offsets[segmentID]].Id
+		if bestSeg == -1 {
+			// first time we're running, no need to compare, just set to current
+			bestSeg = segmentID
+			bestKey = currKey
+			continue
+		}
+
+		if currKey > bestKey {
+			// the segment we are currently looking at has a higher key than our
+			// current best so we can completely ignore it
+			continue
+		}
+
+		if currKey < bestKey {
+			// the segment we are currently looking at is a better match than the
+			// previous, this means, we have found a new favorite, but the previous
+			// best will still be valid in a future round
+			bestSeg = segmentID
+			bestKey = currKey
+			continue
+		}
+
+		if currKey == bestKey {
+			// this the most interesting case: we are looking at a duplicate key. In
+			// this case the rightmost ("latest") segment takes precedence, however,
+			// we must make sure that the previous match gets discarded, otherwise we
+			// will find it again in the next round.
+			//
+			// We can simply increase the offset before updating the bestSeg pointer,
+			// which means we will never look at this element again
+			s.offsets[bestSeg]++
+
+			// now that the old element is discarded, we can update our pointers
+			bestSeg = segmentID
+			bestKey = currKey
+		}
+	}
+
+	if bestSeg == -1 {
+		// we didn't find anything, looks like we have exhausted all segments
+		return DocPointerWithScore{}, false
+	}
+
+	// we can now be sure that bestSeg,bestKey is the latest version of the
+	// lowest key, there is only one job left to do: increase the offset, so we
+	// never find this segment again
+	bestMatch := s.input[bestSeg][s.offsets[bestSeg]]
+	s.offsets[bestSeg]++
+
+	return bestMatch, true
+}
+
+func (s *SortedDocPointerWithScoreMerger) Do(ctx context.Context, segments [][]DocPointerWithScore) ([]DocPointerWithScore, error) {
+	if err := s.init(segments); err != nil {
+		return nil, errors.Wrap(err, "init sorted map decoder")
+	}
+
+	i := 0
+	for {
+		if i%100 == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		match, ok := s.findSegmentWithLowestKey()
+		if !ok {
+			break
+		}
+
+		if match.Frequency == 0 { // tombstone
+			// the latest version of this key was a tombstone, so we can ignore it
+			continue
+		}
+
+		s.output[i] = match
+		i++
+	}
+
+	return s.output[:i], nil
 }
 
 type ById []DocPointerWithScore
@@ -63,7 +220,7 @@ func (t *Terms) CompletelyExhausted() bool {
 }
 
 func (t *Terms) Pivot(minScore float64) bool {
-	minID, pivotPoint, abort := t.findMinID(minScore)
+	minID, pivotPoint, abort := t.FindMinID(minScore)
 	if abort {
 		return true
 	}
@@ -71,40 +228,51 @@ func (t *Terms) Pivot(minScore float64) bool {
 		return false
 	}
 
-	t.advanceAllAtLeast(minID)
-	t.FullSort()
+	t.AdvanceAllAtLeast(minID)
+	t.PartialSort()
 	return false
 }
 
-func (t *Terms) advanceAllAtLeast(minID uint64) {
+func (t *Terms) AdvanceAllAtLeast(minID uint64) {
 	for i := range t.T {
 		t.T[i].AdvanceAtLeast(minID)
 	}
 }
 
-func (t *Terms) findMinID(minScore float64) (uint64, int, bool) {
+func (t *Terms) FindMinID(minScore float64) (uint64, int, bool) {
 	cumScore := float64(0)
-	i := 0
-	for i < len(t.T) && len(t.T) > 0 {
-		term := t.T[i]
+
+	for i, term := range t.T {
 		if term.IsExhausted() {
-			// remove from list
-			t.T = append(t.T[:i], t.T[i+1:]...)
 			continue
 		}
 		cumScore += term.IDF()
 		if cumScore >= minScore {
-			// fmt.Printf("Pivot at %v, %v\n", term.IdPointer(), term.QueryTerm())
 			return term.IdPointer(), i, false
 		}
-		i++
 	}
 
 	return 0, 0, true
 }
 
+func (t *Terms) FindFirstNonExhausted() (int, bool) {
+	for i := range t.T {
+		if !t.T[i].IsExhausted() {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
 func (t *Terms) ScoreNext(averagePropLength float64, config schema.BM25Config, additionalExplanations bool) (uint64, float64, []*DocPointerWithScore) {
 	var docInfos []*DocPointerWithScore
+
+	pos, ok := t.FindFirstNonExhausted()
+	if !ok {
+		// done, nothing left to score
+		return 0, 0, docInfos
+	}
 
 	if len(t.T) == 0 {
 		return 0, 0, docInfos
@@ -114,15 +282,10 @@ func (t *Terms) ScoreNext(averagePropLength float64, config schema.BM25Config, a
 		docInfos = make([]*DocPointerWithScore, t.Count)
 	}
 
-	id := t.T[0].IdPointer()
+	id := t.T[pos].IdPointer()
 	var cumScore float64
-	for i := 0; i < len(t.T); i++ {
+	for i := pos; i < len(t.T); i++ {
 		if t.T[i].IdPointer() != id || t.T[i].IsExhausted() {
-			if t.T[i].IsExhausted() {
-				// remove from list
-				t.T = append(t.T[:i], t.T[i+1:]...)
-				i--
-			}
 			continue
 		}
 		_, score, docInfo := t.T[i].ScoreAndAdvance(averagePropLength, config)
@@ -133,7 +296,6 @@ func (t *Terms) ScoreNext(averagePropLength float64, config schema.BM25Config, a
 	}
 
 	t.FullSort()
-
 	return id, cumScore, docInfos
 }
 
@@ -152,4 +314,22 @@ func (t *Terms) Swap(i, j int) {
 
 func (t *Terms) FullSort() {
 	sort.Sort(t)
+}
+
+func (t *Terms) PartialSort() {
+	// ensure the first element is the one with the lowest id instead of doing a full sort
+	if len(t.T) < 2 {
+		return
+	}
+	min := t.T[0].IdPointer()
+	minIndex := 0
+	for i := 1; i < len(t.T); i++ {
+		if t.T[i].IdPointer() < min {
+			min = t.T[i].IdPointer()
+			minIndex = i
+		}
+	}
+	if minIndex != 0 {
+		t.T[0], t.T[minIndex] = t.T[minIndex], t.T[0]
+	}
 }

--- a/adapters/repos/db/inverted/terms/bm25_terms.go
+++ b/adapters/repos/db/inverted/terms/bm25_terms.go
@@ -1,0 +1,155 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package terms
+
+import (
+	"sort"
+
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+type DocPointerWithScore struct {
+	Id         uint64
+	Frequency  float32
+	PropLength float32
+}
+
+type ById []DocPointerWithScore
+
+func (s ById) Len() int {
+	return len(s)
+}
+
+func (s ById) Less(i, j int) bool {
+	return s[i].Id < s[j].Id
+}
+
+func (s ById) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type Term interface {
+	ScoreAndAdvance(averagePropLength float64, config schema.BM25Config) (uint64, float64, DocPointerWithScore)
+	AdvanceAtLeast(minID uint64)
+	IsExhausted() bool
+	IdPointer() uint64
+	IDF() float64
+	QueryTerm() string
+	QueryTermIndex() int
+	Count() int
+}
+
+type Terms struct {
+	T     []Term
+	Count int
+}
+
+func (t *Terms) CompletelyExhausted() bool {
+	for i := range t.T {
+		if !t.T[i].IsExhausted() {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *Terms) Pivot(minScore float64) bool {
+	minID, pivotPoint, abort := t.findMinID(minScore)
+	if abort {
+		return true
+	}
+	if pivotPoint == 0 {
+		return false
+	}
+
+	t.advanceAllAtLeast(minID)
+	t.FullSort()
+	return false
+}
+
+func (t *Terms) advanceAllAtLeast(minID uint64) {
+	for i := range t.T {
+		t.T[i].AdvanceAtLeast(minID)
+	}
+}
+
+func (t *Terms) findMinID(minScore float64) (uint64, int, bool) {
+	cumScore := float64(0)
+	i := 0
+	for i < len(t.T) && len(t.T) > 0 {
+		term := t.T[i]
+		if term.IsExhausted() {
+			// remove from list
+			t.T = append(t.T[:i], t.T[i+1:]...)
+			continue
+		}
+		cumScore += term.IDF()
+		if cumScore >= minScore {
+			// fmt.Printf("Pivot at %v, %v\n", term.IdPointer(), term.QueryTerm())
+			return term.IdPointer(), i, false
+		}
+		i++
+	}
+
+	return 0, 0, true
+}
+
+func (t *Terms) ScoreNext(averagePropLength float64, config schema.BM25Config, additionalExplanations bool) (uint64, float64, []*DocPointerWithScore) {
+	var docInfos []*DocPointerWithScore
+
+	if len(t.T) == 0 {
+		return 0, 0, docInfos
+	}
+
+	if additionalExplanations {
+		docInfos = make([]*DocPointerWithScore, t.Count)
+	}
+
+	id := t.T[0].IdPointer()
+	var cumScore float64
+	for i := 0; i < len(t.T); i++ {
+		if t.T[i].IdPointer() != id || t.T[i].IsExhausted() {
+			if t.T[i].IsExhausted() {
+				// remove from list
+				t.T = append(t.T[:i], t.T[i+1:]...)
+				i--
+			}
+			continue
+		}
+		_, score, docInfo := t.T[i].ScoreAndAdvance(averagePropLength, config)
+		if additionalExplanations {
+			docInfos[t.T[i].QueryTermIndex()] = &docInfo
+		}
+		cumScore += score
+	}
+
+	t.FullSort()
+
+	return id, cumScore, docInfos
+}
+
+// provide sort interface
+func (t *Terms) Len() int {
+	return len(t.T)
+}
+
+func (t *Terms) Less(i, j int) bool {
+	return t.T[i].IdPointer() < t.T[j].IdPointer()
+}
+
+func (t *Terms) Swap(i, j int) {
+	t.T[i], t.T[j] = t.T[j], t.T[i]
+}
+
+func (t *Terms) FullSort() {
+	sort.Sort(t)
+}


### PR DESCRIPTION
### What's being changed:

- term is turned into an interface
- additionalExplanations are done at topK heap level, instead of full pre-processing
- misc. BM25F improvements

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
