### PR TITLE
fix: gRPC bind host should be the same as the HTTP host

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -122,8 +122,8 @@ func makeMetricsInterceptor(logger logrus.FieldLogger, metrics *monitoring.Prome
 }
 
 func StartAndListen(s *GRPCServer, state *state.State) error {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d",
-		state.ServerConfig.Config.GRPC.Port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d",
+		state.ServerConfig.Hostname, state.ServerConfig.Config.GRPC.Port))
 	if err != nil {
 		return err
 	}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -634,7 +634,7 @@ func parseVotersNames(cfg config.Raft) (m map[string]struct{}) {
 	return m
 }
 
-func configureAPI(api *operations.WeaviateAPI) http.Handler {
+func configureAPI(host string, api *operations.WeaviateAPI) http.Handler {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Minute)
 	defer cancel()
@@ -645,6 +645,8 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		"server_version": config.ServerVersion,
 		"version":        build.Version,
 	}).Infof("configured versions")
+
+	appState.ServerConfig.Hostname = host
 
 	api.ServeError = openapierrors.ServeError
 

--- a/adapters/handlers/rest/server.go
+++ b/adapters/handlers/rest/server.go
@@ -65,7 +65,7 @@ func NewServer(api *operations.WeaviateAPI) *Server {
 // ConfigureAPI configures the API and handlers.
 func (s *Server) ConfigureAPI() {
 	if s.api != nil {
-		s.handler = configureAPI(s.api)
+		s.handler = configureAPI(s.Host, s.api)
 	}
 }
 
@@ -143,7 +143,7 @@ func (s *Server) SetAPI(api *operations.WeaviateAPI) {
 	}
 
 	s.api = api
-	s.handler = configureAPI(api)
+	s.handler = configureAPI(s.Host, api)
 }
 
 func (s *Server) hasScheme(scheme string) bool {


### PR DESCRIPTION
### What's being changed:
Hostname was not passed to gRPC while starting, hence it bound to the default host and port, Now the hostname is passed so that it can start on the configured hostname.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

fixes #5898

### Result SS
![weaviate_grpc_host_change](https://github.com/user-attachments/assets/c2b58df6-feb5-4597-9c21-6d59eeccd066)
