### PR TITLE
Fix infinite `_preload_progress` log message when creating or loading an empty index

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -70,6 +70,9 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 	seedCount := cpi.parallel - 1
 	seeds := cpi.bucket.QuantileKeys(seedCount)
 	if len(seeds) == 0 {
+		// no seeds likely means an empty index. If we exit early, we also need to
+		// stop the progress tracking.
+		stopTracking()
 		return nil
 	}
 


### PR DESCRIPTION
### What's being changed:
* fixes #6491 
* there was an early exit condition for when the cursor returns no checkpoints (i.e. when it is empty), however, this early exit path did not cancel the reporter routine. This is now fixed
* Validated that `v1.25.x` is the first version where this issue occurs, therefore targeting this at `stable/v1.25`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
