### PR TITLE
feat(RBAC): Authorize actions,resources mapping

### DIFF
--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -58,7 +58,7 @@ func setupGraphQLHandlers(
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
 		// authorization requirements.
 
-		err := m.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA)
+		err := m.Authorizer.Authorize(principal, authorization.READ, authorization.Collections()...)
 		if err != nil {
 			metricRequestsTotal.logUserError()
 			switch err.(type) {

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -439,6 +439,6 @@ func (f *fakeBackupBackend) reset() {
 
 type fakeAuthorizer struct{}
 
-func (f *fakeAuthorizer) Authorize(_ *models.Principal, _, _ string) error {
+func (f *fakeAuthorizer) Authorize(_ *models.Principal, _ string, _ ...string) error {
 	return nil
 }

--- a/usecases/auth/authorization/adminlist/authorizer.go
+++ b/usecases/auth/authorization/adminlist/authorizer.go
@@ -38,7 +38,7 @@ func New(cfg Config) *Authorizer {
 
 // Authorize will give full access (to any resource!) if the user is part of
 // the admin list or no access at all if they are not
-func (a *Authorizer) Authorize(principal *models.Principal, verb, resource string) error {
+func (a *Authorizer) Authorize(principal *models.Principal, verb string, resources ...string) error {
 	if principal == nil {
 		principal = newAnonymousPrincipal()
 	}
@@ -53,7 +53,7 @@ func (a *Authorizer) Authorize(principal *models.Principal, verb, resource strin
 		}
 	}
 
-	if verb == "get" || verb == "list" {
+	if verb == "R" {
 		if _, ok := a.readOnlyUsers[principal.Username]; ok {
 			return nil
 		}
@@ -64,7 +64,7 @@ func (a *Authorizer) Authorize(principal *models.Principal, verb, resource strin
 		}
 	}
 
-	return errors.NewForbidden(principal, verb, resource)
+	return errors.NewForbidden(principal, verb, resources...)
 }
 
 func (a *Authorizer) addAdminUserList(users []string) {

--- a/usecases/auth/authorization/adminlist/authorizer_test.go
+++ b/usecases/auth/authorization/adminlist/authorizer_test.go
@@ -31,8 +31,8 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				Username: "johndoe",
 			}
 
-			err := New(cfg).Authorize(principal, "get", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "get", "things"), err,
+			err := New(cfg).Authorize(principal, "R", "things")
+			assert.Equal(t, errors.NewForbidden(principal, "R", "things"), err,
 				"should have the correct err msg")
 		})
 
@@ -43,8 +43,8 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			principal := (*models.Principal)(nil)
-			err := New(cfg).Authorize(principal, "get", "things")
-			assert.Equal(t, errors.NewForbidden(newAnonymousPrincipal(), "get", "things"), err,
+			err := New(cfg).Authorize(principal, "R", "things")
+			assert.Equal(t, errors.NewForbidden(newAnonymousPrincipal(), "R", "things"), err,
 				"should have the correct err msg")
 		})
 
@@ -60,8 +60,8 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				Username: "johndoe",
 			}
 
-			err := New(cfg).Authorize(principal, "get", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "get", "things"), err,
+			err := New(cfg).Authorize(principal, "R", "things")
+			assert.Equal(t, errors.NewForbidden(principal, "R", "things"), err,
 				"should have the correct err msg")
 		})
 
@@ -78,7 +78,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				Username: "johndoe",
 			}
 
-			err := New(cfg).Authorize(principal, "get", "things")
+			err := New(cfg).Authorize(principal, "R", "things")
 			assert.Nil(t, err)
 		})
 
@@ -95,7 +95,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				Username: "johndoe",
 			}
 
-			err := New(cfg).Authorize(principal, "get", "things")
+			err := New(cfg).Authorize(principal, "R", "things")
 			assert.Nil(t, err)
 		})
 
@@ -108,7 +108,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			principal := (*models.Principal)(nil)
-			err := New(cfg).Authorize(principal, "get", "things")
+			err := New(cfg).Authorize(principal, "R", "things")
 			assert.Nil(t, err)
 		})
 	})
@@ -127,8 +127,8 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				"posse",
 			},
 		}
-		err := New(cfg).Authorize(principal, "get", "things")
-		assert.Equal(t, errors.NewForbidden(principal, "get", "things"), err,
+		err := New(cfg).Authorize(principal, "R", "things")
+		assert.Equal(t, errors.NewForbidden(principal, "R", "things"), err,
 			"should have the correct err msg")
 	})
 
@@ -147,7 +147,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				"posse",
 			},
 		}
-		err := New(cfg).Authorize(principal, "get", "things")
+		err := New(cfg).Authorize(principal, "R", "things")
 		assert.Nil(t, err)
 	})
 
@@ -167,7 +167,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			},
 		}
 
-		err := New(cfg).Authorize(principal, "get", "things")
+		err := New(cfg).Authorize(principal, "R", "things")
 		assert.Nil(t, err)
 	})
 
@@ -190,7 +190,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			},
 		}
 
-		err := New(cfg).Authorize(principal, "get", "things")
+		err := New(cfg).Authorize(principal, "R", "things")
 		assert.Nil(t, err)
 	})
 
@@ -213,7 +213,7 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			},
 		}
 
-		err := New(cfg).Authorize(principal, "get", "things")
+		err := New(cfg).Authorize(principal, "R", "things")
 		assert.Nil(t, err)
 	})
 

