### PR TITLE
Remove deprecated Llama2 models from AWS generative e2e tests list

### DIFF
--- a/test/modules/generative-aws/generative_aws_test.go
+++ b/test/modules/generative-aws/generative_aws_test.go
@@ -169,14 +169,6 @@ func testGenerativeAWS(host, region string) func(t *testing.T) {
 				name:            "meta.llama3-70b-instruct-v1:0",
 				generativeModel: "meta.llama3-70b-instruct-v1:0",
 			},
-			{
-				name:            "meta.llama2-13b-chat-v1",
-				generativeModel: "meta.llama2-13b-chat-v1",
-			},
-			{
-				name:            "meta.llama2-70b-chat-v1",
-				generativeModel: "meta.llama2-70b-chat-v1",
-			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

[aws] Remove deprecated Llama2 models from AWS generative e2e tests list

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
