### PR TITLE
Change openai default model to latest

### DIFF
--- a/modules/text2vec-openai/ent/class_settings.go
+++ b/modules/text2vec-openai/ent/class_settings.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	DefaultOpenAIDocumentType    = "text"
-	DefaultOpenAIModel           = "ada"
+	DefaultOpenAIModel           = "text-embedding-3-small"
 	DefaultVectorizeClassName    = true
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false

--- a/test/modules/many-modules/many_modules_openai_test.go
+++ b/test/modules/many-modules/many_modules_openai_test.go
@@ -121,7 +121,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 				require.True(t, ok)
 				require.NotEmpty(t, text2vecOpenAI)
 				if tt.expectDefaultSettings {
-					assert.Equal(t, "ada", text2vecOpenAI["model"])
+					assert.Equal(t, "text-embedding-3-small", text2vecOpenAI["model"])
 					assert.Equal(t, true, text2vecOpenAI["vectorizeClassName"])
 				} else {
 					assert.Equal(t, tt.text2vecOpenAI["model"], text2vecOpenAI["model"])


### PR DESCRIPTION
### What's being changed:

Change openai default model to `text-embedding-3-small`. Note that collections that were created before this change keep their old model.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
