### PR TITLE
Close flat index metadata file when not in use

### DIFF
--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -56,6 +56,7 @@ type flat struct {
 	rootPath            string
 	dims                int32
 	metadata            *bolt.DB
+	metadataLock        *sync.RWMutex
 	store               *lsmkv.Store
 	logger              logrus.FieldLogger
 	distancerProvider   distancer.Provider
@@ -92,6 +93,7 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 		rootPath:             cfg.RootPath,
 		logger:               logger,
 		distancerProvider:    cfg.DistanceProvider,
+		metadataLock:         &sync.RWMutex{},
 		rescore:              extractCompressionRescore(uc),
 		pqResults:            common.NewPqMaxPool(100),
 		compression:          extractCompression(uc),
@@ -697,13 +699,8 @@ func (index *flat) UpdateUserConfig(updated schemaConfig.VectorIndexConfig, call
 }
 
 func (index *flat) Drop(ctx context.Context) error {
-	if index.metadata != nil {
-		if err := index.metadata.Close(); err != nil {
-			return errors.Wrap(err, "close metadata")
-		}
-		if err := index.removeMetadataFile(); err != nil {
-			return err
-		}
+	if err := index.removeMetadataFile(); err != nil {
+		return err
 	}
 	// Shard::drop will take care of handling store's buckets
 	return nil
@@ -716,11 +713,6 @@ func (index *flat) Flush() error {
 }
 
 func (index *flat) Shutdown(ctx context.Context) error {
-	if index.metadata != nil {
-		if err := index.metadata.Close(); err != nil {
-			return errors.Wrap(err, "close metadata")
-		}
-	}
 	// Shard::shutdown will take care of handling store's buckets
 	return nil
 }
@@ -732,18 +724,16 @@ func (index *flat) SwitchCommitLogs(context.Context) error {
 func (index *flat) ListFiles(ctx context.Context, basePath string) ([]string, error) {
 	var files []string
 
-	if index.metadata != nil {
-		metadataFile := index.getMetadataFile()
-		fullPath := filepath.Join(index.rootPath, metadataFile)
+	metadataFile := index.getMetadataFile()
+	fullPath := filepath.Join(index.rootPath, metadataFile)
 
-		if _, err := os.Stat(fullPath); err == nil {
-			relPath, err := filepath.Rel(basePath, fullPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get relative path: %w", err)
-			}
-			files = append(files, relPath)
+	if _, err := os.Stat(fullPath); err == nil {
+		relPath, err := filepath.Rel(basePath, fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get relative path: %w", err)
 		}
 		// If the file doesn't exist, we simply don't add it to the list
+		files = append(files, relPath)
 	}
 
 	return files, nil

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -298,6 +298,7 @@ func TestFlat_QueryVectorDistancer(t *testing.T) {
 
 			index, err := New(Config{
 				ID:               "id",
+				RootPath:         t.TempDir(),
 				DistanceProvider: distancr,
 			}, flatent.UserConfig{
 				PQ: pq,

--- a/adapters/repos/db/vector/flat/metadata_test.go
+++ b/adapters/repos/db/vector/flat/metadata_test.go
@@ -44,10 +44,18 @@ func Test_FlatDimensions(t *testing.T) {
 		require.Equal(t, int32(0), index.dims)
 	})
 
+	t.Run("metadata is closed after index creation", func(t *testing.T) {
+		require.Nil(t, index.metadata, "metadata file should be closed")
+	})
+
 	t.Run("dimensions updated", func(t *testing.T) {
 		err = index.Add(ctx, 1, []float32{1, 2, 3})
 		require.Nil(t, err)
 		require.Equal(t, int32(3), index.dims)
+	})
+
+	t.Run("metadata is closed after insert", func(t *testing.T) {
+		require.Nil(t, index.metadata, "metadata file should be closed")
 	})
 
 	t.Run("error when adding vector with wrong dimensions", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
- The flat index keeps dimension information for validation etc in `meta.db`
- To reduce pressure on max open files in multi-tenant scenarios this file is now closed when not in use

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
