### PR TITLE
Fix redundant retries for non-multi-tenancy collections when querying tenants

### DIFF
--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -290,7 +290,7 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 
 	// find out who the leader is
 	var leader string
-	f := func() error {
+	if err := backoff.Retry(func() error {
 		if leader = s.store.Leader(); leader == "" {
 			err := s.leaderErr()
 			s.log.Warnf("query: could not find leader: %s", err)
@@ -298,9 +298,8 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 		}
 
 		return nil
-	}
-	bf := backoff.WithMaxRetries(backoff.NewConstantBackOff(200*time.Millisecond), 10)
-	if err := backoff.Retry(f, backoff.WithContext(bf, ctx)); err != nil {
+	}, backoff.WithContext(backoff.WithMaxRetries(
+		backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx)); err != nil {
 		s.log.Errorf("query: failed to find leader after retries: %s", err)
 		return &cmd.QueryResponse{}, err
 	}

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -23,6 +23,7 @@ import (
 	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
 	"github.com/sirupsen/logrus"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/cluster/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -174,6 +175,8 @@ func toRPCError(err error) error {
 		ec = codes.ResourceExhausted
 	case errors.Is(err, types.ErrNotOpen):
 		ec = codes.Unavailable
+	case errors.Is(err, schema.ErrMTDisabled):
+		ec = codes.FailedPrecondition
 	default:
 		ec = codes.Internal
 	}

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -30,6 +30,7 @@ var (
 	ErrClassExists   = errors.New("class already exists")
 	ErrClassNotFound = errors.New("class not found")
 	ErrShardNotFound = errors.New("shard not found")
+	ErrMTDisabled    = errors.New("multi-tenancy is not enabled")
 )
 
 type ClassInfo struct {
@@ -246,7 +247,7 @@ func (s *schema) multiTenancyEnabled(class string) (bool, *metaClass, ClassInfo,
 	}
 	info := s.Classes[class].ClassInfo()
 	if !info.MultiTenancy.Enabled {
-		return false, nil, ClassInfo{}, fmt.Errorf("multi-tenancy is not enabled for class %q", class)
+		return false, nil, ClassInfo{}, fmt.Errorf("%w for class %q", ErrMTDisabled, class)
 	}
 	return true, meta, info, nil
 }


### PR DESCRIPTION
This PR resolves [issue](https://github.com/weaviate/weaviate/issues/6261)  where requests to query tenants for collections that do not use multi-tenancy result in prolonged response times and unnecessary retries

**Problem**

1. When a serving node receives a request to query tenants for a specific class, it forwards the request to the leader node via an RPC call.
2. The leader node unnecessarily retries querying the schema even when it receives an error indicating that multi-tenancy is not enabled for the class.
3. If a non-leader node also retries the request to the leader, this further prolong the waiting time.


### What's being changed:
- Restrict retries to retryable sections: Only retry operations that are genuinely retryable, such as leader identification.
- Stop retries for non-supported classes: Prevent non-leader nodes from retrying requests when it is known that the class does not support multi-tenancy.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
