### PR TITLE
Fix returning metadata from referenced class

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -654,6 +654,8 @@ func extractPropertiesRequest(reqProps *pb.PropertiesRequest, getClass func(stri
 						className, prop.ReferenceProperty, schemaProp.DataType)
 				}
 			}
+			linkedClass := getClass(linkedClassName)
+
 			var refProperties []search.SelectProperty
 			var addProps additional.Properties
 			if prop.Properties != nil {
@@ -662,7 +664,6 @@ func extractPropertiesRequest(reqProps *pb.PropertiesRequest, getClass func(stri
 					return nil, errors.Wrap(err, "extract properties request")
 				}
 			}
-			linkedClass := getClass(linkedClassName)
 			if prop.Metadata != nil {
 				addProps, err = extractAdditionalPropsFromMetadata(linkedClass, prop.Metadata, targetVectors, vectorSearch)
 				if err != nil {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -662,8 +662,9 @@ func extractPropertiesRequest(reqProps *pb.PropertiesRequest, getClass func(stri
 					return nil, errors.Wrap(err, "extract properties request")
 				}
 			}
+			linkedClass := getClass(linkedClassName)
 			if prop.Metadata != nil {
-				addProps, err = extractAdditionalPropsFromMetadata(class, prop.Metadata, targetVectors, vectorSearch)
+				addProps, err = extractAdditionalPropsFromMetadata(linkedClass, prop.Metadata, targetVectors, vectorSearch)
 				if err != nil {
 					return nil, errors.Wrap(err, "extract additional props for refs")
 				}
@@ -750,8 +751,9 @@ func extractPropertiesRequestDeprecated(reqProps *pb.PropertiesRequest, getClass
 					return nil, errors.Wrap(err, "extract properties request")
 				}
 			}
+			linkedClass := getClass(linkedClassName)
 			if prop.Metadata != nil {
-				addProps, err = extractAdditionalPropsFromMetadata(class, prop.Metadata, targetVectors, vectorSearch)
+				addProps, err = extractAdditionalPropsFromMetadata(linkedClass, prop.Metadata, targetVectors, vectorSearch)
 				if err != nil {
 					return nil, errors.Wrap(err, "extract additional props for refs")
 				}

--- a/test/acceptance_with_python/conftest.py
+++ b/test/acceptance_with_python/conftest.py
@@ -10,11 +10,11 @@ from weaviate.collections.classes.config import (
     _VectorizerConfigCreate,
     _InvertedIndexConfigCreate,
     _ReferencePropertyBase,
-    _GenerativeConfigCreate,
+    _GenerativeProvider,
     _ReplicationConfigCreate,
     _MultiTenancyConfigCreate,
     _VectorIndexConfigCreate,
-    _RerankerConfigCreate,
+    _RerankerProvider,
 )
 from weaviate.collections.classes.types import Properties
 from weaviate.config import AdditionalConfig
@@ -36,7 +36,7 @@ class CollectionFactory(Protocol):
         ] = None,
         inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
         multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
-        generative_config: Optional[_GenerativeConfigCreate] = None,
+        generative_config: Optional[_GenerativeProvider] = None,
         headers: Optional[Dict[str, str]] = None,
         ports: Tuple[int, int] = (8080, 50051),
         data_model_properties: Optional[Type[Properties]] = None,
@@ -44,7 +44,7 @@ class CollectionFactory(Protocol):
         replication_config: Optional[_ReplicationConfigCreate] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         description: Optional[str] = None,
-        reranker_config: Optional[_RerankerConfigCreate] = None,
+        reranker_config: Optional[_RerankerProvider] = None,
     ) -> Collection[Any, Any]:
         """Typing for fixture."""
         ...
@@ -76,7 +76,7 @@ def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None
         ] = None,
         inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
         multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
-        generative_config: Optional[_GenerativeConfigCreate] = None,
+        generative_config: Optional[_GenerativeProvider] = None,
         headers: Optional[Dict[str, str]] = None,
         ports: Tuple[int, int] = (8080, 50051),
         data_model_properties: Optional[Type[Properties]] = None,
@@ -84,7 +84,7 @@ def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None
         replication_config: Optional[_ReplicationConfigCreate] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         description: Optional[str] = None,
-        reranker_config: Optional[_RerankerConfigCreate] = None,
+        reranker_config: Optional[_RerankerProvider] = None,
     ) -> Collection[Any, Any]:
         nonlocal client_fixture, name_fixture
         name_fixture = _sanitize_collection_name(request.node.name) + name

