### PR TITLE
[Monitoring] Segregate objects and vectors_compressed segment counts

### DIFF
--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -25,24 +25,27 @@ type (
 )
 
 type Metrics struct {
-	CompactionReplace         *prometheus.GaugeVec
-	CompactionSet             *prometheus.GaugeVec
-	CompactionMap             *prometheus.GaugeVec
-	CompactionRoaringSet      *prometheus.GaugeVec
-	CompactionRoaringSetRange *prometheus.GaugeVec
-	ActiveSegments            *prometheus.GaugeVec
-	bloomFilters              prometheus.ObserverVec
-	SegmentObjects            *prometheus.GaugeVec
-	SegmentSize               *prometheus.GaugeVec
-	SegmentCount              *prometheus.GaugeVec
-	startupDurations          prometheus.ObserverVec
-	startupDiskIO             prometheus.ObserverVec
-	objectCount               prometheus.Gauge
-	memtableDurations         prometheus.ObserverVec
-	memtableSize              *prometheus.GaugeVec
-	DimensionSum              *prometheus.GaugeVec
+	CompactionReplace            *prometheus.GaugeVec
+	CompactionSet                *prometheus.GaugeVec
+	CompactionMap                *prometheus.GaugeVec
+	CompactionRoaringSet         *prometheus.GaugeVec
+	CompactionRoaringSetRange    *prometheus.GaugeVec
+	ActiveSegments               *prometheus.GaugeVec
+	ObjectsBucketSegments        *prometheus.GaugeVec
+	CompressedVecsBucketSegments *prometheus.GaugeVec
+	bloomFilters                 prometheus.ObserverVec
+	SegmentObjects               *prometheus.GaugeVec
+	SegmentSize                  *prometheus.GaugeVec
+	SegmentCount                 *prometheus.GaugeVec
+	startupDurations             prometheus.ObserverVec
+	startupDiskIO                prometheus.ObserverVec
+	objectCount                  prometheus.Gauge
+	memtableDurations            prometheus.ObserverVec
+	memtableSize                 *prometheus.GaugeVec
+	DimensionSum                 *prometheus.GaugeVec
 
-	groupClasses bool
+	groupClasses        bool
+	criticalBucketsOnly bool
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -85,12 +88,21 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 
 	return &Metrics{
 		groupClasses:              promMetrics.Group,
+		criticalBucketsOnly:       promMetrics.LSMCriticalBucketsOnly,
 		CompactionReplace:         replace,
 		CompactionSet:             set,
 		CompactionMap:             stratMap,
 		CompactionRoaringSet:      roaringSet,
 		CompactionRoaringSetRange: roaringSetRange,
 		ActiveSegments: promMetrics.LSMSegmentCount.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		ObjectsBucketSegments: promMetrics.LSMObjectsBucketSegmentCount.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		CompressedVecsBucketSegments: promMetrics.LSMCompressedVecsBucketSegmentCount.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,
 		}),

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -494,17 +495,18 @@ func (sg *SegmentGroup) monitorSegments() {
 	// Keeping metering to only the critical buckets helps
 	// cut down on noise when monitoring
 	if sg.metrics.criticalBucketsOnly {
-		if !strings.HasSuffix(sg.dir, helpers.ObjectsBucketLSM) ||
-			!strings.HasSuffix(sg.dir, helpers.VectorsCompressedBucketLSM) {
+		bucket := path.Base(sg.dir)
+		if bucket != helpers.ObjectsBucketLSM &&
+			bucket != helpers.VectorsCompressedBucketLSM {
 			return
 		}
-		if strings.HasSuffix(sg.dir, helpers.ObjectsBucketLSM) {
+		if bucket == helpers.ObjectsBucketLSM {
 			sg.metrics.ObjectsBucketSegments.With(prometheus.Labels{
 				"strategy": sg.strategy,
 				"path":     sg.dir,
 			}).Set(float64(sg.Len()))
 		}
-		if strings.HasSuffix(sg.dir, helpers.VectorsCompressedBucketLSM) {
+		if bucket == helpers.VectorsCompressedBucketLSM {
 			sg.metrics.CompressedVecsBucketSegments.With(prometheus.Labels{
 				"strategy": sg.strategy,
 				"path":     sg.dir,

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -487,11 +487,30 @@ func (sg *SegmentGroup) stripTmpExtension(oldPath, left, right string) (string, 
 }
 
 func (sg *SegmentGroup) monitorSegments() {
-	if sg.metrics == nil || sg.metrics.groupClasses ||
-		// Keeping metering to only the critical buckets helps
-		// cut down on noise when monitoring
-		!strings.HasSuffix(sg.dir, helpers.ObjectsBucketLSM) ||
-		!strings.HasSuffix(sg.dir, helpers.VectorsCompressedBucketLSM) {
+	if sg.metrics == nil || sg.metrics.groupClasses {
+		return
+	}
+
+	// Keeping metering to only the critical buckets helps
+	// cut down on noise when monitoring
+	if sg.metrics.criticalBucketsOnly {
+		if !strings.HasSuffix(sg.dir, helpers.ObjectsBucketLSM) ||
+			!strings.HasSuffix(sg.dir, helpers.VectorsCompressedBucketLSM) {
+			return
+		}
+		if strings.HasSuffix(sg.dir, helpers.ObjectsBucketLSM) {
+			sg.metrics.ObjectsBucketSegments.With(prometheus.Labels{
+				"strategy": sg.strategy,
+				"path":     sg.dir,
+			}).Set(float64(sg.Len()))
+		}
+		if strings.HasSuffix(sg.dir, helpers.VectorsCompressedBucketLSM) {
+			sg.metrics.CompressedVecsBucketSegments.With(prometheus.Labels{
+				"strategy": sg.strategy,
+				"path":     sg.dir,
+			}).Set(float64(sg.Len()))
+		}
+		sg.reportSegmentStats()
 		return
 	}
 
@@ -499,7 +518,10 @@ func (sg *SegmentGroup) monitorSegments() {
 		"strategy": sg.strategy,
 		"path":     sg.dir,
 	}).Set(float64(sg.Len()))
+	sg.reportSegmentStats()
+}
 
+func (sg *SegmentGroup) reportSegmentStats() {
 	stats := sg.segmentLevelStats()
 	stats.fillMissingLevels()
 	stats.report(sg.metrics, sg.strategy, sg.dir)

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -58,7 +58,7 @@ func FromEnv(config *Config) error {
 			// not about classes or shards.
 			config.Monitoring.Group = true
 		}
-		if entcfg.Enabled("PROMETHEUS_MONITOR_CRITICAL_BUCKETS_ONLY") {
+		if entcfg.Enabled(os.Getenv("PROMETHEUS_MONITOR_CRITICAL_BUCKETS_ONLY")) {
 			config.Monitoring.MonitorCriticalBucketsOnly = true
 		}
 	}

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -58,6 +58,9 @@ func FromEnv(config *Config) error {
 			// not about classes or shards.
 			config.Monitoring.Group = true
 		}
+		if entcfg.Enabled("PROMETHEUS_MONITOR_CRITICAL_BUCKETS_ONLY") {
+			config.Monitoring.MonitorCriticalBucketsOnly = true
+		}
 	}
 
 	if entcfg.Enabled(os.Getenv("TRACK_VECTOR_DIMENSIONS")) {

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -317,11 +317,11 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		LSMObjectsBucketSegmentCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_objects_bucket_segment_count",
 			Help: "Number of segments per shard in the objects bucket",
-		}, []string{}),
+		}, []string{"strategy", "class_name", "shard_name", "path"}),
 		LSMCompressedVecsBucketSegmentCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_compressed_vecs_bucket_segment_count",
 			Help: "Number of segments per shard in the vectors_compressed bucket",
-		}, []string{}),
+		}, []string{"strategy", "class_name", "shard_name", "path"}),
 		LSMBloomFilters: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "lsm_bloom_filters_duration_ms",
 			Help: "Duration of bloom filter operations",

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -19,43 +19,46 @@ import (
 )
 
 type Config struct {
-	Enabled bool   `json:"enabled" yaml:"enabled"`
-	Tool    string `json:"tool" yaml:"tool"`
-	Port    int    `json:"port" yaml:"port"`
-	Group   bool   `json:"group_classes" yaml:"group_classes"`
+	Enabled                    bool   `json:"enabled" yaml:"enabled"`
+	Tool                       string `json:"tool" yaml:"tool"`
+	Port                       int    `json:"port" yaml:"port"`
+	Group                      bool   `json:"group_classes" yaml:"group_classes"`
+	MonitorCriticalBucketsOnly bool   `json:"monitor_critical_buckets_only" yaml:"monitor_critical_buckets_only"`
 }
 
 type PrometheusMetrics struct {
-	BatchTime                         *prometheus.HistogramVec
-	BatchSizeBytes                    *prometheus.SummaryVec
-	BatchSizeObjects                  prometheus.Summary
-	BatchSizeTenants                  prometheus.Summary
-	BatchDeleteTime                   *prometheus.SummaryVec
-	ObjectsTime                       *prometheus.SummaryVec
-	LSMBloomFilters                   *prometheus.SummaryVec
-	AsyncOperations                   *prometheus.GaugeVec
-	LSMSegmentCount                   *prometheus.GaugeVec
-	LSMSegmentCountByLevel            *prometheus.GaugeVec
-	LSMSegmentObjects                 *prometheus.GaugeVec
-	LSMSegmentSize                    *prometheus.GaugeVec
-	LSMMemtableSize                   *prometheus.GaugeVec
-	LSMMemtableDurations              *prometheus.SummaryVec
-	ObjectCount                       *prometheus.GaugeVec
-	QueriesCount                      *prometheus.GaugeVec
-	RequestsTotal                     *prometheus.GaugeVec
-	QueriesDurations                  *prometheus.HistogramVec
-	QueriesFilteredVectorDurations    *prometheus.SummaryVec
-	QueryDimensions                   *prometheus.CounterVec
-	QueryDimensionsCombined           prometheus.Counter
-	GoroutinesCount                   *prometheus.GaugeVec
-	BackupRestoreDurations            *prometheus.SummaryVec
-	BackupStoreDurations              *prometheus.SummaryVec
-	BucketPauseDurations              *prometheus.SummaryVec
-	BackupRestoreClassDurations       *prometheus.SummaryVec
-	BackupRestoreBackupInitDurations  *prometheus.SummaryVec
-	BackupRestoreFromStorageDurations *prometheus.SummaryVec
-	BackupRestoreDataTransferred      *prometheus.CounterVec
-	BackupStoreDataTransferred        *prometheus.CounterVec
+	BatchTime                           *prometheus.HistogramVec
+	BatchSizeBytes                      *prometheus.SummaryVec
+	BatchSizeObjects                    prometheus.Summary
+	BatchSizeTenants                    prometheus.Summary
+	BatchDeleteTime                     *prometheus.SummaryVec
+	ObjectsTime                         *prometheus.SummaryVec
+	LSMBloomFilters                     *prometheus.SummaryVec
+	AsyncOperations                     *prometheus.GaugeVec
+	LSMSegmentCount                     *prometheus.GaugeVec
+	LSMObjectsBucketSegmentCount        *prometheus.GaugeVec
+	LSMCompressedVecsBucketSegmentCount *prometheus.GaugeVec
+	LSMSegmentCountByLevel              *prometheus.GaugeVec
+	LSMSegmentObjects                   *prometheus.GaugeVec
+	LSMSegmentSize                      *prometheus.GaugeVec
+	LSMMemtableSize                     *prometheus.GaugeVec
+	LSMMemtableDurations                *prometheus.SummaryVec
+	ObjectCount                         *prometheus.GaugeVec
+	QueriesCount                        *prometheus.GaugeVec
+	RequestsTotal                       *prometheus.GaugeVec
+	QueriesDurations                    *prometheus.HistogramVec
+	QueriesFilteredVectorDurations      *prometheus.SummaryVec
+	QueryDimensions                     *prometheus.CounterVec
+	QueryDimensionsCombined             prometheus.Counter
+	GoroutinesCount                     *prometheus.GaugeVec
+	BackupRestoreDurations              *prometheus.SummaryVec
+	BackupStoreDurations                *prometheus.SummaryVec
+	BucketPauseDurations                *prometheus.SummaryVec
+	BackupRestoreClassDurations         *prometheus.SummaryVec
+	BackupRestoreBackupInitDurations    *prometheus.SummaryVec
+	BackupRestoreFromStorageDurations   *prometheus.SummaryVec
+	BackupRestoreDataTransferred        *prometheus.CounterVec
+	BackupStoreDataTransferred          *prometheus.CounterVec
 
 	// offload metric
 	TenantCloudOffloadDurations       *prometheus.SummaryVec
@@ -112,6 +115,9 @@ type PrometheusMetrics struct {
 	TombstoneDeleteListSize       *prometheus.GaugeVec
 
 	Group bool
+	// Keeping metering to only the critical buckets (objects, vectors_compressed)
+	// helps cut down on noise when monitoring
+	LSMCriticalBucketsOnly bool
 
 	// Deprecated metrics, keeping around because the classification features
 	// seems to sill use the old logic. However, those metrics are not actually
@@ -231,6 +237,7 @@ func init() {
 
 func InitConfig(cfg Config) {
 	metrics.Group = cfg.Group
+	metrics.LSMCriticalBucketsOnly = cfg.MonitorCriticalBucketsOnly
 }
 
 func GetMetrics() *PrometheusMetrics {
@@ -307,6 +314,14 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "lsm_active_segments",
 			Help: "Number of currently present segments per shard",
 		}, []string{"strategy", "class_name", "shard_name", "path"}),
+		LSMObjectsBucketSegmentCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lsm_objects_bucket_segment_count",
+			Help: "Number of segments per shard in the objects bucket",
+		}, []string{}),
+		LSMCompressedVecsBucketSegmentCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lsm_compressed_vecs_bucket_segment_count",
+			Help: "Number of segments per shard in the vectors_compressed bucket",
+		}, []string{}),
 		LSMBloomFilters: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "lsm_bloom_filters_duration_ms",
 			Help: "Duration of bloom filter operations",


### PR DESCRIPTION
### What's being changed:

To improve granularity of segment counts, this patch separates the counts of `objects` and `vectors_compressed` buckets into distinct metrics

To make use of this bucket filtering, make sure `PROMETHEUS_MONITOR_CRITICAL_BUCKETS_ONLY` is enabled 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
