### PR TITLE
Fix requested distance for object with ID larger than cache

### DIFF
--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -926,6 +926,9 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 		} else {
 			queryVecEncode := index.bq.Encode(queryVector)
 			distFunc = func(nodeID uint64) (float32, error) {
+				if int32(nodeID) > index.bqCache.Len() {
+					return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, index.bqCache.Len())
+				}
 				vec, err := index.bqCache.Get(context.Background(), nodeID)
 				if err != nil {
 					return 0, err

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -307,7 +307,7 @@ func TestFlat_QueryVectorDistancer(t *testing.T) {
 			require.Equal(t, distance, float32(1.))
 
 			// get distance for non-existing node above default cache size
-			distance, err = dist.DistanceToNode(1001)
+			_, err = dist.DistanceToNode(1001)
 			require.NotNil(t, err)
 		})
 	}

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -305,6 +305,10 @@ func TestFlat_QueryVectorDistancer(t *testing.T) {
 			distance, err := dist.DistanceToNode(0)
 			require.Nil(t, err)
 			require.Equal(t, distance, float32(1.))
+
+			// get distance for non-existing node above default cache size
+			distance, err = dist.DistanceToNode(1001)
+			require.NotNil(t, err)
 		})
 	}
 }

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -565,6 +565,10 @@ func (h *hnsw) QueryVectorDistancer(queryVector []float32) common.QueryVectorDis
 	if h.compressed.Load() {
 		dist, returnFn := h.compressor.NewDistancer(queryVector)
 		f := func(nodeID uint64) (float32, error) {
+			if int(nodeID) > len(h.nodes) {
+				return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, len(h.nodes))
+			}
+
 			return dist.DistanceToNode(nodeID)
 		}
 		return common.QueryVectorDistancer{DistanceFunc: f, CloseFunc: returnFn}
@@ -572,6 +576,9 @@ func (h *hnsw) QueryVectorDistancer(queryVector []float32) common.QueryVectorDis
 	} else {
 		distancer := h.distancerProvider.New(queryVector)
 		f := func(nodeID uint64) (float32, error) {
+			if int(nodeID) > len(h.nodes) {
+				return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, len(h.nodes))
+			}
 			return h.distanceToFloatNode(distancer, nodeID)
 		}
 		return common.QueryVectorDistancer{DistanceFunc: f}

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -90,3 +90,43 @@ func TestNilCheckOnPartiallyCleanedNode(t *testing.T) {
 		assert.True(t, ok)
 	})
 }
+
+func TestQueryVectorDistancer(t *testing.T) {
+	vectors := [][]float32{
+		{100, 100}, // first to import makes this the EP, it is far from any query which means it will be replaced.
+		{2, 2},     // a good potential entrypoint, but we will corrupt it later on
+		{1, 1},     // the perfect search result
+	}
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "bug-2155",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewL2SquaredProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[int(id)], nil
+		},
+	}, ent.UserConfig{
+		MaxConnections: 30,
+		EFConstruction: 128,
+
+		// The actual size does not matter for this test, but if it defaults to
+		// zero it will constantly think it's full and needs to be deleted - even
+		// after just being deleted, so make sure to use a positive number here.
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+
+	index.Add(uint64(0), []float32{-1, 0})
+
+	dist := index.QueryVectorDistancer([]float32{0, 0})
+	require.NotNil(t, dist)
+	distance, err := dist.DistanceToNode(0)
+	require.Nil(t, err)
+	require.Equal(t, distance, float32(1.))
+
+	// get distance for non-existing node above default cache size
+	distance, err = dist.DistanceToNode(1001)
+	require.NotNil(t, err)
+}

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -127,6 +127,6 @@ func TestQueryVectorDistancer(t *testing.T) {
 	require.Equal(t, distance, float32(1.))
 
 	// get distance for non-existing node above default cache size
-	distance, err = dist.DistanceToNode(1001)
+	_, err = dist.DistanceToNode(1001)
 	require.NotNil(t, err)
 }


### PR DESCRIPTION
### What's being changed:

When doing a multi target search, we calculate the distance for objects that have not been part of the initial vector search. This could cause a panic if the docId we were using was larger than the cache-array for another target vector

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
