### PR TITLE
refact:AuthZ: use authorization resources paths instead of custom strings

### DIFF
--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -58,7 +58,7 @@ func setupGraphQLHandlers(
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
 		// authorization requirements.
 
-		err := m.Authorizer.Authorize(principal, authorization.LIST, "schema/*")
+		err := m.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA)
 		if err != nil {
 			metricRequestsTotal.logUserError()
 			switch err.(type) {

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -11,6 +11,12 @@
 
 package authorization
 
+import (
+	"fmt"
+
+	"github.com/go-openapi/strfmt"
+)
+
 const (
 	// HEAD: Represents the HTTP HEAD method, which is used to retrieve metadata of a resource without
 	// fetching the resource itself.
@@ -36,3 +42,85 @@ const (
 	// UPDATE: Represents the HTTP PUT method, which is used to update an existing resource.
 	UPDATE = "update"
 )
+
+const (
+	// ALL_SCHEMA represents all schema-related resources.
+	ALL_SCHEMA = "schema/*"
+	// SCHEMA_TENANTS represents the schema tenants resource.
+	SCHEMA_TENANTS = "schema/tenants"
+	// SCHEMA_OBJECTS represents the schema objects resource.
+	SCHEMA_OBJECTS = "schema/objects"
+	// ALL_TRAVERSAL represents all traversal-related resources.
+	ALL_TRAVERSAL = "traversal/*"
+	// ALL_CLASSIFICATIONS represents all classification-related resources.
+	ALL_CLASSIFICATIONS = "classifications/*"
+	// NODES represents the nodes resource.
+	NODES = "nodes"
+	// CLUSTER represents the cluster resource.
+	CLUSTER = "cluster"
+	// ALL_BATCH represents all batch-related resources.
+	ALL_BATCH = "batch/*"
+	// BATCH_OBJECTS represents the batch objects resource.
+	BATCH_OBJECTS = "batch/objects"
+	// OBJECTS represents the objects resource.
+	OBJECTS = "objects"
+)
+
+// SchemaShard returns the path for a specific schema shard.
+// Parameters:
+// - class: The class name.
+// - shard: The shard name.
+// Returns: The formatted schema shard path.
+func SchemaShard(class, shard string) string {
+	return fmt.Sprintf("schema/%s/shards/%s", class, shard)
+}
+
+// ClassShards returns the path for all shards of a specific class.
+// Parameters:
+// - class: The class name.
+// Returns: The formatted class shards path.
+func ClassShards(class string) string {
+	return fmt.Sprintf("schema/%s/shards", class)
+}
+
+// Objects returns the path for a specific object or class.
+// Parameters:
+// - class: The class name (optional).
+// - id: The object ID (optional).
+// Returns: The formatted objects path.
+func Objects(class string, id strfmt.UUID) string {
+	if class != "" && id != "" {
+		return fmt.Sprintf("objects/%s/%s", class, id)
+	}
+
+	if id != "" {
+		return fmt.Sprintf("objects/%s", id)
+	}
+
+	if class != "" {
+		return fmt.Sprintf("objects/%s", class)
+	}
+
+	return OBJECTS
+}
+
+// Backup returns the path for a specific backup.
+// Parameters:
+// - backend: The backup backend name.
+// - id: The backup ID (optional).
+// Returns: The formatted backup path.
+func Backup(backend, id string) string {
+	if id == "" {
+		return fmt.Sprintf("backups/%s", backend)
+	}
+	return fmt.Sprintf("backups/%s/%s", backend, id)
+}
+
+// Restore returns the path for restoring a specific backup.
+// Parameters:
+// - backend: The backup backend name.
+// - id: The backup ID.
+// Returns: The formatted restore path.
+func Restore(backend, id string) string {
+	return fmt.Sprintf("backups/%s/%s/restore", backend, id)
+}

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -72,14 +72,10 @@ const (
 // - shard: The shard name.
 // Returns: The formatted schema shard path.
 func SchemaShard(class, shard string) string {
-	return fmt.Sprintf("schema/%s/shards/%s", class, shard)
-}
+	if class != "" && shard != "" {
+		return fmt.Sprintf("schema/%s/shards/%s", class, shard)
+	}
 
-// ClassShards returns the path for all shards of a specific class.
-// Parameters:
-// - class: The class name.
-// Returns: The formatted class shards path.
-func ClassShards(class string) string {
 	return fmt.Sprintf("schema/%s/shards", class)
 }
 
@@ -90,11 +86,11 @@ func ClassShards(class string) string {
 // Returns: The formatted objects path.
 func Objects(class string, id strfmt.UUID) string {
 	if class != "" && id != "" {
-		return fmt.Sprintf("objects/%s/%s", class, id)
+		return fmt.Sprintf("objects/%s/%s", class, id.String())
 	}
 
 	if id != "" {
-		return fmt.Sprintf("objects/%s", id)
+		return fmt.Sprintf("objects/%s", id.String())
 	}
 
 	if class != "" {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -76,8 +76,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		logOperation(s.logger, "try_backup", req.ID, req.Backend, begin, err)
 	}(time.Now())
 
-	path := fmt.Sprintf("backups/%s/%s", req.Backend, req.ID)
-	if err := s.authorizer.Authorize(pr, authorization.ADD, path); err != nil {
+	if err := s.authorizer.Authorize(pr, authorization.ADD, authorization.Backup(req.Backend, req.ID)); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, req.Backend, req.ID)
@@ -124,8 +123,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	defer func(begin time.Time) {
 		logOperation(s.logger, "try_restore", req.ID, req.Backend, begin, err)
 	}(time.Now())
-	path := fmt.Sprintf("backups/%s/%s/restore", req.Backend, req.ID)
-	if err := s.authorizer.Authorize(pr, authorization.RESTORE, path); err != nil {
+	if err := s.authorizer.Authorize(pr, authorization.RESTORE, authorization.Restore(req.Backend, req.ID)); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, req.Backend, req.ID)
@@ -176,8 +174,7 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 	defer func(begin time.Time) {
 		logOperation(s.logger, "backup_status", backupID, backend, begin, err)
 	}(time.Now())
-	path := fmt.Sprintf("backups/%s/%s", backend, backupID)
-	if err := s.authorizer.Authorize(principal, authorization.GET, path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.GET, authorization.Backup(backend, backupID)); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, backend, backupID)
@@ -199,8 +196,7 @@ func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Pri
 	defer func(begin time.Time) {
 		logOperation(s.logger, "restoration_status", backupID, backend, time.Now(), err)
 	}(time.Now())
-	path := fmt.Sprintf("backups/%s/%s/restore", backend, backupID)
-	if err := s.authorizer.Authorize(principal, authorization.GET, path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.GET, authorization.Restore(backend, backupID)); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, backend, backupID)
@@ -223,8 +219,7 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 		logOperation(s.logger, "cancel_backup", backupID, backend, begin, err)
 	}(time.Now())
 
-	path := fmt.Sprintf("backups/%s/%s", backend, backupID)
-	if err := s.authorizer.Authorize(principal, authorization.DELETE, path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.DELETE, authorization.Backup(backend, backupID)); err != nil {
 		return err
 	}
 
@@ -275,8 +270,7 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 	defer func(begin time.Time) {
 		logOperation(s.logger, "list_backup", "", backend, time.Now(), err)
 	}(time.Now())
-	path := fmt.Sprintf("backups/%s", backend)
-	if err := s.authorizer.Authorize(principal, authorization.GET, path); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.GET, authorization.Backup(backend, "")); err != nil {
 		return nil, err
 	}
 

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -131,7 +131,7 @@ type NeighborRef struct {
 }
 
 func (c *Classifier) Schedule(ctx context.Context, principal *models.Principal, params models.Classification) (*models.Classification, error) {
-	err := c.authorizer.Authorize(principal, authorization.CREATE, "classifications/*")
+	err := c.authorizer.Authorize(principal, authorization.CREATE, authorization.ALL_CLASSIFICATIONS)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (c *Classifier) assignNewID(params *models.Classification) error {
 }
 
 func (c *Classifier) Get(ctx context.Context, principal *models.Principal, id strfmt.UUID) (*models.Classification, error) {
-	err := c.authorizer.Authorize(principal, authorization.GET, "classifications/*")
+	err := c.authorizer.Authorize(principal, authorization.GET, authorization.ALL_CLASSIFICATIONS)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -49,7 +49,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
-	if err := m.authorizer.Authorize(principal, authorization.LIST, "nodes"); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.LIST, authorization.NODES); err != nil {
 		return nil, err
 	}
 	return m.db.GetNodeStatus(ctxWithTimeout, className, verbosity)
@@ -61,7 +61,7 @@ func (m *Manager) GetNodeStatistics(ctx context.Context,
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
-	if err := m.authorizer.Authorize(principal, authorization.LIST, "cluster"); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.LIST, authorization.CLUSTER); err != nil {
 		return nil, err
 	}
 	return m.db.GetNodeStatistics(ctxWithTimeout)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -31,7 +31,7 @@ import (
 func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.CREATE, "objects")
+	err := m.authorizer.Authorize(principal, authorization.CREATE, authorization.OBJECTS)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -30,7 +30,7 @@ var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be
 func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
 ) (BatchObjects, error) {
-	err := b.authorizer.Authorize(principal, authorization.CREATE, "batch/objects")
+	err := b.authorizer.Authorize(principal, authorization.CREATE, authorization.BATCH_OBJECTS)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -31,7 +31,7 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	match *models.BatchDeleteMatch, dryRun *bool, output *string,
 	repl *additional.ReplicationProperties, tenant string,
 ) (*BatchDeleteResponse, error) {
-	err := b.authorizer.Authorize(principal, authorization.DELETE, "batch/objects")
+	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.BATCH_OBJECTS)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (b *BatchManager) DeleteObjectsFromGRPC(ctx context.Context, principal *mod
 	params BatchDeleteParams,
 	repl *additional.ReplicationProperties, tenant string,
 ) (BatchDeleteResult, error) {
-	err := b.authorizer.Authorize(principal, authorization.DELETE, "batch/objects")
+	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.BATCH_OBJECTS)
 	if err != nil {
 		return BatchDeleteResult{}, err
 	}

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -32,7 +32,7 @@ import (
 func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Principal,
 	refs []*models.BatchReference, repl *additional.ReplicationProperties,
 ) (BatchReferences, error) {
-	err := b.authorizer.Authorize(principal, authorization.UPDATE, "batch/*")
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.ALL_BATCH)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -32,11 +32,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	principal *models.Principal, class string, id strfmt.UUID,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
-	path := fmt.Sprintf("objects/%s/%s", class, id)
-	if class == "" {
-		path = fmt.Sprintf("objects/%s", id)
-	}
-	err := m.authorizer.Authorize(principal, authorization.DELETE, path)
+	err := m.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(class, id))
 	if err != nil {
 		return err
 	}

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -30,11 +30,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, additional additional.Properties,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
-	path := fmt.Sprintf("objects/%s", id)
-	if class != "" {
-		path = fmt.Sprintf("objects/%s/%s", class, id)
-	}
-	err := m.authorizer.Authorize(principal, authorization.GET, path)
+	err := m.authorizer.Authorize(principal, authorization.GET, authorization.Objects(class, id))
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +61,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	offset *int64, limit *int64, sort *string, order *string, after *string,
 	addl additional.Properties, tenant string,
 ) ([]*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.LIST, "objects")
