### PR TITLE
refact: unify AuthZ interface & add mocks

### DIFF
--- a/modules/text2vec-contextionary/classification/classifier_test.go
+++ b/modules/text2vec-contextionary/classification/classifier_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	testhelper "github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	usecasesclassfication "github.com/weaviate/weaviate/usecases/classification"
 )
 
@@ -96,7 +97,7 @@ func TestContextualClassifier_Classify(t *testing.T) {
 	t.Run("with valid data", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 
 		vectorRepo := newFakeVectorRepoContextual(testDataToBeClassified(), testDataPossibleTargets())
 		logger, _ := test.NewNullLogger()
@@ -173,7 +174,7 @@ func TestContextualClassifier_Classify(t *testing.T) {
 	t.Run("when errors occur during classification", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
 		vectorRepo.errorOnAggregate = errors.New("something went wrong")
 		logger, _ := test.NewNullLogger()
@@ -222,7 +223,7 @@ func TestContextualClassifier_Classify(t *testing.T) {
 	t.Run("when there is nothing to be classified", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(nil, testDataAlreadyClassified())
 		logger, _ := test.NewNullLogger()
 		classifier := usecasesclassfication.New(sg, repo, vectorRepo, authorizer, logger, nil)

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -235,12 +235,6 @@ func (f *fakeVectorRepoKNN) get(id strfmt.UUID) (*models.Object, bool) {
 	return t, ok
 }
 
-type fakeAuthorizer struct{}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return nil
-}
-
 func newFakeVectorRepoContextual(unclassified, targets search.Results) *fakeVectorRepoContextual {
 	return &fakeVectorRepoContextual{
 		unclassified: unclassified,

--- a/test/acceptance_with_go_client/compression/compression_test.go
+++ b/test/acceptance_with_go_client/compression/compression_test.go
@@ -202,7 +202,6 @@ func createClassTargetVectors(t *testing.T, client *wvt.Client, className string
 	err := client.Schema().ClassCreator().
 		WithClass(class).
 		Do(context.Background())
-
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/test/acceptance_with_go_client/fixtures/food.go
+++ b/test/acceptance_with_go_client/fixtures/food.go
@@ -135,7 +135,6 @@ func createSchema(t *testing.T, client *weaviate.Client, class *models.Class) {
 	err := client.Schema().ClassCreator().
 		WithClass(class).
 		Do(context.Background())
-
 	if err != nil {
 		return
 	}

--- a/usecases/auth/authorization/mocks/authorizer.go
+++ b/usecases/auth/authorization/mocks/authorizer.go
@@ -1,0 +1,47 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package mocks
+
+import (
+	models "github.com/weaviate/weaviate/entities/models"
+)
+
+type AuthZReq struct {
+	Principal *models.Principal
+	Verb      string
+	Resource  string
+}
+
+type fakeAuthorizer struct {
+	err      error
+	requests []AuthZReq
+}
+
+func NewMockAuthorizer(errs ...error) *fakeAuthorizer {
+	if len(errs) > 0 {
+		return &fakeAuthorizer{err: errs[0]}
+	}
+	return &fakeAuthorizer{}
+}
+
+// Authorize provides a mock function with given fields: principal, verb, resource
+func (a *fakeAuthorizer) Authorize(principal *models.Principal, verb string, resource string) error {
+	a.requests = append(a.requests, AuthZReq{principal, verb, resource})
+	if a.err != nil {
+		return a.err
+	}
+	return nil
+}
+
+func (a *fakeAuthorizer) Calls() []AuthZReq {
+	return a.requests
+}

--- a/usecases/auth/authorization/mocks/authorizer.go
+++ b/usecases/auth/authorization/mocks/authorizer.go
@@ -29,6 +29,7 @@ type FakeAuthorizer struct {
 func NewMockAuthorizer() *FakeAuthorizer {
 	return &FakeAuthorizer{}
 }
+
 func (a *FakeAuthorizer) SetErr(err error) {
 	a.err = err
 }

--- a/usecases/auth/authorization/mocks/authorizer.go
+++ b/usecases/auth/authorization/mocks/authorizer.go
@@ -21,20 +21,20 @@ type AuthZReq struct {
 	Resource  string
 }
 
-type fakeAuthorizer struct {
+type FakeAuthorizer struct {
 	err      error
 	requests []AuthZReq
 }
 
-func NewMockAuthorizer(errs ...error) *fakeAuthorizer {
-	if len(errs) > 0 {
-		return &fakeAuthorizer{err: errs[0]}
-	}
-	return &fakeAuthorizer{}
+func NewMockAuthorizer() *FakeAuthorizer {
+	return &FakeAuthorizer{}
+}
+func (a *FakeAuthorizer) SetErr(err error) {
+	a.err = err
 }
 
 // Authorize provides a mock function with given fields: principal, verb, resource
-func (a *fakeAuthorizer) Authorize(principal *models.Principal, verb string, resource string) error {
+func (a *FakeAuthorizer) Authorize(principal *models.Principal, verb string, resource string) error {
 	a.requests = append(a.requests, AuthZReq{principal, verb, resource})
 	if a.err != nil {
 		return a.err
@@ -42,6 +42,6 @@ func (a *fakeAuthorizer) Authorize(principal *models.Principal, verb string, res
 	return nil
 }
 
-func (a *fakeAuthorizer) Calls() []AuthZReq {
+func (a *FakeAuthorizer) Calls() []AuthZReq {
 	return a.requests
 }

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 // A component-test like test suite that makes sure that every available UC is
@@ -95,36 +96,21 @@ func Test_Authorization(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
-				authorizer := &authDenier{}
+				authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
 				s := NewScheduler(authorizer, nil, nil, nil, nil, &fakeSchemaManger{}, logger)
 				require.NotNil(t, s)
 
 				args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)
 				out, _ := callFuncByName(s, test.methodName, args...)
 
-				require.Len(t, authorizer.calls, 1, "authorizer must be called")
+				require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 				assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 					"execution must abort with authorizer error")
-				assert.Equal(t, authorizeCall{principal, test.expectedVerb, test.expectedResource},
-					authorizer.calls[0], "correct parameters must have been used on authorizer")
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+					authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 			})
 		}
 	})
-}
-
-type authorizeCall struct {
-	principal *models.Principal
-	verb      string
-	resource  string
-}
-
-type authDenier struct {
-	calls []authorizeCall
-}
-
-func (a *authDenier) Authorize(principal *models.Principal, verb, resource string) error {
-	a.calls = append(a.calls, authorizeCall{principal, verb, resource})
-	return errors.New("just a test fake")
 }
 
 // inspired by https://stackoverflow.com/a/33008200

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -96,7 +96,8 @@ func Test_Authorization(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
-				authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
+				authorizer := mocks.NewMockAuthorizer()
+				authorizer.SetErr(errors.New("just a test fake"))
 				s := NewScheduler(authorizer, nil, nil, nil, nil, &fakeSchemaManger{}, logger)
 				require.NotNil(t, s)
 

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 const (
@@ -689,5 +690,5 @@ func createManager(sourcer Sourcer, schema schemaManger, backend modulecapabilit
 	}
 
 	logger, _ := test.NewNullLogger()
-	return NewHandler(logger, &fakeAuthorizer{}, schema, sourcer, backends)
+	return NewHandler(logger, mocks.NewMockAuthorizer(), schema, sourcer, backends)
 }

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/backup"
-	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // Version of backup structure
@@ -41,10 +41,6 @@ var regExpID = regexp.MustCompile("^[a-z0-9_-]+$")
 
 type BackupBackendProvider interface {
 	BackupBackend(backend string) (modulecapabilities.BackupBackend, error)
-}
-
-type authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
 }
 
 type schemaManger interface {
@@ -74,7 +70,7 @@ type Handler struct {
 	node string
 	// deps
 	logger     logrus.FieldLogger
-	authorizer authorizer
+	authorizer authorization.Authorizer
 	backupper  *backupper
 	restorer   *restorer
 	backends   BackupBackendProvider
@@ -82,7 +78,7 @@ type Handler struct {
 
 func NewHandler(
 	logger logrus.FieldLogger,
-	authorizer authorizer,
+	authorizer authorization.Authorizer,
 	schema schemaManger,
 	sourcer Sourcer,
 	backends BackupBackendProvider,

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -112,12 +112,6 @@ func (f *fakeSchemaManger) NodeName() string {
 	return f.nodeName
 }
 
-type fakeAuthorizer struct{}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return nil
-}
-
 func TestFilterClasses(t *testing.T) {
 	tests := []struct {
 		in  []string

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 var (
@@ -35,7 +36,7 @@ const (
 type Scheduler struct {
 	// deps
 	logger     logrus.FieldLogger
-	authorizer authorizer
+	authorizer authorization.Authorizer
 	backupper  *coordinator
 	restorer   *coordinator
 	backends   BackupBackendProvider
@@ -43,7 +44,7 @@ type Scheduler struct {
 
 // NewScheduler creates a new scheduler with two coordinators
 func NewScheduler(
-	authorizer authorizer,
+	authorizer authorization.Authorizer,
 	client client,
 	sourcer selector,
 	backends BackupBackendProvider,

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -755,7 +757,7 @@ type fakeScheduler struct {
 	schema       fakeSchemaManger
 	backend      *fakeBackend
 	backendErr   error
-	auth         *fakeAuthorizer
+	auth         authorization.Authorizer
 	nodeResolver nodeResolver
 	log          logrus.FieldLogger
 }
@@ -765,7 +767,7 @@ func newFakeScheduler(resolver nodeResolver) *fakeScheduler {
 	fc.backend = newFakeBackend()
 	fc.backendErr = nil
 	logger, _ := test.NewNullLogger()
-	fc.auth = &fakeAuthorizer{}
+	fc.auth = mocks.NewMockAuthorizer()
 	fc.log = logger
 	if resolver == nil {
 		fc.nodeResolver = &fakeNodeResolver{}

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	libvectorizer "github.com/weaviate/weaviate/usecases/vectorizer"
@@ -60,14 +61,10 @@ type Classifier struct {
 	repo                  Repo
 	vectorRepo            vectorRepo
 	vectorClassSearchRepo modulecapabilities.VectorClassSearchRepo
-	authorizer            authorizer
+	authorizer            authorization.Authorizer
 	distancer             distancer
 	modulesProvider       ModulesProvider
 	logger                logrus.FieldLogger
-}
-
-type authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
 }
 
 type ModulesProvider interface {
@@ -77,7 +74,7 @@ type ModulesProvider interface {
 		params modulecapabilities.ClassifyParams) (modulecapabilities.ClassifyItemFn, error)
 }
 
-func New(sg schemaUC.SchemaGetter, cr Repo, vr vectorRepo, authorizer authorizer,
+func New(sg schemaUC.SchemaGetter, cr Repo, vr vectorRepo, authorizer authorization.Authorizer,
 	logger logrus.FieldLogger, modulesProvider ModulesProvider,
 ) *Classifier {
 	return &Classifier{

--- a/usecases/classification/classifier_test.go
+++ b/usecases/classification/classifier_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	testhelper "github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func newNullLogger() *logrus.Logger {
@@ -36,7 +37,7 @@ func newNullLogger() *logrus.Logger {
 func Test_Classifier_KNN(t *testing.T) {
 	t.Run("with invalid data", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
-		_, err := New(sg, nil, nil, &fakeAuthorizer{}, newNullLogger(), nil).
+		_, err := New(sg, nil, nil, mocks.NewMockAuthorizer(), newNullLogger(), nil).
 			Schedule(context.Background(), nil, models.Classification{})
 		assert.NotNil(t, err, "should error with invalid user input")
 	})
@@ -47,7 +48,7 @@ func Test_Classifier_KNN(t *testing.T) {
 	t.Run("with valid data", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
 		classifier := New(sg, repo, vectorRepo, authorizer, newNullLogger(), nil)
 
@@ -121,7 +122,7 @@ func Test_Classifier_KNN(t *testing.T) {
 	t.Run("when errors occur during classification", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
 		vectorRepo.errorOnAggregate = errors.New("something went wrong")
 		classifier := New(sg, repo, vectorRepo, authorizer, newNullLogger(), nil)
@@ -170,7 +171,7 @@ func Test_Classifier_KNN(t *testing.T) {
 	t.Run("when there is nothing to be classified", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(nil, testDataAlreadyClassified())
 		classifier := New(sg, repo, vectorRepo, authorizer, newNullLogger(), nil)
 
@@ -213,7 +214,7 @@ func Test_Classifier_Custom_Classifier(t *testing.T) {
 	t.Run("with unreconginzed custom module classifier name", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 
 		vectorRepo := newFakeVectorRepoContextual(testDataToBeClassified(), testDataPossibleTargets())
 		logger, _ := test.NewNullLogger()
@@ -262,7 +263,7 @@ func Test_Classifier_Custom_Classifier(t *testing.T) {
 	t.Run("with valid data", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 
 		vectorRepo := newFakeVectorRepoContextual(testDataToBeClassified(), testDataPossibleTargets())
 		logger, _ := test.NewNullLogger()
@@ -338,7 +339,7 @@ func Test_Classifier_Custom_Classifier(t *testing.T) {
 	t.Run("when errors occur during classification", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
 		vectorRepo.errorOnAggregate = errors.New("something went wrong")
 		logger, _ := test.NewNullLogger()
@@ -387,7 +388,7 @@ func Test_Classifier_Custom_Classifier(t *testing.T) {
 	t.Run("when there is nothing to be classified", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(nil, testDataAlreadyClassified())
 		logger, _ := test.NewNullLogger()
 		classifier := New(sg, repo, vectorRepo, authorizer, logger, nil)
@@ -428,7 +429,7 @@ func Test_Classifier_WhereFilterValidation(t *testing.T) {
 	t.Run("when invalid whereFilters are received", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
 		classifier := New(sg, repo, vectorRepo, authorizer, newNullLogger(), nil)
 
@@ -512,7 +513,7 @@ func Test_Classifier_WhereFilterValidation(t *testing.T) {
 	t.Run("[deprecated string] when valueString whereFilters are received", func(t *testing.T) {
 		sg := &fakeSchemaGetter{testSchema()}
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
 		classifier := New(sg, repo, vectorRepo, authorizer, newNullLogger(), nil)
 

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -241,12 +241,6 @@ func (f *fakeVectorRepoKNN) get(id strfmt.UUID) (*models.Object, bool) {
 	return t, ok
 }
 
-type fakeAuthorizer struct{}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return nil
-}
-
 func newFakeVectorRepoContextual(unclassified, targets search.Results) *fakeVectorRepoContextual {
 	return &fakeVectorRepoContextual{
 		unclassified: unclassified,

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	testhelper "github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/classification"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -107,7 +108,7 @@ func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 
 	t.Run("classification journey", func(t *testing.T) {
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		classifier := classification.New(sg, repo, vrepo, authorizer, logger, nil)
 
 		params := models.Classification{
@@ -224,7 +225,7 @@ func Test_Classifier_ZeroShot_SaveConsistency(t *testing.T) {
 
 	t.Run("classification journey", func(t *testing.T) {
 		repo := newFakeClassificationRepo()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		classifier := classification.New(sg, repo, vrepo, authorizer, logger, nil)
 
 		params := models.Classification{

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -317,12 +317,6 @@ func largeTestDataSize(size int) search.Results {
 	return out
 }
 
-type fakeAuthorizer struct{}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return nil
-}
-
 func beaconRef(target string) *models.SingleRef {
 	beacon := fmt.Sprintf("weaviate://localhost/%s", target)
 	return &models.SingleRef{Beacon: strfmt.URI(beacon)}

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -17,14 +17,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 const GetNodeStatusTimeout = 30 * time.Second
-
-type authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
-}
 
 type db interface {
 	GetNodeStatus(ctx context.Context, className, verbosity string) ([]*models.NodeStatus, error)
@@ -33,12 +30,12 @@ type db interface {
 
 type Manager struct {
 	logger        logrus.FieldLogger
-	authorizer    authorizer
+	authorizer    authorization.Authorizer
 	db            db
 	schemaManager *schemaUC.Manager
 }
 
-func NewManager(logger logrus.FieldLogger, authorizer authorizer,
+func NewManager(logger logrus.FieldLogger, authorizer authorization.Authorizer,
 	db db, schemaManager *schemaUC.Manager,
 ) *Manager {
 	return &Manager{logger, authorizer, db, schemaManager}

--- a/usecases/objects/add_test.go
+++ b/usecases/objects/add_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -69,7 +70,7 @@ func Test_Add_Object_WithNoVectorizerModule(t *testing.T) {
 				},
 			},
 		}
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 
 		modulesProvider = getFakeModulesProvider()
@@ -264,7 +265,7 @@ func Test_Add_Object_WithExternalVectorizerModule(t *testing.T) {
 		}
 		locks := &fakeLocks{}
 		cfg := &config.WeaviateConfig{}
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		metrics := &fakeMetrics{}
 		modulesProvider = getFakeModulesProvider()
@@ -378,7 +379,7 @@ func Test_Add_Object_OverrideVectorizer(t *testing.T) {
 		}
 		locks := &fakeLocks{}
 		cfg := &config.WeaviateConfig{}
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		modulesProvider = getFakeModulesProvider()
 		metrics := &fakeMetrics{}
@@ -439,7 +440,7 @@ func Test_AddObjectEmptyProperties(t *testing.T) {
 		}
 		locks := &fakeLocks{}
 		cfg := &config.WeaviateConfig{}
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		modulesProvider = getFakeModulesProvider()
 		metrics := &fakeMetrics{}
@@ -495,7 +496,7 @@ func Test_AddObjectWithUUIDProps(t *testing.T) {
 		}
 		locks := &fakeLocks{}
 		cfg := &config.WeaviateConfig{}
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		modulesProvider = getFakeModulesProvider()
 		metrics := &fakeMetrics{}

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -175,7 +175,8 @@ func Test_Kinds_Authorization(t *testing.T) {
 				schemaManager := &fakeSchemaManager{}
 				locks := &fakeLocks{}
 				cfg := &config.WeaviateConfig{}
-				authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
+				authorizer := mocks.NewMockAuthorizer()
+				authorizer.SetErr(errors.New("just a test fake"))
 				vectorRepo := &fakeVectorRepo{}
 				manager := NewManager(locks, schemaManager,
 					cfg, logger, authorizer,
@@ -270,7 +271,8 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 			schemaManager := &fakeSchemaManager{}
 			locks := &fakeLocks{}
 			cfg := &config.WeaviateConfig{}
-			authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
+			authorizer := mocks.NewMockAuthorizer()
+			authorizer.SetErr(errors.New("just a test fake"))
 			vectorRepo := &fakeVectorRepo{}
 			modulesProvider := getFakeModulesProvider()
 			manager := NewBatchManager(vectorRepo, modulesProvider, locks, schemaManager, cfg, logger, authorizer, nil)

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -174,7 +175,7 @@ func Test_Kinds_Authorization(t *testing.T) {
 				schemaManager := &fakeSchemaManager{}
 				locks := &fakeLocks{}
 				cfg := &config.WeaviateConfig{}
-				authorizer := &authDenier{}
+				authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
 				vectorRepo := &fakeVectorRepo{}
 				manager := NewManager(locks, schemaManager,
 					cfg, logger, authorizer,
@@ -183,15 +184,15 @@ func Test_Kinds_Authorization(t *testing.T) {
 				args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)
 				out, _ := callFuncByName(manager, test.methodName, args...)
 
-				require.Len(t, authorizer.calls, 1, "authorizer must be called")
+				require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 				aerr := out[len(out)-1].Interface().(error)
 				if err, ok := aerr.(*Error); !ok || !err.Forbidden() {
 					assert.Equal(t, errors.New("just a test fake"), aerr,
 						"execution must abort with authorizer error")
 				}
 
-				assert.Equal(t, authorizeCall{principal, test.expectedVerb, test.expectedResource},
-					authorizer.calls[0], "correct parameters must have been used on authorizer")
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+					authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 			})
 		}
 	})
@@ -269,7 +270,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 			schemaManager := &fakeSchemaManager{}
 			locks := &fakeLocks{}
 			cfg := &config.WeaviateConfig{}
-			authorizer := &authDenier{}
+			authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
 			vectorRepo := &fakeVectorRepo{}
 			modulesProvider := getFakeModulesProvider()
 			manager := NewBatchManager(vectorRepo, modulesProvider, locks, schemaManager, cfg, logger, authorizer, nil)
@@ -277,28 +278,13 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 			args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)
 			out, _ := callFuncByName(manager, test.methodName, args...)
 
-			require.Len(t, authorizer.calls, 1, "authorizer must be called")
+			require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 			assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 				"execution must abort with authorizer error")
-			assert.Equal(t, authorizeCall{principal, test.expectedVerb, test.expectedResource},
-				authorizer.calls[0], "correct parameters must have been used on authorizer")
+			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+				authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 		}
 	})
-}
-
-type authorizeCall struct {
-	principal *models.Principal
-	verb      string
-	resource  string
-}
-
-type authDenier struct {
-	calls []authorizeCall
-}
-
-func (a *authDenier) Authorize(principal *models.Principal, verb, resource string) error {
-	a.calls = append(a.calls, authorizeCall{principal, verb, resource})
-	return errors.New("just a test fake")
 }
 
 // inspired by https://stackoverflow.com/a/33008200

--- a/usecases/objects/batch_add_test.go
+++ b/usecases/objects/batch_add_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -68,7 +69,7 @@ func Test_BatchManager_AddObjects_WithNoVectorizerModule(t *testing.T) {
 			GetSchemaResponse: schema,
 		}
 		logger, _ := test.NewNullLogger()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		modulesProvider = getFakeModulesProvider()
 		manager = NewBatchManager(vectorRepo, modulesProvider, locks,
 			schemaManager, config, logger, authorizer, nil)
@@ -292,7 +293,7 @@ func Test_BatchManager_AddObjects_WithExternalVectorizerModule(t *testing.T) {
 			GetSchemaResponse: schema,
 		}
 		logger, _ := test.NewNullLogger()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		modulesProvider = getFakeModulesProvider()
 		manager = NewBatchManager(vectorRepo, modulesProvider, locks,
 			schemaManager, config, logger, authorizer, nil)
@@ -437,7 +438,7 @@ func Test_BatchManager_AddObjectsEmptyProperties(t *testing.T) {
 			GetSchemaResponse: schema,
 		}
 		logger, _ := test.NewNullLogger()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		modulesProvider = getFakeModulesProvider()
 		manager = NewBatchManager(vectorRepo, modulesProvider, locks,
 			schemaManager, config, logger, authorizer, nil)

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -63,7 +64,7 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			GetSchemaResponse: schema,
 		}
 		logger, _ := test.NewNullLogger()
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		modulesProvider := getFakeModulesProvider()
 		manager = NewBatchManager(vectorRepo, modulesProvider, locks,
 			schemaManager, config, logger, authorizer, nil)

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
@@ -27,7 +28,7 @@ type BatchManager struct {
 	locks             locks
 	schemaManager     schemaManager
 	logger            logrus.FieldLogger
-	authorizer        authorizer
+	authorizer        authorization.Authorizer
 	vectorRepo        BatchVectorRepo
 	modulesProvider   ModulesProvider
 	autoSchemaManager *autoSchemaManager
@@ -51,7 +52,7 @@ type batchRepoNew interface {
 // NewBatchManager creates a new manager
 func NewBatchManager(vectorRepo BatchVectorRepo, modulesProvider ModulesProvider,
 	locks locks, schemaManager schemaManager, config *config.WeaviateConfig,
-	logger logrus.FieldLogger, authorizer authorizer,
+	logger logrus.FieldLogger, authorizer authorization.Authorizer,
 	prom *monitoring.PrometheusMetrics,
 ) *BatchManager {
 	return &BatchManager{

--- a/usecases/objects/delete_test.go
+++ b/usecases/objects/delete_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -73,7 +74,7 @@ func newDeleteDependency() (*Manager, *fakeVectorRepo) {
 		new(fakeSchemaManager),
 		new(config.WeaviateConfig),
 		logger,
-		new(fakeAuthorizer),
+		mocks.NewMockAuthorizer(),
 		vectorRepo,
 		getFakeModulesProvider(),
 		new(fakeMetrics), nil)

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -201,14 +201,6 @@ func (f *fakeLocks) LockSchema() (func() error, error) {
 	return func() error { return nil }, f.Err
 }
 
-type fakeAuthorizer struct {
-	Err error
-}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return f.Err
-}
-
 type fakeVectorRepo struct {
 	mock.Mock
 }

--- a/usecases/objects/get_test.go
+++ b/usecases/objects/get_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
-	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -1061,7 +1060,7 @@ type fakeGetManager struct {
 	repo            *fakeVectorRepo
 	extender        *fakeExtender
 	projector       *fakeProjector
-	authorizer      authorization.Authorizer
+	authorizer      *mocks.FakeAuthorizer
 	locks           *fakeLocks
 	metrics         *fakeMetrics
 	modulesProvider *fakeModulesProvider

--- a/usecases/objects/get_test.go
+++ b/usecases/objects/get_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -57,7 +59,7 @@ func Test_GetAction(t *testing.T) {
 		cfg := &config.WeaviateConfig{}
 		cfg.Config.QueryDefaults.Limit = 20
 		cfg.Config.QueryMaximumResults = 200
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		extender = &fakeExtender{}
 		projectorFake = &fakeProjector{}
@@ -686,7 +688,7 @@ func Test_GetThing(t *testing.T) {
 		cfg := &config.WeaviateConfig{}
 		cfg.Config.QueryDefaults.Limit = 20
 		cfg.Config.QueryMaximumResults = 200
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		extender = &fakeExtender{}
 		projectorFake = &fakeProjector{}
@@ -1059,7 +1061,7 @@ type fakeGetManager struct {
 	repo            *fakeVectorRepo
 	extender        *fakeExtender
 	projector       *fakeProjector
-	authorizer      *fakeAuthorizer
+	authorizer      authorization.Authorizer
 	locks           *fakeLocks
 	metrics         *fakeMetrics
 	modulesProvider *fakeModulesProvider
@@ -1070,7 +1072,7 @@ func newFakeGetManager(schema schema.Schema, opts ...func(*fakeGetManager)) fake
 		repo:            new(fakeVectorRepo),
 		extender:        new(fakeExtender),
 		projector:       new(fakeProjector),
-		authorizer:      new(fakeAuthorizer),
+		authorizer:      mocks.NewMockAuthorizer(),
 		locks:           new(fakeLocks),
 		metrics:         new(fakeMetrics),
 		modulesProvider: new(fakeModulesProvider),

--- a/usecases/objects/head_test.go
+++ b/usecases/objects/head_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func Test_HeadObject(t *testing.T) {
@@ -74,7 +73,7 @@ func Test_HeadObject(t *testing.T) {
 		},
 	}
 	for i, tc := range tests {
-		m.authorizer = mocks.NewMockAuthorizer(tc.authErr)
+		m.authorizer.SetErr(tc.authErr)
 		m.locks.Err = tc.lockErr
 		if tc.authErr == nil && tc.lockErr == nil {
 			m.repo.On("Exists", tc.class, id).Return(tc.mockedOk, tc.mockedErr).Once()

--- a/usecases/objects/head_test.go
+++ b/usecases/objects/head_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func Test_HeadObject(t *testing.T) {
@@ -73,7 +74,7 @@ func Test_HeadObject(t *testing.T) {
 		},
 	}
 	for i, tc := range tests {
-		m.authorizer.Err = tc.authErr
+		m.authorizer = mocks.NewMockAuthorizer(tc.authErr)
 		m.locks.Err = tc.lockErr
 		if tc.authErr == nil && tc.lockErr == nil {
 			m.repo.On("Exists", tc.class, id).Return(tc.mockedOk, tc.mockedErr).Once()

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/versioned"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
@@ -73,7 +74,7 @@ type Manager struct {
 	locks             locks
 	schemaManager     schemaManager
 	logger            logrus.FieldLogger
-	authorizer        authorizer
+	authorizer        authorization.Authorizer
 	vectorRepo        VectorRepo
 	timeSource        timeSource
 	modulesProvider   ModulesProvider
@@ -119,10 +120,6 @@ type locks interface {
 	LockSchema() (func() error, error)
 }
 
-type authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
-}
-
 type VectorRepo interface {
 	PutObject(ctx context.Context, concept *models.Object, vector []float32, vectors models.Vectors,
 		repl *additional.ReplicationProperties, schemaVersion uint64) error
@@ -162,7 +159,7 @@ type ModulesProvider interface {
 // NewManager creates a new manager
 func NewManager(locks locks, schemaManager schemaManager,
 	config *config.WeaviateConfig, logger logrus.FieldLogger,
-	authorizer authorizer, vectorRepo VectorRepo,
+	authorizer authorization.Authorizer, vectorRepo VectorRepo,
 	modulesProvider ModulesProvider, metrics objectsMetrics, allocChecker *memwatch.Monitor,
 ) *Manager {
 	if allocChecker == nil {

--- a/usecases/objects/query_test.go
+++ b/usecases/objects/query_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func TestQuery(t *testing.T) {
@@ -139,7 +140,7 @@ func TestQuery(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m.authorizer.Err = tc.authErr
+			m.authorizer = mocks.NewMockAuthorizer(tc.authErr)
 			m.locks.Err = tc.lockErr
 			if tc.authErr == nil && tc.lockErr == nil {
 				m.repo.On("Query", &tc.wantQueryInput).Return(tc.mockedDBResponse, tc.mockedErr).Once()

--- a/usecases/objects/query_test.go
+++ b/usecases/objects/query_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func TestQuery(t *testing.T) {
@@ -140,7 +139,7 @@ func TestQuery(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m.authorizer = mocks.NewMockAuthorizer(tc.authErr)
+			m.authorizer.SetErr(tc.authErr)
 			m.locks.Err = tc.lockErr
 			if tc.authErr == nil && tc.lockErr == nil {
 				m.repo.On("Query", &tc.wantQueryInput).Return(tc.mockedDBResponse, tc.mockedErr).Once()

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func Test_ReferencesAddDeprecated(t *testing.T) {
@@ -206,7 +207,7 @@ func Test_ReferenceAdd(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := newFakeGetManager(zooAnimalSchemaForTest())
-			m.authorizer.Err = tc.ErrAuth
+			m.authorizer = mocks.NewMockAuthorizer(tc.ErrAuth)
 			m.locks.Err = tc.ErrLock
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			m.modulesProvider.On("UsingRef2Vec", mock.Anything).Return(false)
@@ -351,7 +352,7 @@ func Test_ReferenceUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := newFakeGetManager(zooAnimalSchemaForTest())
-			m.authorizer.Err = tc.ErrAuth
+			m.authorizer = mocks.NewMockAuthorizer(tc.ErrAuth)
 			m.locks.Err = tc.ErrLock
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			srcObj := &search.Result{
@@ -544,7 +545,7 @@ func Test_ReferenceDelete(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := newFakeGetManager(zooAnimalSchemaForTest())
-			m.authorizer.Err = tc.ErrAuth
+			m.authorizer = mocks.NewMockAuthorizer(tc.ErrAuth)
 			m.locks.Err = tc.ErrLock
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			srcObj := &search.Result{

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 func Test_ReferencesAddDeprecated(t *testing.T) {
@@ -207,7 +206,7 @@ func Test_ReferenceAdd(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := newFakeGetManager(zooAnimalSchemaForTest())
-			m.authorizer = mocks.NewMockAuthorizer(tc.ErrAuth)
+			m.authorizer.SetErr(tc.ErrAuth)
 			m.locks.Err = tc.ErrLock
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			m.modulesProvider.On("UsingRef2Vec", mock.Anything).Return(false)
@@ -352,7 +351,7 @@ func Test_ReferenceUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := newFakeGetManager(zooAnimalSchemaForTest())
-			m.authorizer = mocks.NewMockAuthorizer(tc.ErrAuth)
+			m.authorizer.SetErr(tc.ErrAuth)
 			m.locks.Err = tc.ErrLock
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			srcObj := &search.Result{
@@ -545,7 +544,7 @@ func Test_ReferenceDelete(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := newFakeGetManager(zooAnimalSchemaForTest())
-			m.authorizer = mocks.NewMockAuthorizer(tc.ErrAuth)
+			m.authorizer.SetErr(tc.ErrAuth)
 			m.locks.Err = tc.ErrLock
 			m.schemaManager.(*fakeSchemaManager).GetschemaErr = tc.ErrSchema
 			srcObj := &search.Result{

--- a/usecases/objects/update_test.go
+++ b/usecases/objects/update_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -66,7 +67,7 @@ func Test_UpdateAction(t *testing.T) {
 		cfg := &config.WeaviateConfig{}
 		cfg.Config.QueryDefaults.Limit = 20
 		cfg.Config.QueryMaximumResults = 200
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		logger, _ := test.NewNullLogger()
 		extender = &fakeExtender{}
 		projectorFake = &fakeProjector{}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -179,7 +179,8 @@ func Test_Schema_Authorization(t *testing.T) {
 		principal := &models.Principal{}
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
-				authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
+				authorizer := mocks.NewMockAuthorizer()
+				authorizer.SetErr(errors.New("just a test fake"))
 				handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
 				fakeSchemaManager.On("ReadOnlySchema").Return(models.Schema{})
 				fakeSchemaManager.On("ReadOnlyClass", mock.Anything).Return(models.Class{})

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
 // A component-test like test suite that makes sure that every available UC is
@@ -178,7 +179,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		principal := &models.Principal{}
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
-				authorizer := &authDenier{}
+				authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
 				handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
 				fakeSchemaManager.On("ReadOnlySchema").Return(models.Schema{})
 				fakeSchemaManager.On("ReadOnlyClass", mock.Anything).Return(models.Class{})
@@ -192,29 +193,14 @@ func Test_Schema_Authorization(t *testing.T) {
 				}
 				out, _ := callFuncByName(handler, test.methodName, args...)
 
-				require.Len(t, authorizer.calls, 1, "Authorizer must be called")
+				require.Len(t, authorizer.Calls(), 1, "Authorizer must be called")
 				assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 					"execution must abort with Authorizer error")
-				assert.Equal(t, authorizeCall{principal, test.expectedVerb, test.expectedResource},
-					authorizer.calls[0], "correct parameters must have been used on Authorizer")
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+					authorizer.Calls()[0], "correct parameters must have been used on Authorizer")
 			})
 		}
 	})
-}
-
-type authorizeCall struct {
-	principal *models.Principal
-	verb      string
-	resource  string
-}
-
-type authDenier struct {
-	calls []authorizeCall
-}
-
-func (a *authDenier) Authorize(principal *models.Principal, verb, resource string) error {
-	a.calls = append(a.calls, authorizeCall{principal, verb, resource})
-	return errors.New("just a test fake")
 }
 
 // inspired by https://stackoverflow.com/a/33008200

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/versioned"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -118,7 +119,7 @@ type Handler struct {
 	validator validator
 
 	logger                  logrus.FieldLogger
-	Authorizer              authorizer
+	Authorizer              authorization.Authorizer
 	config                  config.Config
 	vectorizerValidator     VectorizerValidator
 	moduleConfig            ModuleConfig
@@ -134,7 +135,7 @@ func NewHandler(
 	schemaReader SchemaReader,
 	schemaManager SchemaManager,
 	validator validator,
-	logger logrus.FieldLogger, authorizer authorizer, config config.Config,
+	logger logrus.FieldLogger, authorizer authorization.Authorizer, config config.Config,
 	configParser VectorConfigParser, vectorizerValidator VectorizerValidator,
 	invertedConfigValidator InvertedConfigValidator,
 	moduleConfig ModuleConfig, clusterState clusterState,

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/scaler"
@@ -43,14 +45,14 @@ func newTestHandler(t *testing.T, db clusterSchema.Indexer) (*Handler, *fakeSche
 		DefaultVectorDistanceMetric: "cosine",
 	}
 	handler, err := NewHandler(
-		schemaManager, schemaManager, &fakeValidator{}, logger, &fakeAuthorizer{nil},
+		schemaManager, schemaManager, &fakeValidator{}, logger, mocks.NewMockAuthorizer(),
 		cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, fakes.NewFakeClusterState(), &fakeScaleOutManager{}, nil)
 	require.Nil(t, err)
 	return &handler, schemaManager
 }
 
-func newTestHandlerWithCustomAuthorizer(t *testing.T, db clusterSchema.Indexer, authorizer authorizer) (*Handler, *fakeSchemaManager) {
+func newTestHandlerWithCustomAuthorizer(t *testing.T, db clusterSchema.Indexer, authorizer authorization.Authorizer) (*Handler, *fakeSchemaManager) {
 	cfg := config.Config{}
 	metaHandler := &fakeSchemaManager{}
 	logger, _ := test.NewNullLogger()
@@ -134,14 +136,6 @@ func (f *fakeDB) GetShardsStatus(class, tenant string) (models.ShardStatusList, 
 
 func (f *fakeDB) TriggerSchemaUpdateCallbacks() {
 	f.Called()
-}
-
-type fakeAuthorizer struct {
-	err error
-}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return f.err
 }
 
 type fakeScaleOutManager struct{}

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/scaler"
@@ -37,7 +38,7 @@ type Manager struct {
 	validator    validator
 	repo         SchemaStore
 	logger       logrus.FieldLogger
-	Authorizer   authorizer
+	Authorizer   authorization.Authorizer
 	config       config.Config
 	clusterState clusterState
 
@@ -197,7 +198,7 @@ func NewManager(validator validator,
 	schemaManager SchemaManager,
 	schemaReader SchemaReader,
 	repo SchemaStore,
-	logger logrus.FieldLogger, authorizer authorizer, config config.Config,
+	logger logrus.FieldLogger, authorizer authorization.Authorizer, config config.Config,
 	configParser VectorConfigParser, vectorizerValidator VectorizerValidator,
 	invertedConfigValidator InvertedConfigValidator,
 	moduleConfig ModuleConfig, clusterState clusterState,
@@ -226,10 +227,6 @@ func NewManager(validator validator,
 	}
 
 	return m, nil
-}
-
-type authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
 }
 
 // func (m *Manager) migrateSchemaIfNecessary(ctx context.Context, localSchema *State) error {

--- a/usecases/traverser/authorization_test.go
+++ b/usecases/traverser/authorization_test.go
@@ -78,7 +78,8 @@ func Test_Traverser_Authorization(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		for _, test := range tests {
 			locks := &fakeLocks{}
-			authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
+			authorizer := mocks.NewMockAuthorizer()
+			authorizer.SetErr(errors.New("just a test fake"))
 			vectorRepo := &fakeVectorRepo{}
 			explorer := &fakeExplorer{}
 			schemaGetter := &fakeSchemaGetter{}

--- a/usecases/traverser/authorization_test.go
+++ b/usecases/traverser/authorization_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -77,7 +78,7 @@ func Test_Traverser_Authorization(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		for _, test := range tests {
 			locks := &fakeLocks{}
-			authorizer := &authDenier{}
+			authorizer := mocks.NewMockAuthorizer(errors.New("just a test fake"))
 			vectorRepo := &fakeVectorRepo{}
 			explorer := &fakeExplorer{}
 			schemaGetter := &fakeSchemaGetter{}
@@ -88,28 +89,13 @@ func Test_Traverser_Authorization(t *testing.T) {
 			args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)
 			out, _ := callFuncByName(manager, test.methodName, args...)
 
-			require.Len(t, authorizer.calls, 1, "authorizer must be called")
+			require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 			assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 				"execution must abort with authorizer error")
-			assert.Equal(t, authorizeCall{principal, test.expectedVerb, test.expectedResource},
-				authorizer.calls[0], "correct parameters must have been used on authorizer")
+			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+				authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 		}
 	})
-}
-
-type authorizeCall struct {
-	principal *models.Principal
-	verb      string
-	resource  string
-}
-
-type authDenier struct {
-	calls []authorizeCall
-}
-
-func (a *authDenier) Authorize(principal *models.Principal, verb, resource string) error {
-	a.calls = append(a.calls, authorizeCall{principal, verb, resource})
-	return errors.New("just a test fake")
 }
 
 // inspired by https://stackoverflow.com/a/33008200

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -147,12 +147,6 @@ func (f *fakeVectorSearcher) ResolveReferences(ctx context.Context, objs search.
 	return nil, nil
 }
 
-type fakeAuthorizer struct{}
-
-func (f *fakeAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
-	return nil
-}
-
 type fakeVectorRepo struct {
 	mock.Mock
 }

--- a/usecases/traverser/traverser.go
+++ b/usecases/traverser/traverser.go
@@ -19,8 +19,8 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
-	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/modules"
 	"github.com/weaviate/weaviate/usecases/ratelimiter"
@@ -32,16 +32,12 @@ type locks interface {
 	LockSchema() (func() error, error)
 }
 
-type authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
-}
-
 // Traverser can be used to dynamically traverse the knowledge graph
 type Traverser struct {
 	config                  *config.WeaviateConfig
 	locks                   locks
 	logger                  logrus.FieldLogger
-	authorizer              authorizer
+	authorizer              authorization.Authorizer
 	vectorSearcher          VectorSearcher
 	explorer                explorer
 	schemaGetter            schema.SchemaGetter
@@ -67,7 +63,7 @@ type explorer interface {
 
 // NewTraverser to traverse the knowledge graph
 func NewTraverser(config *config.WeaviateConfig, locks locks,
-	logger logrus.FieldLogger, authorizer authorizer,
+	logger logrus.FieldLogger, authorizer authorization.Authorizer,
 	vectorSearcher VectorSearcher,
 	explorer explorer, schemaGetter schema.SchemaGetter,
 	modulesProvider ModulesProvider,

--- a/usecases/traverser/traverser_aggregate_test.go
+++ b/usecases/traverser/traverser_aggregate_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -29,7 +30,7 @@ func Test_Traverser_Aggregate(t *testing.T) {
 	principal := &models.Principal{}
 	logger, _ := test.NewNullLogger()
 	locks := &fakeLocks{}
-	authorizer := &fakeAuthorizer{}
+	authorizer := mocks.NewMockAuthorizer()
 	vectorRepo := &fakeVectorRepo{}
 	explorer := &fakeExplorer{}
 	schemaGetter := &fakeSchemaGetter{aggregateTestSchema}

--- a/usecases/traverser/traverser_explore_concepts_test.go
+++ b/usecases/traverser/traverser_explore_concepts_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_ExploreConcepts(t *testing.T) {
 	t.Run("without any near searchers", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -43,7 +44,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("with two searchers set at the same time", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -64,7 +65,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
 	})
 	t.Run("nearCustomText with no movements set", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -127,7 +128,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearCustomText without optional params", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -187,7 +188,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearObject with id param", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -253,7 +254,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearObject with beacon param", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -319,7 +320,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearCustomText with limit and distance set", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -363,7 +364,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearCustomText with limit and certainty set", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -404,7 +405,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearCustomText with minimum distance set to 0.4", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -433,7 +434,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("nearCustomText with minimum certainty set to 0.6", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -474,7 +475,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("near text with movements set", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
@@ -547,7 +548,7 @@ func Test_ExploreConcepts(t *testing.T) {
 	})
 
 	t.Run("near text with movements and objects set", func(t *testing.T) {
-		authorizer := &fakeAuthorizer{}
+		authorizer := mocks.NewMockAuthorizer()
 		locks := &fakeLocks{}
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}


### PR DESCRIPTION
### What's being changed:
as  preparation for RBAC this refactor is needed instead of redefining the `Authorizer` interface (it removes 6 duplicated interfaces) in every package, supply it on from authorization package and add mock to be the source of truth for AuthZ impl. and remove any duplication 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
