### PR TITLE
Updates all tools/dev shebangs to /usr/bin/env

### DIFF
--- a/tools/dev/delve_connect.sh
+++ b/tools/dev/delve_connect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/dev/flakyness.sh
+++ b/tools/dev/flakyness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Jump to root directory
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit 1

--- a/tools/dev/goreleaser_and_sign.sh
+++ b/tools/dev/goreleaser_and_sign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eou pipefail
 
 # run from Weaviate Root!

--- a/tools/dev/keycloak/get_token.sh
+++ b/tools/dev/keycloak/get_token.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/tools/dev/restart_dev_environment.sh
+++ b/tools/dev/restart_dev_environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/dev/run_debug_server.sh
+++ b/tools/dev/run_debug_server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CONFIG=${1:-local-development}
 

--- a/tools/dev/run_dev_server_no_network.sh
+++ b/tools/dev/run_dev_server_no_network.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Jump to root directory
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit 1

--- a/tools/dev/run_test_server.sh
+++ b/tools/dev/run_test_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Jump to root directory
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit 1

--- a/tools/dev/vector_search.sh
+++ b/tools/dev/vector_search.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 search_term="${1:required}"
 

--- a/tools/gen-code-from-swagger.sh
+++ b/tools/gen-code-from-swagger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/tools/prepare_release.sh
+++ b/tools/prepare_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 
 set -euo pipefail
 

--- a/tools/test/run_ci_server.sh
+++ b/tools/test/run_ci_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # This scripts starts a Weaviate server with the test scheme and waits until weaviate is up and running.


### PR DESCRIPTION
Thank you for this great project! I assume that this change will not require its own tests or specifically configured pipelines, and so I have checked all items in the review checklist: but this is my first contribution and so am happy to be corrected if it does.

### What's being changed:
On systems such as NixOS where the shell is not located at /bin/bash, it is more robust to have a shebang for scripts that sources the binary from the user environment. Thus this PR just standardizes the use of a `#!/usr/bin/env bash` shebang across all scripts in the tools directory. (It seems that some of these scripts use this shebang already, and so I am assuming that this is a reasonable change.)

### Review checklist

- [X] Documentation has been updated, if necessary. Link to changed documentation:
- [X] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
