### PR TITLE
performance: bitmaps merged using external container buffer

### DIFF
--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -48,6 +48,7 @@ type Aggregator struct {
 	tenant                 string
 	nestedCrossRefLimit    int64
 	bitmapFactory          *roaringset.BitmapFactory
+	bitmapContainerBufPool roaringset.ContainerBufPool
 	modules                *modules.Provider
 }
 
@@ -59,6 +60,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 	isFallbackToSearchable inverted.IsFallbackToSearchable,
 	tenant string, nestedCrossRefLimit int64,
 	bitmapFactory *roaringset.BitmapFactory,
+	bitmapContainerBufPool roaringset.ContainerBufPool,
 	modules *modules.Provider,
 ) *Aggregator {
 	return &Aggregator{
@@ -75,6 +77,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 		tenant:                 tenant,
 		nestedCrossRefLimit:    nestedCrossRefLimit,
 		bitmapFactory:          bitmapFactory,
+		bitmapContainerBufPool: bitmapContainerBufPool,
 		modules:                modules,
 	}
 }

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -75,6 +75,9 @@ func (fa *filteredAggregator) hybrid(ctx context.Context) (*aggregation.Result, 
 		if err != nil {
 			return nil, nil, err
 		}
+		if allowList != nil {
+			defer allowList.Close()
+		}
 
 		res, dists, err := fa.objectVectorSearch(ctx, vec, allowList)
 		if err != nil {
@@ -106,6 +109,9 @@ func (fa *filteredAggregator) filtered(ctx context.Context) (*aggregation.Result
 	allowList, err := fa.buildAllowList(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if allowList != nil {
+		defer allowList.Close()
 	}
 
 	if len(fa.params.SearchVector) > 0 {

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -90,6 +90,9 @@ func (g *grouper) fetchDocIDs(ctx context.Context) (ids []uint64, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if allowList != nil {
+		defer allowList.Close()
+	}
 
 	if len(g.params.SearchVector) > 0 {
 		ids, _, err = g.vectorSearch(ctx, allowList, g.params.SearchVector)

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -91,7 +91,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 	if a.params.Filters != nil {
 		allow, err = inverted.NewSearcher(a.logger, a.store, a.getSchema.ReadOnlyClass, nil,
 			a.classSearcher, a.stopwords, a.shardVersion, a.isFallbackToSearchable,
-			a.tenant, a.nestedCrossRefLimit, a.bitmapFactory).
+			a.tenant, a.nestedCrossRefLimit, a.bitmapFactory, a.bitmapContainerBufPool).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},
 				a.params.ClassName)
 		if err != nil {

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -260,16 +261,17 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 			QueryMaximumResults: maxResults,
 			ReplicationFactor:   NewAtomicInt64(1),
 		},
-		partitioningEnabled:   shardState.PartitioningEnabled,
-		invertedIndexConfig:   iic,
-		vectorIndexUserConfig: vic,
-		logger:                logger,
-		getSchema:             schemaGetter,
-		centralJobQueue:       repo.jobQueueCh,
-		stopwords:             sd,
-		indexCheckpoints:      checkpts,
-		allocChecker:          memwatch.NewDummyMonitor(),
-		shardCreateLocks:      esync.NewKeyLocker(),
+		partitioningEnabled:    shardState.PartitioningEnabled,
+		invertedIndexConfig:    iic,
+		vectorIndexUserConfig:  vic,
+		logger:                 logger,
+		getSchema:              schemaGetter,
+		centralJobQueue:        repo.jobQueueCh,
+		stopwords:              sd,
+		indexCheckpoints:       checkpts,
+		allocChecker:           memwatch.NewDummyMonitor(),
+		shardCreateLocks:       esync.NewKeyLocker(),
+		bitmapContainerBufPool: roaringset.NewContainerBufPoolNoop(),
 	}
 	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
 	idx.initCycleCallbacksNoop()

--- a/adapters/repos/db/helpers/wrapped_allow_list.go
+++ b/adapters/repos/db/helpers/wrapped_allow_list.go
@@ -22,6 +22,10 @@ func newWrappedAllowList(al AllowList) AllowList {
 	}
 }
 
+func (al *wrappedAllowList) Close() {
+	al.wAllowList.Close()
+}
+
 func (al *wrappedAllowList) Insert(ids ...uint64) {
 	fids := make([]uint64, 0, len(ids))
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 
 	"github.com/pkg/errors"
 
@@ -210,6 +211,8 @@ type Index struct {
 
 	asyncReplicationLock sync.RWMutex
 
+	bitmapContainerBufPool roaringset.ContainerBufPool
+
 	closeLock sync.RWMutex
 	closed    bool
 }
@@ -271,6 +274,7 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 		indexCheckpoints:       indexCheckpoints,
 		allocChecker:           allocChecker,
 		shardCreateLocks:       esync.NewKeyLocker(),
+		bitmapContainerBufPool: roaringset.NewContainerBufPool(),
 	}
 	index.closingCtx, index.closingCancel = context.WithCancel(context.Background())
 

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -84,10 +84,11 @@ func Test_Filters_String(t *testing.T) {
 	})
 
 	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200))
+	containerBufPool := roaringset.NewContainerBufPoolNoop()
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory, containerBufPool)
 
 	type test struct {
 		name                     string
@@ -342,9 +343,11 @@ func Test_Filters_Int(t *testing.T) {
 	}
 
 	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(maxDocID))
