### PR TITLE
chore(test): TestMappings flakiness open files explicitly instead of defer 

### DIFF
--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -183,14 +183,7 @@ func TestMappings(t *testing.T) {
 			require.Nil(t, file.Close())
 		}
 
-		switch runtime.GOOS {
-		case "linux":
-			// any further mapping should fail
-			require.NotNil(t, m.CheckMappingAndReserve(1, 60))
-		case "darwin":
-			// any further mapping should not fail
-			require.Nil(t, m.CheckMappingAndReserve(1, 60))
-		}
+		require.Nil(t, m.CheckMappingAndReserve(1, 60))
 	})
 
 	t.Run("check mappings for dummy", func(t *testing.T) {

--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -164,7 +164,6 @@ func TestMappings(t *testing.T) {
 			m.Refresh(true)
 			file, err := os.OpenFile(path+"example"+strconv.FormatInt(int64(i), 10)+".txt", os.O_CREATE|os.O_RDWR, 0o666)
 			require.Nil(t, err)
-			defer file.Close()
 			_, err = file.Write([]byte("Hello"))
 			require.Nil(t, err)
 
@@ -178,9 +177,10 @@ func TestMappings(t *testing.T) {
 				require.Nil(t, m.CheckMappingAndReserve(1, 0))
 				data, err := syscall.Mmap(int(file.Fd()), 0, int(fileInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
 				require.Nil(t, err)
-
-				defer syscall.Munmap(data)
+				require.Nil(t, syscall.Munmap(data))
 			}
+
+			require.Nil(t, file.Close())
 		}
 
 		switch runtime.GOOS {
@@ -203,7 +203,7 @@ func TestMappings(t *testing.T) {
 			m.Refresh(true)
 			file, err := os.OpenFile(path+"example"+strconv.FormatInt(int64(i), 10)+".txt", os.O_CREATE|os.O_RDWR, 0o666)
 			require.Nil(t, err)
-			defer file.Close()
+
 			_, err = file.Write([]byte("Hello"))
 			require.Nil(t, err)
 
@@ -214,7 +214,8 @@ func TestMappings(t *testing.T) {
 			data, err := syscall.Mmap(int(file.Fd()), 0, int(fileInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
 			require.Nil(t, err)
 
-			defer syscall.Munmap(data)
+			require.Nil(t, syscall.Munmap(data))
+			require.Nil(t, file.Close())
 		}
 	})
 


### PR DESCRIPTION
### What's being changed:
defers shall not be inside a loop, that could lead the files are open until the loop finishes 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
