### PR TITLE
feature(bm25): :sparkles: Better BM25 benchmarking with additional options and batch dataset loading

### DIFF
--- a/test/benchmark_bm25/cmd/import.go
+++ b/test/benchmark_bm25/cmd/import.go
@@ -35,6 +35,9 @@ func init() {
 	importCmd.PersistentFlags().Float32VarP(&Alpha, "alpha", "a", DefaultAlpha, "Weighting for keyword vs vector search. Alpha = 0 (Default) is pure BM25 search.")
 	importCmd.PersistentFlags().StringVarP(&Ranking, "ranking", "r", DefaultRanking, "Which ranking algorithm should be used for hybrid search, rankedFusion (default) and relativeScoreFusion.")
 	importCmd.PersistentFlags().IntVarP(&QueriesInterval, "query-interval", "i", DefaultQueriesInterval, "run queries every this number of inserts")
+	importCmd.PersistentFlags().IntVarP(&Limit, "limit", "l", DefaultLimit, "Limit the number of results returned by the query")
+	importCmd.PersistentFlags().BoolVarP(&AdditionalExplanations, "additional-explanations", "e", DefaultAdditionalExplanations, "Request additional explanations for the query results")
+	importCmd.PersistentFlags().BoolVarP(&PrintDetailedResults, "print-detailed-results", "p", DefaultPrintDetailedResults, "Print detailed results")
 }
 
 type IndexingExperimentResult struct {
@@ -78,18 +81,18 @@ var importCmd = &cobra.Command{
 			return fmt.Errorf("parse dataset cfg file: %w", err)
 		}
 
-		if err := client.Schema().AllDeleter().Do(context.Background()); err != nil {
-			return fmt.Errorf("clear schema prior to import: %w", err)
-		}
+		//if err := client.Schema().AllDeleter().Do(context.Background()); err != nil {
+		//	return fmt.Errorf("clear schema prior to import: %w", err)
+		//}
 
 		experimentResults := make([]IndexingExperimentResult, len(datasets.Datasets))
 		queryResults := make([]*QueryExperimentResult, 0)
 
 		for di, dataset := range datasets.Datasets {
 
-			c, err := lib.ParseCorpi(dataset, MultiplyProperties)
-			if err != nil {
-				return err
+			// delete the class if it exists
+			if err := client.Schema().ClassDeleter().WithClassName(lib.ClassNameFromDatasetID(dataset.ID)).Do(context.Background()); err != nil {
+				return fmt.Errorf("delete class for %s: %w", dataset, err)
 			}
 
 			if err := client.Schema().ClassCreator().
@@ -97,7 +100,7 @@ var importCmd = &cobra.Command{
 				Do(context.Background()); err != nil {
 				return fmt.Errorf("create schema for %s: %w", dataset, err)
 			}
-
+			log.Print("importing dataset " + dataset.ID)
 			queries := make([]lib.Query, 0)
 			if QueriesInterval != -1 {
 				log.Print("parse queries")
@@ -111,24 +114,42 @@ var importCmd = &cobra.Command{
 			start := time.Now()
 			startBatch := time.Now()
 			batch := client.Batch().ObjectsBatcher()
-			for i, corp := range c {
-				id := uuid.MustParse(fmt.Sprintf("%032x", i)).String()
-				props := map[string]interface{}{
-					"modulo_10":   i % 10,
-					"modulo_100":  i % 100,
-					"modulo_1000": i % 1000,
-				}
-				indexCount := i + 1
 
-				for key, value := range corp {
-					props[key] = value
-				}
+			indexCount := 0
 
-				batch.WithObjects(&models.Object{
-					ID:         strfmt.UUID(id),
-					Class:      lib.ClassNameFromDatasetID(dataset.ID),
-					Properties: props,
-				})
+			c, err := lib.ParseCorpi(dataset, MultiplyProperties)
+			if err != nil {
+				return err
+			}
+
+			i := 0
+			for c.Next(BatchSize) == nil {
+				data := c.Data
+
+				if len(data) == 0 {
+					break
+				}
+				for _, corp := range data {
+					id := uuid.MustParse(fmt.Sprintf("%032x", i)).String()
+					props := map[string]interface{}{
+						"modulo_10":   i % 10,
+						"modulo_100":  i % 100,
+						"modulo_1000": i % 1000,
+					}
+
+					for key, value := range corp {
+						props[key] = value
+					}
+
+					batch.WithObjects(&models.Object{
+						ID:         strfmt.UUID(id),
+						Class:      lib.ClassNameFromDatasetID(dataset.ID),
+						Properties: props,
+					})
+
+					i++
+					indexCount++
+				}
 
 				if indexCount%BatchSize == 0 {
 					br, err := batch.Do(context.Background())
@@ -141,15 +162,15 @@ var importCmd = &cobra.Command{
 					}
 				}
 
-				if indexCount%1000 == 0 {
+				if indexCount%BatchSize == 0 {
 					totalTimeBatch := time.Since(startBatch).Seconds()
 					totalTime := time.Since(start).Seconds()
 					startBatch = time.Now()
-					log.Printf("imported %d/%d objects in %.3f, time per 1k objects: %.3f, objects per second: %.0f", indexCount, len(c), totalTimeBatch, totalTime/float64(indexCount)*1000, float64(indexCount)/totalTime)
+					log.Printf("imported %d objects in %.3f, time per 1k objects: %.3f, objects per second: %.0f", indexCount, totalTimeBatch, totalTime/float64(indexCount)*1000, float64(indexCount)/totalTime)
 				}
 
 				if QueriesInterval > 0 && indexCount%QueriesInterval == 0 {
-					result, err := query(client, queries, dataset)
+					result, err := query(client, queries, dataset, indexCount)
 					if err != nil {
 						return fmt.Errorf("query: %w", err)
 					}
@@ -158,7 +179,29 @@ var importCmd = &cobra.Command{
 				}
 			}
 
-			if len(c)%BatchSize != 0 {
+			if len(c.Data) != 0 {
+				data := c.Data
+				for _, corp := range data {
+					id := uuid.MustParse(fmt.Sprintf("%032x", i)).String()
+					props := map[string]interface{}{
+						"modulo_10":   i % 10,
+						"modulo_100":  i % 100,
+						"modulo_1000": i % 1000,
+					}
+
+					for key, value := range corp {
+						props[key] = value
+					}
+
+					batch.WithObjects(&models.Object{
+						ID:         strfmt.UUID(id),
+						Class:      lib.ClassNameFromDatasetID(dataset.ID),
+						Properties: props,
+					})
+
+					i++
+					indexCount++
+				}
 				// we need to send one final batch
 				br, err := batch.Do(context.Background())
 				if err != nil {
@@ -169,12 +212,15 @@ var importCmd = &cobra.Command{
 				}
 				totalTimeBatch := time.Since(startBatch).Seconds()
 				totalTime := time.Since(start).Seconds()
-				log.Printf("imported finished %d/%d objects in %.3f, time per 1k objects: %.3f, objects per second: %.0f", len(c), len(c), totalTimeBatch, totalTime/float64(len(c))*1000, float64(len(c))/totalTime)
+				log.Printf("imported %d objects in %.3f, time per 1k objects: %.3f, objects per second: %.0f", indexCount, totalTimeBatch, totalTime/float64(indexCount)*1000, float64(indexCount)/totalTime)
 			}
 
-			if QueriesInterval != -1 && len(c)%BatchSize != 0 {
+			totalTime := time.Since(start).Seconds()
+			log.Printf("importing finished %d objects in %.3f, time per 1k objects: %.3f, objects per second: %.0f", indexCount, totalTime, totalTime/float64(indexCount)*1000, float64(indexCount)/totalTime)
+
+			if QueriesInterval != -1 && indexCount%QueriesInterval != 0 {
 				// run queries after full import
-				result, err := query(client, queries, dataset)
+				result, err := query(client, queries, dataset, indexCount)
 				if err != nil {
 					return fmt.Errorf("query: %w", err)
 				}
@@ -183,12 +229,12 @@ var importCmd = &cobra.Command{
 
 			experimentResults[di] = IndexingExperimentResult{
 				Dataset:            dataset.ID,
-				Objects:            len(c),
+				Objects:            indexCount,
 				MultiplyProperties: MultiplyProperties,
 				Vectorize:          Vectorizer,
 				ImportTime:         time.Since(start).Seconds(),
-				ImportTimePer1000:  time.Since(start).Seconds() / float64(len(c)) * 1000,
-				ObjectsPerSecond:   float64(len(c)) / time.Since(start).Seconds(),
+				ImportTimePer1000:  time.Since(start).Seconds() / float64(indexCount) * 1000,
+				ObjectsPerSecond:   float64(indexCount) / time.Since(start).Seconds(),
 			}
 		}
 		// pretty print results fas TSV
@@ -202,7 +248,7 @@ var importCmd = &cobra.Command{
 		fmt.Printf("Dataset\tObjects\tQueries\tFilterObjectPercentage\tAlpha\tRanking\tQueryTime\tQueryTimePer1000\tQueriesPerSecond\tQueryTimePer1000000Documents\tMin\tMax\tP50\tP90\tP99\tnDCG\tP@1\tP@5\n")
 		for _, result := range queryResults {
 			ranking, _ := strconv.ParseFloat(result.Ranking, 64) // Convert result.Ranking to float64
-			fmt.Printf("%s\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n", result.Dataset, result.Objects, result.Queries, result.FilterObjectPercentage, result.Alpha, ranking, result.TotalQueryTime, result.QueryTimePer1000, result.QueriesPerSecond, result.QueryTimePer1000000Documents, float32(result.Min.Milliseconds())/1000.0, float32(result.Max.Milliseconds())/1000.0, float32(result.P50.Milliseconds())/1000.0, float32(result.P90.Milliseconds())/1000.0, float32(result.P99.Milliseconds())/1000.0, result.Scores.CurrentNDCG(), result.Scores.CurrentPrecisionAt1(), result.Scores.CurrentPrecisionAt5())
+			fmt.Printf("%s\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n", result.Dataset, result.Objects, result.Queries, result.FilterObjectPercentage, result.Alpha, ranking, result.TotalQueryTime, result.AvgQueryTime.Seconds(), result.QueriesPerSecond, result.QueryTimePer1000000Documents, float32(result.Min.Milliseconds())/1000.0, float32(result.Max.Milliseconds())/1000.0, float32(result.P50.Milliseconds())/1000.0, float32(result.P90.Milliseconds())/1000.0, float32(result.P99.Milliseconds())/1000.0, result.Scores.CurrentNDCG(), result.Scores.CurrentPrecisionAt1(), result.Scores.CurrentPrecisionAt5())
 		}
 
 		return nil

--- a/test/benchmark_bm25/cmd/query.go
+++ b/test/benchmark_bm25/cmd/query.go
@@ -13,10 +13,13 @@ package cmd
 
 import (
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -24,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/filters"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/benchmark_bm25/lib"
 )
 
@@ -42,8 +46,8 @@ type QueryExperimentResult struct {
 	Ranking string
 	// The time it took to query the dataset
 	TotalQueryTime float64
-	// Average time to query 1000 objects
-	QueryTimePer1000 float64
+	// Average query time
+	AvgQueryTime time.Duration
 	// Average time to query per 1000 indexed objects
 	QueryTimePer1000000Documents float64
 	// Objects per second
@@ -67,10 +71,50 @@ func init() {
 	queryCmd.PersistentFlags().IntVarP(&QueriesCount, "count", "c", DefaultQueriesCount, "run only the specified amount of queries, negative numbers mean unlimited")
 	queryCmd.PersistentFlags().IntVarP(&FilterObjectPercentage, "filter", "f", DefaultFilterObjectPercentage, "The given percentage of objects are filtered out. Off by default, use <=0 to disable")
 	queryCmd.PersistentFlags().Float32VarP(&Alpha, "alpha", "a", DefaultAlpha, "Weighting for keyword vs vector search. Alpha = 0 (Default) is pure BM25 search.")
-	queryCmd.PersistentFlags().StringVarP(&Ranking, "ranking´", "r", DefaultRanking, "Which ranking algorithm should be used for hybrid search, rankedFusion (default) and relativeScoreFusion.")
+	queryCmd.PersistentFlags().StringVarP(&Ranking, "ranking", "r", DefaultRanking, "Which ranking algorithm should be used for hybrid search, rankedFusion (default) and relativeScoreFusion.")
+	queryCmd.PersistentFlags().IntVarP(&Limit, "limit", "l", DefaultLimit, "Limit the number of results returned by the query")
+	queryCmd.PersistentFlags().BoolVarP(&AdditionalExplanations, "additional-explanations", "e", DefaultAdditionalExplanations, "Request additional explanations for the query results")
+	queryCmd.PersistentFlags().BoolVarP(&PrintDetailedResults, "print-detailed-results", "p", DefaultPrintDetailedResults, "Print detailed results")
 }
 
-func query(client *weaviate.Client, q lib.Queries, ds lib.Dataset) (*QueryExperimentResult, error) {
+func writeQueryResultsToFile(results *models.GraphQLResponse, filename, collection, queryId string, additionalExplanations bool) {
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	header := []string{"queryId", "id", "score"}
+	if additionalExplanations {
+		header = append(header, "explainScore")
+	}
+
+	// Write the header
+	writer.Write(header)
+	for _, obj := range results.Data["Get"].(map[string]interface{})[collection].([]interface{}) {
+		id := obj.(map[string]interface{})["_additional"].(map[string]interface{})["id"].(string)
+		score := obj.(map[string]interface{})["_additional"].(map[string]interface{})["score"].(string)
+
+		// round score to 2 decimal places
+		scoreFloat, err := strconv.ParseFloat(score, 64)
+		if err != nil {
+			log.Fatal(err)
+		}
+		score = fmt.Sprintf("%.2f", scoreFloat)
+
+		line := []string{queryId, id, score}
+		if additionalExplanations {
+			line = append(line, obj.(map[string]interface{})["_additional"].(map[string]interface{})["explainScore"].(string))
+		}
+
+		writer.Write(line)
+	}
+}
+
+func query(client *weaviate.Client, q lib.Queries, ds lib.Dataset, index int) (*QueryExperimentResult, error) {
 	propNameWithId := lib.SanitizePropName(ds.Queries.PropertyWithId)
 	propertiesToMatch := ds.Queries.PropertiesToMatch
 	for i := 0; i < len(propertiesToMatch); i++ {
@@ -79,9 +123,27 @@ func query(client *weaviate.Client, q lib.Queries, ds lib.Dataset) (*QueryExperi
 	className := lib.ClassNameFromDatasetID(ds.ID)
 	times := []time.Duration{}
 	scores := lib.Scores{}
+
+	// unix timestamp as string
+	t := strconv.FormatInt(time.Now().Unix(), 10)
+	propName := strings.Join(propertiesToMatch, "_")
+	if len(propertiesToMatch) == 0 {
+		propName = "all"
+	}
+	if index >= 0 {
+		propName = propName + "_" + strconv.Itoa(index)
+	}
+	filename := t + "_" + className + "_" + propName + ".csv"
+
+	additionalFlags := "id"
+	if PrintDetailedResults {
+		additionalFlags = "id score explainScore"
+	}
 	for i, query := range q {
 		before := time.Now()
-		queryBuilder := client.GraphQL().Get().WithClassName(className).WithLimit(100).WithFields(graphql.Field{Name: "_additional { id }"}, graphql.Field{Name: propNameWithId})
+		var queryBuilder *graphql.GetBuilder
+
+		queryBuilder = client.GraphQL().Get().WithClassName(className).WithLimit(Limit).WithFields(graphql.Field{Name: "_additional { " + additionalFlags + " }"}, graphql.Field{Name: propNameWithId})
 		if Alpha == 0 {
 			bm25 := &graphql.BM25ArgumentBuilder{}
 			bm25.WithQuery(query.Query)
@@ -110,6 +172,12 @@ func query(client *weaviate.Client, q lib.Queries, ds lib.Dataset) (*QueryExperi
 			return nil, errors.New(result.Errors[0].Message)
 		}
 		times = append(times, time.Since(before))
+
+		// print result scores and ids to a csv file
+		if PrintDetailedResults {
+			queryId := strconv.Itoa(i)
+			writeQueryResultsToFile(result, filename, className, queryId, AdditionalExplanations)
+		}
 
 		logMsg := fmt.Sprintf("completed %d/%d queries.", i, len(q))
 
@@ -150,7 +218,7 @@ func query(client *weaviate.Client, q lib.Queries, ds lib.Dataset) (*QueryExperi
 		Alpha:                        Alpha,
 		Ranking:                      Ranking,
 		TotalQueryTime:               totalTime,
-		QueryTimePer1000:             stat.Mean.Seconds() * 1000,
+		AvgQueryTime:                 stat.Mean,
 		QueriesPerSecond:             1 / stat.Mean.Seconds(),
 		QueryTimePer1000000Documents: float64(stat.Mean.Milliseconds()) * 1000000 / float64(objCount),
 		Min:                          stat.Min,
@@ -190,7 +258,7 @@ var queryCmd = &cobra.Command{
 
 		results := make([]*QueryExperimentResult, len(datasets.Datasets))
 		for di, ds := range datasets.Datasets {
-
+			log.Print("querying dataset " + ds.ID)
 			log.Print("parse queries")
 			q, err := lib.ParseQueries(ds, QueriesCount)
 			if err != nil {
@@ -199,7 +267,7 @@ var queryCmd = &cobra.Command{
 			log.Print("queries parsed")
 			log.Print("start querying")
 
-			result, err := query(client, q, ds)
+			result, err := query(client, q, ds, -1)
 			if err != nil {
 				return err
 			}
@@ -209,10 +277,10 @@ var queryCmd = &cobra.Command{
 		}
 
 		fmt.Printf("\nQuery Results:\n")
-		fmt.Printf("Dataset\tObjects\tQueries\tFilterObjectPercentage\tAlpha\tRanking\tQueryTime\tQueryTimePer1000\tQueriesPerSecond\tQueryTimePer1000000Documents\tMin\tMax\tP50\tP90\tP99\tnDCG\tP@1\tP@5\n")
+		fmt.Printf("Dataset\tObjects\tQueries\tFilterObjectPercentage\tAlpha\tRanking\tQueryTime\tAvgQueryTime\tQueriesPerSecond\tQueryTimePer1000000Documents\tMin\tMax\tP50\tP90\tP99\tnDCG\tP@1\tP@5\n")
 		for _, result := range results {
 			ranking, _ := strconv.ParseFloat(result.Ranking, 64) // Convert result.Ranking to float64
-			fmt.Printf("%s\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n", result.Dataset, result.Objects, result.Queries, result.FilterObjectPercentage, result.Alpha, ranking, result.TotalQueryTime, result.QueryTimePer1000, result.QueriesPerSecond, result.QueryTimePer1000000Documents, float32(result.Min.Milliseconds())/1000.0, float32(result.Max.Milliseconds())/1000.0, float32(result.P50.Milliseconds())/1000.0, float32(result.P90.Milliseconds())/1000.0, float32(result.P99.Milliseconds())/1000.0, result.Scores.CurrentNDCG(), result.Scores.CurrentPrecisionAt1(), result.Scores.CurrentPrecisionAt5())
+			fmt.Printf("%s\t%d\t%d\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\n", result.Dataset, result.Objects, result.Queries, result.FilterObjectPercentage, result.Alpha, ranking, result.TotalQueryTime, result.AvgQueryTime.Seconds(), result.QueriesPerSecond, result.QueryTimePer1000000Documents, result.Min.Seconds(), result.Max.Seconds(), result.P50.Seconds(), result.P90.Seconds(), result.P99.Seconds(), result.Scores.CurrentNDCG(), result.Scores.CurrentPrecisionAt1(), result.Scores.CurrentPrecisionAt5())
 		}
 
 		return nil

--- a/test/benchmark_bm25/cmd/root.go
+++ b/test/benchmark_bm25/cmd/root.go
@@ -29,6 +29,9 @@ var (
 	Alpha                  float32
 	Ranking                string
 	Vectorizer             bool
+	Limit                  int
+	AdditionalExplanations bool
+	PrintDetailedResults   bool
 )
 
 const (
@@ -42,6 +45,9 @@ const (
 	DefaultAlpha                  = 0
 	DefaultRanking                = "ranked_fusion"
 	DefaultVectorizer             = false
+	DefaultLimit                  = 100
+	DefaultAdditionalExplanations = false
+	DefaultPrintDetailedResults   = false
 )
 
 var rootCmd = &cobra.Command{

--- a/test/benchmark_bm25/lib/dataset_corpus.go
+++ b/test/benchmark_bm25/lib/dataset_corpus.go
@@ -20,49 +20,69 @@ import (
 	"path/filepath"
 )
 
-type Corpi []Corpus
+type Corpi struct {
+	Data     []Corpus
+	scanner  *bufio.Scanner
+	r        *rand.Rand
+	ds       Dataset
+	multiply int
+}
 
 type Corpus map[string]string
 
-// TODO: just loading the whole corpus into memory isn't very efficient, this
-// could be improved by iterating one object at a time, e.g. with a callback
-func ParseCorpi(ds Dataset, multiply int) (Corpi, error) {
+func ParseCorpi(ds Dataset, multiply int) (*Corpi, error) {
 	p := filepath.Join(ds.Path, "corpus.jsonl")
 	f, err := os.Open(p)
 	if err != nil {
 		return nil, fmt.Errorf("open queries file at %s: %w", p, err)
 	}
-
-	defer f.Close()
-
 	scanner := bufio.NewScanner(f)
-
 	// we need reproducible random numbers to be able to compare different runs. This only needs to be stable for a
 	// given version of the code. If it produces different numbers after a dependency update it doesn't matter.
 	r := rand.New(rand.NewSource(9))
 
-	c := Corpi{}
-	for scanner.Scan() {
+	c := &Corpi{
+		Data:     []Corpus{},
+		scanner:  scanner,
+		r:        r,
+		ds:       ds,
+		multiply: multiply,
+	}
+
+	return c, nil
+}
+
+func (c *Corpi) Next(count int) error {
+	i := 0
+
+	c.Data = []Corpus{}
+
+	for i < count {
+
+		if !c.scanner.Scan() && c.scanner.Err() != nil {
+			return c.scanner.Err()
+		}
+
 		obj := map[string]interface{}{}
-		if err := json.Unmarshal(scanner.Bytes(), &obj); err != nil {
-			return nil, err
+		if err := json.Unmarshal(c.scanner.Bytes(), &obj); err != nil {
+			return err
 		}
 
 		corp := Corpus{}
-		for _, prop := range ds.Corpus.IndexedProperties {
+		for _, prop := range c.ds.Corpus.IndexedProperties {
 			propStr, ok := obj[prop].(string)
 			if !ok {
-				return nil, fmt.Errorf("indexed property %s is not a string: %T",
+				return fmt.Errorf("indexed property %s is not a string: %T",
 					prop, obj[prop])
 			}
 
 			corp[SanitizePropName(prop)] = propStr
-			for i := 1; i < multiply; i++ {
+			for i := 1; i < c.multiply; i++ {
 				newName := fmt.Sprintf("%s_copy_%d", SanitizePropName(prop), i)
 				var propString string
-				if len(c) > 1 { // get the content of the property from another object, to get more varied results
-					otherObjectIndex := r.Intn(len(corp))
-					propString = c[otherObjectIndex][SanitizePropName(prop)]
+				if len(c.Data) > 1 { // get the content of the property from another object, to get more varied results
+					otherObjectIndex := c.r.Intn(len(corp))
+					propString = c.Data[otherObjectIndex][SanitizePropName(prop)]
 				} else {
 					propString = propStr
 				}
@@ -70,7 +90,7 @@ func ParseCorpi(ds Dataset, multiply int) (Corpi, error) {
 			}
 		}
 
-		for _, prop := range ds.Corpus.UnindexedProperties {
+		for _, prop := range c.ds.Corpus.UnindexedProperties {
 			propStr, ok := obj[prop].(string)
 			if !ok {
 				propStr = fmt.Sprintf("%v", obj[prop])
@@ -79,8 +99,9 @@ func ParseCorpi(ds Dataset, multiply int) (Corpi, error) {
 			corp[SanitizePropName(prop)] = propStr
 		}
 
-		c = append(c, corp)
+		c.Data = append(c.Data, corp)
+		i++
 	}
 
-	return c, nil
+	return nil
 }


### PR DESCRIPTION
### What's being changed:

**Import:**
- read data from disk in batches instead of fully loading dataset into disk before starting indexing

**Query:**
- add parameter for query limit
- add parameter to store query results to disk
- enable/disable additional explanations

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
