### PR TITLE
Update golangci-lint to 1.61 and fix linter errors

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v5
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.54
+          version: v1.61
           args: --timeout=5m
   protolint:
     name: protolint

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,11 +16,10 @@ jobs:
           go-version: '1.22'
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v6
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.61
-          args: --timeout=5m
   protolint:
     name: protolint
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,16 @@ issues:
         - staticcheck
       path: test/acceptance/grpc/list_value_return_test.go
       text: 'SA1019' # TODO: remove this once deprecated gRPC fields are removed from API
+    # Exclude 'unused' linter for assembly files
+    - linters:
+        - unused
+      path: adapters/repos/db/vector/hnsw/distancer/asm/dot_inline.go
+      text: "func `dot[357]`"
+    - linters:
+        - unused
+      path: adapters/repos/db/vector/hnsw/distancer/asm/l2_inline.go
+      text: "func `l2[35]`"
+
 run:
   timeout: 5m
   build-tags:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ issues:
       path: test/acceptance/grpc/list_value_return_test.go
       text: 'SA1019' # TODO: remove this once deprecated gRPC fields are removed from API
 run:
+  timeout: 5m
   build-tags:
     - integrationTest
     - integrationTestSlow

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,6 @@ repos:
         entry: ./tools/linter_go_routines.sh
         language: system
         types: [ go ]
-      - id: swagger
-        name: swagger
-        entry: ./tools/gen-code-from-swagger.sh
-        language: system
-        types: [ go ]
   -   repo: https://github.com/psf/black
       rev: 24.2.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,17 @@ repos:
         entry: ./tools/linter_go_routines.sh
         language: system
         types: [ go ]