+	err := m.authorizer.Authorize(principal, authorization.LIST, authorization.OBJECTS)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +80,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Principal,
 	id strfmt.UUID,
 ) (*models.Class, error) {
-	err := m.authorizer.Authorize(principal, authorization.GET, fmt.Sprintf("objects/%s", id.String()))
+	err := m.authorizer.Authorize(principal, authorization.GET, authorization.Objects("", id))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -14,7 +14,6 @@ package objects
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -26,10 +25,7 @@ import (
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, class string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	path := fmt.Sprintf("objects/%s", id)
-	if class != "" {
-		path = fmt.Sprintf("objects/%s/%s", class, id)
-	}
+	path := authorization.Objects(class, id)
 	if err := m.authorizer.Authorize(principal, authorization.HEAD, path); err != nil {
 		return false, &Error{path, StatusForbidden, err}
 	}

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -46,7 +46,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{"bad request", StatusBadRequest, err}
 	}
 	cls, id := updates.Class, updates.ID
-	path := fmt.Sprintf("objects/%s/%s", cls, id)
+	path := authorization.Objects(cls, id)
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -13,7 +13,6 @@ package objects
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -67,7 +66,7 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
-	path := fmt.Sprintf("objects/%s", params.Class)
+	path := authorization.Objects(params.Class, "")
 	if err := m.authorizer.Authorize(principal, authorization.LIST, path); err != nil {
 		return nil, &Error{path, StatusForbidden, err}
 	}

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -52,7 +52,7 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		}
 		input.Class = objectRes.Object().Class
 	}
