### PR TITLE
refact:AuthZ:  use authorization verbs instead of custom strings

### DIFF
--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/graphql"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/schema"
@@ -57,7 +58,7 @@ func setupGraphQLHandlers(
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
 		// authorization requirements.
 
-		err := m.Authorizer.Authorize(principal, "list", "schema/*")
+		err := m.Authorizer.Authorize(principal, authorization.LIST, "schema/*")
 		if err != nil {
 			metricRequestsTotal.logUserError()
 			switch err.(type) {

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -1,0 +1,38 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package authorization
+
+const (
+	// HEAD: Represents the HTTP HEAD method, which is used to retrieve metadata of a resource without
+	// fetching the resource itself.
+	HEAD = "head"
+	// VALIDATE: Represents a custom action to validate a resource.
+	// This is not a standard HTTP method but can be used for specific validation operations.
+	VALIDATE = "validate"
+	// LIST: Represents a custom action to list resources.
+	// This is not a standard HTTP method but can be used to list multiple resources.
+	LIST = "list"
+	// GET: Represents the HTTP GET method, which is used to retrieve a resource.
+	GET = "get"
+	// ADD: Represents a custom action to add a resource.
+	// This is not a standard HTTP method but can be used for specific add operations.
+	ADD = "add"
+	// CREATE: Represents the HTTP POST method, which is used to create a new resource.
+	CREATE = "create"
+	// RESTORE: Represents a custom action to restore a resource.
+	// This is not a standard HTTP method but can be used for specific restore operations.
+	RESTORE = "restore"
+	// DELETE: Represents the HTTP DELETE method, which is used to delete a resource.
+	DELETE = "delete"
+	// UPDATE: Represents the HTTP PUT method, which is used to update an existing resource.
+	UPDATE = "update"
+)

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
@@ -41,37 +42,37 @@ func Test_Authorization(t *testing.T) {
 		{
 			methodName:       "Backup",
 			additionalArgs:   []interface{}{req},
-			expectedVerb:     "add",
+			expectedVerb:     authorization.ADD,
 			expectedResource: "backups/s3/123",
 		},
 		{
 			methodName:       "BackupStatus",
 			additionalArgs:   []interface{}{"s3", "123"},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "backups/s3/123",
 		},
 		{
 			methodName:       "Restore",
 			additionalArgs:   []interface{}{req},
-			expectedVerb:     "restore",
+			expectedVerb:     authorization.RESTORE,
 			expectedResource: "backups/s3/123/restore",
 		},
 		{
 			methodName:       "RestorationStatus",
 			additionalArgs:   []interface{}{"s3", "123"},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "backups/s3/123/restore",
 		},
 		{
 			methodName:       "Cancel",
 			additionalArgs:   []interface{}{"s3", "123"},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: "backups/s3/123",
 		},
 		{
 			methodName:       "List",
 			additionalArgs:   []interface{}{"s3"},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "backups/s3",
 		},
 	}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -77,7 +77,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 	}(time.Now())
 
 	path := fmt.Sprintf("backups/%s/%s", req.Backend, req.ID)
-	if err := s.authorizer.Authorize(pr, "add", path); err != nil {
+	if err := s.authorizer.Authorize(pr, authorization.ADD, path); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, req.Backend, req.ID)
@@ -125,7 +125,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		logOperation(s.logger, "try_restore", req.ID, req.Backend, begin, err)
 	}(time.Now())
 	path := fmt.Sprintf("backups/%s/%s/restore", req.Backend, req.ID)
-	if err := s.authorizer.Authorize(pr, "restore", path); err != nil {
+	if err := s.authorizer.Authorize(pr, authorization.RESTORE, path); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, req.Backend, req.ID)
@@ -177,7 +177,7 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 		logOperation(s.logger, "backup_status", backupID, backend, begin, err)
 	}(time.Now())
 	path := fmt.Sprintf("backups/%s/%s", backend, backupID)
