### PR TITLE
performance: buffers pool for cloned NotEqual bitmaps

### DIFF
--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -75,6 +75,9 @@ func (fa *filteredAggregator) hybrid(ctx context.Context) (*aggregation.Result, 
 		if err != nil {
 			return nil, nil, err
 		}
+		if allowList != nil {
+			defer allowList.Close()
+		}
 
 		res, dists, err := fa.objectVectorSearch(ctx, vec, allowList)
 		if err != nil {
@@ -106,6 +109,9 @@ func (fa *filteredAggregator) filtered(ctx context.Context) (*aggregation.Result
 	allowList, err := fa.buildAllowList(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if allowList != nil {
+		defer allowList.Close()
 	}
 
 	if len(fa.params.SearchVector) > 0 {

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -90,6 +90,9 @@ func (g *grouper) fetchDocIDs(ctx context.Context) (ids []uint64, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if allowList != nil {
+		defer allowList.Close()
+	}
 
 	if len(g.params.SearchVector) > 0 {
 		ids, _, err = g.vectorSearch(ctx, allowList, g.params.SearchVector)

--- a/adapters/repos/db/helpers/wrapped_allow_list.go
+++ b/adapters/repos/db/helpers/wrapped_allow_list.go
@@ -22,6 +22,10 @@ func newWrappedAllowList(al AllowList) AllowList {
 	}
 }
 
+func (al *wrappedAllowList) Close() {
+	al.wAllowList.Close()
+}
+
 func (al *wrappedAllowList) Insert(ids ...uint64) {
 	fids := make([]uint64, 0, len(ids))
 

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -83,7 +83,7 @@ func Test_Filters_String(t *testing.T) {
 		require.Nil(t, bWithFrequency.FlushAndSwitch())
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -268,6 +268,7 @@ func Test_Filters_String(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListBeforeUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("update", func(t *testing.T) {
@@ -290,6 +291,7 @@ func Test_Filters_String(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListAfterUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("restore inverted index, so test suite can be run again",
@@ -339,7 +341,7 @@ func Test_Filters_Int(t *testing.T) {
 		{val: 16, ids: []uint64{16}},
 	}
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(maxDocID), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(maxDocID))
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
 		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
@@ -552,6 +554,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListBeforeUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("update", func(t *testing.T) {
@@ -565,6 +568,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListAfterUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("restore inverted index, so we can run test suite again", func(t *testing.T) {
@@ -776,6 +780,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListBeforeUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("update", func(t *testing.T) {
@@ -788,6 +793,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListAfterUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("restore inverted index, so we can run test suite again", func(t *testing.T) {
@@ -997,6 +1003,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListBeforeUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("update", func(t *testing.T) {
@@ -1009,6 +1016,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListAfterUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("restore inverted index, so we can run test suite again", func(t *testing.T) {
@@ -1055,7 +1063,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 		require.Nil(t, bWithFrequency.FlushAndSwitch())
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -1112,6 +1120,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListBeforeUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("update", func(t *testing.T) {
@@ -1133,6 +1142,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListAfterUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("restore inverted index, so we can run test suite again",
@@ -1222,8 +1232,8 @@ func newFakeMaxIDGetter(maxID uint64) func() uint64 {
 }
 
 func notEqualsExpectedResults(maxID uint64, skip uint64) []uint64 {
-	allow := make([]uint64, 0, maxID)
-	for i := uint64(0); i < maxID; i++ {
+	allow := make([]uint64, 0, maxID+1)
+	for i := uint64(0); i <= maxID; i++ {
 		if i != skip {
 			allow = append(allow, i)
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -168,6 +168,7 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 
 	for i := 1; i < len(dbms); i++ {
 		mergeFn(dbms[i].docIDs)
+		dbms[i].release()
 	}
 	return dbms[0], nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -93,7 +93,8 @@ func TestPropValuePairs_Merging(t *testing.T) {
 					pv.children[i] = &propValuePair{
 						operator: filters.OperatorEqual,
 						docIDs: docBitmap{
-							docIDs: tc.bitmaps[i],
+							docIDs:  tc.bitmaps[i],
+							release: noopRelease,
 						},
 					}
 				}

--- a/adapters/repos/db/inverted/row_reader.go
+++ b/adapters/repos/db/inverted/row_reader.go
@@ -81,7 +81,7 @@ func (rr *RowReader) equal(ctx context.Context, readFn ReadFn) error {
 		return err
 	}
 
-	_, err = readFn(rr.value, rr.transformToBitmap(v))
+	_, err = readFn(rr.value, rr.transformToBitmap(v), noopRelease)
 	return err
 }
 
@@ -92,9 +92,9 @@ func (rr *RowReader) notEqual(ctx context.Context, readFn ReadFn) error {
 	}
 
 	// Invert the Equal results for an efficient NotEqual
-	inverted := rr.bitmapFactory.GetBitmap()
+	inverted, release := rr.bitmapFactory.GetBitmap()
 	inverted.AndNot(rr.transformToBitmap(v))
-	_, err = readFn(rr.value, inverted)
+	_, err = readFn(rr.value, inverted, release)
 	return err
 }
 
@@ -115,7 +115,7 @@ func (rr *RowReader) greaterThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (rr *RowReader) lessThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func (rr *RowReader) like(ctx context.Context, readFn ReadFn) error {
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/inverted/row_reader_frequency.go
+++ b/adapters/repos/db/inverted/row_reader_frequency.go
@@ -76,7 +76,7 @@ func (rr *RowReaderFrequency) equal(ctx context.Context, readFn ReadFn) error {
 		return err
 	}
 
-	_, err = readFn(rr.value, rr.transformToBitmap(v))
+	_, err = readFn(rr.value, rr.transformToBitmap(v), noopRelease)
 	return err
 }
 
@@ -87,9 +87,9 @@ func (rr *RowReaderFrequency) notEqual(ctx context.Context, readFn ReadFn) error
 	}
 
 	// Invert the Equal results for an efficient NotEqual
-	inverted := rr.bitmapFactory.GetBitmap()
+	inverted, release := rr.bitmapFactory.GetBitmap()
 	inverted.AndNot(rr.transformToBitmap(v))
-	_, err = readFn(rr.value, inverted)
+	_, err = readFn(rr.value, inverted, release)
 	return err
 }
 
@@ -110,7 +110,7 @@ func (rr *RowReaderFrequency) greaterThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (rr *RowReaderFrequency) lessThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -198,7 +198,7 @@ func (rr *RowReaderFrequency) like(ctx context.Context, readFn ReadFn) error {
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/inverted/row_reader_roaring_set_test.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set_test.go
@@ -16,8 +16,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -61,10 +59,11 @@ func TestRowReaderRoaringSet(t *testing.T) {
 			operator: filters.OperatorNotEqual,
 			expected: []kvData{
 				{"ccc", func() []uint64 {
-					bm := sroar.NewBitmap()
-					bm.SetMany([]uint64{111, 222, 333})
-					return roaringset.NewInvertedBitmap(
-						bm, maxDocID+roaringset.DefaultBufferIncrement, logrus.New()).ToArray()
+					bm := sroar.Prefill(maxDocID)
+					for _, x := range []uint64{111, 222, 333} {
+						bm.Remove(x)
+					}
+					return bm.ToArray()
 				}()},
 			},
 		},
@@ -186,13 +185,14 @@ func TestRowReaderRoaringSet(t *testing.T) {
 		type readResult struct {
 			k []byte
 			v *sroar.Bitmap
+			r func()
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
 			result := []readResult{}
 			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, data)
-			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap) (bool, error) {
-				result = append(result, readResult{k, v})
+			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
+				result = append(result, readResult{k, v, release})
 				return true, nil
 			})
 
@@ -203,6 +203,7 @@ func TestRowReaderRoaringSet(t *testing.T) {
 				for _, expectedV := range expectedKV.v {
 					assert.True(t, result[i].v.Contains(expectedV))
 				}
+				result[i].r()
 			}
 		})
 
@@ -215,8 +216,8 @@ func TestRowReaderRoaringSet(t *testing.T) {
 
 			result := []readResult{}
 			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, data)
-			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap) (bool, error) {
-				result = append(result, readResult{k, v})
+			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
+				result = append(result, readResult{k, v, release})
 				if len(result) >= limit {
 					return false, nil
 				}
@@ -230,6 +231,7 @@ func TestRowReaderRoaringSet(t *testing.T) {
 				for _, expectedV := range expectedKV.v {
 					assert.True(t, result[i].v.Contains(expectedV))
 				}
+				result[i].r()
 			}
 		})
 	}
@@ -294,7 +296,6 @@ func createRowReaderRoaringSet(value []byte, operator filters.Operator, data []k
 			}
 			return nil, entlsmkv.NotFound
 		},
-		bitmapFactory: roaringset.NewBitmapFactory(
-			func() uint64 { return maxDocID }, logrus.New()),
+		bitmapFactory: roaringset.NewBitmapFactory(func() uint64 { return maxDocID }),
 	}
 }

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -23,6 +23,8 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
+var noopRelease = func() {}
+
 func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
 	pv *propValuePair,
 ) (bm docBitmap, err error) {
@@ -72,12 +74,14 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
-	var readFn ReadFn = func(k []byte, docIDs *sroar.Bitmap) (bool, error) {
+	var readFn ReadFn = func(k []byte, docIDs *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = docIDs
+			out.release = release
 			isEmpty = false
 		} else {
 			out.docIDs.Or(docIDs)
+			release()
 		}
 
 		// NotEqual requires the full set of potentially existing doc ids
@@ -119,6 +123,7 @@ func (s *Searcher) docBitmapInvertedRoaringSetRange(ctx context.Context, b *lsmk
 
 	out := newUninitializedDocBitmap()
 	out.docIDs = docIds
+	out.release = noopRelease
 	return out, nil
 }
 
@@ -127,12 +132,14 @@ func (s *Searcher) docBitmapInvertedSet(ctx context.Context, b *lsmkv.Bucket,
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
-	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap) (bool, error) {
+	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = ids
+			out.release = release
 			isEmpty = false
 		} else {
 			out.docIDs.Or(ids)
+			release()
 		}
 
 		// NotEqual requires the full set of potentially existing doc ids
@@ -162,12 +169,14 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
-	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap) (bool, error) {
+	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = ids
+			out.release = release
 			isEmpty = false
 		} else {
 			out.docIDs.Or(ids)
+			release()
 		}
 
 		// NotEqual requires the full set of potentially existing doc ids

--- a/adapters/repos/db/inverted/searcher_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_integration_test.go
@@ -98,7 +98,7 @@ func TestObjects(t *testing.T) {
 		}
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -197,7 +197,7 @@ func TestDocIDs(t *testing.T) {
 		}
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter - 1))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -238,7 +238,7 @@ func TestDocIDs(t *testing.T) {
 					},
 				},
 			},
-			expectedMatches: len(charSet)*multiplier - 1,
+			expectedMatches: (len(charSet) - 1) * multiplier,
 		},
 	}
 
@@ -246,6 +246,7 @@ func TestDocIDs(t *testing.T) {
 		allow, err := searcher.DocIDs(context.Background(), &tc.filter, additional.Properties{}, className)
 		require.Nil(t, err)
 		assert.Equal(t, tc.expectedMatches, allow.Len())
+		allow.Close()
 	}
 }
 

--- a/adapters/repos/db/roaringset/helpers.go
+++ b/adapters/repos/db/roaringset/helpers.go
@@ -14,16 +14,7 @@ package roaringset
 import (
 	"sync"
 
-	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/entities/concurrency"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-
 	"github.com/weaviate/sroar"
-)
-
-var (
-	prefillBufferSize  = 65_536
-	prefillMaxRoutines = 4
 )
 
 func NewBitmap(values ...uint64) *sroar.Bitmap {
@@ -53,160 +44,133 @@ func Condense(bm *sroar.Bitmap) *sroar.Bitmap {
 	return condensed
 }
 
-// NewInvertedBitmap creates a bitmap that as all IDs filled from 0 to maxVal.
-// Then the source bitmap is subtracted (AndNot) from the all-ids bitmap,
-// resulting in a bitmap containing all ids from 0 to maxVal except the ones
-// that were set on the source.
-func NewInvertedBitmap(source *sroar.Bitmap, maxVal uint64, logger logrus.FieldLogger) *sroar.Bitmap {
-	bm := NewBitmapPrefill(maxVal, logger)
-	bm.AndNot(source)
-	return bm
-}
+// defaultIdIncrement  is the amount of bits greater than <maxId>
+// to reduce the amount of times BitmapFactory has to reallocate.
+const defaultIdIncrement = uint64(1024)
 
-// Creates prefilled bitmap with values from 0 to maxVal (included).
-//
-// It is designed to be more performant both
-// time-wise (compared to Set/SetMany)
-// and memory-wise (compared to FromSortedList accepting entire slice of elements)
-// Method creates multiple small bitmaps using FromSortedList (slice is reusable)
-// and ORs them together to get final bitmap.
-// For maxVal > prefillBufferSize (65_536) and multiple CPUs available task is performed
-// by up to prefillMaxRoutines (4) goroutines.
-func NewBitmapPrefill(maxVal uint64, logger logrus.FieldLogger) *sroar.Bitmap {
-	routinesLimit := concurrency.NoMoreThanNUMCPU(prefillMaxRoutines)
-	if routinesLimit == 1 || maxVal <= uint64(prefillBufferSize) {
-		return newBitmapPrefillSequential(maxVal)
-	}
-	return newBitmapPrefillParallel(maxVal, routinesLimit, logger)
-}
+type MaxIdGetterFunc func() uint64
 
-func newBitmapPrefillSequential(maxVal uint64) *sroar.Bitmap {
-	inc := uint64(prefillBufferSize)
-	buf := make([]uint64, prefillBufferSize)
-	finalBM := sroar.NewBitmap()
-
-	for i := uint64(0); i <= maxVal; i += inc {
-		j := uint64(0)
-		for ; j < inc && i+j <= maxVal; j++ {
-			buf[j] = i + j
-		}
-		finalBM.Or(sroar.FromSortedList(buf[:j]))
-	}
-	return finalBM
-}
-
-func newBitmapPrefillParallel(maxVal uint64, routinesLimit int, logger logrus.FieldLogger) *sroar.Bitmap {
-	inc := uint64(prefillBufferSize / routinesLimit)
-	lock := new(sync.Mutex)
-	ch := make(chan uint64, routinesLimit)
-	wg := new(sync.WaitGroup)
-	wg.Add(routinesLimit)
-	finalBM := sroar.NewBitmap()
-
-	for r := 0; r < routinesLimit; r++ {
-		f := func() {
-			buf := make([]uint64, inc)
-
-			for i := range ch {
-				j := uint64(0)
-				for ; j < inc && i+j <= maxVal; j++ {
-					buf[j] = i + j
-				}
-				bm := sroar.FromSortedList(buf[:j])
-
-				lock.Lock()
-				finalBM.Or(bm)
-				lock.Unlock()
-			}
-			wg.Done()
-		}
-		enterrors.GoWrapper(f, logger)
-	}
-
-	for i := uint64(0); i <= maxVal; i += inc {
-		ch <- i
-	}
-	close(ch)
-	wg.Wait()
-	return finalBM
-}
-
-type MaxValGetterFunc func() uint64
-
-const (
-	// DefaultBufferIncrement  is the amount of bits greater than <maxVal>
-	// to reduce the amount of times BitmapFactory has to reallocate.
-	DefaultBufferIncrement = uint64(100)
-)
-
-// BitmapFactory exists to prevent an expensive call to
-// NewBitmapPrefill each time NewInvertedBitmap is invoked
+// BitmapFactory exists to provide prefilled bitmaps using pool (reducing allocation of memory)
+// and favor cloning (faster) over prefilling bitmap from scratch each time bitmap is requested
 type BitmapFactory struct {
-	bitmap        *sroar.Bitmap
-	maxValGetter  MaxValGetterFunc
-	currentMaxVal uint64
-	lock          sync.RWMutex
+	lock           *sync.RWMutex
+	prefilled      *sroar.Bitmap
+	bufPool        *BitmapBufPool
+	maxIdGetter    MaxIdGetterFunc
+	prefilledMaxId uint64
 }
 
-func NewBitmapFactory(maxValGetter MaxValGetterFunc, logger logrus.FieldLogger) *BitmapFactory {
-	maxVal := maxValGetter() + DefaultBufferIncrement
+func NewBitmapFactory(maxIdGetter MaxIdGetterFunc) *BitmapFactory {
+	prefilledMaxId := maxIdGetter() + defaultIdIncrement
+	prefilled := sroar.Prefill(prefilledMaxId)
+
 	return &BitmapFactory{
-		bitmap:        NewBitmapPrefill(maxVal, logger),
-		maxValGetter:  maxValGetter,
-		currentMaxVal: maxVal,
+		lock:           new(sync.RWMutex),
+		prefilled:      prefilled,
+		bufPool:        NewBitmapBufPool(prefilled.LenInBytes(), 1.2),
+		maxIdGetter:    maxIdGetter,
+		prefilledMaxId: prefilledMaxId,
 	}
 }
 
 // GetBitmap returns a prefilled bitmap, which is cloned from a shared internal.
 // This method is safe to call concurrently. The purpose behind sharing an
-// internal bitmap, is that a Clone() operation is much cheaper than prefilling
-// a map up to <maxDocID> elements is an expensive operation, and this way we
-// only have to do it once.
-func (bmf *BitmapFactory) GetBitmap() *sroar.Bitmap {
-	bmf.lock.RLock()
-	maxVal := bmf.maxValGetter()
+// internal bitmap, is that a Clone() operation is cheaper than prefilling
+// a bitmap up to <maxDocID>
+func (bmf *BitmapFactory) GetBitmap() (cloned *sroar.Bitmap, release func()) {
+	bitmap, release, removeRange := bmf.getBitmap()
+	bitmap.RemoveRange(removeRange[0], removeRange[1])
+	return bitmap, release
+}
 
-	// We don't need to expand, maxVal is unchanged
-	{
-		if maxVal <= bmf.currentMaxVal {
-			cloned := bmf.bitmap.Clone()
-			bmf.lock.RUnlock()
-			return cloned
-		}
+func (bmf *BitmapFactory) getBitmap() (cloned *sroar.Bitmap, release func(), removeRange [2]uint64) {
+	bmf.lock.RLock()
+
+	maxId := bmf.maxIdGetter()
+	prefilledMaxId := bmf.prefilledMaxId
+
+	// No need to expand, maxId is included
+	if maxId <= prefilledMaxId {
+		cloned, release = bmf.clone()
+		bmf.lock.RUnlock()
+		return cloned, release, [2]uint64{maxId + 1, prefilledMaxId + 1}
 	}
 
 	bmf.lock.RUnlock()
 	bmf.lock.Lock()
 	defer bmf.lock.Unlock()
 
+	maxId = bmf.maxIdGetter()
+	prefilledMaxId = bmf.prefilledMaxId
+
 	// 2nd check to ensure bitmap wasn't expanded by
 	// concurrent request white waiting for write lock
-	{
-		maxVal = bmf.maxValGetter()
-		if maxVal <= bmf.currentMaxVal {
-			return bmf.bitmap.Clone()
-		}
+	if maxId <= prefilledMaxId {
+		cloned, release = bmf.clone()
+		return cloned, release, [2]uint64{maxId + 1, prefilledMaxId + 1}
 	}
 
-	// maxVal has grown to exceed even the buffer,
-	// time to expand
-	{
-		length := maxVal + DefaultBufferIncrement - bmf.currentMaxVal
-		list := make([]uint64, length)
-		for i := uint64(0); i < length; i++ {
-			list[i] = bmf.currentMaxVal + i + 1
-		}
-
-		bmf.bitmap.Or(sroar.FromSortedList(list))
-		bmf.currentMaxVal = maxVal + DefaultBufferIncrement
-	}
-
-	return bmf.bitmap.Clone()
+	// expand bitmap with additional ids
+	prefilledMaxId = maxId + defaultIdIncrement
+	bmf.prefilled.FillUp(prefilledMaxId)
+	bmf.prefilledMaxId = prefilledMaxId
+	cloned, release = bmf.clone()
+	return cloned, release, [2]uint64{maxId + 1, prefilledMaxId + 1}
 }
 
-// ActualMaxVal returns the highest value in the bitmap not including the buffer
-func (bmf *BitmapFactory) ActualMaxVal() uint64 {
-	bmf.lock.RLock()
-	defer bmf.lock.RUnlock()
-	return bmf.maxValGetter()
+func (bmf *BitmapFactory) clone() (cloned *sroar.Bitmap, release func()) {
+	buf, release := bmf.bufPool.Get(bmf.prefilled.LenInBytes())
+	cloned = bmf.prefilled.CloneToBuf(buf)
+	return
+}
+
+type BitmapBufPool struct {
+	pool          *sync.Pool
+	lock          *sync.Mutex
+	capFactor     float32
+	initialMinCap int
+}
+
+func NewBitmapBufPool(initialMinCap int, capFactor float32) *BitmapBufPool {
+	p := &BitmapBufPool{
+		capFactor:     capFactor,
+		initialMinCap: initialMinCap,
+		lock:          new(sync.Mutex),
+	}
+
+	p.pool = &sync.Pool{
+		New: p.createBuf,
+	}
+	return p
+}
+
+func (p *BitmapBufPool) Get(minCap int) (buf []byte, put func()) {
+	ptr := p.pool.Get().(*[]byte)
+	buf = *ptr
+	if cap(buf) < minCap {
+		p.updateInitialMinCap(minCap)
+		*ptr = *p.createBuf().(*[]byte)
+		buf = *ptr
+	} else if len(buf) > 0 {
+		buf = buf[:0]
+		*ptr = buf
+	}
+	return buf, func() { p.pool.Put(ptr) }
+}
+
+func (p *BitmapBufPool) createBuf() any {
+	p.lock.Lock()
+	minCap := p.initialMinCap
+	p.lock.Unlock()
+
+	buf := make([]byte, 0, int(float32(minCap)*p.capFactor))
+	return &buf
+}
+
+func (p *BitmapBufPool) updateInitialMinCap(minCap int) {
+	p.lock.Lock()
+	if minCap > p.initialMinCap {
+		p.initialMinCap = minCap
+	}
+	p.lock.Unlock()
 }

--- a/adapters/repos/db/roaringset/helpers_test.go
+++ b/adapters/repos/db/roaringset/helpers_test.go
@@ -12,16 +12,11 @@
 package roaringset
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/weaviate/sroar"
+	"github.com/stretchr/testify/require"
 )
-
-var logger, _ = test.NewNullLogger()
 
 func TestBitmap_Condense(t *testing.T) {
 	t.Run("And with itself (internal array)", func(t *testing.T) {
@@ -135,136 +130,6 @@ func TestBitmap_Condense(t *testing.T) {
 	})
 }
 
-func TestBitmap_Prefill(t *testing.T) {
-	t.Run("sequential", func(t *testing.T) {
-		for _, maxVal := range []uint64{1_000, 10_000, 100_000, 1_000_000, uint64(prefillBufferSize)} {
-			t.Run(fmt.Sprint(maxVal), func(t *testing.T) {
-				bm := newBitmapPrefillSequential(maxVal)
-
-				// +1, due to 0 included
-				assert.Equal(t, int(maxVal)+1, bm.GetCardinality())
-
-				// remove all except maxVal
-				bm.RemoveRange(0, maxVal)
-
-				assert.Equal(t, 1, bm.GetCardinality())
-				assert.True(t, bm.Contains(maxVal))
-			})
-		}
-	})
-
-	t.Run("parallel", func(t *testing.T) {
-		for _, maxVal := range []uint64{1_000, 10_000, 100_000, 1_000_000, uint64(prefillBufferSize)} {
-			for _, routinesLimit := range []int{2, 3, 4, 5, 6, 7, 8} {
-				t.Run(fmt.Sprint(maxVal), func(t *testing.T) {
-					bm := newBitmapPrefillParallel(maxVal, routinesLimit, logger)
-
-					// +1, due to 0 included
-					assert.Equal(t, int(maxVal)+1, bm.GetCardinality())
-
-					// remove all except maxVal
-					bm.RemoveRange(0, maxVal)
-
-					assert.Equal(t, 1, bm.GetCardinality())
-					assert.True(t, bm.Contains(maxVal))
-				})
-			}
-		}
-	})
-
-	t.Run("conditional - sequential or parallel", func(t *testing.T) {
-		for _, maxVal := range []uint64{1_000, 10_000, 100_000, 1_000_000, uint64(prefillBufferSize)} {
-			t.Run(fmt.Sprint(maxVal), func(t *testing.T) {
-				bm := NewBitmapPrefill(maxVal, logger)
-
-				// +1, due to 0 included
-				assert.Equal(t, int(maxVal)+1, bm.GetCardinality())
-
-				// remove all except maxVal
-				bm.RemoveRange(0, maxVal)
-
-				assert.Equal(t, 1, bm.GetCardinality())
-				assert.True(t, bm.Contains(maxVal))
-			})
-		}
-	})
-}
-
-func TestBitmap_Inverted(t *testing.T) {
-	type test struct {
-		name          string
-		source        []uint64
-		maxVal        uint64
-		shouldContain []uint64
-	}
-
-	tests := []test{
-		{
-			name:          "just 0, no source",
-			source:        nil,
-			maxVal:        0,
-			shouldContain: []uint64{0},
-		},
-		{
-			name:          "no matches in source",
-			source:        nil,
-			maxVal:        7,
-			shouldContain: []uint64{0, 1, 2, 3, 4, 5, 6, 7},
-		},
-		{
-			name:          "some matches in source",
-			source:        []uint64{3, 4, 5},
-			maxVal:        7,
-			shouldContain: []uint64{0, 1, 2, 6, 7},
-		},
-		{
-			name:          "source has higher val than max val",
-			source:        []uint64{3, 4, 5, 8},
-			maxVal:        7,
-			shouldContain: []uint64{0, 1, 2, 6, 7},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			source := sroar.NewBitmap()
-			source.SetMany(test.source)
-			out := NewInvertedBitmap(source, test.maxVal, logger)
-			outSlice := out.ToArray()
-			assert.Equal(t, test.shouldContain, outSlice)
-		})
-	}
-}
-
-func TestBitmapFactory(t *testing.T) {
-	maxVal := uint64(10)
-	maxValGetter := func() uint64 { return maxVal }
-	bmf := NewBitmapFactory(maxValGetter, logger)
-	t.Logf("card: %d", bmf.bitmap.GetCardinality())
-
-	currMax := bmf.currentMaxVal
-	t.Run("max val set correctly", func(t *testing.T) {
-		assert.Equal(t, maxVal+DefaultBufferIncrement, currMax)
-	})
-
-	t.Run("max val increased to threshold does not change cardinality", func(t *testing.T) {
-		maxVal += 100
-		assert.NotNil(t, bmf.GetBitmap())
-		assert.Equal(t, currMax, bmf.currentMaxVal)
-		assert.Equal(t, currMax+1, uint64(bmf.bitmap.GetCardinality()))
-		assert.Equal(t, maxVal, bmf.ActualMaxVal())
-	})
-
-	t.Run("max val surpasses threshold, cardinality increased", func(t *testing.T) {
-		maxVal += 1
-		assert.NotNil(t, bmf.GetBitmap())
-		currMax += 1 + DefaultBufferIncrement
-		assert.Equal(t, currMax, bmf.currentMaxVal)
-		assert.Equal(t, currMax+1, uint64(bmf.bitmap.GetCardinality()))
-		assert.Equal(t, maxVal, bmf.ActualMaxVal())
-	})
-}
-
 func slice(from, to uint64) []uint64 {
 	len := to - from
 	s := make([]uint64, len)
@@ -272,4 +137,62 @@ func slice(from, to uint64) []uint64 {
 		s[i] = from + i
 	}
 	return s
+}
+
+func TestBitmapFactory(t *testing.T) {
+	maxId := uint64(10)
+	maxIdGetter := func() uint64 { return maxId }
+	bmf := NewBitmapFactory(maxIdGetter)
+
+	t.Run("prefilled bitmap includes increment", func(t *testing.T) {
+		expPrefilledMaxId := maxId + defaultIdIncrement
+		expPrefilledCardinality := int(maxId + defaultIdIncrement + 1)
+
+		bm, release := bmf.GetBitmap()
+		defer release()
+
+		require.NotNil(t, bm)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, expPrefilledCardinality, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm.Maximum())
+		assert.Equal(t, int(maxId)+1, bm.GetCardinality())
+	})
+
+	t.Run("maxId increased up to increment threshold does not change internal bitmap", func(t *testing.T) {
+		expPrefilledMaxId := bmf.prefilled.Maximum()
+
+		maxId += 10
+		bm1, release1 := bmf.GetBitmap()
+		defer release1()
+
+		require.NotNil(t, bm1)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, int(expPrefilledMaxId)+1, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm1.Maximum())
+		assert.Equal(t, int(maxId)+1, bm1.GetCardinality())
+
+		maxId += (defaultIdIncrement - 10)
+		bm2, release2 := bmf.GetBitmap()
+		defer release2()
+
+		require.NotNil(t, bm2)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, int(expPrefilledMaxId)+1, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm2.Maximum())
+		assert.Equal(t, int(maxId)+1, bm2.GetCardinality())
+	})
+
+	t.Run("maxId surpasses increment threshold changes internal bitmap", func(t *testing.T) {
+		maxId += 1
+		expPrefilledMaxId := maxId + defaultIdIncrement
+
+		bm, release := bmf.GetBitmap()
+		defer release()
+
+		require.NotNil(t, bm)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, int(expPrefilledMaxId)+1, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm.Maximum())
+		assert.Equal(t, int(maxId)+1, bm.GetCardinality())
+	})
 }

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -180,7 +180,8 @@ func (s *Shard) initIndexCounterVersionerAndBitmapFactory() error {
 		return fmt.Errorf("init index counter: %w", err)
 	}
 	s.counter = counter
-	s.bitmapFactory = roaringset.NewBitmapFactory(s.counter.Get, s.index.logger)
+	// counter is incremented whenever new docID is fetched, therefore last docID is lower by 1
+	s.bitmapFactory = roaringset.NewBitmapFactory(func() uint64 { return s.counter.Get() - 1 })
 
 	dataPresent := s.counter.PreviewNext() != 0
 	versionPath := path.Join(s.path(), "version")

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -308,6 +308,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 			}
 
 			filterDocIds = objs
+			defer objs.Close()
 		}
 
 		className := s.index.Config.ClassName
@@ -425,6 +426,10 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors [][]float3
 			dists []float32
 		)
 		eg.Go(func() error {
+			if allowList != nil {
+				defer allowList.Close()
+			}
+
 			queue, err := s.getIndexQueue(targetVector)
 			if err != nil {
 				return err

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -157,6 +157,7 @@ func (s *Shard) findDocIDs(ctx context.Context, filters *filters.LocalFilter) ([
 	if err != nil {
 		return nil, err
 	}
+	defer allowList.Close()
 	return allowList.Slice(), nil
 }
 

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -655,6 +655,9 @@ func (s *FastSet) Truncate(uint64) helpers.AllowList {
 	panic("DeepCopy")
 }
 
+func (s *FastSet) Close() {
+}
+
 func (s *FastSet) Iterator() helpers.AllowListIterator {
 	return &fastIterator{
 		source:  s,


### PR DESCRIPTION
### What's being changed:
- native sroar's `Prefill` and `FillUp` methods are used to created prefilled bitmap for `NotEqual` operator
- native sroar's `CloneToBuf` method is used to clone bitmap to provided buffer
- prefilled bitmaps used for `NotEqual` operator are cloned to buffers managed by pool
- `Close` method is added to `AllowList` to release underlying bitmap (in case bitmaps data are contained in buffer managed by pool)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
