### PR TITLE
Update the Querier to use the Tenant Data Version

### DIFF
--- a/exp/query/api.go
+++ b/exp/query/api.go
@@ -100,7 +100,7 @@ func (a *API) Search(ctx context.Context, req *SearchRequest) (*SearchResponse, 
 
 	info, belongsToNodes, tenantVersion, err := a.schema.TenantStatus(ctx, req.Collection, req.Tenant)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get tenant status: collection: %q, tenant %q: %w", req.Collection, req.Tenant, err)
 	}
 
 	if info != TenantOffLoadingStatus {
@@ -202,7 +202,7 @@ func (a *API) propertyFilters(
 	if class == nil {
 		class, err = a.schema.Collection(ctx, collection)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get class info from schema: %w", err)
+			return nil, fmt.Errorf("failed to get class info for %q from schema: %w", collection, err)
 		}
 	}
 

--- a/exp/query/api.go
+++ b/exp/query/api.go
@@ -65,7 +65,7 @@ type API struct {
 
 type SchemaQuerier interface {
 	// TenantStatus returns (STATUS, BELONGSTONODES, VERSION) tuple
-	TenantStatus(ctx context.Context, collection, tenant string) (string, []string, uint64, error)
+	TenantStatus(ctx context.Context, collection, tenant string) (string, []string, int64, error)
 	Collection(ctx context.Context, collection string) (*models.Class, error)
 }
 

--- a/exp/query/api_test.go
+++ b/exp/query/api_test.go
@@ -231,7 +231,7 @@ var testSchemaInfo = &mockSchemaInfo{
 	},
 }
 
-func (m *mockSchemaInfo) TenantStatus(_ context.Context, collection, tenant string) (string, []string, uint64, error) {
+func (m *mockSchemaInfo) TenantStatus(_ context.Context, collection, tenant string) (string, []string, int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/exp/query/cache.go
+++ b/exp/query/cache.go
@@ -89,8 +89,8 @@ func (d *DiskCache) Tenant(collection, tenantID string) (*TenantCache, error) {
 
 // AddTenant is called after having the files in right directory
 // AddTenant checks if file is present on that directory
-// deterministically generated from `collection` & `tenant` with basePath
-func (d *DiskCache) AddTenant(collection, tenantID string, version uint64) error {
+// deterministically generated from `collection` & `tenant` & `version` with basePath
+func (d *DiskCache) AddTenant(collection, tenantID string, version int64) error {
 	timer := prometheus.NewTimer(d.metrics.OpsDuration.WithLabelValues(collection, tenantID, "put")) // "put" is the operation type, meaning the write path of the cache.
 	defer timer.ObserveDuration()
 
@@ -179,7 +179,7 @@ func (d *DiskCache) TenantKey(collection, tenantID string) string {
 type TenantCache struct {
 	Collection   string
 	TenantID     string
-	Version      uint64
+	Version      int64
 	LastAccessed time.Time
 
 	basePath string

--- a/exp/query/grpc.go
+++ b/exp/query/grpc.go
@@ -13,6 +13,7 @@ package query
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	v1 "github.com/weaviate/weaviate/adapters/handlers/grpc/v1"
@@ -44,7 +45,7 @@ func NewGRPC(api *API, schema SchemaQuerier, log logrus.FieldLogger) *GRPC {
 func (g *GRPC) Search(ctx context.Context, req *protocol.SearchRequest) (*protocol.SearchReply, error) {
 	class, err := g.schema.Collection(ctx, req.Collection)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("search: failed to get collection %q: %w", req.Collection, err)
 	}
 
 	getClass := func(name string) *models.Class {

--- a/exp/query/lsm_fetcher_test.go
+++ b/exp/query/lsm_fetcher_test.go
@@ -69,11 +69,11 @@ func TestLSMFetcher_withCache(t *testing.T) {
 
 	cases := []struct {
 		name                string
-		version             uint64
+		version             int64
 		expectedCacheHit    int
 		expectedUpstreamHit int
 		addTenant           bool
-		addTenantVersion    uint64
+		addTenantVersion    int64
 	}{
 		{
 			name:                "version-0 should always download from upstream",
@@ -161,7 +161,7 @@ func TestLSMFetcher_concurrentInflights(t *testing.T) {
 	testNode := "test-node"
 	testCollection := "test-collection"
 	testTenant := "test-tenant"
-	testVersion := uint64(23)
+	testVersion := int64(23)
 
 	var (
 		wg   sync.WaitGroup
@@ -227,7 +227,7 @@ func (m *mockCache) Tenant(collection, tenantID string) (*TenantCache, error) {
 	return tc, nil
 }
 
-func (m *mockCache) AddTenant(collection, tenantID string, version uint64) error {
+func (m *mockCache) AddTenant(collection, tenantID string, version int64) error {
 	tc := &TenantCache{
 		Collection: collection,
 		TenantID:   tenantID,

--- a/exp/queryschema/info_test.go
+++ b/exp/queryschema/info_test.go
@@ -23,105 +23,138 @@ import (
 )
 
 func TestTenantInfo(t *testing.T) {
-	t.Run("tenant with frozen state", func(t *testing.T) {
-		schema := mockSchema(t)
+	t.Run("unauthorized", func(t *testing.T) {
+		schema := mockSchema(t, nil, "", 0, nil, http.StatusUnauthorized)
 		ctx := context.Background()
 		svr := httptest.NewServer(schema)
 		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
 
-		status, belongsToNodes, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
-		require.NoError(t, err)
-		assert.Equal(t, status, "FROZEN")
-		assert.Equal(t, []string{"node-1, node-2"}, belongsToNodes)
+		_, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		require.ErrorContains(t, err, "unauthorized")
 	})
 
-	t.Run("tenant with non-frozen state", func(t *testing.T) {
-		schema := mockSchema(t)
-		schema.returnActive = true // return non-frozen tenant
-
+	t.Run("not found", func(t *testing.T) {
+		schema := mockSchema(t, nil, "", 0, nil, http.StatusNotFound)
 		ctx := context.Background()
 		svr := httptest.NewServer(schema)
 		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
 
-		status, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		_, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
 		require.ErrorIs(t, err, ErrTenantNotFound)
-		require.Empty(t, status)
 	})
 
-	t.Run("error getting tenant status", func(t *testing.T) {
-		schema := mockSchema(t)
-		schema.returnError = true // return error in getting tenant info
-
+	t.Run("error code but no error set on body", func(t *testing.T) {
+		schema := mockSchema(t, nil, "", 0, nil, http.StatusInternalServerError)
 		ctx := context.Background()
 		svr := httptest.NewServer(schema)
 		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
 
-		status, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		_, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		require.ErrorContains(t, err, "error is not set")
+	})
+
+	t.Run("errors in body", func(t *testing.T) {
+		errMessages := []ErrorResponse{{"some important error"}, {"another important error"}}
+		schema := mockSchema(t, errMessages, "", 0, nil, http.StatusInternalServerError)
+		ctx := context.Background()
+		svr := httptest.NewServer(schema)
+		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
+
+		_, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
 		require.ErrorContains(t, err, "some important error")
-		require.Empty(t, status)
+		require.ErrorContains(t, err, "another important error")
 	})
 
-	t.Run("empty tenants", func(t *testing.T) {
-		schema := mockSchema(t)
-		schema.returnEmpty = true // return error in getting tenant info
-
+	t.Run("tenant with frozen state", func(t *testing.T) {
+		schema := mockSchema(t, nil, "FROZEN", 1, []string{"node-1", "node-2"}, 0)
 		ctx := context.Background()
 		svr := httptest.NewServer(schema)
 		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
 
-		status, _, _, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
-		require.ErrorIs(t, err, ErrTenantNotFound)
-		require.Empty(t, status)
+		status, belongsToNodes, dataVersion, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		require.NoError(t, err)
+		assert.Equal(t, "FROZEN", status)
+		assert.Equal(t, []string{"node-1", "node-2"}, belongsToNodes)
+		assert.Equal(t, int64(1), dataVersion)
+	})
+
+	t.Run("tenant with data version 2", func(t *testing.T) {
+		schema := mockSchema(t, nil, "FROZEN", 2, []string{"node-1", "node-2"}, 0)
+		ctx := context.Background()
+		svr := httptest.NewServer(schema)
+		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
+
+		status, belongsToNodes, dataVersion, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		require.NoError(t, err)
+		assert.Equal(t, "FROZEN", status)
+		assert.Equal(t, []string{"node-1", "node-2"}, belongsToNodes)
+		assert.Equal(t, int64(2), dataVersion)
+	})
+
+	t.Run("tenant with five belongs to nodes", func(t *testing.T) {
+		schema := mockSchema(t, nil, "FROZEN", 1, []string{"node-1", "node-2", "node-3", "node-4", "node-5"}, 0)
+		ctx := context.Background()
+		svr := httptest.NewServer(schema)
+		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
+
+		status, belongsToNodes, dataVersion, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		require.NoError(t, err)
+		assert.Equal(t, "FROZEN", status)
+		assert.Equal(t, []string{"node-1", "node-2", "node-3", "node-4", "node-5"}, belongsToNodes)
+		assert.Equal(t, int64(1), dataVersion)
+	})
+
+	t.Run("tenant with active state", func(t *testing.T) {
+		schema := mockSchema(t, nil, "ACTIVE", 0, []string{"node-1", "node-2"}, 0)
+		ctx := context.Background()
+		svr := httptest.NewServer(schema)
+		info := NewSchemaInfo(svr.URL, DefaultSchemaPrefix)
+
+		status, belongsToNodes, dataVersion, err := info.TenantStatus(ctx, "sample-collection", "captain-america")
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVE", status)
+		assert.Equal(t, []string{"node-1", "node-2"}, belongsToNodes)
+		assert.Equal(t, int64(0), dataVersion)
 	})
 }
 
 type schema struct {
-	t            *testing.T
-	returnError  bool
-	returnActive bool
-	returnEmpty  bool
+	t                    *testing.T
+	returnErrors         []ErrorResponse
+	returnBelongsToNodes []string
+	returnStatus         string
+	returnDataVersion    int64
+	// if 0, then WriteHeader will not be called
+	// so the default status will be 200
+	httpStatus int
 }
 
+// ServerHTTP json encodes the mock response and uses the httpStatus if set.
+// If httpStatus is 0, then the default status will be 200.
 func (s *schema) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	res := Response{}
-
-	switch {
-	case s.returnError:
-		res = Response{
-			Error: []ErrorResponse{
-				{
-					Message: "some important error",
-				},
-			},
-		}
-	case s.returnActive:
-		res = Response{
-			Name:           "iron-man",
-			Status:         "ACTIVE",
-			BelongsToNodes: []string{"node-1"},
-		}
-
-	case s.returnEmpty:
-		// do not append anything
-	default:
-		res = Response{
-			Name:           "captain-america",
-			Status:         "FROZEN",
-			BelongsToNodes: []string{"node-1, node-2"},
-		}
-
+	res := Response{
+		Error:          s.returnErrors,
+		BelongsToNodes: s.returnBelongsToNodes,
+		Status:         s.returnStatus,
+		DataVersion:    s.returnDataVersion,
 	}
-
+	if s.httpStatus != 0 {
+		w.WriteHeader(s.httpStatus)
+	}
 	if err := json.NewEncoder(w).Encode(res); err != nil {
 		require.NoError(s.t, err)
 	}
 }
 
-func mockSchema(t *testing.T) *schema {
+func mockSchema(t *testing.T, returnErrors []ErrorResponse, returnStatus string,
+	returnDataVersion int64, returnBelongsToNodes []string, httpStatus int,
+) *schema {
 	return &schema{
-		t:            t,
-		returnError:  false,
-		returnActive: false,
-		returnEmpty:  false,
+		t:                    t,
+		returnErrors:         returnErrors,
+		returnStatus:         returnStatus,
+		returnDataVersion:    returnDataVersion,
+		returnBelongsToNodes: returnBelongsToNodes,
+		httpStatus:           httpStatus,
 	}
 }


### PR DESCRIPTION
### What's being changed:

Update the querier to use the new tenant data so that the querier can reuse its local data cache when the tenant data in S3 has not changed.

Also modify the code/tests in `queryschema` to more accurately reflect the relevant core API.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
