### PR TITLE
Annotate allow list in slow log: individual rows vs merge

### DIFF
--- a/adapters/repos/db/helpers/slow_queries_details.go
+++ b/adapters/repos/db/helpers/slow_queries_details.go
@@ -55,6 +55,34 @@ func AnnotateSlowQueryLog(ctx context.Context, key string, value any) {
 	}
 }
 
+func AnnotateSlowQueryLogAppend(ctx context.Context, key string, value any) {
+	val := ctx.Value("slow_query_details")
+	if val == nil {
+		return
+	}
+
+	details, ok := val.(*SlowQueryDetails)
+	if !ok {
+		return
+	}
+
+	details.Lock()
+	defer details.Unlock()
+
+	prev, ok := details.values[key]
+	if !ok {
+		prev = make([]any, 0)
+	}
+
+	asList, ok := prev.([]any)
+	if !ok {
+		return
+	}
+
+	asList = append(asList, value)
+	details.values[key] = asList
+}
+
 func ExtractSlowQueryDetails(ctx context.Context) map[string]any {
 	val := ctx.Value("slow_query_details")
 	if val == nil {

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -53,7 +53,7 @@ func newPropValuePair(class *models.Class, logger logrus.FieldLogger) (*propValu
 	return &propValuePair{logger: logger, docIDs: newDocBitmap(), Class: class}, nil
 }
 
-func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
+func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) error {
 	if pv.operator.OnValue() {
 
 		// TODO text_rbm_inverted_index find better way check whether prop len
@@ -87,7 +87,6 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
 			return errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
 		}
 
-		ctx := context.TODO() // TODO: pass through instead of spawning new
 		dbm, err := s.docBitmap(ctx, b, limit, pv)
 		if err != nil {
 			return err
@@ -105,7 +104,7 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int) error {
 				// otherwise we run into situations where each subfilter on their own
 				// runs into the limit, possibly yielding in "less than limit" results
 				// after merging.
-				err := child.fetchDocIDs(s, 0)
+				err := child.fetchDocIDs(ctx, s, 0)
 				if err != nil {
 					return errors.Wrapf(err, "nested child %d", i)
 				}


### PR DESCRIPTION
### What's being changed:

* `build_allow_list` is broken down further in the slowlog
* It adds one entry per row individual filter leaf
* And one entry to merge all leaves into a final bitmap

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
