### PR TITLE
Change task_type parameter to task to support JinaAI V3 embedding models

### DIFF
--- a/modules/text2vec-jinaai/clients/jinaai.go
+++ b/modules/text2vec-jinaai/clients/jinaai.go
@@ -38,14 +38,14 @@ const (
 )
 
 type (
-	taskType      string
+	task          string
 	embeddingType string
 )
 
 const (
 	// taskType
-	retrievalQuery   taskType = "retrieval.query"
-	retrievalPassage taskType = "retrieval.passage"
+	retrievalQuery   task = "retrieval.query"
+	retrievalPassage task = "retrieval.passage"
 	// embeddingType
 	embeddingTypeFloat   embeddingType = "float"
 	embeddingTypeBase64  embeddingType = "base64"
@@ -58,7 +58,7 @@ type embeddingsRequest struct {
 	Model         string        `json:"model,omitempty"`
 	EmbeddingType embeddingType `json:"embedding_type,omitempty"`
 	Normalized    bool          `json:"normalized,omitempty"`
-	TaskType      *taskType     `json:"task_type,omitempty"`
+	Task          *task         `json:"task,omitempty"`
 	Dimensions    *int64        `json:"dimensions,omitempty"`
 }
 
@@ -127,9 +127,9 @@ func (v *vectorizer) getVectorizationConfig(cfg moduletools.ClassConfig) ent.Vec
 }
 
 func (v *vectorizer) vectorize(ctx context.Context,
-	input []string, model string, taskType taskType, config ent.VectorizationConfig,
+	input []string, model string, task task, config ent.VectorizationConfig,
 ) (*modulecomponents.VectorizationResult, error) {
-	body, err := json.Marshal(v.getEmbeddingsRequest(input, model, taskType, config.Dimensions))
+	body, err := json.Marshal(v.getEmbeddingsRequest(input, model, task, config.Dimensions))
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal body")
 	}
@@ -194,11 +194,11 @@ func (v *vectorizer) getError(statusCode int, errorMessage string) error {
 	return fmt.Errorf("connection to: %s failed with status: %d", endpoint, statusCode)
 }
 
-func (v *vectorizer) getEmbeddingsRequest(input []string, model string, taskType taskType, dimensions *int64) embeddingsRequest {
+func (v *vectorizer) getEmbeddingsRequest(input []string, model string, task task, dimensions *int64) embeddingsRequest {
 	req := embeddingsRequest{Input: input, Model: model, EmbeddingType: embeddingTypeFloat, Normalized: false}
 	if strings.Contains(model, "v3") {
 		// v3 models require taskType and dimensions params
-		req.TaskType = &taskType
+		req.Task = &task
 		req.Dimensions = dimensions
 	}
 	return req


### PR DESCRIPTION
### What's being changed:

Change `task_type` parameter to `task` to support JinaAI V3 embedding models.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
