### PR TITLE
feat: Convert "MAINTENANCE_NODES" configuration to dynamic config #6069

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -205,7 +205,7 @@ func (i *indices) maintenanceModeHandler() http.HandlerFunc {
 			i.maintenanceModeEnabled = false
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("maintainance mode set"))
+		w.Write([]byte("maintenance mode set"))
 	}
 }
 

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -188,6 +188,27 @@ func NewIndices(shards shards, db db, auth auth, maintenanceModeEnabled bool, lo
 	}
 }
 
+func (i *indices) MaintainanceMode() http.Handler {
+  return i.auth.handleFunc(i.maintainanceModeHandler())
+}
+
+func (i *indices) maintainanceModeHandler() http.HandlerFunc {
+  return func(w http.ResponseWriter, r* http.Request) {
+    maintainanceMode := r.URL.Query().Get("maintainanceMode")
+    if maintainanceMode != "true" && maintainanceMode != "false" {
+      http.Error(w, "Bad request", http.StatusBadRequest)
+      return
+    }
+    if maintainanceMode == "true" {
+      i.maintenanceModeEnabled = true
+    } else {
+      i.maintenanceModeEnabled = false
+    }
+    w.WriteHeader(http.StatusOK)
+    w.Write([]byte("maintainance mode set"))
+  }
+}
+
 func (i *indices) Indices() http.Handler {
 	return i.auth.handleFunc(i.indicesHandler())
 }

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -188,18 +188,18 @@ func NewIndices(shards shards, db db, auth auth, maintenanceModeEnabled bool, lo
 	}
 }
 
