### PR TITLE
💅  add support for sending azure deployment id and resource name via request headers

### DIFF
--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -36,8 +36,8 @@ import (
 
 var compile, _ = regexp.Compile(`{([\w\s]*?)}`)
 
-func buildUrlFn(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
-	if resourceName != "" && deploymentID != "" {
+func buildUrlFn(isLegacy, isAzure bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
+	if isAzure {
 		host := baseURL
 		if host == "" || host == "https://api.openai.com" {
 			// Fall back to old assumption
@@ -58,7 +58,7 @@ type openai struct {
 	openAIApiKey       string
 	openAIOrganization string
 	azureApiKey        string
-	buildUrl           func(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error)
+	buildUrl           func(isLegacy, isAzure bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error)
 	httpClient         *http.Client
 	logger             logrus.FieldLogger
 }
@@ -227,10 +227,23 @@ func (v *openai) getResponseParams(usage *usage) map[string]interface{} {
 
 func (v *openai) buildOpenAIUrl(ctx context.Context, settings config.ClassSettings) (string, error) {
 	baseURL := settings.BaseURL()
+
+	deploymentID := settings.DeploymentID()
+	resourceName := settings.ResourceName()
+
 	if headerBaseURL := v.getValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		baseURL = headerBaseURL
 	}
-	return v.buildUrl(settings.IsLegacy(), settings.ResourceName(), settings.DeploymentID(), baseURL, settings.ApiVersion())
+
+	if headerDeploymentID := v.getValueFromContext(ctx, "X-Azure-Deployment-Id"); headerDeploymentID != "" {
+		deploymentID = headerDeploymentID
+	}
+
+	if headerResourceName := v.getValueFromContext(ctx, "X-Azure-Resource-Name"); headerResourceName != "" {
+		resourceName = headerResourceName
+	}
+
+	return v.buildUrl(settings.IsLegacy(), settings.IsAzure(), resourceName, deploymentID, baseURL, settings.ApiVersion())
 }
 
 func (v *openai) generateInput(prompt string, params openaiparams.Params, settings config.ClassSettings) (generateInput, error) {

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -35,8 +35,8 @@ func nullLogger() logrus.FieldLogger {
 	return l
 }
 
-func fakeBuildUrl(serverURL string, isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
-	endpoint, err := buildUrlFn(isLegacy, resourceName, deploymentID, baseURL, apiVersion)
+func fakeBuildUrl(serverURL string, isAzure, isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
+	endpoint, err := buildUrlFn(isLegacy, isAzure, resourceName, deploymentID, baseURL, apiVersion)
 	if err != nil {
 		return "", err
 	}
@@ -46,23 +46,23 @@ func fakeBuildUrl(serverURL string, isLegacy bool, resourceName, deploymentID, b
 
 func TestBuildUrlFn(t *testing.T) {
 	t.Run("buildUrlFn returns default OpenAI Client", func(t *testing.T) {
-		url, err := buildUrlFn(false, "", "", config.DefaultOpenAIBaseURL, config.DefaultApiVersion)
+		url, err := buildUrlFn(false, false, "", "", config.DefaultOpenAIBaseURL, config.DefaultApiVersion)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://api.openai.com/v1/chat/completions", url)
 	})
-	t.Run("buildUrlFn returns Azure Client", func(t *testing.T) {
-		url, err := buildUrlFn(false, "resourceID", "deploymentID", "", config.DefaultApiVersion)
+	t.Run("buildUrlFn returns Azure Client when isAzure is true", func(t *testing.T) {
+		url, err := buildUrlFn(false, true, "resourceID", "deploymentID", "", config.DefaultApiVersion)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/chat/completions?api-version=2024-02-01", url)
 	})
 	t.Run("buildUrlFn loads from environment variable", func(t *testing.T) {
-		url, err := buildUrlFn(false, "", "", "https://foobar.some.proxy", config.DefaultApiVersion)
+		url, err := buildUrlFn(false, false, "", "", "https://foobar.some.proxy", config.DefaultApiVersion)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://foobar.some.proxy/v1/chat/completions", url)
 		os.Unsetenv("OPENAI_BASE_URL")
 	})
 	t.Run("buildUrlFn returns Azure Client with custom baseURL", func(t *testing.T) {
-		url, err := buildUrlFn(false, "resourceID", "deploymentID", "customBaseURL", config.DefaultApiVersion)
+		url, err := buildUrlFn(false, true, "resourceID", "deploymentID", "customBaseURL", config.DefaultApiVersion)
 		assert.Nil(t, err)
 		assert.Equal(t, "customBaseURL/openai/deployments/deploymentID/chat/completions?api-version=2024-02-01", url)
 	})
@@ -87,8 +87,8 @@ func TestGetAnswer(t *testing.T) {
 		defer server.Close()
 
 		c := New("openAIApiKey", "", "", 0, nullLogger())
-		c.buildUrl = func(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
-			return fakeBuildUrl(server.URL, isLegacy, resourceName, deploymentID, baseURL, apiVersion)
+		c.buildUrl = func(isLegacy, isAzure bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
+			return fakeBuildUrl(server.URL, isAzure, isLegacy, resourceName, deploymentID, baseURL, apiVersion)
 		}
 
 		expected := modulecapabilities.GenerateResponse{
@@ -113,8 +113,8 @@ func TestGetAnswer(t *testing.T) {
 		defer server.Close()
 
 		c := New("openAIApiKey", "", "", 0, nullLogger())
-		c.buildUrl = func(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
-			return fakeBuildUrl(server.URL, isLegacy, resourceName, deploymentID, baseURL, apiVersion)
+		c.buildUrl = func(isLegacy, isAzure bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
+			return fakeBuildUrl(server.URL, isAzure, isLegacy, resourceName, deploymentID, baseURL, apiVersion)
 		}
 
 		_, err := c.GenerateAllResults(context.Background(), textProperties, "What is my name?", nil, false, nil)
@@ -139,6 +139,25 @@ func TestGetAnswer(t *testing.T) {
 		buildURL, err = c.buildOpenAIUrl(context.TODO(), settings)
 		require.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/v1/chat/completions", buildURL)
+	})
+
+	t.Run("when X-Azure-DeploymentId is passed", func(t *testing.T) {
+		settings := &fakeClassSettings{
+			isAzure:      true,
+			resourceName: "classResourceName",
+			deploymentID: "classDeploymentId",
+			apiVersion:   "2024-02-01",
+		}
+		c := New("", "", "", 0, nullLogger())
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Deployment-Id", []string{"headerDeploymentId"})
+		ctxWithValue = context.WithValue(ctxWithValue,
+			"X-Azure-Resource-Name", []string{"headerResourceName"})
+
+		buildURL, err := c.buildOpenAIUrl(ctxWithValue, settings)
+		require.NoError(t, err)
+		assert.Equal(t, "https://headerResourceName.openai.azure.com/openai/deployments/headerDeploymentId/chat/completions?api-version=2024-02-01", buildURL)
 	})
 }
 

--- a/modules/generative-openai/config/class_settings.go
+++ b/modules/generative-openai/config/class_settings.go
@@ -152,9 +152,11 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		return errors.Errorf("wrong Azure OpenAI apiVersion, available api versions are: %v", availableApiVersions)
 	}
 
-	err := ic.validateAzureConfig(ic.ResourceName(), ic.DeploymentID())
-	if err != nil {
-		return err
+	if ic.IsAzure() {
+		err := ic.validateAzureConfig(ic.ResourceName(), ic.DeploymentID())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -163,6 +165,11 @@ func (ic *classSettings) Validate(class *models.Class) error {
 func (ic *classSettings) getStringProperty(name, defaultValue string) *string {
 	asString := ic.propertyValuesHelper.GetPropertyAsStringWithNotExists(ic.cfg, name, "", defaultValue)
 	return &asString
+}
+
+func (ic *classSettings) getBoolProperty(name string, defaultValue bool) *bool {
+	asBool := ic.propertyValuesHelper.GetPropertyAsBool(ic.cfg, name, false)
+	return &asBool
 }
 
 func (ic *classSettings) getFloatProperty(name string, defaultValue *float64) *float64 {
@@ -227,7 +234,7 @@ func (ic *classSettings) DeploymentID() string {
 }
 
 func (ic *classSettings) IsAzure() bool {
-	return ic.ResourceName() != "" && ic.DeploymentID() != ""
+	return *ic.getBoolProperty("isAzure", false) || (ic.ResourceName() != "" && ic.DeploymentID() != "")
 }
 
 func (ic *classSettings) validateAzureConfig(resourceName string, deploymentId string) error {

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -245,6 +245,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"resourceName": "resource-name",
+					"isAzure":      true,
 				},
 			},
 			wantErr: errors.Errorf("both resourceName and deploymentId must be provided"),
@@ -254,6 +255,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"deploymentId": "deployment-name",
+					"isAzure":      true,
 				},
 			},
 			wantErr: errors.Errorf("both resourceName and deploymentId must be provided"),

--- a/modules/generative-openai/config/class_settings_test.go
+++ b/modules/generative-openai/config/class_settings_test.go
@@ -122,6 +122,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "Azure OpenAI config",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
+					"isAzure":          true,
 					"resourceName":     "weaviate",
 					"deploymentId":     "gpt-3.5-turbo",
 					"maxTokens":        4097,
@@ -148,6 +149,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "Azure OpenAI config with baseURL",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
+					"isAzure":          true,
 					"baseURL":          "some-base-url",
 					"resourceName":     "weaviate",
 					"deploymentId":     "gpt-3.5-turbo",

--- a/modules/qna-openai/clients/qna_test.go
+++ b/modules/qna-openai/clients/qna_test.go
@@ -49,8 +49,8 @@ func TestGetAnswer(t *testing.T) {
 		defer server.Close()
 
 		c := New("openAIApiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID string) (string, error) {
-			return buildUrl(server.URL, resourceName, deploymentID)
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
+			return buildUrl(server.URL, resourceName, deploymentID, isAzure)
 		}
 
 		expected := ent.AnswerResult{
@@ -77,8 +77,8 @@ func TestGetAnswer(t *testing.T) {
 		defer server.Close()
 
 		c := New("openAIApiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID string) (string, error) {
-			return buildUrl(server.URL, resourceName, deploymentID)
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
+			return buildUrl(server.URL, resourceName, deploymentID, isAzure)
 		}
 
 		_, err := c.Answer(context.Background(), "My name is John", "What is my name?", nil)
@@ -93,13 +93,26 @@ func TestGetAnswer(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Openai-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
-		buildURL, err := c.buildOpenAIUrl(ctxWithValue, "http://default-url.com", "", "")
+		buildURL, err := c.buildOpenAIUrl(ctxWithValue, "http://default-url.com", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, "http://base-url-passed-in-header.com/v1/completions", buildURL)
 
-		buildURL, err = c.buildOpenAIUrl(context.TODO(), "http://default-url.com", "", "")
+		buildURL, err = c.buildOpenAIUrl(context.TODO(), "http://default-url.com", "", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/v1/completions", buildURL)
+	})
+
+	t.Run("when X-Azure-DeploymentId is passed", func(t *testing.T) {
+		c := New("", "", "", 0, nullLogger())
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Deployment-Id", []string{"headerDeploymentId"})
+		ctxWithValue = context.WithValue(ctxWithValue,
+			"X-Azure-Resource-Name", []string{"headerResourceName"})
+
+		buildURL, err := c.buildOpenAIUrl(ctxWithValue, "", "", "", true)
+		require.NoError(t, err)
+		assert.Equal(t, "https://headerResourceName.openai.azure.com/openai/deployments/headerDeploymentId/completions?api-version=2022-12-01", buildURL)
 	})
 }
 

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -206,9 +206,19 @@ func (v *client) vectorize(ctx context.Context, input []string, model string, co
 
 func (v *client) buildURL(ctx context.Context, config ent.VectorizationConfig) (string, error) {
 	baseURL, resourceName, deploymentID, apiVersion, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure
+
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		baseURL = headerBaseURL
 	}
+
+	if headerDeploymentID := modulecomponents.GetValueFromContext(ctx, "X-Azure-Deployment-Id"); headerDeploymentID != "" {
+		deploymentID = headerDeploymentID
+	}
+
+	if headerResourceName := modulecomponents.GetValueFromContext(ctx, "X-Azure-Resource-Name"); headerResourceName != "" {
+		resourceName = headerResourceName
+	}
+
 	return v.buildUrlFn(baseURL, resourceName, deploymentID, apiVersion, isAzure)
 }
 

--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -252,6 +252,24 @@ func TestClient(t *testing.T) {
 		assert.Equal(t, "http://default-url.com/v1/embeddings", buildURL)
 	})
 
+	t.Run("when X-Azure-* headers are passed", func(t *testing.T) {
+		c := New("", "", "", 0, nullLogger())
+
+		config := ent.VectorizationConfig{
+			IsAzure:    true,
+			ApiVersion: "",
+		}
+
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Deployment-Id", []string{"spoofDeployment"})
+		ctxWithValue = context.WithValue(ctxWithValue,
+			"X-Azure-Resource-Name", []string{"spoofResource"})
+
+		buildURL, err := c.buildURL(ctxWithValue, config)
+		require.NoError(t, err)
+		assert.Equal(t, "https://spoofResource.openai.azure.com/openai/deployments/spoofDeployment/embeddings?api-version=", buildURL)
+	})
+
 	t.Run("pass rate limit headers requests", func(t *testing.T) {
 		c := New("", "", "", 0, nullLogger())
 

--- a/modules/text2vec-openai/ent/class_settings.go
+++ b/modules/text2vec-openai/ent/class_settings.go
@@ -119,7 +119,7 @@ func (cs *classSettings) IsThirdPartyProvider() bool {
 }
 
 func (cs *classSettings) IsAzure() bool {
-	return cs.ResourceName() != "" && cs.DeploymentID() != ""
+	return cs.BaseClassSettings.GetPropertyAsBool("isAzure", false) || (cs.ResourceName() != "" && cs.DeploymentID() != "")
 }
 
 func (cs *classSettings) Dimensions() *int64 {
@@ -162,9 +162,11 @@ func (cs *classSettings) Validate(class *models.Class) error {
 		return err
 	}
 
-	err := cs.validateAzureConfig(cs.ResourceName(), cs.DeploymentID(), cs.ApiVersion())
-	if err != nil {
-		return err
+	if cs.IsAzure() {
+		err := cs.validateAzureConfig(cs.ResourceName(), cs.DeploymentID(), cs.ApiVersion())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -295,7 +295,7 @@ type CORS struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key, X-OctoAI-Api-Key, X-Anthropic-Baseurl, X-Anthropic-Api-Key, X-Databricks-Endpoint, X-Databricks-Token, X-Friendli-Token, X-Friendli-Baseurl"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Azure-Deployment-Id, X-Azure-Resource-Name, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key, X-OctoAI-Api-Key, X-Anthropic-Baseurl, X-Anthropic-Api-Key, X-Databricks-Endpoint, X-Databricks-Token, X-Friendli-Token, X-Friendli-Baseurl"
 )
 
 func (r ResourceUsage) Validate() error {


### PR DESCRIPTION
### What's being changed:

When using Azure OpenAI, the deployment had to be configured in the vectorizer config when setting up the schema. With this change, it is possible to omit it in the schema, or overwrite the setting on a per request base, similar to how you can set a different Azure API Key, via `X-Azure-Deployment-Id` and `X-Azure-Resource-Name` headers.

In addition to this, there is a new config option for openai modules `isAzure` which specifies whether the vectorizer should use Azure, and prevents developers from having to setup a spoof resourceName or deploymentId when setting up the schema. It should also lead to issues such as this one #4649 becoming less likely, as errors should then be about Azure OpenAI and not OpenAI.

This change implements #3605.

### Review checklist

- [ ] Documentation has been updated, if necessary. **(I'll provide a docs PR as well as updates to the weaviate-client npm package in case this PR is accepted)**
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
