### PR TITLE
Fix hybrid subsearches with offset

### DIFF
--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client==4.5.1
+weaviate-client==4.6.1
 
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.5.0

--- a/test/acceptance_with_python/test_hybrid.py
+++ b/test/acceptance_with_python/test_hybrid.py
@@ -1,0 +1,54 @@
+import uuid
+from typing import Optional
+
+import pytest
+
+from weaviate.classes.config import Configure, Property, DataType
+import weaviate.classes as wvc
+from weaviate.collections.classes.grpc import HybridVectorType
+
+from .conftest import CollectionFactory
+
+
+UUID1 = uuid.uuid4()
+UUID2 = uuid.uuid4()
+UUID3 = uuid.uuid4()
+UUID4 = uuid.uuid4()
+
+
+@pytest.mark.parametrize("vector", [None, wvc.query.HybridVector.near_text("summer dress")])
+def test_hybrid_with_offset(
+    collection_factory: CollectionFactory, vector: Optional[HybridVectorType]
+) -> None:
+    collection = collection_factory(
+        properties=[Property(name="name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+
+    ret = collection.data.insert_many(
+        [
+            {"name": entry}
+            for entry in [
+                "mountain hike",
+                "banana apple",
+                "road trip",
+                "coconut smoothie",
+                "beach vacation",
+                "apple pie",
+                "banana split",
+                "mountain biking",
+                "apple cider",
+                "beach volleyball",
+                "sailing",
+            ]
+        ]
+    )
+    assert ret.has_errors is False
+
+    hy = collection.query.hybrid("summer dress")
+    assert len(hy.objects) > 0
+
+    hy_offset = collection.query.hybrid("summer dress", offset=2, vector=vector)
+    assert len(hy_offset.objects) + 2 == len(hy.objects)

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -221,18 +221,19 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		Autocut: params.Pagination.Autocut,
 	}
 
+	// pagination is handled after combining results
 	vectorParams := params
 	vectorParams.Pagination = &filters.Pagination{
 		Limit:   params.Pagination.Limit,
-		Offset:  params.Pagination.Offset,
-		Autocut: params.Pagination.Autocut,
+		Offset:  0,
+		Autocut: -1,
 	}
 
 	keywordParams := params
 	keywordParams.Pagination = &filters.Pagination{
 		Limit:   params.Pagination.Limit,
-		Offset:  params.Pagination.Offset,
-		Autocut: params.Pagination.Autocut,
+		Offset:  0,
+		Autocut: -1,
 	}
 
 	// If the user has given any weight to the vector search, choose 1 of three possible vector searches


### PR DESCRIPTION
### What's being changed:

When doing a hybrid search with nearText/vector subsearch
-  the vector search applied the offset
- the hybrid searcher would apply the offset again

resulting in objects being skipped for the output

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
