### PR TITLE
chore(test): add sleep in TestActivationDeactivation_Restarts for EC handling 

### DIFF
--- a/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
@@ -654,10 +654,10 @@ func assertInactiveTenantObjects(t *testing.T, client *wvt.Client, className, te
 			WithTenant(tenantName).
 			Do(context.Background())
 
-		require.NotNil(t, err)
+		assert.NotNil(t, err)
 		clientErr := err.(*fault.WeaviateClientError)
 		assert.Equal(t, 422, clientErr.StatusCode)
 		assert.Contains(t, clientErr.Msg, "tenant not active")
-		require.Nil(t, objects)
-	}, 5*time.Second, 500*time.Microsecond, "tenant was active, expected to be inactive")
+		assert.Nil(t, objects)
+	}, 5*time.Second, 1*time.Second, "tenant was active, expected to be inactive")
 }

--- a/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
@@ -645,6 +645,10 @@ func assertActiveTenantObjects(t *testing.T, client *wvt.Client, className, tena
 }
 
 func assertInactiveTenantObjects(t *testing.T, client *wvt.Client, className, tenantName string) {
+	// Data objects in Weaviate are eventually consistent, therefore we have to add some sleep time
+	// to make sure that the tenant was deactivate in all nodes
+	// see docs: https://github.com/weaviate/weaviate-io/blob/main/developers/weaviate/concepts/replication-architecture/consistency.md#data-objects
+	time.Sleep(2 * time.Second)
 	objects, err := client.Data().ObjectsGetter().
 		WithClassName(className).
 		WithTenant(tenantName).


### PR DESCRIPTION
### What's being changed:

Data objects in Weaviate are eventually consistent, therefore we have to add some sleep time
to make sure that the tenant was deactivate in all nodes before trying to read them 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
