### PR TITLE
chore: Change default configs on `querier`

### DIFF
--- a/cmd/weaviate/README.md
+++ b/cmd/weaviate/README.md
@@ -257,6 +257,7 @@ with weaviate.connect_to_local(
 - [ ] Support BM25 search
 - [ ] Support other indexes other than flat index with Binary Quantization(BQ)
 - [ ] Remove hard coded dependency with `contextionary`.
+- [ ] Make querier respect `PROMETHEUS_MONITORING_ENABLED` env config.
 - [ ] Integrate `query.Search` with core weaviate's http, grpc and graphql endpoints for frozen tenants.
 - [x] Instrument `grpc` server
 - [x] Instrument `http` server

--- a/cmd/weaviate/README.md
+++ b/cmd/weaviate/README.md
@@ -256,6 +256,7 @@ with weaviate.connect_to_local(
 - [ ] Handle "empty write-ahead-log found" warnings on `querier`
 - [ ] Support BM25 search
 - [ ] Support other indexes other than flat index with Binary Quantization(BQ)
+- [ ] Remove hard coded dependency with `contextionary`.
 - [ ] Integrate `query.Search` with core weaviate's http, grpc and graphql endpoints for frozen tenants.
 - [x] Instrument `grpc` server
 - [x] Instrument `http` server

--- a/exp/query/api.go
+++ b/exp/query/api.go
@@ -325,7 +325,7 @@ func (a *API) loadOrDownloadLSM(ctx context.Context, collection, tenant string) 
 	defer a.omu.Unlock()
 
 	_, err := os.Stat(localPath)
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) || a.config.AlwaysFetchObjectStore {
 		// src - s3://<collection>/<tenant>/<node>/
 		// dst (local) - <data-path/<collection>/<tenant>
 		if err := a.offload.Download(ctx, collection, tenant, nodeName); err != nil {

--- a/exp/query/config.go
+++ b/exp/query/config.go
@@ -25,4 +25,9 @@ type Config struct {
 	DataPath string `long:"datapath" description:"place to look for tenant data after downloading it from object storage" default:"/tmp"`
 
 	VectorizerAddr string `long:"vectorize-addr" description:"vectorizer address to be used to vectorize near-text query" default:"0.0.0.0:9999"`
+
+	// AlwaysFetchObjectStore flag ignore what version does local querier has and fetch from
+	// object store (source of truth) all the time.
+	// NOTE: Enabling this (without any intermediate cache) can introduce more latency. Can be used to during performance testing, debugging, correctness check, etc.
+	AlwaysFetchObjectStore bool `long:"always-fetch-objectstore" description:"always fetch from object storage during query, skip local querier state." default:"false"`
 }

--- a/exp/query/config.go
+++ b/exp/query/config.go
@@ -13,7 +13,7 @@ package query
 
 // Config represents any type of configs and flags to control the querier
 type Config struct {
-	GRPCListenAddr string `long:"grpc.listen" description:"gRPC address that query node listens at" default:"0.0.0.0:9091"`
+	GRPCListenAddr string `long:"grpc.listen" description:"gRPC address that query node listens at" default:"0.0.0.0:7071"`
 	SchemaAddr     string `long:"schema.addr" description:"address to get schema information" default:"http://0.0.0.0:8080"`
 	S3URL          string `long:"s3.url" description:"s3 URL to query offloaded tenants (e.g: s3://<url>)"`
 	S3Endpoint     string `long:"s3.endpoint" description:"s3 endpoint to if mocking s3 (e.g: via minio)"`


### PR DESCRIPTION
### What's being changed:

Rationale: To make it work well with our helm chart
(9091 is already used by prometheus server)

Also introduce a flag to download from object storage (source of truth) always (default=false)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
