### PR TITLE
Fix palm to google renaming with legacy vectors

### DIFF
--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -293,12 +293,22 @@ func (p *Provider) shouldIncludeClassArgument(class *models.Class, module string
 				}
 			}
 		}
+		for _, altName := range altNames {
+			if class.Vectorizer == altName {
+				return true
+			}
+		}
 		return class.Vectorizer == module
 	}
 	if moduleConfig, ok := class.ModuleConfig.(map[string]interface{}); ok {
-		existsConfigForModule := moduleConfig[module] != nil
-		if existsConfigForModule {
+		if _, ok := moduleConfig[module]; ok {
 			return true
+		} else if len(altNames) > 0 {
+			for _, altName := range altNames {
+				if _, ok := moduleConfig[altName]; ok {
+					return true
+				}
+			}
 		}
 	}
 	// Allow Text2Text (Generative, QnA, Summarize, NER) modules to be registered to a given class


### PR DESCRIPTION
### What's being changed:

Fixes issue where after upgrade collection no longer recognizes `*-palm` vectorizers configured using legacy vector configuration.

This fix adds checks for module's alternative names in missing places.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
