### PR TITLE
[PQ] Modify vector segments sum metric if segments is 0

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/schema"
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/monitoring"
@@ -37,7 +38,7 @@ const (
 
 func (s *Shard) Dimensions(ctx context.Context) int {
 	keyLen := 4
-	return s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
+	sum, _ := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
 		// consider only keys of len 4, skipping ones prefixed with vector name
 		if len(k) == keyLen {
 			dimLength := binary.LittleEndian.Uint32(k)
@@ -45,12 +46,13 @@ func (s *Shard) Dimensions(ctx context.Context) int {
 		}
 		return 0
 	})
+	return sum
 }
 
 func (s *Shard) DimensionsForVec(ctx context.Context, vecName string) int {
 	nameLen := len(vecName)
 	keyLen := nameLen + 4
-	return s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
+	sum, _ := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
 		// consider only keys of len vecName + 4, prefixed with vecName
 		if len(k) == keyLen && strings.HasPrefix(string(k), vecName) {
 			dimLength := binary.LittleEndian.Uint32(k[nameLen:])
@@ -58,17 +60,12 @@ func (s *Shard) DimensionsForVec(ctx context.Context, vecName string) int {
 		}
 		return 0
 	})
+	return sum
 }
 
 func (s *Shard) QuantizedDimensions(ctx context.Context, segments int) int {
-	// Exit early if segments is 0 (unset), in this case PQ will use the same number of dimensions
-	// as the segment size
-	if segments <= 0 {
-		return s.Dimensions(ctx)
-	}
-
 	keyLen := 4
-	return s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
+	sum, dimensions := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
 		// consider only keys of len 4, skipping ones prefixed with vector name
 		if len(k) == keyLen {
 			if dimLength := binary.LittleEndian.Uint32(k); dimLength > 0 {
@@ -76,19 +73,15 @@ func (s *Shard) QuantizedDimensions(ctx context.Context, segments int) int {
 			}
 		}
 		return 0
-	}) * segments
+	})
+
+	return sum * correctEmptySegments(segments, dimensions)
 }
 
 func (s *Shard) QuantizedDimensionsForVec(ctx context.Context, segments int, vecName string) int {
-	// Exit early if segments is 0 (unset), in this case PQ will use the same number of dimensions
-	// as the segment size
-	if segments <= 0 {
-		return s.DimensionsForVec(ctx, vecName)
-	}
-
 	nameLen := len(vecName)
 	keyLen := nameLen + 4
-	return s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
+	sum, dimensions := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) int {
 		// consider only keys of len vecName + 4, prefixed with vecName
 		if len(k) == keyLen && strings.HasPrefix(string(k), vecName) {
 			if dimLength := binary.LittleEndian.Uint32(k[nameLen:]); dimLength > 0 {
@@ -96,24 +89,31 @@ func (s *Shard) QuantizedDimensionsForVec(ctx context.Context, segments int, vec
 			}
 		}
 		return 0
-	}) * segments
+	})
+
+	return sum * correctEmptySegments(segments, dimensions)
 }
 
-func (s *Shard) calcDimensions(ctx context.Context, calcEntry func(k []byte, v []lsmkv.MapPair) int) int {
+func (s *Shard) calcDimensions(ctx context.Context, calcEntry func(k []byte, v []lsmkv.MapPair) int) (sum int, dimensions int) {
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {
-		return 0
+		return 0, 0
 	}
 
 	c := b.MapCursor()
 	defer c.Close()
 
-	sum := 0
+	sum = 0
+	dimForKey := 0
 	for k, v := c.First(ctx); k != nil; k, v = c.Next(ctx) {
-		sum += calcEntry(k, v)
+		dimForKey = calcEntry(k, v)
+		sum += dimForKey
+		if dimensions == 0 && dimForKey > 0 {
+			dimensions = dimForKey
+		}
 	}
 
-	return sum
+	return sum, dimensions
 }
 
 func (s *Shard) initDimensionTracking() {
@@ -322,4 +322,13 @@ func getDimensionCategory(cfg schema.VectorIndexConfig) (DimensionCategory, int)
 		}
 	}
 	return DimensionCategoryStandard, 0
