### PR TITLE
feat: segments cleanup improvements

### DIFF
--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -198,7 +198,7 @@ func FromEnv(config *Config) error {
 		config.Persistence.LSMMaxSegmentSize = DefaultPersistenceLSMMaxSegmentSize
 	}
 
-	if err := parsePositiveInt(
+	if err := parseNonNegativeInt(
 		"PERSISTENCE_LSM_SEGMENTS_CLEANUP_INTERVAL_HOURS",
 		func(hours int) { config.Persistence.LSMSegmentsCleanupIntervalSeconds = hours * 3600 },
 		DefaultPersistenceLSMSegmentsCleanupIntervalSeconds,
@@ -618,20 +618,39 @@ func (c *Config) parseMemtableConfig() error {
 	return nil
 }
 
-func parsePositiveInt(varName string, cb func(val int), defaultValue int) error {
-	if v := os.Getenv(varName); v != "" {
-		asInt, err := strconv.Atoi(v)
-		if err != nil {
-			return fmt.Errorf("parse %s as int: %w", varName, err)
-		} else if asInt <= 0 {
-			return fmt.Errorf("%s must be a positive value larger 0", varName)
+func parsePositiveInt(envName string, cb func(val int), defaultValue int) error {
+	return parseInt(envName, defaultValue, func(val int) error {
+		if val <= 0 {
+			return fmt.Errorf("%s must be a positive value larger 0", envName)
 		}
+		return nil
+	}, cb)
+}
 
-		cb(asInt)
-	} else {
-		cb(defaultValue)
+func parseNonNegativeInt(envName string, cb func(val int), defaultValue int) error {
+	return parseInt(envName, defaultValue, func(val int) error {
+		if val < 0 {
+			return fmt.Errorf("%s must be an integer greater than or equal 0", envName)
+		}
+		return nil
+	}, cb)
+}
+
+func parseInt(envName string, defaultValue int, verify func(val int) error, cb func(val int)) error {
+	var err error
+	asInt := defaultValue
+
+	if v := os.Getenv(envName); v != "" {
+		asInt, err = strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("parse %s as int: %w", envName, err)
+		}
+		if err = verify(asInt); err != nil {
+			return err
+		}
 	}
 
+	cb(asInt)
 	return nil
 }
 


### PR DESCRIPTION
### What's being changed:
- Compaction has precedence over cleanup. Cleanup is forced to run at least every 12 hours if it was not called due to compaction being always successful (having candidates to merge)
- `PERSISTENCE_LSM_SEGMENTS_CLEANUP_INTERVAL_HOURS` accepts 0 as valid value


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
