### PR TITLE
chore: fix lint usage of deprecated strfmt.UUIDPattern

### DIFF
--- a/test/acceptance/actions/add_test.go
+++ b/test/acceptance/actions/add_test.go
@@ -16,11 +16,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/entities/models"
-
-	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -52,7 +51,8 @@ func addingObjects(t *testing.T) {
 		// Ensure that the response is OK
 		helper.AssertRequestOk(t, resp, err, func() {
 			object := resp.Payload
-			assert.Regexp(t, strfmt.UUIDPattern, object.ID)
+			_, err := uuid.Parse(object.ID.String())
+			assert.NoError(t, err)
 
 			schema, ok := object.Properties.(map[string]interface{})
 			if !ok {

--- a/test/acceptance/objects/objects_test.go
+++ b/test/acceptance/objects/objects_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
-
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/weaviate/weaviate/client/objects"
@@ -72,7 +72,8 @@ func creatingObjects(t *testing.T) {
 		// Ensure that the response is OK
 		helper.AssertRequestOk(t, resp, err, func() {
 			object := resp.Payload
-			assert.Regexp(t, strfmt.UUIDPattern, object.ID)
+			_, err := uuid.Parse(object.ID.String())
+			assert.NoError(t, err)
 
 			schema, ok := object.Properties.(map[string]interface{})
 			if !ok {
@@ -158,7 +159,8 @@ func creatingObjects(t *testing.T) {
 		// Ensure that the response is OK
 		helper.AssertRequestOk(t, resp, err, func() {
 			object := resp.Payload
-			assert.Regexp(t, strfmt.UUIDPattern, object.ID)
+			_, err := uuid.Parse(object.ID.String())
+			assert.NoError(t, err)
 
 			schema, ok := object.Properties.(map[string]interface{})
 			if !ok {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