+	containerBufPool := roaringset.NewContainerBufPoolNoop()
+
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory, containerBufPool)
 
 	type test struct {
 		name                     string
@@ -583,8 +586,9 @@ func Test_Filters_Int(t *testing.T) {
 	t.Run("strategy roaringset", func(t *testing.T) {
 		propName := "inverted-without-frequency-roaringset"
 		bucketName := helpers.BucketFromPropNameLSM(propName)
-		require.NoError(t, store.CreateOrLoadBucket(context.Background(),
-			bucketName, lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+		require.NoError(t, store.CreateOrLoadBucket(context.Background(), bucketName,
+			lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+			lsmkv.WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop())))
 		bucket := store.Bucket(bucketName)
 
 		t.Run("import data", func(t *testing.T) {
@@ -807,8 +811,9 @@ func Test_Filters_Int(t *testing.T) {
 	t.Run("strategy roaringsetrange", func(t *testing.T) {
 		propName := "inverted-without-frequency-roaringsetrange"
 		bucketName := helpers.BucketRangeableFromPropNameLSM(propName)
-		require.NoError(t, store.CreateOrLoadBucket(context.Background(),
-			bucketName, lsmkv.WithStrategy(lsmkv.StrategyRoaringSetRange)))
+		require.NoError(t, store.CreateOrLoadBucket(context.Background(), bucketName,
+			lsmkv.WithStrategy(lsmkv.StrategyRoaringSetRange),
+			lsmkv.WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop())))
 		bucket := store.Bucket(bucketName)
 
 		t.Run("import data", func(t *testing.T) {
@@ -1064,10 +1069,11 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 	})
 
 	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200))
+	containerBufPool := roaringset.NewContainerBufPoolNoop()
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory, containerBufPool)
 
 	type test struct {
 		name                     string

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -83,7 +83,7 @@ func Test_Filters_String(t *testing.T) {
 		require.Nil(t, bWithFrequency.FlushAndSwitch())
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -268,6 +268,7 @@ func Test_Filters_String(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListBeforeUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("update", func(t *testing.T) {
@@ -290,6 +291,7 @@ func Test_Filters_String(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListAfterUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("restore inverted index, so test suite can be run again",
@@ -339,7 +341,7 @@ func Test_Filters_Int(t *testing.T) {
 		{val: 16, ids: []uint64{16}},
 	}
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(maxDocID), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(maxDocID))
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
 		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
@@ -552,6 +554,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListBeforeUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("update", func(t *testing.T) {
@@ -565,6 +568,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListAfterUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("restore inverted index, so we can run test suite again", func(t *testing.T) {
@@ -776,6 +780,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListBeforeUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("update", func(t *testing.T) {
@@ -788,6 +793,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListAfterUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("restore inverted index, so we can run test suite again", func(t *testing.T) {
@@ -997,6 +1003,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListBeforeUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("update", func(t *testing.T) {
@@ -1009,6 +1016,7 @@ func Test_Filters_Int(t *testing.T) {
 						additional.Properties{}, className)
 					assert.NoError(t, err)
 					assert.Equal(t, test.expectedListAfterUpdate, res.Slice())
+					res.Close()
 				})
 
 				t.Run("restore inverted index, so we can run test suite again", func(t *testing.T) {
@@ -1055,7 +1063,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 		require.Nil(t, bWithFrequency.FlushAndSwitch())
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(200))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -1112,6 +1120,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListBeforeUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("update", func(t *testing.T) {
@@ -1133,6 +1142,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 					additional.Properties{}, className)
 				assert.Nil(t, err)
 				assert.Equal(t, test.expectedListAfterUpdate.Slice(), res.Slice())
+				res.Close()
 			})
 
 			t.Run("restore inverted index, so we can run test suite again",
@@ -1222,8 +1232,8 @@ func newFakeMaxIDGetter(maxID uint64) func() uint64 {
 }
 
 func notEqualsExpectedResults(maxID uint64, skip uint64) []uint64 {
-	allow := make([]uint64, 0, maxID)
-	for i := uint64(0); i < maxID; i++ {
+	allow := make([]uint64, 0, maxID+1)
+	for i := uint64(0); i <= maxID; i++ {
 		if i != skip {
 			allow = append(allow, i)
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -14,14 +14,15 @@ package inverted
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/sroar"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -55,7 +56,6 @@ func newPropValuePair(class *models.Class, logger logrus.FieldLogger) (*propValu
 
 func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) error {
 	if pv.operator.OnValue() {
-
 		// TODO text_rbm_inverted_index find better way check whether prop len
 		if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
 			!pv.Class.InvertedIndexConfig.IndexPropertyLength {
@@ -125,35 +125,51 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 		return &pv.docIDs, nil
 	}
 
-	if pv.operator != filters.OperatorAnd && pv.operator != filters.OperatorOr {
+	switch pv.operator {
+	case filters.OperatorAnd:
+	case filters.OperatorOr:
+		// ok
+	default:
 		return nil, fmt.Errorf("unsupported operator: %s", pv.operator.Name())
 	}
-	if len(pv.children) == 0 {
+
+	switch len(pv.children) {
+	case 0:
 		return nil, fmt.Errorf("no children for operator: %s", pv.operator.Name())
+	case 1:
+		return &pv.children[0].docIDs, nil
 	}
 
+	var err error
 	dbms := make([]*docBitmap, len(pv.children))
 	for i, child := range pv.children {
-		dbm, err := child.mergeDocIDs()
+		dbms[i], err = child.mergeDocIDs()
 		if err != nil {
 			return nil, errors.Wrapf(err, "retrieve doc bitmap of child %d", i)
 		}
-		dbms[i] = dbm
 	}
 
-	mergeRes := dbms[0].docIDs.Clone()
-	mergeFn := mergeRes.And
+	var mergeFn func(*sroar.Bitmap) *sroar.Bitmap
 	if pv.operator == filters.OperatorOr {
-		mergeFn = mergeRes.Or
+		// biggest to smallest, so smaller bitmaps are merged into biggest one,
+		// minimising chance of expanding destination bitmap (memory allocations)
+		sort.Slice(dbms, func(i, j int) bool {
+			return dbms[i].docIDs.CompareNumKeys(dbms[j].docIDs) > 0
+		})
+		mergeFn = dbms[0].docIDs.Or
+	} else {
+		// smallest to biggest, so data is removed from smallest bitmap
+		// allowing bigger bitmaps to be garbage collected asap
+		sort.Slice(dbms, func(i, j int) bool {
+			return dbms[i].docIDs.CompareNumKeys(dbms[j].docIDs) < 0
+		})
+		mergeFn = dbms[0].docIDs.And
 	}
 
 	for i := 1; i < len(dbms); i++ {
 		mergeFn(dbms[i].docIDs)
 	}
-
-	return &docBitmap{
-		docIDs: roaringset.Condense(mergeRes),
-	}, nil
+	return dbms[0], nil
 }
 
 func (pv *propValuePair) getBucketName() string {

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -168,6 +168,7 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 
 	for i := 1; i < len(dbms); i++ {
 		mergeFn(dbms[i].docIDs)
+		dbms[i].release()
 	}
 	return dbms[0], nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -83,6 +83,7 @@ func TestPropValuePairs_Merging(t *testing.T) {
 			},
 		}
 
+		buf := make(roaringset.ContainerBuf, 4100)
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				pv := &propValuePair{
@@ -99,7 +100,7 @@ func TestPropValuePairs_Merging(t *testing.T) {
 					}
 				}
 
-				dbm, err := pv.mergeDocIDs()
+				dbm, err := pv.mergeDocIDs(buf)
 
 				require.Nil(t, err)
 				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -93,7 +93,8 @@ func TestPropValuePairs_Merging(t *testing.T) {
 					pv.children[i] = &propValuePair{
 						operator: filters.OperatorEqual,
 						docIDs: docBitmap{
-							docIDs: tc.bitmaps[i],
+							docIDs:  tc.bitmaps[i],
+							release: noopRelease,
 						},
 					}
 				}

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestPropValuePairs_Merging(t *testing.T) {
-	t.Run("always creates new underlying bitmap", func(t *testing.T) {
+	t.Run("reuses one of underlying bitmaps", func(t *testing.T) {
 		type testCase struct {
 			name string
 
@@ -102,9 +102,14 @@ func TestPropValuePairs_Merging(t *testing.T) {
 
 				require.Nil(t, err)
 				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())
-				assert.False(t, tc.bitmaps[0] == dbm.docIDs)
-				assert.False(t, tc.bitmaps[1] == dbm.docIDs)
-				assert.False(t, tc.bitmaps[2] == dbm.docIDs)
+
+				sameCounter := 0
+				for _, bm := range tc.bitmaps {
+					if bm == dbm.docIDs {
+						sameCounter++
+					}
+				}
+				assert.Equal(t, 1, sameCounter)
 			})
 		}
 	})

--- a/adapters/repos/db/inverted/row_reader.go
+++ b/adapters/repos/db/inverted/row_reader.go
@@ -81,7 +81,7 @@ func (rr *RowReader) equal(ctx context.Context, readFn ReadFn) error {
 		return err
 	}
 
-	_, err = readFn(rr.value, rr.transformToBitmap(v))
+	_, err = readFn(rr.value, rr.transformToBitmap(v), noopRelease)
 	return err
 }
 
@@ -92,9 +92,9 @@ func (rr *RowReader) notEqual(ctx context.Context, readFn ReadFn) error {
 	}
 
 	// Invert the Equal results for an efficient NotEqual
-	inverted := rr.bitmapFactory.GetBitmap()
+	inverted, release := rr.bitmapFactory.GetBitmap()
 	inverted.AndNot(rr.transformToBitmap(v))
-	_, err = readFn(rr.value, inverted)
+	_, err = readFn(rr.value, inverted, release)
 	return err
 }
 
@@ -115,7 +115,7 @@ func (rr *RowReader) greaterThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (rr *RowReader) lessThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func (rr *RowReader) like(ctx context.Context, readFn ReadFn) error {
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/inverted/row_reader_frequency.go
+++ b/adapters/repos/db/inverted/row_reader_frequency.go
@@ -76,7 +76,7 @@ func (rr *RowReaderFrequency) equal(ctx context.Context, readFn ReadFn) error {
 		return err
 	}
 
-	_, err = readFn(rr.value, rr.transformToBitmap(v))
+	_, err = readFn(rr.value, rr.transformToBitmap(v), noopRelease)
 	return err
 }
 
@@ -87,9 +87,9 @@ func (rr *RowReaderFrequency) notEqual(ctx context.Context, readFn ReadFn) error
 	}
 
 	// Invert the Equal results for an efficient NotEqual
-	inverted := rr.bitmapFactory.GetBitmap()
+	inverted, release := rr.bitmapFactory.GetBitmap()
 	inverted.AndNot(rr.transformToBitmap(v))
-	_, err = readFn(rr.value, inverted)
+	_, err = readFn(rr.value, inverted, release)
 	return err
 }
 
@@ -110,7 +110,7 @@ func (rr *RowReaderFrequency) greaterThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (rr *RowReaderFrequency) lessThan(ctx context.Context, readFn ReadFn,
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}
@@ -198,7 +198,7 @@ func (rr *RowReaderFrequency) like(ctx context.Context, readFn ReadFn) error {
 			continue
 		}
 
-		continueReading, err := readFn(k, rr.transformToBitmap(v))
+		continueReading, err := readFn(k, rr.transformToBitmap(v), noopRelease)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -30,13 +30,14 @@ type RowReaderRoaringSet struct {
 	newCursor     func() lsmkv.CursorRoaringSet
 	getter        func(key []byte) (*sroar.Bitmap, error)
 	bitmapFactory *roaringset.BitmapFactory
+	buf           roaringset.ContainerBuf
 }
 
 // If keyOnly is set, the RowReaderRoaringSet will request key-only cursors
 // wherever cursors are used, the specified value arguments in the
 // ReadFn will always be empty
 func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte, operator filters.Operator,
-	keyOnly bool, bitmapFactory *roaringset.BitmapFactory,
+	keyOnly bool, bitmapFactory *roaringset.BitmapFactory, buf roaringset.ContainerBuf,
 ) *RowReaderRoaringSet {
 	getter := bucket.RoaringSetGet
 	newCursor := bucket.CursorRoaringSet
@@ -50,6 +51,7 @@ func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte, operator filters
 		newCursor:     newCursor,
 		getter:        getter,
 		bitmapFactory: bitmapFactory,
+		buf:           buf,
 	}
 }
 
@@ -115,7 +117,7 @@ func (rr *RowReaderRoaringSet) notEqual(ctx context.Context,
 	}
 
 	inverted, release := rr.bitmapFactory.GetBitmap()
-	inverted.AndNot(v)
+	inverted.AndNotBuf(v, rr.buf)
 	_, err = readFn(rr.value, inverted, release)
 	return err
 }

--- a/adapters/repos/db/inverted/row_reader_roaring_set_test.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set_test.go
@@ -297,5 +297,6 @@ func createRowReaderRoaringSet(value []byte, operator filters.Operator, data []k
 			return nil, entlsmkv.NotFound
 		},
 		bitmapFactory: roaringset.NewBitmapFactory(func() uint64 { return maxDocID }),
+		buf:           make(roaringset.ContainerBuf, roaringset.ContainerBufSize),
 	}
 }

--- a/adapters/repos/db/inverted/row_reader_roaring_set_test.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set_test.go
@@ -16,8 +16,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -61,10 +59,11 @@ func TestRowReaderRoaringSet(t *testing.T) {
 			operator: filters.OperatorNotEqual,
 			expected: []kvData{
 				{"ccc", func() []uint64 {
-					bm := sroar.NewBitmap()
-					bm.SetMany([]uint64{111, 222, 333})
-					return roaringset.NewInvertedBitmap(
-						bm, maxDocID+roaringset.DefaultBufferIncrement, logrus.New()).ToArray()
+					bm := sroar.Prefill(maxDocID)
+					for _, x := range []uint64{111, 222, 333} {
+						bm.Remove(x)
+					}
+					return bm.ToArray()
 				}()},
 			},
 		},
@@ -186,13 +185,14 @@ func TestRowReaderRoaringSet(t *testing.T) {
 		type readResult struct {
 			k []byte
 			v *sroar.Bitmap
+			r func()
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
 			result := []readResult{}
 			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, data)
-			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap) (bool, error) {
-				result = append(result, readResult{k, v})
+			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
+				result = append(result, readResult{k, v, release})
 				return true, nil
 			})
 
@@ -203,6 +203,7 @@ func TestRowReaderRoaringSet(t *testing.T) {
 				for _, expectedV := range expectedKV.v {
 					assert.True(t, result[i].v.Contains(expectedV))
 				}
+				result[i].r()
 			}
 		})
 
@@ -215,8 +216,8 @@ func TestRowReaderRoaringSet(t *testing.T) {
 
 			result := []readResult{}
 			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, data)
-			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap) (bool, error) {
-				result = append(result, readResult{k, v})
+			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
+				result = append(result, readResult{k, v, release})
 				if len(result) >= limit {
 					return false, nil
 				}
@@ -230,6 +231,7 @@ func TestRowReaderRoaringSet(t *testing.T) {
 				for _, expectedV := range expectedKV.v {
 					assert.True(t, result[i].v.Contains(expectedV))
 				}
+				result[i].r()
 			}
 		})
 	}
@@ -294,7 +296,6 @@ func createRowReaderRoaringSet(value []byte, operator filters.Operator, data []k
 			}
 			return nil, entlsmkv.NotFound
 		},
-		bitmapFactory: roaringset.NewBitmapFactory(
-			func() uint64 { return maxDocID }, logrus.New()),
+		bitmapFactory: roaringset.NewBitmapFactory(func() uint64 { return maxDocID }),
 	}
 }

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -23,6 +23,8 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
+var noopRelease = func() {}
+
 func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
 	pv *propValuePair,
 ) (bm docBitmap, err error) {
@@ -72,12 +74,14 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
-	var readFn ReadFn = func(k []byte, docIDs *sroar.Bitmap) (bool, error) {
+	var readFn ReadFn = func(k []byte, docIDs *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = docIDs
+			out.release = release
 			isEmpty = false
 		} else {
 			out.docIDs.Or(docIDs)
+			release()
 		}
 
 		// NotEqual requires the full set of potentially existing doc ids
@@ -119,6 +123,7 @@ func (s *Searcher) docBitmapInvertedRoaringSetRange(ctx context.Context, b *lsmk
 
 	out := newUninitializedDocBitmap()
 	out.docIDs = docIds
+	out.release = noopRelease
 	return out, nil
 }
 
@@ -127,12 +132,14 @@ func (s *Searcher) docBitmapInvertedSet(ctx context.Context, b *lsmkv.Bucket,
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
-	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap) (bool, error) {
+	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = ids
+			out.release = release
 			isEmpty = false
 		} else {
 			out.docIDs.Or(ids)
+			release()
 		}
 
 		// NotEqual requires the full set of potentially existing doc ids
@@ -162,12 +169,14 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
-	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap) (bool, error) {
+	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = ids
+			out.release = release
 			isEmpty = false
 		} else {
 			out.docIDs.Or(ids)
+			release()
 		}
 
 		// NotEqual requires the full set of potentially existing doc ids

--- a/adapters/repos/db/inverted/searcher_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_integration_test.go
@@ -99,10 +99,11 @@ func TestObjects(t *testing.T) {
 	})
 
 	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter))
+	containerBufPool := roaringset.NewContainerBufPoolNoop()
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory, containerBufPool)
 
 	t.Run("run tests", func(t *testing.T) {
 		t.Run("NotEqual", func(t *testing.T) {
@@ -198,10 +199,11 @@ func TestDocIDs(t *testing.T) {
 	})
 
 	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter - 1))
+	containerBufPool := roaringset.NewContainerBufPoolNoop()
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory, containerBufPool)
 
 	type testCase struct {
 		expectedMatches int

--- a/adapters/repos/db/inverted/searcher_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_integration_test.go
@@ -98,7 +98,7 @@ func TestObjects(t *testing.T) {
 		}
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -197,7 +197,7 @@ func TestDocIDs(t *testing.T) {
 		}
 	})
 
-	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter), logger)
+	bitmapFactory := roaringset.NewBitmapFactory(newFakeMaxIDGetter(docIDCounter - 1))
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		fakeStopwordDetector{}, 2, func() bool { return false }, "",
@@ -238,7 +238,7 @@ func TestDocIDs(t *testing.T) {
 					},
 				},
 			},
-			expectedMatches: len(charSet)*multiplier - 1,
+			expectedMatches: (len(charSet) - 1) * multiplier,
 		},
 	}
 