-	if err := s.authorizer.Authorize(principal, "get", path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.GET, path); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, backend, backupID)
@@ -200,7 +200,7 @@ func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Pri
 		logOperation(s.logger, "restoration_status", backupID, backend, time.Now(), err)
 	}(time.Now())
 	path := fmt.Sprintf("backups/%s/%s/restore", backend, backupID)
-	if err := s.authorizer.Authorize(principal, "get", path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.GET, path); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, backend, backupID)
@@ -224,7 +224,7 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 	}(time.Now())
 
 	path := fmt.Sprintf("backups/%s/%s", backend, backupID)
-	if err := s.authorizer.Authorize(principal, "delete", path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.DELETE, path); err != nil {
 		return err
 	}
 
@@ -276,7 +276,7 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 		logOperation(s.logger, "list_backup", "", backend, time.Now(), err)
 	}(time.Now())
 	path := fmt.Sprintf("backups/%s", backend)
-	if err := s.authorizer.Authorize(principal, "get", path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.GET, path); err != nil {
 		return nil, err
 	}
 

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -131,7 +131,7 @@ type NeighborRef struct {
 }
 
 func (c *Classifier) Schedule(ctx context.Context, principal *models.Principal, params models.Classification) (*models.Classification, error) {
-	err := c.authorizer.Authorize(principal, "create", "classifications/*")
+	err := c.authorizer.Authorize(principal, authorization.CREATE, "classifications/*")
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (c *Classifier) assignNewID(params *models.Classification) error {
 }
 
 func (c *Classifier) Get(ctx context.Context, principal *models.Principal, id strfmt.UUID) (*models.Classification, error) {
-	err := c.authorizer.Authorize(principal, "get", "classifications/*")
+	err := c.authorizer.Authorize(principal, authorization.GET, "classifications/*")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -49,7 +49,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
-	if err := m.authorizer.Authorize(principal, "list", "nodes"); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.LIST, "nodes"); err != nil {
 		return nil, err
 	}
 	return m.db.GetNodeStatus(ctxWithTimeout, className, verbosity)
@@ -61,7 +61,7 @@ func (m *Manager) GetNodeStatistics(ctx context.Context,
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
-	if err := m.authorizer.Authorize(principal, "list", "cluster"); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.LIST, "cluster"); err != nil {
 		return nil, err
 	}
 	return m.db.GetNodeStatistics(ctxWithTimeout)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/classcache"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
@@ -30,7 +31,7 @@ import (
 func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	err := m.authorizer.Authorize(principal, "create", "objects")
+	err := m.authorizer.Authorize(principal, authorization.CREATE, "objects")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -56,31 +57,31 @@ func Test_Kinds_Authorization(t *testing.T) {
 		{
 			methodName:       "GetObject",
 			additionalArgs:   []interface{}{"", strfmt.UUID("foo"), additional.Properties{}},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "objects/foo",
 		},
 		{
 			methodName:       "DeleteObject",
 			additionalArgs:   []interface{}{"class", strfmt.UUID("foo")},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: "objects/class/foo",
 		},
 		{ // deprecated by the one above
 			methodName:       "DeleteObject",
 			additionalArgs:   []interface{}{"", strfmt.UUID("foo")},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: "objects/foo",
 		},
 		{
 			methodName:       "UpdateObject",
 			additionalArgs:   []interface{}{"class", strfmt.UUID("foo"), (*models.Object)(nil)},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "objects/class/foo",
 		},
 		{ // deprecated by the one above
 			methodName:       "UpdateObject",
 			additionalArgs:   []interface{}{"", strfmt.UUID("foo"), (*models.Object)(nil)},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "objects/foo",
 		},
 		{
@@ -89,19 +90,19 @@ func Test_Kinds_Authorization(t *testing.T) {
 				&models.Object{Class: "class", ID: "foo"},
 				(*additional.ReplicationProperties)(nil),
 			},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "objects/class/foo",
 		},
 		{
 			methodName:       "GetObjectsClass",
 			additionalArgs:   []interface{}{strfmt.UUID("foo")},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "objects/foo",
 		},
 		{
 			methodName:       "GetObjectClassFromName",
 			additionalArgs:   []interface{}{strfmt.UUID("foo")},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "objects/foo",
 		},
 		{
@@ -136,19 +137,19 @@ func Test_Kinds_Authorization(t *testing.T) {
 		{
 			methodName:       "AddObjectReference",
 			additionalArgs:   []interface{}{AddReferenceInput{Class: "class", ID: strfmt.UUID("foo"), Property: "some prop"}, (*models.SingleRef)(nil)},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "objects/class/foo",
 		},
 		{
 			methodName:       "DeleteObjectReference",
 			additionalArgs:   []interface{}{strfmt.UUID("foo"), "some prop", (*models.SingleRef)(nil)},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "objects/foo",
 		},
 		{
 			methodName:       "UpdateObjectReferences",
 			additionalArgs:   []interface{}{&PutReferenceInput{Class: "class", ID: strfmt.UUID("foo"), Property: "some prop"}},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "objects/class/foo",
 		},
 	}
@@ -225,7 +226,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 				[]*models.BatchReference{},
 				&additional.ReplicationProperties{},
 			},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "batch/*",
 		},
 
@@ -238,7 +239,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 				&additional.ReplicationProperties{},
 				"",
 			},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: "batch/objects",
 		},
 		{
@@ -248,7 +249,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 				&additional.ReplicationProperties{},
 				"",
 			},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: "batch/objects",
 		},
 	}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
 
