### PR TITLE
BM25: decode tf and prop len in parallel and faster additionalExplanations

### DIFF
--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -875,9 +875,3 @@ func (dbm *docBitmap) IDsWithLimit(limit int) []uint64 {
 
 	return out
 }
-
-type docPointerWithScore struct {
-	id         uint64
-	frequency  float32
-	propLength float32
-}

--- a/adapters/repos/db/inverted/terms/terms.go
+++ b/adapters/repos/db/inverted/terms/terms.go
@@ -14,7 +14,6 @@ package terms
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"math"
 	"sort"
 
@@ -305,7 +304,6 @@ func (t *Terms) ScoreNext(averagePropLength float64, config schema.BM25Config, a
 		}
 		term := t.T[i]
 		_, score, docInfo := term.ScoreAndAdvance(averagePropLength, config)
-		fmt.Printf("score: %f, id: %d, term: %s idf: %f %f %f %d\n", score, id, term.QueryTerm, term.Idf, docInfo.Frequency, docInfo.PropLength, docInfo.Id)
 		if additionalExplanations {
 			docInfos[term.QueryTermIndex] = &docInfo
 		}

--- a/adapters/repos/db/inverted/terms/terms.go
+++ b/adapters/repos/db/inverted/terms/terms.go
@@ -1,0 +1,348 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package terms
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+type DocPointerWithScore struct {
+	Id         uint64
+	Frequency  float32
+	PropLength float32
+}
+
+func (d *DocPointerWithScore) FromBytes(in []byte, boost float32) error {
+	key := in[2:10]
+
+	if len(in) == 12 {
+		d.Id = binary.BigEndian.Uint64(key)
+		d.Frequency = 0
+		d.PropLength = 0
+		return nil
+	}
+
+	value := in[12:]
+
+	return d.FromKeyVal(key, value, boost)
+}
+
+func (d *DocPointerWithScore) FromKeyVal(key []byte, value []byte, boost float32) error {
+	d.Id = binary.BigEndian.Uint64(key)
+	d.Frequency = math.Float32frombits(binary.LittleEndian.Uint32(value[:4])) * boost
+	d.PropLength = math.Float32frombits(binary.LittleEndian.Uint32(value[4:]))
+	return nil
+}
+
+type SortedDocPointerWithScoreMerger struct {
+	input   [][]DocPointerWithScore
+	output  []DocPointerWithScore
+	offsets []int
+}
+
+func NewSortedDocPointerWithScoreMerger() *SortedDocPointerWithScoreMerger {
+	return &SortedDocPointerWithScoreMerger{}
+}
+
+func (s *SortedDocPointerWithScoreMerger) init(segments [][]DocPointerWithScore) error {
+	s.input = segments
+
+	// all offset pointers initialized at 0 which is where we want to start
+	s.offsets = make([]int, len(segments))
+
+	// The maximum output is the sum of all the input segments if there are only
+	// unique keys and zero tombstones. If there are duplicate keys (i.e.
+	// updates) or tombstones, we will slice off some elements of the output
+	// later, but this way we can be sure each index will always be initialized
+	// correctly
+	maxOutput := 0
+	for _, seg := range segments {
+		maxOutput += len(seg)
+	}
+	s.output = make([]DocPointerWithScore, maxOutput)
+
+	return nil
+}
+
+func (s *SortedDocPointerWithScoreMerger) findSegmentWithLowestKey() (DocPointerWithScore, bool) {
+	bestSeg := -1
+	bestKey := uint64(0)
+
+	for segmentID := 0; segmentID < len(s.input); segmentID++ {
+		// check if a segment is already exhausted, then skip
+		if s.offsets[segmentID] >= len(s.input[segmentID]) {
+			continue
+		}
+
+		currKey := s.input[segmentID][s.offsets[segmentID]].Id
+		if bestSeg == -1 {
+			// first time we're running, no need to compare, just set to current
+			bestSeg = segmentID
+			bestKey = currKey
+			continue
+		}
+
+		if currKey > bestKey {
+			// the segment we are currently looking at has a higher key than our
+			// current best so we can completely ignore it
+			continue
+		}
+
+		if currKey < bestKey {
+			// the segment we are currently looking at is a better match than the
+			// previous, this means, we have found a new favorite, but the previous
+			// best will still be valid in a future round
+			bestSeg = segmentID
+			bestKey = currKey
+			continue
+		}
+
+		if currKey == bestKey {
+			// this the most interesting case: we are looking at a duplicate key. In
+			// this case the rightmost ("latest") segment takes precedence, however,
+			// we must make sure that the previous match gets discarded, otherwise we
+			// will find it again in the next round.
+			//
+			// We can simply increase the offset before updating the bestSeg pointer,
+			// which means we will never look at this element again
+			s.offsets[bestSeg]++
+
+			// now that the old element is discarded, we can update our pointers
+			bestSeg = segmentID
+			bestKey = currKey
+		}
+	}
+
+	if bestSeg == -1 {
+		// we didn't find anything, looks like we have exhausted all segments
+		return DocPointerWithScore{}, false
+	}
+
+	// we can now be sure that bestSeg,bestKey is the latest version of the
+	// lowest key, there is only one job left to do: increase the offset, so we
+	// never find this segment again
+	bestMatch := s.input[bestSeg][s.offsets[bestSeg]]
+	s.offsets[bestSeg]++
+
+	return bestMatch, true
+}
+
+func (s *SortedDocPointerWithScoreMerger) Do(ctx context.Context, segments [][]DocPointerWithScore) ([]DocPointerWithScore, error) {
+	if err := s.init(segments); err != nil {
+		return nil, errors.Wrap(err, "init sorted map decoder")
+	}
+
+	i := 0
+	for {
+		if i%100 == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		match, ok := s.findSegmentWithLowestKey()
+		if !ok {
+			break
+		}
+
+		if match.Frequency == 0 { // tombstone
+			// the latest version of this key was a tombstone, so we can ignore it
+			continue
+		}
+
+		s.output[i] = match
+		i++
+	}
+
+	return s.output[:i], nil
+}
+
+type Term struct {
+	// doubles as max impact (with tf=1, the max impact would be 1*Idf), if there
+	// is a boost for a queryTerm, simply apply it here once
+	Idf float64
+
+	IdPointer      uint64
+	PosPointer     uint64
+	Data           []DocPointerWithScore
+	Exhausted      bool
+	QueryTerm      string
+	QueryTermIndex int
+}
+
+func (t *Term) ScoreAndAdvance(averagePropLength float64, config schema.BM25Config) (uint64, float64, DocPointerWithScore) {
+	id := t.IdPointer
+	pair := t.Data[t.PosPointer]
+	freq := float64(pair.Frequency)
+	tf := freq / (freq + config.K1*(1-config.B+config.B*float64(pair.PropLength)/averagePropLength))
+
+	// advance
+	t.PosPointer++
+	if t.PosPointer >= uint64(len(t.Data)) {
+		t.Exhausted = true
+		t.IdPointer = math.MaxUint64 // force them to the end of the term list
+	} else {
+		t.IdPointer = t.Data[t.PosPointer].Id
+	}
+
+	return id, tf * t.Idf, pair
+}
+
+func (t *Term) AdvanceAtLeast(minID uint64) {
+	for t.IdPointer < minID {
+		t.PosPointer++
+		if t.PosPointer >= uint64(len(t.Data)) {
+			t.Exhausted = true
+			t.IdPointer = math.MaxUint64 // force them to the end of the term list
+			return
+		}
+		t.IdPointer = t.Data[t.PosPointer].Id
+	}
+}
+
+func (t *Term) Count() int {
+	return len(t.Data)
+}
+
+type Terms struct {
+	T     []*Term
+	Count int
+}
+
+func (t *Terms) CompletelyExhausted() bool {
+	for i := range t.T {
+		if !t.T[i].Exhausted {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *Terms) Pivot(minScore float64) bool {
+	minID, pivotPoint, abort := t.FindMinID(minScore)
+	if abort {
+		return true
+	}
+	if pivotPoint == 0 {
+		return false
+	}
+
+	t.AdvanceAllAtLeast(minID)
+
+	// we don't need to sort the entire list, just the first pivotPoint elements
+	t.PartialSort()
+	return false
+}
+
+func (t *Terms) AdvanceAllAtLeast(minID uint64) {
+	for i := range t.T {
+		t.T[i].AdvanceAtLeast(minID)
+	}
+}
+
+func (t *Terms) FindMinID(minScore float64) (uint64, int, bool) {
+	cumScore := float64(0)
+
+	for i, term := range t.T {
+		if term.Exhausted {
+			continue
+		}
+		cumScore += term.Idf
+		if cumScore >= minScore {
+			return term.IdPointer, i, false
+		}
+	}
+
+	return 0, 0, true
+}
+
+func (t *Terms) FindFirstNonExhausted() (int, bool) {
+	for i := range t.T {
+		if !t.T[i].Exhausted {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
+func (t *Terms) ScoreNext(averagePropLength float64, config schema.BM25Config, additionalExplanations bool) (uint64, float64, []*DocPointerWithScore) {
+	var docInfos []*DocPointerWithScore
+
+	pos, ok := t.FindFirstNonExhausted()
+	if !ok {
+		// done, nothing left to score
+		return 0, 0, docInfos
+	}
+
+	if len(t.T) == 0 {
+		return 0, 0, docInfos
+	}
+
+	if additionalExplanations {
+		docInfos = make([]*DocPointerWithScore, t.Count)
+	}
+
+	id := t.T[pos].IdPointer
+	var cumScore float64
+	for i := pos; i < len(t.T); i++ {
+		if t.T[i].IdPointer != id || t.T[i].Exhausted {
+			continue
+		}
+		term := t.T[i]
+		_, score, docInfo := term.ScoreAndAdvance(averagePropLength, config)
+		fmt.Printf("score: %f, id: %d, term: %s idf: %f %f %f %d\n", score, id, term.QueryTerm, term.Idf, docInfo.Frequency, docInfo.PropLength, docInfo.Id)
+		if additionalExplanations {
+			docInfos[term.QueryTermIndex] = &docInfo
+		}
+		cumScore += score
+	}
+
+	t.FullSort()
+	return id, cumScore, docInfos
+}
+
+// provide sort interface
+func (t *Terms) Len() int {
+	return len(t.T)
+}
+
+func (t *Terms) Less(i, j int) bool {
+	return t.T[i].IdPointer < t.T[j].IdPointer
+}
+
+func (t *Terms) Swap(i, j int) {
+	t.T[i], t.T[j] = t.T[j], t.T[i]
+}
+
+func (t *Terms) FullSort() {
+	sort.Sort(t)
+}
+
+func (t *Terms) PartialSort() {
+	min := uint64(0)
+	minIndex := -1
+	for i := 0; i < len(t.T); i++ {
+		if minIndex == -1 || (t.T[i].IdPointer < min && !t.T[i].Exhausted) {
+			min = t.T[i].IdPointer
+			minIndex = i
+		}
+	}
+	if minIndex > 0 {
+		t.T[0], t.T[minIndex] = t.T[minIndex], t.T[0]
+	}
+}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -660,7 +660,6 @@ func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 	}
 
 	segments := [][]MapPair{}
-	// before := time.Now()
 	disk, err := b.disk.getCollectionBySegments(key)
 	if err != nil {
 		if err != nil && err != lsmkv.NotFound {
@@ -682,11 +681,6 @@ func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 		segments = append(segments, segmentDecoded)
 	}
 
-	// fmt.Printf("--map-list: get all disk segments took %s\n", time.Since(before))
-
-	// before = time.Now()
-	// fmt.Printf("--map-list: append all disk segments took %s\n", time.Since(before))
-
 	if b.flushing != nil {
 		v, err := b.flushing.getMap(key)
 		if err != nil {
@@ -698,7 +692,6 @@ func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 		segments = append(segments, v)
 	}
 
-	// before = time.Now()
 	v, err := b.active.getMap(key)
 	if err != nil {
 		if err != nil && err != lsmkv.NotFound {
@@ -706,12 +699,6 @@ func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 		}
 	}
 	segments = append(segments, v)
-	// fmt.Printf("--map-list: get all active segments took %s\n", time.Since(before))
-
-	// before = time.Now()
-	// defer func() {
-	// 	fmt.Printf("--map-list: run decoder took %s\n", time.Since(before))
-	// }()
 
 	if c.legacyRequireManualSorting {
 		// Sort to support segments which were stored in an unsorted fashion
@@ -1075,7 +1062,6 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 	}
 
 	segments := [][]terms.DocPointerWithScore{}
-	// before := time.Now()
 	disk, err := b.disk.getCollectionBySegments(key)
 	if err != nil && !errors.Is(err, lsmkv.NotFound) {
 		return nil, err
@@ -1095,11 +1081,6 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 		segments = append(segments, segmentDecoded)
 	}
 
-	// fmt.Printf("--map-list: get all disk segments took %s\n", time.Since(before))
-
-	// before = time.Now()
-	// fmt.Printf("--map-list: append all disk segments took %s\n", time.Since(before))
-
 	if b.flushing != nil {
 		mem, err := b.flushing.getMap(key)
 		if err != nil && !errors.Is(err, lsmkv.NotFound) {
@@ -1114,7 +1095,6 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 		segments = append(segments, docPointers)
 	}
 
-	// before = time.Now()
 	mem, err := b.active.getMap(key)
 	if err != nil && !errors.Is(err, lsmkv.NotFound) {
 		return nil, err
@@ -1126,12 +1106,6 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 		}
 	}
 	segments = append(segments, docPointers)
-	// fmt.Printf("--map-list: get all active segments took %s\n", time.Since(before))
-
-	// before = time.Now()
-	// defer func() {
-	// 	fmt.Printf("--map-list: run decoder took %s\n", time.Since(before))
-	// }()
 
 	if c.legacyRequireManualSorting {
 		// Sort to support segments which were stored in an unsorted fashion

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -1062,4 +1063,84 @@ func (b *Bucket) WriteWAL() error {
 	defer b.flushLock.RUnlock()
 
 	return b.active.writeWAL()
+}
+
+func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBoost float32, cfgs ...MapListOption) ([]terms.DocPointerWithScore, error) {
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	c := MapListOptionConfig{}
+	for _, cfg := range cfgs {
+		cfg(&c)
+	}
+
+	segments := [][]terms.DocPointerWithScore{}
+	// before := time.Now()
+	disk, err := b.disk.getCollectionBySegments(key)
+	if err != nil && !errors.Is(err, lsmkv.NotFound) {
+		return nil, err
+	}
+
+	for i := range disk {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		segmentDecoded := make([]terms.DocPointerWithScore, len(disk[i]))
+		for j, v := range disk[i] {
+			if err := segmentDecoded[j].FromBytes(v.value, propBoost); err != nil {
+				return nil, err
+			}
+		}
+		segments = append(segments, segmentDecoded)
+	}
+
+	// fmt.Printf("--map-list: get all disk segments took %s\n", time.Since(before))
+
+	// before = time.Now()
+	// fmt.Printf("--map-list: append all disk segments took %s\n", time.Since(before))
+
+	if b.flushing != nil {
+		mem, err := b.flushing.getMap(key)
+		if err != nil && !errors.Is(err, lsmkv.NotFound) {
+			return nil, err
+		}
+		docPointers := make([]terms.DocPointerWithScore, len(mem))
+		for i, v := range mem {
+			if err := docPointers[i].FromKeyVal(v.Key, v.Value, propBoost); err != nil {
+				return nil, err
+			}
+		}
+		segments = append(segments, docPointers)
+	}
+
+	// before = time.Now()
+	mem, err := b.active.getMap(key)
+	if err != nil && !errors.Is(err, lsmkv.NotFound) {
+		return nil, err
+	}
+	docPointers := make([]terms.DocPointerWithScore, len(mem))
+	for i, v := range mem {
+		if err := docPointers[i].FromKeyVal(v.Key, v.Value, propBoost); err != nil {
+			return nil, err
+		}
+	}
+	segments = append(segments, docPointers)
+	// fmt.Printf("--map-list: get all active segments took %s\n", time.Since(before))
+
+	// before = time.Now()
+	// defer func() {
+	// 	fmt.Printf("--map-list: run decoder took %s\n", time.Since(before))
+	// }()
+
+	if c.legacyRequireManualSorting {
+		// Sort to support segments which were stored in an unsorted fashion
+		for i := range segments {
+			sort.Slice(segments[i], func(a, b int) bool {
+				return segments[i][a].Id < segments[i][b].Id
+			})
+		}
+	}
+
+	return terms.NewSortedDocPointerWithScoreMerger().Do(ctx, segments)
 }


### PR DESCRIPTION
### What's being changed:

- decode tf and prop len in parallel when loading from segments
- faster additionalExp as it is now separate from data load

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
