### PR TITLE
chore: support object deletion resolution in async replication

### DIFF
--- a/adapters/repos/db/shard_hashbeater.go
+++ b/adapters/repos/db/shard_hashbeater.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/interval"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -330,7 +331,7 @@ func (s *Shard) hashBeat() (stats hashBeatStats, err error) {
 func (s *Shard) stepsTowardsShardConsistency(ctx context.Context,
 	shardName string, host string, initialToken, finalToken uint64, limit int,
 ) (localObjects, remoteObjects, propagations int, err error) {
-	const maxBatchSize = 1_000
+	const maxBatchSize = 100
 
 	for localLastReadToken := initialToken; localLastReadToken < finalToken; {
 		localDigests, newLocalLastReadToken, err := s.index.DigestObjectsInTokenRange(ctx, shardName, localLastReadToken, finalToken, maxBatchSize)
@@ -429,18 +430,48 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context,
 				continue
 			}
 
+			var vectors models.Vectors
+
+			if replicaObj.Object.Vectors != nil {
+				vectors = make(models.Vectors, len(replicaObj.Object.Vectors))
+				for i, v := range replicaObj.Object.Vectors {
+					vectors[i] = v
+				}
+			}
+
 			obj := &objects.VObject{
+				ID:              replicaObj.ID,
 				LatestObject:    &replicaObj.Object.Object,
 				Vector:          replicaObj.Object.Vector,
+				Vectors:         vectors,
 				StaleUpdateTime: remoteStaleUpdateTime[replicaObj.ID.String()],
 			}
 
 			mergeObjs = append(mergeObjs, obj)
 		}
 
-		_, err = s.index.replicator.Overwrite(ctx, host, s.class.Class, shardName, mergeObjs)
+		resp, err := s.index.replicator.Overwrite(ctx, host, s.class.Class, shardName, mergeObjs)
 		if err != nil {
 			return localObjects, remoteObjects, propagations, fmt.Errorf("propagating local objects: %w", err)
+		}
+
+		for _, r := range resp {
+			// NOTE: deleted objects are not propagated but locally deleted when conflict is detected
+
+			if !r.Deleted ||
+				s.index.Config.DeletionStrategy == models.ReplicationConfigDeletionStrategyNoAutomatedResolution {
+				continue
+			}
+
+			if s.index.Config.DeletionStrategy == models.ReplicationConfigDeletionStrategyDeleteOnConflict ||
+				(s.index.Config.DeletionStrategy == models.ReplicationConfigDeletionStrategyTimeBasedResolution &&
+					r.UpdateTime > localDigestsByUUID[r.ID].UpdateTime) {
+
+				err := s.DeleteObject(ctx, strfmt.UUID(r.ID), time.UnixMilli(r.UpdateTime))
+				if err != nil {
+					return localObjects, remoteObjects, propagations, fmt.Errorf("deleting local objects: %w", err)
+				}
+			}
 		}
 
 		propagations += len(mergeObjs)

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -326,11 +326,7 @@ func (s *Shard) upsertObjectHashTree(object *storobj.Object, uuidBytes []byte, s
 
 	copy(objectDigest[:], uuidBytes)
 
-	if status.docIDChanged {
-		if status.oldUpdateTime < 1 {
-			return fmt.Errorf("invalid object previous update time")
-		}
-
+	if status.oldUpdateTime > 0 {
 		// Given only latest object version is maintained, previous registration is erased
 		binary.BigEndian.PutUint64(objectDigest[16:], uint64(status.oldUpdateTime))
 		s.hashtree.AggregateLeafWith(token, objectDigest[:])


### PR DESCRIPTION
### What's being changed:

In async replication, deleted objects are not propagated but locally deleted when a conflict is detected when propagating a local object.

Due to the impossibility to scan over deleted objects and to handle existing deleted objects without an associated deletionTime, async replication does not distinguish between deleted or not present objects.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
