### PR TITLE
UX: Make GQL transform in `GET/DELETE` similar to `CREATE`

### DIFF
--- a/test/acceptance_with_python/test_collection.py
+++ b/test/acceptance_with_python/test_collection.py
@@ -1,0 +1,37 @@
+import weaviate
+import weaviate.classes as wvc
+
+def test_collection_casing() -> None:
+    with weaviate.connect_to_local() as client:
+        # Goal: Collection create/get/delete should automatically transform class name to GQL (first letter caps).
+
+        # create collection with all "lower" case -> GQL ("Testcollectioncase")
+        assert client.collections.create_from_dict({
+            "class": "testcollectioncase",
+            "vectorizer": "none",
+            }
+        ) is not None
+
+        # GET should also tranform to GQL
+        assert client.collections.get("testcollectioncase") is not None
+
+        # DELETE should also transform to GQL
+        client.collections.delete("testcollectioncase")
+        col = client.collections.get("testcollectioncase")
+        assert col.exists() is False
+
+        # same with mult-word with "_"
+        assert client.collections.create_from_dict({
+            "class": "test_collection_case",
+            "vectorizer": "none",
+            }
+        ) is not None
+
+
+        # GET should also tranform to GQL
+        assert client.collections.get("test_collection_case") is not None
+
+        # DELETE should also transform to GQL
+        client.collections.delete("test_collection_case")
+        col = client.collections.get("testcollectioncase")
+        assert col.exists() is False

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -43,6 +43,8 @@ func (h *Handler) GetClass(ctx context.Context, principal *models.Principal, nam
 	if err := h.Authorizer.Authorize(principal, "list", "schema/*"); err != nil {
 		return nil, err
 	}
+	name = schema.UppercaseClassName(name)
+
 	cl := h.schemaReader.ReadOnlyClass(name)
 	return cl, nil
 }
@@ -53,12 +55,15 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 	if err := h.Authorizer.Authorize(principal, "list", "schema/*"); err != nil {
 		return nil, 0, err
 	}
+
+	name = schema.UppercaseClassName(name)
+
 	if consistency {
 		vclasses, err := h.schemaManager.QueryReadOnlyClasses(name)
 		return vclasses[name].Class, vclasses[name].Version, err
 	}
-	class, _ := h.schemaReader.ReadOnlyClassWithVersion(ctx, name, 0)
-	return class, 0, nil
+	class, err := h.schemaReader.ReadOnlyClassWithVersion(ctx, name, 0)
+	return class, 0, err
 }
 
 func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
@@ -200,6 +205,8 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 	if err != nil {
 		return err
 	}
+
+	class = schema.UppercaseClassName(class)
 
 	_, err = h.schemaManager.DeleteClass(ctx, class)
 	return err

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -1503,20 +1503,101 @@ func Test_DeleteClass(t *testing.T) {
 			},
 			expErr: false,
 		},
+		{
+			name:          "class delete should auto transform to GQL convention",
+			classToDelete: "c1", // all lower case form
+			existing: []*models.Class{
+				{Class: "C1", VectorIndexType: "hnsw"}, // GQL form
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			expected: []*models.Class{
+				classWithDefaultsSet(t, "OtherClass"), // should still delete `C1` class name
+			},
+			expErr: false,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 
-			fakeSchemaManager.On("DeleteClass", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			// NOTE: mocking schema manager's `DeleteClass` (not handler's)
+			// underlying schemaManager should still work with canonical class name.
+			canonical := schema.UppercaseClassName(test.classToDelete)
+			fakeSchemaManager.On("DeleteClass", canonical).Return(nil)
 
+			// but layer above like handler's `DeleteClass` should work independent of case sensitivity.
 			err := handler.DeleteClass(ctx, nil, test.classToDelete)
 			if test.expErr {
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), test.expErrMsg)
 			} else {
 				require.Nil(t, err)
+			}
+			fakeSchemaManager.AssertExpectations(t)
+		})
+	}
+}
+
+func Test_GetConsistentClass(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		classToGet string
+		expErr     bool
+		expErrMsg  string
+		existing   []*models.Class
+		expected   *models.Class
+	}{
+		{
+			name:       "class exists",
+			classToGet: "C1",
+			existing: []*models.Class{
+				{Class: "C1", VectorIndexType: "hnsw"},
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			expected: classWithDefaultsSet(t, "C1"),
+			expErr:   false,
+		},
+		{
+			name:       "class does not exist",
+			classToGet: "C1",
+			existing: []*models.Class{
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			expected: &models.Class{}, // empty
+			expErr:   false,
+		},
+		{
+			name:       "class get should auto transform to GQL convention",
+			classToGet: "c1", // lowercase
+			existing: []*models.Class{
+				{Class: "C1", VectorIndexType: "hnsw"}, // original class is GQL form
+				{Class: "OtherClass", VectorIndexType: "hnsw"},
+			},
+			expected: classWithDefaultsSet(t, "C1"),
+			expErr:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+
+			// underlying schemaManager should still work with canonical class name.
+			canonical := schema.UppercaseClassName(test.classToGet)
+			fakeSchemaManager.On("ReadOnlyClassWithVersion", mock.Anything, canonical, mock.Anything).Return(test.expected, nil)
+
+			// but layer above like `GetConsistentClass` should work independent of case sensitivity.
+			got, _, err := handler.GetConsistentClass(ctx, nil, test.classToGet, false)
+			if test.expErr {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), test.expErrMsg)
+			} else {
+				require.Nil(t, err)
+				assert.Equal(t, got, test.expected)
 			}
 			fakeSchemaManager.AssertExpectations(t)
 		})


### PR DESCRIPTION

### What's being changed:


Related:
1. https://github.com/weaviate/weaviate/pull/6434
2. https://github.com/weaviate/weaviate/issues/5789

Now when user try to get or delete collection, the collection name is case-insensitive.

#### Before

GET http://localhost:8080/v1/schema/Question - OK
GET http://localhost:8080/v1/schema/question - 404

DELETE http://localhost:8080/v1/schema/Question - OK 
DELETE http://localhost:8080/v1/schema/question - 404

#### After
GET http://localhost:8080/v1/schema/Question - OK
GET http://localhost:8080/v1/schema/question - OK

DELETE http://localhost:8080/v1/schema/Question - OK 
DELETE http://localhost:8080/v1/schema/question - OK

**Changes:**

1. Convert `class` name into canonical GQL naming before doing any get or delete


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