--- a/test/acceptance_with_python/conftest.py
+++ b/test/acceptance_with_python/conftest.py
@@ -10,11 +10,11 @@ from weaviate.collections.classes.config import (
     _VectorizerConfigCreate,
     _InvertedIndexConfigCreate,
     _ReferencePropertyBase,
-    _GenerativeProvider,
+    _GenerativeConfigCreate,
     _ReplicationConfigCreate,
     _MultiTenancyConfigCreate,
     _VectorIndexConfigCreate,
-    _RerankerProvider,
+    _RerankerConfigCreate,
 )
 from weaviate.collections.classes.types import Properties
 from weaviate.config import AdditionalConfig
@@ -36,7 +36,7 @@ class CollectionFactory(Protocol):
         ] = None,
         inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
         multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
-        generative_config: Optional[_GenerativeProvider] = None,
+        generative_config: Optional[_GenerativeConfigCreate] = None,
         headers: Optional[Dict[str, str]] = None,
         ports: Tuple[int, int] = (8080, 50051),
         data_model_properties: Optional[Type[Properties]] = None,
@@ -44,7 +44,7 @@ class CollectionFactory(Protocol):
         replication_config: Optional[_ReplicationConfigCreate] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         description: Optional[str] = None,
-        reranker_config: Optional[_RerankerProvider] = None,
+        reranker_config: Optional[_RerankerConfigCreate] = None,
     ) -> Collection[Any, Any]:
         """Typing for fixture."""
         ...
@@ -76,7 +76,7 @@ def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None
         ] = None,
         inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,
         multi_tenancy_config: Optional[_MultiTenancyConfigCreate] = None,
-        generative_config: Optional[_GenerativeProvider] = None,
+        generative_config: Optional[_GenerativeConfigCreate] = None,
         headers: Optional[Dict[str, str]] = None,
         ports: Tuple[int, int] = (8080, 50051),
         data_model_properties: Optional[Type[Properties]] = None,
@@ -84,7 +84,7 @@ def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None
         replication_config: Optional[_ReplicationConfigCreate] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         description: Optional[str] = None,
-        reranker_config: Optional[_RerankerProvider] = None,
+        reranker_config: Optional[_RerankerConfigCreate] = None,
     ) -> Collection[Any, Any]:
         nonlocal client_fixture, name_fixture
         name_fixture = _sanitize_collection_name(request.node.name) + name

--- a/test/acceptance_with_python/test_refs.py
+++ b/test/acceptance_with_python/test_refs.py
@@ -103,6 +103,7 @@ def test_return_metadata_ref(collection_factory: CollectionFactory) -> None:
     source = collection_factory(
         name="source",
         references=[wvc.config.ReferenceProperty(name="ref", target_collection=target.name)],
+        vectorizer_config=wvc.config.Configure.Vectorizer.none(),
     )
 
     uuid_target = target.data.insert(

--- a/test/acceptance_with_python/test_refs.py
+++ b/test/acceptance_with_python/test_refs.py
@@ -89,3 +89,29 @@ def test_ref_with_multiple_cycle(collection_factory: CollectionFactory) -> None:
     ret2_objects = sorted(ret[2].references["ref"].objects, key=lambda x: x.properties["name"])
     assert ret2_objects[0].properties["name"] == "A"
     assert ret2_objects[1].properties["name"] == "B"
+
+
+def test_return_metadata_ref(collection_factory: CollectionFactory) -> None:
+    target = collection_factory(
+        name="target",
+        vectorizer_config=[
+            wvc.config.Configure.NamedVectors.none(name="bringYourOwn1"),
+            wvc.config.Configure.NamedVectors.none(name="bringYourOwn2"),
+        ],
+    )
+
+    source = collection_factory(
+        name="source",
+        references=[wvc.config.ReferenceProperty(name="ref", target_collection=target.name)],
+    )
+
+    uuid_target = target.data.insert(
+        properties={}, vector={"bringYourOwn1": [1, 2, 3], "bringYourOwn2": [4, 5, 6]}
+    )
+    source.data.insert(properties={}, references={"ref": uuid_target})
+
+    res = source.query.fetch_objects(
+        return_references=wvc.query.QueryReference(link_on="ref", include_vector=True)
+    )
+
+    assert res.objects[0].references["ref"].objects[0].vector["bringYourOwn1"] == [1, 2, 3]


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/weaviate/issues/6279

Superseeds https://github.com/weaviate/weaviate/pull/6278 and adds tests

Fixes that metadata (vectors etc) is pulled from the referenced class and not the source class.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