@@ -246,6 +246,7 @@ func TestDocIDs(t *testing.T) {
 		allow, err := searcher.DocIDs(context.Background(), &tc.filter, additional.Properties{}, className)
 		require.Nil(t, err)
 		assert.Equal(t, tc.expectedMatches, allow.Len())
+		allow.Close()
 	}
 }
 

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -233,7 +233,9 @@ func (r *ShardInvertedReindexer) createTempBucket(ctx context.Context, name stri
 	strategy string, options ...lsmkv.BucketOption,
 ) error {
 	tempName := helpers.TempBucketFromBucketName(name)
-	bucketOptions := append(options, lsmkv.WithStrategy(strategy))
+	bucketOptions := append(options,
+		lsmkv.WithStrategy(strategy),
+		lsmkv.WithBitmapContainerBufPool(r.shard.Index().bitmapContainerBufPool))
 
 	if err := r.shard.Store().CreateBucket(ctx, tempName, bucketOptions...); err != nil {
 		return errors.Wrapf(err, "failed creating temp bucket '%s'", tempName)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/interval"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -133,6 +134,7 @@ type Bucket struct {
 	// introduces latency of segment availability, for the tradeoff of
 	// ensuring segment files have integrity before reading them.
 	disableChecksumValidation bool
+	bitmapContainerBufPool    roaringset.ContainerBufPool
 }
 
 func NewBucketCreator() *Bucket { return &Bucket{} }
@@ -196,7 +198,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 			maxSegmentSize:            b.maxSegmentSize,
 			cleanupInterval:           b.segmentsCleanupInterval,
 			disableChecksumValidation: b.disableChecksumValidation,
-		}, b.allocChecker)
+		}, b.allocChecker, b.bitmapContainerBufPool)
 	if err != nil {
 		return nil, fmt.Errorf("init disk segments: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -182,6 +183,13 @@ Configurability of buckets
 func WithForceCompation(opt bool) BucketOption {
 	return func(b *Bucket) error {
 		b.forceCompaction = opt
+		return nil
+	}
+}
+
+func WithBitmapContainerBufPool(pool roaringset.ContainerBufPool) BucketOption {
+	return func(b *Bucket) error {
+		b.bitmapContainerBufPool = pool
 		return nil
 	}
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -95,5 +95,8 @@ func (b *Bucket) RoaringSetGet(key []byte) (*sroar.Bitmap, error) {
 		layers = append(layers, active)
 	}
 
-	return layers.Flatten(false), nil
+	buf, put := b.bitmapContainerBufPool.Get()
+	defer put()
+
+	return layers.Flatten(false, buf), nil
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -61,8 +61,10 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 		readers = append(readers, b.flushing.newRoaringSetRangeReader())
 	}
 	readers = append(readers, b.active.newRoaringSetRangeReader())
+	buf, put := b.bitmapContainerBufPool.Get()
 
-	return roaringsetrange.NewCombinedReader(readers, func() {
+	return roaringsetrange.NewCombinedReader(readers, buf, func() {
+		put()
 		releaseSegmentGroup()
 		b.flushLock.RUnlock()
 	}, concurrency.NUMCPU_2, b.logger)

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
 func testCtx() context.Context {
@@ -260,6 +261,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_Random,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -267,6 +269,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_Random,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -277,6 +280,7 @@ func TestCompaction(t *testing.T) {
 			},
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -286,6 +290,7 @@ func TestCompaction(t *testing.T) {
 			},
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -294,6 +299,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_RemoveUnnecessary,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -301,6 +307,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_RemoveUnnecessary,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -309,6 +316,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_FrequentPutDeleteOperations,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -316,6 +324,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetStrategy_FrequentPutDeleteOperations,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -326,6 +335,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_Random,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -333,6 +343,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_Random,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -343,6 +354,7 @@ func TestCompaction(t *testing.T) {
 			},
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -352,6 +364,7 @@ func TestCompaction(t *testing.T) {
 			},
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -360,6 +373,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_RemoveUnnecessary,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -367,6 +381,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_RemoveUnnecessary,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -375,6 +390,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 		{
@@ -382,6 +398,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 				WithKeepTombstones(true),
 			},
 		},
@@ -390,6 +407,7 @@ func TestCompaction(t *testing.T) {
 			f:    compactionRoaringSetRangeStrategy_BugfixOverwrittenBuffer,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 	}

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 )
@@ -237,6 +238,7 @@ func TestConcurrentWriting_RoaringSet(t *testing.T) {
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 		cyclemanager.NewCallbackGroupNoop(), flushGroup,
 		WithStrategy(StrategyRoaringSet),
+		WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 		WithMemtableThreshold(1000))
 	require.Nil(t, err)
 
@@ -321,6 +323,7 @@ func TestConcurrentWriting_RoaringSetRange(t *testing.T) {
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 		cyclemanager.NewCallbackGroupNoop(), flushGroup,
 		WithStrategy(StrategyRoaringSetRange),
+		WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 		WithMemtableThreshold(1000),
 		WithUseBloomFilter(false))
 	require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -67,11 +67,14 @@ func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 	}
 	innerCursors = append(innerCursors, b.active.newRoaringSetCursor())
 
+	buf, put := b.bitmapContainerBufPool.Get()
+
 	// cursors are in order from oldest to newest, with the memtable cursor
 	// being at the very top
 	return &cursorRoaringSet{
-		combinedCursor: roaringset.NewCombinedCursor(innerCursors, keyOnly),
+		combinedCursor: roaringset.NewCombinedCursor(innerCursors, keyOnly, buf),
 		unlock: func() {
+			put()
 			unlockSegmentGroup()
 			b.flushLock.RUnlock()
 		},

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -118,6 +118,7 @@ func (m *Memtable) roaringSetAddRemoveSlices(key []byte, additions []uint64, del
 	return nil
 }
 
+// returned bitmaps are cloned and safe to mutate
 func (m *Memtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
 	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return roaringset.BitmapLayer{}, err

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 )
@@ -483,7 +484,8 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-			WithStrategy(StrategyRoaringSet))
+			WithStrategy(StrategyRoaringSet),
+			WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()))
 		require.Nil(t, err)
 
 		key1 := []byte("test1-key-1")
