### PR TITLE
feat(v1/schema/collection): Make collection name case in-sensitive for `GET` and `DELETE`

### DIFF
--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -44,6 +44,8 @@ func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, nam
 	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections(name)...); err != nil {
 		return nil, err
 	}
+	name = schema.UppercaseClassName(name)
+
 	cl := h.schemaReader.ReadOnlyClass(name)
 	return cl, nil
 }
@@ -54,6 +56,7 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Collections(name)...); err != nil {
 		return nil, 0, err
 	}
+	name = schema.UppercaseClassName(name)
 	if consistency {
 		vclasses, err := h.schemaManager.QueryReadOnlyClasses(name)
 		return vclasses[name].Class, vclasses[name].Version, err
@@ -201,6 +204,8 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 	if err != nil {
 		return err
 	}
+
+	class = schema.UppercaseClassName(class)
 
 	_, err = h.schemaManager.DeleteClass(ctx, class)
 	return err


### PR DESCRIPTION

### What's being changed:

Now when user try to get or delete collection, the collection name is case-insensitive.

#### Before

GET http://localhost:8080/v1/schema/Question - OK
GET http://localhost:8080/v1/schema/question - 404

DELETE http://localhost:8080/v1/schema/Question - OK 
DELETE http://localhost:8080/v1/schema/question - 404

#### After
GET http://localhost:8080/v1/schema/Question - OK
GET http://localhost:8080/v1/schema/question - OK

DELETE http://localhost:8080/v1/schema/Question - OK 
DELETE http://localhost:8080/v1/schema/question - OK

**Changes:**

1. Convert `class` name into canonical GQL naming before doing any get or delete

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
