### PR TITLE
gh-5730: enable class creation while node down and MT disabled

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
@@ -112,8 +112,9 @@ func multiShardState(nodeCount int) *sharding.State {
 		nodeList[i] = fmt.Sprintf("node-%d", i)
 	}
 
-	s, err := sharding.InitState("multi-shard-test-index", config,
-		mocks.NewMockNodeSelector(nodeList...), 1, false)
+	selector := mocks.NewMockNodeSelector(nodeList...)
+	s, err := sharding.InitState("multi-shard-test-index", config, selector.LocalName(),
+		selector.StorageCandidates(), 1, false)
 	if err != nil {
 		panic(err)
 	}

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -119,7 +119,8 @@ func singleShardState() *sharding.State {
 		panic(err)
 	}
 
-	s, err := sharding.InitState("test-index", config, mocks.NewMockNodeSelector("node1"), 1, false)
+	selector := mocks.NewMockNodeSelector("node1")
+	s, err := sharding.InitState("test-index", config, selector.LocalName(), selector.StorageCandidates(), 1, false)
 	if err != nil {
 		panic(err)
 	}
@@ -135,8 +136,8 @@ func multiShardState() *sharding.State {
 		panic(err)
 	}
 
-	s, err := sharding.InitState("multi-shard-test-index", config,
-		mocks.NewMockNodeSelector("node1"), 1, false)
+	selector := mocks.NewMockNodeSelector("node1")
+	s, err := sharding.InitState("multi-shard-test-index", config, selector.LocalName(), selector.StorageCandidates(), 1, false)
 	if err != nil {
 		panic(err)
 	}

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -123,8 +123,9 @@ func singleShardState() *sharding.State {
 		panic(err)
 	}
 
-	s, err := sharding.InitState("test-index", config,
-		mocks.NewMockNodeSelector("node1"), 1, false)
+	selector := mocks.NewMockNodeSelector("node1")
+	s, err := sharding.InitState("test-index", config, selector.LocalName(),
+		selector.StorageCandidates(), 1, false)
 	if err != nil {
 		panic(err)
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -133,7 +133,7 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 
 	shardState, err := sharding.InitState(cls.Class,
 		cls.ShardingConfig.(shardingcfg.Config),
-		h.clusterState, cls.ReplicationConfig.Factor,
+		h.clusterState.LocalName(), h.schemaManager.StorageCandidates(), cls.ReplicationConfig.Factor,
 		schema.MultiTenancyEnabled(cls))
 	if err != nil {
 		return nil, 0, fmt.Errorf("init sharding state: %w", err)

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -1422,7 +1422,7 @@ func TestRestoreClass_WithCircularRefs(t *testing.T) {
 		require.Nil(t, err)
 
 		nodes := mocks.NewMockNodeSelector("node1", "node2")
-		shardingState, err := sharding.InitState(classRaw.Class, shardingConfig, nodes, 1, false)
+		shardingState, err := sharding.InitState(classRaw.Class, shardingConfig, nodes.LocalName(), nodes.StorageCandidates(), 1, false)
 		require.Nil(t, err)
 
 		shardingBytes, err := shardingState.JSON()
@@ -1452,7 +1452,7 @@ func TestRestoreClass_WithNodeMapping(t *testing.T) {
 		require.Nil(t, err)
 
 		nodes := mocks.NewMockNodeSelector("node1", "node2")
-		shardingState, err := sharding.InitState(classRaw.Class, shardingConfig, nodes, 2, false)
+		shardingState, err := sharding.InitState(classRaw.Class, shardingConfig, nodes.LocalName(), nodes.StorageCandidates(), 2, false)
 		require.Nil(t, err)
 
 		shardingBytes, err := shardingState.JSON()

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -117,7 +117,7 @@ func (f *fakeSchemaManager) ClassInfo(class string) (ci clusterSchema.ClassInfo)
 }
 
 func (f *fakeSchemaManager) StorageCandidates() []string {
-	return []string{}
+	return []string{"node-1"}
 }
 
 func (f *fakeSchemaManager) ClassInfoWithVersion(ctx context.Context, class string, version uint64) (clusterSchema.ClassInfo, error) {

--- a/usecases/sharding/state_test.go
+++ b/usecases/sharding/state_test.go
@@ -31,7 +31,7 @@ func TestState(t *testing.T) {
 	require.Nil(t, err)
 
 	nodes := mocks.NewMockNodeSelector("node1", "node2")
-	state, err := InitState("my-index", cfg, nodes, 1, false)
+	state, err := InitState("my-index", cfg, nodes.LocalName(), nodes.StorageCandidates(), 1, false)
 	require.Nil(t, err)
 
 	physicalCount := map[string]int{}
@@ -149,7 +149,7 @@ func TestInitState(t *testing.T) {
 				}, 3)
 				require.Nil(t, err)
 
-				state, err := InitState("my-index", cfg, nodes, int64(test.replicationFactor), false)
+				state, err := InitState("my-index", cfg, nodes.LocalName(), nodes.StorageCandidates(), int64(test.replicationFactor), false)
 				if !test.ok {
 					require.NotNil(t, err)
 					return
@@ -285,7 +285,7 @@ func TestAddPartition(t *testing.T) {
 	require.Nil(t, err)
 
 	nodes := mocks.NewMockNodeSelector("node1", "node2")
-	s, err := InitState("my-index", cfg, nodes, 1, true)
+	s, err := InitState("my-index", cfg, nodes.LocalName(), nodes.StorageCandidates(), 1, true)
 	require.Nil(t, err)
 
 	s.AddPartition("A", nodes1, models.TenantActivityStatusHOT)


### PR DESCRIPTION
### What's being changed:
this PR normalize all the candidates getter to be provided from RAFT instead of memberlist to be more fault tolerant for schema changes 

issue https://github.com/weaviate/weaviate/issues/5730 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
