### PR TITLE
Add reason why shard is read-only

### DIFF
--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -134,7 +134,7 @@ type upgradableIndexer interface {
 }
 
 type shardStatusUpdater interface {
-	compareAndSwapStatus(old, new string) (storagestate.Status, error)
+	compareAndSwapStatusIndexingAndReady(old, new string) (storagestate.Status, error)
 	Name() string
 }
 
@@ -415,12 +415,12 @@ func (q *IndexQueue) indexer() {
 			}
 
 			if q.Size() == 0 {
-				_, _ = q.Shard.compareAndSwapStatus(storagestate.StatusIndexing.String(), storagestate.StatusReady.String())
+				_, _ = q.Shard.compareAndSwapStatusIndexingAndReady(storagestate.StatusIndexing.String(), storagestate.StatusReady.String())
 				q.indexLock.RUnlock()
 				continue
 			}
 
-			status, err := q.Shard.compareAndSwapStatus(storagestate.StatusReady.String(), storagestate.StatusIndexing.String())
+			status, err := q.Shard.compareAndSwapStatusIndexingAndReady(storagestate.StatusReady.String(), storagestate.StatusIndexing.String())
 			if status != storagestate.StatusIndexing || err != nil {
 				q.Logger.WithField("status", status).WithError(err).Warn("failed to set shard status to 'indexing', trying again in " + q.IndexInterval.String())
 				q.indexLock.RUnlock()

--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -990,7 +990,7 @@ type mockShard struct {
 	compareAndSwapStatusFn func(old, new string) (storagestate.Status, error)
 }
 
-func (m *mockShard) compareAndSwapStatus(old, new string) (storagestate.Status, error) {
+func (m *mockShard) compareAndSwapStatusIndexingAndReady(old, new string) (storagestate.Status, error) {
 	if m.compareAndSwapStatusFn == nil {
 		return storagestate.Status(new), nil
 	}

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -161,7 +161,7 @@ func (i *Index) writableShard(name string) (ShardLike, func(), *replica.SimpleRe
 			{Code: replica.StatusShardNotFound, Msg: name},
 		}}
 	}
-	if localShard.isReadOnly() {
+	if localShard.isReadOnly() != nil {
 		release()
 
 		return nil, func() {}, &replica.SimpleResponse{Errors: []replica.Error{{

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -18,7 +18,6 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/weaviate/weaviate/entities/interval"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -130,7 +129,7 @@ func (db *DB) diskUseReadonly(du diskUse) {
 	diskROPercent := db.config.ResourceUsage.DiskUse.ReadOnlyPercentage
 	if diskROPercent > 0 {
 		if pu := du.percentUsed(); pu > float64(diskROPercent) {
-			db.setShardsReadOnly()
+			db.setShardsReadOnly(fmt.Sprintf("disk usage too high. Currently at %.2f%%, threshold set to %.2f%%\"", pu, float64(diskROPercent)))
 			db.logger.WithField("action", "set_shard_read_only").
 				WithField("path", db.config.RootPath).
 				Warnf("Set READONLY, disk usage currently at %.2f%%, threshold set to %.2f%%",
@@ -143,7 +142,7 @@ func (db *DB) memUseReadonly(mon *memwatch.Monitor) {
 	memROPercent := db.config.ResourceUsage.MemUse.ReadOnlyPercentage
 	if memROPercent > 0 {
 		if pu := mon.Ratio() * 100; pu > float64(memROPercent) {
-			db.setShardsReadOnly()
+			db.setShardsReadOnly(fmt.Sprintf("memory usage too high. Currently at %.2f%%, threshold set to %.2f%%\"", pu, float64(memROPercent)))
 			db.logger.WithField("action", "set_shard_read_only").
 				WithField("path", db.config.RootPath).
 				Warnf("Set READONLY, memory usage currently at %.2f%%, threshold set to %.2f%%",
@@ -152,11 +151,11 @@ func (db *DB) memUseReadonly(mon *memwatch.Monitor) {
 	}
 }
 
-func (db *DB) setShardsReadOnly() {
+func (db *DB) setShardsReadOnly(reason string) {
 	db.indexLock.Lock()
 	for _, index := range db.indices {
 		index.ForEachShard(func(name string, shard ShardLike) error {
-			err := shard.UpdateStatus(storagestate.StatusReadOnly.String())
+			err := shard.SetStatusReadonly(reason)
 			if err != nil {
 				db.logger.WithField("action", "set_shard_read_only").
 					WithField("path", db.config.RootPath).

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -129,7 +129,7 @@ func (db *DB) diskUseReadonly(du diskUse) {
 	diskROPercent := db.config.ResourceUsage.DiskUse.ReadOnlyPercentage
 	if diskROPercent > 0 {
 		if pu := du.percentUsed(); pu > float64(diskROPercent) {
-			db.setShardsReadOnly(fmt.Sprintf("disk usage too high. Currently at %.2f%%, threshold set to %.2f%%\"", pu, float64(diskROPercent)))
+			db.setShardsReadOnly(fmt.Sprintf("disk usage too high. Set to read-only at %.2f%%, threshold set to %.2f%%\"", pu, float64(diskROPercent)))
 			db.logger.WithField("action", "set_shard_read_only").
 				WithField("path", db.config.RootPath).
 				Warnf("Set READONLY, disk usage currently at %.2f%%, threshold set to %.2f%%",
@@ -142,7 +142,7 @@ func (db *DB) memUseReadonly(mon *memwatch.Monitor) {
 	memROPercent := db.config.ResourceUsage.MemUse.ReadOnlyPercentage
 	if memROPercent > 0 {
 		if pu := mon.Ratio() * 100; pu > float64(memROPercent) {
-			db.setShardsReadOnly(fmt.Sprintf("memory usage too high. Currently at %.2f%%, threshold set to %.2f%%\"", pu, float64(memROPercent)))
+			db.setShardsReadOnly(fmt.Sprintf("memory usage too high. Set to read-only at %.2f%%, threshold set to %.2f%%\"", pu, float64(memROPercent)))
 			db.logger.WithField("action", "set_shard_read_only").
 				WithField("path", db.config.RootPath).
 				Warnf("Set READONLY, memory usage currently at %.2f%%, threshold set to %.2f%%",

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -61,6 +61,7 @@ type ShardLike interface {
 	GetStatus() storagestate.Status // Return the shard status
 	GetStatusNoLoad() storagestate.Status
 	UpdateStatus(status string) error                                                   // Set shard status
+	SetStatusReadonly(reason string) error                                              // Set shard status
 	FindUUIDs(ctx context.Context, filters *filters.LocalFilter) ([]strfmt.UUID, error) // Search and return document ids
 
 	Counter() *indexcounter.Counter
@@ -177,7 +178,7 @@ type Shard struct {
 	propLenTracker    *inverted.JsonShardMetaData
 	versioner         *shardVersioner
 
-	status              storagestate.Status
+	status              ShardStatus
 	statusLock          sync.Mutex
 	propertyIndicesLock sync.RWMutex
 
@@ -266,11 +267,11 @@ func (s *Shard) segmentCleanupConfig() lsmkv.BucketOption {
 }
 
 func (s *Shard) UpdateVectorIndexConfig(ctx context.Context, updated schemaConfig.VectorIndexConfig) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
-	err := s.UpdateStatus(storagestate.StatusReadOnly.String())
+	err := s.SetStatusReadonly("UpdateVectorIndexConfig")
 	if err != nil {
 		return fmt.Errorf("attempt to mark read-only: %w", err)
 	}
@@ -281,10 +282,10 @@ func (s *Shard) UpdateVectorIndexConfig(ctx context.Context, updated schemaConfi
 }
 
 func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schemaConfig.VectorIndexConfig) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
-	if err := s.UpdateStatus(storagestate.StatusReadOnly.String()); err != nil {
+	if err := s.SetStatusReadonly("UpdateVectorIndexConfig"); err != nil {
 		return fmt.Errorf("attempt to mark read-only: %w", err)
 	}
 

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -20,7 +20,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
@@ -94,9 +93,10 @@ func geoPropID(propName string) string {
 func (s *Shard) updatePropertySpecificIndices(object *storobj.Object,
 	status objectInsertStatus,
 ) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
+
 	s.propertyIndicesLock.RLock()
 	defer s.propertyIndicesLock.RUnlock()
 
@@ -125,8 +125,8 @@ func (s *Shard) updatePropertySpecificIndex(propName string,
 func (s *Shard) updateGeoIndex(propName string, index propertyspecific.Index,
 	obj *storobj.Object, status objectInsertStatus,
 ) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	// geo props were not changed
@@ -146,8 +146,8 @@ func (s *Shard) updateGeoIndex(propName string, index propertyspecific.Index,
 func (s *Shard) addToGeoIndex(propName string, index propertyspecific.Index,
 	obj *storobj.Object, status objectInsertStatus,
 ) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	if obj.Properties() == nil {
@@ -177,8 +177,8 @@ func (s *Shard) addToGeoIndex(propName string, index propertyspecific.Index,
 func (s *Shard) deleteFromGeoIndex(index propertyspecific.Index,
 	docID uint64,
 ) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	if err := index.GeoIndex.Delete(docID); err != nil {

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -93,7 +93,7 @@ func geoPropID(propName string) string {
 func (s *Shard) updatePropertySpecificIndices(object *storobj.Object,
 	status objectInsertStatus,
 ) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -125,7 +125,7 @@ func (s *Shard) updatePropertySpecificIndex(propName string,
 func (s *Shard) updateGeoIndex(propName string, index propertyspecific.Index,
 	obj *storobj.Object, status objectInsertStatus,
 ) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -146,7 +146,7 @@ func (s *Shard) updateGeoIndex(propName string, index propertyspecific.Index,
 func (s *Shard) addToGeoIndex(propName string, index propertyspecific.Index,
 	obj *storobj.Object, status objectInsertStatus,
 ) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -177,7 +177,7 @@ func (s *Shard) addToGeoIndex(propName string, index propertyspecific.Index,
 func (s *Shard) deleteFromGeoIndex(index propertyspecific.Index,
 	docID uint64,
 ) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -26,7 +26,6 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -57,7 +56,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		shut:         false,
 		shutdownLock: new(sync.RWMutex),
 
-		status: storagestate.StatusLoading,
+		status: NewShardStatus(),
 	}
 
 	defer func() {

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -15,16 +15,14 @@ import (
 	"context"
 	"fmt"
 
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/entities/storagestate"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 )
 
 func (s *Shard) initProperties(eg *enterrors.ErrorGroupWrapper, class *models.Class) {
@@ -88,8 +86,8 @@ func (s *Shard) initPropertyBuckets(ctx context.Context, eg *enterrors.ErrorGrou
 }
 
 func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Property) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	bucketOpts := []lsmkv.BucketOption{
@@ -142,8 +140,8 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 }
 
 func (s *Shard) createPropertyLengthIndex(ctx context.Context, prop *models.Property) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	// some datatypes are not added to the inverted index, so we can skip them here
@@ -165,8 +163,8 @@ func (s *Shard) createPropertyLengthIndex(ctx context.Context, prop *models.Prop
 }
 
 func (s *Shard) createPropertyNullIndex(ctx context.Context, prop *models.Property) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	return s.store.CreateOrLoadBucket(ctx,
@@ -180,8 +178,8 @@ func (s *Shard) createPropertyNullIndex(ctx context.Context, prop *models.Proper
 }
 
 func (s *Shard) addIDProperty(ctx context.Context) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	err := s.store.CreateOrLoadBucket(ctx,
@@ -200,8 +198,8 @@ func (s *Shard) addIDProperty(ctx context.Context) error {
 }
 
 func (s *Shard) addDimensionsProperty(ctx context.Context) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	// Note: this data would fit the "Set" type better, but since the "Map" type
@@ -222,8 +220,8 @@ func (s *Shard) addDimensionsProperty(ctx context.Context) error {
 }
 
 func (s *Shard) addTimestampProperties(ctx context.Context) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	if err := s.addCreationTimeUnixProperty(ctx); err != nil {

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -86,7 +86,7 @@ func (s *Shard) initPropertyBuckets(ctx context.Context, eg *enterrors.ErrorGrou
 }
 
 func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Property) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 }
 
 func (s *Shard) createPropertyLengthIndex(ctx context.Context, prop *models.Property) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -163,7 +163,7 @@ func (s *Shard) createPropertyLengthIndex(ctx context.Context, prop *models.Prop
 }
 
 func (s *Shard) createPropertyNullIndex(ctx context.Context, prop *models.Property) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -178,7 +178,7 @@ func (s *Shard) createPropertyNullIndex(ctx context.Context, prop *models.Proper
 }
 
 func (s *Shard) addIDProperty(ctx context.Context) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -198,7 +198,7 @@ func (s *Shard) addIDProperty(ctx context.Context) error {
 }
 
 func (s *Shard) addDimensionsProperty(ctx context.Context) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
@@ -220,7 +220,7 @@ func (s *Shard) addDimensionsProperty(ctx context.Context) error {
 }
 
 func (s *Shard) addTimestampProperties(ctx context.Context) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -477,7 +477,7 @@ func (l *LazyLoadShard) Versioner() *shardVersioner {
 	return l.shard.Versioner()
 }
 
-func (l *LazyLoadShard) isReadOnly() bool {
+func (l *LazyLoadShard) isReadOnly() error {
 	l.mustLoad()
 	return l.shard.isReadOnly()
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -162,6 +162,11 @@ func (l *LazyLoadShard) UpdateStatus(status string) error {
 	return l.shard.UpdateStatus(status)
 }
 
+func (l *LazyLoadShard) SetStatusReadonly(reason string) error {
+	l.mustLoad()
+	return l.shard.SetStatusReadonly(reason)
+}
+
 func (l *LazyLoadShard) FindUUIDs(ctx context.Context, filters *filters.LocalFilter) ([]strfmt.UUID, error) {
 	if err := l.Load(ctx); err != nil {
 		return []strfmt.UUID{}, err

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -12,24 +12,39 @@
 package db
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
+type ShardStatus struct {
+	Status storagestate.Status
+	Reason string
+}
+
+func NewShardStatus() ShardStatus {
+	return ShardStatus{Status: storagestate.StatusLoading}
+}
+
+func (s *ShardStatus) Init() {
+	s.Status = storagestate.StatusReady
+	s.Reason = ""
+}
+
 func (s *Shard) initStatus() {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
-	s.status = storagestate.StatusReady
+	s.status.Init()
 }
 
 func (s *Shard) GetStatus() storagestate.Status {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
-	return s.status
+	return s.status.Status
 }
 
 // Same implem for for a regular shard, this only differ in lazy loaded shards
@@ -41,33 +56,58 @@ func (s *Shard) isReadOnly() bool {
 	return s.GetStatus() == storagestate.StatusReadOnly
 }
 
-func (s *Shard) compareAndSwapStatus(old, new string) (storagestate.Status, error) {
+func (s *Shard) readOnlyError() error {
+	if s.status.Status == storagestate.StatusReadOnly {
+		return storagestate.ErrStatusReadOnlyWithReason(s.status.Reason)
+	}
+	return nil
+}
+
+func (s *Shard) compareAndSwapStatusIndexingAndReady(old, new string) (storagestate.Status, error) {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
-	if s.status.String() != old {
-		return s.status, nil
+	if (old != storagestate.StatusIndexing.String() && old != storagestate.StatusReady.String()) ||
+		(old != storagestate.StatusIndexing.String() && old != storagestate.StatusReady.String()) {
+		return s.status.Status, fmt.Errorf("can only swap between indexing and ready, got %v and %v", old, new)
 	}
 
-	return s.status, s.updateStatusUnlocked(new)
+	if s.status.Status.String() != old {
+		return s.status.Status, nil
+	}
+
+	return s.status.Status, s.updateStatusUnlocked(new, "")
+}
+
+func (s *Shard) SetStatusReadonly(reason string) error {
+	s.statusLock.Lock()
+	defer s.statusLock.Unlock()
+
+	return s.updateStatusUnlocked(storagestate.StatusReadOnly.String(), reason)
 }
 
 func (s *Shard) UpdateStatus(in string) error {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
-	return s.updateStatusUnlocked(in)
+	reason := ""
+	if in == storagestate.StatusReadOnly.String() {
+		reason = "manually set"
+	}
+
+	return s.updateStatusUnlocked(in, reason)
 }
 
 // updateStatusUnlocked updates the status without locking the statusLock.
 // Warning: Use UpdateStatus instead.
-func (s *Shard) updateStatusUnlocked(in string) error {
+func (s *Shard) updateStatusUnlocked(in, reason string) error {
 	targetStatus, err := storagestate.ValidateStatus(strings.ToUpper(in))
 	if err != nil {
 		return errors.Wrap(err, in)
 	}
 
-	s.status = targetStatus
+	s.status.Status = targetStatus
+	s.status.Reason = reason
 
 	err = s.updateStoreStatus(targetStatus)
 	if err != nil {
@@ -78,7 +118,8 @@ func (s *Shard) updateStatusUnlocked(in string) error {
 		WithField("action", "update shard status").
 		WithField("class", s.index.Config.ClassName).
 		WithField("shard", s.name).
-		WithField("status", in)
+		WithField("status", in).
+		WithField("readOnlyReason", reason)
 
 	return nil
 }

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -65,7 +65,7 @@ func (s *Shard) compareAndSwapStatusIndexingAndReady(old, new string) (storagest
 	defer s.statusLock.Unlock()
 
 	if (old != storagestate.StatusIndexing.String() && old != storagestate.StatusReady.String()) ||
-		(old != storagestate.StatusIndexing.String() && old != storagestate.StatusReady.String()) {
+		(new != storagestate.StatusIndexing.String() && new != storagestate.StatusReady.String()) {
 		return s.status.Status, fmt.Errorf("can only swap between indexing and ready, got %v and %v", old, new)
 	}
 

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -52,11 +52,8 @@ func (s *Shard) GetStatusNoLoad() storagestate.Status {
 	return s.GetStatus()
 }
 
-func (s *Shard) isReadOnly() bool {
-	return s.GetStatus() == storagestate.StatusReadOnly
-}
-
-func (s *Shard) readOnlyError() error {
+// isReadOnly returns an error if shard is readOnly and nil otherwise
+func (s *Shard) isReadOnly() error {
 	if s.status.Status == storagestate.StatusReadOnly {
 		return storagestate.ErrStatusReadOnlyWithReason(s.status.Reason)
 	}
@@ -92,7 +89,7 @@ func (s *Shard) UpdateStatus(in string) error {
 
 	reason := ""
 	if in == storagestate.StatusReadOnly.String() {
-		reason = "manually set"
+		reason = "manually set by user"
 	}
 
 	return s.updateStatusUnlocked(in, reason)

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -68,11 +68,12 @@ func TestShard_UpdateStatus(t *testing.T) {
 	})
 
 	t.Run("mark shard readonly and fail to insert", func(t *testing.T) {
-		err := shd.UpdateStatus(storagestate.StatusReadOnly.String())
+		err := shd.SetStatusReadonly("testing")
 		require.Nil(t, err)
 
 		err = shd.PutObject(ctx, testObject(className))
-		require.EqualError(t, err, storagestate.ErrStatusReadOnly.Error())
+		require.Contains(t, err.Error(), storagestate.ErrStatusReadOnly.Error())
+		require.Contains(t, err.Error(), "testing")
 	})
 
 	t.Run("mark shard ready and insert successfully", func(t *testing.T) {

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -30,7 +30,7 @@ import (
 // return value map[int]error gives the error for the index as it received it
 func (s *Shard) DeleteObjectBatch(ctx context.Context, uuids []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects {
 	s.activityTracker.Add(1)
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return objects.BatchSimpleObjects{
 			objects.BatchSimpleObject{Err: err},
 		}

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -24,16 +24,15 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
 // return value map[int]error gives the error for the index as it received it
 func (s *Shard) DeleteObjectBatch(ctx context.Context, uuids []strfmt.UUID, dryRun bool) objects.BatchSimpleObjects {
 	s.activityTracker.Add(1)
-	if s.isReadOnly() {
+	if err := s.readOnlyError(); err != nil {
 		return objects.BatchSimpleObjects{
-			objects.BatchSimpleObject{Err: storagestate.ErrStatusReadOnly},
+			objects.BatchSimpleObject{Err: err},
 		}
 	}
 	return newDeleteObjectsBatcher(s).Delete(ctx, uuids, dryRun)

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
@@ -35,8 +34,8 @@ func (s *Shard) PutObjectBatch(ctx context.Context,
 	objects []*storobj.Object,
 ) []error {
 	s.activityTracker.Add(1)
-	if s.isReadOnly() {
-		return []error{storagestate.ErrStatusReadOnly}
+	if err := s.readOnlyError(); err != nil {
+		return []error{err}
 	}
 
 	return s.putBatch(ctx, objects)

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -34,7 +34,7 @@ func (s *Shard) PutObjectBatch(ctx context.Context,
 	objects []*storobj.Object,
 ) []error {
 	s.activityTracker.Add(1)
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return []error{err}
 	}
 

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -29,7 +29,7 @@ import (
 // return value map[int]error gives the error for the index as it received it
 func (s *Shard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {
 	s.activityTracker.Add(1)
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return []error{err}
 	}
 

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -29,8 +29,8 @@ import (
 // return value map[int]error gives the error for the index as it received it
 func (s *Shard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {
 	s.activityTracker.Add(1)
-	if s.isReadOnly() {
-		return []error{errors.Errorf("shard is read-only")}
+	if err := s.readOnlyError(); err != nil {
+		return []error{err}
 	}
 
 	return newReferencesBatcher(s).References(ctx, refs)

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -23,7 +23,7 @@ import (
 )
 
 func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID) error {
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -19,13 +19,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID) error {
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
@@ -28,8 +27,8 @@ var errObjectNotFound = errors.New("object not found")
 
 func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) error {
 	s.activityTracker.Add(1)
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
 
 	if s.hasTargetVectors() {

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -27,7 +27,7 @@ var errObjectNotFound = errors.New("object not found")
 
 func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) error {
 	s.activityTracker.Add(1)
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -31,7 +31,7 @@ import (
 
 func (s *Shard) PutObject(ctx context.Context, object *storobj.Object) error {
 	s.activityTracker.Add(1)
-	if err := s.readOnlyError(); err != nil {
+	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 	uid, err := uuid.MustParse(object.ID().String()).MarshalBinary()

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -26,20 +26,19 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (s *Shard) PutObject(ctx context.Context, object *storobj.Object) error {
 	s.activityTracker.Add(1)
-	if s.isReadOnly() {
-		return storagestate.ErrStatusReadOnly
+	if err := s.readOnlyError(); err != nil {
+		return err
 	}
-	uuid, err := uuid.MustParse(object.ID().String()).MarshalBinary()
+	uid, err := uuid.MustParse(object.ID().String()).MarshalBinary()
 	if err != nil {
 		return err
 	}
-	return s.putOne(ctx, uuid, object)
+	return s.putOne(ctx, uid, object)
 }
 
 func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object) error {

--- a/entities/storagestate/status.go
+++ b/entities/storagestate/status.go
@@ -11,7 +11,10 @@
 
 package storagestate
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	StatusReadOnly Status = "READONLY"
@@ -19,6 +22,10 @@ const (
 	StatusLoading  Status = "LOADING"
 	StatusReady    Status = "READY"
 )
+
+var ErrStatusReadOnlyWithReason = func(reason string) error {
+	return fmt.Errorf("store is read-only due to: %v", reason)
+}
 
 var (
 	ErrStatusReadOnly = errors.New("store is read-only")


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/weaviate/issues/5808

Adds a reason why a shard is readonly

Examples:

```
collection.config.update_shards(
    status="READONLY",
    shard_names=[shard.name for shard in collection.config.get_shards()] 
)

uuid_query = collection.data.insert(properties={"title": "something"})
```

results in

> weaviate.exceptions.UnexpectedStatusCodeError: Object was not added! Unexpected status code: 500, with response body: {'error': [{'message': 'put object: import into index products: put local object: shard="rTccHXd5gYKm": store is read-only due to: manually set'}]}.

When there are too many memory allocations:

> 'update prop-specific indices: store is read-only due to: memory usage too high. Currently at 0.00%, threshold set to 1.00%"'

(Note that I manually changed the threshold to <1% to be able to trigger it, that is why the numbers on the error don't match.)

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
