### PR TITLE
fix: :bug: Avoid reading NaN and correct propLength if NaN or Zero to a sane default

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -163,6 +163,7 @@ func (b *BM25Searcher) wand(
 		// A NaN here is the results of a corrupted prop length tracker.
 		// This is a workaround to try and avoid 0 or NaN scores.
 		// There is an extra check below in case all prop lengths are NaN or 0.
+		// Related issue https://github.com/weaviate/weaviate/issues/6247
 		if !math.IsNaN(float64(propMean)) {
 			averagePropLength += float64(propMean)
 			averagePropLengthCount++
@@ -189,6 +190,7 @@ func (b *BM25Searcher) wand(
 
 	// If this value is zero or NaN, the prop length tracker is fully corrupted.
 	// This is a workaround to avoid 0 or NaN scores.
+	// Related issue https://github.com/weaviate/weaviate/issues/6247
 	if math.IsNaN(averagePropLength) || averagePropLength == 0 {
 		averagePropLength = 40.0 // sane default, if all prop lengths are NaN or 0
 	}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -145,6 +145,7 @@ func (b *BM25Searcher) wand(
 	}
 
 	averagePropLength := 0.
+	averagePropLengthCount := 0
 	for _, propertyWithBoost := range params.Properties {
 		property := propertyWithBoost
 		propBoost := 1
@@ -159,7 +160,13 @@ func (b *BM25Searcher) wand(
 		if err != nil {
 			return nil, nil, err
 		}
-		averagePropLength += float64(propMean)
+		// A NaN here is the results of a corrupted prop length tracker.
+		// This is a workaround to try and avoid 0 or NaN scores.
+		// There is an extra check below in case all prop lengths are NaN or 0.
+		if !math.IsNaN(float64(propMean)) {
+			averagePropLength += float64(propMean)
+			averagePropLengthCount++
+		}
 
 		prop, err := schema.GetPropertyByName(class, property)
 		if err != nil {
@@ -178,7 +185,13 @@ func (b *BM25Searcher) wand(
 		}
 	}
 
-	averagePropLength = averagePropLength / float64(len(params.Properties))
+	averagePropLength = averagePropLength / float64(averagePropLengthCount)
+
+	// If this value is zero or NaN, the prop length tracker is fully corrupted.
+	// This is a workaround to avoid 0 or NaN scores.
+	if math.IsNaN(averagePropLength) || averagePropLength == 0 {
+		averagePropLength = 40.0 // sane default, if all prop lengths are NaN or 0
+	}
 
 	// 100 is a reasonable expected capacity for the total number of terms to query.
 	allRequests := make([]termListRequest, 0, 100)


### PR DESCRIPTION
### What's being changed:

- Avoid NaN properties when computing average.
- If there are no new properties, use sane default of 40.
- Related issue #6247

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
