### PR TITLE
Add support for X-Goog-* headers

### DIFF
--- a/modules/multi2vec-google/clients/google_test.go
+++ b/modules/multi2vec-google/clients/google_test.go
@@ -173,7 +173,7 @@ func TestClient(t *testing.T) {
 
 		require.NotNil(t, err)
 		assert.Equal(t, "Google API Key: no api key found "+
-			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key or X-Google-Studio-Api-Key "+
+			"neither in request header: X-Palm-Api-Key or X-Goog-Api-Key or X-Goog-Vertex-Api-Key or X-Goog-Studio-Api-Key "+
 			"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY", err.Error())
 	})
 
@@ -194,7 +194,7 @@ func TestClient(t *testing.T) {
 
 		require.NotNil(t, err)
 		assert.Equal(t, "Google API Key: no api key found "+
-			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key or X-Google-Studio-Api-Key "+
+			"neither in request header: X-Palm-Api-Key or X-Goog-Api-Key or X-Goog-Vertex-Api-Key or X-Goog-Studio-Api-Key "+
 			"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY", err.Error())
 	})
 }

--- a/modules/text2vec-google/clients/google_test.go
+++ b/modules/text2vec-google/clients/google_test.go
@@ -149,7 +149,7 @@ func TestClient(t *testing.T) {
 
 		require.NotNil(t, err)
 		assert.Equal(t, err.Error(), "Google API Key: no api key found "+
-			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key or X-Google-Studio-Api-Key "+
+			"neither in request header: X-Palm-Api-Key or X-Goog-Api-Key or X-Goog-Vertex-Api-Key or X-Goog-Studio-Api-Key "+
 			"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY")
 	})
 
@@ -170,7 +170,7 @@ func TestClient(t *testing.T) {
 
 		require.NotNil(t, err)
 		assert.Equal(t, "Google API Key: no api key found "+
-			"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key or X-Google-Studio-Api-Key "+
+			"neither in request header: X-Palm-Api-Key or X-Goog-Api-Key or X-Goog-Vertex-Api-Key or X-Goog-Studio-Api-Key "+
 			"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY", err.Error())
 	})
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -302,7 +302,7 @@ type CORS struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Goog-Api-Key, X-Goog-Vertex-Api-Key, X-Goog-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key"
 )
 
 func (r ResourceUsage) Validate() error {

--- a/usecases/modulecomponents/apikey/google.go
+++ b/usecases/modulecomponents/apikey/google.go
@@ -33,18 +33,27 @@ func NewGoogleApiKey() *GoogleApiKey {
 
 func (g *GoogleApiKey) GetApiKey(ctx context.Context, envApiKeyValue string, useGenerativeAIEndpoint, useGoogleAuth bool) (string, error) {
 	if useGenerativeAIEndpoint {
+		if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Goog-Studio-Api-Key"); apiKey != "" {
+			return apiKey, nil
+		}
 		if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Google-Studio-Api-Key"); apiKey != "" {
 			return apiKey, nil
 		}
 	} else {
+		if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Goog-Vertex-Api-Key"); apiKey != "" {
+			return apiKey, nil
+		}
 		if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Google-Vertex-Api-Key"); apiKey != "" {
 			return apiKey, nil
 		}
 	}
-	if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Google-Api-Key"); apiKey != "" {
+	if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Goog-Api-Key"); apiKey != "" {
 		return apiKey, nil
 	}
 	if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Palm-Api-Key"); apiKey != "" {
+		return apiKey, nil
+	}
+	if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Google-Api-Key"); apiKey != "" {
 		return apiKey, nil
 	}
 	if !useGenerativeAIEndpoint && useGoogleAuth {
@@ -54,7 +63,7 @@ func (g *GoogleApiKey) GetApiKey(ctx context.Context, envApiKeyValue string, use
 		return envApiKeyValue, nil
 	}
 	return "", errors.New("no api key found " +
-		"neither in request header: X-Palm-Api-Key or X-Google-Api-Key or X-Google-Vertex-Api-Key or X-Google-Studio-Api-Key " +
+		"neither in request header: X-Palm-Api-Key or X-Goog-Api-Key or X-Goog-Vertex-Api-Key or X-Goog-Studio-Api-Key " +
 		"nor in environment variable under PALM_APIKEY or GOOGLE_APIKEY")
 }
 


### PR DESCRIPTION
### What's being changed:

This PR adds support for `X-Goog-*` headers. This change is needed when working with GCP deployments bc Google is cutting out all headers that start with `X-Google`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
