### PR TITLE
Enable creation of relatd GH issues from main repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@
 ### Cross-functional impact
 
 - [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
-- This change requires corresponding changes in the client libraries. Check for each affected client library to automatically create a corresponding issue.
-    - [ ] Python
-    - [ ] JavaScript/TypeScript
-    - [ ] Go
-    - [ ] Java
+- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
+    - [ ] Python (weaviate-python-client)
+    - [ ] JavaScript/TypeScript (typescript-client)
+    - [ ] Go (weaviate-go-client)
+    - [ ] Java (java-client)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,12 @@
 - [ ] Chaos pipeline run or not necessary. Link to pipeline:
 - [ ] All new code is covered by tests where it is reasonable.
 - [ ] Performance tests have been run or not necessary.
+
+### Cross-functional impact
+
+- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
+- This change requires corresponding changes in the client libraries. Check for each affected client library to automatically create a corresponding issue.
+    - [ ] Python
+    - [ ] JavaScript/TypeScript
+    - [ ] Go
+    - [ ] Java

--- a/.github/workflows/create-cross-functional-issues.yml
+++ b/.github/workflows/create-cross-functional-issues.yml
@@ -14,11 +14,11 @@ jobs:
   create-cross-functional-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Check PR body
         id: check_pr
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.CROSS_REPO_ISSUE_WRITER_TOKEN}}
           script: |

--- a/.github/workflows/create-cross-functional-issues.yml
+++ b/.github/workflows/create-cross-functional-issues.yml
@@ -1,0 +1,75 @@
+name: Create Cross-Functional Issues
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_body:
+        description: 'PR body content for testing'
+        required: true
+        default: '- [x] This change requires public documentation (weaviate-io) to be updated.'
+
+jobs:
+  create-cross-functional-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check PR body
+        id: check_pr
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.CROSS_REPO_ISSUE_WRITER_TOKEN}}
+          script: |
+            const pr = context.payload.pull_request ?
+              context.payload.pull_request :
+              await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              }).then(res => res.data);
+
+            const body = pr.body || '';
+
+            const checkboxes = [
+              { repo: 'weaviate-io-test', regex: /- \[x\] This change requires public documentation \(weaviate-io\) to be updated/ },
+              { repo: 'weaviate-python-client-test', regex: /- \[x\] Python \(weaviate-python-client\)/ },
+              { repo: 'typescript-client-test', regex: /- \[x\] JavaScript\/TypeScript \(typescript-client\)/ },
+              { repo: 'weaviate-go-client-test', regex: /- \[x\] Go \(weaviate-go-client\)/ },
+              { repo: 'java-client-test', regex: /- \[x\] Java \(java-client\)/ }
+            ];
+
+            const results = checkboxes.map(checkbox => ({
+              repo: checkbox.repo,
+              checked: checkbox.regex.test(body)
+            }));
+
+            console.log('Checkbox results:', JSON.stringify(results));
+            return results;
+
+      - name: Create issues in respective repos
+        uses: actions/github-script@v6
+        env:
+          RESULTS: ${{ steps.check_pr.outputs.result }}
+        with:
+          github-token: ${{secrets.CROSS_REPO_ISSUE_WRITER_TOKEN}}
+          script: |
+            const results = JSON.parse(process.env.RESULTS);
+            const pr = context.payload.pull_request;
+
+            for (const result of results) {
+              if (result.checked) {
+                const issueTitle = `Update ${result.repo} for PR #${pr.number}`;
+                const issueBody = `A change in [PR #${pr.number}](${pr.html_url}) requires updates in the ${result.repo} repository.`;
+
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: result.repo,
+                  title: issueTitle,
+                  body: issueBody
+                });
+
+                console.log(`Created issue in ${result.repo}`);
+              }
+            }

--- a/.github/workflows/create-cross-functional-issues.yml
+++ b/.github/workflows/create-cross-functional-issues.yml
@@ -33,11 +33,11 @@ jobs:
             const body = pr.body || '';
 
             const checkboxes = [
-              { repo: 'weaviate-io-test', regex: /- \[x\] This change requires public documentation \(weaviate-io\) to be updated/ },
-              { repo: 'weaviate-python-client-test', regex: /- \[x\] Python \(weaviate-python-client\)/ },
-              { repo: 'typescript-client-test', regex: /- \[x\] JavaScript\/TypeScript \(typescript-client\)/ },
-              { repo: 'weaviate-go-client-test', regex: /- \[x\] Go \(weaviate-go-client\)/ },
-              { repo: 'java-client-test', regex: /- \[x\] Java \(java-client\)/ }
+              { repo: 'weaviate-io', regex: /- \[x\] This change requires public documentation \(weaviate-io\) to be updated/ },
+              { repo: 'weaviate-python-client', regex: /- \[x\] Python \(weaviate-python-client\)/ },
+              { repo: 'typescript-client', regex: /- \[x\] JavaScript\/TypeScript \(typescript-client\)/ },
+              { repo: 'weaviate-go-client', regex: /- \[x\] Go \(weaviate-go-client\)/ },
+              { repo: 'java-client', regex: /- \[x\] Java \(java-client\)/ }
             ];
 
             const results = checkboxes.map(checkbox => ({

--- a/.github/workflows/create-cross-functional-issues.yml
+++ b/.github/workflows/create-cross-functional-issues.yml
@@ -33,11 +33,11 @@ jobs:
             const body = pr.body || '';
 
             const checkboxes = [
-              { repo: 'weaviate-io', regex: /- \[x\] This change requires public documentation \(weaviate-io\) to be updated/ },
-              { repo: 'weaviate-python-client', regex: /- \[x\] Python \(weaviate-python-client\)/ },
-              { repo: 'typescript-client', regex: /- \[x\] JavaScript\/TypeScript \(typescript-client\)/ },
-              { repo: 'weaviate-go-client', regex: /- \[x\] Go \(weaviate-go-client\)/ },
-              { repo: 'java-client', regex: /- \[x\] Java \(java-client\)/ }
+              { repo: 'weaviate-io-test', regex: /- \[x\] This change requires public documentation \(weaviate-io\) to be updated/ },
+              { repo: 'weaviate-python-client-test', regex: /- \[x\] Python \(weaviate-python-client\)/ },
+              { repo: 'typescript-client-test', regex: /- \[x\] JavaScript\/TypeScript \(typescript-client\)/ },
+              { repo: 'weaviate-go-client-test', regex: /- \[x\] Go \(weaviate-go-client\)/ },
+              { repo: 'java-client-test', regex: /- \[x\] Java \(java-client\)/ }
             ];
 
             const results = checkboxes.map(checkbox => ({

--- a/.github/workflows/create-cross-functional-issues.yml
+++ b/.github/workflows/create-cross-functional-issues.yml
@@ -2,7 +2,7 @@ name: Create Cross-Functional Issues
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened]
   workflow_dispatch:
     inputs:
       pr_body:


### PR DESCRIPTION
Motivation:

- Many core repo changes necessitate creation of related issues on related repositories. For example:
    - On the docs repo, or the client repositories

This PR proposes creating additional checkboxes and related GH actions to automate these steps

### What's being changed:

- Introduce a new section on a standard PR template
- Add a GH actions file that will automatically create issues on related repositories, if the checkboxes are checked

*Note*: A new GitHub secret must be added with admin access to issues on the related repositories (weaviate-io, weaviate-python-client, typescript-client, weaviate-go-client, java-client).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
