### PR TITLE
Improve UX of named vectors with old-style vectors

### DIFF
--- a/test/acceptance_with_python/test_named_vectors.py
+++ b/test/acceptance_with_python/test_named_vectors.py
@@ -1,4 +1,6 @@
+import pytest
 import weaviate.classes as wvc
+from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateInsertManyAllFailedError
 
 from .conftest import CollectionFactory
 
@@ -29,3 +31,52 @@ def test_create_named_vectors_with_and_without_vectorizer(
     obj = collection.query.fetch_object_by_id(uuid, include_vector=True)
     assert obj.vector["AllExplicit"] is not None
     assert obj.vector["bringYourOwn"] is not None
+
+
+def test_single_named_vectors_without_names(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[wvc.config.Property(name="title", data_type=wvc.config.DataType.TEXT)],
+        vectorizer_config=[wvc.config.Configure.NamedVectors.none("title")],
+    )
+
+    # insert object with single non-named vector.
+    uuid1 = collection.data.insert(properties={"title": "Hello"}, vector=[1, 2, 3])
+    obj = collection.query.fetch_object_by_id(uuid1, include_vector=True)
+    assert "title" in obj.vector
+
+    ret = collection.data.insert_many(
+        [wvc.data.DataObject(properties={"title": "Hello"}, vector=[1, 2, 3])]
+    )
+    obj_batch = collection.query.fetch_object_by_id(ret.uuids[0], include_vector=True)
+    assert "title" in obj_batch.vector
+
+
+def test_named_vectors_without_names(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[wvc.config.Property(name="title", data_type=wvc.config.DataType.TEXT)],
+        vectorizer_config=[
+            wvc.config.Configure.NamedVectors.none("first"),
+            wvc.config.Configure.NamedVectors.none("second"),
+        ],
+    )
+    with pytest.raises(UnexpectedStatusCodeError):
+        collection.data.insert(properties={"title": "Hello"}, vector=[1, 2, 3])
+
+    with pytest.raises(WeaviateInsertManyAllFailedError):
+        collection.data.insert_many(
+            [wvc.data.DataObject(properties={"title": "Hello"}, vector=[1, 2, 3])]
+        )
+
+
+def test_single_vectorizer_with_named_vectors(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[wvc.config.Property(name="title", data_type=wvc.config.DataType.TEXT)],
+        vectorizer_config=wvc.config.Configure.Vectorizer.none(),
+    )
+    with pytest.raises(UnexpectedStatusCodeError):
+        collection.data.insert(properties={"title": "Hello"}, vector={"something": [1, 2, 3]})
+
+    with pytest.raises(WeaviateInsertManyAllFailedError):
+        collection.data.insert_many(
+            [wvc.data.DataObject(properties={"title": "Hello"}, vector={"something": [1, 2, 3]})]
+        )

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -85,6 +85,10 @@ func (v *Validator) Object(ctx context.Context, class *models.Class,
 		return fmt.Errorf(ErrorMissingClass)
 	}
 
+	if err := v.vector(ctx, class, incoming); err != nil {
+		return err
+	}
+
 	return v.properties(ctx, class, incoming, existing)
 }
 

--- a/usecases/objects/validation/vector_validation.go
+++ b/usecases/objects/validation/vector_validation.go
@@ -1,0 +1,43 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func (v *Validator) vector(ctx context.Context, class *models.Class,
+	incomingObject *models.Object,
+) error {
+	if len(class.VectorConfig) > 1 && len(incomingObject.Vector) > 0 {
+		return fmt.Errorf("collection %v is configured with multiple named vectors %v, but recieved a single vector", class.Class, class.VectorConfig)
+	}
+
+	if class.VectorIndexConfig != nil && len(incomingObject.Vectors) > 0 {
+		return fmt.Errorf("collection %v is configured without multiple named vectors, but recieved named vectors: %v", class.Class, incomingObject.Vectors)
+	}
+
+	// if there is only one named vector we can assume that the single vector
+	if len(class.VectorConfig) == 1 && len(incomingObject.Vector) > 0 {
+		namedVectorName := ""
+		for key := range class.VectorConfig {
+			namedVectorName = key
+		}
+		incomingObject.Vectors = map[string]models.Vector{namedVectorName: models.Vector(incomingObject.Vector)}
+		incomingObject.Vector = nil
+	}
+
+	return nil
+}

