### PR TITLE
Make TestDelete_WithoutCleaningUpTombstones actually not call CleanUpTombstonedNodes()

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -109,11 +109,6 @@ func TestDelete_WithoutCleaningUpTombstones(t *testing.T) {
 		}
 	})
 
-	t.Run("vector cache holds half the original vectors", func(t *testing.T) {
-		vectorIndex.CleanUpTombstonedNodes(neverStop)
-		assert.Equal(t, len(vectors)/2, int(vectorIndex.cache.CountVectors()))
-	})
-
 	t.Run("start a search that should only contain the remaining elements", func(t *testing.T) {
 		res, _, err := vectorIndex.SearchByVector([]float32{0.1, 0.1, 0.1}, 20, nil)
 		require.Nil(t, err)


### PR DESCRIPTION
### What's being changed:
As the name of the test suggests, it is supposed to test the behaviour of the system when tombstones have not been cleaned up yet.

The call to `CleanUpTombstonedNodes()` was added in https://github.com/weaviate/weaviate/commit/d6d4a6b4146b4cd59cfc93524c8b956816aa5ff2, which is not the correct  way of making this test pass I think @abdelr.

Since `vectorIndex.cache.CountVectors()` seems not be updated with the new number of objects after the deletion without running the tombstone cleanup, I've removed that check. If there is another way of checking the number of objects that works here or if the `vectorIndex.cache.CountVectors()` is supposed to hold the updated number of objects after deletion, please let me know, so that we do not hide an error here.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
