### PR TITLE
[HNSW] Switch rescore error log to metric

### DIFF
--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -40,6 +40,7 @@ type Metrics struct {
 	tombstoneStart                prometheus.Gauge
 	tombstoneEnd                  prometheus.Gauge
 	tombstoneProgress             prometheus.Gauge
+	rescoreErrors                 prometheus.Counter
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics,
@@ -160,6 +161,11 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		"shard_name": shardName,
 	})
 
+	rescoreErrors := prom.VectorRescoreErrors.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
 	return &Metrics{
 		enabled:                       true,
 		tombstones:                    tombstones,
@@ -182,6 +188,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		tombstoneStart:                tombstoneStart,
 		tombstoneEnd:                  tombstoneEnd,
 		tombstoneProgress:             tombstoneProgress,
+		rescoreErrors:                 rescoreErrors,
 	}
 }
 
@@ -305,6 +312,14 @@ func (m *Metrics) DeleteVector() {
 	}
 
 	m.delete.Inc()
+}
+
+func (m *Metrics) TrackRescoreError() {
+	if !m.enabled {
+		return
+	}
+
+	m.rescoreErrors.Inc()
 }
 
 func (m *Metrics) SetSize(size int) {

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -601,10 +601,11 @@ func (h *hnsw) rescore(res *priorityqueue.Queue[any], k int, compressorDistancer
 				res.Pop()
 			}
 		} else {
+			h.metrics.TrackRescoreError()
 			h.logger.
 				WithField("action", "rescore").
 				WithError(err).
-				Warnf("could not rescore node %d", id)
+				Debugf("could not rescore node %d", id)
 		}
 	}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -83,6 +83,7 @@ type PrometheusMetrics struct {
 	VectorSegmentsSum                  *prometheus.GaugeVec
 	VectorDimensionsSumByVector        *prometheus.GaugeVec
 	VectorSegmentsSumByVector          *prometheus.GaugeVec
+	VectorRescoreErrors                *prometheus.CounterVec
 
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.SummaryVec
@@ -174,6 +175,7 @@ func (pm *PrometheusMetrics) DeleteShard(className, shardName string) error {
 	pm.VectorIndexMaintenanceDurations.DeletePartialMatch(labels)
 	pm.VectorIndexDurations.DeletePartialMatch(labels)
 	pm.VectorIndexSize.DeletePartialMatch(labels)
+	pm.VectorRescoreErrors.DeletePartialMatch(labels)
 	pm.StartupProgress.DeletePartialMatch(labels)
 	pm.StartupDurations.DeletePartialMatch(labels)
 	pm.StartupDiskIO.DeletePartialMatch(labels)
@@ -421,6 +423,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "vector_segments_sum_by_vector",
 			Help: "Total segments in a shard for target vector if quantization enabled",
 		}, []string{"class_name", "shard_name", "target_vector"}),
+		VectorRescoreErrors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "vector_rescore_errors",
+			Help: "Total number of vector rescore errors",
+		}, []string{"class_name", "shard_name"}),
 
 		// Startup metrics
 		StartupProgress: promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
### What's being changed:
- Change the rescore error from Warn to Debug, and use a metric instead as when this error occurs it will log multiple times per search request

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
