### PR TITLE
Read objects concurrently in aggregations

### DIFF
--- a/adapters/repos/db/aggregator/boolean.go
+++ b/adapters/repos/db/aggregator/boolean.go
@@ -14,6 +14,7 @@ package aggregator
 import (
 	"bytes"
 	"encoding/binary"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -24,6 +25,7 @@ func newBoolAggregator() *boolAggregator {
 }
 
 type boolAggregator struct {
+	sync.Mutex
 	countTrue  uint64
 	countFalse uint64
 }
@@ -51,6 +53,8 @@ func (a *boolAggregator) AddBoolRow(value []byte, count uint64) error {
 }
 
 func (a *boolAggregator) AddBool(value bool) error {
+	a.Lock()
+	defer a.Unlock()
 	if value {
 		a.countTrue++
 	} else {

--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -71,6 +72,7 @@ func addDateAggregations(prop *aggregation.Property,
 }
 
 type dateAggregator struct {
+	sync.Mutex
 	count        uint64
 	maxCount     uint64
 	min          timestamp
@@ -133,6 +135,8 @@ func (a *dateAggregator) AddTimestampRow(b []byte, count uint64) error {
 }
 
 func (a *dateAggregator) addRow(ts timestamp, count uint64) error {
+	a.Lock()
+	defer a.Unlock()
 	if count == 0 {
 		// skip
 		return nil

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -158,7 +158,7 @@ func (fa *filteredAggregator) properties(ctx context.Context,
 		propertyNames = append(propertyNames, k)
 	}
 
-	err = docid.ScanObjectsLSM(fa.store, ids, scan, propertyNames)
+	err = docid.ScanObjectsLSM(fa.store, ids, scan, propertyNames, fa.logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "properties view tx")
 	}

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -78,7 +78,7 @@ func (g *grouper) groupFiltered(ctx context.Context) ([]group, error) {
 	if err := docid.ScanObjectsLSM(g.store, ids,
 		func(prop *models.PropertySchema, docID uint64) (bool, error) {
 			return true, g.addElementById(prop, docID)
-		}, []string{g.params.GroupBy.Property.String()}); err != nil {
+		}, []string{g.params.GroupBy.Property.String()}, g.logger); err != nil {
 		return nil, err
 	}
 

--- a/adapters/repos/db/aggregator/iterator.go
+++ b/adapters/repos/db/aggregator/iterator.go
@@ -82,16 +82,17 @@ func iteratorConcurrentlyReplace(b *lsmkv.Bucket, aggregateFunc func(b []byte) e
 	}
 
 	// S3: Read from last checkpoint to end:
-	enterrors.GoWrapper(func() {
+	eg.Go(func() error {
 		c := b.Cursor()
 		defer c.Close()
 
 		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
 			err := aggregateFunc(v)
 			if err != nil {
-				return
+				return err
 			}
 		}
+		return nil
 	}, logger)
 
 	return eg.Wait()
@@ -155,16 +156,17 @@ func iteratorConcurrentlySet(b *lsmkv.Bucket, aggregateFunc func(k []byte, v [][
 	}
 
 	// S3: Read from last checkpoint to end:
-	enterrors.GoWrapper(func() {
+	eg.Go(func() error {
 		c := b.SetCursor()
 		defer c.Close()
 
 		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
 			err := aggregateFunc(k, v)
 			if err != nil {
-				return
+				return err
 			}
 		}
+		return nil
 	}, logger)
 
 	return eg.Wait()
@@ -228,16 +230,17 @@ func iteratorConcurrentlyRoaringSet(b *lsmkv.Bucket, aggregateFunc func(k []byte
 	}
 
 	// S3: Read from last checkpoint to end:
-	enterrors.GoWrapper(func() {
+	eg.Go(func() error {
 		c := b.CursorRoaringSet()
 		defer c.Close()
 
 		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
 			err := aggregateFunc(k, v)
 			if err != nil {
-				return
+				return err
 			}
 		}
+		return nil
 	}, logger)
 
 	return eg.Wait()

--- a/adapters/repos/db/aggregator/iterator.go
+++ b/adapters/repos/db/aggregator/iterator.go
@@ -106,6 +106,7 @@ func iteratorConcurrently(b *lsmkv.Bucket, newCursor func() Cursor, aggregateFun
 	// in case all keys are in memory
 	if len(seeds) == 0 {
 		c := newCursor()
+		defer c.Close()
 		for k, v, vv, bi := c.First(); k != nil; k, v, vv, bi = c.Next() {
 			err := aggregateFunc(k, v, vv, bi)
 			if err != nil {

--- a/adapters/repos/db/aggregator/iterator.go
+++ b/adapters/repos/db/aggregator/iterator.go
@@ -101,7 +101,7 @@ func iteratorConcurrently(b *lsmkv.Bucket, newCursor func() Cursor, aggregateFun
 	// we're looking at the whole object, so this is neither a Set, nor a Map, but
 	// a Replace strategy
 
-	seedCount := 2*runtime.GOMAXPROCS(0) - 1
+	seedCount := 2 * runtime.GOMAXPROCS(0)
 	seeds := b.QuantileKeys(seedCount)
 	// in case all keys are in memory
 	if len(seeds) == 0 {

--- a/adapters/repos/db/aggregator/iterator.go
+++ b/adapters/repos/db/aggregator/iterator.go
@@ -1,0 +1,214 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package aggregator
+
+import (
+	"bytes"
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+func iteratorConcurrentlyReplace(b *lsmkv.Bucket, aggregateFunc func(b []byte) error, logger logrus.FieldLogger) error {
+	// we're looking at the whole object, so this is neither a Set, nor a Map, but
+	// a Replace strategy
+
+	seedCount := 2*runtime.GOMAXPROCS(0) - 1
+	seeds := b.QuantileKeys(seedCount)
+	if len(seeds) == 0 {
+		return nil
+	}
+
+	eg := enterrors.NewErrorGroupWrapper(logger)
+
+	// There are three scenarios:
+	// 1. Read from beginning to first checkpoint
+	// 2. Read from checkpoint n to checkpoint n+1
+	// 3. Read from last checkpoint to end
+
+	// S1: Read from beginning to first checkpoint:
+	eg.Go(func() error {
+		c := b.Cursor()
+		defer c.Close()
+
+		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
+			err := aggregateFunc(v)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	// S2: Read from checkpoint n to checkpoint n+1, stop at last checkpoint:
+	for i := 0; i < len(seeds)-1; i++ {
+		start := seeds[i]
+		end := seeds[i+1]
+
+		eg.Go(func() error {
+			c := b.Cursor()
+			defer c.Close()
+
+			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
+				err := aggregateFunc(v)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	// S3: Read from last checkpoint to end:
+	enterrors.GoWrapper(func() {
+		c := b.Cursor()
+		defer c.Close()
+
+		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
+			err := aggregateFunc(v)
+			if err != nil {
+				return
+			}
+		}
+	}, logger)
+
+	return eg.Wait()
+}
+
+func iteratorConcurrentlySet(b *lsmkv.Bucket, aggregateFunc func(k []byte, v [][]byte) error, logger logrus.FieldLogger) error {
+	seedCount := 2*runtime.GOMAXPROCS(0) - 1
+	seeds := b.QuantileKeys(seedCount)
+	if len(seeds) == 0 {
+		return nil
+	}
+
+	eg := enterrors.NewErrorGroupWrapper(logger)
+
+	// There are three scenarios:
+	// 1. Read from beginning to first checkpoint
+	// 2. Read from checkpoint n to checkpoint n+1
+	// 3. Read from last checkpoint to end
+
+	// S1: Read from beginning to first checkpoint:
+	eg.Go(func() error {
+		c := b.SetCursor()
+		defer c.Close()
+
+		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
+			err := aggregateFunc(k, v)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	// S2: Read from checkpoint n to checkpoint n+1, stop at last checkpoint:
+	for i := 0; i < len(seeds)-1; i++ {
+		start := seeds[i]
+		end := seeds[i+1]
+
+		eg.Go(func() error {
+			c := b.SetCursor()
+			defer c.Close()
+
+			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
+				err := aggregateFunc(k, v)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	// S3: Read from last checkpoint to end:
+	enterrors.GoWrapper(func() {
+		c := b.SetCursor()
+		defer c.Close()
+
+		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
+			err := aggregateFunc(k, v)
+			if err != nil {
+				return
+			}
+		}
+	}, logger)
+
+	return eg.Wait()
+}
+
+func iteratorConcurrentlyRoaringSet(b *lsmkv.Bucket, aggregateFunc func(k []byte, v *sroar.Bitmap) error, logger logrus.FieldLogger) error {
+	seedCount := 2*runtime.GOMAXPROCS(0) - 1
+	seeds := b.QuantileKeys(seedCount)
+	if len(seeds) == 0 {
+		return nil
+	}
+
+	eg := enterrors.NewErrorGroupWrapper(logger)
+
+	// There are three scenarios:
+	// 1. Read from beginning to first checkpoint
+	// 2. Read from checkpoint n to checkpoint n+1
+	// 3. Read from last checkpoint to end
+
+	// S1: Read from beginning to first checkpoint:
+	eg.Go(func() error {
+		c := b.CursorRoaringSet()
+		defer c.Close()
+
+		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
+			err := aggregateFunc(k, v)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	// S2: Read from checkpoint n to checkpoint n+1, stop at last checkpoint:
+	for i := 0; i < len(seeds)-1; i++ {
+		start := seeds[i]
+		end := seeds[i+1]
+
+		eg.Go(func() error {
+			c := b.CursorRoaringSet()
+			defer c.Close()
+
+			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
+				err := aggregateFunc(k, v)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	// S3: Read from last checkpoint to end:
+	enterrors.GoWrapper(func() {
+		c := b.CursorRoaringSet()
+		defer c.Close()
+
+		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
+			err := aggregateFunc(k, v)
+			if err != nil {
+				return
+			}
+		}
+	}, logger)
+
+	return eg.Wait()
+}

--- a/adapters/repos/db/aggregator/iterator.go
+++ b/adapters/repos/db/aggregator/iterator.go
@@ -27,7 +27,17 @@ func iteratorConcurrentlyReplace(b *lsmkv.Bucket, aggregateFunc func(b []byte) e
 
 	seedCount := 2*runtime.GOMAXPROCS(0) - 1
 	seeds := b.QuantileKeys(seedCount)
+	// in case all keys are in memory
 	if len(seeds) == 0 {
+		c := b.Cursor()
+		defer c.Close()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			err := aggregateFunc(v)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -90,7 +100,17 @@ func iteratorConcurrentlyReplace(b *lsmkv.Bucket, aggregateFunc func(b []byte) e
 func iteratorConcurrentlySet(b *lsmkv.Bucket, aggregateFunc func(k []byte, v [][]byte) error, logger logrus.FieldLogger) error {
 	seedCount := 2*runtime.GOMAXPROCS(0) - 1
 	seeds := b.QuantileKeys(seedCount)
+	// in case all keys are in memory
 	if len(seeds) == 0 {
+		c := b.SetCursor()
+		defer c.Close()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			err := aggregateFunc(k, v)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -153,7 +173,17 @@ func iteratorConcurrentlySet(b *lsmkv.Bucket, aggregateFunc func(k []byte, v [][
 func iteratorConcurrentlyRoaringSet(b *lsmkv.Bucket, aggregateFunc func(k []byte, v *sroar.Bitmap) error, logger logrus.FieldLogger) error {
 	seedCount := 2*runtime.GOMAXPROCS(0) - 1
 	seeds := b.QuantileKeys(seedCount)
+	// in case all keys are in memory
 	if len(seeds) == 0 {
+		c := b.CursorRoaringSet()
+		defer c.Close()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			err := aggregateFunc(k, v)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -14,6 +14,7 @@ package aggregator
 import (
 	"math"
 	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -83,6 +84,7 @@ func newNumericalAggregator() *numericalAggregator {
 }
 
 type numericalAggregator struct {
+	sync.Mutex
 	count        uint64
 	min          float64
 	max          float64
@@ -142,6 +144,8 @@ func (a *numericalAggregator) AddInt64Row(number []byte, count uint64) error {
 }
 
 func (a *numericalAggregator) AddNumberRow(number float64, count uint64) error {
+	a.Lock()
+	defer a.Unlock()
 	if count == 0 {
 		// skip
 		return nil

--- a/adapters/repos/db/aggregator/references.go
+++ b/adapters/repos/db/aggregator/references.go
@@ -13,6 +13,7 @@ package aggregator
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/weaviate/weaviate/entities/aggregation"
 )
@@ -38,11 +39,14 @@ func newRefAggregator() *refAggregator {
 }
 
 type refAggregator struct {
+	sync.Mutex
 	count        uint64
 	valueCounter map[string]uint64
 }
 
 func (a *refAggregator) AddReference(ref map[string]interface{}) error {
+	a.Lock()
+	defer a.Unlock()
 	a.count++
 
 	beacon, ok := ref["beacon"].(string)

--- a/adapters/repos/db/aggregator/text.go
+++ b/adapters/repos/db/aggregator/text.go
@@ -13,6 +13,7 @@ package aggregator
 
 import (
 	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -36,6 +37,7 @@ func newTextAggregator(limit int) *textAggregator {
 }
 
 type textAggregator struct {
+	sync.Mutex
 	max   int
 	count uint64
 
@@ -67,6 +69,8 @@ func (a *Aggregator) parseAndAddTextRow(agg *textAggregator,
 }
 
 func (a *textAggregator) AddText(value string) error {
+	a.Lock()
+	defer a.Unlock()
 	a.count++
 
 	itemCount := a.itemCounter[value]

--- a/adapters/repos/db/aggregator/unfiltered_type_specific.go
+++ b/adapters/repos/db/aggregator/unfiltered_type_specific.go
@@ -77,10 +77,7 @@ func (ua unfilteredAggregator) boolArrayProperty(ctx context.Context,
 	agg := newBoolAggregator()
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddBoolArrayRow(agg, v, prop.Name); err != nil {
-			return err
-		}
-		return nil
+		return ua.parseAndAddBoolArrayRow(agg, v, prop.Name)
 	}
 
 	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
@@ -307,10 +304,7 @@ func (ua unfilteredAggregator) dateArrayProperty(ctx context.Context,
 	agg := newDateAggregator()
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddDateArrayRow(agg, v, prop.Name); err != nil {
-			return err
-		}
-		return nil
+		return ua.parseAndAddDateArrayRow(agg, v, prop.Name)
 	}
 
 	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
@@ -452,10 +446,7 @@ func (ua unfilteredAggregator) textProperty(ctx context.Context,
 	agg := newTextAggregator(limit)
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddTextRow(agg, v, prop.Name); err != nil {
-			return err
-		}
-		return nil
+		return ua.parseAndAddTextRow(agg, v, prop.Name)
 	}
 
 	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
@@ -484,10 +475,7 @@ func (ua unfilteredAggregator) numberArrayProperty(ctx context.Context,
 	agg := newNumericalAggregator()
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddNumberArrayRow(agg, v, prop.Name); err != nil {
-			return err
-		}
-		return nil
+		return ua.parseAndAddNumberArrayRow(agg, v, prop.Name)
 	}
 
 	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)

--- a/adapters/repos/db/aggregator/unfiltered_type_specific.go
+++ b/adapters/repos/db/aggregator/unfiltered_type_specific.go
@@ -40,24 +40,20 @@ func (ua unfilteredAggregator) boolProperty(ctx context.Context,
 
 	// bool never has a frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		c := b.CursorRoaringSet()
-		defer c.Close()
+		extract := func(k []byte, v *sroar.Bitmap) error {
+			return ua.parseAndAddBoolRowRoaringSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			err := ua.parseAndAddBoolRowRoaringSet(agg, k, v)
-			if err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	} else {
-		c := b.SetCursor() // bool never has a frequency, so it's always a Set
-		defer c.Close()
+		extract := func(k []byte, v [][]byte) error {
+			return ua.parseAndAddBoolRowSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			err := ua.parseAndAddBoolRowSet(agg, k, v)
-			if err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	}
 
@@ -80,14 +76,16 @@ func (ua unfilteredAggregator) boolArrayProperty(ctx context.Context,
 
 	agg := newBoolAggregator()
 
-	c := b.Cursor()
-	defer c.Close()
-
-	for k, v := c.First(); k != nil; k, v = c.Next() {
-		err := ua.parseAndAddBoolArrayRow(agg, v, prop.Name)
-		if err != nil {
-			return nil, err
+	extract := func(v []byte) error {
+		if err := ua.parseAndAddBoolArrayRow(agg, v, prop.Name); err != nil {
+			return err
 		}
+		return nil
+	}
+
+	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	if err != nil {
+		return nil, err
 	}
 
 	out.BooleanAggregation = agg.Res()
@@ -161,22 +159,20 @@ func (ua unfilteredAggregator) floatProperty(ctx context.Context,
 
 	// flat never has a frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		c := b.CursorRoaringSet()
-		defer c.Close()
+		extract := func(k []byte, v *sroar.Bitmap) error {
+			return ua.parseAndAddFloatRowRoaringSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if err := ua.parseAndAddFloatRowRoaringSet(agg, k, v); err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	} else {
-		c := b.SetCursor()
-		defer c.Close()
+		extract := func(k []byte, v [][]byte) error {
+			return ua.parseAndAddFloatRowSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if err := ua.parseAndAddFloatRowSet(agg, k, v); err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	}
 
@@ -202,23 +198,20 @@ func (ua unfilteredAggregator) intProperty(ctx context.Context,
 
 	// int never has a frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		c := b.CursorRoaringSet()
-		defer c.Close()
+		extract := func(k []byte, v *sroar.Bitmap) error {
+			return ua.parseAndAddIntRowRoaringSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if err := ua.parseAndAddIntRowRoaringSet(agg, k, v); err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	} else {
+		extract := func(k []byte, v [][]byte) error {
+			return ua.parseAndAddIntRowSet(agg, k, v)
+		}
 
-		c := b.SetCursor()
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if err := ua.parseAndAddIntRowSet(agg, k, v); err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	}
 
@@ -244,22 +237,20 @@ func (ua unfilteredAggregator) dateProperty(ctx context.Context,
 
 	// dates don't have frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		c := b.CursorRoaringSet()
-		defer c.Close()
+		extract := func(k []byte, v *sroar.Bitmap) error {
+			return ua.parseAndAddDateRowRoaringSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if err := ua.parseAndAddDateRowRoaringSet(agg, k, v); err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	} else {
-		c := b.SetCursor()
-		defer c.Close()
+		extract := func(k []byte, v [][]byte) error {
+			return ua.parseAndAddDateRowSet(agg, k, v)
+		}
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if err := ua.parseAndAddDateRowSet(agg, k, v); err != nil {
-				return nil, err
-			}
+		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+			return nil, err
 		}
 	}
 
@@ -315,13 +306,13 @@ func (ua unfilteredAggregator) dateArrayProperty(ctx context.Context,
 
 	agg := newDateAggregator()
 
-	c := b.Cursor()
-	defer c.Close()
+	extract := func(v []byte) error {
+		return ua.parseAndAddDateArrayRow(agg, v, prop.Name)
+	}
 
-	for k, v := c.First(); k != nil; k, v = c.Next() {
-		if err := ua.parseAndAddDateArrayRow(agg, v, prop.Name); err != nil {
-			return nil, err
-		}
+	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	if err != nil {
+		return nil, err
 	}
 
 	addDateAggregations(&out, prop.Aggregators, agg)
@@ -457,15 +448,13 @@ func (ua unfilteredAggregator) textProperty(ctx context.Context,
 
 	agg := newTextAggregator(limit)
 
-	// we're looking at the whole object, so this is neither a Set, nor a Map, but
-	// a Replace strategy
-	c := b.Cursor()
-	defer c.Close()
+	extract := func(v []byte) error {
+		return ua.parseAndAddTextRow(agg, v, prop.Name)
+	}
 
-	for k, v := c.First(); k != nil; k, v = c.Next() {
-		if err := ua.parseAndAddTextRow(agg, v, prop.Name); err != nil {
-			return nil, err
-		}
+	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	if err != nil {
+		return nil, err
 	}
 
 	out.TextAggregation = agg.Res()
@@ -488,13 +477,13 @@ func (ua unfilteredAggregator) numberArrayProperty(ctx context.Context,
 
 	agg := newNumericalAggregator()
 
-	c := b.Cursor()
-	defer c.Close()
+	extract := func(v []byte) error {
+		return ua.parseAndAddNumberArrayRow(agg, v, prop.Name)
+	}
 
-	for k, v := c.First(); k != nil; k, v = c.Next() {
-		if err := ua.parseAndAddNumberArrayRow(agg, v, prop.Name); err != nil {
-			return nil, err
-		}
+	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	if err != nil {
+		return nil, err
 	}
 
 	addNumericalAggregations(&out, prop.Aggregators, agg)

--- a/adapters/repos/db/aggregator/unfiltered_type_specific.go
+++ b/adapters/repos/db/aggregator/unfiltered_type_specific.go
@@ -77,7 +77,7 @@ func (ua unfilteredAggregator) boolArrayProperty(ctx context.Context,
 	agg := newBoolAggregator()
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddBoolArrayRow(agg, k, prop.Name); err != nil {
+		if err := ua.parseAndAddBoolArrayRow(agg, v, prop.Name); err != nil {
 			return err
 		}
 		return nil
@@ -307,7 +307,7 @@ func (ua unfilteredAggregator) dateArrayProperty(ctx context.Context,
 	agg := newDateAggregator()
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddDateArrayRow(agg, k, prop.Name); err != nil {
+		if err := ua.parseAndAddDateArrayRow(agg, v, prop.Name); err != nil {
 			return err
 		}
 		return nil
@@ -452,7 +452,7 @@ func (ua unfilteredAggregator) textProperty(ctx context.Context,
 	agg := newTextAggregator(limit)
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddTextRow(agg, k, prop.Name); err != nil {
+		if err := ua.parseAndAddTextRow(agg, v, prop.Name); err != nil {
 			return err
 		}
 		return nil
@@ -484,7 +484,7 @@ func (ua unfilteredAggregator) numberArrayProperty(ctx context.Context,
 	agg := newNumericalAggregator()
 
 	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
-		if err := ua.parseAndAddNumberArrayRow(agg, k, prop.Name); err != nil {
+		if err := ua.parseAndAddNumberArrayRow(agg, v, prop.Name); err != nil {
 			return err
 		}
 		return nil

--- a/adapters/repos/db/aggregator/unfiltered_type_specific.go
+++ b/adapters/repos/db/aggregator/unfiltered_type_specific.go
@@ -40,19 +40,19 @@ func (ua unfilteredAggregator) boolProperty(ctx context.Context,
 
 	// bool never has a frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		extract := func(k []byte, v *sroar.Bitmap) error {
-			return ua.parseAndAddBoolRowRoaringSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddBoolRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
-		extract := func(k []byte, v [][]byte) error {
-			return ua.parseAndAddBoolRowSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddBoolRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -76,14 +76,14 @@ func (ua unfilteredAggregator) boolArrayProperty(ctx context.Context,
 
 	agg := newBoolAggregator()
 
-	extract := func(v []byte) error {
-		if err := ua.parseAndAddBoolArrayRow(agg, v, prop.Name); err != nil {
+	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+		if err := ua.parseAndAddBoolArrayRow(agg, k, prop.Name); err != nil {
 			return err
 		}
 		return nil
 	}
 
-	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -159,19 +159,19 @@ func (ua unfilteredAggregator) floatProperty(ctx context.Context,
 
 	// flat never has a frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		extract := func(k []byte, v *sroar.Bitmap) error {
-			return ua.parseAndAddFloatRowRoaringSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddFloatRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
-		extract := func(k []byte, v [][]byte) error {
-			return ua.parseAndAddFloatRowSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddFloatRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -198,19 +198,19 @@ func (ua unfilteredAggregator) intProperty(ctx context.Context,
 
 	// int never has a frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		extract := func(k []byte, v *sroar.Bitmap) error {
-			return ua.parseAndAddIntRowRoaringSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddIntRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
-		extract := func(k []byte, v [][]byte) error {
-			return ua.parseAndAddIntRowSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddIntRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -237,19 +237,19 @@ func (ua unfilteredAggregator) dateProperty(ctx context.Context,
 
 	// dates don't have frequency, so it's either a Set or RoaringSet
 	if b.Strategy() == lsmkv.StrategyRoaringSet {
-		extract := func(k []byte, v *sroar.Bitmap) error {
-			return ua.parseAndAddDateRowRoaringSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddDateRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrentlyRoaringSet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
-		extract := func(k []byte, v [][]byte) error {
-			return ua.parseAndAddDateRowSet(agg, k, v)
+		extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+			return ua.parseAndAddDateRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrentlySet(b, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -306,11 +306,14 @@ func (ua unfilteredAggregator) dateArrayProperty(ctx context.Context,
 
 	agg := newDateAggregator()
 
-	extract := func(v []byte) error {
-		return ua.parseAndAddDateArrayRow(agg, v, prop.Name)
+	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+		if err := ua.parseAndAddDateArrayRow(agg, k, prop.Name); err != nil {
+			return err
+		}
+		return nil
 	}
 
-	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -448,11 +451,14 @@ func (ua unfilteredAggregator) textProperty(ctx context.Context,
 
 	agg := newTextAggregator(limit)
 
-	extract := func(v []byte) error {
-		return ua.parseAndAddTextRow(agg, v, prop.Name)
+	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+		if err := ua.parseAndAddTextRow(agg, k, prop.Name); err != nil {
+			return err
+		}
+		return nil
 	}
 
-	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -477,11 +483,14 @@ func (ua unfilteredAggregator) numberArrayProperty(ctx context.Context,
 
 	agg := newNumericalAggregator()
 
-	extract := func(v []byte) error {
-		return ua.parseAndAddNumberArrayRow(agg, v, prop.Name)
+	extract := func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error {
+		if err := ua.parseAndAddNumberArrayRow(agg, k, prop.Name); err != nil {
+			return err
+		}
+		return nil
 	}
 
-	err := iteratorConcurrentlyReplace(b, extract, ua.logger)
+	err := iteratorConcurrently(b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -13,6 +13,7 @@ package docid
 
 import (
 	"encoding/binary"
+	"math"
 	"runtime"
 	"sync"
 
@@ -93,7 +94,7 @@ func (os *objectScannerLSM) scan() error {
 	lock := sync.Mutex{}
 	eg := enterrors.NewErrorGroupWrapper(os.logger)
 	concurrency := 2 * runtime.GOMAXPROCS(0)
-	stride := max(len(os.pointers)/concurrency, 1)
+	stride := int(math.Ceil(max(float64(len(os.pointers))/float64(concurrency), 1)))
 	for i := 0; i < concurrency; i++ {
 		start := i * stride
 		end := min(start+stride, len(os.pointers))

--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -93,10 +93,13 @@ func (os *objectScannerLSM) scan() error {
 	lock := sync.Mutex{}
 	eg := enterrors.NewErrorGroupWrapper(os.logger)
 	concurrency := 2 * runtime.GOMAXPROCS(0)
-	stride := len(os.pointers) / concurrency
+	stride := max(len(os.pointers)/concurrency, 1)
 	for i := 0; i < concurrency; i++ {
 		start := i * stride
 		end := min(start+stride, len(os.pointers))
+		if start >= len(os.pointers) {
+			break
+		}
 		f := func() error {
 			// each object is scanned one after the other, so we can reuse the same memory allocations for all objects
 			docIDBytes := make([]byte, 8)


### PR DESCRIPTION
### What's being changed:

read concurrently from disk in aggregations

Unfiltered aggregations for the sphere dataset went from 54s to 13s.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