+}
+
+func correctEmptySegments(segments int, dimensions int) int {
+	// If segments is 0 (unset), in this case PQ will calculate the number of segments
+	// based on the number of dimensions
+	if segments > 0 {
+		return segments
+	}
+	return common.CalculateOptimalSegments(dimensions)
 }

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -404,6 +404,68 @@ func getSingleShardNameFromRepo(repo *DB, className string) string {
 }
 
 func Test_DimensionTrackingMetrics(t *testing.T) {
+	type testConfig struct {
+		name            string
+		className       string
+		classConfig     func() *models.Class
+		vectorConfig    func() *enthnsw.UserConfig
+		expectedDims    float64
+		expectedSegs    float64
+		importDimension int
+	}
+
+	tests := []testConfig{
+		{
+			name:      "HNSW",
+			className: "HNSW",
+			vectorConfig: func() *enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				return &cfg
+			},
+			expectedDims:    6400.0, // 100 objects * 64 dimensions
+			expectedSegs:    0.0,
+			importDimension: 64,
+		},
+		{
+			name:      "BQ",
+			className: "BQ",
+			vectorConfig: func() *enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.BQ.Enabled = true
+				return &cfg
+			},
+			expectedDims:    0.0,
+			expectedSegs:    800.0, // 100 objects * 64 dimensions / 8 for BQ
+			importDimension: 64,
+		},
+		{
+			name:      "PQ",
+			className: "PQ",
+			vectorConfig: func() *enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.PQ.Enabled = true
+				cfg.PQ.Segments = 10
+				return &cfg
+			},
+			expectedDims:    0.0,
+			expectedSegs:    1000.0, // 100 objects * 10 segments
+			importDimension: 64,
+		},
+		{
+			name:      "PQ with zero segments",
+			className: "PQZ",
+			vectorConfig: func() *enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.PQ.Enabled = true
+				cfg.PQ.Segments = 0
+				return &cfg
+			},
+			expectedDims:    0.0,
+			expectedSegs:    3200.0, // 100 objects * 32 segments (segments = 64/2 due to auto calculation)
+			importDimension: 64,
+		},
+	}
+
 	r := getRandomSeed()
 	dirName := t.TempDir()
 	var shardName string