@@ -583,7 +585,8 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(StrategyRoaringSet))
+				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()))
 			require.Nil(t, err)
 
 			bRec = b
@@ -623,7 +626,8 @@ func TestRoaringSetRangeStrategy_RecoverFromWAL(t *testing.T) {
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-			WithStrategy(StrategyRoaringSetRange))
+			WithStrategy(StrategyRoaringSetRange),
+			WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()))
 		require.Nil(t, err)
 
 		key1 := uint64(1)
@@ -729,7 +733,8 @@ func TestRoaringSetRangeStrategy_RecoverFromWAL(t *testing.T) {
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(StrategyRoaringSetRange))
+				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()))
 			require.Nil(t, err)
 
 			bRec = b

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -70,8 +70,9 @@ type SegmentGroup struct {
 	compactLeftOverSegments   bool // see bucket for more details
 	disableChecksumValidation bool
 
-	allocChecker   memwatch.AllocChecker
-	maxSegmentSize int64
+	allocChecker           memwatch.AllocChecker
+	maxSegmentSize         int64
+	bitmapContainerBufPool roaringset.ContainerBufPool
 
 	segmentCleaner     segmentCleaner
 	cleanupInterval    time.Duration
@@ -96,7 +97,7 @@ type sgConfig struct {
 
 func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 	compactionCallbacks cyclemanager.CycleCallbackGroup, cfg sgConfig,
-	allocChecker memwatch.AllocChecker,
+	allocChecker memwatch.AllocChecker, bitmapContainerBufPool roaringset.ContainerBufPool,
 ) (*SegmentGroup, error) {
 	list, err := os.ReadDir(cfg.dir)
 	if err != nil {
@@ -123,6 +124,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 		allocChecker:              allocChecker,
 		lastCompactionCall:        now,
 		lastCleanupCall:           now,
+		bitmapContainerBufPool:    bitmapContainerBufPool,
 	}
 
 	segmentIndex := 0

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -564,7 +564,7 @@ func (sg *SegmentGroup) roaringSetGet(key []byte) (roaringset.BitmapLayers, erro
 
 	// start with first and do not exit
 	for _, segment := range sg.segments {
-		rs, err := segment.roaringSetGet(key)
+		layer, err := segment.roaringSetGet(key)
 		if err != nil {
 			if errors.Is(err, lsmkv.NotFound) {
 				continue
@@ -573,7 +573,7 @@ func (sg *SegmentGroup) roaringSetGet(key []byte) (roaringset.BitmapLayers, erro
 			return nil, err
 		}
 
-		out = append(out, rs)
+		out = append(out, layer)
 	}
 
 	return out, nil

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -281,8 +281,11 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 		leftCursor := leftSegment.newRoaringSetCursor()
 		rightCursor := rightSegment.newRoaringSetCursor()
 
+		buf, put := sg.bitmapContainerBufPool.Get()
+		defer put()
+
 		c := roaringset.NewCompactor(f, leftCursor, rightCursor,
-			level, scratchSpacePath, cleanupTombstones)
+			level, scratchSpacePath, cleanupTombstones, buf)
 
 		if sg.metrics != nil {
 			sg.metrics.CompactionRoaringSet.With(prometheus.Labels{"path": pathLabel}).Set(1)
@@ -297,8 +300,11 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 		leftCursor := leftSegment.newRoaringSetRangeCursor()
 		rightCursor := rightSegment.newRoaringSetRangeCursor()
 
+		buf, put := sg.bitmapContainerBufPool.Get()
+		defer put()
+
 		c := roaringsetrange.NewCompactor(f, leftCursor, rightCursor,
-			level, cleanupTombstones)
+			level, cleanupTombstones, buf)
 
 		if sg.metrics != nil {
 			sg.metrics.CompactionRoaringSetRange.With(prometheus.Labels{"path": pathLabel}).Set(1)

--- a/adapters/repos/db/lsmkv/strategies_roaringset_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaringset_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
@@ -31,6 +32,7 @@ func TestRoaringSetStrategy(t *testing.T) {
 			f:    roaringsetInsertAndSetAdd,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSet),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 	}

--- a/adapters/repos/db/lsmkv/strategies_roaringsetrange_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaringsetrange_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 )
@@ -32,6 +33,7 @@ func TestRoaringSetRangeStrategy(t *testing.T) {
 			f:    roaringsetrangeInsertAndSetAdd,
 			opts: []BucketOption{
 				WithStrategy(StrategyRoaringSetRange),
+				WithBitmapContainerBufPool(roaringset.NewContainerBufPoolNoop()),
 			},
 		},
 	}

--- a/adapters/repos/db/roaringset/binary_search_tree.go
+++ b/adapters/repos/db/roaringset/binary_search_tree.go
@@ -257,6 +257,9 @@ func (n *BinarySearchNode) flattenInOrder() []*BinarySearchNode {
 	key := make([]byte, len(n.Key))
 	copy(key, n.Key)
 
+	// Node's Value has to be copied, not to be mutated when BST is updated.
+	// Since memtable flush needs condensing, Condense here serves as cloning here
+	// instead of separate clone + optional condense calls
 	right = append([]*BinarySearchNode{{
 		Key: key,
 		Value: BitmapLayer{

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -289,10 +289,10 @@ func (c *nodeCompactor) takeRightKey() error {
 func (c *nodeCompactor) cleanupValues(additions, deletions *sroar.Bitmap,
 ) (add, del *sroar.Bitmap, skip bool) {
 	if !c.cleanupDeletions {
-		return additions, deletions, false
+		return Condense(additions), Condense(deletions), false
 	}
 	if !additions.IsEmpty() {
-		return additions, c.emptyBitmap, false
+		return Condense(additions), c.emptyBitmap, false
 	}
 	return nil, nil, true
 }

--- a/adapters/repos/db/roaringset/compactor_test.go
+++ b/adapters/repos/db/roaringset/compactor_test.go
@@ -402,6 +402,7 @@ func Test_Compactor(t *testing.T) {
 		},
 	}
 
+	buf := make(ContainerBuf, ContainerBufSize)
 	for _, test := range tests {
 		t.Run("[keep]"+test.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -413,7 +414,7 @@ func Test_Compactor(t *testing.T) {
 			f, err := os.Create(segmentFile)
 			require.NoError(t, err)
 
-			c := NewCompactor(f, leftCursor, rightCursor, 5, dir+"/scratch", false)
+			c := NewCompactor(f, leftCursor, rightCursor, 5, dir+"/scratch", false, buf)
 			require.NoError(t, c.Do())
 
 			require.NoError(t, f.Close())
@@ -454,7 +455,7 @@ func Test_Compactor(t *testing.T) {
 			f, err := os.Create(segmentFile)
 			require.NoError(t, err)
 
-			c := NewCompactor(f, leftCursor, rightCursor, 5, dir+"/scratch", true)
+			c := NewCompactor(f, leftCursor, rightCursor, 5, dir+"/scratch", true, buf)
 			require.NoError(t, c.Do())
 
 			require.NoError(t, f.Close())

--- a/adapters/repos/db/roaringset/cursor.go
+++ b/adapters/repos/db/roaringset/cursor.go
@@ -24,6 +24,7 @@ type CombinedCursor struct {
 	cursors []InnerCursor
 	states  []innerCursorState
 	keyOnly bool
+	buf     ContainerBuf
 }
 
 type InnerCursor interface {
@@ -41,8 +42,8 @@ type innerCursorState struct {
 // When keyOnly flag is set, only keys are returned by First/Next/Seek access methods,
 // 2nd value returned is expected to be nil
 // When keyOnly is not set, 2nd value is always bitmap. Returned bitmap can be empty (e.g. for Next call after last element was already returned)
-func NewCombinedCursor(innerCursors []InnerCursor, keyOnly bool) *CombinedCursor {
-	return &CombinedCursor{cursors: innerCursors, keyOnly: keyOnly}
+func NewCombinedCursor(innerCursors []InnerCursor, keyOnly bool, buf ContainerBuf) *CombinedCursor {
+	return &CombinedCursor{cursors: innerCursors, keyOnly: keyOnly, buf: buf}
 }
 
 func (c *CombinedCursor) First() ([]byte, *sroar.Bitmap) {
@@ -110,7 +111,7 @@ func (c *CombinedCursor) getResultFromStates(states []innerCursorState) ([]byte,
 		return nil, nil
 	}
 
-	bm := layers.Flatten(true)
+	bm := layers.Flatten(true, c.buf)
 	if key == nil {
 		return nil, bm
 	}

--- a/adapters/repos/db/roaringset/cursor.go
+++ b/adapters/repos/db/roaringset/cursor.go
@@ -110,7 +110,7 @@ func (c *CombinedCursor) getResultFromStates(states []innerCursorState) ([]byte,
 		return nil, nil
 	}
 
-	bm := layers.Flatten()
+	bm := layers.Flatten(true)
 	if key == nil {
 		return nil, bm
 	}

--- a/adapters/repos/db/roaringset/cursor_test.go
+++ b/adapters/repos/db/roaringset/cursor_test.go
@@ -398,7 +398,7 @@ func createCursor(t *testing.T, bsts ...*BinarySearchTree) *CombinedCursor {
 	for _, bst := range bsts {
 		innerCursors = append(innerCursors, NewBinarySearchTreeCursor(bst))
 	}
-	return NewCombinedCursor(innerCursors, false)
+	return NewCombinedCursor(innerCursors, false, make(ContainerBuf, ContainerBufSize))
 }
 
 func createCursorKeyOnly(t *testing.T, bsts ...*BinarySearchTree) *CombinedCursor {

--- a/adapters/repos/db/roaringset/helpers.go
+++ b/adapters/repos/db/roaringset/helpers.go
@@ -14,16 +14,7 @@ package roaringset
 import (
 	"sync"
 
-	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/entities/concurrency"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-
 	"github.com/weaviate/sroar"
-)
-
-var (
-	prefillBufferSize  = 65_536
-	prefillMaxRoutines = 4
 )
 
 func NewBitmap(values ...uint64) *sroar.Bitmap {
@@ -53,160 +44,133 @@ func Condense(bm *sroar.Bitmap) *sroar.Bitmap {
 	return condensed
 }
 
-// NewInvertedBitmap creates a bitmap that as all IDs filled from 0 to maxVal.
-// Then the source bitmap is subtracted (AndNot) from the all-ids bitmap,
-// resulting in a bitmap containing all ids from 0 to maxVal except the ones
-// that were set on the source.
-func NewInvertedBitmap(source *sroar.Bitmap, maxVal uint64, logger logrus.FieldLogger) *sroar.Bitmap {
-	bm := NewBitmapPrefill(maxVal, logger)
-	bm.AndNot(source)
-	return bm
-}
+// defaultIdIncrement  is the amount of bits greater than <maxId>
+// to reduce the amount of times BitmapFactory has to reallocate.
+const defaultIdIncrement = uint64(1024)
 
-// Creates prefilled bitmap with values from 0 to maxVal (included).
-//
-// It is designed to be more performant both
-// time-wise (compared to Set/SetMany)
-// and memory-wise (compared to FromSortedList accepting entire slice of elements)
-// Method creates multiple small bitmaps using FromSortedList (slice is reusable)
-// and ORs them together to get final bitmap.
-// For maxVal > prefillBufferSize (65_536) and multiple CPUs available task is performed
-// by up to prefillMaxRoutines (4) goroutines.
-func NewBitmapPrefill(maxVal uint64, logger logrus.FieldLogger) *sroar.Bitmap {
-	routinesLimit := concurrency.NoMoreThanNUMCPU(prefillMaxRoutines)
-	if routinesLimit == 1 || maxVal <= uint64(prefillBufferSize) {
-		return newBitmapPrefillSequential(maxVal)
-	}
-	return newBitmapPrefillParallel(maxVal, routinesLimit, logger)
-}
+type MaxIdGetterFunc func() uint64
 
-func newBitmapPrefillSequential(maxVal uint64) *sroar.Bitmap {
-	inc := uint64(prefillBufferSize)
-	buf := make([]uint64, prefillBufferSize)
-	finalBM := sroar.NewBitmap()
-
-	for i := uint64(0); i <= maxVal; i += inc {
-		j := uint64(0)
-		for ; j < inc && i+j <= maxVal; j++ {
-			buf[j] = i + j
-		}
-		finalBM.Or(sroar.FromSortedList(buf[:j]))
-	}
-	return finalBM
-}
-
-func newBitmapPrefillParallel(maxVal uint64, routinesLimit int, logger logrus.FieldLogger) *sroar.Bitmap {
-	inc := uint64(prefillBufferSize / routinesLimit)
-	lock := new(sync.Mutex)
-	ch := make(chan uint64, routinesLimit)
-	wg := new(sync.WaitGroup)
-	wg.Add(routinesLimit)
-	finalBM := sroar.NewBitmap()
-
-	for r := 0; r < routinesLimit; r++ {
-		f := func() {
-			buf := make([]uint64, inc)
-
-			for i := range ch {
-				j := uint64(0)
-				for ; j < inc && i+j <= maxVal; j++ {
-					buf[j] = i + j
-				}
-				bm := sroar.FromSortedList(buf[:j])
-
-				lock.Lock()
-				finalBM.Or(bm)
-				lock.Unlock()
-			}
-			wg.Done()
-		}
-		enterrors.GoWrapper(f, logger)
-	}
-
-	for i := uint64(0); i <= maxVal; i += inc {
-		ch <- i
-	}
-	close(ch)
-	wg.Wait()
-	return finalBM
-}
-
-type MaxValGetterFunc func() uint64
-
-const (
-	// DefaultBufferIncrement  is the amount of bits greater than <maxVal>
-	// to reduce the amount of times BitmapFactory has to reallocate.
-	DefaultBufferIncrement = uint64(100)
-)
-
-// BitmapFactory exists to prevent an expensive call to
-// NewBitmapPrefill each time NewInvertedBitmap is invoked
+// BitmapFactory exists to provide prefilled bitmaps using pool (reducing allocation of memory)
+// and favor cloning (faster) over prefilling bitmap from scratch each time bitmap is requested
 type BitmapFactory struct {
-	bitmap        *sroar.Bitmap
-	maxValGetter  MaxValGetterFunc
-	currentMaxVal uint64
-	lock          sync.RWMutex
+	lock           *sync.RWMutex
+	prefilled      *sroar.Bitmap
+	bufPool        *BitmapBufPool
+	maxIdGetter    MaxIdGetterFunc
+	prefilledMaxId uint64
 }
 
-func NewBitmapFactory(maxValGetter MaxValGetterFunc, logger logrus.FieldLogger) *BitmapFactory {
-	maxVal := maxValGetter() + DefaultBufferIncrement
+func NewBitmapFactory(maxIdGetter MaxIdGetterFunc) *BitmapFactory {
+	prefilledMaxId := maxIdGetter() + defaultIdIncrement
+	prefilled := sroar.Prefill(prefilledMaxId)
+
 	return &BitmapFactory{
-		bitmap:        NewBitmapPrefill(maxVal, logger),
-		maxValGetter:  maxValGetter,
-		currentMaxVal: maxVal,
+		lock:           new(sync.RWMutex),
+		prefilled:      prefilled,
+		bufPool:        NewBitmapBufPool(prefilled.LenInBytes(), 1.2),
+		maxIdGetter:    maxIdGetter,
+		prefilledMaxId: prefilledMaxId,
 	}
 }
 
 // GetBitmap returns a prefilled bitmap, which is cloned from a shared internal.
 // This method is safe to call concurrently. The purpose behind sharing an
-// internal bitmap, is that a Clone() operation is much cheaper than prefilling
-// a map up to <maxDocID> elements is an expensive operation, and this way we
-// only have to do it once.
-func (bmf *BitmapFactory) GetBitmap() *sroar.Bitmap {
-	bmf.lock.RLock()
-	maxVal := bmf.maxValGetter()
+// internal bitmap, is that a Clone() operation is cheaper than prefilling
+// a bitmap up to <maxDocID>
+func (bmf *BitmapFactory) GetBitmap() (cloned *sroar.Bitmap, release func()) {
+	bitmap, release, removeRange := bmf.getBitmap()
+	bitmap.RemoveRange(removeRange[0], removeRange[1])
+	return bitmap, release
+}
 
-	// We don't need to expand, maxVal is unchanged
-	{
-		if maxVal <= bmf.currentMaxVal {
-			cloned := bmf.bitmap.Clone()
-			bmf.lock.RUnlock()
-			return cloned
-		}
+func (bmf *BitmapFactory) getBitmap() (cloned *sroar.Bitmap, release func(), removeRange [2]uint64) {
+	bmf.lock.RLock()
+
+	maxId := bmf.maxIdGetter()
+	prefilledMaxId := bmf.prefilledMaxId
+
+	// No need to expand, maxId is included
+	if maxId <= prefilledMaxId {
+		cloned, release = bmf.clone()
+		bmf.lock.RUnlock()
+		return cloned, release, [2]uint64{maxId + 1, prefilledMaxId + 1}
 	}
 
 	bmf.lock.RUnlock()
 	bmf.lock.Lock()
 	defer bmf.lock.Unlock()
 
+	maxId = bmf.maxIdGetter()
+	prefilledMaxId = bmf.prefilledMaxId
+
 	// 2nd check to ensure bitmap wasn't expanded by
 	// concurrent request white waiting for write lock
-	{
-		maxVal = bmf.maxValGetter()
-		if maxVal <= bmf.currentMaxVal {
-			return bmf.bitmap.Clone()
-		}
+	if maxId <= prefilledMaxId {
+		cloned, release = bmf.clone()
+		return cloned, release, [2]uint64{maxId + 1, prefilledMaxId + 1}
 	}
 
-	// maxVal has grown to exceed even the buffer,
-	// time to expand
-	{
-		length := maxVal + DefaultBufferIncrement - bmf.currentMaxVal
-		list := make([]uint64, length)
-		for i := uint64(0); i < length; i++ {
-			list[i] = bmf.currentMaxVal + i + 1
-		}
-
-		bmf.bitmap.Or(sroar.FromSortedList(list))
-		bmf.currentMaxVal = maxVal + DefaultBufferIncrement
-	}
-
-	return bmf.bitmap.Clone()
+	// expand bitmap with additional ids
+	prefilledMaxId = maxId + defaultIdIncrement
+	bmf.prefilled.FillUp(prefilledMaxId)
+	bmf.prefilledMaxId = prefilledMaxId
+	cloned, release = bmf.clone()
+	return cloned, release, [2]uint64{maxId + 1, prefilledMaxId + 1}
 }
 
-// ActualMaxVal returns the highest value in the bitmap not including the buffer
-func (bmf *BitmapFactory) ActualMaxVal() uint64 {
-	bmf.lock.RLock()
-	defer bmf.lock.RUnlock()
-	return bmf.maxValGetter()
+func (bmf *BitmapFactory) clone() (cloned *sroar.Bitmap, release func()) {
+	buf, release := bmf.bufPool.Get(bmf.prefilled.LenInBytes())
+	cloned = bmf.prefilled.CloneToBuf(buf)
+	return
+}
+
+type BitmapBufPool struct {
+	pool          *sync.Pool
+	lock          *sync.Mutex
+	capFactor     float32
+	initialMinCap int
+}
+
+func NewBitmapBufPool(initialMinCap int, capFactor float32) *BitmapBufPool {
+	p := &BitmapBufPool{
+		capFactor:     capFactor,
+		initialMinCap: initialMinCap,
+		lock:          new(sync.Mutex),
+	}
+
+	p.pool = &sync.Pool{
+		New: p.createBuf,
+	}
+	return p
+}
+
+func (p *BitmapBufPool) Get(minCap int) (buf []byte, put func()) {
+	ptr := p.pool.Get().(*[]byte)
+	buf = *ptr
+	if cap(buf) < minCap {
+		p.updateInitialMinCap(minCap)
+		ptr = p.createBuf().(*[]byte)
+		buf = *ptr
+	} else if len(buf) > 0 {
+		buf = buf[:0]
+		*ptr = buf
+	}
+	return buf, func() { p.pool.Put(ptr) }
+}
+
+func (p *BitmapBufPool) createBuf() any {
+	p.lock.Lock()
+	minCap := p.initialMinCap
+	p.lock.Unlock()
+
+	buf := make([]byte, 0, int(float32(minCap)*p.capFactor))
+	return &buf
+}
+
+func (p *BitmapBufPool) updateInitialMinCap(minCap int) {
+	p.lock.Lock()
+	if minCap > p.initialMinCap {
+		p.initialMinCap = minCap
+	}
+	p.lock.Unlock()
 }

--- a/adapters/repos/db/roaringset/helpers_test.go
+++ b/adapters/repos/db/roaringset/helpers_test.go
@@ -12,16 +12,11 @@
 package roaringset
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/weaviate/sroar"
+	"github.com/stretchr/testify/require"
 )
-
-var logger, _ = test.NewNullLogger()
 
 func TestBitmap_Condense(t *testing.T) {
 	t.Run("And with itself (internal array)", func(t *testing.T) {
@@ -135,136 +130,6 @@ func TestBitmap_Condense(t *testing.T) {
 	})
 }
 
-func TestBitmap_Prefill(t *testing.T) {
-	t.Run("sequential", func(t *testing.T) {
-		for _, maxVal := range []uint64{1_000, 10_000, 100_000, 1_000_000, uint64(prefillBufferSize)} {
-			t.Run(fmt.Sprint(maxVal), func(t *testing.T) {
-				bm := newBitmapPrefillSequential(maxVal)
-
-				// +1, due to 0 included
-				assert.Equal(t, int(maxVal)+1, bm.GetCardinality())
-
-				// remove all except maxVal
-				bm.RemoveRange(0, maxVal)
-
-				assert.Equal(t, 1, bm.GetCardinality())
-				assert.True(t, bm.Contains(maxVal))
-			})
-		}
-	})
-
-	t.Run("parallel", func(t *testing.T) {
-		for _, maxVal := range []uint64{1_000, 10_000, 100_000, 1_000_000, uint64(prefillBufferSize)} {
-			for _, routinesLimit := range []int{2, 3, 4, 5, 6, 7, 8} {
-				t.Run(fmt.Sprint(maxVal), func(t *testing.T) {
-					bm := newBitmapPrefillParallel(maxVal, routinesLimit, logger)
-
-					// +1, due to 0 included
-					assert.Equal(t, int(maxVal)+1, bm.GetCardinality())
-
-					// remove all except maxVal
-					bm.RemoveRange(0, maxVal)
-
-					assert.Equal(t, 1, bm.GetCardinality())
-					assert.True(t, bm.Contains(maxVal))
-				})
-			}
-		}
-	})
-
-	t.Run("conditional - sequential or parallel", func(t *testing.T) {
-		for _, maxVal := range []uint64{1_000, 10_000, 100_000, 1_000_000, uint64(prefillBufferSize)} {
-			t.Run(fmt.Sprint(maxVal), func(t *testing.T) {
-				bm := NewBitmapPrefill(maxVal, logger)
-
-				// +1, due to 0 included
-				assert.Equal(t, int(maxVal)+1, bm.GetCardinality())
-
-				// remove all except maxVal
-				bm.RemoveRange(0, maxVal)
-
-				assert.Equal(t, 1, bm.GetCardinality())
-				assert.True(t, bm.Contains(maxVal))
-			})
-		}
-	})
-}
-
-func TestBitmap_Inverted(t *testing.T) {
-	type test struct {
-		name          string
-		source        []uint64
-		maxVal        uint64
-		shouldContain []uint64
-	}
-
-	tests := []test{
-		{
-			name:          "just 0, no source",
-			source:        nil,
-			maxVal:        0,
-			shouldContain: []uint64{0},
-		},
-		{
-			name:          "no matches in source",
-			source:        nil,
-			maxVal:        7,
-			shouldContain: []uint64{0, 1, 2, 3, 4, 5, 6, 7},
-		},
-		{
-			name:          "some matches in source",
-			source:        []uint64{3, 4, 5},
-			maxVal:        7,
-			shouldContain: []uint64{0, 1, 2, 6, 7},
-		},
-		{
-			name:          "source has higher val than max val",
-			source:        []uint64{3, 4, 5, 8},
-			maxVal:        7,
-			shouldContain: []uint64{0, 1, 2, 6, 7},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			source := sroar.NewBitmap()
-			source.SetMany(test.source)
-			out := NewInvertedBitmap(source, test.maxVal, logger)
-			outSlice := out.ToArray()
-			assert.Equal(t, test.shouldContain, outSlice)
-		})
-	}
-}
-
-func TestBitmapFactory(t *testing.T) {
-	maxVal := uint64(10)
-	maxValGetter := func() uint64 { return maxVal }
-	bmf := NewBitmapFactory(maxValGetter, logger)
-	t.Logf("card: %d", bmf.bitmap.GetCardinality())
-
-	currMax := bmf.currentMaxVal
-	t.Run("max val set correctly", func(t *testing.T) {
-		assert.Equal(t, maxVal+DefaultBufferIncrement, currMax)
-	})
-
-	t.Run("max val increased to threshold does not change cardinality", func(t *testing.T) {
-		maxVal += 100
-		assert.NotNil(t, bmf.GetBitmap())
-		assert.Equal(t, currMax, bmf.currentMaxVal)
-		assert.Equal(t, currMax+1, uint64(bmf.bitmap.GetCardinality()))
-		assert.Equal(t, maxVal, bmf.ActualMaxVal())
-	})
-
-	t.Run("max val surpasses threshold, cardinality increased", func(t *testing.T) {
-		maxVal += 1
-		assert.NotNil(t, bmf.GetBitmap())
-		currMax += 1 + DefaultBufferIncrement
-		assert.Equal(t, currMax, bmf.currentMaxVal)
-		assert.Equal(t, currMax+1, uint64(bmf.bitmap.GetCardinality()))
-		assert.Equal(t, maxVal, bmf.ActualMaxVal())
-	})
-}
-
 func slice(from, to uint64) []uint64 {
 	len := to - from
 	s := make([]uint64, len)
@@ -272,4 +137,62 @@ func slice(from, to uint64) []uint64 {
 		s[i] = from + i
 	}
 	return s
+}
+
+func TestBitmapFactory(t *testing.T) {
+	maxId := uint64(10)
+	maxIdGetter := func() uint64 { return maxId }
+	bmf := NewBitmapFactory(maxIdGetter)
+
+	t.Run("prefilled bitmap includes increment", func(t *testing.T) {
+		expPrefilledMaxId := maxId + defaultIdIncrement
+		expPrefilledCardinality := int(maxId + defaultIdIncrement + 1)
+
+		bm, release := bmf.GetBitmap()
+		defer release()
+
+		require.NotNil(t, bm)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, expPrefilledCardinality, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm.Maximum())
+		assert.Equal(t, int(maxId)+1, bm.GetCardinality())
+	})
+
+	t.Run("maxId increased up to increment threshold does not change internal bitmap", func(t *testing.T) {
+		expPrefilledMaxId := bmf.prefilled.Maximum()
+
+		maxId += 10
+		bm1, release1 := bmf.GetBitmap()
+		defer release1()
+
+		require.NotNil(t, bm1)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, int(expPrefilledMaxId)+1, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm1.Maximum())
+		assert.Equal(t, int(maxId)+1, bm1.GetCardinality())
+
+		maxId += (defaultIdIncrement - 10)
+		bm2, release2 := bmf.GetBitmap()
+		defer release2()
+
+		require.NotNil(t, bm2)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, int(expPrefilledMaxId)+1, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm2.Maximum())
+		assert.Equal(t, int(maxId)+1, bm2.GetCardinality())
+	})
+
+	t.Run("maxId surpasses increment threshold changes internal bitmap", func(t *testing.T) {
+		maxId += 1
+		expPrefilledMaxId := maxId + defaultIdIncrement
+
+		bm, release := bmf.GetBitmap()
+		defer release()
+
+		require.NotNil(t, bm)
+		assert.Equal(t, expPrefilledMaxId, bmf.prefilled.Maximum())
+		assert.Equal(t, int(expPrefilledMaxId)+1, bmf.prefilled.GetCardinality())
+		assert.Equal(t, maxId, bm.Maximum())
+		assert.Equal(t, int(maxId)+1, bm.GetCardinality())
+	})
 }

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -82,7 +82,7 @@ type BitmapLayers []BitmapLayer
 //     should be represented in the final bitmap. If the order is reversed and
 //     layer 2 adds X, whereas layer 3 removes X, it is should not be contained
 //     in the final map.
-func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
+func (bml BitmapLayers) Flatten(clone bool, buf ContainerBuf) *sroar.Bitmap {
 	if len(bml) == 0 {
 		return sroar.NewBitmap()
 	}
@@ -93,8 +93,8 @@ func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
 	}
 
 	for i := 1; i < len(bml); i++ {
-		merged.AndNot(bml[i].Deletions)
-		merged.Or(bml[i].Additions)
+		merged.AndNotBuf(bml[i].Deletions, buf)
+		merged.OrBuf(bml[i].Additions, buf)
 	}
 
 	return merged
@@ -107,7 +107,7 @@ func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
 // segments 1 or 2.
 //
 // Merge is intended to be used as part of compactions.
-func (bml BitmapLayers) Merge() (BitmapLayer, error) {
+func (bml BitmapLayers) Merge(buf ContainerBuf) (BitmapLayer, error) {
 	out := BitmapLayer{}
 	if len(bml) != 2 {
 		return out, fmt.Errorf("merge requires exactly two input segments")
@@ -116,12 +116,12 @@ func (bml BitmapLayers) Merge() (BitmapLayer, error) {
 	left, right := bml[0], bml[1]
 
 	additions := left.Additions.Clone()
-	additions.AndNot(right.Deletions)
-	additions.Or(right.Additions)
+	additions.AndNotBuf(right.Deletions, buf)
+	additions.OrBuf(right.Additions, buf)
 
 	deletions := left.Deletions.Clone()
-	deletions.AndNot(right.Additions)
-	deletions.Or(right.Deletions)
+	deletions.AndNotBuf(right.Additions, buf)
+	deletions.OrBuf(right.Deletions, buf)
 
 	out.Additions = additions
 	out.Deletions = deletions

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -82,38 +82,17 @@ type BitmapLayers []BitmapLayer
 //     should be represented in the final bitmap. If the order is reversed and
 //     layer 2 adds X, whereas layer 3 removes X, it is should not be contained
 //     in the final map.
-func (bml BitmapLayers) Flatten() *sroar.Bitmap {
-	if len(bml) == 0 {
-		return sroar.NewBitmap()
-	}
-
-	cur := bml[0]
-	// TODO: is this copy really needed? aren't we already operating on copied
-	// bms?
-	merged := cur.Additions.Clone()
-
-	for i := 1; i < len(bml); i++ {
-		merged.AndNot(bml[i].Deletions)
-		merged.Or(bml[i].Additions)
-	}
-
-	return merged
-}
-
-// FlattenMutate works as Flatten but mutates passed bitmaps:
-// bml[0].Additions and bml[!=0].Deletions.
-// It is important to provide cloned bitmaps if original ones
-// are expected not to change.
-func (bml BitmapLayers) FlattenMutate() *sroar.Bitmap {
+func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
 	if len(bml) == 0 {
 		return sroar.NewBitmap()
 	}
 
 	merged := bml[0].Additions
+	if clone {
+		merged = merged.Clone()
+	}
+
 	for i := 1; i < len(bml); i++ {
-		// AndNot of only common set seems to be faster than AndNot of bigger set
-		// therefore call to And first
-		bml[i].Deletions.And(merged)
 		merged.AndNot(bml[i].Deletions)
 		merged.Or(bml[i].Additions)
 	}
@@ -144,7 +123,7 @@ func (bml BitmapLayers) Merge() (BitmapLayer, error) {
 	deletions.AndNot(right.Additions)
 	deletions.Or(right.Deletions)
 
-	out.Additions = Condense(additions)
-	out.Deletions = Condense(deletions)
+	out.Additions = additions
+	out.Deletions = deletions
 	return out, nil
 }

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -106,7 +106,7 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 				input[i].Deletions = NewBitmap(inp.deletions...)
 			}
 
-			res := input.Flatten()
+			res := input.Flatten(false)
 			for _, x := range test.expectedContained {
 				assert.True(t, res.Contains(x))
 			}

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -98,6 +98,7 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 		},
 	}
 
+	buf := make(ContainerBuf, ContainerBufSize)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := make(BitmapLayers, len(test.inputs))
@@ -106,7 +107,7 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 				input[i].Deletions = NewBitmap(inp.deletions...)
 			}
 
-			res := input.Flatten(false)
+			res := input.Flatten(false, buf)
 			for _, x := range test.expectedContained {
 				assert.True(t, res.Contains(x))
 			}
@@ -228,6 +229,7 @@ func Test_BitmapLayers_Merge(t *testing.T) {
 		},
 	}
 
+	buf := make(ContainerBuf, ContainerBufSize)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := make(BitmapLayers, len(test.inputs))
@@ -236,7 +238,7 @@ func Test_BitmapLayers_Merge(t *testing.T) {
 				input[i].Deletions = NewBitmap(inp.deletions...)
 			}
 
-			res, err := input.Merge()
+			res, err := input.Merge(buf)
 			if test.expectErr {
 				require.NotNil(t, err)
 				return
@@ -321,7 +323,7 @@ func Test_BitmapLayers_Merge_PanicSliceBoundOutOfRange(t *testing.T) {
 	leftLayer := BitmapLayer{Deletions: NewBitmap(genSlice(289_800, 290_100)...)}
 	rightLayer := BitmapLayer{Additions: NewBitmap(genSlice(290_000, 293_000)...)}
 
-	failingDeletionsLayer, err := BitmapLayers{leftLayer, rightLayer}.Merge()
+	failingDeletionsLayer, err := BitmapLayers{leftLayer, rightLayer}.Merge(make(ContainerBuf, ContainerBufSize))
 	assert.Nil(t, err)
 
 	assert.ElementsMatch(t, genSlice(289_800, 290_000), failingDeletionsLayer.Deletions.ToArray())

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -230,6 +230,10 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 	}
 
 	// both segments, merge
+	//
+	// bitmaps' cloning is necessary for both types of cursors: mmap and pread
+	// (pread cursor use buffers to read entire nodes from file, therefore nodes already read
+	// are later overwritten with nodes being read later)
 	nc.deletionsLeft = nc.emptyBitmap
 	if !layerLeft.Deletions.IsEmpty() {
 		nc.deletionsLeft = layerLeft.Deletions.Clone()
@@ -269,6 +273,9 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 
 func (nc *nodeCompactor) mergeLayers(key uint8, additionsLeft, additionsRight *sroar.Bitmap,
 ) roaringset.BitmapLayer {
+	// bitmaps' cloning is necessary for both types of cursors: mmap and pread
+	// (pread cursor use buffers to read entire nodes from file, therefore nodes already read
+	// are later overwritten with nodes being read later)
 	additions := additionsLeft.Clone()
 	additions.AndNot(nc.deletionsRight)
 	additions.Or(additionsRight)

--- a/adapters/repos/db/roaringsetrange/compactor_test.go
+++ b/adapters/repos/db/roaringsetrange/compactor_test.go
@@ -33,6 +33,7 @@ func Test_Compactor(t *testing.T) {
 		expectedErr     string
 	}
 
+	buf := make(roaringset.ContainerBuf, roaringset.ContainerBufSize)
 	tests := []test{
 		{
 			name: "segments with nothing deleted",
@@ -447,7 +448,7 @@ func Test_Compactor(t *testing.T) {
 			f, err := os.Create(segmentFile)
 			require.NoError(t, err)
 
-			c := NewCompactor(f, leftCursor, rightCursor, 5, false)
+			c := NewCompactor(f, leftCursor, rightCursor, 5, false, buf)
 			err = c.Do()
 			require.NoError(t, f.Close())
 
@@ -493,7 +494,7 @@ func Test_Compactor(t *testing.T) {
 			f, err := os.Create(segmentFile)
 			require.NoError(t, err)
 
-			c := NewCompactor(f, leftCursor, rightCursor, 5, true)
+			c := NewCompactor(f, leftCursor, rightCursor, 5, true, buf)
 			err = c.Do()
 			require.NoError(t, f.Close())
 

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -96,7 +96,7 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		layer.Additions.Or(response.layer.Additions)
 	}
 
-	return roaringset.Condense(layer.Additions), nil
+	return layer.Additions, nil
 }
 
 func (r *CombinedReader) Close() {

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -52,7 +53,8 @@ func TestReader(t *testing.T) {
 	seg2Reader := NewSegmentReader(NewGaplessSegmentCursor(newFakeSegmentCursor(memSeg2)))
 	memReader := NewMemtableReader(mem)
 
-	reader := NewCombinedReader([]InnerReader{seg1Reader, seg2Reader, memReader}, func() {}, 4, logger)
+	buf := make(roaringset.ContainerBuf, roaringset.ContainerBufSize)
+	reader := NewCombinedReader([]InnerReader{seg1Reader, seg2Reader, memReader}, buf, func() {}, 4, logger)
 
 	type testCase struct {
 		value    uint64

--- a/adapters/repos/db/roaringsetrange/segment_reader.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader.go
@@ -75,6 +75,9 @@ func (r *SegmentReader) Read(ctx context.Context, value uint64, operator filters
 }
 
 func (r *SegmentReader) firstLayer() (roaringset.BitmapLayer, bool) {
+	// bitmaps' cloning is necessary for both types of cursors: mmap and pread
+	// (pread cursor use buffers to read entire nodes from file, therefore nodes already read
+	// are later overwritten with nodes being read later)
 	_, layer, ok := r.cursor.First()
 	if !ok {
 		return roaringset.BitmapLayer{

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -35,6 +35,7 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params, module
 
 	return aggregator.New(s.store, params, s.index.getSchema, s.index.classSearcher,
 		s.index.stopwords, s.versioner.Version(), queue, s.index.logger, s.GetPropertyLengthTracker(),
-		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory, modules).
+		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory,
+		s.index.bitmapContainerBufPool, modules).
 		Do(ctx)
 }

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -180,7 +180,8 @@ func (s *Shard) initIndexCounterVersionerAndBitmapFactory() error {
 		return fmt.Errorf("init index counter: %w", err)
 	}
 	s.counter = counter
-	s.bitmapFactory = roaringset.NewBitmapFactory(s.counter.Get, s.index.logger)
+	// counter is incremented whenever new docID is fetched, therefore last docID is lower by 1
+	s.bitmapFactory = roaringset.NewBitmapFactory(func() uint64 { return s.counter.Get() - 1 })
 
 	dataPresent := s.counter.PreviewNext() != 0
 	versionPath := path.Join(s.path(), "version")

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -108,7 +108,9 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 		if schema.IsRefDataType(prop.DataType) {
 			if err := s.store.CreateOrLoadBucket(ctx,
 				helpers.BucketFromPropNameMetaCountLSM(prop.Name),
-				append(bucketOpts, lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))...,
+				append(bucketOpts,
+					lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+					lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool))...,
 			); err != nil {
 				return err
 			}
@@ -116,7 +118,9 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 
 		if err := s.store.CreateOrLoadBucket(ctx,
 			helpers.BucketFromPropNameLSM(prop.Name),
-			append(bucketOpts, lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))...,
+			append(bucketOpts,
+				lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+				lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool))...,
 		); err != nil {
 			return err
 		}
@@ -141,6 +145,7 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 			helpers.BucketRangeableFromPropNameLSM(prop.Name),
 			append(bucketOpts,
 				lsmkv.WithStrategy(lsmkv.StrategyRoaringSetRange),
+				lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool),
 				lsmkv.WithUseBloomFilter(false),
 				lsmkv.WithCalcCountNetAdditions(false),
 			)...,
@@ -168,6 +173,7 @@ func (s *Shard) createPropertyLengthIndex(ctx context.Context, prop *models.Prop
 	return s.store.CreateOrLoadBucket(ctx,
 		helpers.BucketFromPropNameLengthLSM(prop.Name),
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool),
 		lsmkv.WithPread(s.index.Config.AvoidMMap),
 		lsmkv.WithAllocChecker(s.index.allocChecker),
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
@@ -184,6 +190,7 @@ func (s *Shard) createPropertyNullIndex(ctx context.Context, prop *models.Proper
 	return s.store.CreateOrLoadBucket(ctx,
 		helpers.BucketFromPropNameNullLSM(prop.Name),
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool),
 		lsmkv.WithPread(s.index.Config.AvoidMMap),
 		lsmkv.WithAllocChecker(s.index.allocChecker),
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
@@ -257,6 +264,7 @@ func (s *Shard) addCreationTimeUnixProperty(ctx context.Context) error {
 		helpers.BucketFromPropNameLSM(filters.InternalPropCreationTimeUnix),
 		s.memtableDirtyConfig(),
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool),
 		lsmkv.WithPread(s.index.Config.AvoidMMap),
 		lsmkv.WithAllocChecker(s.index.allocChecker),
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
@@ -270,6 +278,7 @@ func (s *Shard) addLastUpdateTimeUnixProperty(ctx context.Context) error {
 		helpers.BucketFromPropNameLSM(filters.InternalPropLastUpdateTimeUnix),
 		s.memtableDirtyConfig(),
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapContainerBufPool(s.index.bitmapContainerBufPool),
 		lsmkv.WithPread(s.index.Config.AvoidMMap),
 		lsmkv.WithAllocChecker(s.index.allocChecker),
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -308,6 +308,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 			}
 
 			filterDocIds = objs
+			defer objs.Close()
 		}
 
 		className := s.index.Config.ClassName
@@ -425,6 +426,10 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors [][]float3
 			dists []float32
 		)
 		eg.Go(func() error {
+			if allowList != nil {
+				defer allowList.Close()
+			}
+
 			queue, err := s.getIndexQueue(targetVector)
 			if err != nil {
 				return err

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -301,7 +301,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 				s.index.getSchema.ReadOnlyClass, s.propertyIndices,
 				s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
 				s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit,
-				s.bitmapFactory).
+				s.bitmapFactory, s.index.bitmapContainerBufPool).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
 			if err != nil {
 				return nil, nil, err
@@ -332,7 +332,8 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 	}
 	objs, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		s.propertyIndices, s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
-		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
+		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory,
+		s.index.bitmapContainerBufPool).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName, properties)
 	return objs, nil, err
 }
@@ -604,7 +605,8 @@ func (s *Shard) sortDocIDsAndDists(ctx context.Context, limit int, sort []filter
 func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter, addl additional.Properties) (helpers.AllowList, error) {
 	list, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		s.propertyIndices, s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
-		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
+		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory,
+		s.index.bitmapContainerBufPool).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)
 	if err != nil {
 		return nil, errors.Wrap(err, "build inverted filter allow list")

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -152,7 +152,7 @@ func (b *deleteObjectsBatcher) setErrorAtIndex(err error, index int) {
 func (s *Shard) findDocIDs(ctx context.Context, filters *filters.LocalFilter) ([]uint64, error) {
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		nil, s.index.classSearcher, s.index.stopwords, s.versioner.version, s.isFallbackToSearchable,
-		s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
+		s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory, s.index.bitmapContainerBufPool).
 		DocIDs(ctx, filters, additional.Properties{}, s.index.Config.ClassName)
 	if err != nil {
 		return nil, err

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -157,6 +157,7 @@ func (s *Shard) findDocIDs(ctx context.Context, filters *filters.LocalFilter) ([
 	if err != nil {
 		return nil, err
 	}
+	defer allowList.Close()
 	return allowList.Slice(), nil
 }
 

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -655,6 +655,9 @@ func (s *FastSet) Truncate(uint64) helpers.AllowList {
 	panic("DeepCopy")
 }
 
+func (s *FastSet) Close() {
+}
+
 func (s *FastSet) Iterator() helpers.AllowListIterator {
 	return &fastIterator{
 		source:  s,

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/weaviate/fgprof v0.0.0-20241024091527-0000bf3ee8aa
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.8
+	github.com/weaviate/sroar v0.0.9-0.20241217163137-398775d264ce
 	github.com/weaviate/tiktoken-go v0.0.2
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/text v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/weaviate/fgprof v0.0.0-20241024091527-0000bf3ee8aa h1:yavIOSoUOUfmYlE
 github.com/weaviate/fgprof v0.0.0-20241024091527-0000bf3ee8aa/go.mod h1:2REGzzHg/U0Olsn/1ok6QfqAE/vDuKvb/j2eLrOIP8A=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.8 h1:BUHeYdgX1M36tzhHc3WoaDrZGXOyk9aWAlC6QXstXYM=
-github.com/weaviate/sroar v0.0.8/go.mod h1:I6HAMeJjGMDI8cuFDUK4TIRsy5Csn5RFncNkosyNgKE=
+github.com/weaviate/sroar v0.0.9-0.20241217163137-398775d264ce h1:t2Fo0QSikRAu6W7Kxbc+jPwggWFI8bV+xDwXR7NFADU=
+github.com/weaviate/sroar v0.0.9-0.20241217163137-398775d264ce/go.mod h1:I6HAMeJjGMDI8cuFDUK4TIRsy5Csn5RFncNkosyNgKE=
 github.com/weaviate/tiktoken-go v0.0.2 h1:lkwTMEoXSFSXxYvw1c44/xz3OOAh27L3+3vvNN/TSSg=
 github.com/weaviate/tiktoken-go v0.0.2/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
### What's being changed:
- adds pool for container buffers to be used for bitmaps merging
- used in searcher (merging subresults), row readers (merging bitmaps of filtered keys), compaction (merging bitmaps of matching keys of compacted segments), bucket's cursor (merging bitmaps of matching keys of all segments)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
