### PR TITLE
Increase maximum test time to reduce flakes

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -967,7 +967,7 @@ func TestDelete_ResetLockDoesNotLockForever(t *testing.T) {
 		}()
 		wg.Wait()
 		fmt.Println(ellapsed.Milliseconds())
-		assert.LessOrEqual(t, ellapsed.Milliseconds(), int64(10))
+		assert.LessOrEqual(t, ellapsed.Milliseconds(), int64(100))
 	})
 
 	t.Run("destroy the index", func(t *testing.T) {


### PR DESCRIPTION
Increase timeout because the test is flaky