### PR TITLE
refact: don't authZ User and instead filter the returned roles

### DIFF
--- a/adapters/handlers/rest/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/handlers_authz_assign_roles_test.go
@@ -37,7 +37,7 @@ func TestAssignRoleSuccess(t *testing.T) {
 		},
 	}
 
-	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)[0], authorization.Users(params.ID)[0]).Return(nil)
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)[0]).Return(nil)
 	controller.On("GetRoles", params.Body.Roles[0]).Return(map[string][]authorization.Policy{params.Body.Roles[0]: {}}, nil)
 	controller.On("AddRolesForUser", params.ID, params.Body.Roles).Return(nil)
 
@@ -146,7 +146,7 @@ func TestAssignRoleForbidden(t *testing.T) {
 			controller := mocks.NewController(t)
 			logger, _ := test.NewNullLogger()
 
-			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0], authorization.Users(tt.params.ID)[0]).Return(tt.authorizeErr)
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(tt.authorizeErr)
 
 			h := &authZHandlers{
 				authorizer: authorizer,
@@ -207,7 +207,7 @@ func TestAssignRoleInternalServerError(t *testing.T) {
 			controller := mocks.NewController(t)
 			logger, _ := test.NewNullLogger()
 
-			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0], authorization.Users(tt.params.ID)[0]).Return(nil)
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(nil)
 			controller.On("GetRoles", tt.params.Body.Roles[0]).Return(map[string][]authorization.Policy{tt.params.Body.Roles[0]: {}}, tt.getRolesErr)
 			if tt.getRolesErr == nil {
 				controller.On("AddRolesForUser", tt.params.ID, tt.params.Body.Roles).Return(tt.assignErr)

--- a/adapters/handlers/rest/handlers_authz_get_roles_for_user_test.go
+++ b/adapters/handlers/rest/handlers_authz_get_roles_for_user_test.go
@@ -139,7 +139,7 @@ func TestGetRolesForUserForbidden(t *testing.T) {
 			logger, _ := test.NewNullLogger()
 
 			returnedPolices := map[string][]authorization.Policy{
-				"testRole": []authorization.Policy{
+				"testRole": {
 					{
 						Resource: authorization.Collections("ABC")[0],
 						Verb:     authorization.READ,

--- a/adapters/handlers/rest/handlers_authz_get_roles_for_user_test.go
+++ b/adapters/handlers/rest/handlers_authz_get_roles_for_user_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/authz"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -47,7 +46,7 @@ func TestGetRolesForUserSuccess(t *testing.T) {
 		"testRole": policies,
 	}
 
-	authorizer.On("Authorize", principal, authorization.READ, authorization.Users(params.ID)[0]).Return(nil)
+	authorizer.On("Authorize", principal, authorization.READ, authorization.Roles("testRole")[0]).Return(nil)
 	controller.On("GetRolesForUser", params.ID).Return(returnedPolices, nil)
 
 	h := &authZHandlers{
@@ -123,7 +122,7 @@ func TestGetRolesForUserForbidden(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "authorization error",
+			name: "authorization error no access to role",
 			params: authz.GetRolesForUserParams{
 				ID: "testUser",
 			},
@@ -139,7 +138,18 @@ func TestGetRolesForUserForbidden(t *testing.T) {
 			controller := mocks.NewController(t)
 			logger, _ := test.NewNullLogger()
 
-			authorizer.On("Authorize", tt.principal, authorization.READ, authorization.Users(tt.params.ID)[0]).Return(tt.authorizeErr)
+			returnedPolices := map[string][]authorization.Policy{
+				"testRole": []authorization.Policy{
+					{
+						Resource: authorization.Collections("ABC")[0],
+						Verb:     authorization.READ,
+						Domain:   authorization.SchemaDomain,
+					},
+				},
+			}
+
+			authorizer.On("Authorize", tt.principal, authorization.READ, authorization.Roles("testRole")[0]).Return(tt.authorizeErr)
+			controller.On("GetRolesForUser", tt.params.ID).Return(returnedPolices, nil)
 
 			h := &authZHandlers{
 				authorizer: authorizer,
@@ -184,7 +194,6 @@ func TestGetRolesForUserInternalServerError(t *testing.T) {
 			controller := mocks.NewController(t)
 			logger, _ := test.NewNullLogger()
 
-			authorizer.On("Authorize", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			controller.On("GetRolesForUser", tt.params.ID).Return(nil, tt.getRolesErr)
 
 			h := &authZHandlers{

--- a/adapters/handlers/rest/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/handlers_authz_revoke_roles_test.go
@@ -37,7 +37,7 @@ func TestRevokeRoleSuccess(t *testing.T) {
 		},
 	}
 
-	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)[0], authorization.Users(params.ID)[0]).Return(nil)
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)[0]).Return(nil)
 	controller.On("GetRoles", params.Body.Roles[0]).Return(map[string][]authorization.Policy{params.Body.Roles[0]: {}}, nil)
 	controller.On("RevokeRolesForUser", params.ID, params.Body.Roles[0]).Return(nil)
 
@@ -146,7 +146,7 @@ func TestRevokeRoleForbidden(t *testing.T) {
 			controller := mocks.NewController(t)
 			logger, _ := test.NewNullLogger()
 
-			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0], authorization.Users(tt.params.ID)[0]).Return(tt.authorizeErr)
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(tt.authorizeErr)
 
 			h := &authZHandlers{
 				authorizer: authorizer,
@@ -207,7 +207,7 @@ func TestRevokeRoleInternalServerError(t *testing.T) {
 			controller := mocks.NewController(t)
 			logger, _ := test.NewNullLogger()
 
-			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0], authorization.Users(tt.params.ID)[0]).Return(nil)
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(nil)
 			controller.On("GetRoles", tt.params.Body.Roles[0]).Return(map[string][]authorization.Policy{tt.params.Body.Roles[0]: {}}, tt.getRolesErr)
 			if tt.getRolesErr == nil {
 				controller.On("RevokeRolesForUser", tt.params.ID, tt.params.Body.Roles[0]).Return(tt.revokeErr)


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
