### PR TITLE
Use custom number of dimensions also when using Azure OpenAI

### DIFF
--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -230,7 +230,7 @@ func (v *client) getError(statusCode int, requestID string, resBodyError *openAI
 
 func (v *client) getEmbeddingsRequest(input []string, model string, isAzure bool, dimensions *int64) embeddingsRequest {
 	if isAzure {
-		return embeddingsRequest{Input: input}
+		return embeddingsRequest{Input: input, Dimensions: dimensions}
 	}
 	return embeddingsRequest{Input: input, Model: model, Dimensions: dimensions}
 }


### PR DESCRIPTION
### What's being changed:
When adding support for setting the `Dimensions` parameter to a custom value in 
https://github.com/weaviate/weaviate/commit/5d4a106820754447c04c1e22764167624420c117, it was forgotten to also add that parameter in the case that Azure OpenAI is being used.

Without this, when using Azure OpenAI always the default number of dimensions will be used, disregarding what is set in in the `dimensions` attribute of the `text2vec-openai` `moduleConfig`.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
