### PR TITLE
feature: reindex references

### DIFF
--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -535,6 +535,7 @@ func (a *Analyzer) analyzeRefProp(prop *models.Property,
 	return &Property{
 		Name:               prop.Name,
 		Items:              items,
+		Length:             len(value),
 		HasFilterableIndex: HasFilterableIndex(prop),
 		HasSearchableIndex: HasSearchableIndex(prop),
 		HasRangeableIndex:  HasRangeableIndex(prop),

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -32,7 +33,10 @@ type ShardInvertedReindexTask interface {
 	// callbacks could be added
 	// (like OnPrePauseStore, OnPostPauseStore, OnPreResumeStore, etc)
 	OnPostResumeStore(ctx context.Context, shard ShardLike) error
+	ObjectsIterator(shard ShardLike) objectsIterator
 }
+
+type objectsIterator func(ctx context.Context, fn func(object *storobj.Object) error) error
 
 type ReindexableProperty struct {
 	PropertyName    string
@@ -88,7 +92,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 	}
 	if len(reindexProperties) == 0 {
 		r.logger.
-			WithField("action", "inverted reindex").
+			WithField("action", "inverted_reindex").
 			WithField("index", r.shard.Index().ID()).
 			WithField("shard", r.shard.ID()).
 			Debug("no properties to reindex")
@@ -126,7 +130,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 			return err
 		}
 		r.logger.
-			WithField("action", "inverted reindex").
+			WithField("action", "inverted_reindex").
 			WithField("shard", r.shard.Name()).
 			WithField("property", reindexProperty.PropertyName).
 			WithField("strategy", reindexProperty.DesiredStrategy).
@@ -134,7 +138,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 			Debug("created temporary bucket")
 	}
 
-	if err := r.reindexProperties(ctx, reindexProperties); err != nil {
+	if err := r.reindexProperties(ctx, reindexProperties, task.ObjectsIterator(r.shard)); err != nil {
 		r.logError(err, "failed reindexing properties")
 		return errors.Wrapf(err, "failed reindexing properties on shard '%s'", r.shard.Name())
 	}
@@ -155,7 +159,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 			}
 
 			r.logger.
-				WithField("action", "inverted reindex").
+				WithField("action", "inverted_reindex").
 				WithField("shard", r.shard.Name()).
 				WithField("bucket", bucketsToReindex[i]).
 				WithField("temp_bucket", tempBucketName).
@@ -167,7 +171,7 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 			}
 
 			r.logger.
-				WithField("action", "inverted reindex").
+				WithField("action", "inverted_reindex").
 				WithField("shard", r.shard.Name()).
 				WithField("bucket", bucketsToReindex[i]).
 				WithField("temp_bucket", tempBucketName).
@@ -199,7 +203,7 @@ func (r *ShardInvertedReindexer) pauseStoreActivity(ctx context.Context) error {
 	}
 
 	r.logger.
-		WithField("action", "inverted reindex").
+		WithField("action", "inverted_reindex").
 		WithField("shard", r.shard.Name()).
 		Debug("paused store activity")
 
@@ -218,7 +222,7 @@ func (r *ShardInvertedReindexer) resumeStoreActivity(ctx context.Context, task S
 	}
 
 	r.logger.
-		WithField("action", "inverted reindex").
+		WithField("action", "inverted_reindex").
 		WithField("shard", r.shard.Name()).
 		Debug("resumed store activity")
 
@@ -237,24 +241,25 @@ func (r *ShardInvertedReindexer) createTempBucket(ctx context.Context, name stri
 	return nil
 }
 
