### PR TITLE
RBAC Tenant operation permissions

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5482,7 +5482,11 @@ func init() {
             "create_collections",
             "read_collections",
             "update_collections",
-            "delete_collections"
+            "delete_collections",
+            "create_tenants",
+            "read_tenants",
+            "update_tenants",
+            "delete_tenants"
           ]
         },
         "backups": {
@@ -5559,6 +5563,22 @@ func init() {
           "properties": {
             "role": {
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            }
+          }
+        },
+        "tenants": {
+          "description": "resources applicable for tenant actions",
+          "type": "object",
+          "properties": {
+            "collection": {
+              "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            },
+            "tenant": {
+              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
             }
@@ -12212,7 +12232,11 @@ func init() {
             "create_collections",
             "read_collections",
             "update_collections",
-            "delete_collections"
+            "delete_collections",
+            "create_tenants",
+            "read_tenants",
+            "update_tenants",
+            "delete_tenants"
           ]
         },
         "backups": {
@@ -12289,6 +12313,22 @@ func init() {
           "properties": {
             "role": {
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            }
+          }
+        },
+        "tenants": {
+          "description": "resources applicable for tenant actions",
+          "type": "object",
+          "properties": {
+            "collection": {
+              "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            },
+            "tenant": {
+              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
             }
@@ -12370,6 +12410,22 @@ func init() {
       "properties": {
         "role": {
           "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
+          "type": "string",
+          "default": "*"
+        }
+      }
+    },
+    "PermissionTenants": {
+      "description": "resources applicable for tenant actions",
+      "type": "object",
+      "properties": {
+        "collection": {
+          "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
+          "type": "string",
+          "default": "*"
+        },
+        "tenant": {
+          "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
           "type": "string",
           "default": "*"
         }

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,6 +30,7 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
+
 	// allowed actions in weaviate.
 	// Required: true
 	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections create_tenants read_tenants update_tenants delete_tenants]
@@ -173,6 +174,7 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
+
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -334,6 +336,7 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Backups != nil {
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -349,6 +352,7 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Collections != nil {
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -364,6 +368,7 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Data != nil {
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -379,6 +384,7 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Nodes != nil {
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -394,6 +400,7 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Roles != nil {
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -409,6 +416,7 @@ func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Tenants != nil {
 		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -445,6 +453,7 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 }
@@ -481,6 +490,7 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -520,6 +530,7 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -562,6 +573,7 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -653,6 +665,7 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
+
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
 }
@@ -689,6 +702,7 @@ func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionTenants
 type PermissionTenants struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,10 +30,9 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
-
 	// allowed actions in weaviate.
 	// Required: true
-	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections]
+	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections create_tenants read_tenants update_tenants delete_tenants]
 	Action *string `json:"action"`
 
 	// backups
@@ -50,6 +49,9 @@ type Permission struct {
 
 	// roles
 	Roles *PermissionRoles `json:"roles,omitempty"`
+
+	// tenants
+	Tenants *PermissionTenants `json:"tenants,omitempty"`
 }
 
 // Validate validates this permission
@@ -80,6 +82,10 @@ func (m *Permission) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateTenants(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -90,7 +96,7 @@ var permissionTypeActionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","manage_data","create_data","read_data","update_data","delete_data","read_nodes","manage_roles","read_roles","manage_collections","create_collections","read_collections","update_collections","delete_collections"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","manage_data","create_data","read_data","update_data","delete_data","read_nodes","manage_roles","read_roles","manage_collections","create_collections","read_collections","update_collections","delete_collections","create_tenants","read_tenants","update_tenants","delete_tenants"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -144,6 +150,18 @@ const (
 
 	// PermissionActionDeleteCollections captures enum value "delete_collections"
 	PermissionActionDeleteCollections string = "delete_collections"
+
+	// PermissionActionCreateTenants captures enum value "create_tenants"
+	PermissionActionCreateTenants string = "create_tenants"
+
+	// PermissionActionReadTenants captures enum value "read_tenants"
+	PermissionActionReadTenants string = "read_tenants"
+
+	// PermissionActionUpdateTenants captures enum value "update_tenants"
+	PermissionActionUpdateTenants string = "update_tenants"
+
+	// PermissionActionDeleteTenants captures enum value "delete_tenants"
+	PermissionActionDeleteTenants string = "delete_tenants"
 )
 
 // prop value enum
@@ -155,7 +173,6 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
-
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -263,6 +280,25 @@ func (m *Permission) validateRoles(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Permission) validateTenants(formats strfmt.Registry) error {
+	if swag.IsZero(m.Tenants) { // not required
+		return nil
+	}
+
+	if m.Tenants != nil {
+		if err := m.Tenants.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("tenants")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("tenants")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this permission based on the context it is used
 func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -287,6 +323,10 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTenants(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -294,7 +334,6 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Backups != nil {
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -310,7 +349,6 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Collections != nil {
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -326,7 +364,6 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Data != nil {
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -342,7 +379,6 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Nodes != nil {
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -358,13 +394,27 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Roles != nil {
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("roles")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
+	if m.Tenants != nil {
+		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("tenants")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("tenants")
 			}
 			return err
 		}
@@ -395,7 +445,6 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 }
@@ -432,7 +481,6 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -472,7 +520,6 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -515,7 +562,6 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -607,7 +653,6 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
-
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
 }
@@ -633,6 +678,45 @@ func (m *PermissionRoles) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 	var res PermissionRoles
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// PermissionTenants resources applicable for tenant actions
+//
+// swagger:model PermissionTenants
+type PermissionTenants struct {
+	// string or regex. if a specific collection name, if left empty it will be ALL or *
+	Collection *string `json:"collection,omitempty"`
+
+	// string or regex. if a specific tenant name, if left empty it will be ALL or *
+	Tenant *string `json:"tenant,omitempty"`
+}
+
+// Validate validates this permission tenants
+func (m *PermissionTenants) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this permission tenants based on context it is used
+func (m *PermissionTenants) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *PermissionTenants) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *PermissionTenants) UnmarshalBinary(b []byte) error {
+	var res PermissionTenants
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -79,6 +79,22 @@
             }
           }
         },
+        "tenants": {
+          "type": "object",
+          "description": "resources applicable for tenant actions",
+          "properties": {
+            "collection": {
+              "type": "string",
+              "default": "*",
+              "description": "string or regex. if a specific collection name, if left empty it will be ALL or *"
+            },
+            "tenant": {
+              "type": "string",
+              "default": "*",
+              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *"
+            }
+          }
+        },
         "roles": {
           "type": "object",
           "description": "resources applicable for role actions",
@@ -129,7 +145,12 @@
             "create_collections",
             "read_collections",
             "update_collections",
-            "delete_collections"
+            "delete_collections",
+
+            "create_tenants",
+            "read_tenants",
+            "update_tenants",
+            "delete_tenants"
           ]
         }
       },

--- a/test/acceptance/authz/helper.go
+++ b/test/acceptance/authz/helper.go
@@ -112,3 +112,39 @@ func assertGQL(t *testing.T, query, key string) *models.GraphQLResponse {
 	require.Equal(t, len(resp.Payload.Errors), 0)
 	return resp.Payload
 }
+
+func readTenant(t *testing.T, class string, tenant string, key string) error {
+	params := clschema.NewTenantsGetOneParams().WithClassName(class).WithTenantName(tenant)
+	_, err := helper.Client(t).Schema.TenantsGetOne(params, helper.CreateAuth(key))
+	return err
+}
+
+func readTenants(t *testing.T, class string, key string) error {
+	params := clschema.NewTenantsGetParams().WithClassName(class)
+	_, err := helper.Client(t).Schema.TenantsGet(params, helper.CreateAuth(key))
+	return err
+}
+
+func existsTenant(t *testing.T, class string, tenant string, key string) error {
+	params := clschema.NewTenantExistsParams().WithClassName(class).WithTenantName(tenant)
+	_, err := helper.Client(t).Schema.TenantExists(params, helper.CreateAuth(key))
+	return err
+}
+
+func createTenant(t *testing.T, class string, tenants []*models.Tenant, key string) error {
+	params := clschema.NewTenantsCreateParams().WithClassName(class).WithBody(tenants)
+	_, err := helper.Client(t).Schema.TenantsCreate(params, helper.CreateAuth(key))
+	return err
+}
+
+func deleteTenant(t *testing.T, class string, tenants []string, key string) error {
+	params := clschema.NewTenantsDeleteParams().WithClassName(class).WithTenants(tenants)
+	_, err := helper.Client(t).Schema.TenantsDelete(params, helper.CreateAuth(key))
+	return err
+}
+
+func updateTenantStatus(t *testing.T, class string, tenants []*models.Tenant, key string) error {
+	params := clschema.NewTenantsUpdateParams().WithClassName(class).WithBody(tenants)
+	_, err := helper.Client(t).Schema.TenantsUpdate(params, helper.CreateAuth(key))
+	return err
+}

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -1,0 +1,149 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+)
+
+func TestAuthZTenants(t *testing.T) {
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	adminAuth := helper.CreateAuth(adminKey)
+
+	customUser := "custom-user"
+	customKey := "custom-key"
+
+	readSchemaAction := authorization.ReadCollections
+	readTenantAction := authorization.ReadTenant
+	createTenantAction := authorization.CreateTenant
+	deleteTenantAction := authorization.DeleteTenant
+	updateTenantAction := authorization.UpdateTenant
+
+	ctx := context.Background()
+	compose, err := docker.New().WithWeaviate().
+		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
+		WithRBAC().WithRbacAdmins(adminUser).
+		WithBackendFilesystem().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	className := "AuthzTenantTestClass"
+	deleteObjectClass(t, className, adminAuth)
+	c := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: schema.DataTypeText.PropString(),
+			},
+		},
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	}
+	helper.CreateClassAuth(t, c, adminKey)
+	defer deleteObjectClass(t, className, adminAuth)
+
+	// user needs to be able to create objects and read the configs
+	all := "*"
+
+	createTenantRoleName := "readSchemaAndCreateTenant"
+	createTenantRole := &models.Role{
+		Name: &createTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &createTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	readTenantRoleName := "readSchemaAndReadTenant"
+	readTenantRole := &models.Role{
+		Name: &readTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &readTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	deleteTenantRoleName := "readSchemaAndDeleteTenant"
+	deleteTenantRole := &models.Role{
+		Name: &deleteTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &deleteTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	updateTenantRoleName := "readSchemaAndUpdateTenant"
+	updateTenantRole := &models.Role{
+		Name: &updateTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &updateTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	helper.DeleteRole(t, adminKey, *createTenantRole.Name)
+	helper.DeleteRole(t, adminKey, *readTenantRole.Name)
+	helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
+	helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
+	helper.CreateRole(t, adminKey, createTenantRole)
+	helper.CreateRole(t, adminKey, readTenantRole)
+	helper.CreateRole(t, adminKey, deleteTenantRole)
+	helper.CreateRole(t, adminKey, updateTenantRole)
+	defer helper.DeleteRole(t, adminKey, *createTenantRole.Name)
+	defer helper.DeleteRole(t, adminKey, *readTenantRole.Name)
+	defer helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
+	defer helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
+
+	tenants := []*models.Tenant{{Name: "Tenant1"}}
+
+	t.Run("Create tenant", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createTenantRole.Name, customUser)
+		require.NoError(t, createTenant(t, className, tenants, customKey))
+		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, adminKey))
+	})
+
+	t.Run("Tenant read and exist", func(t *testing.T) {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+
+		helper.AssignRoleToUser(t, adminKey, *readTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *readTenantRole.Name, customUser)
+
+		require.NoError(t, readTenant(t, className, tenants[0].Name, customKey))
+		require.NoError(t, readTenants(t, className, customKey))
+		require.NoError(t, existsTenant(t, className, tenants[0].Name, customKey))
+	})
+
+	t.Run("delete tenant", func(t *testing.T) {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+
+		helper.AssignRoleToUser(t, adminKey, *deleteTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *deleteTenantRole.Name, customUser)
+
+		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, customKey))
+	})
+
+	t.Run("update tenant status", func(t *testing.T) {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+
+		helper.AssignRoleToUser(t, adminKey, *updateTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *updateTenantRole.Name, customUser)
+
+		require.NoError(t, updateTenantStatus(t, className, []*models.Tenant{{Name: "Tenant1", ActivityStatus: "INACTIVE"}}, customKey))
+	})
+}

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package authz
 
 import (

--- a/test/acceptance_with_python/rbac/test_schema.py
+++ b/test/acceptance_with_python/rbac/test_schema.py
@@ -1,7 +1,6 @@
 import pytest
 import weaviate
 import weaviate.classes as wvc
-from weaviate.collections.classes.tenants import Tenant, TenantActivityStatus
 from weaviate.rbac.models import Permissions
 from _pytest.fixtures import SubRequest
 from .conftest import _sanitize_role_name, RoleWrapperProtocol, generate_missing_permissions
@@ -9,9 +8,8 @@ from .conftest import _sanitize_role_name, RoleWrapperProtocol, generate_missing
 pytestmark = pytest.mark.xdist_group(name="rbac")
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_create(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
@@ -19,12 +17,7 @@ def test_rbac_collection_create(
         Permissions.collections(collection=name, read_config=True, create_collection=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
-        col = custom_client.collections.create(
-            name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-        )
-        if mt:
-            col.tenants.create("tenant1")
-
+        custom_client.collections.create(name=name)
         admin_client.collections.delete(name)
 
     for permission in generate_missing_permissions(required_permissions):
@@ -74,24 +67,17 @@ def test_rbac_collection_create_with_ref(
     admin_client.collections.delete([name_target, name_source])
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_read(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
-    col_admin = admin_client.collections.create(
-        name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-    )
-    if mt:
-        col_admin.tenants.create("tenant1")
+    admin_client.collections.create(name=name)
 
     required_permissions = Permissions.collections(collection=name, read_config=True)
     with role_wrapper(admin_client, request, required_permissions):
         col = custom_client.collections.get(name=name)
         assert col.config.get() is not None
-        if mt:
-            assert col.tenants.get() is not None
 
     with role_wrapper(admin_client, request, []):
         col = custom_client.collections.get(name=name)
@@ -99,11 +85,6 @@ def test_rbac_collection_read(
             col.config.get()
         assert e.value.status_code == 403
         assert "forbidden" in e.value.args[0]
-
-        if mt:
-            with pytest.raises(weaviate.exceptions.InsufficientPermissionsError) as ee:
-                col.tenants.get()
-            assert "forbidden" in ee.value.args[0]
 
     admin_client.collections.delete(name)
 
@@ -127,17 +108,12 @@ def test_rbac_schema_read(
     admin_client.collections.delete(name)
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_update(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
-    col_admin = admin_client.collections.create(
-        name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-    )
-    if mt:
-        col_admin.tenants.create("tenant1")
+    admin_client.collections.create(name=name)
 
     required_permissions = [
         Permissions.collections(collection=name, read_config=True, update_config=True),
@@ -145,14 +121,6 @@ def test_rbac_collection_update(
     with role_wrapper(admin_client, request, required_permissions):
         col_custom = custom_client.collections.get(name)
         col_custom.config.update(description="test")
-        if mt:
-            col_custom.tenants.update(
-                Tenant(name="tenant1", activity_status=TenantActivityStatus.INACTIVE)
-            )
-            # ensure that update worked
-            assert (
-                col_admin.tenants.get()["tenant1"].activity_status == TenantActivityStatus.INACTIVE
-            )
 
     for permission in generate_missing_permissions(required_permissions):
         with role_wrapper(admin_client, request, permission):
@@ -161,13 +129,6 @@ def test_rbac_collection_update(
                 col_custom.config.update(description="test")
             assert e.value.status_code == 403
             assert "forbidden" in e.value.args[0]
-
-            if mt:
-                with pytest.raises(weaviate.exceptions.InsufficientPermissionsError) as e:
-                    col_custom.tenants.update(
-                        Tenant(name="tenant1", activity_status=TenantActivityStatus.INACTIVE)
-                    )
-                assert "forbidden" in e.value.args[0]
 
     admin_client.collections.delete(name)
 
@@ -204,17 +165,11 @@ def test_rbac_collection_update_with_ref(
     admin_client.collections.delete([name_target, name_source])
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_delete(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
-    col_admin = admin_client.collections.create(
-        name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-    )
-    if mt:
-        col_admin.tenants.create("tenant1")
 
     required_permissions = [
         Permissions.collections(collection=name, delete_collection=True, read_config=True),
@@ -227,17 +182,7 @@ def test_rbac_collection_delete(
             assert "forbidden" in e.value.args[0]
             assert admin_client.collections.get(name) is not None
 
-            if mt:
-                col_custom = custom_client.collections.get(name)
-                with pytest.raises(weaviate.exceptions.InsufficientPermissionsError) as e:
-                    col_custom.tenants.remove("tenant1")
-                assert e.value.status_code == 403
-                assert "forbidden" in e.value.args[0]
-
     with role_wrapper(admin_client, request, required_permissions):
-        if mt:
-            col_custom = custom_client.collections.get(name)
-            col_custom.tenants.remove("tenant1")
         custom_client.collections.delete(name)
         assert not admin_client.collections.exists(name)
 

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -70,6 +70,15 @@ func AssignRoleToUser(t *testing.T, key, role, user string) {
 	require.Nil(t, err)
 }
 
+func RevokeRoleFromUser(t *testing.T, key, role, user string) {
+	resp, err := Client(t).Authz.RevokeRole(
+		authz.NewRevokeRoleParams().WithID(user).WithBody(authz.RevokeRoleBody{Roles: []string{role}}),
+		CreateAuth(key),
+	)
+	AssertRequestOk(t, resp, err, nil)
+	require.Nil(t, err)
+}
+
 func AddPermissions(t *testing.T, key, role string, permissions ...*models.Permission) {
 	resp, err := Client(t).Authz.AddPermissions(
 		authz.NewAddPermissionsParams().WithID(role).WithBody(authz.AddPermissionsBody{

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -70,6 +70,8 @@ var resourcePatterns = []string{
 	fmt.Sprintf(`^%s/collections/[^/]+/shards/.*$`, authorization.SchemaDomain),
 	fmt.Sprintf(`^%s/collections/[^/]+/shards/[^/]+/objects/.*$`, authorization.DataDomain),
 	fmt.Sprintf(`^%s/collections/[^/]+/shards/[^/]+/objects/[^/]+$`, authorization.DataDomain),
+	fmt.Sprintf(`^%s/collections/[^/]+$`, authorization.TenantDomain),
+	fmt.Sprintf(`^%s/collections/[^/]+/tenants/.*$`, authorization.TenantDomain),
 }
 
 func newPolicy(policy []string) *authorization.Policy {
@@ -302,6 +304,11 @@ func permission(policy []string) (*models.Permission, error) {
 			Tenant:     &splits[4],
 			Object:     &splits[6],
 		}
+	case authorization.TenantDomain:
+		permission.Tenants = &models.PermissionTenants{
+			Collection: &splits[2],
+			Tenant:     &splits[4],
+		}
 	case authorization.RolesDomain:
 		permission.Roles = &models.PermissionRoles{
 			Role: &splits[1],
@@ -328,6 +335,7 @@ func permission(policy []string) (*models.Permission, error) {
 		permission.Nodes = authorization.AllNodes
 		permission.Roles = authorization.AllRoles
 		permission.Collections = authorization.AllCollections
+		permission.Tenants = authorization.AllTenants
 	case authorization.ClusterDomain, authorization.UsersDomain:
 		// do nothing
 	default:

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -230,6 +230,16 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 			object = *permission.Data.Object
 		}
 		resource = CasbinData(collection, tenant, object)
+	case authorization.TenantDomain:
+		collection := "*"
+		tenant := "*"
+		if permission.Tenants != nil && permission.Tenants.Collection != nil {
+			collection = schema.UppercaseClassName(*permission.Tenants.Collection)
+		}
+		if permission.Tenants != nil && permission.Tenants.Tenant != nil {
+			tenant = *permission.Tenants.Tenant
+		}
+		resource = CasbinTenant(collection, tenant)
 	case authorization.BackupsDomain:
 		collection := "*"
 		if permission.Backups != nil {

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -155,6 +155,19 @@ func CasbinData(collection, shard, object string) string {
 	return fmt.Sprintf("%s/collections/%s/shards/%s/objects/%s", authorization.DataDomain, collection, shard, object)
 }
 
+func CasbinTenant(collection, tenant string) string {
+	collection = schema.UppercaseClassesNames(collection)[0]
+	if collection == "" {
+		collection = "*"
+	}
+	if tenant == "" {
+		tenant = "*"
+	}
+	collection = strings.ReplaceAll(collection, "*", ".*")
+	tenant = strings.ReplaceAll(tenant, "*", ".*")
+	return fmt.Sprintf("%s/collections/%s/tenants/%s", authorization.TenantDomain, collection, tenant)
+}
+
 func policy(permission *models.Permission) (*authorization.Policy, error) {
 	if permission.Action == nil {
 		return &authorization.Policy{Resource: InternalPlaceHolder}, nil

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -406,6 +406,70 @@ func Test_policy(t *testing.T) {
 			},
 			tests: objectsDataTests,
 		},
+		{
+			name: "a tenant",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("Foo", ""),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "all tenants in all collections",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("*", "*"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "all tenants in a collection",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("Foo", "*"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "a tenant in all collections",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Tenant: bar,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("*", "bar"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "a tenant in a collection",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+					Tenant:     bar,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("Foo", "bar"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
 	}
 	for _, tt := range tests {
 		for _, ttt := range tt.tests {

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -73,6 +73,12 @@ var (
 		{permissionAction: authorization.UpdateData, testDescription: updateDesc, policyVerb: updateVerb},
 		{permissionAction: authorization.DeleteData, testDescription: deleteDesc, policyVerb: deleteVerb},
 	}
+	tenantsActionTests = []innerTest{
+		{permissionAction: authorization.CreateTenant, testDescription: createDesc, policyVerb: createVerb},
+		{permissionAction: authorization.ReadTenant, testDescription: readDesc, policyVerb: readVerb},
+		{permissionAction: authorization.UpdateTenant, testDescription: updateDesc, policyVerb: updateVerb},
+		{permissionAction: authorization.DeleteTenant, testDescription: deleteDesc, policyVerb: deleteVerb},
+	}
 )
 
 func Test_policy(t *testing.T) {
@@ -475,6 +481,25 @@ func Test_permission(t *testing.T) {
 				},
 			},
 			tests: nodesTests,
+		},
+		{
+			name:   "all tenants",
+			policy: []string{"p", "/collections/*/tenants/*", "", authorization.TenantDomain},
+			permission: &models.Permission{
+				Tenants: authorization.AllTenants,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name:   "a tenant",
+			policy: []string{"p", "/collections/Foo/tenants/*", "", authorization.TenantDomain},
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+					Tenant:     authorization.All,
+				},
+			},
+			tests: tenantsActionTests,
 		},
 		{
 			name:   "all collections",

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -41,6 +41,8 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Allow all shards with ABC", authorization.ShardsMetadata("ABC", "ABC")[0], "*", true},
 		{"Allow all objects", authorization.Objects("", "", ""), "*", true},
 		{"Allow all objects with Tenant1", authorization.Objects("", "Tenant1", ""), "*", true},
+		{"Allow all tenants", authorization.Tenants("")[0], "*", true},
+		{"Allow all tenants with ABC", authorization.Tenants("ABC", "ABC")[0], "*", true},
 
 		// Class level
 		{"Class level collections ABC", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("*", ""), true},
@@ -50,6 +52,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Class level collections Class2 mismatch", authorization.CollectionsMetadata("Class2")[0], conv.CasbinSchema("Class1", ""), false},
 		{"Class level shards ABC TenantX", authorization.ShardsMetadata("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
 		{"Class level objects ABC TenantX objectY", authorization.Objects("ABC", "TenantX", "objectY"), conv.CasbinData("ABC", "*", "*"), true},
+		{"Class level tenant ABC TenantX", authorization.Tenants("ABC", "TenantX")[0], conv.CasbinTenant("ABC", ""), true},
 
 		// Tenants level
 		{"Tenants level shards", authorization.ShardsMetadata("")[0], conv.CasbinSchema("*", "*"), true},
@@ -74,6 +77,17 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Objects level ABC Tenant1 abcd mismatch", authorization.Objects("ABC", "Tenant1", "abcd"), conv.CasbinData("ABC", "Tenant1", "abc"), false},
 		{"Objects level ABC bar abcd", authorization.Objects("ABC", "bar", "abcd"), conv.CasbinData("*", "bar", ""), true},
 
+		// Tenants
+		{"Tenants level tenant", authorization.Tenants("")[0], conv.CasbinTenant("*", "*"), true},
+		{"Tenants level tenant ABC Tenant1", authorization.Tenants("ABC", "Tenant1")[0], conv.CasbinTenant("*", "*"), true},
+		{"Tenants level tenant Class1 Tenant1", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinTenant("*", "Tenant1"), true},
+		{"Tenants level objects Class1 Tenant1 ObjectY", authorization.Objects("Class1", "Tenant1", "ObjectY"), conv.CasbinData("*", "Tenant1", ""), true},
+		{"Tenants level tenant Class1 Tenant2 mismatch", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinTenant("*", "Tenant1"), false},
+		{"Tenants level tenant Class1 Tenant2 mismatch 2", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinTenant("Class2", "Tenant1"), false},
+		{"Tenants level tenant mismatch", authorization.Tenants("")[0], conv.CasbinTenant("Class1", ""), false},
+		{"Tenants level collections Class1", authorization.Tenants("Class1")[0], conv.CasbinTenant("Class1", ""), true},
+		{"Tenants level tenant Class1 tenant1", authorization.Tenants("Class1", "tenant1")[0], conv.CasbinTenant("Class1", ""), true},
+
 		// Regex
 		{"Regex collections ABCD", authorization.CollectionsMetadata("ABCD")[0], conv.CasbinSchema("ABC", ""), false},
 		{"Regex shards ABC", authorization.ShardsMetadata("ABC", "")[0], conv.CasbinSchema("ABC", ""), true},
@@ -81,6 +95,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Regex objects ABCD mismatch", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
 		{"Regex objects ABCD wildcard", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC.*", "*", "*"), true},
 		{"Regex objects BCD mismatch", authorization.Objects("BCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
+		{"Regex tenant ABC", authorization.Tenants("ABC", "")[0], conv.CasbinTenant("ABC", ""), true},
 
 		{"Regex collections ABC wildcard", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
 		{"Regex collections ABC wildcard 2", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
@@ -99,6 +114,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Partial match object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Obj*"), true},
 		{"Special character mismatch", authorization.Objects("Class1", "Shard1", "Object1"), "data/collections/Class1/shards/Shard1/objects/Object1!", false},
 		{"Mismatched object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Object2"), false},
+		{"Mismatched tenant", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinTenant("Class1", "Tenant2"), false},
 	}
 
 	for _, tt := range tests {

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -54,6 +54,10 @@ var (
 		Tenant:     All,
 		Object:     All,
 	}
+	AllTenants = &models.PermissionTenants{
+		Collection: All,
+		Tenant:     All,
+	}
 	AllNodes = &models.PermissionNodes{
 		Verbosity:  String(verbosity.OutputVerbose),
 		Collection: All,
@@ -91,6 +95,11 @@ var (
 	UpdateData = "update_data"
 	DeleteData = "delete_data"
 
+	CreateTenant = "create_tenant"
+	ReadTenant   = "read_tenant"
+	UpdateTenant = "update_tenant"
+	DeleteTenant = "delete_tenant"
+
 	availableWeaviateActions = []string{
 		// Roles domain
 		ManageRoles,
@@ -121,6 +130,12 @@ var (
 		ReadData,
 		UpdateData,
 		DeleteData,
+
+		// Tenant domain
+		CreateTenant,
+		ReadTenant,
+		UpdateTenant,
+		DeleteTenant,
 	}
 )
 
@@ -434,6 +449,7 @@ func viewerPermissions() []*models.Permission {
 			Nodes:       AllNodes,
 			Roles:       AllRoles,
 			Collections: AllCollections,
+			Tenants:     AllTenants,
 		})
 	}
 
@@ -452,6 +468,7 @@ func adminPermissions() []*models.Permission {
 			Nodes:       AllNodes,
 			Roles:       AllRoles,
 			Collections: AllCollections,
+			Tenants:     AllTenants,
 		})
 	}
 

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -39,6 +39,7 @@ const (
 	NodesDomain   = "nodes"
 	BackupsDomain = "backups"
 	SchemaDomain  = "schema"
+	TenantDomain  = "tenant"
 	DataDomain    = "data"
 )
 
@@ -319,6 +320,40 @@ func ShardsData(class string, shards ...string) []string {
 		paths = append(paths, Objects(class, shard, "*"))
 	}
 	return paths
+}
+
+// Tenants generates a list of shard resource strings for a given class and tenants.
+// If the class is an empty string, it defaults to "*". If no tenants are provided,
+// it returns a single resource string with a wildcard for tenants. If tenants are
+// provided, it returns a list of resource strings for each tenants.
+//
+// Parameters:
+//   - class: The class name for the resource. If empty, defaults to "*".
+//   - tenants: A variadic list of shard names. If empty, a wildcard is used.
+//
+// Returns:
+//
+//	A slice of strings representing the resource paths for the given class and tenants.
+func Tenants(class string, tenants ...string) []string {
+	class = schema.UppercaseClassesNames(class)[0]
+	if class == "" {
+		class = "*"
+	}
+
+	if len(tenants) == 0 || (len(tenants) == 1 && (tenants[0] == "" || tenants[0] == "*")) {
+		return []string{fmt.Sprintf("%s/collections/%s/tenants/*", TenantDomain, class)}
+	}
+
+	resources := make([]string, len(tenants))
+	for idx := range tenants {
+		if tenants[idx] == "" {
+			resources[idx] = fmt.Sprintf("%s/collections/%s/tenants/*", TenantDomain, class)
+		} else {
+			resources[idx] = fmt.Sprintf("%s/collections/%s/tenants/%s", TenantDomain, class, tenants[idx])
+		}
+	}
+
+	return resources
 }
 
 // Objects generates a string representing a path to objects within a collection and shard.

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -39,7 +39,7 @@ const (
 	NodesDomain   = "nodes"
 	BackupsDomain = "backups"
 	SchemaDomain  = "schema"
-	TenantDomain  = "tenant"
+	TenantDomain  = "tenants"
 	DataDomain    = "data"
 )
 
@@ -95,10 +95,10 @@ var (
 	UpdateData = "update_data"
 	DeleteData = "delete_data"
 
-	CreateTenant = "create_tenant"
-	ReadTenant   = "read_tenant"
-	UpdateTenant = "update_tenant"
-	DeleteTenant = "delete_tenant"
+	CreateTenant = "create_tenants"
+	ReadTenant   = "read_tenants"
+	UpdateTenant = "update_tenants"
+	DeleteTenant = "delete_tenants"
 
 	availableWeaviateActions = []string{
 		// Roles domain

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -170,3 +170,26 @@ func TestObjects(t *testing.T) {
 		})
 	}
 }
+
+func TestTenants(t *testing.T) {
+	tests := []struct {
+		name     string
+		class    string
+		shards   []string
+		expected []string
+	}{
+		{"No class, no tenant", "", []string{}, []string{fmt.Sprintf("%s/collections/*/tenants/*", TenantDomain)}},
+		{"Class, no tenant", "class1", []string{}, []string{fmt.Sprintf("%s/collections/Class1/tenants/*", TenantDomain)}},
+		{"No class, single tenant", "", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/*/tenants/tenant1", TenantDomain)}},
+		{"Class, single tenants", "class1", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain)}},
+		{"Class, multiple tenants", "class1", []string{"tenant1", "tenant2"}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain), fmt.Sprintf("%s/collections/Class1/tenants/tenant2", TenantDomain)}},
+		{"Class, empty tenant", "class1", []string{"tenant1", ""}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain), fmt.Sprintf("%s/collections/Class1/tenants/*", TenantDomain)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Tenants(tt.class, tt.shards...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -112,7 +112,7 @@ func Test_Schema_Authorization(t *testing.T) {
 			methodName:        "AddTenants",
 			additionalArgs:    []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
 			expectedVerb:      authorization.CREATE,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 		{
 			methodName: "UpdateTenants",
@@ -120,31 +120,25 @@ func Test_Schema_Authorization(t *testing.T) {
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
 			expectedVerb:      authorization.UPDATE,
-			expectedResources: authorization.ShardsMetadata("className", "P1"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 		{
 			methodName:        "DeleteTenants",
 			additionalArgs:    []interface{}{"className", []string{"P1"}},
 			expectedVerb:      authorization.DELETE,
-			expectedResources: authorization.ShardsMetadata("className", "P1"),
-		},
-		{
-			methodName:        "GetTenants",
-			additionalArgs:    []interface{}{"className"},
-			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 		{
 			methodName:        "GetConsistentTenants",
 			additionalArgs:    []interface{}{"className", false, []string{}},
 			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className"),
 		},
 		{
 			methodName:        "ConsistentTenantExists",
 			additionalArgs:    []interface{}{"className", false, "P1"},
 			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 	}
 

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -42,7 +42,14 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.ShardsMetadata(class)...); err != nil {
+	tenantNames := make([]string, len(tenants))
+	for i, tenant := range tenants {
+		tenantNames[i] = tenant.Name
+	}
+	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.Tenants(class, tenantNames...)...); err != nil {
+		return 0, err
+	}
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return 0, err
 	}
 
@@ -155,10 +162,10 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 		shardNames[idx] = tenants[idx].Name
 	}
 
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsMetadata(class, shardNames...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Tenants(class, shardNames...)...); err != nil {
 		return nil, err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, shardNames...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return nil, err
 	}
 
@@ -202,10 +209,10 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.ShardsMetadata(class, tenants...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.Tenants(class, tenants...)...); err != nil {
 		return err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenants...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
 	}
 
@@ -223,18 +230,11 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 	return err
 }
 
-// GetTenants is used to get tenants of a class.
-//
-// Class must exist and has partitioning enabled
-func (h *Handler) GetTenants(ctx context.Context, principal *models.Principal, class string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class)...); err != nil {
+func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.TenantResponse, error) {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenants...)...); err != nil {
 		return nil, err
 	}
-	return h.getTenants(class)
-}
-
-func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.TenantResponse, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return nil, err
 	}
 
@@ -288,7 +288,10 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenant)...); err != nil {
+		return err
+	}
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
 	}
 

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -247,32 +247,6 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	return h.getTenantsByNames(class, tenants)
 }
 
-func (h *Handler) getTenants(class string) ([]*models.Tenant, error) {
-	info, err := h.multiTenancy(class)
-	if err != nil || info.Tenants == 0 {
-		return nil, err
-	}
-
-	ts := make([]*models.Tenant, info.Tenants)
-	f := func(_ *models.Class, ss *sharding.State) error {
-		if n := len(ss.Physical); n > len(ts) {
-			ts = make([]*models.Tenant, n)
-		} else if n < len(ts) {
-			ts = ts[:n]
-		}
-		i := 0
-		for tenant := range ss.Physical {
-			ts[i] = &models.Tenant{
-				Name:           tenant,
-				ActivityStatus: schema.ActivityStatus(ss.Physical[tenant].Status),
-			}
-			i++
-		}
-		return nil
-	}
-	return ts, h.schemaReader.Read(class, f)
-}
-
 func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 	info := h.schemaReader.ClassInfo(class)
 	if !info.Exists {


### PR DESCRIPTION
### What's being changed:

Adds an extra permission for tenant operations and migrates all tenant over to using it. Now collection operations have the collection permission and tenant operations have the tenant permission.

The paths support collection and tenant level filtering, but we will only expose collection level filtering for now and add the tenant filtering later.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
