### PR TITLE
Fix groupBy with references

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -1367,22 +1367,44 @@ func TestGRPCRequest(t *testing.T) {
 			error: true,
 		},
 		{
-			name: "group by",
+			name: "group by normal prop",
 			req: &pb.SearchRequest{
 				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
 				GroupBy:    &pb.GroupBy{Path: []string{"name"}, NumberOfGroups: 2, ObjectsPerGroup: 3},
 				NearVector: &pb.NearVector{Vector: []float32{1, 2, 3}},
+				Properties: &pb.PropertiesRequest{},
 			},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
-				Properties: defaultTestClassProps,
+				Properties: search.SelectProperties{{Name: "name", IsPrimitive: true, IsObject: false}},
 				AdditionalProperties: additional.Properties{
 					Vector:  true,
 					NoProps: false,
 					Group:   true,
 				},
 				NearVector: &searchparams.NearVector{Vectors: [][]float32{{1, 2, 3}}},
-				GroupBy:    &searchparams.GroupBy{Groups: 2, ObjectsPerGroup: 3, Property: "name", Properties: defaultTestClassProps},
+				GroupBy:    &searchparams.GroupBy{Groups: 2, ObjectsPerGroup: 3, Property: "name", Properties: search.SelectProperties{{Name: "name", IsPrimitive: true, IsObject: false}}},
+			},
+			error: false,
+		},
+		{
+			name: "group by ref prop",
+			req: &pb.SearchRequest{
+				Collection: classname, Metadata: &pb.MetadataRequest{Vector: true},
+				GroupBy:    &pb.GroupBy{Path: []string{"ref"}, NumberOfGroups: 2, ObjectsPerGroup: 3},
+				NearVector: &pb.NearVector{Vector: []float32{1, 2, 3}},
+				Properties: &pb.PropertiesRequest{},
+			},
+			out: dto.GetParams{
+				ClassName: classname, Pagination: defaultPagination,
+				Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, IsObject: false}},
+				AdditionalProperties: additional.Properties{
+					Vector:  true,
+					NoProps: false,
+					Group:   true,
+				},
+				NearVector: &searchparams.NearVector{Vectors: [][]float32{{1, 2, 3}}},
+				GroupBy:    &searchparams.GroupBy{Groups: 2, ObjectsPerGroup: 3, Property: "ref", Properties: search.SelectProperties{{Name: "ref", IsPrimitive: false, IsObject: false}}},
 			},
 			error: false,
 		},

--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -45,10 +45,8 @@ func (s *Shard) groupResults(ctx context.Context, ids []uint64,
 		return nil, nil, fmt.Errorf("%w: unrecognized data type for property: %s", err, groupBy.Property)
 	}
 
-	props := []string{}
-	for _, propTmp := range properties {
-		props = append(props, propTmp)
-	}
+	var props []string
+	props = append(props, properties...)
 	for _, propTmp := range groupBy.Properties {
 		props = append(props, propTmp.Name)
 	}

--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -45,7 +45,15 @@ func (s *Shard) groupResults(ctx context.Context, ids []uint64,
 		return nil, nil, fmt.Errorf("%w: unrecognized data type for property: %s", err, groupBy.Property)
 	}
 
-	return newGrouper(ids, dists, groupBy, objsBucket, dt, additional, properties).Do(ctx)
+	props := []string{}
+	for _, propTmp := range properties {
+		props = append(props, propTmp)
+	}
+	for _, propTmp := range groupBy.Properties {
+		props = append(props, propTmp.Name)
+	}
+
+	return newGrouper(ids, dists, groupBy, objsBucket, dt, additional, props).Do(ctx)
 }
 
 type grouper struct {

--- a/test/acceptance_with_python/test_groupby.py
+++ b/test/acceptance_with_python/test_groupby.py
@@ -1,0 +1,60 @@
+from typing import Optional
+
+import pytest
+import weaviate
+import weaviate.classes as wvc
+from .conftest import CollectionFactory
+
+
+@pytest.mark.parametrize("return_refs", [None, [wvc.query.QueryReference(link_on="ref")]])
+def test_groupby_with_refs(
+    collection_factory: CollectionFactory, return_refs: Optional[wvc.query.QueryReference]
+) -> None:
+    col = collection_factory(
+        properties=[wvc.config.Property(name="text", data_type=wvc.config.DataType.TEXT)],
+        vectorizer_config=wvc.config.Configure.Vectorizer.none(),
+    )
+    col.config.add_reference(wvc.config.ReferenceProperty(name="ref", target_collection=col.name))
+
+    uuids = [
+        str(uid)
+        for uid in col.data.insert_many(
+            [
+                wvc.data.DataObject(properties={"text": "a1"}, vector=[1, 0, 0]),
+                wvc.data.DataObject(properties={"text": "a2"}, vector=[0, 1, 0]),
+                wvc.data.DataObject(properties={"text": "a2"}, vector=[0, 0, 1]),
+            ]
+        ).uuids.values()
+    ]
+
+    for uid in uuids:
+        col.data.reference_add_many(
+            [wvc.data.DataReference(from_property="ref", from_uuid=uid, to_uuid=uid)]
+        )
+
+    res = col.query.near_object(
+        uuids[0],
+        group_by=wvc.query.GroupBy(prop="ref", objects_per_group=2, number_of_groups=3),
+        return_references=return_refs,
+    )
+    assert len(res.groups) == 3
+
+    # repeat with GQL - slightly different code path in
+    client = weaviate.connect_to_local()
+    hits = "hits{ref{... on " + col.name + "{_additional{id}}} _additional{id distance}}"
+    group = f"group{{ id groupedBy {{ value path }} count maxDistance minDistance {hits} }}"
+    _additional = f"_additional{{ {group} }}"
+    res = client.graphql_raw_query(
+        f"""{{
+                Get {{
+                    {col.name}(nearObject: {{id: "{uuids[0]}"}} groupBy:{{path: [\"ref\"] groups: 3 objectsPerGroup: 10}}) {{
+                        {_additional}
+                    }}
+                }}
+            }}"""
+    )
+
+    assert res.errors is None
+    for group in res.get[col.name]:
+        assert len(group["_additional"]["group"]["hits"]) == 1
+        assert group["_additional"]["group"]["hits"][0]["ref"] is not None


### PR DESCRIPTION
### What's being changed:

Fixes a couple of groupBy issues:
- property was not correctly unmarshalled when it was not requested as return value
- (GRPC) refs could not be parsed because they were added with IsPrimitive=true 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
