### PR TITLE
Return body in error if it cannot be decoded

### DIFF
--- a/modules/generative-anyscale/clients/anyscale.go
+++ b/modules/generative-anyscale/clients/anyscale.go
@@ -109,7 +109,7 @@ func (v *anyscale) Generate(ctx context.Context, cfg moduletools.ClassConfig, pr
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {

--- a/modules/generative-aws/clients/aws.go
+++ b/modules/generative-aws/clients/aws.go
@@ -323,19 +323,19 @@ func (v *awsClient) getBedrockResponseMessage(model string, bodyBytes []byte) (s
 	var content string
 	var resBodyMap map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &resBodyMap); err != nil {
-		return "", errors.Wrap(err, "unmarshal response body")
+		return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if v.isCohereCommandRModel(model) {
 		var resBody bedrockCohereCommandRResponse
 		if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-			return "", errors.Wrap(err, "unmarshal response body")
+			return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 		}
 		return resBody.Text, nil
 	} else if v.isAnthropicClaude3Model(model) {
 		var resBody bedrockAnthropicClaude3Response
 		if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-			return "", errors.Wrap(err, "unmarshal response body")
+			return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 		}
 		if len(resBody.Content) > 0 && resBody.Content[0].Text != nil {
 			return *resBody.Content[0].Text, nil
@@ -344,13 +344,13 @@ func (v *awsClient) getBedrockResponseMessage(model string, bodyBytes []byte) (s
 	} else if v.isAnthropicModel(model) {
 		var resBody bedrockAnthropicClaudeResponse
 		if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-			return "", errors.Wrap(err, "unmarshal response body")
+			return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 		}
 		return resBody.Completion, nil
 	} else if v.isAI21Model(model) {
 		var resBody bedrockAI21Response
 		if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-			return "", errors.Wrap(err, "unmarshal response body")
+			return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 		}
 		if len(resBody.Completions) > 0 {
 			return resBody.Completions[0].Data.Text, nil
@@ -359,7 +359,7 @@ func (v *awsClient) getBedrockResponseMessage(model string, bodyBytes []byte) (s
 	} else if v.isMistralAIModel(model) {
 		var resBody bedrockMistralAIResponse
 		if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-			return "", errors.Wrap(err, "unmarshal response body")
+			return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 		}
 		if len(resBody.Outputs) > 0 {
 			return resBody.Outputs[0].Text, nil
@@ -368,14 +368,14 @@ func (v *awsClient) getBedrockResponseMessage(model string, bodyBytes []byte) (s
 	} else if v.isMetaModel(model) {
 		var resBody bedrockMetaResponse
 		if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-			return "", errors.Wrap(err, "unmarshal response body")
+			return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 		}
 		return resBody.Generation, nil
 	}
 
 	var resBody bedrockGenerateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return "", errors.Wrap(err, "unmarshal response body")
+		return "", errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if len(resBody.Results) == 0 && len(resBody.Generations) == 0 {
@@ -394,7 +394,7 @@ func (v *awsClient) getBedrockResponseMessage(model string, bodyBytes []byte) (s
 func (v *awsClient) parseSagemakerResponse(bodyBytes []byte, res *http.Response) (*generativemodels.GenerateResponse, error) {
 	var resBody sagemakerGenerateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Message != nil {

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -113,7 +113,7 @@ func (v *cohere) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {

--- a/modules/generative-google/clients/google.go
+++ b/modules/generative-google/clients/google.go
@@ -228,7 +228,7 @@ func (v *google) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 func (v *google) parseGenerateMessageResponse(statusCode int, bodyBytes []byte) (*generativemodels.GenerateResponse, error) {
 	var resBody generateMessageResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if err := v.checkResponse(statusCode, resBody.Error); err != nil {
@@ -247,7 +247,7 @@ func (v *google) parseGenerateMessageResponse(statusCode int, bodyBytes []byte) 
 func (v *google) parseGenerateContentResponse(statusCode int, bodyBytes []byte) (*generativemodels.GenerateResponse, error) {
 	var resBody generateContentResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if err := v.checkResponse(statusCode, resBody.Error); err != nil {
@@ -269,7 +269,7 @@ func (v *google) parseGenerateContentResponse(statusCode int, bodyBytes []byte) 
 func (v *google) parseResponse(statusCode int, bodyBytes []byte) (*generativemodels.GenerateResponse, error) {
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if err := v.checkResponse(statusCode, resBody.Error); err != nil {

--- a/modules/generative-mistral/clients/mistral.go
+++ b/modules/generative-mistral/clients/mistral.go
@@ -116,7 +116,7 @@ func (v *mistral) Generate(ctx context.Context, cfg moduletools.ClassConfig, pro
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {

--- a/modules/generative-ollama/clients/ollama.go
+++ b/modules/generative-ollama/clients/ollama.go
@@ -98,7 +98,7 @@ func (v *ollama) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if resBody.Error != "" {

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -138,7 +138,7 @@ func (v *openai) Generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {

--- a/modules/img2vec-neural/clients/vectorizer.go
+++ b/modules/img2vec-neural/clients/vectorizer.go
@@ -71,7 +71,7 @@ func (v *vectorizer) Vectorize(ctx context.Context,
 
 	var resBody vecResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/multi2vec-bind/clients/vectorizer.go
+++ b/modules/multi2vec-bind/clients/vectorizer.go
@@ -76,7 +76,7 @@ func (v *vectorizer) Vectorize(ctx context.Context,
 
 	var resBody vecResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {

--- a/modules/multi2vec-clip/clients/vectorizer.go
+++ b/modules/multi2vec-clip/clients/vectorizer.go
@@ -71,7 +71,7 @@ func (v *vectorizer) Vectorize(ctx context.Context,
 
 	var resBody vecResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/multi2vec-google/clients/google.go
+++ b/modules/multi2vec-google/clients/google.go
@@ -137,7 +137,7 @@ func (v *google) sendRequest(ctx context.Context,
 
 	var resBody embeddingsResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return 0, embeddingsResponse{}, errors.Wrap(err, "unmarshal response body")
+		return 0, embeddingsResponse{}, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	return res.StatusCode, resBody, nil

--- a/modules/ner-transformers/clients/ner.go
+++ b/modules/ner-transformers/clients/ner.go
@@ -88,7 +88,7 @@ func (n *ner) GetTokens(ctx context.Context, property,
 
 	var resBody nerResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -118,7 +118,7 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 
 	var resBody answersResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {

--- a/modules/reranker-cohere/clients/ranker.go
+++ b/modules/reranker-cohere/clients/ranker.go
@@ -150,7 +150,7 @@ func (c *client) performRank(ctx context.Context, query string, documents []stri
 
 	var rankResponse RankResponse
 	if err := json.Unmarshal(bodyBytes, &rankResponse); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 	return c.toDocumentScores(documents, rankResponse.Results), nil
 }

--- a/modules/reranker-transformers/clients/ranker.go
+++ b/modules/reranker-transformers/clients/ranker.go
@@ -129,7 +129,7 @@ func (c *client) performRank(ctx context.Context,
 
 	var resBody RankResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {

--- a/modules/reranker-voyageai/clients/ranker.go
+++ b/modules/reranker-voyageai/clients/ranker.go
@@ -150,7 +150,7 @@ func (c *client) performRank(ctx context.Context, query string, documents []stri
 
 	var rankResponse RankResponse
 	if err := json.Unmarshal(bodyBytes, &rankResponse); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 	return c.toDocumentScores(documents, rankResponse.Data), nil
 }

--- a/modules/sum-transformers/client/client.go
+++ b/modules/sum-transformers/client/client.go
@@ -84,7 +84,7 @@ func (c *client) GetSummary(ctx context.Context, property, text string,
 
 	var resBody sumResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/text-spellcheck/clients/spellcheck.go
+++ b/modules/text-spellcheck/clients/spellcheck.go
@@ -82,7 +82,7 @@ func (s *spellCheck) Check(ctx context.Context, text []string) (*ent.SpellCheckR
 
 	var resBody spellCheckResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/text2vec-aws/clients/aws.go
+++ b/modules/text2vec-aws/clients/aws.go
@@ -258,7 +258,7 @@ func (v *awsClient) makeRequest(req *http.Request, delayInSeconds int, maxRetrie
 func (v *awsClient) parseBedrockResponse(bodyBytes []byte, input []string) (*ent.VectorizationResult, error) {
 	var resBody bedrockEmbeddingResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 	if len(resBody.Embedding) == 0 && len(resBody.Embeddings) == 0 {
 		return nil, fmt.Errorf("could not obtain vector from AWS Bedrock")
@@ -279,7 +279,7 @@ func (v *awsClient) parseBedrockResponse(bodyBytes []byte, input []string) (*ent
 func (v *awsClient) parseSagemakerResponse(bodyBytes []byte, res *http.Response, input []string) (*ent.VectorizationResult, error) {
 	var resBody sagemakerEmbeddingResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Message != nil {

--- a/modules/text2vec-cohere/clients/cohere.go
+++ b/modules/text2vec-cohere/clients/cohere.go
@@ -147,7 +147,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	}
 	var resBody embeddingsResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode >= 500 {

--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -192,7 +192,7 @@ func (v *google) parseGenerativeAIApiResponse(statusCode int,
 ) (*ent.VectorizationResult, error) {
 	var resBody batchEmbedTextResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if err := v.checkResponse(statusCode, resBody.Error); err != nil {
@@ -224,7 +224,7 @@ func (v *google) parseEmbeddingsResponse(statusCode int,
 ) (*ent.VectorizationResult, error) {
 	var resBody embeddingsResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if err := v.checkResponse(statusCode, resBody.Error); err != nil {

--- a/modules/text2vec-gpt4all/clients/gpt4all.go
+++ b/modules/text2vec-gpt4all/clients/gpt4all.go
@@ -66,7 +66,7 @@ func (c *client) Vectorize(ctx context.Context, text string) (*ent.Vectorization
 
 	var resBody vecResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {

--- a/modules/text2vec-huggingface/clients/huggingface.go
+++ b/modules/text2vec-huggingface/clients/huggingface.go
@@ -195,7 +195,7 @@ func (v *vectorizer) decodeVector(bodyBytes []byte) ([][]float32, []error, error
 		if err := json.Unmarshal(bodyBytes, &embObject); err != nil {
 			var embBert embeddingBert
 			if err := json.Unmarshal(bodyBytes, &embBert); err != nil {
-				return nil, nil, errors.Wrap(err, "unmarshal response body")
+				return nil, nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 			}
 
 			if len(embBert) == 1 && len(embBert[0]) > 0 {

--- a/modules/text2vec-jinaai/clients/jinaai.go
+++ b/modules/text2vec-jinaai/clients/jinaai.go
@@ -164,7 +164,7 @@ func (v *vectorizer) vectorize(ctx context.Context,
 
 	var resBody embedding
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {

--- a/modules/text2vec-mistral/clients/mistral.go
+++ b/modules/text2vec-mistral/clients/mistral.go
@@ -117,7 +117,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	}
 	var resBody embeddingsResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {

--- a/modules/text2vec-ollama/clients/ollama.go
+++ b/modules/text2vec-ollama/clients/ollama.go
@@ -89,7 +89,7 @@ func (v *ollama) parseEmbeddingsResponse(statusCode int,
 ) (*ent.VectorizationResult, error) {
 	var resBody embeddingsResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if resBody.Error != "" {

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -178,7 +178,7 @@ func (v *client) vectorize(ctx context.Context, input []string, model string, co
 
 	var resBody embedding
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, nil, errors.Wrap(err, "unmarshal response body")
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {

--- a/modules/text2vec-transformers/clients/transformers.go
+++ b/modules/text2vec-transformers/clients/transformers.go
@@ -87,7 +87,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input string,
 
 	var resBody vecRequest
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/text2vec-voyageai/clients/voyageai.go
+++ b/modules/text2vec-voyageai/clients/voyageai.go
@@ -125,7 +125,7 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	}
 	var resBody embeddingsResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 {


### PR DESCRIPTION
### What's being changed:

Include the body of the response from third party providers if it cannot be unmarshalled. Allows our users to see what was returned and to fix it.

Closes: https://github.com/weaviate/weaviate/issues/3567 https://github.com/weaviate/weaviate/issues/2010

also: https://forum.weaviate.io/t/setup-issues-with-sagemaker-endpoint/7285


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
