### PR TITLE
Add limit to using ACORN on high selectivity filters

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -48,6 +48,7 @@ type VectorCompressor interface {
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vector []float32)
 	Prefetch(id uint64)
+	CountVectors() int64
 	PrefillCache()
 
 	DistanceBetweenCompressedVectorsFromIDs(ctx context.Context, x, y uint64) (float32, error)
@@ -78,6 +79,10 @@ func (compressor *quantizedVectorsCompressor[T]) GrowCache(size uint64) {
 
 func (compressor *quantizedVectorsCompressor[T]) SetCacheMaxSize(size int64) {
 	compressor.cache.UpdateMaxSize(size)
+}
+
+func (compressor *quantizedVectorsCompressor[T]) CountVectors() int64 {
+	return compressor.cache.CountVectors()
 }
 
 func (compressor *quantizedVectorsCompressor[T]) GetCacheMaxSize() int64 {


### PR DESCRIPTION
### What's being changed:
- Add limit on ACORN to only use if filter is not > 40% of the entire dataset.
- We may revisit this in the future but testing has shown ACORN works best when the filter is not too large and the existing sweeping implementation works very well for high selectivity filters.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
