### PR TITLE
Fix PQ compression with not enough data

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -45,7 +45,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 	data := h.cache.All()
 	if cfg.PQ.Enabled {
 		if h.isEmpty() {
-			return errors.New("Compress command cannot be executed before inserting some data. Please, insert your data first.")
+			return errors.New("compress command cannot be executed before inserting some data")
 		}
 		dims := int(h.dims)
 
@@ -84,7 +84,8 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store,
 			h.allocChecker)
 		if err != nil {
-			return fmt.Errorf("Compressing vectors: %w", err)
+			h.pqConfig.Enabled = false
+			return fmt.Errorf("compressing vectors: %w", err)
 		}
 		h.commitLog.AddPQ(h.compressor.ExposeFields())
 	} else {


### PR DESCRIPTION
### What's being changed:
Previously when trying to use PQ compression algorithm with a number of vectors smaller than the number of K-Means centroids, there was the error message in loop (`compressing vectors: not enough data to fit the kmeans`).
Now the proposed solution disable PQ when PQ configuration fails and it logs  once the error.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
