### PR TITLE
Don't return internal rate limit to client, but copy instead

### DIFF
--- a/usecases/modulecomponents/batch/fakes_for_test.go
+++ b/usecases/modulecomponents/batch/fakes_for_test.go
@@ -88,11 +88,19 @@ func (c *fakeBatchClientWithRL) Vectorize(ctx context.Context,
 	}
 	c.rateLimit.LastOverwrite = time.Now()
 	return &modulecomponents.VectorizationResult{
-		Vector:     vectors,
-		Dimensions: 4,
-		Text:       text,
-		Errors:     errors,
-	}, c.rateLimit, reqError
+			Vector:     vectors,
+			Dimensions: 4,
+			Text:       text,
+			Errors:     errors,
+		}, &modulecomponents.RateLimits{
+			LastOverwrite:     c.rateLimit.LastOverwrite,
+			RemainingTokens:   c.rateLimit.RemainingTokens,
+			RemainingRequests: c.rateLimit.RemainingRequests,
+			LimitTokens:       c.rateLimit.LimitTokens,
+			ResetTokens:       c.rateLimit.ResetTokens,
+			ResetRequests:     c.rateLimit.ResetRequests,
+			LimitRequests:     c.rateLimit.LimitRequests,
+		}, reqError
 }
 
 func (c *fakeBatchClientWithRL) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {


### PR DESCRIPTION
### What's being changed:

Fix another race in batch test => don't return internal rate limit to client

(pure test-race)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