-	path := fmt.Sprintf("objects/%s/%s", input.Class, input.ID)
+	path := authorization.Objects(input.Class, input.ID)
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -73,7 +73,7 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	}
 	input.Class = res.ClassName
 
-	path := fmt.Sprintf("objects/%s/%s", input.Class, input.ID)
+	path := authorization.Objects(input.Class, input.ID)
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -64,7 +64,7 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	}
 	input.Class = res.ClassName
 
-	path := fmt.Sprintf("objects/%s/%s", input.Class, input.ID)
+	path := authorization.Objects(input.Class, input.ID)
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
 		return &Error{path, StatusForbidden, err}
 	}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -30,11 +30,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, updates *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	path := fmt.Sprintf("objects/%s/%s", class, id)
-	if class == "" {
-		path = fmt.Sprintf("objects/%s", id)
-	}
-	err := m.authorizer.Authorize(principal, authorization.UPDATE, path)
+	err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(class, id))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -25,7 +25,7 @@ import (
 func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principal,
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
-	err := m.authorizer.Authorize(principal, authorization.VALIDATE, "objects")
+	err := m.authorizer.Authorize(principal, authorization.VALIDATE, authorization.OBJECTS)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -112,7 +112,7 @@ func Test_Schema_Authorization(t *testing.T) {
 			methodName:       "AddTenants",
 			additionalArgs:   []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
 			expectedVerb:     authorization.UPDATE,
-			expectedResource: tenantsPath,
+			expectedResource: authorization.SCHEMA_TENANTS,
 		},
 		{
 			methodName: "UpdateTenants",
@@ -120,31 +120,31 @@ func Test_Schema_Authorization(t *testing.T) {
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
 			expectedVerb:     authorization.UPDATE,
-			expectedResource: tenantsPath,
+			expectedResource: authorization.SCHEMA_TENANTS,
 		},
 		{
 			methodName:       "DeleteTenants",
 			additionalArgs:   []interface{}{"className", []string{"P1"}},
 			expectedVerb:     authorization.DELETE,
-			expectedResource: tenantsPath,
+			expectedResource: authorization.SCHEMA_TENANTS,
 		},
 		{
 			methodName:       "GetTenants",
 			additionalArgs:   []interface{}{"className"},
 			expectedVerb:     authorization.GET,
-			expectedResource: tenantsPath,
+			expectedResource: authorization.SCHEMA_TENANTS,
 		},
 		{
 			methodName:       "GetConsistentTenants",
 			additionalArgs:   []interface{}{"className", false, []string{}},
 			expectedVerb:     authorization.GET,
-			expectedResource: tenantsPath,
+			expectedResource: authorization.SCHEMA_TENANTS,
 		},
 		{
 			methodName:       "ConsistentTenantExists",
 			additionalArgs:   []interface{}{"className", false, "P1"},
 			expectedVerb:     authorization.GET,
-			expectedResource: tenantsPath,
+			expectedResource: authorization.SCHEMA_TENANTS,
 		},
 	}
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -41,7 +41,7 @@ import (
 )
 
 func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, name string) (*models.Class, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
 		return nil, err
 	}
 	cl := h.schemaReader.ReadOnlyClass(name)
