### PR TITLE
Fix removing entries for hybrid fusion

### DIFF
--- a/adapters/repos/db/shard_combine_multi_target.go
+++ b/adapters/repos/db/shard_combine_multi_target.go
@@ -152,9 +152,13 @@ func CombineMultiTargetResults(ctx context.Context, shard DistanceForVector, log
 		// remove objects that have missing target vectors
 		if len(scoresToRemove) > 0 {
 			for i := range fusionInput {
-				for j := range fusionInput[i] {
+				for j := len(fusionInput[i]) - 1; j >= 0; j-- {
 					if _, ok := scoresToRemove[*fusionInput[i][j].DocID]; ok {
-						fusionInput[i] = append(fusionInput[i][:j], fusionInput[i][j+1:]...)
+						if j < len(fusionInput[i])-1 {
+							fusionInput[i] = append(fusionInput[i][:j], fusionInput[i][j+1:]...)
+						} else {
+							fusionInput[i] = fusionInput[i][:j]
+						}
 					}
 				}
 			}

--- a/adapters/repos/db/shard_combine_multi_target_test.go
+++ b/adapters/repos/db/shard_combine_multi_target_test.go
@@ -180,6 +180,19 @@ func TestCombiner(t *testing.T) {
 			},
 			out: []search.Result{res(1, 0.05), res(0, 0.375), res(2, 0.60833)},
 		},
+		{
+			name:       "many documents missing entry (score fusion)",
+			targets:    []string{"target1", "target2", "target3", "target4"},
+			joinMethod: &dto.TargetCombination{Type: dto.RelativeScore, Weights: []float32{1, 0.5, 0.25, 0.1}},
+			in: [][]search.Result{
+				{res(0, 0.5), res(1, 0.6), res(2, 0.8), res(3, 0.9)},
+				{res(1, 0.2), res(0, 0.4), res(2, 0.6), res(5, 0.8)},
+				{res(1, 0.2), res(2, 0.4), res(3, 0.6), res(4, 0.8)},
+				{res(6, 0.1), res(0, 0.3), res(2, 0.7), res(3, 0.9)},
+			},
+			out:             []search.Result{res(1, 0.1666), res(0, 0.30555)},
+			missingElements: map[uint64][]string{6: {"target3"}},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/repos/db/shard_combine_multi_target_test.go
+++ b/adapters/repos/db/shard_combine_multi_target_test.go
@@ -183,7 +183,7 @@ func TestCombiner(t *testing.T) {
 		{
 			name:       "many documents missing entry (score fusion)",
 			targets:    []string{"target1", "target2", "target3", "target4"},
-			joinMethod: &dto.TargetCombination{Type: dto.RelativeScore, Weights: []float32{1, 0.5, 0.25, 0.1}},
+			joinMethod: &dto.TargetCombination{Type: dto.RelativeScore, Weights: map[string]float32{"target1": 1, "target2": 0.5, "target3": 0.25, "target4": 0.1}},
 			in: [][]search.Result{
 				{res(0, 0.5), res(1, 0.6), res(2, 0.8), res(3, 0.9)},
 				{res(1, 0.2), res(0, 0.4), res(2, 0.6), res(5, 0.8)},


### PR DESCRIPTION
### What's being changed:

Removing results that had a missing vector for a target could panic for hybrid fusion

Identified as part of https://github.com/weaviate/weaviate/pull/5529 and confirmed by @rlmanrique 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
