### PR TITLE
feat: allow empty roles and return stale roles in GetRoles()

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -77,10 +77,6 @@ func (h *authZHandlers) createRole(params authz.CreateRoleParams, principal *mod
 		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not create role with the same name as builtin role %s", *params.Body.Name)))
 	}
 
-	if len(params.Body.Permissions) == 0 {
-		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("role has to have at least 1 permission")))
-	}
-
 	if err := h.authorizer.Authorize(principal, authorization.CREATE, authorization.Roles(*params.Body.Name)...); err != nil {
 		return authz.NewCreateRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -183,12 +183,6 @@ func (h *authZHandlers) removePermissions(params authz.RemovePermissionsParams, 
 		return authz.NewRemovePermissionsNotFound()
 	}
 
-	rolePerms := role[params.ID]
-
-	if len(rolePerms) <= len(permissions) { // i.e., all permissions are removed
-		return authz.NewRemovePermissionsUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("cannot remove the last permission from role %s", params.ID)))
-	}
-
 	if err := h.controller.RemovePermissions(params.ID, permissions); err != nil {
 		return authz.NewRemovePermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}

--- a/adapters/handlers/rest/authz/handlers_authz_create_role_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_create_role_test.go
@@ -186,16 +186,6 @@ func TestCreateRoleBadRequest(t *testing.T) {
 			expectedError: "role name is required",
 		},
 		{
-			name: "role has to have at least 1 permission",
-			params: authz.CreateRoleParams{
-				Body: &models.Role{
-					Name:        String("newRole"),
-					Permissions: []*models.Permission{},
-				},
-			},
-			expectedError: "role has to have at least 1 permission",
-		},
-		{
 			name: "invalid permission",
 			params: authz.CreateRoleParams{
 				Body: &models.Role{

--- a/adapters/handlers/rest/authz/handlers_authz_remove_permission_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_remove_permission_test.go
@@ -237,44 +237,6 @@ func TestRemovePermissionsRoleNotFound(t *testing.T) {
 	}
 }
 
-func TestRemovePermissionsUnprocessableEntity(t *testing.T) {
-	authorizer := mocks.NewAuthorizer(t)
-	controller := mocks.NewController(t)
-	logger, _ := test.NewNullLogger()
-
-	principal := &models.Principal{Username: "user1"}
-	params := authz.RemovePermissionsParams{
-		ID: "test",
-		Body: authz.RemovePermissionsBody{
-			Permissions: []*models.Permission{
-				{
-					Action: String("manage_roles"),
-					Roles:  &models.PermissionRoles{},
-				},
-				{
-					Action: String("read_data"),
-					Data:   &models.PermissionData{},
-				},
-			},
-		},
-	}
-
-	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.ID)[0]).Return(nil)
-	controller.On("GetRoles", params.ID).Return(map[string][]authorization.Policy{params.ID: {
-		{Resource: "whatever", Verb: authorization.READ, Domain: "whatever"},
-	}}, nil)
-
-	h := &authZHandlers{
-		authorizer: authorizer,
-		controller: controller,
-		logger:     logger,
-	}
-	res := h.removePermissions(params, principal)
-	parsed, ok := res.(*authz.RemovePermissionsUnprocessableEntity)
-	assert.True(t, ok)
-	assert.NotNil(t, parsed)
-}
-
 func TestRemovePermissionsInternalServerError(t *testing.T) {
 	type testCase struct {
 		name          string

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -266,21 +266,10 @@ func TestAuthzRolesJourney(t *testing.T) {
 		require.Equal(t, deleteCollectionsAction, *res.Payload.Permissions[1].Action)
 	})
 
-	t.Run("removing all permissions from role disallowed", func(t *testing.T) {
+	t.Run("removing all permissions from role allowed without role deletion", func(t *testing.T) {
 		_, err := helper.Client(t).Authz.RemovePermissions(authz.NewRemovePermissionsParams().WithID(testRoleName).WithBody(authz.RemovePermissionsBody{
 			Permissions: []*models.Permission{
 				helper.NewCollectionsPermission().WithAction(createCollectionsAction).WithCollection(all).Permission(),
-				helper.NewCollectionsPermission().WithAction(deleteCollectionsAction).WithCollection(all).Permission(),
-			},
-		}), clientAuth)
-		require.NotNil(t, err)
-		_, failed := err.(*authz.RemovePermissionsUnprocessableEntity)
-		require.True(t, failed)
-	})
-
-	t.Run("remove permission from role", func(t *testing.T) {
-		_, err := helper.Client(t).Authz.RemovePermissions(authz.NewRemovePermissionsParams().WithID(testRoleName).WithBody(authz.RemovePermissionsBody{
-			Permissions: []*models.Permission{
 				helper.NewCollectionsPermission().WithAction(deleteCollectionsAction).WithCollection(all).Permission(),
 			},
 		}), clientAuth)
@@ -292,7 +281,7 @@ func TestAuthzRolesJourney(t *testing.T) {
 		require.NotNil(t, role)
 		require.Equal(t, testRoleName, *role.Name)
 		require.Equal(t, 1, len(role.Permissions))
-		require.Equal(t, createCollectionsAction, *role.Permissions[0].Action)
+		require.Nil(t, role.Permissions[0].Action)
 	})
 
 	t.Run("assign role to user", func(t *testing.T) {

--- a/usecases/auth/authorization/conv/casbin_converter.go
+++ b/usecases/auth/authorization/conv/casbin_converter.go
@@ -23,6 +23,7 @@ import (
 func RolesToPolicies(roles ...*models.Role) (map[string][]authorization.Policy, error) {
 	rolesmap := make(map[string][]authorization.Policy)
 	for idx := range roles {
+		rolesmap[*roles[idx].Name] = []authorization.Policy{}
 		for _, permission := range roles[idx].Permissions {
 			policy, err := policy(permission)
 			if err != nil {

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -257,7 +257,8 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 func permission(policy []string) (*models.Permission, error) {
 	mapped := newPolicy(policy)
 
-	if mapped.Resource == "" || mapped.Resource == "wv_internal" {
+	// "wv_internal_empty" is InternalPlaceHolder to handle empty, stale roles
+	if mapped.Resource == "" || mapped.Resource == "wv_internal_empty" {
 		return &models.Permission{
 			Action: authorization.String("no_action"),
 		}, nil

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -159,6 +159,10 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 	if permission.Action == nil {
 		return nil, fmt.Errorf("missing action")
 	}
+
+	if permission.Action == nil || *permission.Action == "no_action" {
+		return &authorization.Policy{}, nil
+	}
 	action, domain, found := strings.Cut(*permission.Action, "_")
 	if !found {
 		return nil, fmt.Errorf("invalid action: %s", *permission.Action)
@@ -252,6 +256,12 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 
 func permission(policy []string) (*models.Permission, error) {
 	mapped := newPolicy(policy)
+
+	if mapped.Resource == "" || mapped.Resource == "wv_internal" {
+		return &models.Permission{
+			Action: authorization.String("no_action"),
+		}, nil
+	}
 
 	if !validVerb(mapped.Verb) {
 		return nil, fmt.Errorf("invalid verb: %s", mapped.Verb)

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -43,7 +43,7 @@ func New(rbacStoragePath string, rbac rbacconf.Config, logger logrus.FieldLogger
 func (m *manager) UpsertRolesPermissions(roles map[string][]authorization.Policy) error {
 	for roleName, policies := range roles {
 		// assign role to internal user to make sure to catch empty roles
-		//e.g. : g, user:wv_internal_empty, role:roleName
+		// e.g. : g, user:wv_internal_empty, role:roleName
 		if _, err := m.casbin.AddRoleForUser(conv.PrefixUserName(conv.InternalPlaceHolder), conv.PrefixRoleName(roleName)); err != nil {
 			return err
 		}

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -42,7 +42,8 @@ func New(rbacStoragePath string, rbac rbacconf.Config, logger logrus.FieldLogger
 
 func (m *manager) UpsertRolesPermissions(roles map[string][]authorization.Policy) error {
 	for roleName, policies := range roles {
-		// dumb name of the role without permissions to make sure it does exists even if there was no permissions
+		// assign role to internal user to make sure to catch empty roles
+		//e.g. : g, user:wv_internal_empty, role:roleName
 		if _, err := m.casbin.AddRoleForUser(conv.PrefixUserName(conv.InternalPlaceHolder), conv.PrefixRoleName(roleName)); err != nil {
 			return err
 		}

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -48,6 +48,8 @@ const (
 	[matchers]
 	m = g(r.sub, p.sub) && keyMatch5(r.obj, p.obj) && regexMatch(r.act, p.act)
 `
+	// InternalPlaceHolder is a place holder to mark empty roles
+	InternalPlaceHolder = "wv_internal_empty"
 )
 
 func createStorage(filePath string) error {

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -48,8 +48,6 @@ const (
 	[matchers]
 	m = g(r.sub, p.sub) && keyMatch5(r.obj, p.obj) && regexMatch(r.act, p.act)
 `
-	// InternalPlaceHolder is a place holder to mark empty roles
-	InternalPlaceHolder = "wv_internal_empty"
 )
 
 func createStorage(filePath string) error {


### PR DESCRIPTION
### What's being changed:
previously, we had hard requirement to allow at least 1 permission with action, with this change 
- we relax our requirements to allow empty roles as place holder 
- return stale roles which they are assigned but has no permissions on GetRole() endpoints

 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
