### PR TITLE
S3 Backup: Do not attempt to increment counter if size is < 0

### DIFF
--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -285,7 +285,7 @@ func (s *s3Client) Write(ctx context.Context, backupID, key, overrideBucket, ove
 		return info.Size, fmt.Errorf("write object %q", remotePath)
 	}
 
-	if metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.
+	if info.Size >= 0 && metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.
 		GetMetricWithLabelValues(Name, "class"); err == nil {
 		metric.Add(float64(float64(info.Size)))
 	}

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -285,8 +285,8 @@ func (s *s3Client) Write(ctx context.Context, backupID, key, overrideBucket, ove
 		return info.Size, fmt.Errorf("write object %q", remotePath)
 	}
 
-	if info.Size >= 0 && metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.
-		GetMetricWithLabelValues(Name, "class"); err == nil {
+	if metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.
+		GetMetricWithLabelValues(Name, "class"); err == nil && info.Size >= 0 {
 		metric.Add(float64(float64(info.Size)))
 	}
 	return info.Size, nil


### PR DESCRIPTION
To fix https://github.com/weaviate/weaviate/issues/6642. If the backup store is GCS, the value of info.Size is -1 and in this case, do not attempt to increment the counter, since it will fail

### What's being changed:


### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.