### PR TITLE
Fix flaky TestNamedVectors_Cluster_AsyncIndexing tests

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_batch.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_batch.go
@@ -85,6 +85,10 @@ func testBatchObject(host string) func(t *testing.T) {
 				}
 			})
 
+			t.Run("check if all objects have been indexed", func(t *testing.T) {
+				testAllObjectsIndexed(t, client, className)
+			})
+
 			t.Run("GraphQL get vectors", func(t *testing.T) {
 				for id := range fixtures.Books() {
 					resultVectors := getVectors(t, client, className, id, targetVectors...)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects_properties.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects_properties.go
@@ -160,6 +160,10 @@ func testCreateWithModulePropertiesObject(host string) func(t *testing.T) {
 				}
 			})
 
+			t.Run("check if all objects have been indexed", func(t *testing.T) {
+				testAllObjectsIndexed(t, client, className)
+			})
+
 			t.Run("GraphQL get vectors", func(t *testing.T) {
 				for id := range fixtures.Books() {
 					resultVectors := getVectors(t, client, className, id, targetVectorsWithProperties...)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_restart.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_restart.go
@@ -74,6 +74,10 @@ func TestRestart(compose *docker.DockerCompose) func(t *testing.T) {
 				}
 			})
 
+			t.Run("check if all objects have been indexed", func(t *testing.T) {
+				testAllObjectsIndexed(t, client, className)
+			})
+
 			t.Run("GraphQL get vectors", func(t *testing.T) {
 				for id := range fixtures.Books() {
 					resultVectors := getVectors(t, client, className, id, targetVectors...)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
@@ -280,11 +280,11 @@ func getVectorsWithNearArgs(t *testing.T, client *wvt.Client,
 	var resp *models.GraphQLResponse
 	var err error
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		resp, err = get.Do(context.Background())
 		require.NoError(t, err)
 		ids := acceptance_with_go_client.GetIds(t, resp, className)
-		return slices.Contains(ids, id)
+		assert.True(ct, slices.Contains(ids, id))
 	}, 5*time.Second, 200*time.Millisecond)
 
 	return acceptance_with_go_client.GetVectors(t, resp, className, withCertainty, targetVectors...)
@@ -315,4 +315,20 @@ func checkTargetVectors(t *testing.T, resultVectors map[string][]float32) {
 	assert.NotEqual(t, resultVectors[c11y_flat], resultVectors[transformers_flat])
 	assert.NotEqual(t, resultVectors[c11y_pq], resultVectors[transformers_pq])
 	assert.NotEqual(t, resultVectors[c11y_bq], resultVectors[transformers_bq])
+}
+
+func testAllObjectsIndexed(t *testing.T, client *wvt.Client, className string) {
+	// wait for all of the objects to get indexed
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := client.Cluster().NodesStatusGetter().
+			WithClass(className).
+			WithOutput("verbose").
+			Do(context.Background())
+		require.NoError(ct, err)
+		for _, n := range resp.Nodes {
+			for _, s := range n.Shards {
+				assert.Equal(ct, "READY", s.VectorIndexingStatus)
+			}
+		}
+	}, 15*time.Second, 500*time.Millisecond)
 }


### PR DESCRIPTION
### What's being changed:

Fix flaky TestNamedVectors_Cluster_AsyncIndexing tests in acceptance with go client project.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
