### PR TITLE
Parse `policy[1]` when building `Policy`

### DIFF
--- a/test/acceptance/authz/permissions_test.go
+++ b/test/acceptance/authz/permissions_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package test
 
 import (

--- a/test/acceptance/authz/permissions_test.go
+++ b/test/acceptance/authz/permissions_test.go
@@ -1,0 +1,128 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestAuthzRolesWithPermissions(t *testing.T) {
+	existingUser := "existing-user"
+	existingKey := "existing-key"
+	adminRole := "admin"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviate().WithRBAC().WithRbacUser(existingUser, existingKey, adminRole).Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %v", err)
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	t.Run("create and get a role to create all collections", func(t *testing.T) {
+		name := "create-all-collections"
+		err := helper.CreateRole(t, existingKey, &models.Role{
+			Name: String(name),
+			Permissions: []*models.Permission{
+				{Action: String("create_collections"), Collection: String("*")},
+			},
+		})
+		require.Nil(t, err)
+		role, err := helper.GetRoleByName(t, existingKey, name)
+		require.Nil(t, err)
+		require.NotNil(t, role)
+		require.Equal(t, name, *role.Name)
+		require.Len(t, role.Permissions, 1)
+		require.Equal(t, "create_collections", *role.Permissions[0].Action)
+		require.Equal(t, "*", *role.Permissions[0].Collection)
+	})
+
+	t.Run("create and get a role to create all tenants in a collection", func(t *testing.T) {
+		name := "create-all-tenants-in-foo"
+		err := helper.CreateRole(t, existingKey, &models.Role{
+			Name: String(name),
+			Permissions: []*models.Permission{
+				{Action: String("create_collections"), Collection: String("foo")},
+				{Action: String("create_tenants"), Collection: String("*")},
+			},
+		})
+		require.Nil(t, err)
+		role, err := helper.GetRoleByName(t, existingKey, name)
+		require.Nil(t, err)
+		require.NotNil(t, role)
+		require.Equal(t, name, *role.Name)
+		require.Len(t, role.Permissions, 2)
+		require.Equal(t, "create_collections", *role.Permissions[0].Action)
+		require.Equal(t, "foo", *role.Permissions[0].Collection)
+		require.Equal(t, "create_tenants", *role.Permissions[1].Action)
+		require.Equal(t, "*", *role.Permissions[1].Collection)
+	})
+
+	t.Run("create and get a role to manage all roles", func(t *testing.T) {
+		name := "manage-all-roles"
+		err := helper.CreateRole(t, existingKey, &models.Role{
+			Name: String(name),
+			Permissions: []*models.Permission{
+				{Action: String("manage_roles"), Role: String("*")},
+			},
+		})
+		require.Nil(t, err)
+		role, err := helper.GetRoleByName(t, existingKey, name)
+		require.Nil(t, err)
+		require.NotNil(t, role)
+		require.Equal(t, name, *role.Name)
+		require.Len(t, role.Permissions, 1)
+		require.Equal(t, "manage_roles", *role.Permissions[0].Action)
+		require.Equal(t, "*", *role.Permissions[0].Role)
+	})
+
+	t.Run("create and get a role to manage one role", func(t *testing.T) {
+		name := "manage-one-role"
+		err := helper.CreateRole(t, existingKey, &models.Role{
+			Name: String(name),
+			Permissions: []*models.Permission{
+				{Action: String("manage_roles"), Role: String("foo")},
+			},
+		})
+		require.Nil(t, err)
+		role, err := helper.GetRoleByName(t, existingKey, name)
+		require.Nil(t, err)
+		require.NotNil(t, role)
+		require.Equal(t, name, *role.Name)
+		require.Len(t, role.Permissions, 1)
+		require.Equal(t, "manage_roles", *role.Permissions[0].Action)
+		require.Equal(t, "foo", *role.Permissions[0].Role)
+	})
+
+	t.Run("create and get a role to read two roles", func(t *testing.T) {
+		name := "read-one-role"
+		err := helper.CreateRole(t, existingKey, &models.Role{
+			Name: String(name),
+			Permissions: []*models.Permission{
+				{Action: String("read_roles"), Role: String("foo")},
+				{Action: String("read_roles"), Role: String("bar")},
+			},
+		})
+		require.Nil(t, err)
+		role, err := helper.GetRoleByName(t, existingKey, name)
+		require.Nil(t, err)
+		require.NotNil(t, role)
+		require.Equal(t, name, *role.Name)
+		require.Len(t, role.Permissions, 2)
+		require.Equal(t, "read_roles", *role.Permissions[0].Action)
+		require.Equal(t, "foo", *role.Permissions[0].Role)
+		require.Equal(t, "read_roles", *role.Permissions[1].Action)
+		require.Equal(t, "bar", *role.Permissions[1].Role)
+	})
+}

--- a/test/acceptance/authz/permissions_test.go
+++ b/test/acceptance/authz/permissions_test.go
@@ -43,15 +43,13 @@ func TestAuthzRolesWithPermissions(t *testing.T) {
 
 	t.Run("create and get a role to create all collections", func(t *testing.T) {
 		name := "create-all-collections"
-		err := helper.CreateRole(t, existingKey, &models.Role{
+		helper.CreateRole(t, existingKey, &models.Role{
 			Name: String(name),
 			Permissions: []*models.Permission{
 				{Action: String("create_collections"), Collection: String("*")},
 			},
 		})
-		require.Nil(t, err)
-		role, err := helper.GetRoleByName(t, existingKey, name)
-		require.Nil(t, err)
+		role := helper.GetRoleByName(t, existingKey, name)
 		require.NotNil(t, role)
 		require.Equal(t, name, *role.Name)
 		require.Len(t, role.Permissions, 1)
@@ -61,16 +59,14 @@ func TestAuthzRolesWithPermissions(t *testing.T) {
 
 	t.Run("create and get a role to create all tenants in a collection", func(t *testing.T) {
 		name := "create-all-tenants-in-foo"
-		err := helper.CreateRole(t, existingKey, &models.Role{
+		helper.CreateRole(t, existingKey, &models.Role{
 			Name: String(name),
 			Permissions: []*models.Permission{
 				{Action: String("create_collections"), Collection: String("foo")},
 				{Action: String("create_tenants"), Collection: String("*")},
 			},
 		})
-		require.Nil(t, err)
-		role, err := helper.GetRoleByName(t, existingKey, name)
-		require.Nil(t, err)
+		role := helper.GetRoleByName(t, existingKey, name)
 		require.NotNil(t, role)
 		require.Equal(t, name, *role.Name)
 		require.Len(t, role.Permissions, 2)
@@ -82,15 +78,13 @@ func TestAuthzRolesWithPermissions(t *testing.T) {
 
 	t.Run("create and get a role to manage all roles", func(t *testing.T) {
 		name := "manage-all-roles"
-		err := helper.CreateRole(t, existingKey, &models.Role{
+		helper.CreateRole(t, existingKey, &models.Role{
 			Name: String(name),
 			Permissions: []*models.Permission{
 				{Action: String("manage_roles"), Role: String("*")},
 			},
 		})
-		require.Nil(t, err)
-		role, err := helper.GetRoleByName(t, existingKey, name)
-		require.Nil(t, err)
+		role := helper.GetRoleByName(t, existingKey, name)
 		require.NotNil(t, role)
 		require.Equal(t, name, *role.Name)
 		require.Len(t, role.Permissions, 1)
@@ -100,15 +94,14 @@ func TestAuthzRolesWithPermissions(t *testing.T) {
 
 	t.Run("create and get a role to manage one role", func(t *testing.T) {
 		name := "manage-one-role"
-		err := helper.CreateRole(t, existingKey, &models.Role{
+		helper.CreateRole(t, existingKey, &models.Role{
 			Name: String(name),
 			Permissions: []*models.Permission{
 				{Action: String("manage_roles"), Role: String("foo")},
 			},
 		})
 		require.Nil(t, err)
-		role, err := helper.GetRoleByName(t, existingKey, name)
-		require.Nil(t, err)
+		role := helper.GetRoleByName(t, existingKey, name)
 		require.NotNil(t, role)
 		require.Equal(t, name, *role.Name)
 		require.Len(t, role.Permissions, 1)
@@ -118,16 +111,14 @@ func TestAuthzRolesWithPermissions(t *testing.T) {
 
 	t.Run("create and get a role to read two roles", func(t *testing.T) {
 		name := "read-one-role"
-		err := helper.CreateRole(t, existingKey, &models.Role{
+		helper.CreateRole(t, existingKey, &models.Role{
 			Name: String(name),
 			Permissions: []*models.Permission{
 				{Action: String("read_roles"), Role: String("foo")},
 				{Action: String("read_roles"), Role: String("bar")},
 			},
 		})
-		require.Nil(t, err)
-		role, err := helper.GetRoleByName(t, existingKey, name)
-		require.Nil(t, err)
+		role := helper.GetRoleByName(t, existingKey, name)
 		require.NotNil(t, role)
 		require.Equal(t, name, *role.Name)
 		require.Len(t, role.Permissions, 2)

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -47,22 +47,19 @@ func TestAuthzBuiltInRolesJourney(t *testing.T) {
 	defer helper.ResetClient()
 
 	t.Run("get all roles to check if i have perm.", func(t *testing.T) {
-		res, err := helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), clientAuth)
+		roles, err := helper.GetRoles(t, existingKey)
 		require.Nil(t, err)
-		require.Equal(t, 3, len(res.Payload))
+		require.Equal(t, 3, len(roles))
 	})
 
 	t.Run("create builtin role", func(t *testing.T) {
-		_, err = helper.Client(t).Authz.CreateRole(
-			authz.NewCreateRoleParams().WithBody(&models.Role{
-				Name: &adminRole,
-				Permissions: []*models.Permission{{
-					Action:     String("create_collections"),
-					Collection: String("*"),
-				}},
-			}),
-			clientAuth,
-		)
+		err = helper.CreateRole(t, existingKey, &models.Role{
+			Name: &adminRole,
+			Permissions: []*models.Permission{{
+				Action:     String("create_collections"),
+				Collection: String("*"),
+			}},
+		})
 		require.NotNil(t, err)
 		err, forbidden := err.(*authz.CreateRoleForbidden)
 		require.True(t, forbidden)
@@ -70,10 +67,7 @@ func TestAuthzBuiltInRolesJourney(t *testing.T) {
 	})
 
 	t.Run("delete builtin role", func(t *testing.T) {
-		_, err = helper.Client(t).Authz.DeleteRole(
-			authz.NewDeleteRoleParams().WithID(adminRole),
-			clientAuth,
-		)
+		err = helper.DeleteRole(t, existingKey, adminRole)
 		require.NotNil(t, err)
 		err, forbidden := err.(*authz.DeleteRoleForbidden)
 		require.True(t, forbidden)
@@ -142,38 +136,36 @@ func TestAuthzRolesJourney(t *testing.T) {
 	defer helper.ResetClient()
 
 	t.Run("get all roles before create", func(t *testing.T) {
-		res, err := helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), clientAuth)
+		roles, err := helper.GetRoles(t, existingKey)
 		require.Nil(t, err)
-		require.Equal(t, 3, len(res.Payload))
-		// require.Equal(t, existingRole, *res.Payload[0].Name)
+		require.Equal(t, 3, len(roles))
 	})
 
 	t.Run("create role", func(t *testing.T) {
-		_, err = helper.Client(t).Authz.CreateRole(
-			authz.NewCreateRoleParams().WithBody(&models.Role{
+		err = helper.CreateRole(t, existingKey,
+			&models.Role{
 				Name: &testRole,
 				Permissions: []*models.Permission{{
 					Action:     &testAction1,
 					Collection: &all,
 				}},
-			}),
-			clientAuth,
-		)
+			})
 		require.Nil(t, err)
 	})
 
 	t.Run("get all roles after create", func(t *testing.T) {
-		res, err := helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), clientAuth)
+		roles, err := helper.GetRoles(t, existingKey)
 		require.Nil(t, err)
-		require.Equal(t, 4, len(res.Payload))
+		require.Equal(t, 4, len(roles))
 	})
 
 	t.Run("get role by name", func(t *testing.T) {
-		res, err := helper.Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(testRole), clientAuth)
+		role, err := helper.GetRoleByName(t, existingKey, testRole)
 		require.Nil(t, err)
-		require.Equal(t, testRole, *res.Payload.Name)
-		require.Equal(t, 1, len(res.Payload.Permissions))
-		require.Equal(t, testAction1, *res.Payload.Permissions[0].Action)
+		require.NotNil(t, role)
+		require.Equal(t, testRole, *role.Name)
+		require.Equal(t, 1, len(role.Permissions))
+		require.Equal(t, testAction1, *role.Permissions[0].Action)
 	})
 
 	t.Run("add permission to role", func(t *testing.T) {
@@ -202,11 +194,12 @@ func TestAuthzRolesJourney(t *testing.T) {
 	})
 
 	t.Run("get role by name after removing permission", func(t *testing.T) {
-		res, err := helper.Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(testRole), clientAuth)
+		role, err := helper.GetRoleByName(t, existingKey, testRole)
 		require.Nil(t, err)
-		require.Equal(t, testRole, *res.Payload.Name)
-		require.Equal(t, 1, len(res.Payload.Permissions))
-		require.Equal(t, testAction1, *res.Payload.Permissions[0].Action)
+		require.NotNil(t, role)
+		require.Equal(t, testRole, *role.Name)
+		require.Equal(t, 1, len(role.Permissions))
+		require.Equal(t, testAction1, *role.Permissions[0].Action)
 	})
 
 	t.Run("assign role to user", func(t *testing.T) {
@@ -242,7 +235,7 @@ func TestAuthzRolesJourney(t *testing.T) {
 	})
 
 	t.Run("delete role by name", func(t *testing.T) {
-		_, err = helper.Client(t).Authz.DeleteRole(authz.NewDeleteRoleParams().WithID(testRole), clientAuth)
+		err = helper.DeleteRole(t, existingKey, testRole)
 		require.Nil(t, err)
 	})
 
@@ -254,13 +247,13 @@ func TestAuthzRolesJourney(t *testing.T) {
 	})
 
 	t.Run("get all roles after delete", func(t *testing.T) {
-		res, err := helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), clientAuth)
+		roles, err := helper.GetRoles(t, existingKey)
 		require.Nil(t, err)
-		require.Equal(t, 3, len(res.Payload))
+		require.Equal(t, 3, len(roles))
 	})
 
 	t.Run("get non-existent role by name", func(t *testing.T) {
-		_, err := helper.Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(testRole), clientAuth)
+		err := helper.GetRoleByNameError(t, existingKey, testRole)
 		require.NotNil(t, err)
 		require.ErrorIs(t, err, authz.NewGetRoleNotFound())
 	})
@@ -319,9 +312,9 @@ func TestAuthzRolesMultiNodeJourney(t *testing.T) {
 
 	t.Run("add role while 1 node is down", func(t *testing.T) {
 		t.Run("get all roles before create", func(t *testing.T) {
-			res, err := helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), clientAuth)
+			roles, err := helper.GetRoles(t, existingKey)
 			require.Nil(t, err)
-			require.Equal(t, 3, len(res.Payload))
+			require.Equal(t, 3, len(roles))
 		})
 
 		t.Run("StopNode-3", func(t *testing.T) {
@@ -329,16 +322,13 @@ func TestAuthzRolesMultiNodeJourney(t *testing.T) {
 		})
 
 		t.Run("create role", func(t *testing.T) {
-			_, err = helper.Client(t).Authz.CreateRole(
-				authz.NewCreateRoleParams().WithBody(&models.Role{
-					Name: &testRole,
-					Permissions: []*models.Permission{{
-						Action:     &testAction1,
-						Collection: &all,
-					}},
-				}),
-				clientAuth,
-			)
+			err = helper.CreateRole(t, existingKey, &models.Role{
+				Name: &testRole,
+				Permissions: []*models.Permission{{
+					Action:     &testAction1,
+					Collection: &all,
+				}},
+			})
 			require.Nil(t, err)
 		})
 
@@ -349,17 +339,18 @@ func TestAuthzRolesMultiNodeJourney(t *testing.T) {
 		helper.SetupClient(compose.GetWeaviateNode3().URI())
 
 		t.Run("get all roles after create", func(t *testing.T) {
-			res, err := helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), clientAuth)
+			roles, err := helper.GetRoles(t, existingKey)
 			require.Nil(t, err)
-			require.Equal(t, 4, len(res.Payload))
+			require.Equal(t, 4, len(roles))
 		})
 
 		t.Run("get role by name", func(t *testing.T) {
-			res, err := helper.Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(testRole), clientAuth)
+			role, err := helper.GetRoleByName(t, existingKey, testRole)
 			require.Nil(t, err)
-			require.Equal(t, testRole, *res.Payload.Name)
-			require.Equal(t, 1, len(res.Payload.Permissions))
-			require.Equal(t, testAction1, *res.Payload.Permissions[0].Action)
+			require.NotNil(t, role)
+			require.Equal(t, testRole, *role.Name)
+			require.Equal(t, 1, len(role.Permissions))
+			require.Equal(t, testAction1, *role.Permissions[0].Action)
 		})
 
 		t.Run("add permission to role Node3", func(t *testing.T) {
@@ -375,12 +366,13 @@ func TestAuthzRolesMultiNodeJourney(t *testing.T) {
 		t.Run("get role by name after adding permission Node1", func(t *testing.T) {
 			// EventuallyWithT to handle EC in RAFT reads
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				res, err := helper.Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(testRole), clientAuth)
+				role, err := helper.GetRoleByName(t, existingKey, testRole)
 				require.Nil(t, err)
-				require.Equal(t, testRole, *res.Payload.Name)
-				require.Equal(t, 2, len(res.Payload.Permissions))
-				require.Equal(t, testAction1, *res.Payload.Permissions[0].Action)
-				require.Equal(t, testAction2, *res.Payload.Permissions[1].Action)
+				require.NotNil(t, role)
+				require.Equal(t, testRole, *role.Name)
+				require.Equal(t, 2, len(role.Permissions))
+				require.Equal(t, testAction1, *role.Permissions[0].Action)
+				require.Equal(t, testAction2, *role.Permissions[1].Action)
 			}, 3*time.Second, 500*time.Millisecond)
 		})
 	})

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -1,0 +1,37 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/weaviate/weaviate/client/authz"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func CreateRole(t *testing.T, key string, role *models.Role) error {
+	resp, err := Client(t).Authz.CreateRole(authz.NewCreateRoleParams().WithBody(role), CreateAuth(key))
+	AssertRequestOk(t, resp, err, nil)
+	return err
+}
+
+func GetRoles(t *testing.T, key string) ([]*models.Role, error) {
+	resp, err := Client(t).Authz.GetRoles(authz.NewGetRolesParams(), CreateAuth(key))
+	AssertRequestOk(t, resp, err, nil)
+	return resp.Payload, err
+}
+
+func DeleteRole(t *testing.T, key, role string) error {
+	resp, err := Client(t).Authz.DeleteRole(authz.NewDeleteRoleParams().WithID(role), CreateAuth(key))
+	AssertRequestOk(t, resp, err, nil)
+	return err
+}
+
+func GetRoleByName(t *testing.T, key, role string) (*models.Role, error) {
+	resp, err := Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(role), CreateAuth(key))
+	AssertRequestOk(t, resp, err, nil)
+	return resp.Payload, err
+}
+
+func GetRoleByNameError(t *testing.T, key, role string) error {
+	_, err := Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(role), CreateAuth(key))
+	return err
+}

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package helper
 
 import (

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -14,35 +14,34 @@ package helper
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/authz"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-func CreateRole(t *testing.T, key string, role *models.Role) error {
+func CreateRole(t *testing.T, key string, role *models.Role) {
 	resp, err := Client(t).Authz.CreateRole(authz.NewCreateRoleParams().WithBody(role), CreateAuth(key))
 	AssertRequestOk(t, resp, err, nil)
-	return err
+	require.Nil(t, err)
 }
 
-func GetRoles(t *testing.T, key string) ([]*models.Role, error) {
+func GetRoles(t *testing.T, key string) []*models.Role {
 	resp, err := Client(t).Authz.GetRoles(authz.NewGetRolesParams(), CreateAuth(key))
 	AssertRequestOk(t, resp, err, nil)
-	return resp.Payload, err
+	require.Nil(t, err)
+	return resp.Payload
 }
 
-func DeleteRole(t *testing.T, key, role string) error {
+func DeleteRole(t *testing.T, key, role string) {
 	resp, err := Client(t).Authz.DeleteRole(authz.NewDeleteRoleParams().WithID(role), CreateAuth(key))
 	AssertRequestOk(t, resp, err, nil)
-	return err
+	require.Nil(t, err)
 }
 
-func GetRoleByName(t *testing.T, key, role string) (*models.Role, error) {
+func GetRoleByName(t *testing.T, key, role string) *models.Role {
 	resp, err := Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(role), CreateAuth(key))
 	AssertRequestOk(t, resp, err, nil)
-	return resp.Payload, err
-}
-
-func GetRoleByNameError(t *testing.T, key, role string) error {
-	_, err := Client(t).Authz.GetRole(authz.NewGetRoleParams().WithID(role), CreateAuth(key))
-	return err
+	require.Nil(t, err)
+	require.NotNil(t, resp.Payload)
+	return resp.Payload
 }

--- a/usecases/auth/authorization/rbac/types.go
+++ b/usecases/auth/authorization/rbac/types.go
@@ -110,10 +110,14 @@ type Policy struct {
 
 func newPolicy(policy []string) *Policy {
 	return &Policy{
-		resource: policy[1],
+		resource: fromCasbinResource(policy[1]),
 		verb:     policy[2],
 		domain:   policy[3],
 	}
+}
+
+func fromCasbinResource(resource string) string {
+	return strings.ReplaceAll(resource, ".*", "*")
 }
 
 func pRoles(role string) string {
@@ -157,7 +161,6 @@ func pObjects(collection, shard, object string) string {
 	}
 	collection = strings.ReplaceAll(collection, "*", ".*")
 	shard = strings.ReplaceAll(shard, "*", ".*")
-	collection = strings.ReplaceAll(collection, "*", ".*")
 	object = strings.ReplaceAll(object, "*", ".*")
 	return fmt.Sprintf("collections/%s/shards/%s/objects/%s", collection, shard, object)
 }

--- a/usecases/auth/authorization/rbac/types_test.go
+++ b/usecases/auth/authorization/rbac/types_test.go
@@ -531,8 +531,8 @@ func Test_pRoles(t *testing.T) {
 		role     string
 		expected string
 	}{
-		{role: "", expected: "roles/*"},
-		{role: "*", expected: "roles/*"},
+		{role: "", expected: "roles/.*"},
+		{role: "*", expected: "roles/.*"},
 		{role: "foo", expected: "roles/foo"},
 	}
 	for _, tt := range tests {
@@ -549,9 +549,9 @@ func Test_pCollections(t *testing.T) {
 		collection string
 		expected   string
 	}{
-		{collection: "", expected: "collections/*"},
-		{collection: "*", expected: "collections/*"},
-		{collection: "foo", expected: "collections/foo"},
+		{collection: "", expected: "collections/.*/*"},
+		{collection: "*", expected: "collections/.*/*"},
+		{collection: "foo", expected: "collections/foo/*"},
 	}
 	for _, tt := range tests {
 		name := fmt.Sprintf("collection: %s", tt.collection)
@@ -568,13 +568,13 @@ func Test_pShards(t *testing.T) {
 		shard      string
 		expected   string
 	}{
-		{collection: "", shard: "", expected: "collections/*/shards/*"},
-		{collection: "*", shard: "*", expected: "collections/*/shards/*"},
-		{collection: "foo", shard: "", expected: "collections/foo/shards/*"},
-		{collection: "foo", shard: "*", expected: "collections/foo/shards/*"},
-		{collection: "", shard: "bar", expected: "collections/*/shards/bar"},
-		{collection: "*", shard: "bar", expected: "collections/*/shards/bar"},
-		{collection: "foo", shard: "bar", expected: "collections/foo/shards/bar"},
+		{collection: "", shard: "", expected: "collections/.*/shards/.*/*"},
+		{collection: "*", shard: "*", expected: "collections/.*/shards/.*/*"},
+		{collection: "foo", shard: "", expected: "collections/foo/shards/.*/*"},
+		{collection: "foo", shard: "*", expected: "collections/foo/shards/.*/*"},
+		{collection: "", shard: "bar", expected: "collections/.*/shards/bar/*"},
+		{collection: "*", shard: "bar", expected: "collections/.*/shards/bar/*"},
+		{collection: "foo", shard: "bar", expected: "collections/foo/shards/bar/*"},
 	}
 	for _, tt := range tests {
 		name := fmt.Sprintf("collection: %s; shard: %s", tt.collection, tt.shard)
@@ -592,26 +592,42 @@ func Test_pObjects(t *testing.T) {
 		object     string
 		expected   string
 	}{
-		{collection: "", shard: "", object: "", expected: "collections/*/shards/*/objects/*"},
-		{collection: "*", shard: "*", object: "*", expected: "collections/*/shards/*/objects/*"},
-		{collection: "foo", shard: "", object: "", expected: "collections/foo/shards/*/objects/*"},
-		{collection: "foo", shard: "*", object: "*", expected: "collections/foo/shards/*/objects/*"},
-		{collection: "", shard: "bar", object: "", expected: "collections/*/shards/bar/objects/*"},
-		{collection: "*", shard: "bar", object: "*", expected: "collections/*/shards/bar/objects/*"},
-		{collection: "", shard: "", object: "baz", expected: "collections/*/shards/*/objects/baz"},
-		{collection: "*", shard: "*", object: "baz", expected: "collections/*/shards/*/objects/baz"},
-		{collection: "foo", shard: "bar", object: "", expected: "collections/foo/shards/bar/objects/*"},
-		{collection: "foo", shard: "bar", object: "*", expected: "collections/foo/shards/bar/objects/*"},
-		{collection: "foo", shard: "", object: "baz", expected: "collections/foo/shards/*/objects/baz"},
-		{collection: "foo", shard: "*", object: "baz", expected: "collections/foo/shards/*/objects/baz"},
-		{collection: "", shard: "bar", object: "baz", expected: "collections/*/shards/bar/objects/baz"},
-		{collection: "*", shard: "bar", object: "baz", expected: "collections/*/shards/bar/objects/baz"},
+		{collection: "", shard: "", object: "", expected: "collections/.*/shards/.*/objects/.*"},
+		{collection: "*", shard: "*", object: "*", expected: "collections/.*/shards/.*/objects/.*"},
+		{collection: "foo", shard: "", object: "", expected: "collections/foo/shards/.*/objects/.*"},
+		{collection: "foo", shard: "*", object: "*", expected: "collections/foo/shards/.*/objects/.*"},
+		{collection: "", shard: "bar", object: "", expected: "collections/.*/shards/bar/objects/.*"},
+		{collection: "*", shard: "bar", object: "*", expected: "collections/.*/shards/bar/objects/.*"},
+		{collection: "", shard: "", object: "baz", expected: "collections/.*/shards/.*/objects/baz"},
+		{collection: "*", shard: "*", object: "baz", expected: "collections/.*/shards/.*/objects/baz"},
+		{collection: "foo", shard: "bar", object: "", expected: "collections/foo/shards/bar/objects/.*"},
+		{collection: "foo", shard: "bar", object: "*", expected: "collections/foo/shards/bar/objects/.*"},
+		{collection: "foo", shard: "", object: "baz", expected: "collections/foo/shards/.*/objects/baz"},
+		{collection: "foo", shard: "*", object: "baz", expected: "collections/foo/shards/.*/objects/baz"},
+		{collection: "", shard: "bar", object: "baz", expected: "collections/.*/shards/bar/objects/baz"},
+		{collection: "*", shard: "bar", object: "baz", expected: "collections/.*/shards/bar/objects/baz"},
 		{collection: "foo", shard: "bar", object: "baz", expected: "collections/foo/shards/bar/objects/baz"},
 	}
 	for _, tt := range tests {
 		name := fmt.Sprintf("collection: %s; shard: %s; object: %s", tt.collection, tt.shard, tt.object)
 		t.Run(name, func(t *testing.T) {
 			p := pObjects(tt.collection, tt.shard, tt.object)
+			require.Equal(t, tt.expected, p)
+		})
+	}
+}
+
+func Test_fromCasbinResource(t *testing.T) {
+	tests := []struct {
+		resource string
+		expected string
+	}{
+		{resource: "collections/.*/shards/.*/objects/.*", expected: "collections/*/shards/*/objects/*"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("resource: %s", tt.resource)
+		t.Run(name, func(t *testing.T) {
+			p := fromCasbinResource(tt.resource)
 			require.Equal(t, tt.expected, p)
 		})
 	}

--- a/usecases/auth/authorization/rbac/types_test.go
+++ b/usecases/auth/authorization/rbac/types_test.go
@@ -525,3 +525,82 @@ func Test_permission(t *testing.T) {
 		}
 	}
 }
+
+func Test_pRoles(t *testing.T) {
+	tests := []struct {
+		role     string
+		expected string
+	}{
+		{role: "", expected: "roles/*"},
+		{role: "foo", expected: "roles/foo"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("role: %s", tt.role)
+		t.Run(name, func(t *testing.T) {
+			p := pRoles(tt.role)
+			require.Equal(t, tt.expected, p)
+		})
+	}
+}
+
+func Test_pCollections(t *testing.T) {
+	tests := []struct {
+		collection string
+		expected   string
+	}{
+		{collection: "", expected: "collections/*"},
+		{collection: "foo", expected: "collections/foo"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("collection: %s", tt.collection)
+		t.Run(name, func(t *testing.T) {
+			p := pCollections(tt.collection)
+			require.Equal(t, tt.expected, p)
+		})
+	}
+}
+
+func Test_pShards(t *testing.T) {
+	tests := []struct {
+		collection string
+		shard      string
+		expected   string
+	}{
+		{collection: "", shard: "", expected: "collections/*/shards/*"},
+		{collection: "foo", shard: "", expected: "collections/foo/shards/*"},
+		{collection: "", shard: "bar", expected: "collections/*/shards/bar"},
+		{collection: "foo", shard: "bar", expected: "collections/foo/shards/bar"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("collection: %s; shard: %s", tt.collection, tt.shard)
+		t.Run(name, func(t *testing.T) {
+			p := pShards(tt.collection, tt.shard)
+			require.Equal(t, tt.expected, p)
+		})
+	}
+}
+
+func Test_pObjects(t *testing.T) {
+	tests := []struct {
+		collection string
+		shard      string
+		object     string
+		expected   string
+	}{
+		{collection: "", shard: "", object: "", expected: "collections/*/shards/*/objects/*"},
+		{collection: "foo", shard: "", object: "", expected: "collections/foo/shards/*/objects/*"},
+		{collection: "", shard: "bar", object: "", expected: "collections/*/shards/bar/objects/*"},
+		{collection: "", shard: "", object: "baz", expected: "collections/*/shards/*/objects/baz"},
+		{collection: "foo", shard: "bar", object: "", expected: "collections/foo/shards/bar/objects/*"},
+		{collection: "foo", shard: "", object: "baz", expected: "collections/foo/shards/*/objects/baz"},
+		{collection: "", shard: "bar", object: "baz", expected: "collections/*/shards/bar/objects/baz"},
+		{collection: "foo", shard: "bar", object: "baz", expected: "collections/foo/shards/bar/objects/baz"},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("collection: %s; shard: %s; object: %s", tt.collection, tt.shard, tt.object)
+		t.Run(name, func(t *testing.T) {
+			p := pObjects(tt.collection, tt.shard, tt.object)
+			require.Equal(t, tt.expected, p)
+		})
+	}
+}

--- a/usecases/auth/authorization/rbac/types_test.go
+++ b/usecases/auth/authorization/rbac/types_test.go
@@ -532,6 +532,7 @@ func Test_pRoles(t *testing.T) {
 		expected string
 	}{
 		{role: "", expected: "roles/*"},
+		{role: "*", expected: "roles/*"},
 		{role: "foo", expected: "roles/foo"},
 	}
 	for _, tt := range tests {
@@ -549,6 +550,7 @@ func Test_pCollections(t *testing.T) {
 		expected   string
 	}{
 		{collection: "", expected: "collections/*"},
+		{collection: "*", expected: "collections/*"},
 		{collection: "foo", expected: "collections/foo"},
 	}
 	for _, tt := range tests {
@@ -567,8 +569,11 @@ func Test_pShards(t *testing.T) {
 		expected   string
 	}{
 		{collection: "", shard: "", expected: "collections/*/shards/*"},
+		{collection: "*", shard: "*", expected: "collections/*/shards/*"},
 		{collection: "foo", shard: "", expected: "collections/foo/shards/*"},
+		{collection: "foo", shard: "*", expected: "collections/foo/shards/*"},
 		{collection: "", shard: "bar", expected: "collections/*/shards/bar"},
+		{collection: "*", shard: "bar", expected: "collections/*/shards/bar"},
 		{collection: "foo", shard: "bar", expected: "collections/foo/shards/bar"},
 	}
 	for _, tt := range tests {
@@ -588,12 +593,19 @@ func Test_pObjects(t *testing.T) {
 		expected   string
 	}{
 		{collection: "", shard: "", object: "", expected: "collections/*/shards/*/objects/*"},
+		{collection: "*", shard: "*", object: "*", expected: "collections/*/shards/*/objects/*"},
 		{collection: "foo", shard: "", object: "", expected: "collections/foo/shards/*/objects/*"},
+		{collection: "foo", shard: "*", object: "*", expected: "collections/foo/shards/*/objects/*"},
 		{collection: "", shard: "bar", object: "", expected: "collections/*/shards/bar/objects/*"},
+		{collection: "*", shard: "bar", object: "*", expected: "collections/*/shards/bar/objects/*"},
 		{collection: "", shard: "", object: "baz", expected: "collections/*/shards/*/objects/baz"},
+		{collection: "*", shard: "*", object: "baz", expected: "collections/*/shards/*/objects/baz"},
 		{collection: "foo", shard: "bar", object: "", expected: "collections/foo/shards/bar/objects/*"},
+		{collection: "foo", shard: "bar", object: "*", expected: "collections/foo/shards/bar/objects/*"},
 		{collection: "foo", shard: "", object: "baz", expected: "collections/foo/shards/*/objects/baz"},
+		{collection: "foo", shard: "*", object: "baz", expected: "collections/foo/shards/*/objects/baz"},
 		{collection: "", shard: "bar", object: "baz", expected: "collections/*/shards/bar/objects/baz"},
+		{collection: "*", shard: "bar", object: "baz", expected: "collections/*/shards/bar/objects/baz"},
 		{collection: "foo", shard: "bar", object: "baz", expected: "collections/foo/shards/bar/objects/baz"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What's being changed:

- Ensure that `.*` is parsed to `*` from casbin when building the `rbac.Policy` struct
- Adds unit tests for the `pX` methods
- Adds acceptance tests for creating and getting roles with specific permissions through the REST API

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
