### PR TITLE
RBAC: audit log & pretty print returned paths on err

### DIFF
--- a/usecases/auth/authorization/conv/casbin_converter.go
+++ b/usecases/auth/authorization/conv/casbin_converter.go
@@ -12,7 +12,9 @@
 package conv
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -46,6 +48,20 @@ func PermissionToPolicies(permissions ...*models.Permission) ([]*authorization.P
 	}
 
 	return policies, nil
+}
+
+func PathToPermission(verb, path string) (*models.Permission, error) {
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid path")
+	}
+
+	domain := parts[0]
+	if domain == "meta" {
+		domain = parts[1]
+	}
+
+	return permission([]string{"", path, verb, domain})
 }
 
 func PoliciesToPermission(policies ...authorization.Policy) ([]*models.Permission, error) {

--- a/usecases/auth/authorization/conv/casbin_converter.go
+++ b/usecases/auth/authorization/conv/casbin_converter.go
@@ -52,16 +52,11 @@ func PermissionToPolicies(permissions ...*models.Permission) ([]*authorization.P
 
 func PathToPermission(verb, path string) (*models.Permission, error) {
 	parts := strings.Split(path, "/")
-	if len(parts) < 2 {
+	if len(parts) < 1 {
 		return nil, fmt.Errorf("invalid path")
 	}
 
-	domain := parts[0]
-	if domain == "meta" {
-		domain = parts[1]
-	}
-
-	return permission([]string{"", path, verb, domain})
+	return permission([]string{"", path, verb, parts[0]})
 }
 
 func PoliciesToPermission(policies ...authorization.Policy) ([]*models.Permission, error) {

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -13,6 +13,7 @@ package rbac
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/casbin/casbin/v2"
 	"github.com/sirupsen/logrus"
@@ -159,12 +160,6 @@ func (m *manager) Authorize(principal *models.Principal, verb string, resources 
 
 	// TODO batch enforce
 	for _, resource := range resources {
-		m.logger.WithFields(logrus.Fields{
-			"user":     principal.Username,
-			"resource": resource,
-			"action":   verb,
-		}).Debug("checking for role")
-
 		allow, err := m.casbin.Enforce(principal.Username, resource, verb)
 		if err != nil {
 			m.logger.WithFields(logrus.Fields{
@@ -175,11 +170,70 @@ func (m *manager) Authorize(principal *models.Principal, verb string, resources 
 			return err
 		}
 
-		// TODO audit-log ?
+		perm, err := conv.PathToPermission(verb, resource)
+		if err != nil {
+			return err
+		}
+
+		m.logger.WithFields(logrus.Fields{
+			"action":         "authorize",
+			"user":           principal.Username,
+			"resources":      prettyPermissionsResources(perm),
+			"request_action": prettyPermissionsActions(perm),
+			"results":        prettyStatus(allow),
+		}).Info()
+
 		if !allow {
-			return errors.NewForbidden(principal, verb, resources...)
+			return errors.NewForbidden(principal, prettyPermissionsActions(perm), prettyPermissionsResources(perm))
 		}
 	}
 
 	return nil
+}
+
+func prettyPermissionsActions(perm *models.Permission) string {
+	if perm == nil || perm.Action == nil {
+		return ""
+	}
+	return *perm.Action
+}
+
+func prettyPermissionsResources(perm *models.Permission) string {
+	res := ""
+	if perm == nil {
+		return ""
+	}
+
+	if perm.Collection != nil && *perm.Collection != "" {
+		res += fmt.Sprintf("Collection: %s,", *perm.Collection)
+	}
+
+	if perm.Tenant != nil && *perm.Tenant != "" {
+		res += fmt.Sprintf(" Tenant: %s,", *perm.Tenant)
+	}
+
+	if perm.Object != nil && *perm.Object != "" {
+		res += fmt.Sprintf(" Object: %s,", *perm.Object)
+	}
+
+	if perm.Role != nil && *perm.Role != "" {
+		res += fmt.Sprintf(" Role: %s,", *perm.Role)
+	}
+
+	if perm.User != nil && *perm.User != "" {
+		res += fmt.Sprintf(" User: %s,", *perm.User)
+	}
+
+	if many := strings.Count(res, ","); many == 1 {
+		res = strings.ReplaceAll(res, ",", "")
+		res = strings.TrimSpace(res)
+	}
+	return res
+}
+
+func prettyStatus(value bool) string {
+	if value {
+		return "success"
+	}
+	return "failed"
 }

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -163,9 +163,10 @@ func (m *manager) Authorize(principal *models.Principal, verb string, resources 
 		allow, err := m.casbin.Enforce(principal.Username, resource, verb)
 		if err != nil {
 			m.logger.WithFields(logrus.Fields{
-				"user":     principal.Username,
-				"resource": resource,
-				"action":   verb,
+				"action":         "authorize",
+				"user":           principal.Username,
+				"resource":       resource,
+				"request_action": verb,
 			}).WithError(err).Error("failed to enforce policy")
 			return err
 		}


### PR DESCRIPTION
### What's being changed:
this PR 
- adds audit log for all authZ requests 
  e.g.  `action=authorize build_git_commit=66d2875e8 build_go_version=go1.22.4 build_image_tag=feat/rbac build_wv_version=1.28.0-dev request_action=create_roles resources="Role: dddd" results=failed user=jane@doe.com`
  
- pretty print the response on Forbidden 
```
{
    "error": [
        {
            "message": "forbidden: user 'jane@doe.com' has insufficient permissions to create_roles [Role: dddd]"
        }
    ]
}
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
