### PR TITLE
chore: skip data inserted before async replication

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -284,9 +284,21 @@ func (b *Bucket) GetFlushCallbackCtrl() cyclemanager.CycleCallbackCtrl {
 }
 
 func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Object) error) error {
-	i := 0
 	cursor := b.Cursor()
 	defer cursor.Close()
+
+	return b.iterateObjectsCursor(ctx, cursor, f)
+}
+
+func (b *Bucket) IterateObjectsWith(ctx context.Context, desiredSecondaryIndexCount int, f func(object *storobj.Object) error) error {
+	cursor := b.CursorWith(desiredSecondaryIndexCount)
+	defer cursor.Close()
+
+	return b.iterateObjectsCursor(ctx, cursor, f)
+}
+
+func (b *Bucket) iterateObjectsCursor(ctx context.Context, cursor *CursorReplace, f func(object *storobj.Object) error) error {
+	i := 0
 
 	for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
 		obj, err := storobj.FromBinary(v)

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -91,12 +91,29 @@ func (sg *SegmentGroup) newCursors() ([]innerCursorReplace, func()) {
 	return out, sg.maintenanceLock.RUnlock
 }
 
+func (sg *SegmentGroup) newCursorsWith(desiredSecondaryIndexCount int) ([]innerCursorReplace, func()) {
+	sg.maintenanceLock.RLock()
+	out := make([]innerCursorReplace, 0, len(sg.segments))
+
+	for _, segment := range sg.segments {
+		if int(segment.secondaryIndexCount) != desiredSecondaryIndexCount {
+			continue
+		}
+		out = append(out, segment.newCursor())
+	}
+
+	return out, sg.maintenanceLock.RUnlock
+}
+
 func (sg *SegmentGroup) newCursorsWithSecondaryIndex(pos int) ([]innerCursorReplace, func()) {
 	sg.maintenanceLock.RLock()
-	out := make([]innerCursorReplace, len(sg.segments))
+	out := make([]innerCursorReplace, 0, len(sg.segments))
 
-	for i, segment := range sg.segments {
-		out[i] = segment.newCursorWithSecondaryIndex(pos)
+	for _, segment := range sg.segments {
+		if int(segment.secondaryIndexCount) <= pos {
+			continue
+		}
+		out = append(out, segment.newCursorWithSecondaryIndex(pos))
 	}
 
 	return out, sg.maintenanceLock.RUnlock

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -89,6 +89,11 @@ func (sg *SegmentGroup) findCompactionCandidates() (pair []int, level uint16) {
 	for leftId := len(sg.segments) - 2; leftId >= 0; leftId-- {
 		left, right := sg.segments[leftId], sg.segments[leftId+1]
 
+		if left.secondaryIndexCount != right.secondaryIndexCount {
+			// only pair of segments with the same secondary indexes are compacted
+			continue
+		}
+
 		if left.level == right.level {
 			if sg.compactionFitsSizeLimit(left, right) {
 				// max size not exceeded

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -398,7 +398,9 @@ func (s *Shard) initHashTree(ctx context.Context) error {
 
 		objCount := 0
 
-		err := bucket.IterateObjects(ctx, func(object *storobj.Object) error {
+		// data inserted before v1.26 does not contain the required secondary index
+		// to support async replication thus such data is not inserted into the hashtree
+		err := bucket.IterateObjectsWith(ctx, 2, func(object *storobj.Object) error {
 			if time.Since(prevContextEvaluation) > time.Second {
 				if ctx.Err() != nil {
 					return ctx.Err()


### PR DESCRIPTION
### What's being changed:

Objects inserted before release 1.26.x are skipped from async replication due to the lack of the required secondary index.
Those objects could still be replicated by means of read-repair approach

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
