### PR TITLE
Fix logger formatter default params

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -186,13 +186,13 @@ func calcCPUs(cpuString string) (int, error) {
 }
 
 func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *state.State {
-	appState := startupRoutine(ctx, options)
-
 	build.Version = parseVersionFromSwaggerSpec() // Version is always static and loaded from swagger spec.
 
 	// config.ServerVersion is deprecated: It's there to be backward compatible
 	// use build.Version instead.
 	config.ServerVersion = build.Version
+
+	appState := startupRoutine(ctx, options)
 
 	if appState.ServerConfig.Config.Monitoring.Enabled {
 		appState.TenantActivity = tenantactivity.NewHandler()
@@ -788,22 +788,10 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 // Defaults to log level info and json format
 func logger() *logrus.Logger {
 	logger := logrus.New()
-	logger.SetFormatter(&WeaviateTextFormatter{
-		build.Revision,
-		build.Version,
-		config.ServerVersion,
-		goruntime.Version(),
-		&logrus.TextFormatter{},
-	})
+	logger.SetFormatter(NewWeaviateTextFormatter())
 
 	if os.Getenv("LOG_FORMAT") != "text" {
-		logger.SetFormatter(&WeaviateJSONFormatter{
-			build.Revision,
-			build.Version,
-			config.ServerVersion,
-			goruntime.Version(),
-			&logrus.JSONFormatter{},
-		})
+		logger.SetFormatter(NewWeaviateJSONFormatter())
 	}
 	switch os.Getenv("LOG_LEVEL") {
 	case "panic":

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -13,11 +13,22 @@ package rest
 
 import (
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/usecases/build"
 )
 
 type WeaviateJSONFormatter struct {
-	gitHash, imageTag, serverVersion, goVersion string
 	*logrus.JSONFormatter
+	gitHash, imageTag, serverVersion, goVersion string
+}
+
+func NewWeaviateJSONFormatter() logrus.Formatter {
+	return &WeaviateJSONFormatter{
+		&logrus.JSONFormatter{},
+		build.Revision,
+		build.Branch,
+		build.Version,
+		build.GoVersion,
+	}
 }
 
 func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
@@ -29,8 +40,18 @@ func (wf *WeaviateJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 }
 
 type WeaviateTextFormatter struct {
-	gitHash, imageTag, serverVersion, goVersion string
 	*logrus.TextFormatter
+	gitHash, imageTag, serverVersion, goVersion string
+}
+
+func NewWeaviateTextFormatter() logrus.Formatter {
+	return &WeaviateTextFormatter{
+		&logrus.TextFormatter{},
+		build.Revision,
+		build.Branch,
+		build.Version,
+		build.GoVersion,
+	}
 }
 
 func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {

--- a/usecases/build/build.go
+++ b/usecases/build/build.go
@@ -41,6 +41,10 @@ var (
 	GoVersion string
 )
 
+func init() {
+	GoVersion = runtime.Version()
+}
+
 const (
 	AppName = "weaviate"
 )
@@ -51,5 +55,5 @@ func SetPrometheusBuildInfo() {
 	version.Branch = Branch
 	version.BuildUser = BuildUser
 	version.BuildDate = BuildDate
-	version.GoVersion = runtime.Version()
+	version.GoVersion = GoVersion
 }


### PR DESCRIPTION
### What's being changed:

Fix logger formatter default params such as `weaviate_version` `go_version`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
