### PR TITLE
queue: change default chunk size

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	// defaultChunkSize is the maximum size of each chunk file. Set to 100MB.
-	defaultChunkSize = 100 * 1024 * 1024
+	// defaultChunkSize is the maximum size of each chunk file. Defaults to 10MB.
+	defaultChunkSize = 10 * 1024 * 1024
 
 	// defaultStaleTimeout is the duration after which a partial chunk is considered stale.
 	// If no tasks are pushed to the queue for this duration, the partial chunk is scheduled.


### PR DESCRIPTION
### What's being changed:

This changes the default chunk file size from 100MB to 10MB for the on-disk queue.
This is useful for multi-tenancy scenarios where we have many queues, this will allow the Scheduler to process smaller portions of each queue at each tick.
This makes the processing of multiple queues smoother, as opposed to dealing with large chunks one by one, which could give the impression that queues are not being processed.

Import time and indexing time are similar in both cases.

```
// with 100MB and 1M OpenAI vectors
INFO[0056] Total load time                               duration=56.286651959s
INFO[0056] Waiting for queue to be empty                
INFO[0429] Queue ready                                   duration=6m12.727410416s
INFO[0429] Total load and queue ready                    duration=7m9.014105s
```

```
// with 10MB and 1M OpenAI vectors
INFO[0058] Total load time                               duration=58.196619541s
INFO[0058] Waiting for queue to be empty                
INFO[0431] Queue ready                                   duration=6m12.635499709s
INFO[0431] Total load and queue ready                    duration=7m10.8321735s
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