@@ -51,7 +51,7 @@ func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, nam
 func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Principal,
 	name string, consistency bool,
 ) (*models.Class, uint64, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
 		return nil, 0, err
 	}
 	if consistency {
@@ -65,7 +65,7 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 	principal *models.Principal, names ...string,
 ) (map[string]versioned.Class, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +99,7 @@ func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	cls *models.Class,
 ) (*models.Class, uint64, error) {
-	err := h.Authorizer.Authorize(principal, authorization.CREATE, "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.SCHEMA_OBJECTS)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -197,7 +197,7 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 
 // DeleteClass from the schema
 func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, class string) error {
-	err := h.Authorizer.Authorize(principal, authorization.DELETE, "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.SCHEMA_OBJECTS)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) error {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_OBJECTS)
 	if err != nil || updated == nil {
 		return err
 	}

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -166,7 +166,7 @@ func NewHandler(
 
 // GetSchema retrieves a locally cached copy of the schema
 func (h *Handler) GetSchema(principal *models.Principal) (schema.Schema, error) {
-	err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*")
+	err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA)
 	if err != nil {
 		return schema.Schema{}, err
 	}
@@ -176,7 +176,7 @@ func (h *Handler) GetSchema(principal *models.Principal) (schema.Schema, error) 
 
 // GetSchema retrieves a locally cached copy of the schema
 func (h *Handler) GetConsistentSchema(principal *models.Principal, consistency bool) (schema.Schema, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, "schema/*"); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
 		return schema.Schema{}, err
 	}
 
@@ -216,8 +216,7 @@ func (h *Handler) NodeName() string {
 func (h *Handler) UpdateShardStatus(ctx context.Context,
 	principal *models.Principal, class, shard, status string,
 ) (uint64, error) {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE,
-		fmt.Sprintf("schema/%s/shards/%s", class, shard))
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SchemaShard(class, shard))
 	if err != nil {
 		return 0, err
 	}
@@ -228,7 +227,7 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 func (h *Handler) ShardsStatus(ctx context.Context,
 	principal *models.Principal, class, tenant string,
 ) (models.ShardStatusList, error) {
-	err := h.Authorizer.Authorize(principal, authorization.LIST, fmt.Sprintf("schema/%s/shards", class))
+	err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ClassShards(class))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -227,7 +227,7 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 func (h *Handler) ShardsStatus(ctx context.Context,
 	principal *models.Principal, class, tenant string,
 ) (models.ShardStatusList, error) {
-	err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ClassShards(class))
+	err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.SchemaShard(class, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -27,7 +27,7 @@ import (
 func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Principal,
 	class *models.Class, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_OBJECTS)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -87,7 +87,7 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 func (h *Handler) DeleteClassProperty(ctx context.Context, principal *models.Principal,
 	class string, property string,
 ) error {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, "schema/objects")
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_OBJECTS)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -35,9 +35,6 @@ const (
 	ErrMsgMaxAllowedTenants = "maximum number of tenants allowed to be updated simultaneously is 100. Please reduce the number of tenants in your request and try again"
 )
 
-// tenantsPath is the main path used for authorization
-const tenantsPath = "schema/tenants"
-
 // AddTenants is used to add new tenants to a class
 // Class must exist and has partitioning enabled
 func (h *Handler) AddTenants(ctx context.Context,
@@ -45,7 +42,7 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_TENANTS); err != nil {
 		return 0, err
 	}
 
@@ -153,7 +150,7 @@ func (h *Handler) validateActivityStatuses(ctx context.Context, tenants []*model
 func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal,
 	class string, tenants []*models.Tenant,
 ) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_TENANTS); err != nil {
 		return nil, err
 	}
 
@@ -197,7 +194,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.DELETE, tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.SCHEMA_TENANTS); err != nil {
 		return err
 	}
 	for i, name := range tenants {
@@ -218,14 +215,14 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) GetTenants(ctx context.Context, principal *models.Principal, class string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.GET, tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.GET, authorization.SCHEMA_TENANTS); err != nil {
 		return nil, err
 	}
 	return h.getTenants(class)
 }
 
 func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.GET, tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.GET, authorization.SCHEMA_TENANTS); err != nil {
 		return nil, err
 	}
 
