### PR TITLE
Reduce log level of memtable retrieval duration warning

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -356,7 +356,7 @@ func (b *Bucket) get(key []byte) ([]byte, error) {
 	if time.Since(beforeMemtable) > 100*time.Millisecond {
 		b.logger.WithField("duration", time.Since(beforeMemtable)).
 			WithField("action", "lsm_bucket_get_active_memtable").
-			Warnf("Waited more than 100ms to retrieve object from memtable")
+			Debugf("Waited more than 100ms to retrieve object from memtable")
 	}
 	if err == nil {
 		// item found and no error, return and stop searching, since the strategy


### PR DESCRIPTION
### What's being changed:

This was not meant to be a `WARNING` in the first place. Should have been a `DEBUG`.

The durations might still be interesting as a prometheus metric in the future, but for now just trying to make the logs less chatty ;-)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
