### PR TITLE
fix: replace ctx with timeout with background ctx in backup acceptance tests

### DIFF
--- a/test/modules/backup-azure/backup_backend_test.go
+++ b/test/modules/backup-azure/backup_backend_test.go
@@ -53,8 +53,7 @@ func Test_AzureBackend_Backup(t *testing.T) {
 }
 
 func moduleLevelStoreBackupMeta(t *testing.T) {
-	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	testCtx := context.Background()
 
 	dataDir := t.TempDir()
 	className := "BackupClass"
@@ -134,8 +133,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 }
 
 func moduleLevelCopyObjects(t *testing.T) {
-	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	testCtx := context.Background()
 
 	dataDir := t.TempDir()
 	key := "moduleLevelCopyObjects"

--- a/test/modules/backup-azure/backup_journey_test.go
+++ b/test/modules/backup-azure/backup_journey_test.go
@@ -14,7 +14,6 @@ package test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -37,8 +36,7 @@ const (
 )
 
 func Test_BackupJourney(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	t.Run("single node", func(t *testing.T) {
 		t.Log("pre-instance env setup")

--- a/test/modules/backup-azure/multi_tenant_backup_test.go
+++ b/test/modules/backup-azure/multi_tenant_backup_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -29,8 +28,7 @@ const (
 )
 
 func Test_MultiTenantBackupJourney(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	tenantNames := make([]string, numTenants)
 	for i := range tenantNames {

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -53,8 +53,7 @@ func Test_GCSBackend_Backup(t *testing.T) {
 }
 
 func moduleLevelStoreBackupMeta(t *testing.T) {
-	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	testCtx := context.Background()
 
 	dataDir := t.TempDir()
 	className := "BackupClass"
@@ -137,8 +136,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 }
 
 func moduleLevelCopyObjects(t *testing.T) {
-	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	testCtx := context.Background()
 
 	dataDir := t.TempDir()
 	key := "moduleLevelCopyObjects"
@@ -177,8 +175,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 }
 
 func moduleLevelCopyFiles(t *testing.T) {
-	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	testCtx := context.Background()
 
 	dataDir := t.TempDir()
 	key := "moduleLevelCopyFiles"

--- a/test/modules/backup-gcs/backup_journey_test.go
+++ b/test/modules/backup-gcs/backup_journey_test.go
@@ -14,7 +14,6 @@ package test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -39,8 +38,7 @@ const (
 )
 
 func Test_BackupJourney(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	t.Run("single node", func(t *testing.T) {
 		t.Log("pre-instance env setup")

--- a/test/modules/backup-gcs/multi_tenant_backup_test.go
+++ b/test/modules/backup-gcs/multi_tenant_backup_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -27,8 +26,7 @@ import (
 const numTenants = 50
 
 func Test_MultiTenantBackupJourney(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	tenantNames := make([]string, numTenants)
 	for i := range tenantNames {

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -53,8 +53,7 @@ func Test_S3Backend_Backup(t *testing.T) {
 }
 
 func moduleLevelStoreBackupMeta(t *testing.T) {
-	testCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	testCtx := context.Background()
 
 	dataDir := t.TempDir()
 	className := "BackupClass"

--- a/test/modules/backup-s3/backup_journey_test.go
+++ b/test/modules/backup-s3/backup_journey_test.go
@@ -14,7 +14,6 @@ package test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -42,8 +41,7 @@ const (
 
 func Test_BackupJourney(t *testing.T) {
 	t.Run("single node", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -74,8 +72,7 @@ func Test_BackupJourney(t *testing.T) {
 	})
 
 	t.Run("multiple node", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)

--- a/test/modules/backup-s3/multi_tenant_backup_test.go
+++ b/test/modules/backup-s3/multi_tenant_backup_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -32,8 +31,7 @@ func Test_MultiTenantBackupJourney(t *testing.T) {
 	}
 
 	t.Run("single node", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -64,8 +62,7 @@ func Test_MultiTenantBackupJourney(t *testing.T) {
 	})
 
 	t.Run("multiple node", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