@@ -29,7 +30,7 @@ var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be
 func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
 ) (BatchObjects, error) {
-	err := b.authorizer.Authorize(principal, "create", "batch/objects")
+	err := b.authorizer.Authorize(principal, authorization.CREATE, "batch/objects")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // DeleteObjects deletes objects in batch based on the match filter
@@ -30,7 +31,7 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	match *models.BatchDeleteMatch, dryRun *bool, output *string,
 	repl *additional.ReplicationProperties, tenant string,
 ) (*BatchDeleteResponse, error) {
-	err := b.authorizer.Authorize(principal, "delete", "batch/objects")
+	err := b.authorizer.Authorize(principal, authorization.DELETE, "batch/objects")
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (b *BatchManager) DeleteObjectsFromGRPC(ctx context.Context, principal *mod
 	params BatchDeleteParams,
 	repl *additional.ReplicationProperties, tenant string,
 ) (BatchDeleteResult, error) {
-	err := b.authorizer.Authorize(principal, "delete", "batch/objects")
+	err := b.authorizer.Authorize(principal, authorization.DELETE, "batch/objects")
 	if err != nil {
 		return BatchDeleteResult{}, err
 	}

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/classcache"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -31,7 +32,7 @@ import (
 func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Principal,
 	refs []*models.BatchReference, repl *additional.ReplicationProperties,
 ) (BatchReferences, error) {
-	err := b.authorizer.Authorize(principal, "update", "batch/*")
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, "batch/*")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -35,7 +36,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	if class == "" {
 		path = fmt.Sprintf("objects/%s", id)
 	}
-	err := m.authorizer.Authorize(principal, "delete", path)
+	err := m.authorizer.Authorize(principal, authorization.DELETE, path)
 	if err != nil {
 		return err
 	}

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // GetObject Class from the connected DB
@@ -33,7 +34,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	if class != "" {
 		path = fmt.Sprintf("objects/%s/%s", class, id)
 	}
-	err := m.authorizer.Authorize(principal, "get", path)
+	err := m.authorizer.Authorize(principal, authorization.GET, path)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +65,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	offset *int64, limit *int64, sort *string, order *string, after *string,
 	addl additional.Properties, tenant string,
 ) ([]*models.Object, error) {
-	err := m.authorizer.Authorize(principal, "list", "objects")
+	err := m.authorizer.Authorize(principal, authorization.LIST, "objects")
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Principal,
 	id strfmt.UUID,
 ) (*models.Class, error) {
-	err := m.authorizer.Authorize(principal, "get", fmt.Sprintf("objects/%s", id.String()))
+	err := m.authorizer.Authorize(principal, authorization.GET, fmt.Sprintf("objects/%s", id.String()))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // HeadObject check object's existence in the connected DB
@@ -29,7 +30,7 @@ func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, c
 	if class != "" {
 		path = fmt.Sprintf("objects/%s/%s", class, id)
 	}
-	if err := m.authorizer.Authorize(principal, "head", path); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.HEAD, path); err != nil {
 		return false, &Error{path, StatusForbidden, err}
 	}
 

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
@@ -46,7 +47,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	}
 	cls, id := updates.Class, updates.ID
 	path := fmt.Sprintf("objects/%s/%s", cls, id)
