### PR TITLE
performance: sort bitmaps before merge to reduce memory allocations

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -14,14 +14,15 @@ package inverted
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/sroar"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -55,7 +56,6 @@ func newPropValuePair(class *models.Class, logger logrus.FieldLogger) (*propValu
 
 func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) error {
 	if pv.operator.OnValue() {
-
 		// TODO text_rbm_inverted_index find better way check whether prop len
 		if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
 			!pv.Class.InvertedIndexConfig.IndexPropertyLength {
@@ -125,35 +125,51 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 		return &pv.docIDs, nil
 	}
 
-	if pv.operator != filters.OperatorAnd && pv.operator != filters.OperatorOr {
+	switch pv.operator {
+	case filters.OperatorAnd:
+	case filters.OperatorOr:
+		// ok
+	default:
 		return nil, fmt.Errorf("unsupported operator: %s", pv.operator.Name())
 	}
-	if len(pv.children) == 0 {
+
+	switch len(pv.children) {
+	case 0:
 		return nil, fmt.Errorf("no children for operator: %s", pv.operator.Name())
+	case 1:
+		return &pv.children[0].docIDs, nil
 	}
 
+	var err error
 	dbms := make([]*docBitmap, len(pv.children))
 	for i, child := range pv.children {
-		dbm, err := child.mergeDocIDs()
+		dbms[i], err = child.mergeDocIDs()
 		if err != nil {
 			return nil, errors.Wrapf(err, "retrieve doc bitmap of child %d", i)
 		}
-		dbms[i] = dbm
 	}
 
-	mergeRes := dbms[0].docIDs.Clone()
-	mergeFn := mergeRes.And
+	var mergeFn func(*sroar.Bitmap) *sroar.Bitmap
 	if pv.operator == filters.OperatorOr {
-		mergeFn = mergeRes.Or
+		// biggest to smallest, so smaller bitmaps are merged into biggest one,
+		// minimising chance of expanding destination bitmap (memory allocations)
+		sort.Slice(dbms, func(i, j int) bool {
+			return dbms[i].docIDs.CompareNumKeys(dbms[j].docIDs) > 0
+		})
+		mergeFn = dbms[0].docIDs.Or
+	} else {
+		// smallest to biggest, so data is removed from smallest bitmap
+		// allowing bigger bitmaps to be garbage collected asap
+		sort.Slice(dbms, func(i, j int) bool {
+			return dbms[i].docIDs.CompareNumKeys(dbms[j].docIDs) < 0
+		})
+		mergeFn = dbms[0].docIDs.And
 	}
 
 	for i := 1; i < len(dbms); i++ {
 		mergeFn(dbms[i].docIDs)
 	}
-
-	return &docBitmap{
-		docIDs: roaringset.Condense(mergeRes),
-	}, nil
+	return dbms[0], nil
 }
 
 func (pv *propValuePair) getBucketName() string {

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestPropValuePairs_Merging(t *testing.T) {
-	t.Run("always creates new underlying bitmap", func(t *testing.T) {
+	t.Run("reuses one of underlying bitmaps", func(t *testing.T) {
 		type testCase struct {
 			name string
 
@@ -102,9 +102,14 @@ func TestPropValuePairs_Merging(t *testing.T) {
 
 				require.Nil(t, err)
 				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())
-				assert.False(t, tc.bitmaps[0] == dbm.docIDs)
-				assert.False(t, tc.bitmaps[1] == dbm.docIDs)
-				assert.False(t, tc.bitmaps[2] == dbm.docIDs)
+
+				sameCounter := 0
+				for _, bm := range tc.bitmaps {
+					if bm == dbm.docIDs {
+						sameCounter++
+					}
+				}
+				assert.Equal(t, 1, sameCounter)
 			})
 		}
 	})

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -118,6 +118,7 @@ func (m *Memtable) roaringSetAddRemoveSlices(key []byte, additions []uint64, del
 	return nil
 }
 
+// returned bitmaps are cloned and safe to mutate
 func (m *Memtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
 	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return roaringset.BitmapLayer{}, err

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -564,7 +564,7 @@ func (sg *SegmentGroup) roaringSetGet(key []byte) (roaringset.BitmapLayers, erro
 
 	// start with first and do not exit
 	for _, segment := range sg.segments {
-		rs, err := segment.roaringSetGet(key)
+		layer, err := segment.roaringSetGet(key)
 		if err != nil {
 			if errors.Is(err, lsmkv.NotFound) {
 				continue
@@ -573,7 +573,7 @@ func (sg *SegmentGroup) roaringSetGet(key []byte) (roaringset.BitmapLayers, erro
 			return nil, err
 		}
 
-		out = append(out, rs)
+		out = append(out, layer)
 	}
 
 	return out, nil

--- a/adapters/repos/db/roaringset/binary_search_tree.go
+++ b/adapters/repos/db/roaringset/binary_search_tree.go
@@ -257,6 +257,9 @@ func (n *BinarySearchNode) flattenInOrder() []*BinarySearchNode {
 	key := make([]byte, len(n.Key))
 	copy(key, n.Key)
 
+	// Node's Value has to be copied, not to be mutated when BST is updated.
+	// Since memtable flush needs condensing, Condense here serves as cloning here
+	// instead of separate clone + optional condense calls
 	right = append([]*BinarySearchNode{{
 		Key: key,
 		Value: BitmapLayer{

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -295,10 +295,10 @@ func (c *nodeCompactor) takeRightKey() error {
 func (c *nodeCompactor) cleanupValues(additions, deletions *sroar.Bitmap,
 ) (add, del *sroar.Bitmap, skip bool) {
 	if !c.cleanupDeletions {
-		return additions, deletions, false
+		return Condense(additions), Condense(deletions), false
 	}
 	if !additions.IsEmpty() {
-		return additions, c.emptyBitmap, false
+		return Condense(additions), c.emptyBitmap, false
 	}
 	return nil, nil, true
 }

--- a/adapters/repos/db/roaringset/cursor.go
+++ b/adapters/repos/db/roaringset/cursor.go
@@ -110,7 +110,7 @@ func (c *CombinedCursor) getResultFromStates(states []innerCursorState) ([]byte,
 		return nil, nil
 	}
 
-	bm := layers.Flatten()
+	bm := layers.Flatten(true)
 	if key == nil {
 		return nil, bm
 	}

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -82,38 +82,17 @@ type BitmapLayers []BitmapLayer
 //     should be represented in the final bitmap. If the order is reversed and
 //     layer 2 adds X, whereas layer 3 removes X, it is should not be contained
 //     in the final map.
-func (bml BitmapLayers) Flatten() *sroar.Bitmap {
-	if len(bml) == 0 {
-		return sroar.NewBitmap()
-	}
-
-	cur := bml[0]
-	// TODO: is this copy really needed? aren't we already operating on copied
-	// bms?
-	merged := cur.Additions.Clone()
-
-	for i := 1; i < len(bml); i++ {
-		merged.AndNot(bml[i].Deletions)
-		merged.Or(bml[i].Additions)
-	}
-
-	return merged
-}
-
-// FlattenMutate works as Flatten but mutates passed bitmaps:
-// bml[0].Additions and bml[!=0].Deletions.
-// It is important to provide cloned bitmaps if original ones
-// are expected not to change.
-func (bml BitmapLayers) FlattenMutate() *sroar.Bitmap {
+func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
 	if len(bml) == 0 {
 		return sroar.NewBitmap()
 	}
 
 	merged := bml[0].Additions
+	if clone {
+		merged = merged.Clone()
+	}
+
 	for i := 1; i < len(bml); i++ {
-		// AndNot of only common set seems to be faster than AndNot of bigger set
-		// therefore call to And first
-		bml[i].Deletions.And(merged)
 		merged.AndNot(bml[i].Deletions)
 		merged.Or(bml[i].Additions)
 	}
@@ -144,7 +123,7 @@ func (bml BitmapLayers) Merge() (BitmapLayer, error) {
 	deletions.AndNot(right.Additions)
 	deletions.Or(right.Deletions)
 
-	out.Additions = Condense(additions)
-	out.Deletions = Condense(deletions)
+	out.Additions = additions
+	out.Deletions = deletions
 	return out, nil
 }

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -106,7 +106,7 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 				input[i].Deletions = NewBitmap(inp.deletions...)
 			}
 
-			res := input.Flatten()
+			res := input.Flatten(false)
 			for _, x := range test.expectedContained {
 				assert.True(t, res.Contains(x))
 			}

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -237,6 +237,10 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 	}
 
 	// both segments, merge
+	//
+	// bitmaps' cloning is necessary for both types of cursors: mmap and pread
+	// (pread cursor use buffers to read entire nodes from file, therefore nodes already read
+	// are later overwritten with nodes being read later)
 	nc.deletionsLeft = nc.emptyBitmap
 	if !layerLeft.Deletions.IsEmpty() {
 		nc.deletionsLeft = layerLeft.Deletions.Clone()
@@ -276,6 +280,9 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 
 func (nc *nodeCompactor) mergeLayers(key uint8, additionsLeft, additionsRight *sroar.Bitmap,
 ) roaringset.BitmapLayer {
+	// bitmaps' cloning is necessary for both types of cursors: mmap and pread
+	// (pread cursor use buffers to read entire nodes from file, therefore nodes already read
+	// are later overwritten with nodes being read later)
 	additions := additionsLeft.Clone()
 	additions.AndNot(nc.deletionsRight)
 	additions.Or(additionsRight)

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -96,7 +96,7 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		layer.Additions.Or(response.layer.Additions)
 	}
 
-	return roaringset.Condense(layer.Additions), nil
+	return layer.Additions, nil
 }
 
 func (r *CombinedReader) Close() {

--- a/adapters/repos/db/roaringsetrange/segment_reader.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader.go
@@ -75,6 +75,9 @@ func (r *SegmentReader) Read(ctx context.Context, value uint64, operator filters
 }
 
 func (r *SegmentReader) firstLayer() (roaringset.BitmapLayer, bool) {
+	// bitmaps' cloning is necessary for both types of cursors: mmap and pread
+	// (pread cursor use buffers to read entire nodes from file, therefore nodes already read
+	// are later overwritten with nodes being read later)
 	_, layer, ok := r.cursor.First()
 	if !ok {
 		return roaringset.BitmapLayer{

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/weaviate/fgprof v0.0.0-20241024091527-0000bf3ee8aa
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.8
+	github.com/weaviate/sroar v0.0.9-0.20250102144609-db4336614908
 	github.com/weaviate/tiktoken-go v0.0.2
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/text v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/weaviate/fgprof v0.0.0-20241024091527-0000bf3ee8aa h1:yavIOSoUOUfmYlE
 github.com/weaviate/fgprof v0.0.0-20241024091527-0000bf3ee8aa/go.mod h1:2REGzzHg/U0Olsn/1ok6QfqAE/vDuKvb/j2eLrOIP8A=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.8 h1:BUHeYdgX1M36tzhHc3WoaDrZGXOyk9aWAlC6QXstXYM=
-github.com/weaviate/sroar v0.0.8/go.mod h1:I6HAMeJjGMDI8cuFDUK4TIRsy5Csn5RFncNkosyNgKE=
+github.com/weaviate/sroar v0.0.9-0.20250102144609-db4336614908 h1:JJVF25E91rCbqN0fkJxk7Njv1zp5V3PUUEmpJ1hlbIU=
+github.com/weaviate/sroar v0.0.9-0.20250102144609-db4336614908/go.mod h1:I6HAMeJjGMDI8cuFDUK4TIRsy5Csn5RFncNkosyNgKE=
 github.com/weaviate/tiktoken-go v0.0.2 h1:lkwTMEoXSFSXxYvw1c44/xz3OOAh27L3+3vvNN/TSSg=
 github.com/weaviate/tiktoken-go v0.0.2/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
### What's being changed:
- updates sroar lib to version with `Bitmap::CompareNumKeys` method
- removes unnecessary bitmap clone and condense in `propValuePair::mergeDocIDs` reducing memory allocation
- sorts bitmaps by number of internal containers before merging (merging smaller bitmaps into bigger for `Or`, bigger into smaller for `And`) to minimize chance of necessary memory allocations 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