-func (i *indices) MaintainanceMode() http.Handler {
-	return i.auth.handleFunc(i.maintainanceModeHandler())
+func (i *indices) MaintenanceMode() http.Handler {
+	return i.auth.handleFunc(i.maintenanceModeHandler())
 }
 
-func (i *indices) maintainanceModeHandler() http.HandlerFunc {
+func (i *indices) maintenanceModeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		maintainanceMode := r.URL.Query().Get("maintainanceMode")
-		if maintainanceMode != "true" && maintainanceMode != "false" {
+		maintenanceMode := r.URL.Query().Get("maintenanceMode")
+		if maintenanceMode != "true" && maintenanceMode != "false" {
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
 		}
-		if maintainanceMode == "true" {
+		if maintenanceMode == "true" {
 			i.maintenanceModeEnabled = true
 		} else {
 			i.maintenanceModeEnabled = false

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -189,24 +189,24 @@ func NewIndices(shards shards, db db, auth auth, maintenanceModeEnabled bool, lo
 }
 
 func (i *indices) MaintainanceMode() http.Handler {
-  return i.auth.handleFunc(i.maintainanceModeHandler())
+	return i.auth.handleFunc(i.maintainanceModeHandler())
 }
 
 func (i *indices) maintainanceModeHandler() http.HandlerFunc {
-  return func(w http.ResponseWriter, r* http.Request) {
-    maintainanceMode := r.URL.Query().Get("maintainanceMode")
-    if maintainanceMode != "true" && maintainanceMode != "false" {
-      http.Error(w, "Bad request", http.StatusBadRequest)
-      return
-    }
-    if maintainanceMode == "true" {
-      i.maintenanceModeEnabled = true
-    } else {
-      i.maintenanceModeEnabled = false
-    }
-    w.WriteHeader(http.StatusOK)
-    w.Write([]byte("maintainance mode set"))
-  }
+	return func(w http.ResponseWriter, r *http.Request) {
+		maintainanceMode := r.URL.Query().Get("maintainanceMode")
+		if maintainanceMode != "true" && maintainanceMode != "false" {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		if maintainanceMode == "true" {
+			i.maintenanceModeEnabled = true
+		} else {
+			i.maintenanceModeEnabled = false
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("maintainance mode set"))
+	}
 }
 
 func (i *indices) Indices() http.Handler {

--- a/adapters/handlers/rest/clusterapi/indices_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_test.go
@@ -35,7 +35,6 @@ func TestDynamicMaintainanceModeUpdate(t *testing.T) {
   }
 
 	requestURL := func(suffix string) string {
-    fmt.Println(fmt.Sprintf("%s/indices/maintainance-mode?%s", server.URL, suffix))
 		return fmt.Sprintf("%s/indices/maintainance-mode?%s", server.URL, suffix)
 	}
 

--- a/adapters/handlers/rest/clusterapi/indices_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_test.go
@@ -21,25 +21,25 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
 )
 
-func TestDynamicMaintainanceModeUpdate(t *testing.T) {
+func TestDynamicMaintenanceModeUpdate(t *testing.T) {
 	noopAuth := clusterapi.NewNoopAuthHandler()
 	indices := clusterapi.NewIndices(nil, nil, noopAuth, true, nil)
 	mux := http.NewServeMux()
-	mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
+	mux.Handle("/indices/maintenance-mode", indices.MaintenanceMode())
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	dynamicMaintainanceModeTestRequests := []indicesTestRequest{
-		{"POST", "maintainanceMode=true"},
-		{"POST", "maintainanceMode=false"},
+	dynamicMaintenanceModeTestRequests := []indicesTestRequest{
+		{"POST", "maintenanceMode=true"},
+		{"POST", "maintenanceMode=false"},
 	}
 
 	requestURL := func(suffix string) string {
-		return fmt.Sprintf("%s/indices/maintainance-mode?%s", server.URL, suffix)
+		return fmt.Sprintf("%s/indices/maintenance-mode?%s", server.URL, suffix)
 	}
 
-	for _, testRequest := range dynamicMaintainanceModeTestRequests {
-		t.Run(fmt.Sprintf("maintainance mode test with query %s", testRequest.suffix), func(t *testing.T) {
+	for _, testRequest := range dynamicMaintenanceModeTestRequests {
+		t.Run(fmt.Sprintf("maintenance mode test with query %s", testRequest.suffix), func(t *testing.T) {
 			req, err := http.NewRequest(testRequest.method, requestURL(testRequest.suffix), nil)
 			assert.Nil(t, err)
 			res, err := http.DefaultClient.Do(req)

--- a/adapters/handlers/rest/clusterapi/indices_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_test.go
@@ -22,32 +22,32 @@ import (
 )
 
 func TestDynamicMaintainanceModeUpdate(t *testing.T) {
-  noopAuth := clusterapi.NewNoopAuthHandler()
-  indices := clusterapi.NewIndices(nil, nil, noopAuth, true, nil)
-  mux := http.NewServeMux()
-  mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
-  server := httptest.NewServer(mux)
-  defer server.Close()
+	noopAuth := clusterapi.NewNoopAuthHandler()
+	indices := clusterapi.NewIndices(nil, nil, noopAuth, true, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
+	server := httptest.NewServer(mux)
+	defer server.Close()
 
-  dynamicMaintainanceModeTestRequests := []indicesTestRequest{
-    {"POST", "maintainanceMode=true"},
-    {"POST", "maintainanceMode=false"},
-  }
+	dynamicMaintainanceModeTestRequests := []indicesTestRequest{
+		{"POST", "maintainanceMode=true"},
+		{"POST", "maintainanceMode=false"},
+	}
 
 	requestURL := func(suffix string) string {
 		return fmt.Sprintf("%s/indices/maintainance-mode?%s", server.URL, suffix)
 	}
 
-  for _, testRequest := range dynamicMaintainanceModeTestRequests {
-    t.Run(fmt.Sprintf("maintainance mode test with query %s", testRequest.suffix), func(t *testing.T) {
+	for _, testRequest := range dynamicMaintainanceModeTestRequests {
+		t.Run(fmt.Sprintf("maintainance mode test with query %s", testRequest.suffix), func(t *testing.T) {
 			req, err := http.NewRequest(testRequest.method, requestURL(testRequest.suffix), nil)
 			assert.Nil(t, err)
 			res, err := http.DefaultClient.Do(req)
 			assert.Nil(t, err)
 			defer res.Body.Close()
-      assert.True(t, res.StatusCode == http.StatusOK, "expected %d, got %d", http.StatusOK, res.StatusCode)
-    })
-  }
+			assert.True(t, res.StatusCode == http.StatusOK, "expected %d, got %d", http.StatusOK, res.StatusCode)
+		})
+	}
 }
 
 func TestMaintenanceModeIndices(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -29,6 +29,7 @@ func Serve(appState *state.State) {
 		Debugf("serving cluster api on port %d", port)
 
 	maintenanceModeEnabled := appState.Cluster.MaintenanceModeEnabled()
+  fmt.Println("maintenanceModeEnabled: ", maintenanceModeEnabled)
 	indices := NewIndices(appState.RemoteIndexIncoming, appState.DB, auth, maintenanceModeEnabled, appState.Logger)
 	replicatedIndices := NewReplicatedIndices(appState.RemoteReplicaIncoming, appState.Scaler, auth, maintenanceModeEnabled)
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager(), auth)
@@ -42,6 +43,7 @@ func Serve(appState *state.State) {
 
 	mux.Handle("/nodes/", nodes.Nodes())
 	mux.Handle("/indices/", indices.Indices())
+  mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
 	mux.Handle("/replicas/indices/", replicatedIndices.Indices())
 
 	mux.Handle("/backups/can-commit", backups.CanCommit())

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -29,7 +29,6 @@ func Serve(appState *state.State) {
 		Debugf("serving cluster api on port %d", port)
 
 	maintenanceModeEnabled := appState.Cluster.MaintenanceModeEnabled()
-  fmt.Println("maintenanceModeEnabled: ", maintenanceModeEnabled)
 	indices := NewIndices(appState.RemoteIndexIncoming, appState.DB, auth, maintenanceModeEnabled, appState.Logger)
 	replicatedIndices := NewReplicatedIndices(appState.RemoteReplicaIncoming, appState.Scaler, auth, maintenanceModeEnabled)
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager(), auth)

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -42,7 +42,7 @@ func Serve(appState *state.State) {
 
 	mux.Handle("/nodes/", nodes.Nodes())
 	mux.Handle("/indices/", indices.Indices())
-	mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
+	mux.Handle("/indices/maintenance-mode", indices.MaintenanceMode())
 	mux.Handle("/replicas/indices/", replicatedIndices.Indices())
 
 	mux.Handle("/backups/can-commit", backups.CanCommit())

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -42,7 +42,7 @@ func Serve(appState *state.State) {
 
 	mux.Handle("/nodes/", nodes.Nodes())
 	mux.Handle("/indices/", indices.Indices())
-  mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
+	mux.Handle("/indices/maintainance-mode", indices.MaintainanceMode())
 	mux.Handle("/replicas/indices/", replicatedIndices.Indices())
 
 	mux.Handle("/backups/can-commit", backups.CanCommit())


### PR DESCRIPTION
### What's being changed:
Added a new configuration endpoint `/indices/maintenance-mode` to dynamically change the maintenance mode. Now we don't need to do whole node restart to change it to a maintenance node.
In this endpoint, the configuration is passed as a query parameter `maintenanceMode`, hence to change the mode of a node we just need to hit the endpoint with desired parameter.

/indices/manitenance-mode?maintenanceMode=true => will mark a node as maintenance node
/indices/manitenance-mode?maintenanceMode=false => will unmark a maintenance node


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

/fixes #6069
