### PR TITLE
Lowercase collection/tenant for tenant cache path

### DIFF
--- a/exp/query/cache.go
+++ b/exp/query/cache.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -186,7 +187,7 @@ type TenantCache struct {
 }
 
 func (tc *TenantCache) AbsolutePath() string {
-	return path.Join(tc.basePath, tc.Collection, tc.TenantID, fmt.Sprintf("%d", tc.Version))
+	return path.Join(tc.basePath, strings.ToLower(tc.Collection), strings.ToLower(tc.TenantID), fmt.Sprintf("%d", tc.Version))
 }
 
 // CacheMetrics exposes some insights about how cache operations.

--- a/exp/query/cache_test.go
+++ b/exp/query/cache_test.go
@@ -79,6 +79,17 @@ func TestCache_Tenant(t *testing.T) {
 	assert.ErrorIs(t, err, ErrTenantNotFound)
 }
 
+func TestTenantCache_Casing(t *testing.T) {
+	// Collection/Tenant should be converted to lowercase by the TenantCache for filepaths
+	tt := &TenantCache{
+		Collection: "Test-Collection",
+		TenantID:   "Test-Tenant",
+		Version:    1,
+		basePath:   "/foo",
+	}
+	require.Equal(t, path.Join("/foo", "test-collection", "test-tenant", "1"), tt.AbsolutePath())
+}
+
 func createTempFileWithSize(t *testing.T, dir, prefix string, size int64) *os.File {
 	t.Helper()
 


### PR DESCRIPTION
### What's being changed:

Weaviate core uses lowercase collection/tenant names for filepaths, so this PR converts the querier's cache path code to use lowercase too. Found this issue while writing the acceptance tests, which run on docker linux (eg case-sensitive file system)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
