### PR TITLE
migrate properties from raft when comparing update class

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -208,6 +208,9 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 	}
 
 	update := func(meta *metaClass) error {
+		// Ensure that if non-default values for properties is stored in raft we fix them before processing an update to
+		// avoid triggering diff on properties and therefore discarding a legitimate update.
+		migratePropertiesIfNecessary(&meta.Class)
 		u, err := s.parser.ParseClassUpdate(&meta.Class, req.Class)
 		if err != nil {
 			return fmt.Errorf("%w :parse class update: %w", ErrBadRequest, err)


### PR DESCRIPTION
### What's being changed:

Ensure that when raft processes a class update we migrate properties from the class from raft. This ensures that default value is not nil but the actual default value and avoid discarding updates because a bogus diff on properties is detected.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/11898074917
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
