### PR TITLE
backup(cancellation): make sure backup release indexs fast and all sc…

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -243,7 +243,7 @@ func (i *Index) descriptor(ctx context.Context, backupID string, desc *backup.Cl
 // or is already inactive.
 func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	i.logger.WithField("backup_id", id).WithField("class", i.Config.ClassName).Info("release backup")
-	defer i.resetBackupState()
+	i.resetBackupState()
 	if err := i.resumeMaintenanceCycles(ctx); err != nil {
 		return err
 	}

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -214,6 +214,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 			if errors.Is(err, context.Canceled) {
 				u.setStatus(backup.Cancelled)
 				desc.Status = string(backup.Cancelled)
+				u.releaseIndexes(classes, desc.ID)
 			}
 			err = fmt.Errorf("upload %w: %v", err, u.backend.PutMeta(ctx, desc))
 		} else {
@@ -230,6 +231,7 @@ Loop:
 		select {
 		case cdesc, ok := <-ch:
 			if !ok {
+				u.releaseIndexes(classes, desc.ID)
 				break Loop // we are done
 			}
 			if cdesc.Error != nil {
@@ -247,17 +249,7 @@ Loop:
 			if ctxerr != nil {
 				u.setStatus(backup.Cancelled)
 				desc.Status = string(backup.Cancelled)
-				for _, class := range desc.Classes {
-					className := class.Name
-					enterrors.GoWrapper(func() {
-						if err := u.sourcer.ReleaseBackup(context.Background(), desc.ID, className); err != nil {
-							u.log.WithFields(logrus.Fields{
-								"class":    className,
-								"backupID": desc.ID,
-							}).Error("failed to release backup")
-						}
-					}, u.log)
-				}
+				u.releaseIndexes(classes, desc.ID)
 			}
 			return ctxerr
 		}
@@ -265,6 +257,20 @@ Loop:
 	u.setStatus(backup.Transferred)
 	desc.Status = string(backup.Success)
 	return nil
+}
+
+func (u *uploader) releaseIndexes(classes []string, ID string) {
+	for _, class := range classes {
+		className := class
+		enterrors.GoWrapper(func() {
+			if err := u.sourcer.ReleaseBackup(context.Background(), ID, className); err != nil {
+				u.log.WithFields(logrus.Fields{
+					"class":    className,
+					"backupID": ID,
+				}).Error("failed to release backup")
+			}
+		}, u.log)
+	}
 }
 
 // class uploads one class


### PR DESCRIPTION
there is some scenarios where the backup could be blocked because of some indexes wasn't released to allow for next backup to progress. 

This PR makes sure that the backup released as fast and for all indexes was trying to be backed up in all scenarios like: 
- backup cancelled by the user 
- backup cancelled for any other reason 

this PR shall fixes : https://github.com/weaviate/weaviate-issues/issues/65 where in some scenarios were the backup gets stuck because the previous cancelled backup wasn't fully released (not all indexes was released)
 
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/11632507794
- [x] e2e test: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/11663005236
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
