### PR TITLE
[RBAC] Add policy to role translation

### DIFF
--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -74,9 +74,9 @@ type LevelAndVerbs struct {
 
 // TODO add translation layer between weaviate and Casbin permissions
 var BuiltInRoles = map[string][]LevelAndVerbs{
-	"viewer": {{Level: "database", Verbs: readOnlyVerbs()}, {Level: "collection", Verbs: readOnlyVerbs()}},
-	"editor": {{Level: "database", Verbs: editorVerbs()}, {Level: "collection", Verbs: editorVerbs()}},
-	"admin":  {{Level: "database", Verbs: adminVerbs()}, {Level: "collection", Verbs: adminVerbs()}},
+	"viewer": {{Level: "database", Verbs: readOnlyVerbs()}},
+	"editor": {{Level: "database", Verbs: editorVerbs()}},
+	"admin":  {{Level: "database", Verbs: adminVerbs()}},
 }
 
 func readOnlyVerbs() []string {
@@ -99,14 +99,23 @@ func Verbs[T Action](a T) []string {
 	return a.Verbs()
 }
 
-// Actions
+// ActionsByLevel
 type (
 	Read   string
 	List   string
 	Write  string
 	Update string
 	Delete string
+	All    string
 )
+
+func AllActionsForLevel(level string) []string {
+	var actions []string
+	for key := range ActionsByLevel[level] {
+		actions = append(actions, key)
+	}
+	return actions
+}
 
 func (r Read) Verbs() []string {
 	return []string{HEAD, VALIDATE, GET}
@@ -128,6 +137,10 @@ func (r Delete) Verbs() []string {
 	return []string{HEAD, VALIDATE, DELETE}
 }
 
+func (r All) Verbs() []string {
+	return []string{HEAD, VALIDATE, GET, LIST, CREATE, UPDATE, DELETE}
+}
+
 type Level string
 
 // levels
@@ -139,27 +152,29 @@ var (
 )
 
 var (
-	CreateRole Write  = "create_role"
-	ReadRole   Read   = "read_role"
-	UpdateRole Update = "update_role"
-	DeleteRole Delete = "delete_role"
-	ManageRole Delete = "manage_role" // TODO is it needed ?
+	ManageRole    All = "manage_role" // should not be delete
+	ManageCluster All = "manage_role"
 
 	CreateCollection Write  = "create_collection"
 	ReadCollection   Read   = "read_collection"
 	UpdateCollection Update = "update_collection"
 	DeleteCollection Delete = "delete_collection"
 
-	Actions = map[string]Action{
-		string(CreateRole): CreateRole,
-		string(ReadRole):   ReadRole,
-		string(UpdateRole): UpdateRole,
-		string(DeleteRole): DeleteRole,
-
-		string(CreateCollection): CreateCollection,
-		string(ReadCollection):   ReadCollection,
-		string(UpdateCollection): UpdateCollection,
-		string(DeleteCollection): DeleteCollection,
+	ActionsByLevel = map[string]map[string]Action{
+		"database": {
+			string(ManageRole):       ManageRole,
+			string(ManageCluster):    ManageCluster,
+			string(CreateCollection): CreateCollection,
+			string(ReadCollection):   ReadCollection,
+			string(UpdateCollection): UpdateCollection,
+			string(DeleteCollection): DeleteCollection,
+		},
+		"collection": {
+			string(CreateTenant): CreateTenant,
+			string(ReadTenant):   ReadTenant,
+			string(UpdateTenant): UpdateTenant,
+			string(DeleteTenant): DeleteTenant,
+		},
 	}
 
 	CreateTenant Write  = "create_tenant"
@@ -167,13 +182,11 @@ var (
 	UpdateTenant Update = "update_tenant"
 	DeleteTenant Delete = "delete_tenant"
 
+	// not in first version
 	CreateObject Write  = "create_object"
 	ReadObject   Read   = "read_object"
 	UpdateObject Update = "update_object"
 	DeleteObject Delete = "delete_object"
-
-	CreateBackup Write = "create_backup" // TODO cluster management
-	GetBackup    Read  = "read_backup"   // TODO cluster management ?
 )
 
 // SchemaShard returns the path for a specific schema shard.

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -152,8 +152,9 @@ var (
 )
 
 var (
-	ManageRole    All = "manage_role" // should not be delete
-	ManageCluster All = "manage_role"
+	ManageRole    All  = "manage_role" // should not be delete
+	ReadRole      Read = "manage_role" // should not be delete
+	ManageCluster All  = "manage_role"
 
 	CreateCollection Write  = "create_collection"
 	ReadCollection   Read   = "read_collection"
@@ -163,6 +164,7 @@ var (
 	ActionsByLevel = map[string]map[string]Action{
 		"database": {
 			string(ManageRole):       ManageRole,
+			string(ReadRole):         ReadRole,
 			string(ManageCluster):    ManageCluster,
 			string(CreateCollection): CreateCollection,
 			string(ReadCollection):   ReadCollection,


### PR DESCRIPTION
### What's being changed:

Adds translation from verbs+level to role name

```
import weaviate
import weaviate.classes as wvc
from weaviate.rbac.permissions import RBAC

client = weaviate.connect_to_local(auth_credentials=wvc.init.Auth.api_key("jp-secret-key"))

client.roles.create(name="admin-test", permissions=RBAC.permissions.database(RBAC.actions.database.READ_COLLECTION))

print(client.roles.by_name("admin-test"))
```
results in
```
Role(name='admin-test', collection_permissions=None, database_permissions=[DatabasePermission(actions=[<DatabaseAction.READ_COLLECTION: 'read_collection'>])])
```


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