@@ -428,243 +490,107 @@ func Test_DimensionTrackingMetrics(t *testing.T) {
 
 	migrator := NewMigrator(repo, logger)
 
-	t.Run("set schema type=HNSW", func(t *testing.T) {
-		class := &models.Class{
-			Class:               "HNSW",
-			VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
-			InvertedIndexConfig: invertedConfig(),
-		}
-		schema := schema.Schema{
-			Objects: &models.Schema{
-				Classes: []*models.Class{class},
-			},
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set schema
+			t.Run("set schema", func(t *testing.T) {
+				class := &models.Class{
+					Class:             tc.className,
+					VectorIndexConfig: *tc.vectorConfig(),
+					VectorConfig: map[string]models.VectorConfig{
+						"vec": {
+							VectorIndexConfig: *tc.vectorConfig(),
+						},
+					},
+					InvertedIndexConfig: invertedConfig(),
+				}
+				schema := schema.Schema{
+					Objects: &models.Schema{
+						Classes: []*models.Class{class},
+					},
+				}
 
-		require.Nil(t,
-			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+				require.Nil(t,
+					migrator.AddClass(context.Background(), class, schemaGetter.shardState))
 
-		schemaGetter.schema = schema
-	})
+				schemaGetter.schema = schema
+			})
 
-	t.Run("import objects and validate metric", func(t *testing.T) {
-		dim := 64
-		for i := 0; i < 100; i++ {
-			vec := make([]float32, dim)
-			for j := range vec {
-				vec[j] = r.Float32()
-			}
+			// Import objects and validate metrics
+			t.Run("import objects and validate metrics", func(t *testing.T) {
+				for i := 0; i < 100; i++ {
+					vec := make([]float32, tc.importDimension)
+					for j := range vec {
+						vec[j] = r.Float32()
+					}
 
-			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
-			obj := &models.Object{Class: "HNSW", ID: id}
-			err := repo.PutObject(context.Background(), obj, vec, nil, nil)
-			require.Nil(t, err)
-		}
+					id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
+					obj := &models.Object{Class: tc.className, ID: id}
+					namedVectors := models.Vectors{
+						"vec": vec,
+					}
+					err := repo.PutObject(context.Background(), obj, vec, namedVectors, nil)
+					require.Nil(t, err)
+				}
 
-		publishDimensionMetricsFromRepo(context.Background(), repo, "HNSW")
+				publishDimensionMetricsFromRepo(context.Background(), repo, tc.className)
 
-		shardName = getSingleShardNameFromRepo(repo, "HNSW")
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("HNSW", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 6400.0, metricValue, "dimensions should not have changed")
-	})
+				shardName = getSingleShardNameFromRepo(repo, tc.className)
 
-	t.Run("delete class", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "HNSW")
-		require.Nil(t, err)
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("HNSW", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metric should be reset")
-	})
+				// Check dimensions metric
+				metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues(tc.className, shardName)
+				require.Nil(t, err)
+				metricValue := testutil.ToFloat64(metric)
+				require.Equal(t, tc.expectedDims, metricValue, "dimensions should match expected value")
 
-	t.Run("set schema type=BQ", func(t *testing.T) {
-		vectorIndexConfig := enthnsw.NewDefaultUserConfig()
-		vectorIndexConfig.BQ.Enabled = true
+				// Check segments metric
+				metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues(tc.className, shardName)
+				require.Nil(t, err)
+				metricValue = testutil.ToFloat64(metric)
+				require.Equal(t, tc.expectedSegs, metricValue, "segments should match expected value")
 
-		class := &models.Class{
-			Class:               "BQ",
-			VectorIndexConfig:   vectorIndexConfig,
-			InvertedIndexConfig: invertedConfig(),
-		}
-		schema := schema.Schema{
-			Objects: &models.Schema{
-				Classes: []*models.Class{class},
-			},
-		}
+				// Check named dimensions metric
+				metric, err = metrics.VectorDimensionsSumByVector.GetMetricWithLabelValues(tc.className, shardName, "vec")
+				require.Nil(t, err)
+				metricValue = testutil.ToFloat64(metric)
+				require.Equal(t, tc.expectedDims, metricValue, "named dimensions should match expected value")
 
-		require.Nil(t,
-			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+				// Check named segments metric
+				metric, err = metrics.VectorSegmentsSumByVector.GetMetricWithLabelValues(tc.className, shardName, "vec")
+				require.Nil(t, err)
+				metricValue = testutil.ToFloat64(metric)
+				require.Equal(t, tc.expectedSegs, metricValue, "named segments should match expected value")
+			})
 
-		schemaGetter.schema = schema
-	})
+			// Delete class and verify metrics are reset
+			t.Run("delete class", func(t *testing.T) {
+				err := migrator.DropClass(context.Background(), tc.className)
+				require.Nil(t, err)
 
-	t.Run("import objects and validate metric type=BQ", func(t *testing.T) {
-		dim := 64
-		for i := 0; i < 100; i++ {
-			vec := make([]float32, dim)
-			for j := range vec {
-				vec[j] = r.Float32()
-			}
+				// Verify dimensions metric is reset
+				metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues(tc.className, shardName)
+				require.Nil(t, err)
+				metricValue := testutil.ToFloat64(metric)
+				require.Equal(t, 0.0, metricValue, "dimensions metric should be reset")
 
-			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
-			obj := &models.Object{Class: "BQ", ID: id}
-			err := repo.PutObject(context.Background(), obj, vec, nil, nil)
-			require.Nil(t, err)
-		}
+				// Verify segments metric is reset
+				metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues(tc.className, shardName)
+				require.Nil(t, err)
+				metricValue = testutil.ToFloat64(metric)
+				require.Equal(t, 0.0, metricValue, "segments metric should be reset")
 
-		publishDimensionMetricsFromRepo(context.Background(), repo, "BQ")
+				// Verify dimensions metric is reset
+				metric, err = metrics.VectorDimensionsSumByVector.GetMetricWithLabelValues(tc.className, shardName, "vec")
+				require.Nil(t, err)
+				metricValue = testutil.ToFloat64(metric)
+				require.Equal(t, 0.0, metricValue, "named dimensions metric should be reset")
 
-		shardName = getSingleShardNameFromRepo(repo, "BQ")
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("BQ", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "dimensions should not have changed")
-
-		metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues("BQ", shardName)
-		require.Nil(t, err)
-		metricValue = testutil.ToFloat64(metric)
-		require.Equal(t, 800.0, metricValue, "segments should match")
-	})
-
-	t.Run("delete class type=BQ", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "BQ")
-		require.Nil(t, err)
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("BQ", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metric should be still zero")
-
-		metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues("BQ", shardName)
-		require.Nil(t, err)
-		metricValue = testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metrics should be reset")
-	})
-
-	t.Run("set schema type=PQ", func(t *testing.T) {
-		vectorIndexConfig := enthnsw.NewDefaultUserConfig()
-		vectorIndexConfig.PQ.Enabled = true
-		vectorIndexConfig.PQ.Segments = 10
-
-		class := &models.Class{
-			Class:               "PQ",
-			VectorIndexConfig:   vectorIndexConfig,
-			InvertedIndexConfig: invertedConfig(),
-		}
-		schema := schema.Schema{
-			Objects: &models.Schema{
-				Classes: []*models.Class{class},
-			},
-		}
-
-		require.Nil(t,
-			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
-
-		schemaGetter.schema = schema
-	})
-
-	t.Run("import objects and validate metric type=PQ", func(t *testing.T) {
-		dim := 64
-		for i := 0; i < 100; i++ {
-			vec := make([]float32, dim)
-			for j := range vec {
-				vec[j] = r.Float32()
-			}
-
-			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
-			obj := &models.Object{Class: "PQ", ID: id}
-			err := repo.PutObject(context.Background(), obj, vec, nil, nil)
-			require.Nil(t, err)
-		}
-
-		publishDimensionMetricsFromRepo(context.Background(), repo, "PQ")
-
-		shardName = getSingleShardNameFromRepo(repo, "PQ")
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("PQ", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "dimensions should not have changed")
-
-		metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues("PQ", shardName)
-		require.Nil(t, err)
-		metricValue = testutil.ToFloat64(metric)
-		require.Equal(t, 1000.0, metricValue, "segments should match")
-	})
-
-	t.Run("delete class type=PQ", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "PQ")
-		require.Nil(t, err)
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("PQ", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metric should be still zero")
-
-		metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues("PQ", shardName)
-		require.Nil(t, err)
-		metricValue = testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metrics should be reset")
-	})
-	t.Run("set schema type=PQ segments=0", func(t *testing.T) {
-		vectorIndexConfig := enthnsw.NewDefaultUserConfig()
-		vectorIndexConfig.PQ.Enabled = true
-		vectorIndexConfig.PQ.Segments = 0
-
-		class := &models.Class{
-			Class:               "PQZ",
-			VectorIndexConfig:   vectorIndexConfig,
-			InvertedIndexConfig: invertedConfig(),
-		}
-		schema := schema.Schema{
-			Objects: &models.Schema{
-				Classes: []*models.Class{class},
-			},
-		}
-
-		require.Nil(t,
-			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
-
-		schemaGetter.schema = schema
-	})
-
-	t.Run("import objects and validate metric type=PQ segments=0", func(t *testing.T) {
-		dim := 64
-		for i := 0; i < 100; i++ {
-			vec := make([]float32, dim)
-			for j := range vec {
-				vec[j] = r.Float32()
-			}
-
-			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
-			obj := &models.Object{Class: "PQZ", ID: id}
-			err := repo.PutObject(context.Background(), obj, vec, nil, nil)
-			require.Nil(t, err)
-		}
-
-		publishDimensionMetricsFromRepo(context.Background(), repo, "PQZ")
-
-		shardName = getSingleShardNameFromRepo(repo, "PQZ")
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("PQZ", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "dimensions should not have changed")
-
-		metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues("PQZ", shardName)
-		require.Nil(t, err)
-		metricValue = testutil.ToFloat64(metric)
-		require.Equal(t, 5000.0, metricValue, "segments should match")
-	})
-
-	t.Run("delete class type=PQ segments=0", func(t *testing.T) {
-		err := migrator.DropClass(context.Background(), "PQZ")
-		require.Nil(t, err)
-		metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues("PQZ", shardName)
-		require.Nil(t, err)
-		metricValue := testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metric should be still zero")
-
-		metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues("PQZ", shardName)
-		require.Nil(t, err)
-		metricValue = testutil.ToFloat64(metric)
-		require.Equal(t, 0.0, metricValue, "metrics should be reset")
-	})
+				// Verify segments metric is reset
+				metric, err = metrics.VectorSegmentsSumByVector.GetMetricWithLabelValues(tc.className, shardName, "vec")
+				require.Nil(t, err)
+				metricValue = testutil.ToFloat64(metric)
+				require.Equal(t, 0.0, metricValue, "named segments metric should be reset")
+			})
+		})
+	}
 }

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -322,6 +322,7 @@ func Test_DimensionTracking(t *testing.T) {
 			assert.Equal(t, 6400, shard.Dimensions(context.Background()))
 			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), 64))
 			assert.Equal(t, 1600, shard.QuantizedDimensions(context.Background(), 32))
