### PR TITLE
chore: Adjust the tag name in case of main and stable/v* branch builds

### DIFF
--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -15,15 +15,12 @@ function release() {
   git_branch=$(git branch)
 
   prefix="preview"
-  if [ "$git_branch" == "main" ] || [ "$git_branch" == "stable/v*" ]; then
-    prefix="$(echo $git_branch | sed 's/\//-/g')"
+  if [ "$GITHUB_REF_NAME" == "main" ] || [ "$GITHUB_REF_NAME" == "stable/v"* ]; then
+    prefix="$(echo $GITHUB_REF_NAME | sed 's/\//-/g')"
   fi
 
-
   weaviate_version="$(jq -r '.info.version' < openapi-specs/schema.json)"
-  if [ "$GITHUB_REF_NAME" == "main" ]; then
-    tag_exact="${DOCKER_REPO}:${weaviate_version}-${git_hash}"
-  elif [  "$GITHUB_REF_TYPE" == "tag" ]; then
+  if [  "$GITHUB_REF_TYPE" == "tag" ]; then
         if [ "$GITHUB_REF_NAME" != "v$weaviate_version" ]; then
             echo "The release tag ($GITHUB_REF_NAME) and Weaviate version (v$weaviate_version) are not equal! Can't release."
             return 1


### PR DESCRIPTION
### What's being changed:

This PR introduces a change in how we construct docker image tag names:

For builds that are run for `main` or `stable/v*` branch the tag will look like this: `{branch_name}-{hash}`.

For builds that are run for PR's tag names will look like this: `preview-{pr_title}-{hash}`.

For `tags` tag name will be the `tag`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
