### PR TITLE
Return body in error if it cannot be decoded for 1.26 modules

### DIFF
--- a/modules/generative-anthropic/clients/anthropic.go
+++ b/modules/generative-anthropic/clients/anthropic.go
@@ -127,7 +127,7 @@ func (a *anthropic) Generate(ctx context.Context, cfg moduletools.ClassConfig, p
 	var resBody generateResponse
 
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 && resBody.Type == "error" {

--- a/modules/generative-databricks/clients/databricks.go
+++ b/modules/generative-databricks/clients/databricks.go
@@ -121,7 +121,7 @@ func (v *databricks) Generate(ctx context.Context, cfg moduletools.ClassConfig, 
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.Error != nil {

--- a/modules/generative-friendliai/clients/friendliai.go
+++ b/modules/generative-friendliai/clients/friendliai.go
@@ -113,7 +113,7 @@ func (v *friendliai) Generate(ctx context.Context, cfg moduletools.ClassConfig, 
 
 	var resBody generateResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode == 404 {

--- a/modules/qna-transformers/clients/qna.go
+++ b/modules/qna-transformers/clients/qna.go
@@ -70,7 +70,7 @@ func (q *qna) Answer(ctx context.Context,
 
 	var resBody answersResponse
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode > 399 {

--- a/modules/reranker-jinaai/clients/ranker.go
+++ b/modules/reranker-jinaai/clients/ranker.go
@@ -149,7 +149,7 @@ func (c *client) performRank(ctx context.Context, query string, documents []stri
 
 	var rankResponse RankResponse
 	if err := json.Unmarshal(bodyBytes, &rankResponse); err != nil {
-		return nil, errors.Wrap(err, "unmarshal response body")
+		return nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 	return c.toDocumentScores(documents, rankResponse.Results), nil
 }

--- a/modules/text2vec-databricks/clients/databricks.go
+++ b/modules/text2vec-databricks/clients/databricks.go
@@ -119,7 +119,7 @@ func (v *client) vectorize(ctx context.Context, input []string, config ent.Vecto
 
 	var resBody embedding
 	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
-		return nil, nil, errors.Wrap(err, "unmarshal response body")
+		return nil, nil, errors.Wrap(err, fmt.Sprintf("unmarshal response body. Got: %v", string(bodyBytes)))
 	}
 
 	if res.StatusCode != 200 || resBody.ErrorCode != "" {


### PR DESCRIPTION
### What's being changed:

title

follow up to https://github.com/weaviate/weaviate/pull/6127 for modules that were added in 1.26

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
