### PR TITLE
chore: fix docker push script from CI branch build

### DIFF
--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -13,12 +13,6 @@ function release() {
 
   git_hash=$(echo "$GITHUB_SHA" | cut -c1-7)
 
-  echo "GITHUB_REF_TYPE: $GITHUB_REF_TYPE"
-  echo "GITHUB_REF_NAME: $GITHUB_REF_NAME"
-  echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
-  echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
-  echo "PR_TITLE: $PR_TITLE"
-
   weaviate_version="$(jq -r '.info.version' < openapi-specs/schema.json)"
   if [  "$GITHUB_REF_TYPE" == "tag" ]; then
         if [ "$GITHUB_REF_NAME" != "v$weaviate_version" ]; then
@@ -29,7 +23,7 @@ function release() {
   else
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
-      prefix="$(echo -n $GITHUB_BASE_REF | sed 's/\//-/g')"
+      prefix="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g')"
       tag_preview="${DOCKER_REPO}:${prefix}-${git_hash}"
       weaviate_version="${prefix}-${git_hash}"
     else


### PR DESCRIPTION
### What's being changed:

This PR fixes how we create a docker image tag name when start CI builds from branch.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
