### PR TITLE
fix: remove contexts with timeouts for tests with testcontainers

### DIFF
--- a/test/acceptance/authz/autoschema_test.go
+++ b/test/acceptance/authz/autoschema_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/weaviate/weaviate/test/docker"
 
@@ -40,9 +39,7 @@ func TestAutoschemaAuthZ(t *testing.T) {
 	updateSchemaAction := authorization.UpdateCollections
 	createSchemaAction := authorization.CreateCollections
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.
 		New().
 		WithWeaviate().

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -38,9 +38,7 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 	customUser := "custom-user"
 	customKey := "custom-key"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.
 		New().
 		WithWeaviate().

--- a/test/acceptance/authz/gql_refs_test.go
+++ b/test/acceptance/authz/gql_refs_test.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/client/graphql"
@@ -38,9 +37,7 @@ func TestAuthZGraphQLRefs(t *testing.T) {
 	customUser := "custom-user"
 	customKey := "custom-key"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.
 		New().WithWeaviate().
 		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).

--- a/test/acceptance/authz/gql_simple_test.go
+++ b/test/acceptance/authz/gql_simple_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/authz"
@@ -34,9 +33,7 @@ func TestAuthZGraphQLSingleTenancy(t *testing.T) {
 	customUser := "custom-user"
 	customKey := "custom-key"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.
 		New().
 		WithWeaviate().
@@ -177,9 +174,7 @@ func TestAuthZGraphQLMultiTenancy(t *testing.T) {
 	customUser := "custom-user"
 	customKey := "custom-key"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.
 		New().
 		WithWeaviate().

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -77,9 +77,7 @@ func TestUserWithSimilarBuiltInRoleName(t *testing.T) {
 	adminUser := "admin-user"
 	adminAuth := helper.CreateAuth(adminKey)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
 		WithRBAC().WithRbacAdmins(adminUser).Start(ctx)
 	require.Nil(t, err)
@@ -413,17 +411,18 @@ func TestAuthzRolesMultiNodeJourney(t *testing.T) {
 
 	clientAuth := helper.CreateAuth(adminKey)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().WithWeaviateCluster(3).WithApiKey().WithUserApiKey(adminUser, adminKey).WithRBAC().WithRbacAdmins(adminUser).Start(ctx)
+	mainCtx := context.Background()
+	compose, err := docker.New().WithWeaviateCluster(3).WithApiKey().WithUserApiKey(adminUser, adminKey).WithRBAC().WithRbacAdmins(adminUser).Start(mainCtx)
 	require.Nil(t, err)
 
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %v", err)
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	defer helper.ResetClient()
@@ -553,17 +552,18 @@ func TestAuthzRolesHasPermissionMultipleNodes(t *testing.T) {
 
 	testRole := "test-role"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().WithWeaviateCluster(3).WithApiKey().WithUserApiKey(adminUser, adminKey).WithRBAC().WithRbacAdmins(adminUser).Start(ctx)
+	mainCtx := context.Background()
+	compose, err := docker.New().WithWeaviateCluster(3).WithApiKey().WithUserApiKey(adminUser, adminKey).WithRBAC().WithRbacAdmins(adminUser).Start(mainCtx)
 	require.Nil(t, err)
 
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %v", err)
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	defer helper.ResetClient()

--- a/test/acceptance/cluster_api_auth/cluster_api_auth_test.go
+++ b/test/acceptance/cluster_api_auth/cluster_api_auth_test.go
@@ -14,7 +14,6 @@ package test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,9 +25,7 @@ import (
 )
 
 func TestClusterAPIAuth(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	compose, err := docker.New().With3NodeCluster().
 		WithWeaviateBasicAuth("user", "pass").
 		WithText2VecContextionary().

--- a/test/acceptance/recovery/recovery_test.go
+++ b/test/acceptance/recovery/recovery_test.go
@@ -27,20 +27,22 @@ import (
 // to the new one to force recovery
 func TestRecovery(t *testing.T) {
 	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
-
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	container1Ip := compose.ContainerURI(1)
 	container2Ip := compose.ContainerURI(2)

--- a/test/acceptance/replication/read_repair/crud_test.go
+++ b/test/acceptance/replication/read_repair/crud_test.go
@@ -76,19 +76,21 @@ func TestReplicationTestSuite(t *testing.T) {
 func (suite *ReplicationTestSuite) TestImmediateReplicaCRUD() {
 	t := suite.T()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()
@@ -309,20 +311,20 @@ func (suite *ReplicationTestSuite) TestImmediateReplicaCRUD() {
 
 func (suite *ReplicationTestSuite) TestEventualReplicaCRUD() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/graphql_test.go
+++ b/test/acceptance/replication/read_repair/graphql_test.go
@@ -29,20 +29,21 @@ import (
 
 func (suite *ReplicationTestSuite) TestGraphqlSearch() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/multi_tenancy_test.go
+++ b/test/acceptance/replication/read_repair/multi_tenancy_test.go
@@ -37,20 +37,21 @@ const (
 
 func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
@@ -28,20 +28,21 @@ import (
 
 func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/read_repair_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_test.go
@@ -28,20 +28,21 @@ import (
 
 func (suite *ReplicationTestSuite) TestReadRepair() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/read_repair_timebasedresolution_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_timebasedresolution_test.go
@@ -28,20 +28,21 @@ import (
 
 func (suite *ReplicationTestSuite) TestReadRepairTimebasedResolution() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/scale_test.go
+++ b/test/acceptance/replication/read_repair/scale_test.go
@@ -31,20 +31,21 @@ import (
 
 func (suite *ReplicationTestSuite) TestReplicationFactorIncrease() {
 	t := suite.T()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		Start(ctx)
+		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
+		if err := compose.Terminate(mainCtx); err != nil {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/schema/get_class_consistency_test.go
+++ b/test/acceptance/schema/get_class_consistency_test.go
@@ -14,7 +14,6 @@ package test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,9 +25,7 @@ import (
 )
 
 func TestGetClassWithConsistency(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+	ctx := context.Background()
 	// 3 Node cluster so that we can verify that the proxy to leader feature work
 	compose, err := docker.New().WithWeaviateCluster(3).
 		WithText2VecContextionary().

--- a/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/activation_deactivation_test.go
@@ -237,14 +237,16 @@ func TestActivationDeactivation_Restarts(t *testing.T) {
 }
 
 func testActivationDeactivationWithRestarts(t *testing.T, composeFn composeFn) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	mainCtx := context.Background()
+
+	client, composeCleanup, restart := composeFn(t, mainCtx)
+	defer composeCleanup(t, mainCtx)
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
 	defer cancel()
 
-	client, composeCleanup, restart := composeFn(t, ctx)
-	defer composeCleanup(t, ctx)
-
 	cleanup := func() {
-		err := client.Schema().AllDeleter().Do(context.Background())
+		err := client.Schema().AllDeleter().Do(mainCtx)
 		require.Nil(t, err)
 	}
 

--- a/test/acceptance_with_go_client/multi_tenancy_tests/implicit_activation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/implicit_activation_test.go
@@ -34,11 +34,13 @@ func autoTenantActivationJourney(t *testing.T,
 	),
 	replicationFactor int64,
 ) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	mainCtx := context.Background()
 
-	client, composeCleanup := composeFn(t, ctx)
-	defer composeCleanup(t, ctx)
+	client, composeCleanup := composeFn(t, mainCtx)
+	defer composeCleanup(t, mainCtx)
+
+	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+	defer cancel()
 
 	className := "Pizza"
 	tenantNames := []string{"t1", "t2", "t3", "t4", "t5", "t6"}

--- a/test/modules/offload-s3/offlad_delete_test.go
+++ b/test/modules/offload-s3/offlad_delete_test.go
@@ -31,8 +31,7 @@ import (
 
 func Test_DeleteClassS3Journey(t *testing.T) {
 	t.Run("delete class, deleting frozen tenants", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		mainCtx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -42,14 +41,17 @@ func Test_DeleteClassS3Journey(t *testing.T) {
 			WithOffloadS3("offloading", "us-west-1").
 			WithText2VecContextionary().
 			With3NodeCluster().
-			Start(ctx)
+			Start(mainCtx)
 		require.Nil(t, err)
 
 		defer func() {
-			if err := compose.Terminate(ctx); err != nil {
+			if err := compose.Terminate(mainCtx); err != nil {
 				t.Fatalf("failed to terminate test containers: %s", err.Error())
 			}
 		}()
+
+		ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+		defer cancel()
 
 		helper.SetupClient(compose.GetWeaviate().URI())
 
@@ -194,8 +196,7 @@ func Test_DeleteClassS3Journey(t *testing.T) {
 
 func Test_DeleteAndRecreateS3Journey(t *testing.T) {
 	t.Run("create tenant, freeze, delete, re-create", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)

--- a/test/modules/offload-s3/offload_bucket_test.go
+++ b/test/modules/offload-s3/offload_bucket_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func Test_OffloadBucketNotAutoCreate(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	t.Log("pre-instance env setup")
 	t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -53,8 +52,7 @@ func Test_OffloadBucketNotAutoCreate(t *testing.T) {
 
 func Test_OffloadBucketNotAutoCreateMinioManualCreate(t *testing.T) {
 	t.Run("success because created manually in minio", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		mainCtx := context.Background()
 		bucketname := "offloading"
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -65,14 +63,17 @@ func Test_OffloadBucketNotAutoCreateMinioManualCreate(t *testing.T) {
 			WithText2VecContextionary().
 			WithWeaviateEnv("OFFLOAD_S3_BUCKET_AUTO_CREATE", "false").
 			With3NodeCluster().
-			Start(ctx)
+			Start(mainCtx)
 		require.Nil(t, err)
 
 		defer func() {
-			if err := compose.Terminate(ctx); err != nil {
+			if err := compose.Terminate(mainCtx); err != nil {
 				t.Fatalf("failed to terminate test containers: %s", err.Error())
 			}
 		}()
+
+		ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+		defer cancel()
 
 		helper.SetupClient(compose.GetWeaviate().URI())
 

--- a/test/modules/offload-s3/offload_download_test.go
+++ b/test/modules/offload-s3/offload_download_test.go
@@ -28,8 +28,7 @@ import (
 
 func Test_DownloadS3Journey(t *testing.T) {
 	t.Run("happy path with RF 2 download from s3 provider, HOT status", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -185,8 +184,7 @@ func Test_DownloadS3Journey(t *testing.T) {
 	})
 
 	t.Run("happy path with RF 2 download from s3 provider COLD status", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)

--- a/test/modules/offload-s3/offload_not_enabled_test.go
+++ b/test/modules/offload-s3/offload_not_enabled_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,8 +26,7 @@ import (
 )
 
 func Test_Offload_When_Not_Enabled(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 	compose, err := docker.New().
 		WithText2VecContextionary().
 		With3NodeCluster().

--- a/test/modules/offload-s3/offload_test.go
+++ b/test/modules/offload-s3/offload_test.go
@@ -39,8 +39,7 @@ const (
 
 func Test_Upload_DownloadS3Journey(t *testing.T) {
 	t.Run("happy path with RF 2 upload to s3 provider", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -253,8 +252,7 @@ func Test_Upload_DownloadS3Journey(t *testing.T) {
 }
 
 func Test_AutoTenantActivation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 	t.Log("pre-instance env setup")
 	t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 	t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -455,8 +453,7 @@ func Test_AutoTenantActivation(t *testing.T) {
 }
 
 func Test_ConcurrentFreezeUnfreeze(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 	t.Log("pre-instance env setup")
 	t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 	t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)

--- a/test/modules/offload-s3/offload_upload_test.go
+++ b/test/modules/offload-s3/offload_upload_test.go
@@ -29,8 +29,7 @@ import (
 
 func Test_UploadS3Journey(t *testing.T) {
 	t.Run("happy path with RF 2 upload to s3 provider", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -198,8 +197,7 @@ func Test_UploadS3Journey(t *testing.T) {
 	})
 
 	t.Run("node is down while RF is 3, one weaviate node is down", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		mainCtx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -208,14 +206,17 @@ func Test_UploadS3Journey(t *testing.T) {
 			WithOffloadS3("weaviate-offload", "us-west-1").
 			WithText2VecContextionary().
 			With3NodeCluster().
-			Start(ctx)
+			Start(mainCtx)
 		require.Nil(t, err)
 
 		defer func() {
-			if err := compose.Terminate(ctx); err != nil {
+			if err := compose.Terminate(mainCtx); err != nil {
 				t.Fatalf("failed to terminate test containers: %s", err.Error())
 			}
 		}()
+
+		ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+		defer cancel()
 
 		helper.SetupClient(compose.GetWeaviate().URI())
 
@@ -339,8 +340,7 @@ func Test_UploadS3Journey(t *testing.T) {
 	})
 
 	t.Run("unhappy path with RF 3, cloud provider is down", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		mainCtx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -351,14 +351,17 @@ func Test_UploadS3Journey(t *testing.T) {
 			WithWeaviateEnv("OFFLOAD_TIMEOUT", "2").
 			WithText2VecContextionary().
 			With3NodeCluster().
-			Start(ctx)
+			Start(mainCtx)
 		require.Nil(t, err)
 
 		defer func() {
-			if err := compose.Terminate(ctx); err != nil {
+			if err := compose.Terminate(mainCtx); err != nil {
 				t.Fatalf("failed to terminate test containers: %s", err.Error())
 			}
 		}()
+
+		ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
+		defer cancel()
 
 		helper.SetupClient(compose.GetWeaviate().URI())
 


### PR DESCRIPTION
### What's being changed:

Replaces contexts with timeouts with contexts in tests with testcontainers

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