--- a/usecases/auth/authorization/authorizer.go
+++ b/usecases/auth/authorization/authorizer.go
@@ -21,7 +21,7 @@ import (
 // authorization technique is used in the background (e.g. RBAC, adminlist,
 // ...) is hidden through this interface
 type Authorizer interface {
-	Authorize(principal *models.Principal, verb, resource string) error
+	Authorize(principal *models.Principal, verb string, resources ...string) error
 }
 
 // New Authorizer based on the application-wide config
@@ -40,6 +40,6 @@ type DummyAuthorizer struct{}
 
 // Authorize on the DummyAuthorizer will allow any subject access to any
 // resource
-func (d *DummyAuthorizer) Authorize(principal *models.Principal, verb, resource string) error {
+func (d *DummyAuthorizer) Authorize(principal *models.Principal, verb string, resources ...string) error {
 	return nil
 }

--- a/usecases/auth/authorization/errors/errors.go
+++ b/usecases/auth/authorization/errors/errors.go
@@ -22,16 +22,16 @@ import (
 type Forbidden struct {
 	principal *models.Principal
 	verb      string
-	resource  string
+	resources []string
 }
 
 // NewForbidden creates an explicit Forbidden error with details about the
 // principal and the attempted access on a specific resource
-func NewForbidden(principal *models.Principal, verb, resource string) Forbidden {
+func NewForbidden(principal *models.Principal, verb string, resources ...string) Forbidden {
 	return Forbidden{
 		principal: principal,
 		verb:      verb,
-		resource:  resource,
+		resources: resources,
 	}
 }
 
@@ -46,7 +46,7 @@ func (f Forbidden) Error() string {
 	}
 
 	return fmt.Sprintf("forbidden: user '%s'%s has insufficient permissions to %s %s",
-		f.principal.Username, optionalGroups, f.verb, f.resource)
+		f.principal.Username, optionalGroups, f.verb, f.resources)
 }
 
 func wrapInSingleQuotes(input []string) []string {

--- a/usecases/auth/authorization/errors/errors_test.go
+++ b/usecases/auth/authorization/errors/errors_test.go
@@ -24,7 +24,7 @@ func Test_ForbiddenError_NoGroups(t *testing.T) {
 	}
 
 	err := NewForbidden(principal, "delete", "schema/things")
-	expectedErrMsg := "forbidden: user 'john' has insufficient permissions to delete schema/things"
+	expectedErrMsg := "forbidden: user 'john' has insufficient permissions to delete [schema/things]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 }
 
@@ -35,7 +35,7 @@ func Test_ForbiddenError_SingleGroup(t *testing.T) {
 	}
 
 	err := NewForbidden(principal, "delete", "schema/things")
-	expectedErrMsg := "forbidden: user 'john' (of group 'worstusers') has insufficient permissions to delete schema/things"
+	expectedErrMsg := "forbidden: user 'john' (of group 'worstusers') has insufficient permissions to delete [schema/things]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 }
 
@@ -47,6 +47,6 @@ func Test_ForbiddenError_MultipleGroups(t *testing.T) {
 
 	err := NewForbidden(principal, "delete", "schema/things")
 	expectedErrMsg := "forbidden: user 'john' (of groups 'worstusers', 'fraudsters', 'evilpeople') " +
-		"has insufficient permissions to delete schema/things"
+		"has insufficient permissions to delete [schema/things]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 }

--- a/usecases/auth/authorization/mocks/authorizer.go
+++ b/usecases/auth/authorization/mocks/authorizer.go
@@ -18,7 +18,7 @@ import (
 type AuthZReq struct {
 	Principal *models.Principal
 	Verb      string
-	Resource  string
+	Resources []string
 }
 
 type FakeAuthorizer struct {
@@ -35,8 +35,8 @@ func (a *FakeAuthorizer) SetErr(err error) {
 }
 
 // Authorize provides a mock function with given fields: principal, verb, resource
-func (a *FakeAuthorizer) Authorize(principal *models.Principal, verb string, resource string) error {
-	a.requests = append(a.requests, AuthZReq{principal, verb, resource})
+func (a *FakeAuthorizer) Authorize(principal *models.Principal, verb string, resources ...string) error {
+	a.requests = append(a.requests, AuthZReq{principal, verb, resources})
 	if a.err != nil {
 		return a.err
 	}

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -77,13 +77,13 @@ func Roles(roles ...string) []string {
 //
 //	A slice of strings representing the resource paths.
 func Collections(classes ...string) []string {
-	if len(classes) == 0 {
+	if len(classes) == 0 || (len(classes) == 1 && classes[0] == "") {
 		return []string{"collections/*"}
 	}
 
 	resources := make([]string, len(classes))
 	for idx := range classes {
-		resources[idx] = fmt.Sprintf("collection/%s", classes[idx])
+		resources[idx] = fmt.Sprintf("collections/%s", classes[idx])
 	}
 
 	return resources

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -18,105 +18,140 @@ import (
 )
 
 const (
-	// HEAD: Represents the HTTP HEAD method, which is used to retrieve metadata of a resource without
-	// fetching the resource itself.
-	HEAD = "head"
-	// VALIDATE: Represents a custom action to validate a resource.
-	// This is not a standard HTTP method but can be used for specific validation operations.
-	VALIDATE = "validate"
-	// LIST: Represents a custom action to list resources.
-	// This is not a standard HTTP method but can be used to list multiple resources.
-	LIST = "list"
-	// GET: Represents the HTTP GET method, which is used to retrieve a resource.
-	GET = "get"
-	// ADD: Represents a custom action to add a resource.
-	// This is not a standard HTTP method but can be used for specific add operations.
-	ADD = "add"
-	// CREATE: Represents the HTTP POST method, which is used to create a new resource.
-	CREATE = "create"
-	// RESTORE: Represents a custom action to restore a resource.
-	// This is not a standard HTTP method but can be used for specific restore operations.
-	RESTORE = "restore"
-	// DELETE: Represents the HTTP DELETE method, which is used to delete a resource.
-	DELETE = "delete"
-	// UPDATE: Represents the HTTP PUT method, which is used to update an existing resource.
-	UPDATE = "update"
+
+	// TODO shall be added if the user can CRUD the resource on permission creation
+	// // CRUD allow all actions on a resource
+	// CRUD = "(C)|(R)|(U)|(D)"
+
+	// CREATE Represents the action to create a new resource.
+	CREATE = "C"
+	// READ Represents the action to retrieve a resource.
+	READ = "R"
+	// UPDATE Represents the action to update an existing resource.
+	UPDATE = "U"
+	// DELETE Represents the action to delete a resource.
+	DELETE = "D"
 )
 
-const (
-	// ALL_SCHEMA represents all schema-related resources.
-	ALL_SCHEMA = "schema/*"
-	// SCHEMA_TENANTS represents the schema tenants resource.
-	SCHEMA_TENANTS = "schema/tenants"
-	// SCHEMA_OBJECTS represents the schema objects resource.
-	SCHEMA_OBJECTS = "schema/objects"
-	// ALL_TRAVERSAL represents all traversal-related resources.
-	ALL_TRAVERSAL = "traversal/*"
-	// ALL_CLASSIFICATIONS represents all classification-related resources.
-	ALL_CLASSIFICATIONS = "classifications/*"
-	// NODES represents the nodes resource.
-	NODES = "nodes"
-	// CLUSTER represents the cluster resource.
-	CLUSTER = "cluster"
-	// ALL_BATCH represents all batch-related resources.
-	ALL_BATCH = "batch/*"
-	// BATCH_OBJECTS represents the batch objects resource.
-	BATCH_OBJECTS = "batch/objects"
-	// OBJECTS represents the objects resource.
-	OBJECTS = "objects"
-)
-
-// SchemaShard returns the path for a specific schema shard.
-// Parameters:
-// - class: The class name.
-// - shard: The shard name.
-// Returns: The formatted schema shard path.
-func SchemaShard(class, shard string) string {
-	if class != "" && shard != "" {
-		return fmt.Sprintf("schema/%s/shards/%s", class, shard)
-	}
-
-	return fmt.Sprintf("schema/%s/shards", class)
+// Cluster returns a string representing the cluster authorization scope.
+// The returned string is "cluster/*", which can be used to specify that
+// the authorization applies to all resources within the cluster.
+func Cluster() string {
+	return "cluster/*"
 }
 
-// Objects returns the path for a specific object or class.
+// Roles generates a list of role resource strings based on the provided role names.
+// If no role names are provided, it returns a default role resource string "roles/*".
+//
 // Parameters:
-// - class: The class name (optional).
-// - id: The object ID (optional).
-// Returns: The formatted objects path.
-func Objects(class string, id strfmt.UUID) string {
-	if class != "" && id != "" {
-		return fmt.Sprintf("objects/%s/%s", class, id.String())
+//
+//	roles - A variadic parameter representing the role names.
+//
+// Returns:
+//
+//	A slice of strings where each string is a formatted role resource string.
+func Roles(roles ...string) []string {
+	if len(roles) == 0 {
+		return []string{
+			"roles/*",
+		}
 	}
 
-	if id != "" {
-		return fmt.Sprintf("objects/%s", id.String())
+	resources := make([]string, len(roles))
+	for idx := range roles {
+		resources[idx] = fmt.Sprintf("roles/%s", roles[idx])
 	}
 
-	if class != "" {
-		return fmt.Sprintf("objects/%s", class)
-	}
-
-	return OBJECTS
+	return resources
 }
 
-// Backup returns the path for a specific backup.
+// Collections generates a list of resource strings for the given classes.
+// If no classes are provided, it returns a default resource string "collections/*".
+// Each class is formatted as "collection/{class}".
+//
 // Parameters:
-// - backend: The backup backend name.
-// - id: The backup ID (optional).
-// Returns: The formatted backup path.
-func Backup(backend, id string) string {
-	if id == "" {
-		return fmt.Sprintf("backups/%s", backend)
+//
+//	classes - a variadic parameter representing the class names.
+//
+// Returns:
+//
+//	A slice of strings representing the resource paths.
+func Collections(classes ...string) []string {
+	if len(classes) == 0 {
+		return []string{"collections/*"}
 	}
-	return fmt.Sprintf("backups/%s/%s", backend, id)
+
+	resources := make([]string, len(classes))
+	for idx := range classes {
+		resources[idx] = fmt.Sprintf("collection/%s", classes[idx])
+	}
+
+	return resources
 }
 
-// Restore returns the path for restoring a specific backup.
+// Shards generates a list of shard resource strings for a given class and shards.
+// If the class is an empty string, it defaults to "*". If no shards are provided,
+// it returns a single resource string with a wildcard for shards. If shards are
+// provided, it returns a list of resource strings for each shard.
+//
 // Parameters:
-// - backend: The backup backend name.
-// - id: The backup ID.
-// Returns: The formatted restore path.
-func Restore(backend, id string) string {
-	return fmt.Sprintf("backups/%s/%s/restore", backend, id)
+//   - class: The class name for the resource. If empty, defaults to "*".
+//   - shards: A variadic list of shard names. If empty, a wildcard is used.
+//
+// Returns:
+//
+//	A slice of strings representing the resource paths for the given class and shards.
+func Shards(class string, shards ...string) []string {
+	if class == "" {
+		class = "*"
+	}
+
+	if len(shards) == 0 {
+		return []string{fmt.Sprintf("collection/%s/shards/*", class)}
+	}
+
+	resources := make([]string, len(shards))
+	for idx := range shards {
+		if shards[idx] == "" {
+			resources[idx] = fmt.Sprintf("collection/%s/shards/*", class)
+		} else {
+			resources[idx] = fmt.Sprintf("collection/%s/shards/%s", class, shards[idx])
+		}
+	}
+
+	return resources
+}
+
+// Objects generates a string representing a path to objects within a collection and shard.
+// The path format varies based on the provided class, shard, and id parameters.
+//
+// Parameters:
+// - class: the class of the collection (string)
+// - shard: the shard identifier (string)
+// - id: the unique identifier of the object (strfmt.UUID)
+//
+// Returns:
+// - A string representing the path to the objects, with wildcards (*) used for any empty parameters.
+//
+// Example outputs:
+// - "collections/*/shards/*/objects/*" if all parameters are empty
+// - "collections/*/shards/*/objects/{id}" if only id is provided
+// - "collections/{class}/shards/{shard}/objects/{id}" if all parameters are provided
+func Objects(class, shard string, id strfmt.UUID) string {
+	if class == "" && shard == "" && id == "" {
+		return "collections/*/shards/*/objects/*"
+	} else if class == "" && shard == "" {
+		return fmt.Sprintf("collections/*/shards/*/objects/%s", id)
+	} else if class == "" && id == "" {
+		return fmt.Sprintf("collections/*/shards/%s/objects/*", shard)
+	} else if shard == "" && id == "" {
+		return fmt.Sprintf("collections/%s/shards/*/objects/*", class)
+	} else if class == "" {
+		return fmt.Sprintf("collections/*/shards/%s/objects/%s", shard, id)
+	} else if shard == "" {
+		return fmt.Sprintf("collections/%s/shards/*/objects/%s", class, id)
+	} else if id == "" {
+		return fmt.Sprintf("collections/%s/shards/%s/objects/*", class, shard)
+	}
+	return fmt.Sprintf("collections/%s/shards/%s/objects/%s", class, shard, id)
 }

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -50,8 +50,9 @@ func TestCollections(t *testing.T) {
 		expected []string
 	}{
 		{"No classes", []string{}, []string{"collections/*"}},
-		{"Single class", []string{"class1"}, []string{"collection/class1"}},
-		{"Multiple classes", []string{"class1", "class2"}, []string{"collection/class1", "collection/class2"}},
+		{"Single empty class", []string{""}, []string{"collections/*"}},
+		{"Single class", []string{"class1"}, []string{"collections/class1"}},
+		{"Multiple classes", []string{"class1", "class2"}, []string{"collections/class1", "collections/class2"}},
 	}
 
 	for _, tt := range tests {

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -1,0 +1,112 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package authorization
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoles(t *testing.T) {
+	tests := []struct {
+		name     string
+		roles    []string
+		expected []string
+	}{
+		{"No roles", []string{}, []string{"roles/*"}},
+		{"Single role", []string{"admin"}, []string{"roles/admin"}},
+		{"Multiple roles", []string{"admin", "user"}, []string{"roles/admin", "roles/user"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Roles(tt.roles...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCluster(t *testing.T) {
+	expected := "cluster/*"
+	result := Cluster()
+	assert.Equal(t, expected, result)
+}
+
+func TestCollections(t *testing.T) {
+	tests := []struct {
+		name     string
+		classes  []string
+		expected []string
+	}{
+		{"No classes", []string{}, []string{"collections/*"}},
+		{"Single class", []string{"class1"}, []string{"collection/class1"}},
+		{"Multiple classes", []string{"class1", "class2"}, []string{"collection/class1", "collection/class2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Collections(tt.classes...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShards(t *testing.T) {
+	tests := []struct {
+		name     string
+		class    string
+		shards   []string
+		expected []string
+	}{
+		{"No class, no shards", "", []string{}, []string{"collection/*/shards/*"}},
+		{"Class, no shards", "class1", []string{}, []string{"collection/class1/shards/*"}},
+		{"No class, single shard", "", []string{"shard1"}, []string{"collection/*/shards/shard1"}},
+		{"Class, single shard", "class1", []string{"shard1"}, []string{"collection/class1/shards/shard1"}},
+		{"Class, multiple shards", "class1", []string{"shard1", "shard2"}, []string{"collection/class1/shards/shard1", "collection/class1/shards/shard2"}},
+		{"Class, empty shard", "class1", []string{"shard1", ""}, []string{"collection/class1/shards/shard1", "collection/class1/shards/*"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Shards(tt.class, tt.shards...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestObjects(t *testing.T) {
+	tests := []struct {
+		name     string
+		class    string
+		shard    string
+		id       strfmt.UUID
+		expected string
+	}{
+		{"No class, no shard, no id", "", "", "", "collections/*/shards/*/objects/*"},
+		{"Class, no shard, no id", "class1", "", "", "collections/class1/shards/*/objects/*"},
+		{"No class, shard, no id", "", "shard1", "", "collections/*/shards/shard1/objects/*"},
+		{"No class, no shard, id", "", "", "id1", "collections/*/shards/*/objects/id1"},
+		{"Class, shard, no id", "class1", "shard1", "", "collections/class1/shards/shard1/objects/*"},
+		{"Class, no shard, id", "class1", "", "id1", "collections/class1/shards/*/objects/id1"},
+		{"No class, shard, id", "", "shard1", "id1", "collections/*/shards/shard1/objects/id1"},
+		{"Class, shard, id", "class1", "shard1", "id1", "collections/class1/shards/shard1/objects/id1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Objects(tt.class, tt.shard, tt.id)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -42,38 +42,38 @@ func Test_Authorization(t *testing.T) {
 		{
 			methodName:       "Backup",
 			additionalArgs:   []interface{}{req},
-			expectedVerb:     authorization.ADD,
-			expectedResource: "backups/s3/123",
+			expectedVerb:     authorization.CREATE,
+			expectedResource: authorization.Cluster(),
 		},
 		{
 			methodName:       "BackupStatus",
 			additionalArgs:   []interface{}{"s3", "123", "", ""},
-			expectedVerb:     authorization.GET,
-			expectedResource: "backups/s3/123",
+			expectedVerb:     authorization.READ,
+			expectedResource: authorization.Cluster(),
 		},
 		{
 			methodName:       "Restore",
 			additionalArgs:   []interface{}{req},
-			expectedVerb:     authorization.RESTORE,
-			expectedResource: "backups/s3/123/restore",
+			expectedVerb:     authorization.CREATE,
+			expectedResource: authorization.Cluster(),
 		},
 		{
 			methodName:       "RestorationStatus",
 			additionalArgs:   []interface{}{"s3", "123", "", ""},
-			expectedVerb:     authorization.GET,
-			expectedResource: "backups/s3/123/restore",
+			expectedVerb:     authorization.READ,
+			expectedResource: authorization.Cluster(),
 		},
 		{
 			methodName:       "Cancel",
 			additionalArgs:   []interface{}{"s3", "123", "", ""},
 			expectedVerb:     authorization.DELETE,
-			expectedResource: "backups/s3/123",
+			expectedResource: authorization.Cluster(),
 		},
 		{
 			methodName:       "List",
 			additionalArgs:   []interface{}{"s3"},
-			expectedVerb:     authorization.GET,
-			expectedResource: "backups/s3",
+			expectedVerb:     authorization.READ,
+			expectedResource: authorization.Cluster(),
 		},
 	}
 
@@ -108,7 +108,7 @@ func Test_Authorization(t *testing.T) {
 				require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 				assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 					"execution must abort with authorizer error")
-				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
 					authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 			})
 		}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -76,7 +76,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		logOperation(s.logger, "try_backup", req.ID, req.Backend, begin, err)
 	}(time.Now())
 
-	if err := s.authorizer.Authorize(pr, authorization.ADD, authorization.Backup(req.Backend, req.ID)); err != nil {
+	if err := s.authorizer.Authorize(pr, authorization.CREATE, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
@@ -126,7 +126,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	defer func(begin time.Time) {
 		logOperation(s.logger, "try_restore", req.ID, req.Backend, begin, err)
 	}(time.Now())
-	if err := s.authorizer.Authorize(pr, authorization.RESTORE, authorization.Restore(req.Backend, req.ID)); err != nil {
+	if err := s.authorizer.Authorize(pr, authorization.CREATE, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
@@ -179,7 +179,7 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 	defer func(begin time.Time) {
 		logOperation(s.logger, "backup_status", backupID, backend, begin, err)
 	}(time.Now())
-	if err := s.authorizer.Authorize(principal, authorization.GET, authorization.Backup(backend, backupID)); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.READ, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, backend, backupID, overrideBucket, overridePath)
@@ -201,7 +201,7 @@ func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Pri
 	defer func(begin time.Time) {
 		logOperation(s.logger, "restoration_status", backupID, backend, time.Now(), err)
 	}(time.Now())
-	if err := s.authorizer.Authorize(principal, authorization.GET, authorization.Restore(backend, backupID)); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.READ, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 	store, err := coordBackend(s.backends, backend, backupID, overrideBucket, overridePath)
@@ -224,7 +224,7 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 		logOperation(s.logger, "cancel_backup", backupID, backend, begin, err)
 	}(time.Now())
 
-	if err := s.authorizer.Authorize(principal, authorization.DELETE, authorization.Backup(backend, backupID)); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.DELETE, authorization.Cluster()); err != nil {
 		return err
 	}
 
@@ -275,7 +275,7 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 	defer func(begin time.Time) {
 		logOperation(s.logger, "list_backup", "", backend, time.Now(), err)
 	}(time.Now())
-	if err := s.authorizer.Authorize(principal, authorization.GET, authorization.Backup(backend, "")); err != nil {
+	if err := s.authorizer.Authorize(principal, authorization.READ, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -131,7 +131,7 @@ type NeighborRef struct {
 }
 
 func (c *Classifier) Schedule(ctx context.Context, principal *models.Principal, params models.Classification) (*models.Classification, error) {
-	err := c.authorizer.Authorize(principal, authorization.CREATE, authorization.ALL_CLASSIFICATIONS)
+	err := c.authorizer.Authorize(principal, authorization.UPDATE, authorization.Collections(params.Class)...)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (c *Classifier) assignNewID(params *models.Classification) error {
 }
 
 func (c *Classifier) Get(ctx context.Context, principal *models.Principal, id strfmt.UUID) (*models.Classification, error) {
-	err := c.authorizer.Authorize(principal, authorization.GET, authorization.ALL_CLASSIFICATIONS)
+	err := c.authorizer.Authorize(principal, authorization.READ, authorization.Collections()...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -49,7 +49,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
-	if err := m.authorizer.Authorize(principal, authorization.LIST, authorization.NODES); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 	return m.db.GetNodeStatus(ctxWithTimeout, className, verbosity)
@@ -61,7 +61,7 @@ func (m *Manager) GetNodeStatistics(ctx context.Context,
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
 
-	if err := m.authorizer.Authorize(principal, authorization.LIST, authorization.CLUSTER); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Cluster()); err != nil {
 		return nil, err
 	}
 	return m.db.GetNodeStatistics(ctxWithTimeout)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -31,7 +31,15 @@ import (
 func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(object.Class, object.Tenant)...)
+	var (
+		class  = "*"
+		tenant = "*"
+	)
+	if object != nil {
+		class = object.Class
+		tenant = object.Tenant
+	}
+	err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(class, tenant)...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -31,7 +31,7 @@ import (
 func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.CREATE, authorization.OBJECTS)
+	err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(object.Class, object.Tenant)...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -57,7 +57,7 @@ func Test_Kinds_Authorization(t *testing.T) {
 		{
 			methodName:       "GetObject",
 			additionalArgs:   []interface{}{"", strfmt.UUID("foo"), additional.Properties{}},
-			expectedVerb:     authorization.GET,
+			expectedVerb:     authorization.READ,
 			expectedResource: "objects/foo",
 		},
 		{
@@ -96,13 +96,13 @@ func Test_Kinds_Authorization(t *testing.T) {
 		{
 			methodName:       "GetObjectsClass",
 			additionalArgs:   []interface{}{strfmt.UUID("foo")},
-			expectedVerb:     authorization.GET,
+			expectedVerb:     authorization.READ,
 			expectedResource: "objects/foo",
 		},
 		{
 			methodName:       "GetObjectClassFromName",
 			additionalArgs:   []interface{}{strfmt.UUID("foo")},
-			expectedVerb:     authorization.GET,
+			expectedVerb:     authorization.READ,
 			expectedResource: "objects/foo",
 		},
 		{
@@ -193,7 +193,7 @@ func Test_Kinds_Authorization(t *testing.T) {
 						"execution must abort with authorizer error")
 				}
 
-				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
 					authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 			})
 		}
@@ -284,7 +284,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 			require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 			assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 				"execution must abort with authorizer error")
-			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
 				authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 		}
 	})

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -34,55 +34,55 @@ import (
 
 func Test_Kinds_Authorization(t *testing.T) {
 	type testCase struct {
-		methodName       string
-		additionalArgs   []interface{}
-		expectedVerb     string
-		expectedResource string
+		methodName        string
+		additionalArgs    []interface{}
+		expectedVerb      string
+		expectedResources []string
 	}
 
 	tests := []testCase{
 		// single kind
 		{
-			methodName:       "AddObject",
-			additionalArgs:   []interface{}{(*models.Object)(nil)},
-			expectedVerb:     "create",
-			expectedResource: "objects",
+			methodName:        "AddObject",
+			additionalArgs:    []interface{}{(*models.Object)(nil)},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("", ""),
 		},
 		{
-			methodName:       "ValidateObject",
-			additionalArgs:   []interface{}{(*models.Object)(nil)},
-			expectedVerb:     "validate",
-			expectedResource: "objects",
+			methodName:        "ValidateObject",
+			additionalArgs:    []interface{}{(*models.Object)(nil)},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("", "", "")},
 		},
 		{
-			methodName:       "GetObject",
-			additionalArgs:   []interface{}{"", strfmt.UUID("foo"), additional.Properties{}},
-			expectedVerb:     authorization.READ,
-			expectedResource: "objects/foo",
+			methodName:        "GetObject",
+			additionalArgs:    []interface{}{"", strfmt.UUID("foo"), additional.Properties{}},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("", "", "foo")},
 		},
 		{
-			methodName:       "DeleteObject",
-			additionalArgs:   []interface{}{"class", strfmt.UUID("foo")},
-			expectedVerb:     authorization.DELETE,
-			expectedResource: "objects/class/foo",
+			methodName:        "DeleteObject",
+			additionalArgs:    []interface{}{"class", strfmt.UUID("foo")},
+			expectedVerb:      authorization.DELETE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{ // deprecated by the one above
-			methodName:       "DeleteObject",
-			additionalArgs:   []interface{}{"", strfmt.UUID("foo")},
-			expectedVerb:     authorization.DELETE,
-			expectedResource: "objects/foo",
+			methodName:        "DeleteObject",
+			additionalArgs:    []interface{}{"class", strfmt.UUID("foo")},
+			expectedVerb:      authorization.DELETE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{
-			methodName:       "UpdateObject",
-			additionalArgs:   []interface{}{"class", strfmt.UUID("foo"), (*models.Object)(nil)},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "objects/class/foo",
+			methodName:        "UpdateObject",
+			additionalArgs:    []interface{}{"class", strfmt.UUID("foo"), (*models.Object)(nil)},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{ // deprecated by the one above
-			methodName:       "UpdateObject",
-			additionalArgs:   []interface{}{"", strfmt.UUID("foo"), (*models.Object)(nil)},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "objects/foo",
+			methodName:        "UpdateObject",
+			additionalArgs:    []interface{}{"class", strfmt.UUID("foo"), (*models.Object)(nil)},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{
 			methodName: "MergeObject",
@@ -90,67 +90,67 @@ func Test_Kinds_Authorization(t *testing.T) {
 				&models.Object{Class: "class", ID: "foo"},
 				(*additional.ReplicationProperties)(nil),
 			},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "objects/class/foo",
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{
-			methodName:       "GetObjectsClass",
-			additionalArgs:   []interface{}{strfmt.UUID("foo")},
-			expectedVerb:     authorization.READ,
-			expectedResource: "objects/foo",
+			methodName:        "GetObjectsClass",
+			additionalArgs:    []interface{}{strfmt.UUID("foo")},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("", "", "foo")},
 		},
 		{
-			methodName:       "GetObjectClassFromName",
-			additionalArgs:   []interface{}{strfmt.UUID("foo")},
-			expectedVerb:     authorization.READ,
-			expectedResource: "objects/foo",
+			methodName:        "GetObjectClassFromName",
+			additionalArgs:    []interface{}{strfmt.UUID("foo")},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("", "", "foo")},
 		},
 		{
-			methodName:       "HeadObject",
-			additionalArgs:   []interface{}{"class", strfmt.UUID("foo")},
-			expectedVerb:     "head",
-			expectedResource: "objects/class/foo",
+			methodName:        "HeadObject",
+			additionalArgs:    []interface{}{"class", strfmt.UUID("foo")},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{ // deprecated by the one above
-			methodName:       "HeadObject",
-			additionalArgs:   []interface{}{"", strfmt.UUID("foo")},
-			expectedVerb:     "head",
-			expectedResource: "objects/foo",
+			methodName:        "HeadObject",
+			additionalArgs:    []interface{}{"", strfmt.UUID("foo")},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("", "", "foo")},
 		},
 
 		// query objects
 		{
-			methodName:       "Query",
-			additionalArgs:   []interface{}{new(QueryParams)},
-			expectedVerb:     "list",
-			expectedResource: "objects",
+			methodName:        "Query",
+			additionalArgs:    []interface{}{new(QueryParams)},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Shards("", "")[0]},
 		},
 
 		{ // list objects is deprecated by query
-			methodName:       "GetObjects",
-			additionalArgs:   []interface{}{(*int64)(nil), (*int64)(nil), (*string)(nil), (*string)(nil), additional.Properties{}},
-			expectedVerb:     "list",
-			expectedResource: "objects",
+			methodName:        "GetObjects",
+			additionalArgs:    []interface{}{(*int64)(nil), (*int64)(nil), (*string)(nil), (*string)(nil), additional.Properties{}},
+			expectedVerb:      authorization.READ,
+			expectedResources: []string{authorization.Objects("", "", "")},
 		},
 
 		// reference on objects
 		{
-			methodName:       "AddObjectReference",
-			additionalArgs:   []interface{}{AddReferenceInput{Class: "class", ID: strfmt.UUID("foo"), Property: "some prop"}, (*models.SingleRef)(nil)},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "objects/class/foo",
+			methodName:        "AddObjectReference",
+			additionalArgs:    []interface{}{AddReferenceInput{Class: "class", ID: strfmt.UUID("foo"), Property: "some prop"}, (*models.SingleRef)(nil)},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 		{
-			methodName:       "DeleteObjectReference",
-			additionalArgs:   []interface{}{strfmt.UUID("foo"), "some prop", (*models.SingleRef)(nil)},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "objects/foo",
+			methodName:        "DeleteObjectReference",
+			additionalArgs:    []interface{}{strfmt.UUID("foo"), "some prop", (*models.SingleRef)(nil)},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: []string{authorization.Objects("", "", "foo")},
 		},
 		{
-			methodName:       "UpdateObjectReferences",
-			additionalArgs:   []interface{}{&PutReferenceInput{Class: "class", ID: strfmt.UUID("foo"), Property: "some prop"}},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "objects/class/foo",
+			methodName:        "UpdateObjectReferences",
+			additionalArgs:    []interface{}{&PutReferenceInput{Class: "class", ID: strfmt.UUID("foo"), Property: "some prop"}},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: []string{authorization.Objects("class", "", "foo")},
 		},
 	}
 
@@ -193,7 +193,7 @@ func Test_Kinds_Authorization(t *testing.T) {
 						"execution must abort with authorizer error")
 				}
 
-				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: test.expectedResources},
 					authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 			})
 		}
@@ -202,34 +202,32 @@ func Test_Kinds_Authorization(t *testing.T) {
 
 func Test_BatchKinds_Authorization(t *testing.T) {
 	type testCase struct {
-		methodName       string
-		additionalArgs   []interface{}
-		expectedVerb     string
-		expectedResource string
+		methodName        string
+		additionalArgs    []interface{}
+		expectedVerb      string
+		expectedResources []string
 	}
 
 	tests := []testCase{
 		{
 			methodName: "AddObjects",
 			additionalArgs: []interface{}{
-				[]*models.Object{},
+				[]*models.Object{{}},
 				[]*string{},
 				&additional.ReplicationProperties{},
 			},
-			expectedVerb:     "create",
-			expectedResource: "batch/objects",
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("", ""),
 		},
-
 		{
 			methodName: "AddReferences",
 			additionalArgs: []interface{}{
-				[]*models.BatchReference{},
+				[]*models.BatchReference{{}},
 				&additional.ReplicationProperties{},
 			},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "batch/*",
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("", ""),
 		},
-
 		{
 			methodName: "DeleteObjects",
 			additionalArgs: []interface{}{
@@ -239,8 +237,8 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 				&additional.ReplicationProperties{},
 				"",
 			},
-			expectedVerb:     authorization.DELETE,
-			expectedResource: "batch/objects",
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("", ""),
 		},
 		{
 			methodName: "DeleteObjectsFromGRPC",
@@ -249,8 +247,8 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 				&additional.ReplicationProperties{},
 				"",
 			},
-			expectedVerb:     authorization.DELETE,
-			expectedResource: "batch/objects",
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("", ""),
 		},
 	}
 
@@ -284,7 +282,7 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 			require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 			assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 				"execution must abort with authorizer error")
-			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
+			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: test.expectedResources},
 				authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 		}
 	})

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -37,7 +37,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 	}
 
 	for class, shards := range classesShards {
-		err := b.authorizer.Authorize(principal, authorization.CREATE, authorization.Shards(class, shards...)...)
+		err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(class, shards...)...)
 		if err != nil {
 			return nil, err
 		}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -31,8 +31,13 @@ var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be
 func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
 ) (BatchObjects, error) {
+	classesShards := make(map[string][]string)
 	for _, obj := range objects {
-		err := b.authorizer.Authorize(principal, authorization.CREATE, authorization.Objects(obj.Class, obj.Tenant, ""))
+		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
+	}
+
+	for class, shards := range classesShards {
+		err := b.authorizer.Authorize(principal, authorization.CREATE, authorization.Shards(class, shards...)...)
 		if err != nil {
 			return nil, err
 		}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -31,9 +31,11 @@ var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be
 func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
 ) (BatchObjects, error) {
-	err := b.authorizer.Authorize(principal, authorization.CREATE, authorization.BATCH_OBJECTS)
-	if err != nil {
-		return nil, err
+	for _, obj := range objects {
+		err := b.authorizer.Authorize(principal, authorization.CREATE, authorization.Objects(obj.Class, obj.Tenant, ""))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ctx = classcache.ContextWithClassCache(ctx)

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -31,7 +31,7 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	match *models.BatchDeleteMatch, dryRun *bool, output *string,
 	repl *additional.ReplicationProperties, tenant string,
 ) (*BatchDeleteResponse, error) {
-	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(match.Class, tenant, ""))
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(match.Class, tenant)...)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (b *BatchManager) DeleteObjectsFromGRPC(ctx context.Context, principal *mod
 	params BatchDeleteParams,
 	repl *additional.ReplicationProperties, tenant string,
 ) (BatchDeleteResult, error) {
-	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(params.ClassName.String(), tenant, ""))
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(params.ClassName.String(), tenant)...)
 	if err != nil {
 		return BatchDeleteResult{}, err
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -31,7 +31,11 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	match *models.BatchDeleteMatch, dryRun *bool, output *string,
 	repl *additional.ReplicationProperties, tenant string,
 ) (*BatchDeleteResponse, error) {
-	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(match.Class, tenant)...)
+	class := "*"
+	if match != nil {
+		class = match.Class
+	}
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(class, tenant)...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -31,7 +31,7 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	match *models.BatchDeleteMatch, dryRun *bool, output *string,
 	repl *additional.ReplicationProperties, tenant string,
 ) (*BatchDeleteResponse, error) {
-	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.BATCH_OBJECTS)
+	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(match.Class, tenant, ""))
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (b *BatchManager) DeleteObjectsFromGRPC(ctx context.Context, principal *mod
 	params BatchDeleteParams,
 	repl *additional.ReplicationProperties, tenant string,
 ) (BatchDeleteResult, error) {
-	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.BATCH_OBJECTS)
+	err := b.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(params.ClassName.String(), tenant, ""))
 	if err != nil {
 		return BatchDeleteResult{}, err
 	}

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -32,9 +32,11 @@ import (
 func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Principal,
 	refs []*models.BatchReference, repl *additional.ReplicationProperties,
 ) (BatchReferences, error) {
-	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.ALL_BATCH)
-	if err != nil {
-		return nil, err
+	for _, ref := range refs {
+		err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards("*", ref.Tenant)...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ctx = classcache.ContextWithClassCache(ctx)

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -32,11 +32,14 @@ import (
 func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Principal,
 	refs []*models.BatchReference, repl *additional.ReplicationProperties,
 ) (BatchReferences, error) {
-	for _, ref := range refs {
-		err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards("*", ref.Tenant)...)
-		if err != nil {
-			return nil, err
-		}
+	shardNames := make([]string, len(refs))
+	for idx := range refs {
+		shardNames[idx] = refs[idx].Tenant
+	}
+
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards("*", shardNames...)...)
+	if err != nil {
+		return nil, err
 	}
 
 	ctx = classcache.ContextWithClassCache(ctx)

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -37,7 +37,7 @@ func (b *BatchManager) AddReferences(ctx context.Context, principal *models.Prin
 		shardNames[idx] = refs[idx].Tenant
 	}
 
-	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards("*", shardNames...)...)
+	err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards("", shardNames...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -32,7 +32,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	principal *models.Principal, class string, id strfmt.UUID,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
-	err := m.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(class, id))
+	err := m.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(class, tenant, id))
 	if err != nil {
 		return err
 	}

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -30,7 +30,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, additional additional.Properties,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.GET, authorization.Objects(class, id))
+	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(class, tenant, id))
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	offset *int64, limit *int64, sort *string, order *string, after *string,
 	addl additional.Properties, tenant string,
 ) ([]*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.LIST, authorization.OBJECTS)
+	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects("", tenant, ""))
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Principal,
 	id strfmt.UUID,
 ) (*models.Class, error) {
-	err := m.authorizer.Authorize(principal, authorization.GET, authorization.Objects("", id))
+	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects("", "", id))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -25,9 +25,8 @@ import (
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, class string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	path := authorization.Objects(class, id)
-	if err := m.authorizer.Authorize(principal, authorization.HEAD, path); err != nil {
-		return false, &Error{path, StatusForbidden, err}
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {
+		return false, &Error{err.Error(), StatusForbidden, err}
 	}
 
 	unlock, err := m.locks.LockConnector()

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -46,9 +46,8 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{"bad request", StatusBadRequest, err}
 	}
 	cls, id := updates.Class, updates.ID
-	path := authorization.Objects(cls, id)
-	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
-		return &Error{path, StatusForbidden, err}
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {
+		return &Error{err.Error(), StatusForbidden, err}
 	}
 
 	m.metrics.MergeObjectInc()
@@ -56,7 +55,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 
 	if err := m.allocChecker.CheckAlloc(memwatch.EstimateObjectMemory(updates)); err != nil {
 		m.logger.WithError(err).Errorf("memory pressure: cannot process patch object")
-		return &Error{path, StatusInternalServerError, err}
+		return &Error{err.Error(), StatusInternalServerError, err}
 	}
 
 	ctx = classcache.ContextWithClassCache(ctx)

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -66,7 +66,18 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Shards(params.Class, *params.Tenant)...); err != nil {
+	class := "*"
+	tenant := "*"
+
+	if params != nil && params.Class != "" {
+		class = params.Class
+	}
+
+	if params != nil && params.Tenant != nil && *params.Tenant != "" {
+		tenant = *params.Tenant
+	}
+
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Shards(class, tenant)...); err != nil {
 		return nil, &Error{err.Error(), StatusForbidden, err}
 	}
 	unlock, err := m.locks.LockConnector()

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -66,9 +66,8 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
-	path := authorization.Objects(params.Class, "")
-	if err := m.authorizer.Authorize(principal, authorization.LIST, path); err != nil {
-		return nil, &Error{path, StatusForbidden, err}
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(params.Class, *params.Tenant, "")); err != nil {
+		return nil, &Error{err.Error(), StatusForbidden, err}
 	}
 	unlock, err := m.locks.LockConnector()
 	if err != nil {

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -66,7 +66,7 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(params.Class, *params.Tenant, "")); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Shards(params.Class, *params.Tenant)...); err != nil {
 		return nil, &Error{err.Error(), StatusForbidden, err}
 	}
 	unlock, err := m.locks.LockConnector()

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -52,9 +52,9 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		}
 		input.Class = objectRes.Object().Class
 	}
-	path := authorization.Objects(input.Class, input.ID)
-	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
-		return &Error{path, StatusForbidden, err}
+
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(input.Class, tenant)...); err != nil {
+		return &Error{err.Error(), StatusForbidden, err}
 	}
 
 	unlock, err := m.locks.LockSchema()

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -73,9 +73,8 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	}
 	input.Class = res.ClassName
 
-	path := authorization.Objects(input.Class, input.ID)
-	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
-		return &Error{path, StatusForbidden, err}
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(input.Class, tenant)...); err != nil {
+		return &Error{err.Error(), StatusForbidden, err}
 	}
 
 	unlock, err := m.locks.LockSchema()

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -64,9 +64,8 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	}
 	input.Class = res.ClassName
 
-	path := authorization.Objects(input.Class, input.ID)
-	if err := m.authorizer.Authorize(principal, authorization.UPDATE, path); err != nil {
-		return &Error{path, StatusForbidden, err}
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(input.Class, tenant)...); err != nil {
+		return &Error{err.Error(), StatusForbidden, err}
 	}
 
 	unlock, err := m.locks.LockSchema()

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -30,8 +30,13 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, updates *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(class, id))
-	if err != nil {
+	// can read source
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(class, "", id)); err != nil {
+		return nil, err
+	}
+
+	// can update target
+	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -30,12 +30,6 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, updates *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	// can read source
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(class, "", id)); err != nil {
-		return nil, err
-	}
-
-	// can update target
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {
 		return nil, err
 	}

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -25,7 +25,7 @@ import (
 func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principal,
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
-	err := m.authorizer.Authorize(principal, authorization.VALIDATE, authorization.OBJECTS)
+	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(obj.Class, obj.Tenant, obj.ID))
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -74,9 +74,9 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:        "UpdateClass",
-			additionalArgs:    []interface{}{"oldClass", &models.Class{Class: "newClass"}},
+			additionalArgs:    []interface{}{"class", &models.Class{Class: "class"}},
 			expectedVerb:      authorization.UPDATE,
-			expectedResources: authorization.Collections("oldClass"),
+			expectedResources: authorization.Collections("class"),
 		},
 		{
 			methodName:        "DeleteClass",
@@ -111,7 +111,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		{
 			methodName:        "AddTenants",
 			additionalArgs:    []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
-			expectedVerb:      authorization.UPDATE,
+			expectedVerb:      authorization.CREATE,
 			expectedResources: authorization.Shards("className"),
 		},
 		{
@@ -120,13 +120,13 @@ func Test_Schema_Authorization(t *testing.T) {
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
 			expectedVerb:      authorization.UPDATE,
-			expectedResources: authorization.Shards("className"),
+			expectedResources: authorization.Shards("className", "P1"),
 		},
 		{
 			methodName:        "DeleteTenants",
 			additionalArgs:    []interface{}{"className", []string{"P1"}},
 			expectedVerb:      authorization.DELETE,
-			expectedResources: authorization.Shards("className"),
+			expectedResources: authorization.Shards("className", "P1"),
 		},
 		{
 			methodName:        "GetTenants",

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -30,121 +30,121 @@ import (
 // potentially protected with the Authorization plugin
 func Test_Schema_Authorization(t *testing.T) {
 	type testCase struct {
-		methodName       string
-		additionalArgs   []interface{}
-		expectedVerb     string
-		expectedResource string
+		methodName        string
+		additionalArgs    []interface{}
+		expectedVerb      string
+		expectedResources []string
 	}
 
 	tests := []testCase{
 		{
-			methodName:       "GetSchema",
-			expectedVerb:     "list",
-			expectedResource: "schema/*",
+			methodName:        "GetSchema",
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Collections(),
 		},
 		{
-			methodName:       "GetConsistentSchema",
-			expectedVerb:     "list",
-			additionalArgs:   []interface{}{false},
-			expectedResource: "schema/*",
+			methodName:        "GetConsistentSchema",
+			expectedVerb:      authorization.READ,
+			additionalArgs:    []interface{}{false},
+			expectedResources: authorization.Collections(),
 		},
 		{
-			methodName:       "GetClass",
-			additionalArgs:   []interface{}{"classname"},
-			expectedVerb:     "list",
-			expectedResource: "schema/*",
+			methodName:        "GetClass",
+			additionalArgs:    []interface{}{"classname"},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Collections("classname"),
 		},
 		{
-			methodName:       "GetConsistentClass",
-			additionalArgs:   []interface{}{"classname", false},
-			expectedVerb:     "list",
-			expectedResource: "schema/*",
+			methodName:        "GetConsistentClass",
+			additionalArgs:    []interface{}{"classname", false},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Collections("classname"),
 		},
 		{
-			methodName:       "GetCachedClass",
-			additionalArgs:   []interface{}{"classname"},
-			expectedVerb:     "list",
-			expectedResource: "schema/*",
+			methodName:        "GetCachedClass",
+			additionalArgs:    []interface{}{"classname"},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Collections("classname"),
 		},
 		{
-			methodName:       "AddClass",
-			additionalArgs:   []interface{}{&models.Class{}},
-			expectedVerb:     "create",
-			expectedResource: "schema/objects",
+			methodName:        "AddClass",
+			additionalArgs:    []interface{}{&models.Class{Class: "classname"}},
+			expectedVerb:      authorization.CREATE,
+			expectedResources: authorization.Collections(),
 		},
 		{
-			methodName:       "UpdateClass",
-			additionalArgs:   []interface{}{"somename", &models.Class{}},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "schema/objects",
+			methodName:        "UpdateClass",
+			additionalArgs:    []interface{}{"oldClass", &models.Class{Class: "newClass"}},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Collections("oldClass"),
 		},
 		{
-			methodName:       "DeleteClass",
-			additionalArgs:   []interface{}{"somename"},
-			expectedVerb:     authorization.DELETE,
-			expectedResource: "schema/objects",
+			methodName:        "DeleteClass",
+			additionalArgs:    []interface{}{"somename"},
+			expectedVerb:      authorization.DELETE,
+			expectedResources: authorization.Collections("somename"),
 		},
 		{
-			methodName:       "AddClassProperty",
-			additionalArgs:   []interface{}{&models.Class{}, false, &models.Property{}},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "schema/objects",
+			methodName:        "AddClassProperty",
+			additionalArgs:    []interface{}{&models.Class{Class: "classname"}, false, &models.Property{}},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Collections("classname"),
 		},
 		{
-			methodName:       "DeleteClassProperty",
-			additionalArgs:   []interface{}{"somename", "someprop"},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "schema/objects",
+			methodName:        "DeleteClassProperty",
+			additionalArgs:    []interface{}{"somename", "someprop"},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Collections("somename"),
 		},
 		{
-			methodName:       "UpdateShardStatus",
-			additionalArgs:   []interface{}{"className", "shardName", "targetStatus"},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: "schema/className/shards/shardName",
+			methodName:        "UpdateShardStatus",
+			additionalArgs:    []interface{}{"className", "shardName", "targetStatus"},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("className", "shardName"),
 		},
 		{
-			methodName:       "ShardsStatus",
-			additionalArgs:   []interface{}{"className", "tenant"},
-			expectedVerb:     "list",
-			expectedResource: "schema/className/shards",
+			methodName:        "ShardsStatus",
+			additionalArgs:    []interface{}{"className", "tenant"},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Shards("className", "tenant"),
 		},
 		{
-			methodName:       "AddTenants",
-			additionalArgs:   []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: authorization.SCHEMA_TENANTS,
+			methodName:        "AddTenants",
+			additionalArgs:    []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("className"),
 		},
 		{
 			methodName: "UpdateTenants",
 			additionalArgs: []interface{}{"className", []*models.Tenant{
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
-			expectedVerb:     authorization.UPDATE,
-			expectedResource: authorization.SCHEMA_TENANTS,
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.Shards("className"),
 		},
 		{
-			methodName:       "DeleteTenants",
-			additionalArgs:   []interface{}{"className", []string{"P1"}},
-			expectedVerb:     authorization.DELETE,
-			expectedResource: authorization.SCHEMA_TENANTS,
+			methodName:        "DeleteTenants",
+			additionalArgs:    []interface{}{"className", []string{"P1"}},
+			expectedVerb:      authorization.DELETE,
+			expectedResources: authorization.Shards("className"),
 		},
 		{
-			methodName:       "GetTenants",
-			additionalArgs:   []interface{}{"className"},
-			expectedVerb:     authorization.GET,
-			expectedResource: authorization.SCHEMA_TENANTS,
+			methodName:        "GetTenants",
+			additionalArgs:    []interface{}{"className"},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Shards("className"),
 		},
 		{
-			methodName:       "GetConsistentTenants",
-			additionalArgs:   []interface{}{"className", false, []string{}},
-			expectedVerb:     authorization.GET,
-			expectedResource: authorization.SCHEMA_TENANTS,
+			methodName:        "GetConsistentTenants",
+			additionalArgs:    []interface{}{"className", false, []string{}},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Shards("className"),
 		},
 		{
-			methodName:       "ConsistentTenantExists",
-			additionalArgs:   []interface{}{"className", false, "P1"},
-			expectedVerb:     authorization.GET,
-			expectedResource: authorization.SCHEMA_TENANTS,
+			methodName:        "ConsistentTenantExists",
+			additionalArgs:    []interface{}{"className", false, "P1"},
+			expectedVerb:      authorization.READ,
+			expectedResources: authorization.Shards("className"),
 		},
 	}
 
@@ -198,7 +198,7 @@ func Test_Schema_Authorization(t *testing.T) {
 				require.Len(t, authorizer.Calls(), 1, "Authorizer must be called")
 				assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 					"execution must abort with Authorizer error")
-				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+				assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: test.expectedResources},
 					authorizer.Calls()[0], "correct parameters must have been used on Authorizer")
 			})
 		}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -41,7 +41,7 @@ import (
 )
 
 func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, name string) (*models.Class, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections(name)...); err != nil {
 		return nil, err
 	}
 	cl := h.schemaReader.ReadOnlyClass(name)
@@ -51,7 +51,7 @@ func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, nam
 func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Principal,
 	name string, consistency bool,
 ) (*models.Class, uint64, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections(name)...); err != nil {
 		return nil, 0, err
 	}
 	if consistency {
@@ -65,7 +65,7 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 	principal *models.Principal, names ...string,
 ) (map[string]versioned.Class, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections(names...)...); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +99,7 @@ func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	cls *models.Class,
 ) (*models.Class, uint64, error) {
-	err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.SCHEMA_OBJECTS)
+	err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.Collections()...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -197,7 +197,7 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 
 // DeleteClass from the schema
 func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, class string) error {
-	err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.SCHEMA_OBJECTS)
+	err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.Collections(class)...)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) error {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_OBJECTS)
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Collections(className)...)
 	if err != nil || updated == nil {
 		return err
 	}

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -166,7 +166,7 @@ func NewHandler(
 
 // GetSchema retrieves a locally cached copy of the schema
 func (h *Handler) GetSchema(principal *models.Principal) (schema.Schema, error) {
-	err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA)
+	err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections()...)
 	if err != nil {
 		return schema.Schema{}, err
 	}
@@ -176,7 +176,7 @@ func (h *Handler) GetSchema(principal *models.Principal) (schema.Schema, error) 
 
 // GetSchema retrieves a locally cached copy of the schema
 func (h *Handler) GetConsistentSchema(principal *models.Principal, consistency bool) (schema.Schema, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.ALL_SCHEMA); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections()...); err != nil {
 		return schema.Schema{}, err
 	}
 
@@ -216,7 +216,7 @@ func (h *Handler) NodeName() string {
 func (h *Handler) UpdateShardStatus(ctx context.Context,
 	principal *models.Principal, class, shard, status string,
 ) (uint64, error) {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SchemaShard(class, shard))
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(class, shard)...)
 	if err != nil {
 		return 0, err
 	}
@@ -225,14 +225,14 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 }
 
 func (h *Handler) ShardsStatus(ctx context.Context,
-	principal *models.Principal, class, tenant string,
+	principal *models.Principal, class, shard string,
 ) (models.ShardStatusList, error) {
-	err := h.Authorizer.Authorize(principal, authorization.LIST, authorization.SchemaShard(class, ""))
+	err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Shards(class, shard)...)
 	if err != nil {
 		return nil, err
 	}
 
