### PR TITLE
raft(logs): add action field to raft internal logs

### DIFF
--- a/cluster/log/logger.go
+++ b/cluster/log/logger.go
@@ -104,11 +104,8 @@ func (hclogger *hclogLogrus) Error(msg string, args ...interface{}) {
 }
 
 func (hclogger *hclogLogrus) logToLogrus(level logrus.Level, msg string, args ...interface{}) {
-	logger := hclogger.entry
-	if len(args) > 0 {
-		logger = hclogger.LoggerWith(args).WithField("action", strings.TrimSpace(hclogger.name))
-	}
-	logger.Log(level, hclogger.name+msg)
+	hclogger.entry = hclogger.LoggerWith(args).WithField("action", strings.TrimSpace(hclogger.name))
+	hclogger.entry.Log(level, msg)
 }
 
 func (hclogger *hclogLogrus) IsTrace() bool {
@@ -133,7 +130,8 @@ func (hclogger *hclogLogrus) IsError() bool {
 
 func (hclogger *hclogLogrus) With(args ...interface{}) hclog.Logger {
 	return &hclogLogrus{
-		entry: hclogger.LoggerWith(args),
+		name:  hclogger.name,
+		entry: hclogger.LoggerWith(args).WithField("action", strings.TrimSpace(hclogger.name)),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:
some raft internal logs has empty `action` field , this PR add the action to the missing bits 

e.g. 

```go
{"action":"","build_git_commit":"df1a613a9","build_go_version":"go1.23.0","build_image_tag":"localhost","build_wv_version":"1.25.21","id":"14-18-1728487578672","last-index":18,"last-term":14,"level":"info","msg":"snapshot restore progress","percent-complete":"[100.00]%","read-bytes":28739,"size-in-bytes":28739,"time":"2024-10-22T06:19:58Z"}
```

results 

```go
{"action":"raft","build_git_commit":"ed48f073e","build_go_version":"go1.22.4","build_image_tag":"localhost","build_wv_version":"1.25.21","id":"27-55-1729612158518","last-index":55,"last-term":27,"level":"info","msg":"starting restore from snapshot","size-in-bytes":74,"time":"2024-10-22T17:50:50+02:00"}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
