### PR TITLE
Use bufconn to Avoid Firewall Message when running Unit Tests

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -26,7 +26,10 @@ import (
 	"strings"
 	"time"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
 	"github.com/weaviate/fgprof"
+	"google.golang.org/grpc"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	openapierrors "github.com/go-openapi/errors"
@@ -401,8 +404,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		querierManager := metadata.NewQuerierManager(appState.Logger)
 		metadataServer := metadata.NewServer(
 			appState.ServerConfig.Config.MetadataServer.GrpcListenAddress,
-			1024*1024*1024,
-			true,
 			querierManager,
 			appState.ServerConfig.Config.MetadataServer.DataEventsChannelCapacity,
 			appState.Logger)
@@ -412,7 +413,34 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		enterrors.GoWrapper(func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			if err := metadataServer.Serve(ctx); err != nil {
+			// NOTE this setup code hasn't been cleaned up because there's a good chance we'll
+			// remove the metadata server code entirely in the future, so didn't want to put
+			// time into making it nice and it's hidden behind the metadata server feature flag
+			// anyway
+			listenAddress := appState.ServerConfig.Config.MetadataServer.GrpcListenAddress
+			appState.Logger.WithField(
+				"address", listenAddress,
+			).Info("starting metadata rpc server ...")
+			if listenAddress == "" {
+				appState.Logger.Error("address of rpc server cannot be empty")
+				return
+			}
+
+			// use ListenConfig so we can pass a context to Listen
+			lc := &net.ListenConfig{}
+			listener, err := lc.Listen(ctx, "tcp", listenAddress)
+			if err != nil {
+				appState.Logger.WithError(err).Error("server tcp net.listen")
+				return
+			}
+			var options []grpc.ServerOption
+			options = append(options, grpc.MaxRecvMsgSize(1024*1024*1024))
+			options = append(options,
+				grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+					grpc_sentry.UnaryServerInterceptor(),
+				)))
+
+			if err := metadataServer.Serve(ctx, listener, options); err != nil {
 				appState.Logger.WithError(err).Error("metadata server did not start")
 			}
 		}, appState.Logger)


### PR DESCRIPTION
### What's being changed:

Fixes the issue where running the unit tests causes cause a firewall message to pop up by replacing the grpc server listening on real ports with one that uses [bufconn](https://pkg.go.dev/google.golang.org/grpc/test/bufconn). The code changes aren't too nice because there's a good chance we're going to end up deleting the metadata grpc server in the future, tbd.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
