### PR TITLE
make log level configurable via the api

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -665,7 +665,13 @@ func logger() *logrus.Logger {
 			&logrus.JSONFormatter{},
 		})
 	}
-	logger.SetLevel(logLevelFromString(os.Getenv("LOG_LEVEL")))
+	logLevelStr := os.Getenv("LOG_LEVEL")
+	level, err := logLevelFromString(logLevelStr)
+	if err == logLevelNotRecognized {
+		logger.WithField("log_level_env", logLevelStr).Warn("log level not recognized, defaulting to info")
+		level = logrus.InfoLevel
+	}
+	logger.SetLevel(level)
 	return logger
 }
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -665,25 +665,7 @@ func logger() *logrus.Logger {
 			&logrus.JSONFormatter{},
 		})
 	}
-	switch os.Getenv("LOG_LEVEL") {
-	case "panic":
-		logger.SetLevel(logrus.PanicLevel)
-	case "fatal":
-		logger.SetLevel(logrus.FatalLevel)
-	case "error":
-		logger.SetLevel(logrus.ErrorLevel)
-	case "warn":
-		logger.SetLevel(logrus.WarnLevel)
-	case "warning":
-		logger.SetLevel(logrus.WarnLevel)
-	case "debug":
-		logger.SetLevel(logrus.DebugLevel)
-	case "trace":
-		logger.SetLevel(logrus.TraceLevel)
-	default:
-		logger.SetLevel(logrus.InfoLevel)
-	}
-
+	logger.SetLevel(logLevelFromString(os.Getenv("LOG_LEVEL")))
 	return logger
 }
 

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -27,6 +27,17 @@ import (
 func setupDebugHandlers(appState *state.State) {
 	logger := appState.Logger.WithField("handler", "debug")
 
+	// newLogLevel can be one of: panic, fatal, error, warn, info, debug, trace (defaults to info)
+	http.HandleFunc("/debug/config/logger/level", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		newLogLevel := r.URL.Query().Get("newLogLevel")
+		if newLogLevel == "" {
+			http.Error(w, "newLogLevel is required", http.StatusBadRequest)
+			return
+		}
+		appState.Logger.SetLevel(logLevelFromString(newLogLevel))
+		w.WriteHeader(http.StatusOK)
+	}))
+
 	http.HandleFunc("/debug/index/rebuild/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !config.Enabled(os.Getenv("ASYNC_INDEXING")) {
 			http.Error(w, "async indexing is not enabled", http.StatusNotImplemented)

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -34,7 +34,12 @@ func setupDebugHandlers(appState *state.State) {
 			http.Error(w, "newLogLevel is required", http.StatusBadRequest)
 			return
 		}
-		appState.Logger.SetLevel(logLevelFromString(newLogLevel))
+		level, err := logLevelFromString(newLogLevel)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		appState.Logger.SetLevel(level)
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -12,6 +12,9 @@
 package rest
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,25 +44,27 @@ func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	return wf.TextFormatter.Format(e)
 }
 
-// logLevelFromString converts a string to a logrus log level, defaulting to info if the string is
-// not recognized.
-func logLevelFromString(level string) logrus.Level {
-	switch level {
+var logLevelNotRecognized = errors.New("log level not recognized")
+
+// logLevelFromString converts a string to a logrus log level, returns a logLevelNotRecognized
+// error if the string is not recognized. level is case insensitive.
+func logLevelFromString(level string) (logrus.Level, error) {
+	switch strings.ToLower(level) {
 	case "panic":
-		return logrus.PanicLevel
+		return logrus.PanicLevel, nil
 	case "fatal":
-		return logrus.FatalLevel
+		return logrus.FatalLevel, nil
 	case "error":
-		return logrus.ErrorLevel
+		return logrus.ErrorLevel, nil
 	case "warn", "warning":
-		return logrus.WarnLevel
+		return logrus.WarnLevel, nil
 	case "info":
-		return logrus.InfoLevel
+		return logrus.InfoLevel, nil
 	case "debug":
-		return logrus.DebugLevel
+		return logrus.DebugLevel, nil
 	case "trace":
-		return logrus.TraceLevel
+		return logrus.TraceLevel, nil
 	default:
-		return logrus.InfoLevel
+		return 0, logLevelNotRecognized
 	}
 }

--- a/adapters/handlers/rest/logger.go
+++ b/adapters/handlers/rest/logger.go
@@ -40,3 +40,26 @@ func (wf *WeaviateTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Data["build_go_version"] = wf.goVersion
 	return wf.TextFormatter.Format(e)
 }
+
+// logLevelFromString converts a string to a logrus log level, defaulting to info if the string is
+// not recognized.
+func logLevelFromString(level string) logrus.Level {
+	switch level {
+	case "panic":
+		return logrus.PanicLevel
+	case "fatal":
+		return logrus.FatalLevel
+	case "error":
+		return logrus.ErrorLevel
+	case "warn", "warning":
+		return logrus.WarnLevel
+	case "info":
+		return logrus.InfoLevel
+	case "debug":
+		return logrus.DebugLevel
+	case "trace":
+		return logrus.TraceLevel
+	default:
+		return logrus.InfoLevel
+	}
+}


### PR DESCRIPTION
### What's being changed:

This PR adds the ability to dynamically set the log level via the `/debug` HTTP API.

In the future, it might also be nice to make this available via OS process signals or other non-HTTP approaches. But for now, I hope this will be a useful tool to enable more detailed logging during issues to get more signal. It would also be nice in the future to have the modified log level be optionally limited to a particular module/etc.

For a bit more context, I am hopeful that adding the ability to change log levels without restarting Weaviate will make it easier for us to add "lower-level" log lines (eg at the debug or trace level) since if we're seeing an issue on a node, we can set the debug level down to debug or trace temporarily to get a more detailed picture of what's going on.

One concern is that if we're debugging a node under heavy load, then increasing the number of logs it's producing could cause even more load if there are excessive logs. Separate from this PR we should audit and continue to stay on top of keeping logs reasonable/useful.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
