### PR TITLE
add retry on apply when leader is not found

### DIFF
--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -15,7 +15,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/schema"
@@ -185,21 +187,41 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		))
 	defer t.ObserveDuration()
 
-	if s.store.IsLeader() {
-		return s.store.Execute(req)
-	}
-	if cmd.ApplyRequest_Type_name[int32(req.Type.Number())] == "" {
-		return 0, types.ErrUnknownCommand
-	}
+	var schemaVersion uint64
+	err := backoff.Retry(func() error {
+		var err error
 
-	leader := s.store.Leader()
-	if leader == "" {
-		return 0, s.leaderErr()
-	}
-	resp, err := s.cl.Apply(ctx, leader, req)
-	if err != nil {
-		return 0, err
-	}
+		// Validate the apply first
+		if _, ok := cmd.ApplyRequest_Type_name[int32(req.Type.Number())]; !ok {
+			err = types.ErrUnknownCommand
+			// This is an invalid apply command, don't retry
+			return backoff.Permanent(err)
+		}
 
-	return resp.Version, err
+		// We are the leader, let's apply
+		if s.store.IsLeader() {
+			schemaVersion, err = s.store.Execute(req)
+			// We might fail due to leader not found as we are losing or transferring leadership, retry
+			return err
+		}
+
+		leader := s.store.Leader()
+		if leader == "" {
+			err = s.leaderErr()
+			s.log.Warnf("apply: could not find leader: %s", err)
+			return err
+		}
+
+		var resp *cmd.ApplyResponse
+		resp, err = s.cl.Apply(ctx, leader, req)
+		if err != nil {
+			// Don't retry if the actual apply to the leader failed, we have retry at the network layer already
+			return backoff.Permanent(err)
+		}
+		schemaVersion = resp.Version
+		return nil
+		// Retry at most for 2 seconds, it shouldn't take longer for an election to take place
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx))
+
+	return schemaVersion, err
 }

--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -284,9 +284,10 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 		))
 	defer t.ObserveDuration()
 
-	var err error
 	resp := &cmd.QueryResponse{}
-	backoff.Retry(func() error {
+	err := backoff.Retry(func() error {
+		var err error
+
 		if s.store.IsLeader() {
 			resp, err = s.store.Query(req)
 			return err
@@ -294,9 +295,9 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 
 		leader := s.store.Leader()
 		if leader == "" {
-			lErr := s.leaderErr()
-			s.log.Warnf("query: could not find leader: %s", lErr)
-			return lErr
+			err = s.leaderErr()
+			s.log.Warnf("query: could not find leader: %s", err)
+			return err
 		}
 
 		resp, err = s.cl.Query(ctx, leader, req)


### PR DESCRIPTION
### What's being changed:

Similar to the previous PR where query calls where not retried if a leader wasn't present in the cluster this duplicate that logic for the apply endpoint.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