-	if err := m.authorizer.Authorize(principal, "update", path); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -18,6 +18,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 type QueryInput struct {
@@ -67,7 +68,7 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
 	path := fmt.Sprintf("objects/%s", params.Class)
-	if err := m.authorizer.Authorize(principal, "list", path); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.LIST, path); err != nil {
 		return nil, &Error{path, StatusForbidden, err}
 	}
 	unlock, err := m.locks.LockConnector()

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
 
@@ -52,7 +53,7 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		input.Class = objectRes.Object().Class
 	}
 	path := fmt.Sprintf("objects/%s/%s", input.Class, input.ID)
-	if err := m.authorizer.Authorize(principal, "update", path); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}
 

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // DeleteReferenceInput represents required inputs to delete a reference from an existing object.
@@ -73,7 +74,7 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	input.Class = res.ClassName
 
 	path := fmt.Sprintf("objects/%s/%s", input.Class, input.ID)
-	if err := m.authorizer.Authorize(principal, "update", path); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}
 

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
 
@@ -64,7 +65,7 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	input.Class = res.ClassName
 
 	path := fmt.Sprintf("objects/%s/%s", input.Class, input.ID)
-	if err := m.authorizer.Authorize(principal, "update", path); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}
 

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -33,7 +34,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	if class == "" {
 		path = fmt.Sprintf("objects/%s", id)
 	}
