### PR TITLE
Fix: issues loading tombstones for inverted index

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -518,7 +519,9 @@ func (sg *SegmentGroup) getCollectionAndSegments(key []byte) ([][]value, []*segm
 			if !errors.Is(err, lsmkv.NotFound) {
 				return nil, nil, err
 			}
-			if sg.strategy != StrategyInverted {
+			// inverted segments need to be loaded anyway, even if they don't have
+			// the key, as we need to know if they have tombstones
+			if segment.strategy != segmentindex.StrategyInverted {
 				continue
 			}
 		}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -108,7 +108,7 @@ func (s *segment) GetTombstones() (*sroar.Bitmap, error) {
 	}
 
 	s.invertedData.lockInvertedData.RLock()
-	loaded := false
+	loaded := s.invertedData.tombstonesLoaded
 	s.invertedData.lockInvertedData.RUnlock()
 	if !loaded {
 		return s.loadTombstones()


### PR DESCRIPTION
### What's being changed:

- Properly check for existing loaded state for tombstones
- Actually check for specific segment type when loading segment to load all tombstones

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
