### PR TITLE
Make grpc msg size configurable with 2GB default

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -35,12 +35,10 @@ import (
 	v1 "github.com/weaviate/weaviate/adapters/handlers/grpc/v1"
 )
 
-const maxMsgSize = 104858000 // 10mb, needs to be synchronized with clients
-
 func CreateGRPCServer(state *state.State) *GRPCServer {
 	o := []grpc.ServerOption{
-		grpc.MaxRecvMsgSize(maxMsgSize),
-		grpc.MaxSendMsgSize(maxMsgSize),
+		grpc.MaxRecvMsgSize(state.ServerConfig.Config.GRPC.MaxMsgSize),
+		grpc.MaxSendMsgSize(state.ServerConfig.Config.GRPC.MaxMsgSize),
 	}
 
 	// Add TLS creds for the GRPC connection, if defined.

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4205,6 +4205,10 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
+        "grpc_max_msg_size": {
+          "description": "Max message size for GRPC connection in bytes",
+          "type": "integer"
+        },
         "hostname": {
           "description": "The url of the host.",
           "type": "string",
@@ -9890,6 +9894,10 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
+        "grpc_max_msg_size": {
+          "description": "Max message size for GRPC connection in bytes",
+          "type": "integer"
+        },
         "hostname": {
           "description": "The url of the host.",
           "type": "string",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4205,7 +4205,7 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
-        "grpc_max_msg_size": {
+        "grpcMaxMessageSize": {
           "description": "Max message size for GRPC connection in bytes",
           "type": "integer"
         },
@@ -9894,7 +9894,7 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
-        "grpc_max_msg_size": {
+        "grpcMaxMessageSize": {
           "description": "Max message size for GRPC connection in bytes",
           "type": "integer"
         },

--- a/adapters/handlers/rest/handlers_misc.go
+++ b/adapters/handlers/rest/handlers_misc.go
@@ -50,10 +50,10 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 		}
 
 		res := &models.Meta{
-			Hostname:       serverConfig.GetHostAddress(),
-			Version:        config.ServerVersion,
-			Modules:        metaInfos,
-			GrpcMaxMsgSize: int64(serverConfig.Config.GRPC.MaxMsgSize),
+			Hostname:           serverConfig.GetHostAddress(),
+			Version:            config.ServerVersion,
+			Modules:            metaInfos,
+			GrpcMaxMessageSize: int64(serverConfig.Config.GRPC.MaxMsgSize),
 		}
 		metricRequestsTotal.logOk("")
 		return meta.NewMetaGetOK().WithPayload(res)

--- a/adapters/handlers/rest/handlers_misc.go
+++ b/adapters/handlers/rest/handlers_misc.go
@@ -50,9 +50,10 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 		}
 
 		res := &models.Meta{
-			Hostname: serverConfig.GetHostAddress(),
-			Version:  config.ServerVersion,
-			Modules:  metaInfos,
+			Hostname:       serverConfig.GetHostAddress(),
+			Version:        config.ServerVersion,
+			Modules:        metaInfos,
+			GrpcMaxMsgSize: int64(serverConfig.Config.GRPC.MaxMsgSize),
 		}
 		metricRequestsTotal.logOk("")
 		return meta.NewMetaGetOK().WithPayload(res)

--- a/entities/models/meta.go
+++ b/entities/models/meta.go
@@ -28,6 +28,9 @@ import (
 // swagger:model Meta
 type Meta struct {
 
+	// Max message size for GRPC connection in bytes
+	GrpcMaxMsgSize int64 `json:"grpc_max_msg_size,omitempty"`
+
 	// The url of the host.
 	Hostname string `json:"hostname,omitempty"`
 

--- a/entities/models/meta.go
+++ b/entities/models/meta.go
@@ -29,7 +29,7 @@ import (
 type Meta struct {
 
 	// Max message size for GRPC connection in bytes
-	GrpcMaxMsgSize int64 `json:"grpc_max_msg_size,omitempty"`
+	GrpcMaxMessageSize int64 `json:"grpcMaxMessageSize,omitempty"`
 
 	// The url of the host.
 	Hostname string `json:"hostname,omitempty"`

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -475,7 +475,7 @@
           "description": "Module-specific meta information",
           "type": "object"
         },
-        "grpc_max_msg_size": {
+        "grpcMaxMessageSize": {
           "description": "Max message size for GRPC connection in bytes",
           "type": "integer"
         }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -474,6 +474,10 @@
         "modules": {
           "description": "Module-specific meta information",
           "type": "object"
+        },
+        "grpc_max_msg_size": {
+          "description": "Max message size for GRPC connection in bytes",
+          "type": "integer"
         }
       },
       "type": "object"

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -207,9 +207,10 @@ type Contextionary struct {
 
 // Support independent TLS credentials for gRPC
 type GRPC struct {
-	Port     int    `json:"port" yaml:"port"`
-	CertFile string `json:"certFile" yaml:"certFile"`
-	KeyFile  string `json:"keyFile" yaml:"keyFile"`
+	Port       int    `json:"port" yaml:"port"`
+	CertFile   string `json:"certFile" yaml:"certFile"`
+	KeyFile    string `json:"keyFile" yaml:"keyFile"`
+	MaxMsgSize int    `json:"maxMsgSize" yaml:"maxMsgSize"`
 }
 
 type Profiling struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -384,6 +384,13 @@ func FromEnv(config *Config) error {
 	}
 
 	if err := parsePositiveInt(
+		"GRPC_MAX_MESSAGE_SIZE",
+		func(val int) { config.GRPC.MaxMsgSize = val },
+		DefaultGRPCMaxMsgSize,
+	); err != nil {
+		return err
+	}
+	if err := parsePositiveInt(
 		"GRPC_PORT",
 		func(val int) { config.GRPC.Port = val },
 		DefaultGRPCPort,
@@ -621,7 +628,7 @@ func (c *Config) parseMemtableConfig() error {
 func parsePositiveInt(envName string, cb func(val int), defaultValue int) error {
 	return parseInt(envName, defaultValue, func(val int) error {
 		if val <= 0 {
-			return fmt.Errorf("%s must be a positive value larger 0", envName)
+			return fmt.Errorf("%s must be a positive value larger 0. Got: %v", envName, val)
 		}
 		return nil
 	}, cb)
@@ -669,6 +676,7 @@ const (
 	DefaultPersistenceMemtablesMaxDuration     = 45
 	DefaultMaxConcurrentGetRequests            = 0
 	DefaultGRPCPort                            = 50051
+	DefaultGRPCMaxMsgSize                      = math.MaxInt32 // 2 GB
 	DefaultMinimumReplicationFactor            = 1
 )
 


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/weaviate/issues/5968

- default GRPC message size is 2GB
- configurable by an env var `GRPC_MAX_MESSAGE_SIZE`
- message size is part of the meta endpoint
- clients can pick up the message size and set it accordingly with zero configuration

To test use https://github.com/weaviate/weaviate-python-client/pull/1362 which you can install using `pip install git+https://github.com/weaviate/weaviate-python-client.git@5da5c5d9958c34b18ea985bccc763d96fd79ed43`
.

With an old python client, everything works EXCEPT when a message is send by weaviate that is actually larger than the old limit (10mb). This fails with
```
	debug_error_string = "UNKNOWN:Error received from peer ipv6:%5B::1%5D:50051 {grpc_message:"Received message larger than max (992468921 vs. 104858000)", grpc_status:8, created_time:"2024-10-24T09:35:01.74252+02:00"}"
```
This would not have worked before => no regression

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
