### PR TITLE
chore(test): remove not needed step for verifying tenant freezing

### DIFF
--- a/test/modules/offload-s3/offload_download_test.go
+++ b/test/modules/offload-s3/offload_download_test.go
@@ -134,17 +134,6 @@ func Test_DownloadS3Journey(t *testing.T) {
 			})
 		})
 
-		t.Run("verify tenant status FREEZING", func(t *testing.T) {
-			resp, err := helper.GetTenantsGRPC(t, className)
-			require.Nil(t, err)
-			for _, tn := range resp.Tenants {
-				if tn.Name == tenantNames[0] {
-					require.Equal(t, pb.TenantActivityStatus_TENANT_ACTIVITY_STATUS_FREEZING, tn.ActivityStatus)
-					break
-				}
-			}
-		})
-
 		t.Run("verify tenant status", func(t *testing.T) {
 			assert.EventuallyWithT(t, func(at *assert.CollectT) {
 				resp, err := helper.GetTenantsGRPC(t, className)


### PR DESCRIPTION
### What's being changed:
given the fact we use now grpc for offload, so the requests are fast enough that there is no need to verifying the FREEZING state given that it will verify if it was FROZEN later in the following step  

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
