### PR TITLE
feat(metrics): Add metrics related to cluster communication v1.28

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -29,12 +29,15 @@ import (
 	"github.com/weaviate/fgprof"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
+	armonmetrics "github.com/armon/go-metrics"
+	armonprometheus "github.com/armon/go-metrics/prometheus"
 	"github.com/getsentry/sentry-go"
 	openapierrors "github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
 	"github.com/pbnjay/memory"
 	"github.com/pkg/errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -198,12 +201,35 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	appState := startupRoutine(ctx, options)
 
 	if appState.ServerConfig.Config.Monitoring.Enabled {
-		appState.ServerMetrics = monitoring.NewServerMetrics(appState.ServerConfig.Config.Monitoring, prometheus.DefaultRegisterer)
+		appState.ServerMetrics = monitoring.NewServerMetrics(appState.ServerConfig.Config.Monitoring.MetricsNamespace, prometheus.DefaultRegisterer)
 		appState.TenantActivity = tenantactivity.NewHandler()
 
 		// export build tags to prometheus metric
 		build.SetPrometheusBuildInfo()
 		prometheus.MustRegister(version.NewCollector(build.AppName))
+
+		opts := armonprometheus.PrometheusOpts{
+			Expiration: 0, // never expire any metrics,
+			Registerer: prometheus.DefaultRegisterer,
+		}
+
+		sink, err := armonprometheus.NewPrometheusSinkFrom(opts)
+		if err != nil {
+			panic(err)
+		}
+
+		cfg := armonmetrics.DefaultConfig("weaviate_internal") // to differentiate it's coming from internal packages.
+		cfg.EnableHostname = false                             // no `host` label
+		cfg.EnableHostnameLabel = false                        // no `hostname` label
+		cfg.EnableServiceLabel = false                         // no `service` label
+		cfg.EnableRuntimeMetrics = false                       // runtime metrics already provided by prometheus
+		cfg.EnableTypePrefix = true                            // to have some meaningful suffix to identify type of metrics.
+		cfg.TimerGranularity = time.Second                     // time should always in seconds
+
+		_, err = armonmetrics.NewGlobal(cfg, sink)
+		if err != nil {
+			panic(err)
+		}
 
 		// only monitoring tool supported at the moment is prometheus
 		enterrors.GoWrapper(func() {

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -218,7 +218,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			appState.Logger.WithField("action", "startup").WithError(err).Fatal("failed to create prometheus sink for raft metrics")
 		}
 
-		cfg := armonmetrics.DefaultConfig("weaviate_internal") // to differentiate it's coming from internal packages.
+		cfg := armonmetrics.DefaultConfig("weaviate_internal") // to differentiate it's coming from internal/dependency packages.
 		cfg.EnableHostname = false                             // no `host` label
 		cfg.EnableHostnameLabel = false                        // no `hostname` label
 		cfg.EnableServiceLabel = false                         // no `service` label

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -215,7 +215,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 		sink, err := armonprometheus.NewPrometheusSinkFrom(opts)
 		if err != nil {
-			panic(err)
+			appState.Logger.WithField("action", "startup").WithError(err).Fatal("failed to create prometheus sink for raft metrics")
 		}
 
 		cfg := armonmetrics.DefaultConfig("weaviate_internal") // to differentiate it's coming from internal packages.
@@ -228,7 +228,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 		_, err = armonmetrics.NewGlobal(cfg, sink)
 		if err != nil {
-			panic(err)
+			appState.Logger.WithField("action", "startup").WithError(err).Fatal("failed to create metric registry raft metrics")
 		}
 
 		// only monitoring tool supported at the moment is prometheus

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/usecases/fakes"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -31,6 +33,8 @@ import (
 const raftGrpcMessageMaxSize = 1024 * 1024 * 1024
 
 func TestServerNewError(t *testing.T) {
+	sm := monitoring.NewServerMetrics("rpc_test", prometheus.NewPedanticRegistry())
+
 	var (
 		addr      = fmt.Sprintf("localhost:%v", utils.MustGetFreeTCPPort())
 		members   = &MockMembers{leader: addr}
@@ -39,18 +43,20 @@ func TestServerNewError(t *testing.T) {
 	)
 
 	t.Run("Empty server address", func(t *testing.T) {
-		srv := NewServer(members, executor, "", logger, raftGrpcMessageMaxSize, false)
+		srv := NewServer(members, executor, "", raftGrpcMessageMaxSize, false, sm, logger)
 		assert.NotNil(t, srv.Open())
 	})
 
 	t.Run("Invalid IP", func(t *testing.T) {
-		srv := NewServer(members, executor, "abc", logger, raftGrpcMessageMaxSize, false)
+		srv := NewServer(members, executor, "abc", raftGrpcMessageMaxSize, false, sm, logger)
 		netErr := &net.OpError{}
 		assert.ErrorAs(t, srv.Open(), &netErr)
 	})
 }
 
 func TestRaftRelatedRPC(t *testing.T) {
+	sm := monitoring.NewServerMetrics("rpc_test", prometheus.NewPedanticRegistry())
+
 	tests := []struct {
 		name     string
 		members  *MockMembers
@@ -65,7 +71,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				// Setup var, client and server
 				logger, _ := logrustest.NewNullLogger()
 				ctx := context.Background()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -87,7 +93,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				// Setup var, client and server
 				logger, _ := logrustest.NewNullLogger()
 				ctx := context.Background()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -105,7 +111,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				// Setup var, client and server
 				logger, _ := logrustest.NewNullLogger()
 				ctx := context.Background()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -127,7 +133,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				// Setup var, client and server
 				ctx := context.Background()
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -145,7 +151,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				// Setup var, client and server
 				ctx := context.Background()
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -167,7 +173,7 @@ func TestRaftRelatedRPC(t *testing.T) {
 				// Setup var, client and server
 				ctx := context.Background()
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -189,6 +195,8 @@ func TestRaftRelatedRPC(t *testing.T) {
 }
 
 func TestQueryEndpoint(t *testing.T) {
+	sm := monitoring.NewServerMetrics("rpc_test", prometheus.NewPedanticRegistry())
+
 	tests := []struct {
 		name     string
 		testFunc func(t *testing.T, leaderAddr string, members *MockMembers, executor *MockExecutor)
@@ -199,7 +207,7 @@ func TestQueryEndpoint(t *testing.T) {
 				// Setup var, client and server
 				ctx := context.Background()
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -215,7 +223,7 @@ func TestQueryEndpoint(t *testing.T) {
 				// Setup var, client and server
 				ctx := context.Background()
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -241,7 +249,7 @@ func TestQueryEndpoint(t *testing.T) {
 				// Setup var, client and server
 				ctx := context.Background()
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -276,6 +284,8 @@ func TestQueryEndpoint(t *testing.T) {
 }
 
 func TestApply(t *testing.T) {
+	sm := monitoring.NewServerMetrics("rpc_test", prometheus.NewPedanticRegistry())
+
 	tests := []struct {
 		name     string
 		members  *MockMembers
@@ -293,7 +303,7 @@ func TestApply(t *testing.T) {
 			testFunc: func(t *testing.T, leaderAddr string, members *MockMembers, executor *MockExecutor) {
 				// Setup var, client and server
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -314,7 +324,7 @@ func TestApply(t *testing.T) {
 			testFunc: func(t *testing.T, leaderAddr string, members *MockMembers, executor *MockExecutor) {
 				// Setup var, client and server
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())
@@ -341,7 +351,7 @@ func TestApply(t *testing.T) {
 			testFunc: func(t *testing.T, leaderAddr string, members *MockMembers, executor *MockExecutor) {
 				// Setup var, client and server
 				logger, _ := logrustest.NewNullLogger()
-				server := NewServer(members, executor, leaderAddr, logger, raftGrpcMessageMaxSize, false)
+				server := NewServer(members, executor, leaderAddr, raftGrpcMessageMaxSize, false, sm, logger)
 				assert.Nil(t, server.Open())
 				defer server.Close()
 				client := NewClient(fakes.NewFakeRPCAddressResolver(leaderAddr, nil), raftGrpcMessageMaxSize, false, logrus.StandardLogger())

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -72,7 +72,7 @@ func New(cfg Config) *Service {
 	fsm := NewFSM(cfg)
 	raft := NewRaft(cfg.NodeSelector, &fsm, client)
 
-	svrMetrics := monitoring.NewServerMetrics("weaviate_raft", prometheus.DefaultRegisterer)
+	svrMetrics := monitoring.NewServerMetrics("weaviate_cluster", prometheus.DefaultRegisterer)
 	svr := rpc.NewServer(&fsm, raft, rpcListenAddress, cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled, svrMetrics, cfg.Logger)
 
 	return &Service{

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.13.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/go-hclog v1.6.3
-	github.com/hashicorp/raft v1.7.1
+	github.com/hashicorp/raft v1.7.2-0.20241212131917-a5bc06ccef1d
 	github.com/hashicorp/raft-boltdb/v2 v2.3.0
 	github.com/ikawaha/kagome-dict-ko v0.2.1
 	github.com/ikawaha/kagome-dict/ipa v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/hashicorp/memberlist v0.5.1 h1:mk5dRuzeDNis2bi6LLoQIXfMH7JQvAzt3mQD0v
 github.com/hashicorp/memberlist v0.5.1/go.mod h1:zGDXV6AqbDTKTM6yxW0I4+JtFzZAJVoIPvss4hV8F24=
 github.com/hashicorp/raft v1.7.1 h1:ytxsNx4baHsRZrhUcbt3+79zc4ly8qm7pi0393pSchY=
 github.com/hashicorp/raft v1.7.1/go.mod h1:hUeiEwQQR/Nk2iKDD0dkEhklSsu3jcAcqvPzPoZSAEM=
+github.com/hashicorp/raft v1.7.2-0.20241212131917-a5bc06ccef1d h1:BWZ1TieER2VjiWQgFhvl9VT9MTK/j/IDNML+iiGUG4A=
+github.com/hashicorp/raft v1.7.2-0.20241212131917-a5bc06ccef1d/go.mod h1:hUeiEwQQR/Nk2iKDD0dkEhklSsu3jcAcqvPzPoZSAEM=
 github.com/hashicorp/raft-boltdb v0.0.0-20230125174641-2a8082862702 h1:RLKEcCuKcZ+qp2VlaaZsYZfLOmIiuJNpEi48Rl8u9cQ=
 github.com/hashicorp/raft-boltdb v0.0.0-20230125174641-2a8082862702/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=

--- a/tools/dev/prometheus_config/prometheus.yml
+++ b/tools/dev/prometheus_config/prometheus.yml
@@ -4,6 +4,21 @@ scrape_configs:
   static_configs:
   - targets:
     - host.docker.internal:2112
+- job_name: weaviate1
+  scrape_interval: 15s
+  static_configs:
+  - targets:
+    - host.docker.internal:2113
+- job_name: weaviate2
+  scrape_interval: 15s
+  static_configs:
+  - targets:
+    - host.docker.internal:2114
+- job_name: weaviate3
+  scrape_interval: 15s
+  static_configs:
+  - targets:
+    - host.docker.internal:2115
 - job_name: node
   scrape_interval: 15s
   static_configs:

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -53,6 +53,7 @@ case $CONFIG in
       BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
       ENABLE_MODULES="backup-filesystem" \
       PROMETHEUS_MONITORING_PORT="2112" \
+      PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       CLUSTER_IN_LOCALHOST=true \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
@@ -183,6 +184,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       PROMETHEUS_MONITORING_PORT="2112" \
+      PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       CLUSTER_IN_LOCALHOST=true \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
@@ -207,6 +209,7 @@ case $CONFIG in
       CLUSTER_DATA_BIND_PORT="7103" \
       CLUSTER_JOIN="localhost:7100" \
       PROMETHEUS_MONITORING_PORT="2113" \
+      PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       RAFT_PORT="8302" \
       RAFT_INTERNAL_RPC_PORT="8303" \
       RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
@@ -233,6 +236,7 @@ case $CONFIG in
         CLUSTER_DATA_BIND_PORT="7105" \
         CLUSTER_JOIN="localhost:7100" \
         PROMETHEUS_MONITORING_PORT="2114" \
+	PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
         RAFT_PORT="8304" \
         RAFT_INTERNAL_RPC_PORT="8305" \
         RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
@@ -257,8 +261,11 @@ case $CONFIG in
         CLUSTER_GOSSIP_BIND_PORT="7106" \
         CLUSTER_DATA_BIND_PORT="7107" \
         CLUSTER_JOIN="localhost:7100" \
+        PROMETHEUS_MONITORING_PORT="2115" \
+	PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
         RAFT_PORT="8306" \
         RAFT_INTERNAL_RPC_PORT="8307" \
+	RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
         DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
         ENABLE_MODULES="text2vec-contextionary" \
         go_run ./cmd/weaviate-server \
@@ -725,6 +732,7 @@ case $CONFIG in
       CLUSTER_DATA_BIND_PORT="7103" \
       CLUSTER_JOIN="localhost:7100" \
       PROMETHEUS_MONITORING_PORT="2113" \
+      PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       RAFT_PORT="8302" \
       RAFT_INTERNAL_RPC_PORT="8303" \
       RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
@@ -757,6 +765,7 @@ case $CONFIG in
         CLUSTER_DATA_BIND_PORT="7105" \
         CLUSTER_JOIN="localhost:7100" \
         PROMETHEUS_MONITORING_PORT="2114" \
+	PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
         RAFT_PORT="8304" \
         RAFT_INTERNAL_RPC_PORT="8305" \
         RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -167,41 +167,35 @@ type TenantOffloadMetrics struct {
 	OpsDuration      *prometheus.HistogramVec
 }
 
-func NewServerMetrics(cfg Config, reg prometheus.Registerer) *ServerMetrics {
+func NewServerMetrics(namespace string, reg prometheus.Registerer) *ServerMetrics {
 	r := promauto.With(reg)
 
 	return &ServerMetrics{
 		TCPActiveConnections: r.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: cfg.MetricsNamespace,
+			Namespace: namespace,
 			Name:      "tcp_active_connections",
 			Help:      "Current number of accepted TCP connections.",
 		}, []string{"protocol"}),
 		RequestDuration: r.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: cfg.MetricsNamespace,
+			Namespace: namespace,
 			Name:      "request_duration_seconds",
 			Help:      "Time (in seconds) spent serving HTTP requests.",
 			Buckets:   LatencyBuckets,
 		}, []string{"method", "route", "status_code"}),
-		PerTenantRequestDuration: r.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: cfg.MetricsNamespace,
-			Name:      "per_tenant_request_duration_seconds",
-			Help:      "Time (in seconds) spent serving HTTP requests for a particular tenant.",
-			Buckets:   LatencyBuckets,
-		}, []string{"method", "route", "status_code", "tenant", "collection"}),
 		RequestBodySize: r.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: cfg.MetricsNamespace,
+			Namespace: namespace,
 			Name:      "request_message_bytes",
 			Help:      "Size (in bytes) of messages received in the request.",
 			Buckets:   sizeBuckets,
 		}, []string{"method", "route"}),
 		ResponseBodySize: r.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: cfg.MetricsNamespace,
+			Namespace: namespace,
 			Name:      "response_message_bytes",
 			Help:      "Size (in bytes) of messages sent in response.",
 			Buckets:   sizeBuckets,
 		}, []string{"method", "route"}),
 		InflightRequests: r.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: cfg.MetricsNamespace,
+			Namespace: namespace,
 			Name:      "inflight_requests",
 			Help:      "Current number of inflight requests.",
 		}, []string{"method", "route"}),
@@ -212,14 +206,9 @@ func NewServerMetrics(cfg Config, reg prometheus.Registerer) *ServerMetrics {
 type ServerMetrics struct {
 	TCPActiveConnections *prometheus.GaugeVec
 	RequestDuration      *prometheus.HistogramVec
-
-	// NOTE: Adding it as experimental, since we have unbounded cardinality for number of tenant/shards
-	// we may remove it in future.
-	PerTenantRequestDuration *prometheus.HistogramVec
-
-	RequestBodySize  *prometheus.HistogramVec
-	ResponseBodySize *prometheus.HistogramVec
-	InflightRequests *prometheus.GaugeVec
+	RequestBodySize      *prometheus.HistogramVec
+	ResponseBodySize     *prometheus.HistogramVec
+	InflightRequests     *prometheus.GaugeVec
 }
 
 // Delete Shard deletes existing label combinations that match both


### PR DESCRIPTION
### What's being changed:

Changes:
1. Internal metrics from hashicorp/raft and hashicorp/memberlist Go packages.
2. Overall cluster RPC metrics (to understand QPS, Error rate, latency of overall cluster communication)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
