### PR TITLE
Use a more flexible value

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -967,7 +967,7 @@ func TestDelete_ResetLockDoesNotLockForever(t *testing.T) {
 		}()
 		wg.Wait()
 		fmt.Println(ellapsed.Milliseconds())
-		assert.LessOrEqual(t, ellapsed.Milliseconds(), int64(10))
+		assert.LessOrEqual(t, ellapsed.Milliseconds(), int64(180))
 	})
 
 	t.Run("destroy the index", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Fixing the flaky test introduced by a too restrictive value for the time it takes to complete a tombstones cleanup cycle

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
