### PR TITLE
Add more info to error message

### DIFF
--- a/modules/text2vec-openai/vectorizer/batch_test.go
+++ b/modules/text2vec-openai/vectorizer/batch_test.go
@@ -62,12 +62,12 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 5"}}, // set limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long, long, long, long, long"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "short"}},
-		}, skip: []bool{false, false, false}, wantErrors: map[int]error{1: fmt.Errorf("text too long for vectorization")}},
+		}, skip: []bool{false, false, false}, wantErrors: map[int]error{1: fmt.Errorf("text too long for vectorization. Tokens for text: 15, max tokens per batch: 500000, ApiKey absolute token limit: 10")}},
 		{name: "token too long, last item in batch", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 5"}}, // set limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "short"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long, long, long, long, long"}},
-		}, skip: []bool{false, false, false}, wantErrors: map[int]error{2: fmt.Errorf("text too long for vectorization")}},
+		}, skip: []bool{false, false, false}, wantErrors: map[int]error{2: fmt.Errorf("text too long for vectorization. Tokens for text: 15, max tokens per batch: 500000, ApiKey absolute token limit: 10")}},
 		{name: "skip last item", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "fir test object"}}, // set limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "first object first batch"}},

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -291,8 +291,8 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 			continue
 		}
 
-		if job.tokens[objCounter] > maxTokensPerBatch {
-			job.errs[objCounter] = fmt.Errorf("text too long for vectorization. Tokens for text: %v, max tokens: %v", job.tokens[objCounter], maxTokensPerBatch)
+		if job.tokens[objCounter] > rateLimit.LimitTokens || job.tokens[objCounter] > maxTokensPerBatch {
+			job.errs[objCounter] = fmt.Errorf("text too long for vectorization. Tokens for text: %v, max tokens per batch: %v, ApiKey absolute token limit: %v", job.tokens[objCounter], maxTokensPerBatch, rateLimit.LimitTokens)
 			objCounter++
 			continue
 		}

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -291,8 +291,8 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 			continue
 		}
 
-		if job.tokens[objCounter] > rateLimit.LimitTokens || job.tokens[objCounter] > maxTokensPerBatch {
-			job.errs[objCounter] = fmt.Errorf("text too long for vectorization")
+		if job.tokens[objCounter] > maxTokensPerBatch {
+			job.errs[objCounter] = fmt.Errorf("text too long for vectorization. Tokens for text: %v, max tokens: %v", job.tokens[objCounter], maxTokensPerBatch)
 			objCounter++
 			continue
 		}

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -70,12 +70,12 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 10"}}, // set limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long, long, long, long, long"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "short"}},
-		}, skip: []bool{false, false, false}, wantErrors: map[int]error{1: fmt.Errorf("text too long for vectorization")}},
+		}, skip: []bool{false, false, false}, wantErrors: map[int]error{1: fmt.Errorf("text too long for vectorization. Tokens for text: 43, max tokens per batch: 100, ApiKey absolute token limit: 20")}},
 		{name: "token too long, last item in batch", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 10"}}, // set limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "short"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long, long, long, long, long"}},
-		}, skip: []bool{false, false, false}, wantErrors: map[int]error{2: fmt.Errorf("text too long for vectorization")}},
+		}, skip: []bool{false, false, false}, wantErrors: map[int]error{2: fmt.Errorf("text too long for vectorization. Tokens for text: 43, max tokens per batch: 100, ApiKey absolute token limit: 20")}},
 		{name: "skip last item", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "fir test object"}}, // set limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "first object first batch"}},


### PR DESCRIPTION
### What's being changed:

Might fix https://github.com/weaviate/weaviate/issues/5600

There have been reports that sometimes short documents are rejected by the batching algo with the error "text too long for vectorization" with openAI.

This PR adds more info to the error message. Hopefully this helps to narrow the issue down

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
