### PR TITLE
chore: remove video related fields from multi2vec-cohere class settings

### DIFF
--- a/modules/multi2vec-cohere/ent/class_settings.go
+++ b/modules/multi2vec-cohere/ent/class_settings.go
@@ -78,14 +78,6 @@ func (ic *classSettings) TextFieldsWeights() ([]float32, error) {
 	return ic.getFieldsWeights("text")
 }
 
-func (ic *classSettings) VideoField(property string) bool {
-	return ic.field("videoFields", property)
-}
-
-func (ic *classSettings) VideoFieldsWeights() ([]float32, error) {
-	return ic.getFieldsWeights("video")
-}
-
 func (ic *classSettings) Properties() ([]string, error) {
 	if ic.cfg == nil {
 		// we would receive a nil-config on cross-class requests, such as Explore{}
@@ -93,7 +85,7 @@ func (ic *classSettings) Properties() ([]string, error) {
 	}
 	props := make([]string, 0)
 
-	fields := []string{"textFields", "imageFields", "videoFields"}
+	fields := []string{"textFields", "imageFields"}
 
 	for _, field := range fields {
 		fields, ok := ic.base.GetSettings()[field]


### PR DESCRIPTION
### What's being changed:

This PR removes video related fields from multi2vec-cohere class settings.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
