### PR TITLE
Introduce metrics for tombstone cycle start, end, and progress

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -301,6 +301,8 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 		"tombstones_total":    total_tombstones,
 	}).Infof("class %s: shard %s: starting tombstone cleanup", h.className, h.shardName)
 
+	h.metrics.StartTombstoneCycle()
+
 	executed = true
 	if ok, err := h.reassignNeighborsOf(deleteList, breakCleanUpTombstonedNodes); err != nil {
 		return executed, err
@@ -336,6 +338,8 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 			"duration":            took,
 		}).Infof("class %s: shard %s: completed tombstone cleanup in %s", h.className, h.shardName, took)
 	}
+
+	h.metrics.EndTombstoneCycle()
 
 	return executed, nil
 }
@@ -457,6 +461,10 @@ LOOP:
 		}
 		select {
 		case ch <- uint64(i):
+			if i%1000 == 0 {
+				// updating the metric has virtually no cost, so we can do it every 1k
+				h.metrics.TombstoneCycleProgress(float64(i) / float64(size))
+			}
 			if i%1_000_000 == 0 {
 				// the interval of 1M is rather arbitrary, but if we have less than 1M
 				// nodes in the graph tombstones cleanup should be so fast, we don't

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -72,6 +72,9 @@ type PrometheusMetrics struct {
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
 	VectorIndexTombstoneUnexpected     *prometheus.CounterVec
+	VectorIndexTombstoneCycleStart     *prometheus.GaugeVec
+	VectorIndexTombstoneCycleEnd       *prometheus.GaugeVec
+	VectorIndexTombstoneCycleProgress  *prometheus.GaugeVec
 	VectorIndexOperations              *prometheus.GaugeVec
 	VectorIndexDurations               *prometheus.SummaryVec
 	VectorIndexSize                    *prometheus.GaugeVec
@@ -164,6 +167,9 @@ func (pm *PrometheusMetrics) DeleteShard(className, shardName string) error {
 	pm.VectorIndexTombstoneCleanupThreads.DeletePartialMatch(labels)
 	pm.VectorIndexTombstoneCleanedCount.DeletePartialMatch(labels)
 	pm.VectorIndexTombstoneUnexpected.DeletePartialMatch(labels)
+	pm.VectorIndexTombstoneCycleStart.DeletePartialMatch(labels)
+	pm.VectorIndexTombstoneCycleEnd.DeletePartialMatch(labels)
+	pm.VectorIndexTombstoneCycleProgress.DeletePartialMatch(labels)
 	pm.VectorIndexOperations.DeletePartialMatch(labels)
 	pm.VectorIndexMaintenanceDurations.DeletePartialMatch(labels)
 	pm.VectorIndexDurations.DeletePartialMatch(labels)
@@ -371,6 +377,18 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "vector_index_tombstone_unexpected_total",
 			Help: "Total number of unexpected tombstones that were found, for example because a vector was not found for an existing id in the index",
 		}, []string{"class_name", "shard_name", "operation"}),
+		VectorIndexTombstoneCycleStart: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_tombstone_cycle_start_timestamp_seconds",
+			Help: "Unix epoch timestamp of the start of the current tombstone cleanup cycle",
+		}, []string{"class_name", "shard_name"}),
+		VectorIndexTombstoneCycleEnd: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_tombstone_cycle_end_timestamp_seconds",
+			Help: "Unix epoch timestamp of the end of the last tombstone cleanup cycle. A negative value indicates that the cycle is still running",
+		}, []string{"class_name", "shard_name"}),
+		VectorIndexTombstoneCycleProgress: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_tombstone_cycle_progress",
+			Help: "A ratio (percentage) of the progress of the current tombstone cleanup cycle. 0 indicates the very beginning, 1 is a complete cycle.",
+		}, []string{"class_name", "shard_name"}),
 		VectorIndexOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_index_operations",
 			Help: "Total number of mutating operations on the vector index",


### PR DESCRIPTION
### What's being changed:
Previously, we had to rely on log entries to see when a tombstone cycle started or ended. Now we observe the latest start and end date. In addition there is a progress indicator which shows a value between 0 and 1 indicating the completion percentage.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
