### PR TITLE
[Monitoring] Monitor critical segments counts only

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
@@ -486,7 +487,11 @@ func (sg *SegmentGroup) stripTmpExtension(oldPath, left, right string) (string, 
 }
 
 func (sg *SegmentGroup) monitorSegments() {
-	if sg.metrics == nil || sg.metrics.groupClasses {
+	if sg.metrics == nil || sg.metrics.groupClasses ||
+		// Keeping metering to only the critical buckets helps
+		// cut down on noise when monitoring
+		!strings.HasSuffix(sg.dir, helpers.ObjectsBucketLSM) ||
+		!strings.HasSuffix(sg.dir, helpers.VectorsCompressedBucketLSM) {
 		return
 	}
 


### PR DESCRIPTION
### What's being changed:

To reduce noise when metering LSM bucket segment counts, we should only measure this on the primary primary `objects` and `vectors_compressed` buckets.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
