### PR TITLE
fix: Searcher::objectsByDocID: consider ctx, adjust result size to limit applied

### DIFF
--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -95,7 +95,7 @@ func (s *Searcher) Objects(ctx context.Context, limit int,
 		it = allowList.Iterator()
 	}
 
-	return s.objectsByDocID(it, additional, limit)
+	return s.objectsByDocID(ctx, it, additional, limit)
 }
 
 func (s *Searcher) sort(ctx context.Context, limit int, sort []filters.Sort,
@@ -108,7 +108,7 @@ func (s *Searcher) sort(ctx context.Context, limit int, sort []filters.Sort,
 	return lsmSorter.SortDocIDs(ctx, limit, sort, docIDs)
 }
 
-func (s *Searcher) objectsByDocID(it docIDsIterator,
+func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
 	additional additional.Properties, limit int,
 ) ([]*storobj.Object, error) {
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -116,16 +116,26 @@ func (s *Searcher) objectsByDocID(it docIDsIterator,
 		return nil, fmt.Errorf("objects bucket not found")
 	}
 
-	out := make([]*storobj.Object, it.Len())
-	docIDBytes := make([]byte, 8)
-
 	// Prevent unbounded iteration
 	if limit == 0 {
 		limit = int(config.DefaultQueryMaximumResults)
 	}
+	outlen := it.Len()
+	if outlen > limit {
+		outlen = limit
+	}
+
+	out := make([]*storobj.Object, outlen)
+	docIDBytes := make([]byte, 8)
 
 	i := 0
+	loop := 0
 	for docID, ok := it.Next(); ok; docID, ok = it.Next() {
+		if loop%1000 == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		loop++
+
 		binary.LittleEndian.PutUint64(docIDBytes, docID)
 		res, err := bucket.GetBySecondary(0, docIDBytes)
 		if err != nil {


### PR DESCRIPTION
### What's being changed:
Searcher::objectsByDocID
- accepts context as argument, checks every 1000th loops if it is expired
- result slice's size is adjusted to applied limit 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
