### PR TITLE
Add environment overrides for azure blocksize and concurrency

### DIFF
--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -1,0 +1,184 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modstgazure
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// Test user overrides
+func TestUploadParams(t *testing.T) {
+	defaultBlockSize := int64(40 * 1024 * 1024)
+	defaultEnvironmentValue := int64(11)
+	defaultHeaderValue := int64(13)
+	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	dataDir := t.TempDir()
+
+	azure := New()
+	os.Setenv("BACKUP_AZURE_CONTAINER", "test")
+	os.Setenv("AZURE_STORAGE_ACCOUNT", "test")
+	err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+	require.Nil(t, err)
+
+	t.Run("getBlockSize with no inputs", func(t *testing.T) {
+		blockSize := azure.getBlockSize(testCtx)
+		assert.Equal(t, defaultBlockSize, blockSize)
+	})
+
+	t.Run("getBlockSize with environment variable", func(t *testing.T) {
+		t.Setenv("AZURE_BLOCK_SIZE", "11")
+		azure := New()
+		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		assert.Nil(t, err)
+
+		blockSize := azure.getBlockSize(testCtx)
+		assert.Equal(t, defaultEnvironmentValue, blockSize)
+	})
+
+	t.Run("getBlockSize with invalid environment variable", func(t *testing.T) {
+		t.Setenv("AZURE_BLOCK_SIZE", "invalid")
+		azure := New()
+		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		assert.Nil(t, err)
+
+		blockSize := azure.getBlockSize(testCtx)
+		assert.Equal(t, defaultBlockSize, blockSize)
+	})
+
+	t.Run("getBlockSize with header", func(t *testing.T) {
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Block-Size", []string{"13"})
+
+		blockSize := azure.getBlockSize(ctxWithValue)
+		assert.Equal(t, defaultHeaderValue, blockSize)
+	})
+
+	t.Run("getBlockSize with invalid header", func(t *testing.T) {
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Block-Size", []string{"invalid"})
+
+		blockSize := azure.getBlockSize(ctxWithValue)
+		assert.Equal(t, defaultBlockSize, blockSize)
+	})
+
+	t.Run("getBlockSize with environment variable and header", func(t *testing.T) {
+		t.Setenv("AZURE_BLOCK_SIZE", "11")
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Block-Size", []string{"13"})
+
+		blockSize := azure.getBlockSize(ctxWithValue)
+		assert.Equal(t, defaultHeaderValue, blockSize)
+	})
+
+	t.Run("getConcurrency with no inputs", func(t *testing.T) {
+		concurrency := azure.getConcurrency(testCtx)
+		assert.Equal(t, 1, concurrency)
+	})
+
+	t.Run("getConcurrency with environment variable", func(t *testing.T) {
+		t.Setenv("AZURE_CONCURRENCY", "11")
+		azure := New()
+		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		assert.Nil(t, err)
+
+		concurrency := azure.getConcurrency(testCtx)
+		assert.Equal(t, defaultEnvironmentValue, int64(concurrency))
+	})
+
+	t.Run("getConcurrency with invalid environment variable", func(t *testing.T) {
+		t.Setenv("AZURE_CONCURRENCY", "invalid")
+		azure := New()
+		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		assert.Nil(t, err)
+
+		concurrency := azure.getConcurrency(testCtx)
+		assert.Equal(t, 1, concurrency)
+	})
+
+	t.Run("getConcurrency with header", func(t *testing.T) {
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Concurrency", []string{"13"})
+
+		concurrency := azure.getConcurrency(ctxWithValue)
+		assert.Equal(t, defaultHeaderValue, int64(concurrency))
+	})
+
+	t.Run("getConcurrency with invalid header", func(t *testing.T) {
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Concurrency", []string{"invalid"})
+
+		concurrency := azure.getConcurrency(ctxWithValue)
+		assert.Equal(t, 1, concurrency)
+	})
+
+	t.Run("getConcurrency with environment variable and header", func(t *testing.T) {
+		t.Setenv("AZURE_CONCURRENCY", "11")
+		ctxWithValue := context.WithValue(context.Background(),
+			"X-Azure-Concurrency", []string{"13"})
+
+		concurrency := azure.getConcurrency(ctxWithValue)
+		assert.Equal(t, defaultHeaderValue, int64(concurrency))
+	})
+}
+
+type fakeModuleParams struct {
+	logger   logrus.FieldLogger
+	provider fakeStorageProvider
+	config   config.Config
+}
+
+func newFakeModuleParams(dataPath string) *fakeModuleParams {
+	logger, _ := logrustest.NewNullLogger()
+	return &fakeModuleParams{
+		logger:   logger,
+		provider: fakeStorageProvider{dataPath: dataPath},
+	}
+}
+
+func (f *fakeModuleParams) GetStorageProvider() moduletools.StorageProvider {
+	return &f.provider
+}
+
+func (f *fakeModuleParams) GetAppState() interface{} {
+	return nil
+}
+
+func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
+	return f.logger
+}
+
+func (f *fakeModuleParams) GetConfig() config.Config {
+	return f.config
+}
+
+type fakeStorageProvider struct {
+	dataPath string
+}
+
+func (f *fakeStorageProvider) Storage(name string) (moduletools.Storage, error) {
+	return nil, nil
+}
+
+func (f *fakeStorageProvider) DataPath() string {
+	return f.dataPath
+}

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
 )
 
 type azureClient struct {
@@ -166,8 +168,10 @@ func (a *azureClient) PutObject(ctx context.Context, backupID, key string, data 
 		objectName,
 		reader,
 		&azblob.UploadStreamOptions{
-			Metadata: map[string]*string{"backupid": to.Ptr(backupID)},
-			Tags:     map[string]string{"backupid": backupID},
+			Metadata:    map[string]*string{"backupid": to.Ptr(backupID)},
+			Tags:        map[string]string{"backupid": backupID},
+			BlockSize:   a.getBlockSize(ctx),
+			Concurrency: a.getConcurrency(ctx),
 		})
 	if err != nil {
 		return backup.NewErrInternal(errors.Wrapf(err, "upload stream for object '%s'", objectName))
@@ -215,6 +219,42 @@ func (a *azureClient) WriteToFile(ctx context.Context, backupID, key, destPath s
 	return nil
 }
 
+func (a *azureClient) getBlockSize(ctx context.Context) int64 {
+	blockSize := int64(40 * 1024 * 1024)
+	blockSizeStr := modulecomponents.GetValueFromContext(ctx, "X-Azure-Block-Size")
+
+	if blockSizeStr == "" {
+		blockSizeStr = os.Getenv("AZURE_BLOCK_SIZE")
+	}
+
+	if blockSizeStr != "" {
+		bs, err := strconv.ParseInt(blockSizeStr, 10, 64)
+		if err != nil {
+			return 40 * 1024 * 1024
+		}
+		blockSize = bs
+	}
+	return blockSize
+}
+
+func (a *azureClient) getConcurrency(ctx context.Context) int {
+	concurrency := 1
+	concurrencyStr := modulecomponents.GetValueFromContext(ctx, "X-Azure-Concurrency")
+
+	if concurrencyStr == "" {
+		concurrencyStr = os.Getenv("AZURE_CONCURRENCY")
+	}
+
+	if concurrencyStr != "" {
+		cc, err := strconv.Atoi(concurrencyStr)
+		if err != nil {
+			return 1
+		}
+		concurrency = cc
+	}
+	return concurrency
+}
+
 func (a *azureClient) Write(ctx context.Context, backupID, key string, r io.ReadCloser) (written int64, err error) {
 	path := a.makeObjectName(backupID, key)
 	reader := &reader{src: r}
@@ -228,8 +268,10 @@ func (a *azureClient) Write(ctx context.Context, backupID, key string, r io.Read
 		path,
 		reader,
 		&azblob.UploadStreamOptions{
-			Metadata: map[string]*string{"backupid": to.Ptr(backupID)},
-			Tags:     map[string]string{"backupid": backupID},
+			Metadata:    map[string]*string{"backupid": to.Ptr(backupID)},
+			Tags:        map[string]string{"backupid": backupID},
+			BlockSize:   a.getBlockSize(ctx),
+			Concurrency: a.getConcurrency(ctx),
 		}); err != nil {
 		err = fmt.Errorf("upload stream %q: %w", path, err)
 	}

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -31,6 +31,11 @@ import (
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 )
 
+const (
+	defaultBlockSize   = int64(40 * 1024 * 1024)
+	defaultConcurrency = 1
+)
+
 type azureClient struct {
 	client     *azblob.Client
 	config     clientConfig
@@ -220,7 +225,7 @@ func (a *azureClient) WriteToFile(ctx context.Context, backupID, key, destPath s
 }
 
 func (a *azureClient) getBlockSize(ctx context.Context) int64 {
-	blockSize := int64(40 * 1024 * 1024)
+	blockSize := defaultBlockSize
 	blockSizeStr := modulecomponents.GetValueFromContext(ctx, "X-Azure-Block-Size")
 
 	if blockSizeStr == "" {
@@ -230,7 +235,7 @@ func (a *azureClient) getBlockSize(ctx context.Context) int64 {
 	if blockSizeStr != "" {
 		bs, err := strconv.ParseInt(blockSizeStr, 10, 64)
 		if err != nil {
-			return 40 * 1024 * 1024
+			return defaultBlockSize
 		}
 		blockSize = bs
 	}
@@ -238,7 +243,7 @@ func (a *azureClient) getBlockSize(ctx context.Context) int64 {
 }
 
 func (a *azureClient) getConcurrency(ctx context.Context) int {
-	concurrency := 1
+	concurrency := defaultConcurrency
 	concurrencyStr := modulecomponents.GetValueFromContext(ctx, "X-Azure-Concurrency")
 
 	if concurrencyStr == "" {
@@ -248,7 +253,7 @@ func (a *azureClient) getConcurrency(ctx context.Context) int {
 	if concurrencyStr != "" {
 		cc, err := strconv.Atoi(concurrencyStr)
 		if err != nil {
-			return 1
+			return defaultConcurrency
 		}
 		concurrency = cc
 	}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -302,7 +302,7 @@ type CORS struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Goog-Api-Key, X-Goog-Vertex-Api-Key, X-Goog-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Goog-Api-Key, X-Goog-Vertex-Api-Key, X-Goog-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key, X-Azure-Concurrency, X-Azure-Block-Size"
 )
 
 func (r ResourceUsage) Validate() error {


### PR DESCRIPTION
### What's being changed:

Allow users to specify blocksize and concurrency for azure backups.  Also set defaults to higher than usual

Adds AZURE_BLOCK_SIZE and AZURE_CONCURRENCY environment variables, so that the user can configure the azure upload parameters of "blocksize" and "concurrency"

Also add X-Azure-Block-Size and X-Azure-Concurrency headers to do the same.

Large backups can cause errors, the errors may be caused by low block sizes. This PR allows the user to configure the transfer parameters for their needs

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
