### PR TITLE
Fix: Non-blocking segment initialization on LSM segment flush

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -268,7 +268,7 @@ jobs:
           "--acceptance-only-graphql",
           "--acceptance-only-replication",
           "--acceptance-go-client-only-fast",
-          "--acceptance-only-python"
+          "--acceptance-only-python",
         ]
     steps:
       - uses: actions/checkout@v4
@@ -288,7 +288,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ["--acceptance-go-client-named-vectors"]
+        test: ["--acceptance-go-client-named-vectors", "--acceptance-lsmkv"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1088,7 +1088,9 @@ func (b *Bucket) isReadOnly() bool {
 // calling, but there are some situations where this might be intended, such as
 // in test scenarios or when a force flush is desired.
 func (b *Bucket) FlushAndSwitch() error {
-	b.isFlushing.Store(true)
+	if b.isFlushing.Swap(true) {
+		return fmt.Errorf("unexpected concurrent call to flush and switch")
+	}
 	defer b.isFlushing.Store(false)
 
 	before := time.Now()

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -299,6 +299,14 @@ func (sg *SegmentGroup) add(path string) error {
 	return nil
 }
 
+func (sg *SegmentGroup) addInitializedSegment(segment *segment) error {
+	sg.maintenanceLock.Lock()
+	defer sg.maintenanceLock.Unlock()
+
+	sg.segments = append(sg.segments, segment)
+	return nil
+}
+
 func (sg *SegmentGroup) get(key []byte) ([]byte, error) {
 	sg.maintenanceLock.RLock()
 	defer sg.maintenanceLock.RUnlock()

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -64,6 +66,8 @@ type SegmentGroup struct {
 
 	allocChecker   memwatch.AllocChecker
 	maxSegmentSize int64
+
+	isFlushing *atomic.Bool
 }
 
 type sgConfig struct {
@@ -77,6 +81,7 @@ type sgConfig struct {
 	calcCountNetAdditions bool
 	forceCompaction       bool
 	maxSegmentSize        int64
+	isFlushing            *atomic.Bool
 }
 
 func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
@@ -103,6 +108,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 		compactLeftOverSegments: cfg.forceCompaction,
 		maxSegmentSize:          cfg.maxSegmentSize,
 		allocChecker:            allocChecker,
+		isFlushing:              cfg.isFlushing,
 	}
 
 	segmentIndex := 0
@@ -308,7 +314,13 @@ func (sg *SegmentGroup) addInitializedSegment(segment *segment) error {
 }
 
 func (sg *SegmentGroup) get(key []byte) ([]byte, error) {
+	beforeMaintenanceLock := time.Now()
 	sg.maintenanceLock.RLock()
+	if time.Since(beforeMaintenanceLock) > 100*time.Millisecond {
+		sg.logger.WithField("duration", time.Since(beforeMaintenanceLock)).
+			WithField("action", "lsm_segment_group_get_obtain_maintenance_lock").
+			Debug("waited over 100ms to obtain maintenance lock in segment group get()")
+	}
 	defer sg.maintenanceLock.RUnlock()
 
 	return sg.getWithUpperSegmentBoundary(key, len(sg.segments)-1)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -332,8 +332,9 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 
 	beforeMaintenanceLock := time.Now()
 	sg.maintenanceLock.Lock()
-	if time.Since(beforeMaintenanceLock) > 50*time.Millisecond {
-		sg.logger.WithField("duration", time.Since(beforeMaintenanceLock)).Warn("compaction took longer than 50ms to acquire maintenance lock")
+	if time.Since(beforeMaintenanceLock) > 100*time.Millisecond {
+		sg.logger.WithField("duration", time.Since(beforeMaintenanceLock)).
+			Debug("compaction took more than 100ms to acquire maintenance lock")
 	}
 	defer sg.maintenanceLock.Unlock()
 

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -560,7 +560,7 @@ func (sg *SegmentGroup) compactionFitsSizeLimit(left, right *segment) bool {
 // Warning: waitForFlushingToComplete gives you no synchronization guarantees,
 // it mainly acts as a hint that a flushing has just completed, but it gives no
 // guarantees that a new flushing hasn't started yet. The idea is that it's
-// better to delay the attempt to obtain a a maintenance lock because it will
+// better to delay the attempt to obtain a maintenance lock because it will
 // start blocking user operations if we have to wait for it. But never rely on
 // this behavior alone, always use it in combination with a proper lock.
 func (sg *SegmentGroup) waitForFlushingToComplete(stepSize time.Duration, maxWait time.Duration) {

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -325,7 +326,15 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 		return fmt.Errorf("precompute segment meta: %w", err)
 	}
 
+	// wait for flushing to complete before acquiring the maintenance lock, this
+	// can help avoid blocking user requests
+	sg.waitForFlushingToComplete(10*time.Millisecond, 60*time.Second)
+
+	beforeMaintenanceLock := time.Now()
 	sg.maintenanceLock.Lock()
+	if time.Since(beforeMaintenanceLock) > 50*time.Millisecond {
+		sg.logger.WithField("duration", time.Since(beforeMaintenanceLock)).Warn("compaction took longer than 50ms to acquire maintenance lock")
+	}
 	defer sg.maintenanceLock.Unlock()
 
 	leftSegment := sg.segments[old1]
@@ -546,4 +555,42 @@ func (sg *SegmentGroup) compactionFitsSizeLimit(left, right *segment) bool {
 
 	totalSize := left.size + right.size
 	return totalSize <= sg.maxSegmentSize
+}
+
+// Warning: waitForFlushingToComplete gives you no synchronization guarantees,
+// it mainly acts as a hint that a flushing has just completed, but it gives no
+// guarantees that a new flushing hasn't started yet. The idea is that it's
+// better to delay the attempt to obtain a a maintenance lock because it will
+// start blocking user operations if we have to wait for it. But never rely on
+// this behavior alone, always use it in combination with a proper lock.
+func (sg *SegmentGroup) waitForFlushingToComplete(stepSize time.Duration, maxWait time.Duration) {
+	if !sg.isFlushing.Load() {
+		return
+	}
+
+	begin := time.Now()
+
+	t := time.NewTicker(stepSize)
+	defer t.Stop()
+
+	timeout := time.NewTimer(maxWait)
+
+	for {
+		select {
+		case <-t.C:
+			if !sg.isFlushing.Load() {
+				totalDelay := time.Since(begin)
+				sg.logger.WithField("action", "lsm_compaction_delay").
+					WithField("duration", totalDelay).
+					Debugf("waited %s for flushing to complete", totalDelay)
+				return
+			}
+		case <-timeout.C:
+			sg.logger.WithField("action", "lsm_compaction_delay").
+				WithField("duration", maxWait).
+				Warningf("waited %s for flushing to complete, but it did not complete", maxWait)
+
+			return
+		}
+	}
 }

--- a/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
@@ -1,0 +1,35 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import "fmt"
+
+func (sg *SegmentGroup) initAndPrecomputeNewSegment(path string) (*segment, error) {
+	// During this entire operation we need to make sure that no compaction
+	// happens, otherwise we get a race between the existsOnLower func and
+	// the meta count init.
+	//
+	// Normal operations (user CRUD) are fine.
+	sg.maintenanceLock.RLock()
+	defer sg.maintenanceLock.RUnlock()
+
+	newSegmentIndex := len(sg.segments)
+
+	segment, err := newSegment(path, sg.logger,
+		sg.metrics, sg.makeExistsOnLower(newSegmentIndex),
+		sg.mmapContents, sg.useBloomFilter, sg.calcCountNetAdditions, true)
+	if err != nil {
+		return nil, fmt.Errorf("init and pre-compute new segment %s: %w", path, err)
+	}
+
+	return segment, nil
+}

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -68,7 +68,13 @@ func TestHelloWorld(t *testing.T) {
 	var putOutsideThreshold []float32
 	var getOutsideThreshold []float32
 
+	totalIngested := 0
+	totalSpotChecks := 0
+
 	for _, r := range results {
+		totalIngested += r.ingested
+		totalSpotChecks += r.getSpotChecks
+
 		for r.worstPutQueries.Len() > 0 {
 			tookMs := r.worstPutQueries.Pop().Dist * 1000
 			if tookMs > float32(putThreshold.Milliseconds()) {
@@ -94,6 +100,20 @@ func TestHelloWorld(t *testing.T) {
 		t.Errorf("%d get queries outside threshold (%s) : %v", len(getOutsideThreshold), getThreshold, getOutsideThreshold)
 	} else {
 		logger.Infof("all get queries were within threshold (%s)", getThreshold)
+	}
+
+	// This a sanity check to make sure the test actually ran. The expected total
+	// is a lot more, but if the test were to just block for 60s and do nothing,
+	// this sanity check should catch it.
+	if totalIngested < 500_000 {
+		t.Errorf("expected at least 500k entries but got %d", totalIngested)
+	} else {
+		logger.Infof("ingested %d entries", totalIngested)
+	}
+	if totalSpotChecks < 500_000 {
+		t.Errorf("expected at least 500k spot checks but got %d", totalSpotChecks)
+	} else {
+		logger.Infof("performed %d spot checks", totalSpotChecks)
 	}
 }
 

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package main
 
 import (

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestHelloWorld(t *testing.T) {
+	putThreshold := 100 * time.Millisecond
+	getThreshold := 100 * time.Millisecond
+	trackWorstQueries := 10
+	workers := 4
+
+	dir := t.TempDir()
+	ctx := context.Background()
+	c := lsmkv.NewBucketCreator()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	if n := runtime.GOMAXPROCS(0); n < workers {
+		workers = n
+		logger.Infof("reducing workers to %d", workers)
+	}
+
+	flushCallbacks := cyclemanager.NewCallbackGroup("flush", logger, 1)
+	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
+	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle.Start()
+	compactionCycle := cyclemanager.NewManager(cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
+	compactionCycle.Start()
+
+	bucket, err := c.NewBucket(ctx, filepath.Join(dir, "my-bucket"), "", logger, nil,
+		compactionCallbacks, flushCallbacks,
+		lsmkv.WithPread(true),
+		lsmkv.WithDynamicMemtableSizing(1, 2, 1, 4),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	defer bucket.Shutdown(ctx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	results := make([]result, workers)
+	wg := sync.WaitGroup{}
+	for workerID := 0; workerID < workers; workerID++ {
+		wg.Add(1)
+		go worker(ctx, t, &wg, workerID, bucket, logger, putThreshold, getThreshold, trackWorstQueries, results)
+	}
+
+	wg.Wait()
+	logger.WithField("concurrency", workers).Infof("%d workers completed", workers)
+
+	var putOutsideThreshold []float32
+	var getOutsideThreshold []float32
+
+	for _, r := range results {
+		for r.worstPutQueries.Len() > 0 {
+			tookMs := r.worstPutQueries.Pop().Dist * 1000
+			if tookMs > float32(putThreshold.Milliseconds()) {
+				putOutsideThreshold = append(putOutsideThreshold, tookMs)
+			}
+		}
+
+		for r.worstGetQueries.Len() > 0 {
+			tookMs := r.worstGetQueries.Pop().Dist * 1000
+			if tookMs > float32(getThreshold.Milliseconds()) {
+				getOutsideThreshold = append(getOutsideThreshold, tookMs)
+			}
+		}
+	}
+
+	if len(putOutsideThreshold) > 0 {
+		t.Errorf("%d put queries outside threshold (%s): %v", len(putOutsideThreshold), putThreshold, putOutsideThreshold)
+	} else {
+		logger.Infof("all put queries were within threshold (%s)", putThreshold)
+	}
+
+	if len(getOutsideThreshold) > 0 {
+		t.Errorf("%d get queries outside threshold (%s) : %v", len(getOutsideThreshold), getThreshold, getOutsideThreshold)
+	} else {
+		logger.Infof("all get queries were within threshold (%s)", getThreshold)
+	}
+}
+
+type result struct {
+	workerID        int
+	worstPutQueries *priorityqueue.Queue[float32]
+	worstGetQueries *priorityqueue.Queue[float32]
+	ingested        int
+	getSpotChecks   int
+}
+
+func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int, bucket *lsmkv.Bucket, logger logrus.FieldLogger,
+	putThreshold time.Duration, getThreshold time.Duration, trackWorstQueries int, results []result,
+) {
+	defer wg.Done()
+
+	logger = logger.WithField("worker_id", workerID)
+	worstPutQueries := priorityqueue.NewMin[float32](trackWorstQueries)
+	worstGetQueries := priorityqueue.NewMin[float32](trackWorstQueries)
+
+	i := 0
+	totalAsserted := 0
+	for {
+		if ctx.Err() != nil {
+			break
+		}
+		before := time.Now()
+		bucket.Put([]byte(fmt.Sprintf("worker-%d-key-%d", workerID, i)), []byte(fmt.Sprintf("value-%d", i)))
+		took := time.Since(before)
+		trackWorstQuery(worstPutQueries, i, took, trackWorstQueries)
+		if took > putThreshold {
+			logger.Warnf("put took too long: %s", time.Since(before))
+		}
+
+		// perform spot checks every 10000 iterations
+		// the spot checks pick a random increment between 0 and 100 between ids
+		if i > 100 && i%10000 == 0 {
+			j := 0
+			for j < i {
+				before := time.Now()
+				val, err := bucket.Get([]byte(fmt.Sprintf("worker-%d-key-%d", workerID, j)))
+				if err != nil {
+					t.Errorf("failed to get key-%d: %s", j, err)
+					return
+				}
+				took := time.Since(before)
+				if took > getThreshold {
+					logger.Warnf("get took too long: %s", time.Since(before))
+				}
+
+				if string(val) != fmt.Sprintf("value-%d", j) {
+					t.Errorf("expected value-%d but got %s", j, val)
+				}
+
+				trackWorstQuery(worstGetQueries, j, took, trackWorstQueries)
+
+				totalAsserted++
+				j += rand.Intn(100)
+			}
+		}
+
+		if i%100_000 == 0 {
+			logger.WithField("current_id", i).Infof("worker %d inserted %d entries", workerID, i)
+		}
+
+		i++
+	}
+
+	results[workerID] = result{
+		workerID:        workerID,
+		worstPutQueries: worstPutQueries,
+		worstGetQueries: worstGetQueries,
+		ingested:        i,
+		getSpotChecks:   totalAsserted,
+	}
+
+	logger.WithField("imported", i).WithField("get_spot_checks", totalAsserted).Infof("completed worker")
+}
+
+func trackWorstQuery(heap *priorityqueue.Queue[float32], i int, took time.Duration, trackWorstQueries int) {
+	if heap.Len() < trackWorstQueries {
+		heap.Insert(uint64(i), float32(took.Seconds()))
+	} else if heap.Top().Dist < float32(took.Seconds()) {
+		heap.Pop()
+		heap.Insert(uint64(i), float32(took.Seconds()))
+	}
+}

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-func TestHelloWorld(t *testing.T) {
+func TestLSMKV_ReplaceBucket(t *testing.T) {
 	putThreshold := 100 * time.Millisecond
 	getThreshold := 100 * time.Millisecond
 	trackWorstQueries := 10

--- a/test/run.sh
+++ b/test/run.sh
@@ -257,7 +257,7 @@ function run_acceptance_go_client_named_vectors() {
     # tests with go client are in a separate package with its own dependencies to isolate them
     cd 'test/acceptance_with_go_client'
     for pkg in $(go list ./... | grep 'acceptance_tests_with_client/named_vectors_tests'); do
-      if ! go test -count 1 -race "$pkg"; then
+      if ! go test -v -count 1 -race "$pkg"; then
         echo "Test for $pkg failed" >&2
         return 1
       fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -257,7 +257,7 @@ function run_acceptance_go_client_named_vectors() {
     # tests with go client are in a separate package with its own dependencies to isolate them
     cd 'test/acceptance_with_go_client'
     for pkg in $(go list ./... | grep 'acceptance_tests_with_client/named_vectors_tests'); do
-      if ! go test -v -count 1 -race "$pkg"; then
+      if ! go test -timeout=15m -count 1 -race "$pkg"; then
         echo "Test for $pkg failed" >&2
         return 1
       fi


### PR DESCRIPTION
# Non-blocking LSM segment flush

## Changes

### Status Quo
Previously, a newly flushed segment would be added to the segment group directly. However, this operation held the fairly expensive `flushLock.Lock()` and `maintenanceLock.Lock()` locks. Both of those are `RWMutex`es that use `RLock`s for normal operations (such as user CRUD operations) and use `Lock()` to exchange segments.

The segment group `add()` call would generate all segment metadata **while holding those locks**, this means both the bloom filters (which are a function of segment size) and the net count additions which are both a function of segment size as well as bucket size (i.e. the more objects exist, the slower it gets).

### This PR
- Rather than having “segment init + segment add” as a single operation it’s split into two operations.
- First we init the segment in the background. We only need to hold a `segmentGroup.maintenanceLock.RLock` to make sure this doesn’t race with a concurrent compaction, but it doesn’t require an expensive `flushLock.Lock()`
- Then we add the new segment to the actual segment group, this requires all the same locks from before, but it is super fast because it’s essentially just an array append.
- Initializing the segment "in the background" (i.e. without blocking user CRUD operations) is safe because the flush process is single threaded, so no new segment can be added until the previous segment has completed the entire `FlushAndSwitch` cycle. 

## Benchmark

A simple test that inserts 10M items into a `Replace` bucket and records the top 10 worst put latencies:

### Control (`stable/v1.25`):
```
worst queries: 3785.9849ms
worst queries: 3845.057ms
worst queries: 3927.957ms
worst queries: 3943.977ms
worst queries: 4003.0293ms
worst queries: 4071.7922ms
worst queries: 4178.2466ms
worst queries: 4441.931ms
worst queries: 4473.1943ms
worst queries: 5635.6445ms
```

### Fix candidate (this branch):
```
worst queries: 14.208459ms
worst queries: 15.455667ms
worst queries: 17.009624ms
worst queries: 18.032417ms
worst queries: 18.127916ms
worst queries: 18.559166ms
worst queries: 19.66125ms
worst queries: 20.997583ms
worst queries: 69.789085ms
worst queries: 96.020874ms
```

The test script is [available as a gist here](https://gist.github.com/etiennedi/39ec71b5d00d6991234473193899fcc8).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: 🟢 https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/11256580264
- [x] All new code is covered by tests where it is reasonable: Added a new performance+correctness LSM store acceptance test
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