+			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), 0))
 			return nil
 		})
 	})
@@ -371,7 +372,9 @@ func Test_DimensionTracking(t *testing.T) {
 		idx.ForEachShard(func(name string, shard ShardLike) error {
 			assert.Equal(t, 12800, shard.Dimensions(context.Background()))
 			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), 64))
-			assert.Equal(t, 12800, shard.QuantizedDimensions(context.Background(), 0))
+			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), 32))
+			// segments = 0, will use 128/2 = 64 segments and so value should be 6400
+			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), 0))
 			return nil
 		})
 	})

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -407,7 +407,6 @@ func Test_DimensionTrackingMetrics(t *testing.T) {
 	type testConfig struct {
 		name            string
 		className       string
-		classConfig     func() *models.Class
 		vectorConfig    func() *enthnsw.UserConfig
 		expectedDims    float64
 		expectedSegs    float64

--- a/adapters/repos/db/vector/common/vector_util.go
+++ b/adapters/repos/db/vector/common/vector_util.go
@@ -28,3 +28,16 @@ func VectorsEqual(vecA, vecB []float32) bool {
 	}
 	return true
 }
+
+func CalculateOptimalSegments(dims int) int {
+	if dims >= 2048 && dims%8 == 0 {
+		return dims / 8
+	} else if dims >= 768 && dims%6 == 0 {
+		return dims / 6
+	} else if dims >= 256 && dims%4 == 0 {
+		return dims / 4
+	} else if dims%2 == 0 {
+		return dims / 2
+	}
+	return dims
+}

--- a/adapters/repos/db/vector/common/vector_util_test.go
+++ b/adapters/repos/db/vector/common/vector_util_test.go
@@ -79,3 +79,56 @@ func TestVectorUtil_Equal(t *testing.T) {
 		})
 	}
 }
