### PR TITLE
chore(dev/tools): Log about deleting local persistent state

### DIFF
--- a/tools/dev/restart_dev_environment.sh
+++ b/tools/dev/restart_dev_environment.sh
@@ -15,7 +15,7 @@ if [[ "$*" == *--transformers-passage-query* ]]; then
   ADDITIONAL_SERVICES+=('t2v-transformers-query')
 elif [[ "$*" == *--transformers* ]]; then
   ADDITIONAL_SERVICES+=('t2v-transformers')
-else 
+else
   ADDITIONAL_SERVICES+=('contextionary')
 fi
 if [[ "$*" == *--contextionary* ]]; then
@@ -64,6 +64,7 @@ fi
 
 docker compose -f $DOCKER_COMPOSE_FILE down --remove-orphans
 
+echo "Deleting local persistent state. All the collections and tenants created will be removed"
 rm -rf data data-weaviate-0 data-weaviate-1 data-weaviate-2  backups-weaviate-0 backups-weaviate-1 backups-weaviate-2 connector_state.json schema_state.json
 
 docker compose -f $DOCKER_COMPOSE_FILE up -d "${ADDITIONAL_SERVICES[@]}"


### PR DESCRIPTION


### What's being changed:
When running `restart_dev_environment.sh`, it's not obvious it also removes local persistent state. This PR logs it. Now you see this

```
[+] Running 5/5
 ✔ Container weaviate-backup-s3-1      Removed                                                                                                   0.3s
 ✔ Container weaviate-prometheus-1     Removed                                                                                                   0.2s
 ✔ Container weaviate-grafana-1        Removed                                                                                                   0.2s
 ✔ Container weaviate-contextionary-1  Removed                                                                                                   0.2s
 ✔ Network weaviate_default            Removed                                                                                                   0.1s
Deleting local persistent state. All the collections and tenants created will be removed
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
