### PR TITLE
fix: remove assumption that first node responding full payload provides latest object version

### DIFF
--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -77,7 +77,7 @@ func testGetSchemaWithoutClient(t *testing.T) {
 				},
 				"replicationConfig": map[string]interface{}{
 					"factor":           float64(1),
-					"deletionStrategy": "DeleteOnConflict",
+					"deletionStrategy": "NoAutomatedResolution",
 				},
 				"vectorizer": "text2vec-contextionary", // global default from env var, see docker-compose-test.yml
 				"invertedIndexConfig": map[string]interface{}{

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -234,6 +234,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 			M := 0
 			for i := 0; i < N; i++ {
 				max := 0
+				maxAt := -1
 				lastTime := resp.UpdateTimeAt(i)
 
 				for j := range votes { // count votes
@@ -242,9 +243,10 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 					}
 					if max < votes[j].Count[i] {
 						max = votes[j].Count[i]
+						maxAt = j
 					}
 				}
-				if max >= st.Level {
+				if max >= st.Level && maxAt == contentIdx {
 					M++
 				}
 			}

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -58,7 +58,6 @@ func (f *finderStream) readOne(ctx context.Context,
 		defer close(resultCh)
 		var (
 			votes      = make([]objTuple, 0, st.Level)
-			maxCount   = 0
 			contentIdx = -1
 		)
 
@@ -75,14 +74,26 @@ func (f *finderStream) readOne(ctx context.Context,
 				contentIdx = len(votes)
 			}
 			votes = append(votes, objTuple{resp.sender, resp.UpdateTime, resp.Data, 0, nil})
-			for i := range votes { // count number of votes
-				if votes[i].UTime == resp.UpdateTime {
-					votes[i].ack++
+
+			for i := range votes {
+				if votes[i].UTime != resp.UpdateTime {
+					// incomming response does not match current vote
+					continue
 				}
-				if maxCount < votes[i].ack {
-					maxCount = votes[i].ack
+
+				votes[i].ack++
+
+				if votes[i].ack < st.Level {
+					// current vote does not have enough acks
+					continue
 				}
-				if maxCount >= st.Level && contentIdx >= 0 {
+
+				if votes[i].o.Deleted {
+					resultCh <- objResult{nil, nil}
+					return
+				}
+				if i == contentIdx {
+					// prefetched payload matches agreed vote
 					resultCh <- objResult{votes[contentIdx].o.Object, nil}
 					return
 				}
@@ -134,10 +145,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 	resultCh := make(chan _Result[bool], 1)
 	g := func() {
 		defer close(resultCh)
-		var (
-			votes    = make([]boolTuple, 0, st.Level) // number of votes per replica
-			maxCount = 0
-		)
+		votes := make([]boolTuple, 0, st.Level) // number of votes per replica
 
 		for r := range ch { // len(ch) == st.Level
 			resp := r.Value
@@ -150,18 +158,23 @@ func (f *finderStream) readExistence(ctx context.Context,
 			}
 
 			votes = append(votes, boolTuple{resp.Sender, resp.UpdateTime, resp.RepairResponse, 0, nil})
+
 			for i := range votes { // count number of votes
-				if votes[i].UTime == resp.UpdateTime {
-					votes[i].ack++
+				if votes[i].UTime != resp.UpdateTime {
+					// incomming response does not match current vote
+					continue
 				}
-				if maxCount < votes[i].ack {
-					maxCount = votes[i].ack
+
+				votes[i].ack++
+
+				if votes[i].ack < st.Level {
+					// current vote does not have enough acks
+					continue
 				}
-				if maxCount >= st.Level {
-					exists := !votes[i].o.Deleted && votes[i].o.UpdateTime != 0
-					resultCh <- _Result[bool]{exists, nil}
-					return
-				}
+
+				exists := !votes[i].o.Deleted && votes[i].o.UpdateTime != 0
+				resultCh <- _Result[bool]{exists, nil}
+				return
 			}
 		}
 

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -347,7 +347,15 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 		m := make(map[string]int, len(ids)/2) //
 		for j, x := range lastTimes {
 			if result[j] == nil {
-				if x.Deleted {
+				alreadyDeleted := false
+
+				if rid == contentIdx {
+					alreadyDeleted = vote.batchReply.FullData[j].Deleted
+				} else {
+					alreadyDeleted = vote.batchReply.DigestData[j].Deleted
+				}
+
+				if alreadyDeleted {
 					continue
 				}
 

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -232,13 +232,13 @@ func (m *Manager) setNewClassDefaults(class *models.Class) {
 	if class.ReplicationConfig == nil {
 		class.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(m.config.Replication.MinimumFactor),
-			DeletionStrategy: models.ReplicationConfigDeletionStrategyDeleteOnConflict,
+			DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
 		}
 		return
 	}
 
 	if class.ReplicationConfig.DeletionStrategy == "" {
-		class.ReplicationConfig.DeletionStrategy = models.ReplicationConfigDeletionStrategyDeleteOnConflict
+		class.ReplicationConfig.DeletionStrategy = models.ReplicationConfigDeletionStrategyNoAutomatedResolution
 	}
 }
 

--- a/usecases/schema/commit_failure_test.go
+++ b/usecases/schema/commit_failure_test.go
@@ -159,7 +159,7 @@ func classWithDefaultsWithProps(t *testing.T, name string,
 	class.VectorIndexConfig = fakeVectorConfig{}
 	class.ReplicationConfig = &models.ReplicationConfig{
 		Factor:           1,
-		DeletionStrategy: models.ReplicationConfigDeletionStrategyDeleteOnConflict,
+		DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
 	}
 	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: false}
 


### PR DESCRIPTION


### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
