### PR TITLE
Limit backup search to BACKUP_PATH for remote backends

### DIFF
--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -123,7 +123,7 @@ func (g *azureClient) makeObjectName(overridePath string, parts []string) string
 func (a *azureClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackupDescriptor, error) {
 	var meta []*backup.DistributedBackupDescriptor
 
-	blobs := a.client.NewListBlobsFlatPager(a.config.Container, &azblob.ListBlobsFlatOptions{})
+	blobs := a.client.NewListBlobsFlatPager(a.config.Container, &azblob.ListBlobsFlatOptions{Prefix: to.Ptr(a.config.BackupPath)})
 	for {
 		if !blobs.More() {
 			break

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -122,7 +122,7 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 		return nil, nil
 	}
 
-	iter := bucket.Objects(ctx, &storage.Query{Prefix: g.config.BackupPath})
+	iter := bucket.Objects(ctx, &storage.Query{Prefix: g.config.BackupPath, MatchGlob: "*json"})
 	for {
 		next, err := iter.Next()
 		if errors.Is(err, iterator.Done) {

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -122,7 +122,7 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 		return nil, nil
 	}
 
-	iter := bucket.Objects(ctx, nil)
+	iter := bucket.Objects(ctx, &storage.Query{Prefix: g.config.BackupPath})
 	for {
 		next, err := iter.Next()
 		if errors.Is(err, iterator.Done) {

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -110,7 +110,7 @@ func (s *s3Client) AllBackups(ctx context.Context,
 		s.config.Bucket,
 		minio.ListObjectsOptions{
 			Recursive: true,
-			Prefix:   s.config.BackupPath,
+			Prefix:    s.config.BackupPath,
 		},
 	)
 	for info := range objectsInfo {

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -110,6 +110,7 @@ func (s *s3Client) AllBackups(ctx context.Context,
 		s.config.Bucket,
 		minio.ListObjectsOptions{
 			Recursive: true,
+			Prefix:   s.config.BackupPath,
 		},
 	)
 	for info := range objectsInfo {


### PR DESCRIPTION
### What's being changed:

Code is currently searching all backups in the container, which tends to time out and also has privacy concerns.  This patch limits the search to Prefix: BACKUP_PATH, as appropriate for each backend

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