-	return h.schemaReader.GetShardsStatus(class, tenant)
+	return h.schemaReader.GetShardsStatus(class, shard)
 }
 
 // JoinNode adds the given node to the cluster.

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -27,7 +27,7 @@ import (
 func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Principal,
 	class *models.Class, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_OBJECTS)
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Collections(class.Class)...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -87,7 +87,7 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 func (h *Handler) DeleteClassProperty(ctx context.Context, principal *models.Principal,
 	class string, property string,
 ) error {
-	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_OBJECTS)
+	err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Collections(class)...)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -42,7 +42,7 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_TENANTS); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.Shards(class)...); err != nil {
 		return 0, err
 	}
 
@@ -150,7 +150,12 @@ func (h *Handler) validateActivityStatuses(ctx context.Context, tenants []*model
 func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal,
 	class string, tenants []*models.Tenant,
 ) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.SCHEMA_TENANTS); err != nil {
+	shardNames := make([]string, len(tenants))
+	for idx := range tenants {
+		shardNames[idx] = tenants[idx].Name
+	}
+
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Shards(class, shardNames...)...); err != nil {
 		return nil, err
 	}
 
@@ -194,7 +199,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.SCHEMA_TENANTS); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.Shards(class, tenants...)...); err != nil {
 		return err
 	}
 	for i, name := range tenants {
@@ -215,14 +220,14 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) GetTenants(ctx context.Context, principal *models.Principal, class string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.GET, authorization.SCHEMA_TENANTS); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Shards(class)...); err != nil {
 		return nil, err
 	}
 	return h.getTenants(class)
 }
 
 func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.GET, authorization.SCHEMA_TENANTS); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Shards(class)...); err != nil {
 		return nil, err
 	}
 
