### PR TITLE
skip the schema callbacks when raft schema is still catching up

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -130,7 +130,7 @@ func (s *SchemaManager) Close(ctx context.Context) (err error) {
 	return s.db.Close(ctx)
 }
 
-func (s *SchemaManager) AddClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {
+func (s *SchemaManager) AddClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool, enableSchemaCallback bool) error {
 	req := command.AddClassRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
@@ -144,16 +144,16 @@ func (s *SchemaManager) AddClass(cmd *command.ApplyRequest, nodeID string, schem
 	req.State.SetLocalName(nodeID)
 	return s.apply(
 		applyOp{
-			op:                    cmd.GetType().String(),
-			updateSchema:          func() error { return s.schema.addClass(req.Class, req.State, cmd.Version) },
-			updateStore:           func() error { return s.db.AddClass(req) },
-			schemaOnly:            schemaOnly,
-			triggerSchemaCallback: true,
+			op:                   cmd.GetType().String(),
+			updateSchema:         func() error { return s.schema.addClass(req.Class, req.State, cmd.Version) },
+			updateStore:          func() error { return s.db.AddClass(req) },
+			schemaOnly:           schemaOnly,
+			enableSchemaCallback: enableSchemaCallback,
 		},
 	)
 }
 
-func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {
+func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool, enableSchemaCallback bool) error {
 	req := command.AddClassRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
@@ -174,11 +174,11 @@ func (s *SchemaManager) RestoreClass(cmd *command.ApplyRequest, nodeID string, s
 
 	return s.apply(
 		applyOp{
-			op:                    cmd.GetType().String(),
-			updateSchema:          func() error { return s.schema.addClass(req.Class, req.State, cmd.Version) },
-			updateStore:           func() error { return s.db.AddClass(req) },
-			schemaOnly:            schemaOnly,
-			triggerSchemaCallback: true,
+			op:                   cmd.GetType().String(),
+			updateSchema:         func() error { return s.schema.addClass(req.Class, req.State, cmd.Version) },
+			updateStore:          func() error { return s.db.AddClass(req) },
+			schemaOnly:           schemaOnly,
+			enableSchemaCallback: enableSchemaCallback,
 		},
 	)
 }
@@ -193,7 +193,7 @@ func (s *SchemaManager) ReplaceStatesNodeName(new string) {
 
 // UpdateClass modifies the vectors and inverted indexes associated with a class
 // Other class properties are handled by separate functions
-func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool) error {
+func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, schemaOnly bool, enableSchemaCallback bool) error {
 	req := command.UpdateClassRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
@@ -222,28 +222,28 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 
 	return s.apply(
 		applyOp{
-			op:                    cmd.GetType().String(),
-			updateSchema:          func() error { return s.schema.updateClass(req.Class.Class, update) },
-			updateStore:           func() error { return s.db.UpdateClass(req) },
-			schemaOnly:            schemaOnly,
-			triggerSchemaCallback: true,
+			op:                   cmd.GetType().String(),
+			updateSchema:         func() error { return s.schema.updateClass(req.Class.Class, update) },
+			updateStore:          func() error { return s.db.UpdateClass(req) },
+			schemaOnly:           schemaOnly,
+			enableSchemaCallback: enableSchemaCallback,
 		},
 	)
 }
 
-func (s *SchemaManager) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool) error {
+func (s *SchemaManager) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool, enableSchemaCallback bool) error {
 	return s.apply(
 		applyOp{
-			op:                    cmd.GetType().String(),
-			updateSchema:          func() error { s.schema.deleteClass(cmd.Class); return nil },
-			updateStore:           func() error { return s.db.DeleteClass(cmd.Class) },
-			schemaOnly:            schemaOnly,
-			triggerSchemaCallback: true,
+			op:                   cmd.GetType().String(),
+			updateSchema:         func() error { s.schema.deleteClass(cmd.Class); return nil },
+			updateStore:          func() error { return s.db.DeleteClass(cmd.Class) },
+			schemaOnly:           schemaOnly,
+			enableSchemaCallback: enableSchemaCallback,
 		},
 	)
 }
 
-func (s *SchemaManager) AddProperty(cmd *command.ApplyRequest, schemaOnly bool) error {
+func (s *SchemaManager) AddProperty(cmd *command.ApplyRequest, schemaOnly bool, enableSchemaCallback bool) error {
 	req := command.AddPropertyRequest{}
 	if err := json.Unmarshal(cmd.SubCommand, &req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
@@ -254,11 +254,11 @@ func (s *SchemaManager) AddProperty(cmd *command.ApplyRequest, schemaOnly bool) 
 
 	return s.apply(
 		applyOp{
-			op:                    cmd.GetType().String(),
-			updateSchema:          func() error { return s.schema.addProperty(cmd.Class, cmd.Version, req.Properties...) },
-			updateStore:           func() error { return s.db.AddProperty(cmd.Class, req) },
-			schemaOnly:            schemaOnly,
-			triggerSchemaCallback: true,
+			op:                   cmd.GetType().String(),
+			updateSchema:         func() error { return s.schema.addProperty(cmd.Class, cmd.Version, req.Properties...) },
+			updateStore:          func() error { return s.db.AddProperty(cmd.Class, req) },
+			schemaOnly:           schemaOnly,
+			enableSchemaCallback: enableSchemaCallback,
 		},
 	)
 }
@@ -331,11 +331,11 @@ func (s *SchemaManager) DeleteTenants(cmd *command.ApplyRequest, schemaOnly bool
 }
 
 type applyOp struct {
-	op                    string
-	updateSchema          func() error
-	updateStore           func() error
-	schemaOnly            bool
-	triggerSchemaCallback bool
+	op                   string
+	updateSchema         func() error
+	updateStore          func() error
+	schemaOnly           bool
+	enableSchemaCallback bool
 }
 
 func (op applyOp) validate() error {
@@ -369,7 +369,7 @@ func (s *SchemaManager) apply(op applyOp) error {
 	}
 
 	// Always trigger the schema callback last
-	if op.triggerSchemaCallback {
+	if op.enableSchemaCallback {
 		s.db.TriggerSchemaUpdateCallbacks()
 	}
 	return nil

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -111,6 +111,47 @@ func TestStoreApply(t *testing.T) {
 			},
 		},
 		{
+			name: "AddClass/Success/MetadataOnly",
+			req: raft.Log{Data: cmdAsBytes("C1",
+				cmd.ApplyRequest_TYPE_ADD_CLASS,
+				cmd.AddClassRequest{Class: cls, State: ss},
+				nil)},
+			resp: Response{Error: nil},
+			doBefore: func(m *MockStore) {
+				m.parser.On("ParseClass", mock.Anything).Return(nil)
+				m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+				m.store.cfg.MetadataOnlyVoters = true
+			},
+			doAfter: func(ms *MockStore) error {
+				class := ms.store.SchemaReader().ReadOnlyClass("C1")
+				if class == nil {
+					return fmt.Errorf("class is missing")
+				}
+				return nil
+			},
+		},
+		{
+			name: "AddClass/Success/CatchingUp",
+			req: raft.Log{
+				// Fake the index to higher than 0 as we are always applying the first log entry
+				Index: 2,
+				Data:  cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_CLASS, cmd.AddClassRequest{Class: cls, State: ss}, nil),
+			},
+			resp: Response{Error: nil},
+			doBefore: func(m *MockStore) {
+				m.parser.On("ParseClass", mock.Anything).Return(nil)
+				// Set a high enough last applied index to fake applying a log entry when catching up
+				m.store.lastAppliedIndexToDB.Store(3)
+			},
+			doAfter: func(ms *MockStore) error {
+				class := ms.store.SchemaReader().ReadOnlyClass("C1")
+				if class == nil {
+					return fmt.Errorf("class is missing")
+				}
+				return nil
+			},
+		},
+		{
 			name: "AddClass/DBError",
 			req: raft.Log{
 				Index: 3,


### PR DESCRIPTION
### What's being changed:

Instead of always calling the schema callbacks (aka rebuilding gql) when raft does a schema change, only execute the callbacks when raft not catching up.

This is necessary due to some schema having their classes updated often, or many classes. This can lead to long startup time when weaviate restart as it is replaying raft log entries and rebuilding gql for each of them can take seconds.

See for example: https://forum.weaviate.io/t/raft-make-boostrapping-take-too-long/7474


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/11721321131
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
