### PR TITLE
Fix panic in patch when body is empty

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -430,6 +430,9 @@ func (h *objectHandlers) headObject(params objects.ObjectsClassHeadParams,
 
 func (h *objectHandlers) patchObject(params objects.ObjectsClassPatchParams, principal *models.Principal) middleware.Responder {
 	updates := params.Body
+	if updates == nil {
+		return objects.NewObjectsClassPatchBadRequest()
+	}
 	updates.ID = params.ID
 	updates.Class = params.ClassName
 

--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -673,6 +673,17 @@ func TestEnrichObjectsWithLinks(t *testing.T) {
 		if _, ok := res.(*objects.ObjectsClassPatchNoContent); !ok {
 			t.Errorf("unexpected result %v", res)
 		}
+
+		// test deprecated function
+		fakeManager.patchObjectReturn = nil
+		res = h.patchObjectDeprecated(objects.ObjectsPatchParams{
+			HTTPRequest: httptest.NewRequest("PATCH", "/v1/objects/123", nil),
+			ID:          "123",
+			Body:        nil,
+		}, nil)
+		if _, ok := res.(*objects.ObjectsClassPatchBadRequest); !ok {
+			t.Errorf("unexpected result %v", res)
+		}
 	})
 
 	t.Run("GetObject", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Fixes a panic when the deprecated PATCH was called without a body. Noticed while debugging RBAC stuff

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
