### PR TITLE
Extends `CANCELED` enum to other backup API responses

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3281,7 +3281,8 @@ func init() {
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -3422,7 +3423,8 @@ func init() {
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -3455,7 +3457,8 @@ func init() {
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -8821,7 +8824,8 @@ func init() {
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -8965,7 +8969,8 @@ func init() {
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -8998,7 +9003,8 @@ func init() {
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }

--- a/entities/models/backup_create_response.go
+++ b/entities/models/backup_create_response.go
@@ -47,7 +47,7 @@ type BackupCreateResponse struct {
 	Path string `json:"path,omitempty"`
 
 	// phase of backup creation process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED]
+	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -69,7 +69,7 @@ var backupCreateResponseTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -93,6 +93,9 @@ const (
 
 	// BackupCreateResponseStatusFAILED captures enum value "FAILED"
 	BackupCreateResponseStatusFAILED string = "FAILED"
+
+	// BackupCreateResponseStatusCANCELED captures enum value "CANCELED"
+	BackupCreateResponseStatusCANCELED string = "CANCELED"
 )
 
 // prop value enum

--- a/entities/models/backup_restore_response.go
+++ b/entities/models/backup_restore_response.go
@@ -47,7 +47,7 @@ type BackupRestoreResponse struct {
 	Path string `json:"path,omitempty"`
 
 	// phase of backup restoration process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED]
+	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -69,7 +69,7 @@ var backupRestoreResponseTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -93,6 +93,9 @@ const (
 
 	// BackupRestoreResponseStatusFAILED captures enum value "FAILED"
 	BackupRestoreResponseStatusFAILED string = "FAILED"
+
+	// BackupRestoreResponseStatusCANCELED captures enum value "CANCELED"
+	BackupRestoreResponseStatusCANCELED string = "CANCELED"
 )
 
 // prop value enum

--- a/entities/models/backup_restore_status_response.go
+++ b/entities/models/backup_restore_status_response.go
@@ -44,7 +44,7 @@ type BackupRestoreStatusResponse struct {
 	Path string `json:"path,omitempty"`
 
 	// phase of backup restoration process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED]
+	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -66,7 +66,7 @@ var backupRestoreStatusResponseTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -90,6 +90,9 @@ const (
 
 	// BackupRestoreStatusResponseStatusFAILED captures enum value "FAILED"
 	BackupRestoreStatusResponseStatusFAILED string = "FAILED"
+
+	// BackupRestoreStatusResponseStatusCANCELED captures enum value "CANCELED"
+	BackupRestoreStatusResponseStatusCANCELED string = "CANCELED"
 )
 
 // prop value enum

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -934,7 +934,8 @@
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -1049,7 +1050,8 @@
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }
@@ -1156,7 +1158,8 @@
             "TRANSFERRING",
             "TRANSFERRED",
             "SUCCESS",
-            "FAILED"
+            "FAILED",
+            "CANCELED"
           ]
         }
       }


### PR DESCRIPTION
### What's being changed:

This PR adds the `CANCELED` enum to the rest of the backup API responses

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
