### PR TITLE
Make max_tokens consistent with databricks API

### DIFF
--- a/modules/generative-databricks/clients/databricks.go
+++ b/modules/generative-databricks/clients/databricks.go
@@ -170,8 +170,8 @@ func (v *databricks) getParameters(cfg moduletools.ClassConfig, options interfac
 		params.TopP = &topP
 	}
 	if params.MaxTokens == nil {
-		maxTokens := int(settings.MaxTokens())
-		params.MaxTokens = &maxTokens
+		maxTokens := settings.MaxTokens()
+		params.MaxTokens = maxTokens
 	}
 
 	return params

--- a/modules/generative-databricks/clients/databricks_test.go
+++ b/modules/generative-databricks/clients/databricks_test.go
@@ -154,14 +154,14 @@ func ptString(in string) *string {
 }
 
 type fakeClassSettings struct {
-	maxTokens   float64
+	maxTokens   *int
 	temperature float64
 	topP        float64
 	topK        int
 	endpoint    string
 }
 
-func (s *fakeClassSettings) MaxTokens() float64 {
+func (s *fakeClassSettings) MaxTokens() *int {
 	return s.maxTokens
 }
 

--- a/modules/generative-databricks/config/class_settings.go
+++ b/modules/generative-databricks/config/class_settings.go
@@ -36,7 +36,7 @@ var (
 )
 
 type ClassSettings interface {
-	MaxTokens() float64
+	MaxTokens() *int
 	Temperature() float64
 	TopP() float64
 	TopK() int
@@ -64,7 +64,7 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		return errors.Errorf("Wrong temperature configuration, values are between 0.0 and 1.0")
 	}
 
-	maxTokens := ic.getFloatProperty(maxTokensProperty, &DefaultDatabricksMaxTokens)
+	maxTokens := ic.getIntProperty(maxTokensProperty, nil)
 	if maxTokens != nil && *maxTokens <= 0 {
 		return errors.Errorf("Wrong maxTokens configuration, values should be greater than zero or nil")
 	}
@@ -103,8 +103,8 @@ func (ic *classSettings) getIntProperty(name string, defaultValue *int) *int {
 	return ic.propertyValuesHelper.GetPropertyAsIntWithNotExists(ic.cfg, name, &wrongVal, defaultValue)
 }
 
-func (ic *classSettings) MaxTokens() float64 {
-	return *ic.getFloatProperty(maxTokensProperty, &DefaultDatabricksMaxTokens)
+func (ic *classSettings) MaxTokens() *int {
+	return ic.getIntProperty(maxTokensProperty, nil)
 }
 
 func (ic *classSettings) Temperature() float64 {

--- a/modules/generative-databricks/config/class_settings_test.go
+++ b/modules/generative-databricks/config/class_settings_test.go
@@ -22,10 +22,12 @@ import (
 )
 
 func Test_classSettings_Validate(t *testing.T) {
+	maxTokens42 := 42
+
 	tests := []struct {
 		name            string
 		cfg             moduletools.ClassConfig
-		wantMaxTokens   float64
+		wantMaxTokens   *int
 		wantTemperature float64
 		wantTopP        float64
 		wantTopK        int
@@ -39,7 +41,7 @@ func Test_classSettings_Validate(t *testing.T) {
 					"endpoint": "https://foo.bar.com",
 				},
 			},
-			wantMaxTokens:   8192,
+			wantMaxTokens:   nil,
 			wantTemperature: 1.0,
 			wantTopP:        1,
 			wantTopK:        math.MaxInt64,
@@ -57,7 +59,7 @@ func Test_classSettings_Validate(t *testing.T) {
 					"topK":        1,
 				},
 			},
-			wantMaxTokens:   42,
+			wantMaxTokens:   &maxTokens42,
 			wantTemperature: 0.5,
 			wantTopP:        3,
 			wantTopK:        1,


### PR DESCRIPTION
### What's being changed:

Make max_tokens consistent with [Databrick's Foundation Model API](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html#chat-request):

```txt
Integer greater than zero or null, which represents infinity
```

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
