### PR TITLE
fix: flaky async indexing e2e tests

### DIFF
--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -20,10 +20,13 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/multishard"
@@ -1080,6 +1083,7 @@ func addTestDataRansomNotes(t *testing.T) {
 		numBatches = 50
 	)
 
+	className := "RansomNote"
 	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for i := 0; i < numBatches; i++ {
@@ -1089,13 +1093,31 @@ func addTestDataRansomNotes(t *testing.T) {
 			note := helper.GetRandomString(noteLength)
 
 			batch[j] = &models.Object{
-				Class:      "RansomNote",
+				Class:      className,
 				Properties: map[string]interface{}{"contents": note},
 			}
 		}
 
 		createObjectsBatch(t, batch)
 	}
+
+	t.Run("wait for all objects to be indexed", func(t *testing.T) {
+		// wait for all of the objects to get indexed
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(className)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			resp, err := body.Payload, clientErr
+			require.NoError(ct, err)
+			require.NotEmpty(ct, resp.Nodes)
+			for _, n := range resp.Nodes {
+				require.NotEmpty(ct, n.Shards)
+				for _, s := range n.Shards {
+					assert.Equal(ct, "READY", s.VectorIndexingStatus)
+				}
+			}
+		}, 15*time.Second, 500*time.Millisecond)
+	})
 }
 
 func addTestDataMultiShard(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_batch.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_batch.go
@@ -85,6 +85,10 @@ func testBatchObject(host string) func(t *testing.T) {
 				}
 			})
 
+			t.Run("check if all objects have been indexed", func(t *testing.T) {
+				testAllObjectsIndexed(t, client, className)
+			})
+
 			t.Run("GraphQL get vectors", func(t *testing.T) {
 				for id := range fixtures.Books() {
 					resultVectors := getVectors(t, client, className, id, targetVectors...)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects_properties.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects_properties.go
@@ -160,6 +160,10 @@ func testCreateWithModulePropertiesObject(host string) func(t *testing.T) {
 				}
 			})
 
+			t.Run("check if all objects have been indexed", func(t *testing.T) {
+				testAllObjectsIndexed(t, client, className)
+			})
+
 			t.Run("GraphQL get vectors", func(t *testing.T) {
 				for id := range fixtures.Books() {
 					resultVectors := getVectors(t, client, className, id, targetVectorsWithProperties...)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_restart.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_restart.go
@@ -74,6 +74,10 @@ func TestRestart(compose *docker.DockerCompose) func(t *testing.T) {
 				}
 			})
 
+			t.Run("check if all objects have been indexed", func(t *testing.T) {
+				testAllObjectsIndexed(t, client, className)
+			})
+
 			t.Run("GraphQL get vectors", func(t *testing.T) {
 				for id := range fixtures.Books() {
 					resultVectors := getVectors(t, client, className, id, targetVectors...)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
@@ -280,11 +280,11 @@ func getVectorsWithNearArgs(t *testing.T, client *wvt.Client,
 	var resp *models.GraphQLResponse
 	var err error
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		resp, err = get.Do(context.Background())
 		require.NoError(t, err)
 		ids := acceptance_with_go_client.GetIds(t, resp, className)
-		return slices.Contains(ids, id)
+		assert.True(ct, slices.Contains(ids, id))
 	}, 5*time.Second, 200*time.Millisecond)
 
 	return acceptance_with_go_client.GetVectors(t, resp, className, withCertainty, targetVectors...)
@@ -315,4 +315,22 @@ func checkTargetVectors(t *testing.T, resultVectors map[string][]float32) {
 	assert.NotEqual(t, resultVectors[c11y_flat], resultVectors[transformers_flat])
 	assert.NotEqual(t, resultVectors[c11y_pq], resultVectors[transformers_pq])
 	assert.NotEqual(t, resultVectors[c11y_bq], resultVectors[transformers_bq])
+}
+
+func testAllObjectsIndexed(t *testing.T, client *wvt.Client, className string) {
+	// wait for all of the objects to get indexed
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := client.Cluster().NodesStatusGetter().
+			WithClass(className).
+			WithOutput("verbose").
+			Do(context.Background())
+		require.NoError(ct, err)
+		require.NotEmpty(ct, resp.Nodes)
+		for _, n := range resp.Nodes {
+			require.NotEmpty(ct, n.Shards)
+			for _, s := range n.Shards {
+				assert.Equal(ct, "READY", s.VectorIndexingStatus)
+			}
+		}
+	}, 15*time.Second, 500*time.Millisecond)
 }


### PR DESCRIPTION
### What's being changed:

Fixes flaky tests: 
- TestGraphQL_AsyncIndexing/getting_objects_with_near_fields test, adds a check that waits for all of the objects to be indexed first.
- TestNamedVectors_Cluster_AsyncIndexing tests in acceptance with go client project.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
