### PR TITLE
Remove unsupported models from generative e2e tests

### DIFF
--- a/test/modules/generative-aws/generative_aws_test.go
+++ b/test/modules/generative-aws/generative_aws_test.go
@@ -75,10 +75,6 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 			},
 			// Anthropic
 			{
-				name:            "anthropic.claude-3-5-sonnet-20240620-v1:0",
-				generativeModel: "anthropic.claude-3-5-sonnet-20240620-v1:0",
-			},
-			{
 				name:            "anthropic.claude-3-sonnet-20240229-v1:0",
 				generativeModel: "anthropic.claude-3-sonnet-20240229-v1:0",
 			},
@@ -128,10 +124,6 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 			{
 				name:            "mistral.mistral-large-2402-v1:0",
 				generativeModel: "mistral.mistral-large-2402-v1:0",
-			},
-			{
-				name:            "mistral.mistral-small-2402-v1:0",
-				generativeModel: "mistral.mistral-small-2402-v1:0",
 			},
 			{
 				name:               "absent module config",


### PR DESCRIPTION
### What's being changed:

Remove unsupported models from generative e2e tests:
- anthropic.claude-3-5-sonnet-20240620-v1:0
- mistral.mistral-small-2402-v1:0


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