@@ -279,7 +276,7 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.GET, tenantsPath); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.GET, authorization.SCHEMA_TENANTS); err != nil {
 		return err
 	}
 

--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -31,7 +31,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 	t.metrics.QueriesAggregateInc(params.ClassName.String())
 	defer t.metrics.QueriesAggregateDec(params.ClassName.String())
 
-	err := t.authorizer.Authorize(principal, authorization.GET, "traversal/*")
+	err := t.authorizer.Authorize(principal, authorization.GET, authorization.ALL_TRAVERSAL)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_explore_concepts.go
+++ b/usecases/traverser/traverser_explore_concepts.go
@@ -28,7 +28,7 @@ func (t *Traverser) Explore(ctx context.Context,
 		params.Limit = 20
 	}
 
-	err := t.authorizer.Authorize(principal, authorization.GET, "traversal/*")
+	err := t.authorizer.Authorize(principal, authorization.GET, authorization.ALL_TRAVERSAL)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -42,7 +42,7 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	defer t.metrics.QueriesGetDec(params.ClassName)
 	defer t.metrics.QueriesObserveDuration(params.ClassName, before.UnixMilli())
 
-	err := t.authorizer.Authorize(principal, authorization.GET, "traversal/*")
+	err := t.authorizer.Authorize(principal, authorization.GET, authorization.ALL_TRAVERSAL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

as a follow up for https://github.com/weaviate/weaviate/pull/5917 

change the whole code base to use authorization resource path to avoid any error prone resources and  prep for RBAC



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