@@ -276,7 +281,7 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.GET, authorization.SCHEMA_TENANTS); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Shards(class)...); err != nil {
 		return err
 	}
 

--- a/usecases/traverser/authorization_test.go
+++ b/usecases/traverser/authorization_test.go
@@ -44,21 +44,21 @@ func Test_Traverser_Authorization(t *testing.T) {
 		{
 			methodName:       "GetClass",
 			additionalArgs:   []interface{}{dto.GetParams{}},
-			expectedVerb:     authorization.GET,
+			expectedVerb:     authorization.READ,
 			expectedResource: "traversal/*",
 		},
 
 		{
 			methodName:       "Aggregate",
 			additionalArgs:   []interface{}{&aggregation.Params{}},
-			expectedVerb:     authorization.GET,
+			expectedVerb:     authorization.READ,
 			expectedResource: "traversal/*",
 		},
 
 		{
 			methodName:       "Explore",
 			additionalArgs:   []interface{}{ExploreParams{}},
-			expectedVerb:     authorization.GET,
+			expectedVerb:     authorization.READ,
 			expectedResource: "traversal/*",
 		},
 	}
@@ -94,7 +94,7 @@ func Test_Traverser_Authorization(t *testing.T) {
 			require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 			assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 				"execution must abort with authorizer error")