-func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexableProperties []ReindexableProperty) error {
+func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexableProperties []ReindexableProperty,
+	objectsIterator objectsIterator,
+) error {
 	checker := newReindexablePropertyChecker(reindexableProperties, r.class)
-	objectsBucket := r.shard.Store().Bucket(helpers.ObjectsBucketLSM)
 
 	r.logger.
-		WithField("action", "inverted reindex").
+		WithField("action", "inverted_reindex").
 		WithField("shard", r.shard.Name()).
 		Debug("starting populating indexes")
 
 	i := 0
-	if err := objectsBucket.IterateObjects(ctx, func(object *storobj.Object) error {
-		// check context expired every 100k objects
-		if i%100_000 == 0 && i != 0 {
+	if err := objectsIterator(ctx, func(object *storobj.Object) error {
+		// check context expired every 50k objects
+		if i%50_000 == 0 && i != 0 {
 			if err := r.checkContextExpired(ctx, "iterating through objects stopped due to context canceled"); err != nil {
 				return err
 			}
 			r.logger.
-				WithField("action", "inverted reindex").
+				WithField("action", "inverted_reindex").
 				WithField("shard", r.shard.Name()).
 				Debugf("iterating through objects: %d done", i)
 		}
@@ -282,7 +287,7 @@ func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexa
 	}
 
 	r.logger.
-		WithField("action", "inverted reindex").
+		WithField("action", "inverted_reindex").
 		WithField("shard", r.shard.Name()).
 		Debugf("iterating through objects: %d done", i)
 
@@ -292,80 +297,91 @@ func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexa
 func (r *ShardInvertedReindexer) handleProperty(ctx context.Context, checker *reindexablePropertyChecker,
 	docID uint64, property inverted.Property,
 ) error {
-	reindexablePropValue := checker.isReindexable(property.Name, IndexTypePropValue)
-	reindexablePropSearchableValue := checker.isReindexable(property.Name, IndexTypePropSearchableValue)
-
-	if reindexablePropValue || reindexablePropSearchableValue {
-		schemaProp := checker.getSchemaProp(property.Name)
-
-		var bucketValue, bucketSearchableValue *lsmkv.Bucket
-
-		if reindexablePropValue {
-			bucketValue = r.tempBucket(property.Name, IndexTypePropValue)
-			if bucketValue == nil {
-				return fmt.Errorf("no bucket for prop '%s' value found", property.Name)
-			}
-		}
-		if reindexablePropSearchableValue {
-			bucketSearchableValue = r.tempBucket(property.Name, IndexTypePropSearchableValue)
-			if bucketSearchableValue == nil {
-				return fmt.Errorf("no bucket searchable for prop '%s' value found", property.Name)
-			}
-		}
-
-		propLen := float32(len(property.Items))
-		for _, item := range property.Items {
-			key := item.Data
-			if reindexablePropSearchableValue && inverted.HasSearchableIndex(schemaProp) {
-				pair := r.shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
-				if err := r.shard.addToPropertyMapBucket(bucketSearchableValue, pair, key); err != nil {
-					return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
-				}
-			}
-			if reindexablePropValue && inverted.HasFilterableIndex(schemaProp) {
-				if err := r.shard.addToPropertySetBucket(bucketValue, docID, key); err != nil {
-					return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
-				}
-			}
-		}
-	}
-
-	// add non-nil properties to the null-state inverted index,
-	// but skip internal properties (__meta_count, _id etc)
-	if isMetaCountProperty(property) || isInternalProperty(property) {
+	//  skip internal properties (_id etc)
+	if isInternalProperty(property) {
 		return nil
 	}
 
+	if isMetaCountProperty(property) {
+		propName := strings.TrimSuffix(property.Name, "__meta_count")
+		if checker.isReindexable(propName, IndexTypePropMetaCount) {
+			schemaProp := checker.getSchemaProp(propName)
+			if inverted.HasFilterableIndex(schemaProp) {
+				bucketMeta := r.tempBucket(propName, IndexTypePropMetaCount)
+				if bucketMeta == nil {
+					return fmt.Errorf("no bucket for prop '%s' meta found", propName)
+				}
+				for _, item := range property.Items {
+					if err := r.shard.addToPropertySetBucket(bucketMeta, docID, item.Data); err != nil {
+						return errors.Wrapf(err, "failed adding to prop '%s' meta bucket", property.Name)
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	schemaProp := checker.getSchemaProp(property.Name)
+	if checker.isReindexable(property.Name, IndexTypePropValue) &&
+		inverted.HasFilterableIndex(schemaProp) {
+
+		bucketValue := r.tempBucket(property.Name, IndexTypePropValue)
+		if bucketValue == nil {
+			return fmt.Errorf("no bucket for prop '%s' value found", property.Name)
+		}
+		for _, item := range property.Items {
+			if err := r.shard.addToPropertySetBucket(bucketValue, docID, item.Data); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+			}
+		}
+	}
+	if checker.isReindexable(property.Name, IndexTypePropSearchableValue) &&
+		inverted.HasSearchableIndex(schemaProp) {
+
+		bucketSearchableValue := r.tempBucket(property.Name, IndexTypePropSearchableValue)
+		if bucketSearchableValue == nil {
+			return fmt.Errorf("no bucket searchable for prop '%s' value found", property.Name)
+		}
+		propLen := float32(len(property.Items))
+		for _, item := range property.Items {
+			pair := r.shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+			if err := r.shard.addToPropertyMapBucket(bucketSearchableValue, pair, item.Data); err != nil {
+				return errors.Wrapf(err, "failed adding to prop '%s' value bucket", property.Name)
+			}
+		}
+	}
+
 	// properties where defining a length does not make sense (floats etc.) have a negative entry as length
-	if r.shard.Index().invertedIndexConfig.IndexPropertyLength && property.Length >= 0 {
+	if r.shard.Index().invertedIndexConfig.IndexPropertyLength &&
+		checker.isReindexable(property.Name, IndexTypePropLength) &&
+		property.Length >= 0 {
+
 		key, err := bucketKeyPropertyLength(property.Length)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' length", property.Name)
 		}
-		if checker.isReindexable(property.Name, IndexTypePropLength) {
-			bucketLength := r.tempBucket(property.Name, IndexTypePropLength)
-			if bucketLength == nil {
-				return fmt.Errorf("no bucket for prop '%s' length found", property.Name)
-			}
-			if err := r.shard.addToPropertySetBucket(bucketLength, docID, key); err != nil {
-				return errors.Wrapf(err, "failed adding to prop '%s' length bucket", property.Name)
-			}
+		bucketLength := r.tempBucket(property.Name, IndexTypePropLength)
+		if bucketLength == nil {
+			return fmt.Errorf("no bucket for prop '%s' length found", property.Name)
+		}
+		if err := r.shard.addToPropertySetBucket(bucketLength, docID, key); err != nil {
+			return errors.Wrapf(err, "failed adding to prop '%s' length bucket", property.Name)
 		}
 	}
 
-	if r.shard.Index().invertedIndexConfig.IndexNullState {
+	if r.shard.Index().invertedIndexConfig.IndexNullState &&
+		checker.isReindexable(property.Name, IndexTypePropNull) {
+
 		key, err := bucketKeyPropertyNull(property.Length == 0)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' null", property.Name)
 		}
-		if checker.isReindexable(property.Name, IndexTypePropNull) {
-			bucketNull := r.tempBucket(property.Name, IndexTypePropNull)
-			if bucketNull == nil {
-				return fmt.Errorf("no bucket for prop '%s' null found", property.Name)
-			}
-			if err := r.shard.addToPropertySetBucket(bucketNull, docID, key); err != nil {
-				return errors.Wrapf(err, "failed adding to prop '%s' null bucket", property.Name)
-			}
+		bucketNull := r.tempBucket(property.Name, IndexTypePropNull)
+		if bucketNull == nil {
+			return fmt.Errorf("no bucket for prop '%s' null found", property.Name)
+		}
+		if err := r.shard.addToPropertySetBucket(bucketNull, docID, key); err != nil {
+			return errors.Wrapf(err, "failed adding to prop '%s' null bucket", property.Name)
 		}
 	}
 
@@ -375,35 +391,36 @@ func (r *ShardInvertedReindexer) handleProperty(ctx context.Context, checker *re
 func (r *ShardInvertedReindexer) handleNilProperty(ctx context.Context, checker *reindexablePropertyChecker,
 	docID uint64, nilProperty inverted.NilProperty,
 ) error {
-	if r.shard.Index().invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
+	if r.shard.Index().invertedIndexConfig.IndexPropertyLength &&
+		checker.isReindexable(nilProperty.Name, IndexTypePropLength) &&
+		nilProperty.AddToPropertyLength {
+
 		key, err := bucketKeyPropertyLength(0)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' length", nilProperty.Name)
 		}
-		if checker.isReindexable(nilProperty.Name, IndexTypePropLength) {
-			bucketLength := r.tempBucket(nilProperty.Name, IndexTypePropLength)
-			if bucketLength == nil {
-				return fmt.Errorf("no bucket for prop '%s' length found", nilProperty.Name)
-			}
-			if err := r.shard.addToPropertySetBucket(bucketLength, docID, key); err != nil {
-				return errors.Wrapf(err, "failed adding to prop '%s' length bucket", nilProperty.Name)
-			}
+		bucketLength := r.tempBucket(nilProperty.Name, IndexTypePropLength)
+		if bucketLength == nil {
+			return fmt.Errorf("no bucket for prop '%s' length found", nilProperty.Name)
+		}
+		if err := r.shard.addToPropertySetBucket(bucketLength, docID, key); err != nil {
+			return errors.Wrapf(err, "failed adding to prop '%s' length bucket", nilProperty.Name)
 		}
 	}
 
-	if r.shard.Index().invertedIndexConfig.IndexNullState {
+	if r.shard.Index().invertedIndexConfig.IndexNullState &&
+		checker.isReindexable(nilProperty.Name, IndexTypePropNull) {
+
 		key, err := bucketKeyPropertyNull(true)
 		if err != nil {
 			return errors.Wrapf(err, "failed creating key for prop '%s' null", nilProperty.Name)
 		}
-		if checker.isReindexable(nilProperty.Name, IndexTypePropNull) {
-			bucketNull := r.tempBucket(nilProperty.Name, IndexTypePropNull)
-			if bucketNull == nil {
-				return fmt.Errorf("no bucket for prop '%s' null found", nilProperty.Name)
-			}
-			if err := r.shard.addToPropertySetBucket(bucketNull, docID, key); err != nil {
-				return errors.Wrapf(err, "failed adding to prop '%s' null bucket", nilProperty.Name)
-			}
+		bucketNull := r.tempBucket(nilProperty.Name, IndexTypePropNull)
+		if bucketNull == nil {
+			return fmt.Errorf("no bucket for prop '%s' null found", nilProperty.Name)
+		}
+		if err := r.shard.addToPropertySetBucket(bucketNull, docID, key); err != nil {
+			return errors.Wrapf(err, "failed adding to prop '%s' null bucket", nilProperty.Name)
 		}
 	}
 
@@ -422,6 +439,8 @@ func (r *ShardInvertedReindexer) bucketName(propName string, indexType PropertyI
 		return helpers.BucketFromPropNameLengthLSM(propName)
 	case IndexTypePropNull:
 		return helpers.BucketFromPropNameNullLSM(propName)
+	case IndexTypePropMetaCount:
+		return helpers.BucketFromPropNameMetaCountLSM(propName)
 	default:
 		return ""
 	}
@@ -442,7 +461,7 @@ func (r *ShardInvertedReindexer) checkContextExpired(ctx context.Context, msg st
 
 func (r *ShardInvertedReindexer) logError(err error, msg string, args ...interface{}) {
 	r.logger.
-		WithField("action", "inverted reindex").
+		WithField("action", "inverted_reindex").
 		WithField("shard", r.shard.Name()).
 		WithError(err).
 		Errorf(msg, args...)

--- a/adapters/repos/db/inverted_reindexer_corrupted_index.go
+++ b/adapters/repos/db/inverted_reindexer_corrupted_index.go
@@ -1,0 +1,155 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+type ShardInvertedReindexTask_CorruptedIndex struct {
+	classNamesWithPropertyNames map[string]map[string]struct{}
+}
+
+func (t *ShardInvertedReindexTask_CorruptedIndex) GetPropertiesToReindex(ctx context.Context,
+	shard ShardLike,
+) ([]ReindexableProperty, error) {
+	reindexableProperties := []ReindexableProperty{}
+
+	// shard of selected class
+	props, ok := t.classNamesWithPropertyNames[shard.Index().Config.ClassName.String()]
+	if !ok {
+		return reindexableProperties, nil
+	}
+
+	bucketOptions := []lsmkv.BucketOption{
+		lsmkv.WithDirtyThreshold(time.Duration(shard.Index().Config.MemtablesFlushDirtyAfter) * time.Second),
+	}
+
+	for name := range shard.Store().GetBucketsByName() {
+		// skip non prop buckets
+		switch name {
+		case helpers.ObjectsBucketLSM:
+		case helpers.VectorsBucketLSM:
+		case helpers.VectorsCompressedBucketLSM:
+		case helpers.DimensionsBucketLSM:
+			continue
+		}
+
+		propName, indexType := GetPropNameAndIndexTypeFromBucketName(name)
+		if _, ok := props[propName]; !ok {
+			continue
+		}
+
+		switch indexType {
+		case IndexTypePropValue:
+			reindexableProperties = append(reindexableProperties,
+				ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropValue,
+					DesiredStrategy: lsmkv.StrategyRoaringSet,
+					BucketOptions:   bucketOptions,
+				},
+			)
+		case IndexTypePropSearchableValue:
+			reindexableProperties = append(reindexableProperties,
+				ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropSearchableValue,
+					DesiredStrategy: lsmkv.StrategyMapCollection,
+					BucketOptions:   bucketOptions,
+				},
+			)
+		case IndexTypePropLength:
+			reindexableProperties = append(reindexableProperties,
+				ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropLength,
+					DesiredStrategy: lsmkv.StrategyRoaringSet,
+					BucketOptions:   bucketOptions,
+				},
+			)
+		case IndexTypePropNull:
+			reindexableProperties = append(reindexableProperties,
+				ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropNull,
+					DesiredStrategy: lsmkv.StrategyRoaringSet,
+					BucketOptions:   bucketOptions,
+				},
+			)
+		case IndexTypePropMetaCount:
+			reindexableProperties = append(reindexableProperties,
+				ReindexableProperty{
+					PropertyName:    propName,
+					IndexType:       IndexTypePropMetaCount,
+					DesiredStrategy: lsmkv.StrategyRoaringSet,
+					BucketOptions:   bucketOptions,
+				},
+			)
+		default:
+			// skip remaining
+		}
+
+	}
+
+	return reindexableProperties, nil
+}
+
+func (t *ShardInvertedReindexTask_CorruptedIndex) OnPostResumeStore(ctx context.Context, shard ShardLike) error {
+	return nil
+}
+
+func (t *ShardInvertedReindexTask_CorruptedIndex) ObjectsIterator(shard ShardLike) objectsIterator {
+	class := shard.Index().Config.ClassName.String()
+	props, ok := t.classNamesWithPropertyNames[class]
+	if !ok || len(props) == 0 {
+		return nil
+	}
+
+	propStrings := make([]string, 0, len(props))
+	propStringsList := make([][]string, 0, len(props))
+	for prop := range props {
+		propStrings = append(propStrings, prop)
+		propStringsList = append(propStringsList, []string{prop})
+	}
+
+	propsExtraction := &storobj.PropertyExtraction{
+		PropStrings:     propStrings,
+		PropStringsList: propStringsList,
+	}
+
+	objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
+		cursor := objectsBucket.Cursor()
+		defer cursor.Close()
+
+		i := 0
+		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+			obj, err := storobj.FromBinaryOptional(v, additional.Properties{}, propsExtraction)
+			if err != nil {
+				return fmt.Errorf("cannot unmarshal object %d, %v", i, err)
+			}
+			if err := fn(obj); err != nil {
+				return fmt.Errorf("callback on object '%d' failed: %w", obj.DocID, err)
+			}
+			i++
+		}
+		return nil
+	}
+}

--- a/adapters/repos/db/inverted_reindexer_index_types.go
+++ b/adapters/repos/db/inverted_reindexer_index_types.go
@@ -20,6 +20,7 @@ const (
 	IndexTypePropLength
 	IndexTypePropNull
 	IndexTypePropSearchableValue
+	IndexTypePropMetaCount
 )
 
 func isSupportedPropertyIndexType(indexType PropertyIndexType) bool {
@@ -27,6 +28,7 @@ func isSupportedPropertyIndexType(indexType PropertyIndexType) bool {
 	case IndexTypePropValue,
 		IndexTypePropLength,
 		IndexTypePropNull,
+		IndexTypePropMetaCount,
 		IndexTypePropSearchableValue:
 		return true
 	default:
@@ -46,6 +48,7 @@ func isIndexTypeSupportedByStrategy(indexType PropertyIndexType, strategy string
 	switch indexType {
 	case IndexTypePropLength,
 		IndexTypePropNull,
+		IndexTypePropMetaCount,
 		IndexTypePropValue:
 		return lsmkv.IsExpectedStrategy(strategy, lsmkv.StrategySetCollection, lsmkv.StrategyRoaringSet)
 	case IndexTypePropSearchableValue:

--- a/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
+++ b/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
@@ -118,3 +118,7 @@ func (t *shardInvertedReindexTaskMissingTextFilterable) OnPostResumeStore(ctx co
 	shard.setFallbackToSearchable(false)
 	return nil
 }
+
+func (t *shardInvertedReindexTaskMissingTextFilterable) ObjectsIterator(shard ShardLike) objectsIterator {
+	return shard.Store().Bucket(helpers.ObjectsBucketLSM).IterateObjects
+}

--- a/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
+++ b/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
@@ -73,4 +74,8 @@ func (t *ShardInvertedReindexTaskSetToRoaringSet) GetPropertiesToReindex(ctx con
 
 func (t *ShardInvertedReindexTaskSetToRoaringSet) OnPostResumeStore(ctx context.Context, shard ShardLike) error {
 	return nil
+}
+
+func (t *ShardInvertedReindexTaskSetToRoaringSet) ObjectsIterator(shard ShardLike) objectsIterator {
+	return shard.Store().Bucket(helpers.ObjectsBucketLSM).IterateObjects
 }

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -22,11 +22,11 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-type ShardInvertedReindexTask_CorruptedIndex struct {
+type ShardInvertedReindexTask_SpecifiedIndex struct {
 	classNamesWithPropertyNames map[string]map[string]struct{}
 }
 
-func (t *ShardInvertedReindexTask_CorruptedIndex) GetPropertiesToReindex(ctx context.Context,
+func (t *ShardInvertedReindexTask_SpecifiedIndex) GetPropertiesToReindex(ctx context.Context,
 	shard ShardLike,
 ) ([]ReindexableProperty, error) {
 	reindexableProperties := []ReindexableProperty{}
@@ -111,11 +111,11 @@ func (t *ShardInvertedReindexTask_CorruptedIndex) GetPropertiesToReindex(ctx con
 	return reindexableProperties, nil
 }
 
-func (t *ShardInvertedReindexTask_CorruptedIndex) OnPostResumeStore(ctx context.Context, shard ShardLike) error {
+func (t *ShardInvertedReindexTask_SpecifiedIndex) OnPostResumeStore(ctx context.Context, shard ShardLike) error {
 	return nil
 }
 
-func (t *ShardInvertedReindexTask_CorruptedIndex) ObjectsIterator(shard ShardLike) objectsIterator {
+func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLike) objectsIterator {
 	class := shard.Index().Config.ClassName.String()
 	props, ok := t.classNamesWithPropertyNames[class]
 	if !ok || len(props) == 0 {

--- a/adapters/repos/db/inverted_reindexer_utils.go
+++ b/adapters/repos/db/inverted_reindexer_utils.go
@@ -39,6 +39,10 @@ func GetPropNameAndIndexTypeFromBucketName(bucketName string) (string, PropertyI
 			helpers.BucketSearchableFromPropNameLSM,
 		},
 		{
+			IndexTypePropMetaCount,
+			helpers.BucketFromPropNameMetaCountLSM,
+		},
+		{
 			IndexTypePropValue,
 			helpers.BucketFromPropNameLSM,
 		},

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -794,7 +794,7 @@ func (m *Migrator) doInvertedReindex(ctx context.Context, taskNamesWithArgs map[
 		switch name {
 		case "ShardInvertedReindexTaskSetToRoaringSet":
 			tasks[name] = &ShardInvertedReindexTaskSetToRoaringSet{}
-		case "ShardInvertedReindexTask_CorruptedIndex":
+		case "ShardInvertedReindexTask_SpecifiedIndex":
 			if args == nil {
 				return fmt.Errorf("no args given for %q reindex task", name)
 			}
@@ -809,7 +809,7 @@ func (m *Migrator) doInvertedReindex(ctx context.Context, taskNamesWithArgs map[
 					classNamesWithPropertyNames[class][prop] = struct{}{}
 				}
 			}
-			tasks[name] = &ShardInvertedReindexTask_CorruptedIndex{
+			tasks[name] = &ShardInvertedReindexTask_SpecifiedIndex{
 				classNamesWithPropertyNames: classNamesWithPropertyNames,
 			}
 		}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -116,7 +116,6 @@ type Config struct {
 	ForceFullReplicasSearch             bool                     `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	RecountPropertiesAtStartup          bool                     `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
 	ReindexSetToRoaringsetAtStartup     bool                     `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
-	ReindexCorruptedIndexesAtStartup    map[string][]string      `json:"reindex_corrupted_indexes_at_startup" yaml:"reindex_corrupted_indexes_at_startup"`
 	IndexMissingTextFilterableAtStartup bool                     `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 	DisableGraphQL                      bool                     `json:"disable_graphql" yaml:"disable_graphql"`
 	AvoidMmap                           bool                     `json:"avoid_mmap" yaml:"avoid_mmap"`
@@ -130,6 +129,9 @@ type Config struct {
 	// Raft Specific configuration
 	// TODO-RAFT: Do we want to be able to specify these with config file as well ?
 	Raft Raft
+
+	// map[className][]propertyName
+	ReindexIndexesAtStartup map[string][]string `json:"reindex_indexes_at_startup" yaml:"reindex_indexes_at_startup"`
 }
 
 type moduleProvider interface {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -116,6 +116,7 @@ type Config struct {
 	ForceFullReplicasSearch             bool                     `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	RecountPropertiesAtStartup          bool                     `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
 	ReindexSetToRoaringsetAtStartup     bool                     `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
+	ReindexCorruptedIndexesAtStartup    map[string][]string      `json:"reindex_corrupted_indexes_at_startup" yaml:"reindex_corrupted_indexes_at_startup"`
 	IndexMissingTextFilterableAtStartup bool                     `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 	DisableGraphQL                      bool                     `json:"disable_graphql" yaml:"disable_graphql"`
 	AvoidMmap                           bool                     `json:"avoid_mmap" yaml:"avoid_mmap"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -96,12 +96,14 @@ func FromEnv(config *Config) error {
 		config.IndexMissingTextFilterableAtStartup = true
 	}
 
-	if v := os.Getenv("REINDEX_CORRUPTED_INDEXES_AT_STARTUP"); v != "" {
+	// variable expects string in format:
+	// "Class1:property11,property12;Class2:property21,property22"
+	if v := os.Getenv("REINDEX_INDEXES_AT_STARTUP"); v != "" {
 		asClassesWithProps, err := parseClassNamesWithPropsNames(v)
 		if err != nil {
-			return fmt.Errorf("parse REINDEX_CORRUPTED_INDEXES_AT_STARTUP as class with props: %w", err)
+			return fmt.Errorf("parse REINDEX_INDEXES_AT_STARTUP as class with props: %w", err)
 		}
-		config.ReindexCorruptedIndexesAtStartup = asClassesWithProps
+		config.ReindexIndexesAtStartup = asClassesWithProps
 	}
 
 	if v := os.Getenv("PROMETHEUS_MONITORING_PORT"); v != "" {
@@ -701,8 +703,9 @@ func parseInt(envName string, defaultValue int, verify func(val int) error, cb f
 	return nil
 }
 
+// expects "Class1:property11,property12;Class2:property21,property22"
+// returns map[Class][]property
 func parseClassNamesWithPropsNames(v string) (map[string][]string, error) {
-	// "class1:property11,property12;class2:property21,property22"
 	classNamesWithPropsNames := map[string][]string{}
 
 	regexClass := regexp.MustCompile(`^` + schema.ClassNameRegexCore + `$`)


### PR DESCRIPTION
### What's being changed:
Reindex specified property indexes on db startup. Puts relevant shard's store in Readonly mode and pauses its background activities while reindex is ongoing. Replaces existing buckets with new ones, deleting previous ones afterwards.

Classes and properties are specified by setting env variable `REINDEX_INDEXES_AT_STARTUP=ClassName1:propertyName11,propertyName12;ClassName2:propertyName21,propertyName22`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
