### PR TITLE
Add option of not waiting for self-deployed modules

### DIFF
--- a/modules/qna-transformers/module.go
+++ b/modules/qna-transformers/module.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	qnaadditional "github.com/weaviate/weaviate/modules/qna-transformers/additional"
@@ -138,9 +139,16 @@ func (m *QnAModule) initAdditional(ctx context.Context, timeout time.Duration,
 		return errors.Errorf("required variable QNA_INFERENCE_API is not set")
 	}
 
+	waitForStartup := true
+	if envWaitForStartup := os.Getenv("QNA_WAIT_FOR_STARTUP"); envWaitForStartup != "" {
+		waitForStartup = entcfg.Enabled(envWaitForStartup)
+	}
+
 	client := clients.New(uri, timeout, logger)
-	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
-		return errors.Wrap(err, "init remote vectorizer")
+	if waitForStartup {
+		if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
+			return errors.Wrap(err, "init remote vectorizer")
+		}
 	}
 
 	m.qna = client

--- a/modules/sum-transformers/module.go
+++ b/modules/sum-transformers/module.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	sumadditional "github.com/weaviate/weaviate/modules/sum-transformers/additional"
@@ -66,9 +67,16 @@ func (m *SUMModule) initAdditional(ctx context.Context, timeout time.Duration,
 		return errors.Errorf("required variable SUM_INFERENCE_API is not set")
 	}
 
+	waitForStartup := true
+	if envWaitForStartup := os.Getenv("SUM_WAIT_FOR_STARTUP"); envWaitForStartup != "" {
+		waitForStartup = entcfg.Enabled(envWaitForStartup)
+	}
+
 	client := client.New(uri, timeout, logger)
-	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
-		return errors.Wrap(err, "init remote sum module")
+	if waitForStartup {
+		if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
+			return errors.Wrap(err, "init remote sum module")
+		}
 	}
 
 	m.sum = client

--- a/modules/text2vec-gpt4all/module.go
+++ b/modules/text2vec-gpt4all/module.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
@@ -97,9 +98,16 @@ func (m *GPT4AllModule) initVectorizer(ctx context.Context, timeout time.Duratio
 		return errors.New("required variable GPT4ALL_INFERENCE_API is not set")
 	}
 
+	waitForStartup := true
+	if envWaitForStartup := os.Getenv("GPT4ALL_WAIT_FOR_STARTUP"); envWaitForStartup != "" {
+		waitForStartup = entcfg.Enabled(envWaitForStartup)
+	}
+
 	client := clients.New(uri, timeout, logger)
-	if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
-		return errors.Wrap(err, "init remote vectorizer")
+	if waitForStartup {
+		if err := client.WaitForStartup(ctx, 1*time.Second); err != nil {
+			return errors.Wrap(err, "init remote vectorizer")
+		}
 	}
 
 	m.vectorizer = vectorizer.New(client)


### PR DESCRIPTION
### What's being changed:

This PR adds option to not to wait for self-deployed modules:
 - `multi2vec-clip`
 - `ner-transformers`
 - `qna-transformers`
 - `reranker-transformers`
 - `sum-transformers`
 - `text2vec-gpt4all`
 - `text2vec-transformers`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
