### PR TITLE
BM25 improvements fix

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Run Swagger
         run: ./tools/gen-code-from-swagger.sh
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Run locally Docker build
         run: docker build -t weaviate:${{ github.sha }} .
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Unit test
         run: ./test/run.sh --unit-only
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Integration test
         run: ./test/run.sh --integration-only
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Acceptance tests (modules)
         run: ./test/run.sh ${{ matrix.test }}
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: Acceptance tests
         env:
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: goreleaser
         run: |
@@ -204,7 +204,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
       - name: start weaviate
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 ###############################################################################
 # Base build image
-FROM golang:1.21-alpine AS build_base
+FROM golang:1.22-alpine AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1088,6 +1088,10 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 		}
 		docPointers := make([]terms.DocPointerWithScore, len(mem))
 		for i, v := range mem {
+			if len(v.Value) < 8 {
+				b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(v.Value))
+				continue
+			}
 			if err := docPointers[i].FromKeyVal(v.Key, v.Value, propBoost); err != nil {
 				return nil, err
 			}
@@ -1101,6 +1105,10 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 	}
 	docPointers := make([]terms.DocPointerWithScore, len(mem))
 	for i, v := range mem {
+		if len(v.Value) < 8 {
+			b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(v.Value))
+			continue
+		}
 		if err := docPointers[i].FromKeyVal(v.Key, v.Value, propBoost); err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -162,4 +162,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.22


### PR DESCRIPTION
### What's being changed:

This PR fixes this panic:

```
{"action":"bm25_search","build_git_commit":"d19b41c","build_go_version":"go1.22.7","build_image_tag":"1.27.0-alpha","build_wv_version":"1.27.0-alpha","class":"Book","level":"error","msg":"Recovered from panic: runtime error: slice bounds out of range [:4] with capacity 0, local variables [[]], additional localVars []\n","panic":"runtime error: slice bounds out of range [:4] with capacity 0","shard":"k4PJUGhvJRv6","time":"2024-09-13T00:04:02Z"} 
weaviate-1 | goroutine 3676 [running]: 
weaviate-1 | runtime/debug.Stack() 
weaviate-1 | /usr/local/go/src/runtime/debug/stack.go:24 +0x5e 
weaviate-1 | runtime/debug.PrintStack() 
weaviate-1 | /usr/local/go/src/runtime/debug/stack.go:16 +0x13 
weaviate-1 | github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).setDeferFunc.func1({0xc006af5290, 0x1, 0x1}) 
weaviate-1 | /go/src/github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:76 +0x175 
weaviate-1 | panic({0x20a1740?, 0xc00da8f4a0?}) 
weaviate-1 | /usr/local/go/src/runtime/panic.go:770 +0x132 
weaviate-1 | github.com/weaviate/weaviate/adapters/repos/db/inverted/terms.(*DocPointerWithScore).FromKeyVal(...) 
weaviate-1 | /go/src/github.com/weaviate/weaviate/adapters/repos/db/inverted/terms/terms.go:47 
weaviate-1 | github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).DocPointerWithScoreList(0xc003d08a20, {0x2a61c88, 0xc00399ca50}, {0xc008ef8c00, 0x6, 0x8}, 0x3f800000, {0x0, 0x0, 0x40e50d8000000000?}) 
weaviate-1 | /go/src/github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:1153 +0xb4c 
weaviate-1 | github.com/weaviate/weaviate/adapters/repos/db/inverted.(*BM25Searcher).createTerm.func1() 
weaviate-1 | /go/src/github.com/weaviate/weaviate/adapters/repos/db/inverted/bm25_searcher.go:408 +0x1c7 
weaviate-1 | github.com/weaviate/weaviate/adapters/repos/db/inverted.(*BM25Searcher).createTerm.(*ErrorGroupWrapper).Go.func2() 
weaviate-1 | /go/src/github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:90 +0x97 
weaviate-1 | golang.org/x/sync/errgroup.(*Group).Go.func1() 
weaviate-1 | /go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78 +0x56 
weaviate-1 | created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 3673 
weaviate-1 | /go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:75 +0x96
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
