### PR TITLE
fix concurrent read/write map on leader error

### DIFF
--- a/cluster/resolver/raft.go
+++ b/cluster/resolver/raft.go
@@ -98,5 +98,12 @@ func (a *raft) NewTCPTransport(
 }
 
 func (a *raft) NotResolvedNodes() map[raftImpl.ServerID]struct{} {
-	return a.notResolvedNodes
+	a.nodesLock.Lock()
+	defer a.nodesLock.Unlock()
+
+	newMap := make(map[raftImpl.ServerID]struct{})
+	for k, v := range a.notResolvedNodes {
+		newMap[k] = v
+	}
+	return newMap
 }


### PR DESCRIPTION
### What's being changed:

Copy a map instead of returning a reference to avoid a concurrent read/write error

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
