### PR TITLE
RBAC: alway init casbin and make the authZ only configurable

### DIFF
--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -29,7 +29,6 @@ type manager struct {
 }
 
 func New(rbacStoragePath string, apiKeys config.APIKey, logger logrus.FieldLogger) (*manager, error) {
-
 	casbin, err := Init(apiKeys, rbacStoragePath)
 	if err != nil {
 		return nil, err

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 type manager struct {
@@ -27,8 +28,14 @@ type manager struct {
 	logger logrus.FieldLogger
 }
 
-func New(casbin *casbin.SyncedCachedEnforcer, logger logrus.FieldLogger) *manager {
-	return &manager{casbin, logger}
+func New(rbacStoragePath string, apiKeys config.APIKey, logger logrus.FieldLogger) (*manager, error) {
+
+	casbin, err := Init(apiKeys, rbacStoragePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manager{casbin, logger}, nil
 }
 
 func (m *manager) UpsertRolesPermissions(roles map[string][]authorization.Policy) error {


### PR DESCRIPTION
### What's being changed:
given that we store RBAC now in raft it's required that casbin always enabled in case that RBAC disabled and raft re-apply on start RBAC commands

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
