### PR TITLE
[async] Add `ASYNC_BRUTE_FORCE_SEARCH_LIMIT` option

### DIFF
--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -173,6 +173,9 @@ func NewIndexQueue(
 	if opts.BruteForceSearchLimit == 0 {
 		opts.BruteForceSearchLimit = 100_000
 	}
+	if v, err := strconv.Atoi(os.Getenv("ASYNC_BRUTE_FORCE_SEARCH_LIMIT")); err == nil && v >= 0 {
+		opts.BruteForceSearchLimit = v
+	}
 
 	if opts.StaleTimeout == 0 {
 		opts.StaleTimeout = 5 * time.Second
@@ -567,7 +570,8 @@ func (q *IndexQueue) search(vector []float32, dist float32, maxLimit int, allowL
 		return nil, nil, err
 	}
 
-	if !asyncEnabled() {
+	// Skip merging brute force results if async indexing disabled or brute force search limit is 0
+	if !asyncEnabled() || q.BruteForceSearchLimit == 0 {
 		return indexedResults, distances, nil
 	}
 


### PR DESCRIPTION
### What's being changed:
- When async indexing is enabled, by default it will merge the results from HNSW and any queued vectors. It does this by brute forcing vectors in the queue.
- Currently this is set to 100,000. This PR allows it to be changed via `ASYNC_BRUTE_FORCE_SEARCH_LIMIT`.
- If set to zero it will disable searching the queued vectors and just return the current HNSW results.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
