### PR TITLE
Fix flipping in hybrid search

### DIFF
--- a/test/acceptance_with_python/test_hybrid.py
+++ b/test/acceptance_with_python/test_hybrid.py
@@ -267,3 +267,21 @@ def test_hybrid_with_offset(
 
     hy_offset = collection.query.hybrid("summer dress", offset=2, vector=vector)
     assert len(hy_offset.objects) + 2 == len(hy.objects)
+
+
+def test_flipping(collection_factory: CollectionFactory):
+    collection = collection_factory(
+        properties=[Property(name="name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.none(),
+    )
+
+    collection.data.insert({"name": "banana fruit"}, vector=[1, 0, 0], uuid=UUID1)
+    collection.data.insert({"name": "apple fruit first"}, vector=[1, 0, 0], uuid=UUID2)
+    collection.data.insert({"name": "apple fruit second"}, vector=[1, 0, 0], uuid=UUID3)
+
+    hy = collection.query.hybrid("fruit", vector=[1, 0, 0]).objects
+
+    # repeat search to make sure order is always the same
+    for i in range(10):
+        hy2 = collection.query.hybrid("fruit", vector=[1, 0, 0]).objects
+        assert all(hy[i].uuid == hy2[i].uuid for i in range(len(hy)))

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -66,8 +66,14 @@ func FusionRanked(weights []float64, resultSets [][]*search.Result, setNames []s
 	}
 
 	sort.Slice(sortList, func(i, j int) bool {
-		if sortList[j].Score == sortList[i].Score {
-			return sortList[i].SecondarySortValue > sortList[j].SecondarySortValue
+		a_b := float64(sortList[j].Score - sortList[i].Score)
+		if a_b*a_b < 1e-14 {
+			a_b2 := float64(sortList[j].SecondarySortValue - sortList[i].SecondarySortValue)
+			if a_b2*a_b2 < 1e-14 {
+				return sortList[i].ID > sortList[j].ID
+			} else {
+				return sortList[i].SecondarySortValue > sortList[j].SecondarySortValue
+			}
 		}
 		return float64(sortList[i].Score) > float64(sortList[j].Score)
 	})
@@ -149,7 +155,12 @@ func FusionRelativeScore(weights []float64, resultSets [][]*search.Result, names
 		sort.Slice(concat, func(i, j int) bool {
 			a_b := float64(concat[j].Score - concat[i].Score)
 			if a_b*a_b < 1e-14 {
-				return concat[i].SecondarySortValue > concat[j].SecondarySortValue
+				a_b2 := float64(concat[j].SecondarySortValue - concat[i].SecondarySortValue)
+				if a_b2*a_b2 < 1e-14 {
+					return concat[i].ID > concat[j].ID
+				} else {
+					return concat[i].SecondarySortValue > concat[j].SecondarySortValue
+				}
 			}
 			return float64(concat[i].Score) > float64(concat[j].Score)
 		})
@@ -157,7 +168,12 @@ func FusionRelativeScore(weights []float64, resultSets [][]*search.Result, names
 		sort.Slice(concat, func(i, j int) bool {
 			a_b := float64(concat[j].Score - concat[i].Score)
 			if a_b*a_b < 1e-14 {
-				return concat[i].SecondarySortValue < concat[j].SecondarySortValue
+				a_b2 := float64(concat[j].SecondarySortValue - concat[i].SecondarySortValue)
+				if a_b2*a_b2 < 1e-14 {
+					return concat[i].ID > concat[j].ID
+				} else {
+					return concat[i].SecondarySortValue < concat[j].SecondarySortValue
+				}
 			}
 			return float64(concat[i].Score) < float64(concat[j].Score)
 		})


### PR DESCRIPTION
### What's being changed:

If the hybrid score was identical for different objects AND the vector distance was also the same, objects could flip

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
