### PR TITLE
chore(push_docker): Pass correct branch name to docker build info.

### DIFF
--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -46,11 +46,12 @@ function release() {
     if [ "$pr_title" == "" ]; then
       tag_preview="${DOCKER_REPO}:${prefix}-${git_hash}"
       weaviate_version="${prefix}-${git_hash}"
+      git_branch="$GITHUB_REF_NAME"
     else
       tag_preview="${DOCKER_REPO}:${prefix}-${pr_title}-${git_hash}"
       weaviate_version="${prefix}-${pr_title}-${git_hash}"
+      git_branch="$GITHUB_HEAD_REF"
     fi
-    git_branch="$GITHUB_HEAD_REF"
   fi
 
   args=("--build-arg=GIT_REVISION=$git_revision" "--build-arg=GIT_BRANCH=$git_branch" "--build-arg=BUILD_USER=$build_user" "--build-arg=BUILD_DATE=$build_date" "--platform=linux/amd64,linux/arm64" "--target=weaviate" "--push")

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -12,7 +12,16 @@ function release() {
   tag_preview=
 
   git_revision=$(echo "$GITHUB_SHA" | cut -c1-7)
-  git_branch=$(git rev-parse --abbrev-ref HEAD)
+
+  # NOTE: Getting git branch name needs some work.
+  # CI checkout the code to specific commit. So doing something like `git rev-parse --abbrev-ref HEAD`
+  # to get the branch name won't work.
+  # We use $GITHUB_REF_NAME if code is checked out from `main` or any `tagged` branch.
+  # or $GITHUB_HEAD_REF if code is checked out from any `pull_request`.
+  # More info about those variables can be found here
+  # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
+  git_branch=""
+
   build_user="ci"
   build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -24,12 +33,14 @@ function release() {
   weaviate_version="$(jq -r '.info.version' < openapi-specs/schema.json)"
   if [ "$GITHUB_REF_NAME" == "main" ]; then
     tag_exact="${DOCKER_REPO}:${weaviate_version}-${git_hash}"
+    git_branch="$GITHUB_REF_NAME"
   elif [  "$GITHUB_REF_TYPE" == "tag" ]; then
         if [ "$GITHUB_REF_NAME" != "v$weaviate_version" ]; then
             echo "The release tag ($GITHUB_REF_NAME) and Weaviate version (v$weaviate_version) are not equal! Can't release."
             return 1
         fi
         tag_exact="${DOCKER_REPO}:${weaviate_version}"
+	git_branch="$GITHUB_REF_NAME"
   else
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
@@ -39,6 +50,7 @@ function release() {
       tag_preview="${DOCKER_REPO}:${prefix}-${pr_title}-${git_hash}"
       weaviate_version="${prefix}-${pr_title}-${git_hash}"
     fi
+    git_branch="$GITHUB_HEAD_REF"
   fi
 
   args=("--build-arg=GIT_REVISION=$git_revision" "--build-arg=GIT_BRANCH=$git_branch" "--build-arg=BUILD_USER=$build_user" "--build-arg=BUILD_DATE=$build_date" "--platform=linux/amd64,linux/arm64" "--target=weaviate" "--push")


### PR DESCRIPTION
### What's being changed:

Follow up to https://github.com/weaviate/weaviate/pull/5865

NOTE: Getting git branch name in CI needs some work. CI checkout the code to specific commit. So doing something like `git rev-parse --abbrev-ref HEAD` to get the branch name won't work (it just retuns string `HEAD` and that's not that helpful).
We use `$GITHUB_REF_NAME` if code is checked out from `main` or any `tagged` branch. or `$GITHUB_HEAD_REF` if code is checked out from any `pull_request`.

More info about those variables can be found here
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
