### PR TITLE
Add x-request-id information to errors in generative and QnA modules

### DIFF
--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -130,6 +130,7 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	}
 	defer res.Body.Close()
 
+	requestID := res.Header.Get("x-request-id")
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "read response body")
@@ -141,7 +142,7 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {
-		return nil, v.getError(res.StatusCode, resBody.Error, settings.IsAzure())
+		return nil, v.getError(res.StatusCode, requestID, resBody.Error, settings.IsAzure())
 	}
 
 	textResponse := resBody.Choices[0].Text
@@ -218,15 +219,19 @@ func (v *openai) generateInput(prompt string, settings config.ClassSettings) (ge
 	}
 }
 
-func (v *openai) getError(statusCode int, resBodyError *openAIApiError, isAzure bool) error {
+func (v *openai) getError(statusCode int, requestID string, resBodyError *openAIApiError, isAzure bool) error {
 	endpoint := "OpenAI API"
 	if isAzure {
 		endpoint = "Azure OpenAI API"
 	}
-	if resBodyError != nil {
-		return fmt.Errorf("connection to: %s failed with status: %d error: %v", endpoint, statusCode, resBodyError.Message)
+	errorMsg := fmt.Sprintf("connection to: %s failed with status: %d", endpoint, statusCode)
+	if requestID != "" {
+		errorMsg = fmt.Sprintf("%s request-id: %s", errorMsg, requestID)
 	}
-	return fmt.Errorf("connection to: %s failed with status: %d", endpoint, statusCode)
+	if resBodyError != nil {
+		errorMsg = fmt.Sprintf("%s error: %v", errorMsg, resBodyError.Message)
+	}
+	return errors.New(errorMsg)
 }
 
 func (v *openai) determineTokens(maxTokensSetting float64, classSetting float64, model string, messages []message) (float64, error) {

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -123,6 +123,29 @@ func TestGetAnswer(t *testing.T) {
 		assert.Error(t, err, "connection to OpenAI failed with status: 500 error: some error from the server")
 	})
 
+	t.Run("when the server has a an error and request id is present", func(t *testing.T) {
+		server := httptest.NewServer(&testAnswerHandler{
+			t: t,
+			answer: generateResponse{
+				Error: &openAIApiError{
+					Message: "some error from the server",
+				},
+			},
+			headerRequestID: "some-request-id",
+		})
+		defer server.Close()
+
+		c := New("openAIApiKey", "", "", 0, nullLogger())
+		c.buildUrl = func(isLegacy bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
+			return fakeBuildUrl(server.URL, isLegacy, resourceName, deploymentID, baseURL, apiVersion)
+		}
+
+		_, err := c.GenerateAllResults(context.Background(), textProperties, "What is my name?", nil)
+
+		require.NotNil(t, err)
+		assert.Error(t, err, "connection to OpenAI failed with status: 500 request-id: some-request-id error: some error from the server")
+	})
+
 	t.Run("when X-OpenAI-BaseURL header is passed", func(t *testing.T) {
 		settings := &fakeClassSettings{
 			baseURL: "http://default-url.com",
@@ -145,7 +168,8 @@ func TestGetAnswer(t *testing.T) {
 type testAnswerHandler struct {
 	t *testing.T
 	// the test handler will report as not ready before the time has passed
-	answer generateResponse
+	answer          generateResponse
+	headerRequestID string
 }
 
 func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -156,6 +180,9 @@ func (f *testAnswerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		outBytes, err := json.Marshal(f.answer)
 		require.Nil(f.t, err)
 
+		if f.headerRequestID != "" {
+			w.Header().Add("x-request-id", f.headerRequestID)
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write(outBytes)
 		return

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -110,6 +110,7 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 	}
 	defer res.Body.Close()
 
+	requestID := res.Header.Get("x-request-id")
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "read response body")
@@ -121,7 +122,7 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {
-		return nil, v.getError(res.StatusCode, resBody.Error, settings.IsAzure())
+		return nil, v.getError(res.StatusCode, requestID, resBody.Error, settings.IsAzure())
 	}
 
 	if len(resBody.Choices) > 0 && resBody.Choices[0].Text != "" {
@@ -146,15 +147,19 @@ func (v *qna) buildOpenAIUrl(ctx context.Context, baseURL, resourceName, deploym
 	return v.buildUrlFn(passedBaseURL, resourceName, deploymentID)
 }
 
-func (v *qna) getError(statusCode int, resBodyError *openAIApiError, isAzure bool) error {
+func (v *qna) getError(statusCode int, requestID string, resBodyError *openAIApiError, isAzure bool) error {
 	endpoint := "OpenAI API"
 	if isAzure {
 		endpoint = "Azure OpenAI API"
 	}
-	if resBodyError != nil {
-		return fmt.Errorf("connection to: %s failed with status: %d error: %v", endpoint, statusCode, resBodyError.Message)
+	errorMsg := fmt.Sprintf("connection to: %s failed with status: %d", endpoint, statusCode)
+	if requestID != "" {
+		errorMsg = fmt.Sprintf("%s request-id: %s", errorMsg, requestID)
 	}
-	return fmt.Errorf("connection to: %s failed with status: %d", endpoint, statusCode)
+	if resBodyError != nil {
+		errorMsg = fmt.Sprintf("%s error: %v", errorMsg, resBodyError.Message)
+	}
+	return errors.New(errorMsg)
 }
 
 func (v *qna) getApiKeyHeaderAndValue(apiKey string, isAzure bool) (string, string) {


### PR DESCRIPTION
### What's being changed:

Add `x-request-id` information to errors in generative and QnA modules.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
