### PR TITLE
fixing long locking when cleaning up tombstones

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -881,6 +881,100 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce(t *testing.T) {
 	})
 }
 
+func TestDelete_ResetLockDoesNotLockForever(t *testing.T) {
+	var (
+		vectorIndex *hnsw
+		// there is a single bulk clean event after all the deletes
+		vectors    = vectorsForDeleteTest()
+		rootPath   = t.TempDir()
+		userConfig = ent.UserConfig{
+			MaxConnections: 30,
+			EFConstruction: 128,
+
+			// The actual size does not matter for this test, but if it defaults to
+			// zero it will constantly think it's full and needs to be deleted - even
+			// after just being deleted, so make sure to use a positive number here.
+			VectorCacheMaxObjects: 100000,
+			PQ: ent.PQConfig{
+				Enabled: false,
+				Encoder: ent.PQEncoder{
+					Type:         ent.PQEncoderTypeTile,
+					Distribution: ent.PQEncoderDistributionNormal,
+				},
+			},
+		}
+	)
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(context.Background())
+
+	t.Run("import the test vectors", func(t *testing.T) {
+		index, err := New(Config{
+			RootPath:              rootPath,
+			ID:                    "delete-test",
+			MakeCommitLoggerThunk: MakeNoopCommitLogger,
+			DistanceProvider:      distancer.NewCosineDistanceProvider(),
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				if int(id) >= len(vectors) {
+					return nil, storobj.NewErrNotFoundf(id, "out of range")
+				}
+				return vectors[int(id)], nil
+			},
+			TempVectorForIDThunk: TempVectorForIDThunk(vectors),
+		}, userConfig, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), store)
+		require.Nil(t, err)
+		vectorIndex = index
+
+		for i, vec := range vectors {
+			err := vectorIndex.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+	})
+
+	fmt.Printf("entrypoint before %d\n", vectorIndex.entryPointID)
+	deletedIds := make([]uint64, 0, len(vectors)/2)
+	t.Run("deleting every even element", func(t *testing.T) {
+		for i := range vectors {
+			if i%2 != 0 {
+				continue
+			}
+
+			deletedIds = append(deletedIds, uint64(i))
+			err := vectorIndex.Delete(uint64(i))
+			require.Nil(t, err)
+		}
+	})
+
+	t.Run("running the cleanup and an delete, the delete should not take forever", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			allowList := helpers.NewAllowList(deletedIds...)
+			ok, err := vectorIndex.reassignNeighborsOf(allowList, slowNeverStop)
+			require.Nil(t, err)
+			require.True(t, ok)
+		}()
+		ellapsed := time.Duration(0)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Millisecond * 100)
+			starting := time.Now()
+			err := vectorIndex.Delete(vectorIndex.entryPointID)
+			ellapsed = time.Since(starting)
+			require.Nil(t, err)
+		}()
+		wg.Wait()
+		fmt.Println(ellapsed.Milliseconds())
+		assert.LessOrEqual(t, ellapsed.Milliseconds(), int64(10))
+	})
+
+	t.Run("destroy the index", func(t *testing.T) {
+		require.Nil(t, vectorIndex.Drop(context.Background()))
+	})
+}
+
 func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *testing.T) {
 	var (
 		vectorIndex *hnsw
@@ -1467,6 +1561,11 @@ func bruteForceCosine(vectors [][]float32, query []float32, k int) []uint64 {
 }
 
 func neverStop() bool {
+	return false
+}
+
+func slowNeverStop() bool {
+	time.Sleep(time.Millisecond * 10)
 	return false
 }
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -48,7 +48,7 @@ type hnsw struct {
 	tombstoneLock *sync.RWMutex
 
 	// prevents tombstones cleanup to be performed in parallel with index reset operation
-	resetLock *sync.Mutex
+	resetLock *sync.RWMutex
 	// indicates whether reset operation occurred or not - if so tombstones cleanup method
 	// is aborted as it makes no sense anymore
 	resetCtx       context.Context
@@ -254,7 +254,7 @@ func New(cfg Config, uc ent.UserConfig, tombstoneCallbacks, shardCompactionCallb
 		distancerProvider:   cfg.DistanceProvider,
 		deleteLock:          &sync.Mutex{},
 		tombstoneLock:       &sync.RWMutex{},
-		resetLock:           &sync.Mutex{},
+		resetLock:           &sync.RWMutex{},
 		resetCtx:            resetCtx,
 		resetCtxCancel:      resetCtxCancel,
 		shutdownCtx:         shutdownCtx,


### PR DESCRIPTION
### What's being changed:
We are holding the `resetLock` for the complete tombstones cleanup cycles. This, in combination with very long tombstones cleanup operations prevent other functions from running in a short period of time. This PR adds a test to verify this behaviour and in addition it fixes the problem.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
