### PR TITLE
Don't use a separate process for reading the number of mappings

### DIFF
--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -16,11 +16,9 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/exec"
 	"runtime"
 	"runtime/metrics"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -187,26 +185,32 @@ func (m *Monitor) obtainCurrentMappings() {
 func getCurrentMappings() int64 {
 	switch runtime.GOOS {
 	case "linux":
-		return currentMappingsCommand()
+		return currentMappingsLinux()
 	default:
 		return 0
 	}
 }
 
-func currentMappingsCommand() int64 {
-	cmd := exec.Command("wc", "-l", fmt.Sprintf("/proc/%s/maps", strconv.Itoa(os.Getpid()))) // print mappings
+// Counts the number of mappings by counting the number of lines within the maps file
+func currentMappingsLinux() int64 {
+	filePath := fmt.Sprintf("/proc/%d/maps", os.Getpid())
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
 
-	output, err := cmd.Output()
-	if err != nil {
+	var mappings int64
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		mappings++
+	}
+
+	if err := scanner.Err(); err != nil {
 		return 0
 	}
-	outputNoSpaces := strings.TrimSpace(string(output))
-	stringsSplit := strings.Split(outputNoSpaces, " ")
-	mappings, err := strconv.Atoi(stringsSplit[0])
-	if err != nil {
-		return 0
-	}
-	return int64(mappings)
+
+	return mappings
 }
 
 func getMaxMemoryMappings() int64 {


### PR DESCRIPTION
### What's being changed:
This changes the code for retrieving the memory mappings on linux from running a separate process (executing `wc -l`) to instead reading the file within the main Weaviate process. Motivation for the change is as follows:

I found that creating new processes can lead to problems with the handling of open files. Open file descriptors - of which we can have a lot - are getting inherited no matter what by child processes and even though the `FD_CLOEXEC` flag is set these seem to still be around for a short amount of time before the inherited file descriptors get closed - leading to `unlinkat` errors during calls to `os.RemoveAll()`, mainly here: https://github.com/weaviate/weaviate/blob/9433f6cc3329b2dfd48ef9f32968caa859d32ce7/adapters/repos/db/lsmkv/segmentindex/indexes.go#L138

Errors similar to the following were reported by multiple users on different occasions:
```
{"action":"lsm_memtable_flush","class":"WeaviateDemo3","error":"flush: unlinkat /var/lib/weaviate/weaviatedemo3/PXksOv6syq7H/lsm/objects/segment-1719829104648996364.scratch.d: directory not empty","index":"weaviatedemo3","level":"error","msg":"flush and switch failed","path":"/var/lib/weaviate/weaviatedemo3/PXksOv6syq7H/lsm/objects","shard":"PXksOv6syq7H","time":"2024-07-01T10:18:50Z"}
```
https://forum.weaviate.io/t/weaviate-not-backing-up-for-a-long-time/3116
https://forum.weaviate.io/t/error-when-data-stored-in-aws-efs/2880/3
https://github.com/weaviate/weaviate/issues/5214#issuecomment-2245616279

Please also check out my other comments in issue #5214 for my research on the topic.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
