### PR TITLE
fix: byteops reads buf of length 0 as empty slice instead of nil

### DIFF
--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -108,10 +108,6 @@ func (bo *ReadWriter) ReadBytesFromBufferWithUint32LengthIndicator() []byte {
 	bo.Position += uint32Len
 	bufLen := uint64(binary.LittleEndian.Uint32(bo.Buffer[bo.Position-uint32Len : bo.Position]))
 
-	if bufLen == 0 {
-		return nil
-	}
-
 	bo.Position += bufLen
 	subslice := bo.Buffer[bo.Position-bufLen : bo.Position]
 	return subslice


### PR DESCRIPTION
### What's being changed:

**ReadWriter::ReadBytesFromBufferWithUint32LengthIndicator** used to replace empty `[]byte` with `nil` when length indicator was == 0.
That replacement caused `PrimaryKey` of `SegmentNode` of roaringset index being incorrectly read as `nil` instead of empty `[]byte`, making SegmentCursor also return key = nil, whenever empty string was indexed and stored in segment.
As `key == nil` is a stop condition for looping through segment by cursor and `""` is alphabetically first, segment accessed by cursor seemed empty. That could cause data lost in case of compaction segment containing `""` with other segment,
resulting in merged segment being just copy of the 2nd one.

Note: **ReadWriter::ReadBytesFromBufferWithUint64LengthIndicator** does not have empty `[]byte` to `nil` replacement.

Bug identified thanks to **g_parki**, who reported the issue: https://forum.weaviate.io/t/filter-index-breaks-after-updating-inserting-new-records/7348

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/11796272571
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
