### PR TITLE
Add check for "is already in progress" err in TerminateContainer method

### DIFF
--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -65,7 +65,10 @@ func (d *DockerCompose) Stop(ctx context.Context, container string, timeout *tim
 func (d *DockerCompose) TerminateContainer(ctx context.Context, container string) error {
 	for idx, c := range d.containers {
 		if c.name == container {
-			if err := c.container.Terminate(ctx); err != nil {
+			// TODO : remove this once issue got resolved in testcontainers
+			// this because the timeout is too short and hardcoded
+			// ref https://github.com/testcontainers/testcontainers-go/blob/35bf0cd0707d6ff21a8e7c7fdb39c5dfa560f142/docker.go#L309
+			if err := c.container.Terminate(ctx); err != nil && !strings.Contains(err.Error(), "is already in progress") {
 				return fmt.Errorf("cannot stop %q: %w", c.name, err)
 			}
 			d.containers = append(d.containers[:idx], d.containers[idx+1:]...)


### PR DESCRIPTION
### What's being changed:

Add check for "is already in progress" err in TerminateContainer method

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