+
+func Test_CalculateOptimalSegments(t *testing.T) {
+	type testCase struct {
+		dimensions       int
+		expectedSegments int
+	}
+
+	for _, tc := range []testCase{
+		{
+			dimensions:       2048,
+			expectedSegments: 256,
+		},
+		{
+			dimensions:       1536,
+			expectedSegments: 256,
+		},
+		{
+			dimensions:       768,
+			expectedSegments: 128,
+		},
+		{
+			dimensions:       512,
+			expectedSegments: 128,
+		},
+		{
+			dimensions:       256,
+			expectedSegments: 64,
+		},
+		{
+			dimensions:       125,
+			expectedSegments: 125,
+		},
+		{
+			dimensions:       64,
+			expectedSegments: 32,
+		},
+		{
+			dimensions:       27,
+			expectedSegments: 27,
+		},
+		{
+			dimensions:       19,
+			expectedSegments: 19,
+		},
+		{
+			dimensions:       2,
+			expectedSegments: 1,
+		},
+	} {
+		segments := CalculateOptimalSegments(tc.dimensions)
+		assert.Equal(t, tc.expectedSegments, segments)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -16,24 +16,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 
 	"github.com/weaviate/weaviate/entities/storobj"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
-
-func (h *hnsw) calculateOptimalSegments(dims int) int {
-	if dims >= 2048 && dims%8 == 0 {
-		return dims / 8
-	} else if dims >= 768 && dims%6 == 0 {
-		return dims / 6
-	} else if dims >= 256 && dims%4 == 0 {
-		return dims / 4
-	} else if dims%2 == 0 {
-		return dims / 2
-	}
-	return dims
-}
 
 func (h *hnsw) compress(cfg ent.UserConfig) error {
 	if !cfg.PQ.Enabled && !cfg.BQ.Enabled {
@@ -50,7 +38,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		dims := int(h.dims)
 
 		if cfg.PQ.Segments <= 0 {
-			cfg.PQ.Segments = h.calculateOptimalSegments(dims)
+			cfg.PQ.Segments = common.CalculateOptimalSegments(dims)
 			h.pqConfig.Segments = cfg.PQ.Segments
 		}
 

--- a/adapters/repos/db/vector/hnsw/compress_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_test.go
@@ -25,61 +25,6 @@ import (
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-func TestCompression_CalculateOptimalSegments(t *testing.T) {
-	h := &hnsw{}
-
-	type testCase struct {
-		dimensions       int
-		expectedSegments int
-	}
-
-	for _, tc := range []testCase{
-		{
-			dimensions:       2048,
-			expectedSegments: 256,
-		},
-		{
-			dimensions:       1536,
-			expectedSegments: 256,
-		},
-		{
-			dimensions:       768,
-			expectedSegments: 128,
-		},
-		{
-			dimensions:       512,
-			expectedSegments: 128,
-		},
-		{
-			dimensions:       256,
-			expectedSegments: 64,
-		},
-		{
-			dimensions:       125,
-			expectedSegments: 125,
-		},
-		{
-			dimensions:       64,
-			expectedSegments: 32,
-		},
-		{
-			dimensions:       27,
-			expectedSegments: 27,
-		},
-		{
-			dimensions:       19,
-			expectedSegments: 19,
-		},
-		{
-			dimensions:       2,
-			expectedSegments: 1,
-		},
-	} {
-		segments := h.calculateOptimalSegments(tc.dimensions)
-		assert.Equal(t, tc.expectedSegments, segments)
-	}
-}
-
 func Test_NoRaceCompressReturnsErrorWhenNotEnoughData(t *testing.T) {
 	efConstruction := 64
 	ef := 32


### PR DESCRIPTION
### What's being changed:
- In the case where `segments=0` we calculate the PQ segments to use with `CalculateOptimalSegments`
- The PR moves the calculation out of HNSW, and uses this when calculating the metric
- Changes were also needed to surface dimensions in shard dimension tracking
- Have added tests for named vectors which were missing and also refactored tests to use a table

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
