### PR TITLE
Introduce limit to nested crossref depth in queries

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -58,6 +58,9 @@ const (
 	DefaultBM25b  = float32(0.75)
 )
 
+// DefaultQueryMaxRefDepth describes the max depth of nested references in a query
+const DefaultQueryMaxRefDepth = 3
+
 const (
 	DefaultMaxImportGoroutinesFactor = float64(1.5)
 

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -82,7 +82,7 @@ type Config struct {
 	QueryDefaults                       QueryDefaults            `json:"query_defaults" yaml:"query_defaults"`
 	QueryMaximumResults                 int64                    `json:"query_maximum_results" yaml:"query_maximum_results"`
 	QueryNestedCrossReferenceLimit      int64                    `json:"query_nested_cross_reference_limit" yaml:"query_nested_cross_reference_limit"`
-	QueryCrossReferenceDepthLimit       int                      `json:"query_maximum_cross_regerence_depth" yaml:"query_maximum_cross_regerence_depth"`
+	QueryCrossReferenceDepthLimit       int                      `json:"query_cross_reference_depth_limit" yaml:"query_cross_reference_depth_limit"`
 	Contextionary                       Contextionary            `json:"contextionary" yaml:"contextionary"`
 	Authentication                      Authentication           `json:"authentication" yaml:"authentication"`
 	Authorization                       Authorization            `json:"authorization" yaml:"authorization"`

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -58,9 +58,6 @@ const (
 	DefaultBM25b  = float32(0.75)
 )
 
-// DefaultQueryMaxRefDepth describes the max depth of nested references in a query
-const DefaultQueryMaxRefDepth = 3
-
 const (
 	DefaultMaxImportGoroutinesFactor = float64(1.5)
 
@@ -85,6 +82,7 @@ type Config struct {
 	QueryDefaults                       QueryDefaults            `json:"query_defaults" yaml:"query_defaults"`
 	QueryMaximumResults                 int64                    `json:"query_maximum_results" yaml:"query_maximum_results"`
 	QueryNestedCrossReferenceLimit      int64                    `json:"query_nested_cross_reference_limit" yaml:"query_nested_cross_reference_limit"`
+	QueryCrossReferenceDepthLimit       int                      `json:"query_maximum_cross_regerence_depth" yaml:"query_maximum_cross_regerence_depth"`
 	Contextionary                       Contextionary            `json:"contextionary" yaml:"contextionary"`
 	Authentication                      Authentication           `json:"authentication" yaml:"authentication"`
 	Authorization                       Authorization            `json:"authorization" yaml:"authorization"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -254,6 +254,18 @@ func FromEnv(config *Config) error {
 		config.QueryNestedCrossReferenceLimit = DefaultQueryNestedCrossReferenceLimit
 	}
 
+	if v := os.Getenv("QUERY_CROSS_REFERENCE_DEPTH_LIMIT"); v != "" {
+		limit, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse QUERY_CROSS_REFERENCE_DEPTH_LIMIT as int: %w", err)
+		} else if limit <= 0 {
+			limit = math.MaxInt
+		}
+		config.QueryCrossReferenceDepthLimit = int(limit)
+	} else {
+		config.QueryCrossReferenceDepthLimit = DefaultQueryCrossReferenceDepthLimit
+	}
+
 	if v := os.Getenv("MAX_IMPORT_GOROUTINES_FACTOR"); v != "" {
 		asFloat, err := strconv.ParseFloat(v, 64)
 		if err != nil {
@@ -484,8 +496,11 @@ func parsePositiveInt(varName string, cb func(val int), defaultValue int) error 
 }
 
 const (
-	DefaultQueryMaximumResults            = int64(10000)
+	DefaultQueryMaximumResults = int64(10000)
+	// DefaultQueryNestedCrossReferenceLimit describes the max number of nested crossrefs returned for a query
 	DefaultQueryNestedCrossReferenceLimit = int64(100000)
+	// DefaultQueryCrossReferenceDepthLimit describes the max depth of nested crossrefs in a query
+	DefaultQueryCrossReferenceDepthLimit = 3
 )
 
 const (

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -496,7 +496,7 @@ const (
 	// DefaultQueryNestedCrossReferenceLimit describes the max number of nested crossrefs returned for a query
 	DefaultQueryNestedCrossReferenceLimit = int64(100000)
 	// DefaultQueryCrossReferenceDepthLimit describes the max depth of nested crossrefs in a query
-	DefaultQueryCrossReferenceDepthLimit = 3
+	DefaultQueryCrossReferenceDepthLimit = 5
 )
 
 const (

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -259,7 +259,7 @@ func FromEnv(config *Config) error {
 		if err != nil {
 			return fmt.Errorf("parse QUERY_CROSS_REFERENCE_DEPTH_LIMIT as int: %w", err)
 		} else if limit <= 0 {
-			limit = math.MaxInt
+			limit = DefaultQueryCrossReferenceDepthLimit
 		}
 		config.QueryCrossReferenceDepthLimit = int(limit)
 	} else {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -254,16 +254,12 @@ func FromEnv(config *Config) error {
 		config.QueryNestedCrossReferenceLimit = DefaultQueryNestedCrossReferenceLimit
 	}
 
-	if v := os.Getenv("QUERY_CROSS_REFERENCE_DEPTH_LIMIT"); v != "" {
-		limit, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return fmt.Errorf("parse QUERY_CROSS_REFERENCE_DEPTH_LIMIT as int: %w", err)
-		} else if limit <= 0 {
-			limit = DefaultQueryCrossReferenceDepthLimit
-		}
-		config.QueryCrossReferenceDepthLimit = int(limit)
-	} else {
-		config.QueryCrossReferenceDepthLimit = DefaultQueryCrossReferenceDepthLimit
+	if err := parsePositiveInt(
+		"QUERY_CROSS_REFERENCE_DEPTH_LIMIT",
+		func(val int) { config.QueryCrossReferenceDepthLimit = val },
+		DefaultQueryCrossReferenceDepthLimit,
+	); err != nil {
+		return err
 	}
 
 	if v := os.Getenv("MAX_IMPORT_GOROUTINES_FACTOR"); v != "" {

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -13,11 +13,16 @@ package traverser
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
@@ -44,6 +49,10 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 		return nil, err
 	}
 
+	if err := probeForRefDepthLimit(params.Properties); err != nil {
+		return nil, err
+	}
+
 	unlock, err := t.locks.LockConnector()
 	if err != nil {
 		return nil, enterrors.NewErrLockConnector(err)
@@ -61,4 +70,43 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	}
 
 	return t.explorer.GetClass(ctx, params)
+}
+
+// probeForRefDepthLimit checks to ensure reference nesting depth doesn't exceed the limit
+// provided by QUERY_MAX_REF_DEPTH
+func probeForRefDepthLimit(props search.SelectProperties) error {
+	var (
+		determineDepth func(prop search.SelectProperties, depth int) int
+		maxDepth       = func() int {
+			if raw := os.Getenv("QUERY_MAX_REF_DEPTH"); raw != "" {
+				depth, err := strconv.Atoi(raw)
+				if err != nil {
+					return config.DefaultQueryMaxRefDepth
+				}
+				return depth
+			}
+			return config.DefaultQueryMaxRefDepth
+		}()
+	)
+
+	determineDepth = func(props search.SelectProperties, depth int) int {
+		if depth > maxDepth || len(props) == 0 {
+			return depth
+		}
+
+		prop := props[0]
+		if len(prop.Refs) > 0 {
+			depth++
+			for _, refTarget := range prop.Refs {
+				return determineDepth(refTarget.RefProperties, depth)
+			}
+		}
+
+		return determineDepth(props[1:], depth)
+	}
+
+	if depth := determineDepth(props, 0); depth > maxDepth {
+		return fmt.Errorf("nested references depth exceeds QUERY_MAX_REF_DEPTH (%d)", maxDepth)
+	}
+	return nil
 }

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -70,7 +70,7 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 }
 
 // probeForRefDepthLimit checks to ensure reference nesting depth doesn't exceed the limit
-// provided by QUERY_MAX_REF_DEPTH
+// provided by QUERY_CROSS_REFERENCE_DEPTH_LIMIT
 func (t *Traverser) probeForRefDepthLimit(props search.SelectProperties) error {
 	var (
 		determineDepth func(prop search.SelectProperties, depth int) int

--- a/usecases/traverser/traverser_get_params_test.go
+++ b/usecases/traverser/traverser_get_params_test.go
@@ -195,6 +195,5 @@ func TestGet_NestedRefDepthLimit(t *testing.T) {
 				assert.Nil(t, err)
 			}
 		})
-
 	}
 }

--- a/usecases/traverser/traverser_get_params_test.go
+++ b/usecases/traverser/traverser_get_params_test.go
@@ -135,8 +135,8 @@ func TestGet_NestedRefDepthLimit(t *testing.T) {
 		root := search.SelectProperties{}
 		next := &root
 		for i := 0; i < depth; i++ {
-			*next = append(*next, search.SelectProperty{Name: "Product"})
-			class := search.SelectClass{ClassName: "Brand"}
+			*next = append(*next, search.SelectProperty{Name: "nextNode"})
+			class := search.SelectClass{ClassName: "LinkedListNode"}
 			refs := []search.SelectClass{class}
 			(*next)[0].Refs = refs
 			next = &refs[0].RefProperties

--- a/usecases/traverser/traverser_get_params_test.go
+++ b/usecases/traverser/traverser_get_params_test.go
@@ -135,11 +135,17 @@ func TestGet_NestedRefDepthLimit(t *testing.T) {
 		root := search.SelectProperties{}
 		next := &root
 		for i := 0; i < depth; i++ {
-			*next = append(*next, search.SelectProperty{Name: "nextNode"})
-			class := search.SelectClass{ClassName: "LinkedListNode"}
-			refs := []search.SelectClass{class}
-			(*next)[0].Refs = refs
-			next = &refs[0].RefProperties
+			*next = append(*next,
+				search.SelectProperty{Name: "nextNode"},
+				search.SelectProperty{Name: "otherRef"},
+			)
+			class0 := search.SelectClass{ClassName: "LinkedListNode"}
+			refs0 := []search.SelectClass{class0}
+			(*next)[0].Refs = refs0
+			class1 := search.SelectClass{ClassName: "LinkedListNode"}
+			refs1 := []search.SelectClass{class1}
+			(*next)[1].Refs = refs1
+			next = &refs0[0].RefProperties
 		}
 		return root
 	}


### PR DESCRIPTION
### What's being changed:

With this addition of `QUERY_CROSS_REFERENCE_DEPTH_LIMIT`, Weaviate can now be configured to avoid potential DDoS attacks that attempt to overload the server with queries containing deeply nested cross references.

The depth limit is upheld by a recursive iteration over the properties tree, and includes a short-circuit which is tripped as soon as the max depth is reached.

If `QUERY_CROSS_REFERENCE_DEPTH_LIMIT` is not set, a sane value of `3` is applied by default.

Additionally, with this depth check happening at the `traverser` level, the limit applies to both GQL and gRPC requests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
