### PR TITLE
Introducing Weaviate Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Coverage Status](https://codecov.io/gh/weaviate/weaviate/branch/main/graph/badge.svg)](https://codecov.io/gh/weaviate/weaviate)
 [![Slack](https://img.shields.io/badge/slack--channel-blue?logo=slack)](https://weaviate.io/slack)
 [![GitHub Tutorials](https://img.shields.io/badge/Weaviate_Tutorials-green)](https://github.com/weaviate-tutorials/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Weaviate%20Guru-006BFF)](https://gurubase.io/g/weaviate)
 
 ## Overview
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Weaviate Guru](https://gurubase.io/g/weaviate) to Gurubase. Weaviate Guru uses the data from this repo and data from the [docs](https://weaviate.io/developers/weaviate/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Weaviate Guru", which highlights that Weaviate now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Weaviate Guru in Gurubase, just let me know that's totally fine.
