### PR TITLE
fix: :construction: Fix prop len == NaN to see if it removes Nan scores

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -181,6 +181,13 @@ func (b *BM25Searcher) wand(
 
 	averagePropLength = averagePropLength / float64(len(params.Properties))
 
+	// WIP: The true bug is likely in the prop length tracker,
+	// but this is a workaround to check if this is
+	// the value that is resulting in the NaN scores.
+	if math.IsNaN(averagePropLength) || averagePropLength == 0 {
+		averagePropLength = 40.0
+	}
+
 	// 100 is a reasonable expected capacity for the total number of terms to query.
 	allRequests := make([]termListRequest, 0, 100)
 


### PR DESCRIPTION
### What's being changed:

WIP fix/test to check if checking for propLen == NaN fixes NaN scores.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