--- a/usecases/objects/validation/vector_validation.go
+++ b/usecases/objects/validation/vector_validation.go
@@ -22,11 +22,11 @@ func (v *Validator) vector(ctx context.Context, class *models.Class,
 	incomingObject *models.Object,
 ) error {
 	if len(class.VectorConfig) > 1 && len(incomingObject.Vector) > 0 {
-		return fmt.Errorf("collection %v is configured with multiple named vectors %v, but recieved a single vector", class.Class, class.VectorConfig)
+		return fmt.Errorf("collection %v is configured with multiple named vectors %v, but received a single vector", class.Class, class.VectorConfig)
 	}
 
 	if class.VectorIndexConfig != nil && len(incomingObject.Vectors) > 0 {
-		return fmt.Errorf("collection %v is configured without multiple named vectors, but recieved named vectors: %v", class.Class, incomingObject.Vectors)
+		return fmt.Errorf("collection %v is configured without multiple named vectors, but received named vectors: %v", class.Class, incomingObject.Vectors)
 	}
 
 	// if there is only one named vector we can assume that the single vector

--- a/usecases/objects/validation/vector_validation_test.go
+++ b/usecases/objects/validation/vector_validation_test.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package validation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestVectors(t *testing.T) {
+	specs := map[string]struct {
+		class  *models.Class
+		obj    *models.Object
+		objNew *models.Object
+		expErr bool
+	}{
+		"multiple named vectors with 'old' vector": {
+			class: &models.Class{
+				VectorConfig: map[string]models.VectorConfig{"first": {}, "second": {}, "third": {}}, // content does not matter
+			},
+			obj:    &models.Object{Vector: []float32{1, 2, 3}},
+			expErr: true,
+		},
+		"multiple named vectors with vectors": {
+			class: &models.Class{
+				VectorConfig: map[string]models.VectorConfig{"first": {}, "second": {}, "third": {}}, // content does not matter
+			},
+			obj: &models.Object{
+				Vectors: models.Vectors{"first": []float32{1, 2, 3}},
+			},
+			expErr: false,
+		},
+		"single named vectors with vector": {
+			class: &models.Class{
+				VectorConfig: map[string]models.VectorConfig{"first": {}}, // content does not matter
+			},
+			obj: &models.Object{Vector: []float32{1, 2, 3}},
+			objNew: &models.Object{
+				Vectors: models.Vectors{"first": []float32{1, 2, 3}},
+			},
+			expErr: false,
+		},
+		"old vector with named vectors": {
+			class: &models.Class{
+				VectorIndexConfig: models.VectorConfig{}, // content does not matter
+			},
+			obj: &models.Object{
+				Vectors: models.Vectors{"first": []float32{1, 2, 3}},
+			},
+			expErr: true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			validator := &Validator{exists: func(_ context.Context, class string, _ strfmt.UUID, _ *additional.ReplicationProperties, _ string) (bool, error) {
+				return true, nil
+			}}
+			gotErr := validator.vector(context.Background(), spec.class, spec.obj)
+
+			if spec.objNew != nil {
+				require.Equal(t, spec.objNew, spec.obj)
+			}
+
+			if spec.expErr {
+				require.Error(t, gotErr)
+				return
+			}
+			require.NoError(t, gotErr)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Fixes: https://github.com/weaviate/weaviate/issues/5947

Adds checks and returns error when:
- collection is configured with more than two named vectors but object contains vector
- collection is configured without named vectors but object contains named vectors

Fixes up the input:
- collection is configured with one named vector but object contains vector => single vector is used

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.