### PR TITLE
Add switch to prevent backup cleanup

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
-	entcfg "github.com/weaviate/weaviate/entities/config"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
 	"github.com/weaviate/fgprof"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"google.golang.org/grpc"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
@@ -751,10 +751,9 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 			}
 		}, appState.Logger)
 	}
-	if ! entcfg.Enabled("DISABLE_CLEANUP_UNFINISHED_BACKUPS") {
+	if !entcfg.Enabled("DISABLE_CLEANUP_UNFINISHED_BACKUPS") {
 		enterrors.GoWrapper(
 			func() {
-
 				// cleanup unfinished backups on startup
 				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				defer cancel()

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -751,7 +751,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 			}
 		}, appState.Logger)
 	}
-	if !entcfg.Enabled("DISABLE_CLEANUP_UNFINISHED_BACKUPS") {
+	if !entcfg.Enabled(os.Getenv("DISABLE_CLEANUP_UNFINISHED_BACKUPS")) {
 		enterrors.GoWrapper(
 			func() {
 				// cleanup unfinished backups on startup

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
 	"github.com/weaviate/fgprof"
@@ -750,8 +751,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 			}
 		}, appState.Logger)
 	}
-	suppressCleanup := os.Getenv("WEAVIATE_SUPPRESS_CLEANUP") == "true"
-	if ! suppressCleanup {
+	if ! entcfg.Enabled("DISABLE_CLEANUP_UNFINISHED_BACKUPS") {
 		enterrors.GoWrapper(
 			func() {
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -752,6 +752,9 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	}
 	enterrors.GoWrapper(
 		func() {
+			// cleanup unfinished backups on startup
+			// Wait 5 minutes for permissions to propagate for GCS
+			time.Sleep(5 * time.Minute)
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 			backupScheduler.CleanupUnfinishedBackups(ctx)

--- a/usecases/backup/mocks/BackupBackendProvider.go
+++ b/usecases/backup/mocks/BackupBackendProvider.go
@@ -78,7 +78,8 @@ func (_m *BackupBackendProvider) EnabledBackupBackends() []modulecapabilities.Ba
 func NewBackupBackendProvider(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *BackupBackendProvider {
+},
+) *BackupBackendProvider {
 	mock := &BackupBackendProvider{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mocks/NodeResolver.go
+++ b/usecases/backup/mocks/NodeResolver.go
@@ -109,7 +109,8 @@ func (_m *NodeResolver) NodeHostname(nodeName string) (string, bool) {
 func NewNodeResolver(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *NodeResolver {
+},
+) *NodeResolver {
 	mock := &NodeResolver{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mocks/selector.go
+++ b/usecases/backup/mocks/selector.go
@@ -97,7 +97,8 @@ func (_m *Selector) Shards(ctx context.Context, class string) ([]string, error) 
 func NewSelector(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Selector {
+},
+) *Selector {
 	mock := &Selector{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
### What's being changed:

Backup cleanup is failing on first run because permissions haven't propagated after cluster creation.  This adds an environment variable switch DISABLE_CLEANUP_UNFINISHED_BACKUPS to turn it off

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
