### PR TITLE
add progress indicator for schema catchup on restart

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -523,7 +523,7 @@ func (st *Store) SchemaReader() schema.SchemaReader {
 // see Store.candidates.
 //
 // The value of "last_store_log_applied_index" is the index of the last applied command found when
-// the store was opened, see Store.lastAppliedIndexOnStart.
+// the store was opened, see Store.lastAppliedIndexToDB.
 //
 // The value of "last_applied_index" is the index of the latest update to the store,
 // see Store.lastAppliedIndex.


### PR DESCRIPTION
### What's being changed:

When raft is starting up and applying log entries, if the DB isn't ready yet improve the logging output to make it clear weaviate is making progress
```
│ ":"info","msg":"Schema catching up: applying log entry: [5/11]","time":"2024-10-16T10:02:52Z"}                                       │
│ weaviate {"build_git_commit":"unknown","build_go_version":"go1.22.6","build_image_tag":"unknown","build_wv_version":"1.25.20","level │
│ ":"info","msg":"Schema catching up: applying log entry: [6/11]","time":"2024-10-16T10:02:52Z"}                                       │
│ weaviate {"build_git_commit":"unknown","build_go_version":"go1.22.6","build_image_tag":"unknown","build_wv_version":"1.25.20","level │
│ ":"info","msg":"Schema catching up: applying log entry: [7/11]","time":"2024-10-16T10:02:52Z"}                                       │
│ weaviate {"build_git_commit":"unknown","build_go_version":"go1.22.6","build_image_tag":"unknown","build_wv_version":"1.25.20","level │
│ ":"info","msg":"Schema catching up: applying log entry: [8/11]","time":"2024-10-16T10:02:52Z"}                                       │
│ weaviate {"build_git_commit":"unknown","build_go_version":"go1.22.6","build_image_tag":"unknown","build_wv_version":"1.25.20","level │
│ ":"info","msg":"Schema catching up: applying log entry: [9/11]","time":"2024-10-16T10:02:52Z"}                                       │
│ weaviate {"build_git_commit":"unknown","build_go_version":"go1.22.6","build_image_tag":"unknown","build_wv_version":"1.25.20","level │
│ ":"info","msg":"Schema catching up: applying log entry: [10/11]","time":"2024-10-16T10:02:52Z"}                                      │
│ weaviate {"build_git_commit":"unknown","build_go_version":"go1.22.6","build_image_tag":"unknown","build_wv_version":"1.25.20","level │
│ ":"info","msg":"Schema catching up: applying log entry: [11/11]","time":"2024-10-16T10:02:52Z"}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
