### PR TITLE
Removes bash from the docker image and adds bc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,6 @@ COPY --from=grpc_health_probe_builder /bin/grpc_health_probe /bin/
 COPY --from=server_builder /weaviate-server /bin/weaviate
 RUN mkdir -p /go/pkg/mod/github.com/go-ego
 COPY --from=server_builder /go/pkg/mod/github.com/go-ego /go/pkg/mod/github.com/go-ego
-RUN apk add --no-cache --upgrade bash ca-certificates openssl
+RUN apk add --no-cache --upgrade bc ca-certificates openssl
 RUN mkdir ./modules
 CMD [ "--host", "0.0.0.0", "--port", "8080", "--scheme", "http"]


### PR DESCRIPTION
### What's being changed:
Bash cannot perform floating point math, we will use bc to do that.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