+      - id: golangci-lint
+        name: golangci-lint
+        description: Fast linters runner for Go. Note that only modified files are linted, so linters like 'unused' that need to scan all files won't work as expected.
+        entry: golangci-lint run --new-from-rev HEAD
+        types: [go]
+        language: golang
+        # Please make sure to update the version in the .github/workflows/linter.yml file when updating this version.
+        additional_dependencies:
+          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+        require_serial: true
+        pass_filenames: false
   -   repo: https://github.com/psf/black
       rev: 24.2.0
       hooks:

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -490,7 +490,7 @@ func extractNearTextMove(classname string, Move *pb.NearTextSearch_Move) (nearTe
 
 	if moveAwayReq := Move; moveAwayReq != nil {
 		moveAwayOut.Force = moveAwayReq.Force
-		if moveAwayReq.Uuids != nil && len(moveAwayReq.Uuids) > 0 {
+		if len(moveAwayReq.Uuids) > 0 {
 			moveAwayOut.Objects = make([]nearText2.ObjectMove, len(moveAwayReq.Uuids))
 			for i, objUUid := range moveAwayReq.Uuids {
 				uuidFormat, err := uuid.Parse(objUUid)
@@ -626,7 +626,7 @@ func extractPropertiesRequestDeprecated(reqProps *pb.PropertiesRequest, getClass
 		return nil, nil
 	}
 	props := make([]search.SelectProperty, 0)
-	if reqProps.NonRefProperties != nil && len(reqProps.NonRefProperties) > 0 {
+	if len(reqProps.NonRefProperties) > 0 {
 		for _, prop := range reqProps.NonRefProperties {
 			props = append(props, search.SelectProperty{
 				Name:        schema.LowercaseFirstLetter(prop),
@@ -636,7 +636,7 @@ func extractPropertiesRequestDeprecated(reqProps *pb.PropertiesRequest, getClass
 		}
 	}
 
-	if reqProps.RefProperties != nil && len(reqProps.RefProperties) > 0 {
+	if len(reqProps.RefProperties) > 0 {
 		class := getClass(className)
 		if class == nil {
 			return []search.SelectProperty{}, fmt.Errorf("could not find class %s in schema", className)
@@ -702,7 +702,7 @@ func extractPropertiesRequestDeprecated(reqProps *pb.PropertiesRequest, getClass
 		}
 	}
 
-	if reqProps.ObjectProperties != nil && len(reqProps.ObjectProperties) > 0 {
+	if len(reqProps.ObjectProperties) > 0 {
 		props = append(props, extractNestedProperties(reqProps.ObjectProperties)...)
 	}
 
@@ -713,7 +713,7 @@ func extractNestedProperties(props []*pb.ObjectPropertiesRequest) []search.Selec
 	selectProps := make([]search.SelectProperty, 0)
 	for _, prop := range props {
 		nestedProps := make([]search.SelectProperty, 0)
-		if prop.PrimitiveProperties != nil && len(prop.PrimitiveProperties) > 0 {
+		if len(prop.PrimitiveProperties) > 0 {
 			for _, primitive := range prop.PrimitiveProperties {
 				nestedProps = append(nestedProps, search.SelectProperty{
 					Name:        schema.LowercaseFirstLetter(primitive),
@@ -722,7 +722,7 @@ func extractNestedProperties(props []*pb.ObjectPropertiesRequest) []search.Selec
 				})
 			}
 		}
-		if prop.ObjectProperties != nil && len(prop.ObjectProperties) > 0 {
+		if len(prop.ObjectProperties) > 0 {
 			nestedProps = append(nestedProps, extractNestedProperties(prop.ObjectProperties)...)
 		}
 		selectProps = append(selectProps, search.SelectProperty{

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -84,7 +84,7 @@ func parseNestedFilter(in *models.WhereFilter,
 			operator.Name())
 	}
 
-	if in.Operands == nil || len(in.Operands) == 0 {
+	if len(in.Operands) == 0 {
 		return nil, fmt.Errorf(
 			"operator '%s', but no operands set - add at least one operand",
 			operator.Name())

--- a/adapters/handlers/rest/panics_middleware.go
+++ b/adapters/handlers/rest/panics_middleware.go
@@ -75,7 +75,7 @@ func handlePanics(logger logrus.FieldLogger, metricRequestsTotal restApiRequests
 	logger.WithError(err).WithFields(logrus.Fields{
 		"method": r.Method,
 		"path":   r.URL,
-	}).Errorf(err.Error())
+	}).Error(err.Error())
 	// This was not expected, so we want to print the stack, this will help us
 	// find the source of the issue if the user sends their logs
 	metricRequestsTotal.logServerError("", err)

--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -68,7 +68,7 @@ func (db *DB) BatchPutObjects(ctx context.Context, objs objects.BatchObjects,
 							len(objs), origIdx)
 						break
 					}
-					objs[origIdx].Err = fmt.Errorf(msg)
+					objs[origIdx].Err = errors.New(msg)
 				}
 				continue
 			}

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -434,8 +434,8 @@ func (r *ShardInvertedReindexer) tempBucket(propName string, indexType PropertyI
 
 func (r *ShardInvertedReindexer) checkContextExpired(ctx context.Context, msg string) error {
 	if ctx.Err() != nil {
-		r.logError(ctx.Err(), msg)
-		return errors.Wrapf(ctx.Err(), msg)
+		r.logError(ctx.Err(), "%v", msg)
+		return errors.Wrapf(ctx.Err(), "%v", msg)
 	}
 	return nil
 }

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -609,6 +609,6 @@ func (sg *SegmentGroup) observeReplaceDuration(
 	if took > replaceSegmentWarnThreshold {
 		fields.Warn(msg)
 	} else {
-		fields.Debugf(msg)
+		fields.Debug(msg)
 	}
 }

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -435,7 +435,7 @@ func (sg *SegmentGroup) observeReplaceCompactedDuration(
 	if took > replaceSegmentWarnThreshold {
 		fields.Warn(msg)
 	} else {
-		fields.Debugf(msg)
+		fields.Debug(msg)
 	}
 }
 

--- a/adapters/repos/db/vector/hnsw/distancer/asm/dot_inline.go
+++ b/adapters/repos/db/vector/hnsw/distancer/asm/dot_inline.go
@@ -30,6 +30,7 @@ func dot2[T number, U number](x []T, y []T) U {
 }
 
 //gcassert:inline
+//nolint:unused
 func dot3[T, U number](x []T, y []T) U {
 	sum := x[2] * y[2]
 
@@ -43,6 +44,7 @@ func dot4[T, U number](x []T, y []T) U {
 	return dot2[T, U](x, y) + U(sum)
 }
 
+//nolint:golint,unused
 //gcassert:inline
 func dot5[T, U number](x []T, y []T) U {
 	sum := x[4] * y[4]
@@ -57,6 +59,7 @@ func dot6[T, U number](x []T, y []T) U {
 	return dot4[T, U](x, y) + U(sum)
 }
 
+//nolint:golint,unused
 //gcassert:inline
 func dot7[T, U number](x []T, y []T) U {
 	sum := x[6] * y[6]

--- a/adapters/repos/db/vector/hnsw/distancer/asm/dot_inline.go
+++ b/adapters/repos/db/vector/hnsw/distancer/asm/dot_inline.go
@@ -30,7 +30,6 @@ func dot2[T number, U number](x []T, y []T) U {
 }
 
 //gcassert:inline
-//nolint:unused
 func dot3[T, U number](x []T, y []T) U {
 	sum := x[2] * y[2]
 
@@ -44,7 +43,6 @@ func dot4[T, U number](x []T, y []T) U {
 	return dot2[T, U](x, y) + U(sum)
 }
 
-//nolint:golint,unused
 //gcassert:inline
 func dot5[T, U number](x []T, y []T) U {
 	sum := x[4] * y[4]
@@ -59,7 +57,6 @@ func dot6[T, U number](x []T, y []T) U {
 	return dot4[T, U](x, y) + U(sum)
 }
 
-//nolint:golint,unused
 //gcassert:inline
 func dot7[T, U number](x []T, y []T) U {
 	sum := x[6] * y[6]

--- a/adapters/repos/db/vector/hnsw/distancer/asm/dot_stub_arm64.go
+++ b/adapters/repos/db/vector/hnsw/distancer/asm/dot_stub_arm64.go
@@ -18,7 +18,6 @@ package asm
 //go:generate goat ../c/dot_arm64.c -O3 -e="-mfpu=neon-fp-armv8" -e="-mfloat-abi=hard" -e="--target=arm64" -e="-march=armv8-a+simd+fp"
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -49,15 +48,15 @@ func Dot(x []float32, y []float32) float32 {
 	var res float32
 
 	// The C function expects pointers to the underlying array, not slices.
-	hdrx := (*reflect.SliceHeader)(unsafe.Pointer(&x))
-	hdry := (*reflect.SliceHeader)(unsafe.Pointer(&y))
+	hdrx := unsafe.SliceData(x)
+	hdry := unsafe.SliceData(y)
 
 	l := len(x)
 	dot(
 		// The slice header contains the address of the underlying array.
 		// We only need to cast it to a pointer.
-		unsafe.Pointer(hdrx.Data),
-		unsafe.Pointer(hdry.Data),
+		unsafe.Pointer(hdrx),
+		unsafe.Pointer(hdry),
 		// The C function expects pointers to the result and the length of the arrays.
 		unsafe.Pointer(&res),
 		unsafe.Pointer(&l))

--- a/adapters/repos/db/vector/hnsw/distancer/asm/l2_inline.go
+++ b/adapters/repos/db/vector/hnsw/distancer/asm/l2_inline.go
@@ -28,6 +28,7 @@ func l22[T number, U number](x []T, y []T) U {
 	return sum
 }
 
+//nolint:golint,unused
 func l23[T number, U number](x []T, y []T) U {
 	diff := U(x[2]) - U(y[2])
 	sum := diff * diff
@@ -45,6 +46,7 @@ func l24[T number, U number](x []T, y []T) U {
 	return l22[T, U](x, y) + sum
 }
 
+//nolint:golint,unused
 func l25[T number, U number](x []T, y []T) U {
 	diff := U(x[4]) - U(y[4])
 	sum := diff * diff

--- a/adapters/repos/db/vector/hnsw/distancer/asm/l2_inline.go
+++ b/adapters/repos/db/vector/hnsw/distancer/asm/l2_inline.go
@@ -28,7 +28,6 @@ func l22[T number, U number](x []T, y []T) U {
 	return sum
 }
 
-//nolint:golint,unused
 func l23[T number, U number](x []T, y []T) U {
 	diff := U(x[2]) - U(y[2])
 	sum := diff * diff
@@ -46,7 +45,6 @@ func l24[T number, U number](x []T, y []T) U {
 	return l22[T, U](x, y) + sum
 }
 
-//nolint:golint,unused
 func l25[T number, U number](x []T, y []T) U {
 	diff := U(x[4]) - U(y[4])
 	sum := diff * diff

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -361,12 +361,12 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 			// serialize snapshot
 			b, c, err := schema.LegacySnapshot(st.cfg.NodeID, legacySchema)
 			if err != nil {
-				return fmt.Errorf("create snapshot: %s" + err.Error())
+				return fmt.Errorf("create snapshot: %w", err)
 			}
 			b.Index = st.raft.LastIndex()
 			b.Term = 1
 			if err := st.raft.Restore(b, c, timeout); err != nil {
-				return fmt.Errorf("raft restore: %w" + err.Error())
+				return fmt.Errorf("raft restore: %w", err)
 			}
 			return nil
 		}

--- a/modules/generative-google/clients/google.go
+++ b/modules/generative-google/clients/google.go
@@ -258,7 +258,7 @@ func (v *google) parseGenerateContentResponse(statusCode int, bodyBytes []byte) 
 		if len(resBody.Candidates[0].Content.Parts) > 0 {
 			return v.getGenerateResponse(resBody.Candidates[0].Content.Parts[0].Text)
 		}
-		return nil, fmt.Errorf(v.decodeFinishReason(resBody.Candidates[0].FinishReason))
+		return nil, fmt.Errorf("%s", v.decodeFinishReason(resBody.Candidates[0].FinishReason))
 	}
 
 	return &generativemodels.GenerateResponse{

--- a/modules/text2vec-cohere/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-cohere/vectorizer/fakes_for_test.go
@@ -39,7 +39,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
-			errors[i] = fmt.Errorf(text[i][6:])
+			errors[i] = fmt.Errorf("%s", text[i][6:])
 			continue
 		}
 

--- a/modules/text2vec-contextionary/additional/nearestneighbors/extender.go
+++ b/modules/text2vec-contextionary/additional/nearestneighbors/extender.go
@@ -72,7 +72,7 @@ func (e *Extender) Multi(ctx context.Context, in []search.Result, limit *int) ([
 
 	vectors := make([][]float32, len(in))
 	for i, res := range in {
-		if res.Vector == nil || len(res.Vector) == 0 {
+		if len(res.Vector) == 0 {
 			return nil, fmt.Errorf("item %d has no vector", i)
 		}
 		vectors[i] = res.Vector

--- a/modules/text2vec-contextionary/additional/sempath/builder_params.go
+++ b/modules/text2vec-contextionary/additional/sempath/builder_params.go
@@ -31,7 +31,7 @@ func (p *Params) validate(inputSize, dims int) error {
 		ec.Addf("result length %d is larger than 25 items: semantic path calculation is only suported up to 25 items, set a limit to <= 25", inputSize)
 	}
 
-	if p.SearchVector == nil || len(p.SearchVector) == 0 {
+	if len(p.SearchVector) == 0 {
 		ec.Addf("no valid search vector present, got: %v", p.SearchVector)
 	}
 

--- a/modules/text2vec-contextionary/client/contextionary.go
+++ b/modules/text2vec-contextionary/client/contextionary.go
@@ -266,7 +266,7 @@ func (c *Client) VectorForCorpi(ctx context.Context, corpi []string, overridesMa
 			return nil, nil, fmt.Errorf("could not get vector from remote: %v", err)
 		}
 
-		return nil, nil, vectorizer.NewErrNoUsableWordsf(st.Message())
+		return nil, nil, vectorizer.NewErrNoUsableWordsf("%s", st.Message())
 	}
 
 	return vectorFromProto(res)

--- a/modules/text2vec-mistral/clients/mistral.go
+++ b/modules/text2vec-mistral/clients/mistral.go
@@ -137,10 +137,10 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	if res.StatusCode != 200 {
 		if resBody.Message != "" {
 			errorMessage := getErrorMessage(res.StatusCode, resBody.Message, "connection to Mistral failed with status: %d error: %v")
-			return nil, 0, errors.Errorf(errorMessage)
+			return nil, 0, errors.New(errorMessage)
 		}
 		errorMessage := getErrorMessage(res.StatusCode, "", "connection to Mistral failed with status: %d")
-		return nil, 0, errors.Errorf(errorMessage)
+		return nil, 0, errors.New(errorMessage)
 	}
 
 	if len(resBody.Data) == 0 || len(resBody.Data[0].Embeddings) == 0 {

--- a/modules/text2vec-mistral/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-mistral/vectorizer/fakes_for_test.go
@@ -38,7 +38,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
-			errors[i] = fmt.Errorf(text[i][6:])
+			errors[i] = fmt.Errorf("%s", text[i][6:])
 			continue
 		}
 

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -52,7 +52,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 	}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
-			errors[i] = fmt.Errorf(text[i][6:])
+			errors[i] = fmt.Errorf("%s", text[i][6:])
 			continue
 		}
 

--- a/modules/text2vec-transformers/clients/meta.go
+++ b/modules/text2vec-transformers/clients/meta.go
@@ -71,7 +71,7 @@ func (v *vectorizer) MetaInfo() (map[string]interface{}, error) {
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Errorf(strings.Join(errs, ", "))
+		return nil, errors.New(strings.Join(errs, ", "))
 	}
 	if len(metas) == 1 {
 		for _, meta := range metas {

--- a/modules/text2vec-transformers/clients/startup.go
+++ b/modules/text2vec-transformers/clients/startup.go
@@ -55,7 +55,7 @@ func (v *vectorizer) WaitForStartup(initCtx context.Context,
 		for err := range ch {
 			errs = append(errs, err.Error())
 		}
-		return errors.Errorf(strings.Join(errs, ", "))
+		return errors.New(strings.Join(errs, ", "))
 	}
 	return nil
 }

--- a/modules/text2vec-voyageai/clients/voyageai.go
+++ b/modules/text2vec-voyageai/clients/voyageai.go
@@ -159,10 +159,10 @@ func (v *vectorizer) vectorize(ctx context.Context, input []string,
 	if res.StatusCode != 200 {
 		if resBody.Detail != "" {
 			errorMessage := getErrorMessage(res.StatusCode, resBody.Detail, "connection to VoyageAI failed with status: %d error: %v")
-			return nil, 0, errors.Errorf(errorMessage)
+			return nil, 0, errors.New(errorMessage)
 		}
 		errorMessage := getErrorMessage(res.StatusCode, "", "connection to VoyageAI failed with status: %d")
-		return nil, 0, errors.Errorf(errorMessage)
+		return nil, 0, errors.New(errorMessage)
 	}
 
 	if len(resBody.Data) == 0 || len(resBody.Data[0].Embeddings) == 0 {

--- a/modules/text2vec-voyageai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-voyageai/vectorizer/fakes_for_test.go
@@ -38,7 +38,7 @@ func (c *fakeBatchClient) Vectorize(ctx context.Context,
 	rateLimit := &modulecomponents.RateLimits{RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
-			errors[i] = fmt.Errorf(text[i][6:])
+			errors[i] = fmt.Errorf("%s", text[i][6:])
 			continue
 		}
 

--- a/tools/license_headers/main.go
+++ b/tools/license_headers/main.go
@@ -120,6 +120,6 @@ func startsWithBuildTag(content []byte) bool {
 
 func fatal(err error) {
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err)
 	}
 }

--- a/usecases/auth/authentication/oidc/middleware.go
+++ b/usecases/auth/authentication/oidc/middleware.go
@@ -94,7 +94,7 @@ func (c *Client) validateConfig() error {
 		return nil
 	}
 
-	return fmt.Errorf(strings.Join(msgs, ", "))
+	return fmt.Errorf("%v", strings.Join(msgs, ", "))
 }
 
 // ValidateAndExtract can be used as a middleware for go-swagger
@@ -105,17 +105,17 @@ func (c *Client) ValidateAndExtract(token string, scopes []string) (*models.Prin
 
 	parsed, err := c.verifier.Verify(context.Background(), token)
 	if err != nil {
-		return nil, errors.New(401, err.Error())
+		return nil, errors.New(401, "unauthorized: %v", err)
 	}
 
 	claims, err := c.extractClaims(parsed)
 	if err != nil {
-		return nil, errors.New(500, fmt.Sprintf("oidc: %v", err))
+		return nil, errors.New(500, "oidc: %v", err)
 	}
 
 	username, err := c.extractUsername(claims)
 	if err != nil {
-		return nil, errors.New(500, fmt.Sprintf("oidc: %v", err))
+		return nil, errors.New(500, "oidc: %v", err)
 	}
 
 	groups := c.extractGroups(claims)

--- a/usecases/classification/validation.go
+++ b/usecases/classification/validation.go
@@ -89,7 +89,7 @@ func (v *Validator) knnTypeFeasibility() {
 }
 
 func (v *Validator) basedOnProperties(class *models.Class) {
-	if v.subject.BasedOnProperties == nil || len(v.subject.BasedOnProperties) == 0 {
+	if len(v.subject.BasedOnProperties) == 0 {
 		v.errors.Addf("basedOnProperties must have at least one property")
 		return
 	}
@@ -130,7 +130,7 @@ func (v *Validator) basedOnProperty(class *models.Class, propName string) {
 }
 
 func (v *Validator) classifyProperties(class *models.Class) {
-	if v.subject.ClassifyProperties == nil || len(v.subject.ClassifyProperties) == 0 {
+	if len(v.subject.ClassifyProperties) == 0 {
 		v.errors.Addf("classifyProperties must have at least one property")
 		return
 	}

--- a/usecases/modulecomponents/batch/fakes_for_test.go
+++ b/usecases/modulecomponents/batch/fakes_for_test.go
@@ -52,7 +52,7 @@ func (c *fakeBatchClientWithRL) Vectorize(ctx context.Context,
 	}
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
-			errors[i] = fmt.Errorf(text[i][6:])
+			errors[i] = fmt.Errorf("%s", text[i][6:])
 			continue
 		}
 
@@ -130,7 +130,7 @@ func (c *fakeBatchClientWithoutRL) Vectorize(ctx context.Context,
 	errors := make([]error, len(text))
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
-			errors[i] = fmt.Errorf(text[i][6:])
+			errors[i] = fmt.Errorf("%s", text[i][6:])
 			continue
 		}
 

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -68,7 +68,7 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	}
 
 	if _, _, err = m.autoSchemaManager.autoTenants(ctx, principal, []*models.Object{object}); err != nil {
-		return nil, NewErrInternal(err.Error())
+		return nil, NewErrInternal("%v", err)
 	}
 
 	err = m.validateObjectAndNormalizeNames(ctx, principal, repl, object, nil)
@@ -137,7 +137,7 @@ func (m *Manager) checkIDOrAssignNew(ctx context.Context, principal *models.Prin
 			}
 			return "", err
 		default:
-			return "", NewErrInternal(err.Error())
+			return "", NewErrInternal("%v", err)
 		}
 	}
 

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -328,5 +328,5 @@ func joinErrors(errors []error) error {
 		return nil
 	}
 
-	return fmt.Errorf(strings.Join(errorStrings, ", "))
+	return fmt.Errorf("%s", strings.Join(errorStrings, ", "))
 }

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -13,6 +13,7 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -82,7 +83,7 @@ func (v *Validator) Object(ctx context.Context, class *models.Class,
 	incoming *models.Object, existing *models.Object,
 ) error {
 	if incoming.Class == "" {
-		return fmt.Errorf(ErrorMissingClass)
+		return errors.New(ErrorMissingClass)
 	}
 
 	if err := v.vector(ctx, class, incoming); err != nil {

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -113,7 +113,7 @@ func validateActivityStatuses(tenants []*models.Tenant, allowEmpty bool) error {
 	}
 
 	if len(msgs) != 0 {
-		return uco.NewErrInvalidUserInput(strings.Join(msgs, ", "))
+		return uco.NewErrInvalidUserInput("%s", strings.Join(msgs, ", "))
 	}
 	return nil
 }

--- a/usecases/traverser/traverser_validate_distance_metrics.go
+++ b/usecases/traverser/traverser_validate_distance_metrics.go
@@ -132,7 +132,7 @@ func crossClassDistCompatError(classDistanceConfigs map[string]string) error {
 	}
 	errorMsg = strings.TrimSuffix(errorMsg, ",")
 
-	return fmt.Errorf(errorMsg)
+	return errors.New(errorMsg)
 }
 
 func certaintyUnsupportedError(distType string) error {


### PR DESCRIPTION
### What's being changed:
This PR updates the golangci-lint version to 1.61.0, this change afloat new linter errors which also get addressed in this PR.
Also, as part of the change, the swagger execution gets removed from the pre-commit-config.yaml as it takes several seconds on each commit, making the development less agile. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/11691438972
- [x] End 2 End test. [Link](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/11691443956)
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