-			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resource: test.expectedResource},
+			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
 				authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 		}
 	})

--- a/usecases/traverser/authorization_test.go
+++ b/usecases/traverser/authorization_test.go
@@ -37,7 +37,7 @@ func Test_Traverser_Authorization(t *testing.T) {
 		methodName       string
 		additionalArgs   []interface{}
 		expectedVerb     string
-		expectedResource string
+		expectedResource []string
 	}
 
 	tests := []testCase{
@@ -45,21 +45,21 @@ func Test_Traverser_Authorization(t *testing.T) {
 			methodName:       "GetClass",
 			additionalArgs:   []interface{}{dto.GetParams{}},
 			expectedVerb:     authorization.READ,
-			expectedResource: "traversal/*",
+			expectedResource: authorization.Collections(),
 		},
 
 		{
 			methodName:       "Aggregate",
 			additionalArgs:   []interface{}{&aggregation.Params{}},
 			expectedVerb:     authorization.READ,
-			expectedResource: "traversal/*",
+			expectedResource: authorization.Collections(),
 		},
 
 		{
 			methodName:       "Explore",
 			additionalArgs:   []interface{}{ExploreParams{}},
 			expectedVerb:     authorization.READ,
-			expectedResource: "traversal/*",
+			expectedResource: authorization.Collections(),
 		},
 	}
 