-	err := m.authorizer.Authorize(principal, "update", path)
+	err := m.authorizer.Authorize(principal, authorization.UPDATE, path)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // ValidateObject without adding it to the database. Can be used in UIs for
@@ -24,7 +25,7 @@ import (
 func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principal,
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
-	err := m.authorizer.Authorize(principal, "validate", "objects")
+	err := m.authorizer.Authorize(principal, authorization.VALIDATE, "objects")
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
@@ -74,31 +75,31 @@ func Test_Schema_Authorization(t *testing.T) {
 		{
 			methodName:       "UpdateClass",
 			additionalArgs:   []interface{}{"somename", &models.Class{}},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "schema/objects",
 		},
 		{
 			methodName:       "DeleteClass",
 			additionalArgs:   []interface{}{"somename"},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: "schema/objects",
 		},
 		{
 			methodName:       "AddClassProperty",
 			additionalArgs:   []interface{}{&models.Class{}, false, &models.Property{}},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "schema/objects",
 		},
 		{
 			methodName:       "DeleteClassProperty",
 			additionalArgs:   []interface{}{"somename", "someprop"},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "schema/objects",
 		},
 		{
 			methodName:       "UpdateShardStatus",
 			additionalArgs:   []interface{}{"className", "shardName", "targetStatus"},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: "schema/className/shards/shardName",
 		},
 		{
@@ -110,7 +111,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		{
 			methodName:       "AddTenants",
 			additionalArgs:   []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: tenantsPath,
 		},
 		{
@@ -118,31 +119,31 @@ func Test_Schema_Authorization(t *testing.T) {
 			additionalArgs: []interface{}{"className", []*models.Tenant{
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
-			expectedVerb:     "update",
+			expectedVerb:     authorization.UPDATE,
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "DeleteTenants",
 			additionalArgs:   []interface{}{"className", []string{"P1"}},
-			expectedVerb:     "delete",
+			expectedVerb:     authorization.DELETE,
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "GetTenants",
 			additionalArgs:   []interface{}{"className"},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "GetConsistentTenants",
 			additionalArgs:   []interface{}{"className", false, []string{}},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: tenantsPath,
 		},
 		{
 			methodName:       "ConsistentTenantExists",
 			additionalArgs:   []interface{}{"className", false, "P1"},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: tenantsPath,
 		},
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/entities/versioned"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -40,7 +41,7 @@ import (
 )
 
 func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, name string) (*models.Class, error) {
-	if err := h.Authorizer.Authorize(principal, "list", "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
 		return nil, err
 	}
 	cl := h.schemaReader.ReadOnlyClass(name)
@@ -50,7 +51,7 @@ func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, nam
 func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Principal,
 	name string, consistency bool,
 ) (*models.Class, uint64, error) {
-	if err := h.Authorizer.Authorize(principal, "list", "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
 		return nil, 0, err
 	}
 	if consistency {
@@ -64,7 +65,7 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 	principal *models.Principal, names ...string,
 ) (map[string]versioned.Class, error) {
-	if err := h.Authorizer.Authorize(principal, "list", "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +99,7 @@ func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	cls *models.Class,
 ) (*models.Class, uint64, error) {
-	err := h.Authorizer.Authorize(principal, "create", "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.CREATE, "schema/objects")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -196,7 +197,7 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 
 // DeleteClass from the schema
 func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, class string) error {
-	err := h.Authorizer.Authorize(principal, "delete", "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.DELETE, "schema/objects")
 	if err != nil {
 		return err
 	}
@@ -208,7 +209,7 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) error {
-	err := h.Authorizer.Authorize(principal, "update", "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, "schema/objects")
 	if err != nil || updated == nil {
 		return err
 	}

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -166,7 +166,7 @@ func NewHandler(
 
 // GetSchema retrieves a locally cached copy of the schema
 func (h *Handler) GetSchema(principal *models.Principal) (schema.Schema, error) {
-	err := h.Authorizer.Authorize(principal, "list", "schema/*")
+	err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*")
 	if err != nil {
 		return schema.Schema{}, err
 	}
@@ -176,7 +176,7 @@ func (h *Handler) GetSchema(principal *models.Principal) (schema.Schema, error) 
 
 // GetSchema retrieves a locally cached copy of the schema
 func (h *Handler) GetConsistentSchema(principal *models.Principal, consistency bool) (schema.Schema, error) {
-	if err := h.Authorizer.Authorize(principal, "list", "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
 		return schema.Schema{}, err
 	}
 
@@ -216,7 +216,7 @@ func (h *Handler) NodeName() string {
 func (h *Handler) UpdateShardStatus(ctx context.Context,
 	principal *models.Principal, class, shard, status string,
 ) (uint64, error) {
-	err := h.Authorizer.Authorize(principal, "update",
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE,
 		fmt.Sprintf("schema/%s/shards/%s", class, shard))
 	if err != nil {
 		return 0, err
@@ -228,7 +228,7 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 func (h *Handler) ShardsStatus(ctx context.Context,
 	principal *models.Principal, class, tenant string,
 ) (models.ShardStatusList, error) {
-	err := h.Authorizer.Authorize(principal, "list", fmt.Sprintf("schema/%s/shards", class))
+	err := h.Authorizer.Authorize(principal, authorization.LIST, fmt.Sprintf("schema/%s/shards", class))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -19,6 +19,7 @@ import (
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // AddClassProperty it is upsert operation. it adds properties to a class and updates
@@ -26,7 +27,7 @@ import (
 func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Principal,
 	class *models.Class, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
-	err := h.Authorizer.Authorize(principal, "update", "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, "schema/objects")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -86,7 +87,7 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 func (h *Handler) DeleteClassProperty(ctx context.Context, principal *models.Principal,
 	class string, property string,
 ) error {
-	err := h.Authorizer.Authorize(principal, "update", "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, "schema/objects")
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	modsloads3 "github.com/weaviate/weaviate/modules/offload-s3"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	uco "github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -44,7 +45,7 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
-	if err := h.Authorizer.Authorize(principal, "update", tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, tenantsPath); err != nil {
 		return 0, err
 	}
 
@@ -152,7 +153,7 @@ func (h *Handler) validateActivityStatuses(ctx context.Context, tenants []*model
 func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal,
 	class string, tenants []*models.Tenant,
 ) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, "update", tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, tenantsPath); err != nil {
 		return nil, err
 	}
 
@@ -196,7 +197,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	if err := h.Authorizer.Authorize(principal, "delete", tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.DELETE, tenantsPath); err != nil {
 		return err
 	}
 	for i, name := range tenants {
@@ -217,14 +218,14 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) GetTenants(ctx context.Context, principal *models.Principal, class string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, "get", tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.GET, tenantsPath); err != nil {
 		return nil, err
 	}
 	return h.getTenants(class)
 }
 
 func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, "get", tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.GET, tenantsPath); err != nil {
 		return nil, err
 	}
 
@@ -278,7 +279,7 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	if err := h.Authorizer.Authorize(principal, "get", tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.GET, tenantsPath); err != nil {
 		return err
 	}
 

--- a/usecases/traverser/authorization_test.go
+++ b/usecases/traverser/authorization_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -43,21 +44,21 @@ func Test_Traverser_Authorization(t *testing.T) {
 		{
 			methodName:       "GetClass",
 			additionalArgs:   []interface{}{dto.GetParams{}},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "traversal/*",
 		},
 
 		{
 			methodName:       "Aggregate",
 			additionalArgs:   []interface{}{&aggregation.Params{}},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "traversal/*",
 		},
 
 		{
 			methodName:       "Explore",
 			additionalArgs:   []interface{}{ExploreParams{}},
-			expectedVerb:     "get",
+			expectedVerb:     authorization.GET,
 			expectedResource: "traversal/*",
 		},
 	}

--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -20,6 +20,7 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/modules"
 )
 
@@ -30,7 +31,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 	t.metrics.QueriesAggregateInc(params.ClassName.String())
 	defer t.metrics.QueriesAggregateDec(params.ClassName.String())
 
-	err := t.authorizer.Authorize(principal, "get", "traversal/*")
+	err := t.authorizer.Authorize(principal, authorization.GET, "traversal/*")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_explore_concepts.go
+++ b/usecases/traverser/traverser_explore_concepts.go
@@ -17,6 +17,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // Explore through unstructured search terms
@@ -27,7 +28,7 @@ func (t *Traverser) Explore(ctx context.Context,
 		params.Limit = 20
 	}
 
-	err := t.authorizer.Authorize(principal, "get", "traversal/*")
+	err := t.authorizer.Authorize(principal, authorization.GET, "traversal/*")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -20,6 +20,7 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
@@ -41,7 +42,7 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	defer t.metrics.QueriesGetDec(params.ClassName)
 	defer t.metrics.QueriesObserveDuration(params.ClassName, before.UnixMilli())
 
-	err := t.authorizer.Authorize(principal, "get", "traversal/*")
+	err := t.authorizer.Authorize(principal, authorization.GET, "traversal/*")
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_get_params_test.go
+++ b/usecases/traverser/traverser_get_params_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -158,7 +159,7 @@ func TestGet_NestedRefDepthLimit(t *testing.T) {
 				QueryCrossReferenceDepthLimit: depth,
 			},
 		}
-		return NewTraverser(&cfg, &fakeLocks{}, logger, &fakeAuthorizer{},
+		return NewTraverser(&cfg, &fakeLocks{}, logger, mocks.NewMockAuthorizer(),
 			&fakeVectorRepo{}, &fakeExplorer{}, schemaGetter, nil, nil, -1)
 	}
 


### PR DESCRIPTION
### What's being changed:
change the whole code base to use authorization verbs to avoid any error prone verbs and used as prep for RBAC 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
