### PR TITLE
Use AltNames modules feature in google modules

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1007,11 +1007,6 @@ func registerModules(appState *state.State) error {
 			WithField("action", "startup").
 			WithField("module", modmulti2vecgoogle.Name).
 			Debug("enabled module")
-		appState.Modules.Register(modmulti2vecgoogle.NewWithLegacyName())
-		appState.Logger.
-			WithField("action", "startup").
-			WithField("module", modmulti2vecgoogle.LegacyName).
-			Debug("enabled module")
 	}
 
 	if _, ok := enabledModules[modopenai.Name]; ok {
@@ -1144,11 +1139,6 @@ func registerModules(appState *state.State) error {
 		appState.Logger.
 			WithField("action", "startup").
 			WithField("module", modtext2vecgoogle.Name).
-			Debug("enabled module")
-		appState.Modules.Register(modtext2vecgoogle.NewWithLegacyName())
-		appState.Logger.
-			WithField("action", "startup").
-			WithField("module", modtext2vecgoogle.LegacyName).
 			Debug("enabled module")
 	}
 

--- a/modules/generative-google/config/class_settings.go
+++ b/modules/generative-google/config/class_settings.go
@@ -99,7 +99,7 @@ type classSettings struct {
 func NewClassSettings(cfg moduletools.ClassConfig) ClassSettings {
 	return &classSettings{
 		cfg:                  cfg,
-		propertyValuesHelper: basesettings.NewPropertyValuesHelperWitAltNames("generative-google", []string{"generative-palm"}),
+		propertyValuesHelper: basesettings.NewPropertyValuesHelperWithAltNames("generative-google", []string{"generative-palm"}),
 	}
 }
 

--- a/modules/multi2vec-google/module.go
+++ b/modules/multi2vec-google/module.go
@@ -38,12 +38,7 @@ func New() *Module {
 	return &Module{}
 }
 
-func NewWithLegacyName() *Module {
-	return &Module{withLegacyName: true}
-}
-
 type Module struct {
-	withLegacyName           bool
 	imageVectorizer          imageVectorizer
 	nearImageGraphqlProvider modulecapabilities.GraphQLArguments
 	nearImageSearcher        modulecapabilities.Searcher
@@ -79,10 +74,11 @@ type videoVectorizer interface {
 }
 
 func (m *Module) Name() string {
-	if m.withLegacyName {
-		return LegacyName
-	}
 	return Name
+}
+
+func (m *Module) AltNames() []string {
+	return []string{LegacyName}
 }
 
 func (m *Module) Type() modulecapabilities.ModuleType {
@@ -181,4 +177,5 @@ var (
 	_ = modulecapabilities.Module(New())
 	_ = modulecapabilities.Vectorizer(New())
 	_ = modulecapabilities.InputVectorizer(New())
+	_ = modulecapabilities.ModuleHasAltNames(New())
 )

--- a/modules/multi2vec-google/vectorizer/class_settings.go
+++ b/modules/multi2vec-google/vectorizer/class_settings.go
@@ -51,7 +51,10 @@ type classSettings struct {
 }
 
 func NewClassSettings(cfg moduletools.ClassConfig) *classSettings {
-	return &classSettings{cfg: cfg, base: basesettings.NewBaseClassSettings(cfg, false)}
+	return &classSettings{
+		cfg:  cfg,
+		base: basesettings.NewBaseClassSettingsWithAltNames(cfg, false, "multi2vec-google", []string{"multi2vec-palm"}),
+	}
 }
 
 // Google params
@@ -110,7 +113,7 @@ func (ic *classSettings) Properties() ([]string, error) {
 	fields := []string{"textFields", "imageFields", "videoFields"}
 
 	for _, field := range fields {
-		fields, ok := ic.cfg.Class()[field]
+		fields, ok := ic.base.GetSettings()[field]
 		if !ok {
 			continue
 		}
@@ -137,7 +140,7 @@ func (ic *classSettings) field(name, property string) bool {
 		return false
 	}
 
-	fields, ok := ic.cfg.Class()[name]
+	fields, ok := ic.base.GetSettings()[name]
 	if !ok {
 		return false
 	}
@@ -291,7 +294,7 @@ func (ic *classSettings) validateWeights(name string, count int) error {
 }
 
 func (ic *classSettings) getWeights(name string) ([]interface{}, bool) {
-	weights, ok := ic.cfg.Class()["weights"]
+	weights, ok := ic.base.GetSettings()["weights"]
 	if ok {
 		weightsObject, ok := weights.(map[string]interface{})
 		if ok {

--- a/modules/text2vec-google/module.go
+++ b/modules/text2vec-google/module.go
@@ -41,12 +41,7 @@ func New() *GoogleModule {
 	return &GoogleModule{}
 }
 
-func NewWithLegacyName() *GoogleModule {
-	return &GoogleModule{withLegacyName: true}
-}
-
 type GoogleModule struct {
-	withLegacyName               bool
 	vectorizer                   text2vecbase.TextVectorizer
 	metaProvider                 text2vecbase.MetaProvider
 	graphqlProvider              modulecapabilities.GraphQLArguments
@@ -57,10 +52,11 @@ type GoogleModule struct {
 }
 
 func (m *GoogleModule) Name() string {
-	if m.withLegacyName {
-		return LegacyName
-	}
 	return Name
+}
+
+func (m *GoogleModule) AltNames() []string {
+	return []string{LegacyName}
 }
 
 func (m *GoogleModule) Type() modulecapabilities.ModuleType {
@@ -163,4 +159,5 @@ var (
 	_ = modulecapabilities.MetaProvider(New())
 	_ = modulecapabilities.Searcher(New())
 	_ = modulecapabilities.GraphQLArguments(New())
+	_ = modulecapabilities.ModuleHasAltNames(New())
 )

--- a/modules/text2vec-google/vectorizer/class_settings.go
+++ b/modules/text2vec-google/vectorizer/class_settings.go
@@ -60,7 +60,10 @@ type classSettings struct {
 }
 
 func NewClassSettings(cfg moduletools.ClassConfig) *classSettings {
-	return &classSettings{cfg: cfg, BaseClassSettings: *basesettings.NewBaseClassSettings(cfg, false)}
+	return &classSettings{
+		cfg:               cfg,
+		BaseClassSettings: *basesettings.NewBaseClassSettingsWithAltNames(cfg, false, "text2vec-google", []string{"text2vec-palm"}),
+	}
 }
 
 func (ic *classSettings) Validate(class *models.Class) error {

--- a/test/modules/many-modules/many_modules_sanity_test.go
+++ b/test/modules/many-modules/many_modules_sanity_test.go
@@ -36,7 +36,7 @@ func manyModulesTests(endpoint string) func(t *testing.T) {
 			expectedModuleNames := []string{
 				"generative-cohere", "generative-google", "generative-openai", "generative-aws", "generative-anyscale", "generative-friendliai",
 				"generative-anthropic", "text2vec-cohere", "text2vec-contextionary", "text2vec-openai", "text2vec-huggingface",
-				"text2vec-google", "text2vec-palm", "text2vec-aws", "text2vec-transformers", "qna-openai", "reranker-cohere",
+				"text2vec-google", "text2vec-aws", "text2vec-transformers", "qna-openai", "reranker-cohere",
 				"text2vec-voyageai", "reranker-voyageai",
 			}
 

--- a/usecases/modulecomponents/settings/base_class_settings.go
+++ b/usecases/modulecomponents/settings/base_class_settings.go
@@ -37,6 +37,16 @@ func NewBaseClassSettings(cfg moduletools.ClassConfig, lowerCaseInput bool) *Bas
 	return &BaseClassSettings{cfg: cfg, propertyHelper: &classPropertyValuesHelper{}, lowerCaseInput: lowerCaseInput}
 }
 
+func NewBaseClassSettingsWithAltNames(cfg moduletools.ClassConfig,
+	lowerCaseInput bool, moduleName string, altNames []string,
+) *BaseClassSettings {
+	return &BaseClassSettings{
+		cfg:            cfg,
+		propertyHelper: &classPropertyValuesHelper{moduleName: moduleName, altNames: altNames},
+		lowerCaseInput: lowerCaseInput,
+	}
+}
+
 func (s *BaseClassSettings) LowerCaseInput() bool {
 	return s.lowerCaseInput
 }
@@ -86,7 +96,7 @@ func (s *BaseClassSettings) VectorizeClassName() bool {
 		return DefaultVectorizeClassName
 	}
 
-	vcn, ok := s.cfg.Class()["vectorizeClassName"]
+	vcn, ok := s.GetSettings()["vectorizeClassName"]
 	if !ok {
 		return DefaultVectorizeClassName
 	}
@@ -104,7 +114,7 @@ func (s *BaseClassSettings) Properties() []string {
 		return nil
 	}
 
-	field, ok := s.cfg.Class()["properties"]
+	field, ok := s.GetSettings()["properties"]
 	if !ok {
 		return nil
 	}
@@ -128,7 +138,7 @@ func (s *BaseClassSettings) Properties() []string {
 
 func (s *BaseClassSettings) ValidateClassSettings() error {
 	if s.cfg != nil && len(s.cfg.Class()) > 0 {
-		if field, ok := s.cfg.Class()["properties"]; ok {
+		if field, ok := s.GetSettings()["properties"]; ok {
 			fieldsArray, fieldsArrayOk := field.([]interface{})
 			if fieldsArrayOk {
 				if len(fieldsArray) == 0 {
@@ -212,6 +222,10 @@ func (s *BaseClassSettings) ValidateIndexState(class *models.Class) error {
 		"to true if the class name is contextionary-valid. Alternatively add at least " +
 		"contextionary-valid text/string property which is not excluded from " +
 		"indexing")
+}
+
+func (s *BaseClassSettings) GetSettings() map[string]interface{} {
+	return s.propertyHelper.GetSettings(s.cfg)
 }
 
 func (s *BaseClassSettings) Validate(class *models.Class) error {

--- a/usecases/modulecomponents/settings/class_settings_property_helper.go
+++ b/usecases/modulecomponents/settings/class_settings_property_helper.go
@@ -42,7 +42,7 @@ func NewPropertyValuesHelper(moduleName string) PropertyValuesHelper {
 	return &classPropertyValuesHelper{moduleName: moduleName}
 }
 
-func NewPropertyValuesHelperWitAltNames(moduleName string, altNames []string) PropertyValuesHelper {
+func NewPropertyValuesHelperWithAltNames(moduleName string, altNames []string) PropertyValuesHelper {
 	return &classPropertyValuesHelper{moduleName, altNames}
 }
 
@@ -59,7 +59,7 @@ func (h *classPropertyValuesHelper) GetPropertyAsIntWithNotExists(cfg moduletool
 		// we would receive a nil-config on cross-class requests, such as Explore{}
 		return notExistsValue
 	}
-	return getNumberValue(h.getSettings(cfg), name, defaultValue, notExistsValue)
+	return getNumberValue(h.GetSettings(cfg), name, defaultValue, notExistsValue)
 }
 
 func (h *classPropertyValuesHelper) GetPropertyAsInt64(cfg moduletools.ClassConfig,
@@ -75,7 +75,7 @@ func (h *classPropertyValuesHelper) GetPropertyAsInt64WithNotExists(cfg moduleto
 		// we would receive a nil-config on cross-class requests, such as Explore{}
 		return notExistsValue
 	}
-	return getNumberValue(h.getSettings(cfg), name, defaultValue, notExistsValue)
+	return getNumberValue(h.GetSettings(cfg), name, defaultValue, notExistsValue)
 }
 
 func (h *classPropertyValuesHelper) GetPropertyAsFloat64(cfg moduletools.ClassConfig,
@@ -91,7 +91,7 @@ func (h *classPropertyValuesHelper) GetPropertyAsFloat64WithNotExists(cfg module
 		// we would receive a nil-config on cross-class requests, such as Explore{}
 		return notExistsValue
 	}
-	return getNumberValue(h.getSettings(cfg), name, defaultValue, notExistsValue)
+	return getNumberValue(h.GetSettings(cfg), name, defaultValue, notExistsValue)
 }
 
 func (h *classPropertyValuesHelper) GetPropertyAsString(cfg moduletools.ClassConfig,
@@ -108,7 +108,7 @@ func (h *classPropertyValuesHelper) GetPropertyAsStringWithNotExists(cfg modulet
 		return notExistsValue
 	}
 
-	value := h.getSettings(cfg)[name]
+	value := h.GetSettings(cfg)[name]
 	switch v := value.(type) {
 	case nil:
 		return notExistsValue
@@ -133,7 +133,7 @@ func (h *classPropertyValuesHelper) GetPropertyAsBoolWithNotExists(cfg moduletoo
 		return notExistsValue
 	}
 
-	value := h.getSettings(cfg)[name]
+	value := h.GetSettings(cfg)[name]
 	switch v := value.(type) {
 	case nil:
 		return notExistsValue
@@ -175,7 +175,7 @@ func (h *classPropertyValuesHelper) GetNumber(in interface{}) (float32, error) {
 	}
 }
 
-func (h *classPropertyValuesHelper) getSettings(cfg moduletools.ClassConfig) map[string]interface{} {
+func (h *classPropertyValuesHelper) GetSettings(cfg moduletools.ClassConfig) map[string]interface{} {
 	if h.moduleName != "" {
 		if settings := cfg.ClassByModuleName(h.moduleName); len(settings) > 0 {
 			return settings

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"sync"
 
 	"github.com/weaviate/weaviate/entities/dto"
@@ -268,13 +269,19 @@ func (p *Provider) isGenerativeModule(moduleType modulecapabilities.ModuleType) 
 }
 
 func (p *Provider) shouldIncludeClassArgument(class *models.Class, module string,
-	moduleType modulecapabilities.ModuleType,
+	moduleType modulecapabilities.ModuleType, altNames []string,
 ) bool {
 	if p.isVectorizerModule(moduleType) {
 		for _, vectorConfig := range class.VectorConfig {
 			if vectorizer, ok := vectorConfig.Vectorizer.(map[string]interface{}); ok {
 				if _, ok := vectorizer[module]; ok {
 					return true
+				} else if len(altNames) > 0 {
+					for _, altName := range altNames {
+						if _, ok := vectorizer[altName]; ok {
+							return true
+						}
+					}
 				}
 			}
 		}
@@ -292,19 +299,19 @@ func (p *Provider) shouldIncludeClassArgument(class *models.Class, module string
 }
 
 func (p *Provider) shouldCrossClassIncludeClassArgument(class *models.Class, module string,
-	moduleType modulecapabilities.ModuleType,
+	moduleType modulecapabilities.ModuleType, altNames []string,
 ) bool {
 	if class == nil {
 		return !p.HasMultipleVectorizers()
 	}
-	return p.shouldIncludeClassArgument(class, module, moduleType)
+	return p.shouldIncludeClassArgument(class, module, moduleType, altNames)
 }
 
 func (p *Provider) shouldIncludeArgument(schema *models.Schema, module string,
-	moduleType modulecapabilities.ModuleType,
+	moduleType modulecapabilities.ModuleType, altNames []string,
 ) bool {
 	for _, c := range schema.Classes {
-		if p.shouldIncludeClassArgument(c, module, moduleType) {
+		if p.shouldIncludeClassArgument(c, module, moduleType, altNames) {
 			return true
 		}
 	}
@@ -362,7 +369,7 @@ func (p *Provider) getGenericAdditionalProperty(name string, class *models.Class
 func (p *Provider) GetArguments(class *models.Class) map[string]*graphql.ArgumentConfig {
 	arguments := map[string]*graphql.ArgumentConfig{}
 	for _, module := range p.GetAll() {
-		if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if arg, ok := module.(modulecapabilities.GraphQLArguments); ok {
 				for name, argument := range arg.Arguments() {
 					if argument.GetArgumentsFunction != nil {
@@ -382,11 +389,30 @@ func (p *Provider) GetArguments(class *models.Class) map[string]*graphql.Argumen
 	return arguments
 }
 
+func (p *Provider) getModuleAltNames(module modulecapabilities.Module) []string {
+	if moduleWithAltNames, ok := module.(modulecapabilities.ModuleHasAltNames); ok {
+		return moduleWithAltNames.AltNames()
+	}
+	return nil
+}
+
+func (p *Provider) isModuleNameEqual(module modulecapabilities.Module, targetModule string) bool {
+	if module.Name() == targetModule {
+		return true
+	}
+	if altNames := p.getModuleAltNames(module); len(altNames) > 0 {
+		if slices.Contains(altNames, targetModule) {
+			return true
+		}
+	}
+	return false
+}
+
 // AggregateArguments provides GraphQL Aggregate arguments
 func (p *Provider) AggregateArguments(class *models.Class) map[string]*graphql.ArgumentConfig {
 	arguments := map[string]*graphql.ArgumentConfig{}
 	for _, module := range p.GetAll() {
-		if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if arg, ok := module.(modulecapabilities.GraphQLArguments); ok {
 				for name, argument := range arg.Arguments() {
 					if argument.AggregateArgumentsFunction != nil {
@@ -409,7 +435,7 @@ func (p *Provider) AggregateArguments(class *models.Class) map[string]*graphql.A
 func (p *Provider) ExploreArguments(schema *models.Schema) map[string]*graphql.ArgumentConfig {
 	arguments := map[string]*graphql.ArgumentConfig{}
 	for _, module := range p.GetAll() {
-		if p.shouldIncludeArgument(schema, module.Name(), module.Type()) {
+		if p.shouldIncludeArgument(schema, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if arg, ok := module.(modulecapabilities.GraphQLArguments); ok {
 				for name, argument := range arg.Arguments() {
 					if argument.ExploreArgumentsFunction != nil {
@@ -450,7 +476,7 @@ func (p *Provider) extractSearchParams(arguments map[string]interface{}, class *
 	exractedParams := map[string]interface{}{}
 	exractedCombination := map[string]*dto.TargetCombination{}
 	for _, module := range p.GetAll() {
-		if p.shouldCrossClassIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldCrossClassIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if args, ok := module.(modulecapabilities.GraphQLArguments); ok {
 				for paramName, argument := range args.Arguments() {
 					if param, ok := arguments[paramName]; ok && argument.ExtractFunction != nil {
@@ -487,7 +513,7 @@ func (p *Provider) ValidateSearchParam(name string, value interface{}, className
 
 func (p *Provider) validateSearchParam(name string, value interface{}, class *models.Class) error {
 	for _, module := range p.GetAll() {
-		if p.shouldCrossClassIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldCrossClassIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if args, ok := module.(modulecapabilities.GraphQLArguments); ok {
 				for paramName, argument := range args.Arguments() {
 					if paramName == name && argument.ValidateFunction != nil {
@@ -511,12 +537,12 @@ func (p *Provider) GetAdditionalFields(class *models.Class) map[string]*graphql.
 			if arg, ok := module.(modulecapabilities.AdditionalGenerativeProperties); ok {
 				for name, additionalGenerativeParameter := range arg.AdditionalGenerativeProperties() {
 					additionalGenerativeParameters[name] = additionalGenerativeParameter
-					if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+					if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 						additionalGenerativeDefaultProvider = name
 					}
 				}
 			}
-		} else if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+		} else if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if arg, ok := module.(modulecapabilities.AdditionalProperties); ok {
 				for name, additionalProperty := range arg.AdditionalProperties() {
 					if additionalProperty.GraphQLFieldFunction != nil {
@@ -556,13 +582,13 @@ func (p *Provider) ExtractAdditionalField(className, name string, params []*ast.
 				if arg, ok := module.(modulecapabilities.AdditionalGenerativeProperties); ok {
 					for name, additionalGenerativeParameter := range arg.AdditionalGenerativeProperties() {
 						additionalGenerativeParameters[name] = additionalGenerativeParameter
-						if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+						if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 							additionalGenerativeDefaultProvider = name
 						}
 					}
 				}
 			}
-		} else if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+		} else if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if arg, ok := module.(modulecapabilities.AdditionalProperties); ok {
 				if additionalProperties := arg.AdditionalProperties(); len(additionalProperties) > 0 {
 					if additionalProperty, ok := additionalProperties[name]; ok {
@@ -627,12 +653,12 @@ func (p *Provider) additionalExtend(ctx context.Context, in []search.Result, mod
 				if arg, ok := module.(modulecapabilities.AdditionalGenerativeProperties); ok {
 					for name, additionalGenerativeParameter := range arg.AdditionalGenerativeProperties() {
 						additionalGenerativeParameters[name] = additionalGenerativeParameter
-						if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+						if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 							additionalGenerativeDefaultProvider = name
 						}
 					}
 				}
-			} else if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+			} else if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 				if arg, ok := module.(modulecapabilities.AdditionalProperties); ok {
 					if arg != nil && arg.AdditionalProperties() != nil {
 						for name, additionalProperty := range arg.AdditionalProperties() {
@@ -738,7 +764,7 @@ func (p *Provider) GraphQLAdditionalFieldNames() []string {
 func (p *Provider) RestApiAdditionalProperties(includeProp string, class *models.Class) map[string]interface{} {
 	moduleParams := map[string]interface{}{}
 	for _, module := range p.GetAll() {
-		if p.shouldCrossClassIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldCrossClassIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if arg, ok := module.(modulecapabilities.AdditionalProperties); ok {
 				for name, additionalProperty := range arg.AdditionalProperties() {
 					for _, includePropName := range additionalProperty.RestNames {
@@ -779,11 +805,11 @@ func (p *Provider) VectorFromSearchParam(ctx context.Context, className, targetV
 	targetModule := p.getModuleNameForTargetVector(class, targetVector)
 
 	for _, mod := range p.GetAll() {
-		if p.shouldIncludeClassArgument(class, mod.Name(), mod.Type()) {
+		if p.shouldIncludeClassArgument(class, mod.Name(), mod.Type(), p.getModuleAltNames(mod)) {
 			var moduleName string
 			var vectorSearches modulecapabilities.ArgumentVectorForParams
 			if searcher, ok := mod.(modulecapabilities.Searcher); ok {
-				if mod.Name() == targetModule {
+				if p.isModuleNameEqual(mod, targetModule) {
 					moduleName = mod.Name()
 					vectorSearches = searcher.VectorSearches()
 				}
@@ -883,7 +909,7 @@ func (p *Provider) VectorFromInput(ctx context.Context,
 
 	for _, mod := range p.GetAll() {
 		if mod.Name() == targetModule {
-			if p.shouldIncludeClassArgument(class, mod.Name(), mod.Type()) {
+			if p.shouldIncludeClassArgument(class, mod.Name(), mod.Type(), p.getModuleAltNames(mod)) {
 				if vectorizer, ok := mod.(modulecapabilities.InputVectorizer); ok {
 					// does not access any objects, therefore tenant is irrelevant
 					cfg := NewClassBasedModuleConfig(class, mod.Name(), "", targetVector)
@@ -905,7 +931,7 @@ func (p *Provider) ParseClassifierSettings(name string,
 		return err
 	}
 	for _, module := range p.GetAll() {
-		if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if c, ok := module.(modulecapabilities.ClassificationProvider); ok {
 				for _, classifier := range c.Classifiers() {
 					if classifier != nil && classifier.Name() == name {
@@ -927,7 +953,7 @@ func (p *Provider) GetClassificationFn(className, name string,
 		return nil, err
 	}
 	for _, module := range p.GetAll() {
-		if p.shouldIncludeClassArgument(class, module.Name(), module.Type()) {
+		if p.shouldIncludeClassArgument(class, module.Name(), module.Type(), p.getModuleAltNames(module)) {
 			if c, ok := module.(modulecapabilities.ClassificationProvider); ok {
 				for _, classifier := range c.Classifiers() {
 					if classifier != nil && classifier.Name() == name {


### PR DESCRIPTION
### What's being changed:

Instead of initing the module twice this PR uses built-in AltNames() modules feature in google modules to load them and still support the legacy name.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