@@ -94,7 +94,7 @@ func Test_Traverser_Authorization(t *testing.T) {
 			require.Len(t, authorizer.Calls(), 1, "authorizer must be called")
 			assert.Equal(t, errors.New("just a test fake"), out[len(out)-1].Interface(),
 				"execution must abort with authorizer error")
-			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: []string{test.expectedResource}},
+			assert.Equal(t, mocks.AuthZReq{Principal: principal, Verb: test.expectedVerb, Resources: test.expectedResource},
 				authorizer.Calls()[0], "correct parameters must have been used on authorizer")
 		}
 	})

--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -31,7 +31,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal,
 	t.metrics.QueriesAggregateInc(params.ClassName.String())
 	defer t.metrics.QueriesAggregateDec(params.ClassName.String())
 
-	err := t.authorizer.Authorize(principal, authorization.GET, authorization.ALL_TRAVERSAL)
+	err := t.authorizer.Authorize(principal, authorization.READ, authorization.Collections(params.ClassName.String())...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_explore_concepts.go
+++ b/usecases/traverser/traverser_explore_concepts.go
@@ -28,7 +28,7 @@ func (t *Traverser) Explore(ctx context.Context,
 		params.Limit = 20
 	}
 
-	err := t.authorizer.Authorize(principal, authorization.GET, authorization.ALL_TRAVERSAL)
+	err := t.authorizer.Authorize(principal, authorization.READ, authorization.Collections()...)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -42,7 +42,7 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	defer t.metrics.QueriesGetDec(params.ClassName)
 	defer t.metrics.QueriesObserveDuration(params.ClassName, before.UnixMilli())
 
-	err := t.authorizer.Authorize(principal, authorization.GET, authorization.ALL_TRAVERSAL)
+	err := t.authorizer.Authorize(principal, authorization.READ, authorization.Collections(params.ClassName)...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:


this PR reflect the table below in order to make sure every request has the correct combination of (verb, resource)

| Domain     | Verb | Resource                               | Path                                                           |
|--------------|------------|---------------------------------------|----------------------------------------------------------------|
| Roles        | CRUD       |*                                       | roles/*                                                        |
| Roles        | R          | role name                             | roles/{role_name}                                              |
| Cluster      | CRUD       |*                                       | cluster/*                                                      |
| Collections  | C          | *                                      | collections/*                                                  |
| Collections  | R          | collection name                       | collections/{collection_name}                                   |
| Collections  | U          | collection name                       | collections/{collection_name}                                   |
| Collections  | D          | collection name                       | collections/{collection_name}                                   |
| Tenants      | C          | collection name                       | collections/{collection_name}/shards/*                          |
| Tenants      | R          | collection name, tenant name          | collections/{collection_name}/shards/{shard_name}               |
| Tenants      | U          | collection name, tenant name          | collections/{collection_name}/shards/{shard_name}               |
| Tenants      | D          | collection name, tenant name          | collections/{collection_name}/shards/{shard_name}               |
| Objects      | C          | collection name, tenant name          | collections/{collection_name}/shards/{shard_name}/objects/*     |
| Objects      | R          | collection name, tenant name, object id | collections/{collection_name}/shards/{shard_name}/objects/{object_id} |
| Objects      | U          | collection name, tenant name, object id | collections/{collection_name}/shards/{shard_name}/objects/{object_id} |
| Objects      | D          | collection name, tenant name, object id | collections/{collection_name}/shards/{shard_name}/objects/{object_id} |


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
