### PR TITLE
feat: rbac seperate tenant and collections inside schema

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
@@ -76,7 +76,6 @@ func TestAddPermissionsSuccess(t *testing.T) {
 							Action: String(authorization.CreateCollections),
 							Collections: &models.PermissionCollections{
 								Collection: String("ABC"),
-								Tenant:     String("Tenant1"),
 							},
 						},
 					},
@@ -91,10 +90,8 @@ func TestAddPermissionsSuccess(t *testing.T) {
 				Body: authz.AddPermissionsBody{
 					Permissions: []*models.Permission{
 						{
-							Action: String(authorization.CreateCollections),
-							Collections: &models.PermissionCollections{
-								Tenant: String("Tenant1"),
-							},
+							Action:      String(authorization.CreateCollections),
+							Collections: &models.PermissionCollections{},
 						},
 					},
 				},

--- a/adapters/handlers/rest/authz/handlers_authz_create_role_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_create_role_test.go
@@ -77,7 +77,7 @@ func TestCreateRoleSuccess(t *testing.T) {
 					Permissions: []*models.Permission{
 						{
 							Action: String(authorization.CreateCollections),
-							Collections: &models.PermissionCollections{
+							Tenants: &models.PermissionTenants{
 								Collection: String("ABC"),
 								Tenant:     String("Tenant1"),
 							},
@@ -95,7 +95,7 @@ func TestCreateRoleSuccess(t *testing.T) {
 					Permissions: []*models.Permission{
 						{
 							Action: String(authorization.CreateCollections),
-							Collections: &models.PermissionCollections{
+							Tenants: &models.PermissionTenants{
 								Tenant: String("Tenant1"),
 							},
 						},

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5470,7 +5470,6 @@ func init() {
           "enum": [
             "manage_backups",
             "read_cluster",
-            "manage_data",
             "create_data",
             "read_data",
             "update_data",
@@ -5478,7 +5477,6 @@ func init() {
             "read_nodes",
             "manage_roles",
             "read_roles",
-            "manage_collections",
             "create_collections",
             "read_collections",
             "update_collections",
@@ -5506,11 +5504,6 @@ func init() {
           "properties": {
             "collection": {
               "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
-              "type": "string",
-              "default": "*"
-            },
-            "tenant": {
-              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
             }
@@ -12220,7 +12213,6 @@ func init() {
           "enum": [
             "manage_backups",
             "read_cluster",
-            "manage_data",
             "create_data",
             "read_data",
             "update_data",
@@ -12228,7 +12220,6 @@ func init() {
             "read_nodes",
             "manage_roles",
             "read_roles",
-            "manage_collections",
             "create_collections",
             "read_collections",
             "update_collections",
@@ -12256,11 +12247,6 @@ func init() {
           "properties": {
             "collection": {
               "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
-              "type": "string",
-              "default": "*"
-            },
-            "tenant": {
-              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
             }
@@ -12353,11 +12339,6 @@ func init() {
       "properties": {
         "collection": {
           "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
-          "type": "string",
-          "default": "*"
-        },
-        "tenant": {
-          "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
           "type": "string",
           "default": "*"
         }

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5482,7 +5482,11 @@ func init() {
             "create_collections",
             "read_collections",
             "update_collections",
-            "delete_collections"
+            "delete_collections",
+            "create_tenants",
+            "read_tenants",
+            "update_tenants",
+            "delete_tenants"
           ]
         },
         "backups": {
@@ -5559,6 +5563,22 @@ func init() {
           "properties": {
             "role": {
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            }
+          }
+        },
+        "tenants": {
+          "description": "resources applicable for tenant actions",
+          "type": "object",
+          "properties": {
+            "collection": {
+              "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            },
+            "tenant": {
+              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
             }
@@ -12212,7 +12232,11 @@ func init() {
             "create_collections",
             "read_collections",
             "update_collections",
-            "delete_collections"
+            "delete_collections",
+            "create_tenants",
+            "read_tenants",
+            "update_tenants",
+            "delete_tenants"
           ]
         },
         "backups": {
@@ -12289,6 +12313,22 @@ func init() {
           "properties": {
             "role": {
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            }
+          }
+        },
+        "tenants": {
+          "description": "resources applicable for tenant actions",
+          "type": "object",
+          "properties": {
+            "collection": {
+              "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
+              "type": "string",
+              "default": "*"
+            },
+            "tenant": {
+              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
             }
@@ -12370,6 +12410,22 @@ func init() {
       "properties": {
         "role": {
           "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
+          "type": "string",
+          "default": "*"
+        }
+      }
+    },
+    "PermissionTenants": {
+      "description": "resources applicable for tenant actions",
+      "type": "object",
+      "properties": {
+        "collection": {
+          "description": "string or regex. if a specific collection name, if left empty it will be ALL or *",
+          "type": "string",
+          "default": "*"
+        },
+        "tenant": {
+          "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *",
           "type": "string",
           "default": "*"
         }

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,6 +30,7 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
+
 	// allowed actions in weaviate.
 	// Required: true
 	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections create_tenants read_tenants update_tenants delete_tenants]
@@ -173,6 +174,7 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
+
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -334,6 +336,7 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Backups != nil {
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -349,6 +352,7 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Collections != nil {
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -364,6 +368,7 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Data != nil {
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -379,6 +384,7 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Nodes != nil {
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -394,6 +400,7 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Roles != nil {
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -409,6 +416,7 @@ func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Tenants != nil {
 		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -445,6 +453,7 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 }
@@ -481,6 +490,7 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -520,6 +530,7 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -562,6 +573,7 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -653,6 +665,7 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
+
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
 }
@@ -689,6 +702,7 @@ func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionTenants
 type PermissionTenants struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -33,7 +33,7 @@ type Permission struct {
 
 	// allowed actions in weaviate.
 	// Required: true
-	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections create_tenants read_tenants update_tenants delete_tenants]
+	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes manage_roles read_roles create_collections read_collections update_collections delete_collections create_tenants read_tenants update_tenants delete_tenants]
 	Action *string `json:"action"`
 
 	// backups
@@ -97,7 +97,7 @@ var permissionTypeActionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","manage_data","create_data","read_data","update_data","delete_data","read_nodes","manage_roles","read_roles","manage_collections","create_collections","read_collections","update_collections","delete_collections","create_tenants","read_tenants","update_tenants","delete_tenants"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","create_data","read_data","update_data","delete_data","read_nodes","manage_roles","read_roles","create_collections","read_collections","update_collections","delete_collections","create_tenants","read_tenants","update_tenants","delete_tenants"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -112,9 +112,6 @@ const (
 
 	// PermissionActionReadCluster captures enum value "read_cluster"
 	PermissionActionReadCluster string = "read_cluster"
-
-	// PermissionActionManageData captures enum value "manage_data"
-	PermissionActionManageData string = "manage_data"
 
 	// PermissionActionCreateData captures enum value "create_data"
 	PermissionActionCreateData string = "create_data"
@@ -136,9 +133,6 @@ const (
 
 	// PermissionActionReadRoles captures enum value "read_roles"
 	PermissionActionReadRoles string = "read_roles"
-
-	// PermissionActionManageCollections captures enum value "manage_collections"
-	PermissionActionManageCollections string = "manage_collections"
 
 	// PermissionActionCreateCollections captures enum value "create_collections"
 	PermissionActionCreateCollections string = "create_collections"
@@ -493,9 +487,6 @@ type PermissionCollections struct {
 
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
-
-	// string or regex. if a specific tenant name, if left empty it will be ALL or *
-	Tenant *string `json:"tenant,omitempty"`
 }
 
 // Validate validates this permission collections

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,10 +30,9 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
-
 	// allowed actions in weaviate.
 	// Required: true
-	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections]
+	// Enum: [manage_backups read_cluster manage_data create_data read_data update_data delete_data read_nodes manage_roles read_roles manage_collections create_collections read_collections update_collections delete_collections create_tenants read_tenants update_tenants delete_tenants]
 	Action *string `json:"action"`
 
 	// backups
@@ -50,6 +49,9 @@ type Permission struct {
 
 	// roles
 	Roles *PermissionRoles `json:"roles,omitempty"`
+
+	// tenants
+	Tenants *PermissionTenants `json:"tenants,omitempty"`
 }
 
 // Validate validates this permission
@@ -80,6 +82,10 @@ func (m *Permission) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateTenants(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -90,7 +96,7 @@ var permissionTypeActionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","manage_data","create_data","read_data","update_data","delete_data","read_nodes","manage_roles","read_roles","manage_collections","create_collections","read_collections","update_collections","delete_collections"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","manage_data","create_data","read_data","update_data","delete_data","read_nodes","manage_roles","read_roles","manage_collections","create_collections","read_collections","update_collections","delete_collections","create_tenants","read_tenants","update_tenants","delete_tenants"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -144,6 +150,18 @@ const (
 
 	// PermissionActionDeleteCollections captures enum value "delete_collections"
 	PermissionActionDeleteCollections string = "delete_collections"
+
+	// PermissionActionCreateTenants captures enum value "create_tenants"
+	PermissionActionCreateTenants string = "create_tenants"
+
+	// PermissionActionReadTenants captures enum value "read_tenants"
+	PermissionActionReadTenants string = "read_tenants"
+
+	// PermissionActionUpdateTenants captures enum value "update_tenants"
+	PermissionActionUpdateTenants string = "update_tenants"
+
+	// PermissionActionDeleteTenants captures enum value "delete_tenants"
+	PermissionActionDeleteTenants string = "delete_tenants"
 )
 
 // prop value enum
@@ -155,7 +173,6 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
-
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -263,6 +280,25 @@ func (m *Permission) validateRoles(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Permission) validateTenants(formats strfmt.Registry) error {
+	if swag.IsZero(m.Tenants) { // not required
+		return nil
+	}
+
+	if m.Tenants != nil {
+		if err := m.Tenants.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("tenants")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("tenants")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this permission based on the context it is used
 func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -287,6 +323,10 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateTenants(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -294,7 +334,6 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Backups != nil {
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -310,7 +349,6 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Collections != nil {
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -326,7 +364,6 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Data != nil {
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -342,7 +379,6 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Nodes != nil {
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -358,13 +394,27 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Roles != nil {
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("roles")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
+	if m.Tenants != nil {
+		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("tenants")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("tenants")
 			}
 			return err
 		}
@@ -395,7 +445,6 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 }
@@ -432,7 +481,6 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -472,7 +520,6 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -515,7 +562,6 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -607,7 +653,6 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
-
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
 }
@@ -633,6 +678,45 @@ func (m *PermissionRoles) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 	var res PermissionRoles
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// PermissionTenants resources applicable for tenant actions
+//
+// swagger:model PermissionTenants
+type PermissionTenants struct {
+	// string or regex. if a specific collection name, if left empty it will be ALL or *
+	Collection *string `json:"collection,omitempty"`
+
+	// string or regex. if a specific tenant name, if left empty it will be ALL or *
+	Tenant *string `json:"tenant,omitempty"`
+}
+
+// Validate validates this permission tenants
+func (m *PermissionTenants) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this permission tenants based on context it is used
+func (m *PermissionTenants) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *PermissionTenants) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *PermissionTenants) UnmarshalBinary(b []byte) error {
+	var res PermissionTenants
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -114,11 +114,6 @@
               "type": "string",
               "default": "*",
               "description": "string or regex. if a specific collection name, if left empty it will be ALL or *"
-            },
-            "tenant": {
-              "type": "string",
-              "default": "*",
-              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *"
             }
           }
         },
@@ -130,7 +125,6 @@
 
             "read_cluster",
 
-            "manage_data",
             "create_data",
             "read_data",
             "update_data",
@@ -141,7 +135,6 @@
             "manage_roles",
             "read_roles",
 
-            "manage_collections",
             "create_collections",
             "read_collections",
             "update_collections",

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -79,6 +79,22 @@
             }
           }
         },
+        "tenants": {
+          "type": "object",
+          "description": "resources applicable for tenant actions",
+          "properties": {
+            "collection": {
+              "type": "string",
+              "default": "*",
+              "description": "string or regex. if a specific collection name, if left empty it will be ALL or *"
+            },
+            "tenant": {
+              "type": "string",
+              "default": "*",
+              "description": "string or regex. if a specific tenant name, if left empty it will be ALL or *"
+            }
+          }
+        },
         "roles": {
           "type": "object",
           "description": "resources applicable for role actions",
@@ -129,7 +145,12 @@
             "create_collections",
             "read_collections",
             "update_collections",
-            "delete_collections"
+            "delete_collections",
+
+            "create_tenants",
+            "read_tenants",
+            "update_tenants",
+            "delete_tenants"
           ]
         }
       },

--- a/test/acceptance/authz/autoschema_test.go
+++ b/test/acceptance/authz/autoschema_test.go
@@ -35,10 +35,8 @@ func TestAutoschemaAuthZ(t *testing.T) {
 	adminUser := "admin-user"
 	adminAuth := helper.CreateAuth(adminKey)
 
-	readSchemaAction := authorization.ReadCollections
 	createDataAction := authorization.CreateData
 	updateSchemaAction := authorization.UpdateCollections
-	createSchemaAction := authorization.CreateCollections
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -82,7 +80,7 @@ func TestAutoschemaAuthZ(t *testing.T) {
 	readSchemaRole := &models.Role{
 		Name: &readSchemaAndCreateDataRoleName,
 		Permissions: []*models.Permission{
-			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &authorization.ReadTenant, Tenants: &models.PermissionTenants{Collection: &all}},
 			{Action: &createDataAction, Data: &models.PermissionData{Collection: &all}},
 		},
 	}
@@ -95,8 +93,10 @@ func TestAutoschemaAuthZ(t *testing.T) {
 	}
 	createSchemaRoleName := "createSchema"
 	createSchemaRole := &models.Role{
-		Name:        &createSchemaRoleName,
-		Permissions: []*models.Permission{{Action: &createSchemaAction, Collections: &models.PermissionCollections{Collection: &classNameNew}}},
+		Name: &createSchemaRoleName,
+		Permissions: []*models.Permission{
+			{Action: &authorization.CreateTenant, Tenants: &models.PermissionTenants{Collection: &classNameNew}},
+		},
 	}
 
 	helper.DeleteRole(t, adminKey, *readSchemaRole.Name)

--- a/test/acceptance/authz/autoschema_test.go
+++ b/test/acceptance/authz/autoschema_test.go
@@ -80,7 +80,7 @@ func TestAutoschemaAuthZ(t *testing.T) {
 	readSchemaRole := &models.Role{
 		Name: &readSchemaAndCreateDataRoleName,
 		Permissions: []*models.Permission{
-			{Action: &authorization.ReadTenant, Tenants: &models.PermissionTenants{Collection: &all}},
+			{Action: &authorization.ReadTenants, Tenants: &models.PermissionTenants{Collection: &all}},
 			{Action: &createDataAction, Data: &models.PermissionData{Collection: &all}},
 		},
 	}
@@ -95,7 +95,7 @@ func TestAutoschemaAuthZ(t *testing.T) {
 	createSchemaRole := &models.Role{
 		Name: &createSchemaRoleName,
 		Permissions: []*models.Permission{
-			{Action: &authorization.CreateTenant, Tenants: &models.PermissionTenants{Collection: &classNameNew}},
+			{Action: &authorization.CreateTenants, Tenants: &models.PermissionTenants{Collection: &classNameNew}},
 		},
 	}
 

--- a/test/acceptance/authz/batch_objs_test.go
+++ b/test/acceptance/authz/batch_objs_test.go
@@ -33,8 +33,7 @@ func TestAuthZBatchObjREST(t *testing.T) {
 	customKey := "custom-key"
 	customAuth := helper.CreateAuth(customKey)
 	testRoleName := "test-role"
-	readCollectionsAction := authorization.ReadCollections
-	// readDataAction := authorization.ReadData
+
 	updateDataAction := authorization.UpdateData
 	createDataAction := authorization.CreateData
 
@@ -80,8 +79,8 @@ func TestAuthZBatchObjREST(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &className1},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &className1},
+			Action:  &authorization.ReadTenant,
+			Tenants: &models.PermissionTenants{Collection: &className1},
 		},
 		{
 			Action: &createDataAction,
@@ -92,8 +91,8 @@ func TestAuthZBatchObjREST(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &className2},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &className2},
+			Action:  &authorization.ReadTenant,
+			Tenants: &models.PermissionTenants{Collection: &className2},
 		},
 	}
 	t.Run("all rights for both classes", func(t *testing.T) {

--- a/test/acceptance/authz/batch_objs_test.go
+++ b/test/acceptance/authz/batch_objs_test.go
@@ -79,7 +79,7 @@ func TestAuthZBatchObjREST(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &className1},
 		},
 		{
-			Action:  &authorization.ReadTenant,
+			Action:  &authorization.ReadTenants,
 			Tenants: &models.PermissionTenants{Collection: &className1},
 		},
 		{
@@ -91,7 +91,7 @@ func TestAuthZBatchObjREST(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &className2},
 		},
 		{
-			Action:  &authorization.ReadTenant,
+			Action:  &authorization.ReadTenants,
 			Tenants: &models.PermissionTenants{Collection: &className2},
 		},
 	}

--- a/test/acceptance/authz/helper.go
+++ b/test/acceptance/authz/helper.go
@@ -112,3 +112,39 @@ func assertGQL(t *testing.T, query, key string) *models.GraphQLResponse {
 	require.Equal(t, len(resp.Payload.Errors), 0)
 	return resp.Payload
 }
+
+func readTenant(t *testing.T, class string, tenant string, key string) error {
+	params := clschema.NewTenantsGetOneParams().WithClassName(class).WithTenantName(tenant)
+	_, err := helper.Client(t).Schema.TenantsGetOne(params, helper.CreateAuth(key))
+	return err
+}
+
+func readTenants(t *testing.T, class string, key string) error {
+	params := clschema.NewTenantsGetParams().WithClassName(class)
+	_, err := helper.Client(t).Schema.TenantsGet(params, helper.CreateAuth(key))
+	return err
+}
+
+func existsTenant(t *testing.T, class string, tenant string, key string) error {
+	params := clschema.NewTenantExistsParams().WithClassName(class).WithTenantName(tenant)
+	_, err := helper.Client(t).Schema.TenantExists(params, helper.CreateAuth(key))
+	return err
+}
+
+func createTenant(t *testing.T, class string, tenants []*models.Tenant, key string) error {
+	params := clschema.NewTenantsCreateParams().WithClassName(class).WithBody(tenants)
+	_, err := helper.Client(t).Schema.TenantsCreate(params, helper.CreateAuth(key))
+	return err
+}
+
+func deleteTenant(t *testing.T, class string, tenants []string, key string) error {
+	params := clschema.NewTenantsDeleteParams().WithClassName(class).WithTenants(tenants)
+	_, err := helper.Client(t).Schema.TenantsDelete(params, helper.CreateAuth(key))
+	return err
+}
+
+func updateTenantStatus(t *testing.T, class string, tenants []*models.Tenant, key string) error {
+	params := clschema.NewTenantsUpdateParams().WithClassName(class).WithBody(tenants)
+	_, err := helper.Client(t).Schema.TenantsUpdate(params, helper.CreateAuth(key))
+	return err
+}

--- a/test/acceptance/authz/no_collection_name_test.go
+++ b/test/acceptance/authz/no_collection_name_test.go
@@ -39,7 +39,7 @@ func TestWithoutCollectionName(t *testing.T) {
 
 	readDataAction := authorization.ReadData
 	deleteDataAction := authorization.DeleteData
-	readTenantAction := authorization.ReadTenant
+	readTenantAction := authorization.ReadTenants
 	testRoleName := t.Name() + "role"
 	all := "*"
 
@@ -174,7 +174,7 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 
 	readDataAction := authorization.ReadData
 	updateDataAction := authorization.UpdateData
-	readTenantsAction := authorization.ReadTenant
+	readTenantsAction := authorization.ReadTenants
 	all := "*"
 
 	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{customUser: customKey}, nil)

--- a/test/acceptance/authz/no_collection_name_test.go
+++ b/test/acceptance/authz/no_collection_name_test.go
@@ -39,7 +39,7 @@ func TestWithoutCollectionName(t *testing.T) {
 
 	readDataAction := authorization.ReadData
 	deleteDataAction := authorization.DeleteData
-	readCollectionsAction := authorization.ReadCollections
+	readTenantAction := authorization.ReadTenant
 	testRoleName := t.Name() + "role"
 	all := "*"
 
@@ -77,8 +77,8 @@ func TestWithoutCollectionName(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &className},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &className},
+			Action:  &readTenantAction,
+			Tenants: &models.PermissionTenants{Collection: &className},
 		},
 	}
 	t.Run("Test get object - fail", func(t *testing.T) {
@@ -101,8 +101,8 @@ func TestWithoutCollectionName(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &all},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &all},
+			Action:  &readTenantAction,
+			Tenants: &models.PermissionTenants{Collection: &all},
 		},
 	}
 	t.Run("Test get object - succeed", func(t *testing.T) {
@@ -122,8 +122,8 @@ func TestWithoutCollectionName(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &className},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &className},
+			Action:  &readTenantAction,
+			Tenants: &models.PermissionTenants{Collection: &className},
 		},
 	}
 	t.Run("delete object without collection name fail", func(t *testing.T) {
@@ -146,8 +146,8 @@ func TestWithoutCollectionName(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &all},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &all},
+			Action:  &readTenantAction,
+			Tenants: &models.PermissionTenants{Collection: &all},
 		},
 	}
 	t.Run("delete object without collection name succeed", func(t *testing.T) {
@@ -174,7 +174,7 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 
 	readDataAction := authorization.ReadData
 	updateDataAction := authorization.UpdateData
-	readCollectionsAction := authorization.ReadCollections
+	readTenantsAction := authorization.ReadTenant
 	all := "*"
 
 	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{customUser: customKey}, nil)
@@ -205,12 +205,12 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &articlesCls.Class},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &articlesCls.Class},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &articlesCls.Class},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &paragraphsCls.Class},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &paragraphsCls.Class},
 		},
 	}
 	t.Run("Test add ref only class permissions - fail", func(t *testing.T) {
@@ -238,8 +238,8 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &all},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &all},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &all},
 		},
 	}
 	t.Run("Test add ref all permissions - succeed", func(t *testing.T) {
@@ -281,12 +281,12 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &articlesCls.Class},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &articlesCls.Class},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &articlesCls.Class},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &paragraphsCls.Class},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &paragraphsCls.Class},
 		},
 	}
 	t.Run("Test add ref only class permissions - fail", func(t *testing.T) {
@@ -314,8 +314,8 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &all},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &all},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &all},
 		},
 	}
 	t.Run("Test update ref all permissions - succeed", func(t *testing.T) {
@@ -357,12 +357,12 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &articlesCls.Class},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &articlesCls.Class},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &articlesCls.Class},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &paragraphsCls.Class},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &paragraphsCls.Class},
 		},
 	}
 	t.Run("Test delete ref only class permissions - fail", func(t *testing.T) {
@@ -390,8 +390,8 @@ func TestRefsWithoutCollectionNames(t *testing.T) {
 			Data:   &models.PermissionData{Collection: &all},
 		},
 		{
-			Action:      &readCollectionsAction,
-			Collections: &models.PermissionCollections{Collection: &all},
+			Action:  &readTenantsAction,
+			Tenants: &models.PermissionTenants{Collection: &all},
 		},
 	}
 	t.Run("Test delete ref all permissions - succeed", func(t *testing.T) {

--- a/test/acceptance/authz/permissions_test.go
+++ b/test/acceptance/authz/permissions_test.go
@@ -66,7 +66,6 @@ func TestAuthzRolesWithPermissions(t *testing.T) {
 		require.Len(t, role.Permissions, 1)
 		require.Equal(t, authorization.CreateCollections, *role.Permissions[0].Action)
 		require.Equal(t, testClass.Class, *role.Permissions[0].Collections.Collection)
-		require.Equal(t, "*", *role.Permissions[0].Collections.Tenant)
 	})
 
 	t.Run("create and get a role to manage all roles", func(t *testing.T) {

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -1,0 +1,149 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+)
+
+func TestAuthZTenants(t *testing.T) {
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	adminAuth := helper.CreateAuth(adminKey)
+
+	customUser := "custom-user"
+	customKey := "custom-key"
+
+	readSchemaAction := authorization.ReadCollections
+	readTenantAction := authorization.ReadTenant
+	createTenantAction := authorization.CreateTenant
+	deleteTenantAction := authorization.DeleteTenant
+	updateTenantAction := authorization.UpdateTenant
+
+	ctx := context.Background()
+	compose, err := docker.New().WithWeaviate().
+		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
+		WithRBAC().WithRbacAdmins(adminUser).
+		WithBackendFilesystem().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	className := "AuthzTenantTestClass"
+	deleteObjectClass(t, className, adminAuth)
+	c := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: schema.DataTypeText.PropString(),
+			},
+		},
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	}
+	helper.CreateClassAuth(t, c, adminKey)
+	defer deleteObjectClass(t, className, adminAuth)
+
+	// user needs to be able to create objects and read the configs
+	all := "*"
+
+	createTenantRoleName := "readSchemaAndCreateTenant"
+	createTenantRole := &models.Role{
+		Name: &createTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &createTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	readTenantRoleName := "readSchemaAndReadTenant"
+	readTenantRole := &models.Role{
+		Name: &readTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &readTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	deleteTenantRoleName := "readSchemaAndDeleteTenant"
+	deleteTenantRole := &models.Role{
+		Name: &deleteTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &deleteTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	updateTenantRoleName := "readSchemaAndUpdateTenant"
+	updateTenantRole := &models.Role{
+		Name: &updateTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &updateTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+		},
+	}
+
+	helper.DeleteRole(t, adminKey, *createTenantRole.Name)
+	helper.DeleteRole(t, adminKey, *readTenantRole.Name)
+	helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
+	helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
+	helper.CreateRole(t, adminKey, createTenantRole)
+	helper.CreateRole(t, adminKey, readTenantRole)
+	helper.CreateRole(t, adminKey, deleteTenantRole)
+	helper.CreateRole(t, adminKey, updateTenantRole)
+	defer helper.DeleteRole(t, adminKey, *createTenantRole.Name)
+	defer helper.DeleteRole(t, adminKey, *readTenantRole.Name)
+	defer helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
+	defer helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
+
+	tenants := []*models.Tenant{{Name: "Tenant1"}}
+
+	t.Run("Create tenant", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createTenantRole.Name, customUser)
+		require.NoError(t, createTenant(t, className, tenants, customKey))
+		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, adminKey))
+	})
+
+	t.Run("Tenant read and exist", func(t *testing.T) {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+
+		helper.AssignRoleToUser(t, adminKey, *readTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *readTenantRole.Name, customUser)
+
+		require.NoError(t, readTenant(t, className, tenants[0].Name, customKey))
+		require.NoError(t, readTenants(t, className, customKey))
+		require.NoError(t, existsTenant(t, className, tenants[0].Name, customKey))
+	})
+
+	t.Run("delete tenant", func(t *testing.T) {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+
+		helper.AssignRoleToUser(t, adminKey, *deleteTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *deleteTenantRole.Name, customUser)
+
+		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, customKey))
+	})
+
+	t.Run("update tenant status", func(t *testing.T) {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+
+		helper.AssignRoleToUser(t, adminKey, *updateTenantRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *updateTenantRole.Name, customUser)
+
+		require.NoError(t, updateTenantStatus(t, className, []*models.Tenant{{Name: "Tenant1", ActivityStatus: "INACTIVE"}}, customKey))
+	})
+}

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -32,10 +32,10 @@ func TestAuthZTenants(t *testing.T) {
 	customKey := "custom-key"
 
 	readSchemaAction := authorization.ReadCollections
-	readTenantAction := authorization.ReadTenant
-	createTenantAction := authorization.CreateTenant
-	deleteTenantAction := authorization.DeleteTenant
-	updateTenantAction := authorization.UpdateTenant
+	readTenantAction := authorization.ReadTenants
+	createTenantAction := authorization.CreateTenants
+	deleteTenantAction := authorization.DeleteTenants
+	updateTenantAction := authorization.UpdateTenants
 
 	ctx := context.Background()
 	compose, err := docker.New().WithWeaviate().

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package authz
 
 import (

--- a/test/acceptance_with_python/rbac/test_batch_grpc.py
+++ b/test/acceptance_with_python/rbac/test_batch_grpc.py
@@ -31,9 +31,9 @@ def test_batch_grpc(
 
     required_permissions = [
         Permissions.data(collection=col1.name, create=True, update=True),
-        Permissions.collections(collection=col1.name, read_config=True),
+        Permissions.tenants(collection=col1.name, read=True),
         Permissions.data(collection=col2.name, create=True, update=True),
-        Permissions.collections(collection=col2.name, read_config=True),
+        Permissions.tenants(collection=col2.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         with custom_client.batch.fixed_size() as batch:

--- a/test/acceptance_with_python/rbac/test_object_endpoint.py
+++ b/test/acceptance_with_python/rbac/test_object_endpoint.py
@@ -23,7 +23,7 @@ def test_obj_insert(
 
     required_permissions = [
         Permissions.data(collection=col.name, create=True),
-        Permissions.collections(collection=col.name, read_config=True),
+        Permissions.tenants(collection=col.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -69,7 +69,7 @@ def test_obj_insert_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, create=True),
-        Permissions.collections(collection=source.name, read_config=True),
+        Permissions.tenants(collection=source.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
@@ -110,7 +110,7 @@ def test_obj_replace(
 
     required_permissions = [
         Permissions.data(collection=col.name, update=True),
-        Permissions.collections(collection=col.name, read_config=True),
+        Permissions.tenants(collection=col.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -159,7 +159,7 @@ def test_obj_replace_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
-        Permissions.collections(collection=source.name, read_config=True),
+        Permissions.tenants(collection=source.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
@@ -204,7 +204,7 @@ def test_obj_update(
 
     required_permissions = [
         Permissions.data(collection=col.name, update=True),
-        Permissions.collections(collection=col.name, read_config=True),
+        Permissions.tenants(collection=col.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -252,7 +252,7 @@ def test_obj_update_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
-        Permissions.collections(collection=source.name, read_config=True),
+        Permissions.tenants(collection=source.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
@@ -297,7 +297,7 @@ def test_obj_delete(
 
     required_permissions = [
         Permissions.data(collection=col.name, delete=True),
-        Permissions.collections(collection=col.name, read_config=True),
+        Permissions.tenants(collection=col.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -340,7 +340,7 @@ def test_obj_exists(
 
     required_permissions = [
         Permissions.data(collection=col.name, read=True),
-        Permissions.collections(collection=col.name, read_config=True),
+        Permissions.tenants(collection=col.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check

--- a/test/acceptance_with_python/rbac/test_rbac_refs.py
+++ b/test/acceptance_with_python/rbac/test_rbac_refs.py
@@ -42,7 +42,7 @@ def test_rbac_refs(
     admin_client.roles.delete(role_name)
 
     required_permissions = [
-        Permissions.collections(collection=[source.name, target.name], read_config=True),
+        Permissions.tenants(collection=[source.name, target.name], read=True),
         Permissions.data(collection=source.name, update=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
@@ -142,7 +142,7 @@ def test_batch_delete_with_filter(
     )
 
     required_permissions = [
-        Permissions.collections(collection=[target.name, source.name], read_config=True),
+        Permissions.tenants(collection=[target.name, source.name], read=True),
         Permissions.data(collection=source.name, delete=True, read=True),
         Permissions.data(collection=target.name, read=True),
     ]
@@ -219,7 +219,7 @@ def test_search_with_filter_and_return(
     admin_client.roles.delete(role_name)
 
     required_permissions = [
-        Permissions.collections(collection=[target.name, source.name], read_config=True),
+        Permissions.tenants(collection=[target.name, source.name], read=True),
         Permissions.data(collection=[source.name, target.name], read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
@@ -313,7 +313,7 @@ def test_batch_ref(
 
     # self reference
     required_permissions = [
-        Permissions.collections(collection=source.name, read_config=True),
+        Permissions.tenants(collection=source.name, read=True),
         Permissions.data(collection=source.name, read=True, update=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
@@ -348,7 +348,7 @@ def test_batch_ref(
 
     # ref to one target
     required_permissions = [
-        Permissions.collections(collection=source.name, read_config=True),
+        Permissions.tenants(collection=source.name, read=True),
         Permissions.data(collection=[source.name, target1.name], read=True),
         Permissions.data(collection=source.name, update=True),
         Permissions.collections(collection=target1.name, read_config=True),

--- a/test/acceptance_with_python/rbac/test_schema.py
+++ b/test/acceptance_with_python/rbac/test_schema.py
@@ -1,7 +1,6 @@
 import pytest
 import weaviate
 import weaviate.classes as wvc
-from weaviate.collections.classes.tenants import Tenant, TenantActivityStatus
 from weaviate.rbac.models import Permissions
 from _pytest.fixtures import SubRequest
 from .conftest import _sanitize_role_name, RoleWrapperProtocol, generate_missing_permissions
@@ -9,9 +8,8 @@ from .conftest import _sanitize_role_name, RoleWrapperProtocol, generate_missing
 pytestmark = pytest.mark.xdist_group(name="rbac")
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_create(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
@@ -19,12 +17,7 @@ def test_rbac_collection_create(
         Permissions.collections(collection=name, read_config=True, create_collection=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
-        col = custom_client.collections.create(
-            name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-        )
-        if mt:
-            col.tenants.create("tenant1")
-
+        custom_client.collections.create(name=name)
         admin_client.collections.delete(name)
 
     for permission in generate_missing_permissions(required_permissions):
@@ -74,24 +67,17 @@ def test_rbac_collection_create_with_ref(
     admin_client.collections.delete([name_target, name_source])
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_read(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
-    col_admin = admin_client.collections.create(
-        name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-    )
-    if mt:
-        col_admin.tenants.create("tenant1")
+    admin_client.collections.create(name=name)
 
     required_permissions = Permissions.collections(collection=name, read_config=True)
     with role_wrapper(admin_client, request, required_permissions):
         col = custom_client.collections.get(name=name)
         assert col.config.get() is not None
-        if mt:
-            assert col.tenants.get() is not None
 
     with role_wrapper(admin_client, request, []):
         col = custom_client.collections.get(name=name)
@@ -99,11 +85,6 @@ def test_rbac_collection_read(
             col.config.get()
         assert e.value.status_code == 403
         assert "forbidden" in e.value.args[0]
-
-        if mt:
-            with pytest.raises(weaviate.exceptions.InsufficientPermissionsError) as ee:
-                col.tenants.get()
-            assert "forbidden" in ee.value.args[0]
 
     admin_client.collections.delete(name)
 
@@ -127,17 +108,12 @@ def test_rbac_schema_read(
     admin_client.collections.delete(name)
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_update(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
-    col_admin = admin_client.collections.create(
-        name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-    )
-    if mt:
-        col_admin.tenants.create("tenant1")
+    admin_client.collections.create(name=name)
 
     required_permissions = [
         Permissions.collections(collection=name, read_config=True, update_config=True),
@@ -145,14 +121,6 @@ def test_rbac_collection_update(
     with role_wrapper(admin_client, request, required_permissions):
         col_custom = custom_client.collections.get(name)
         col_custom.config.update(description="test")
-        if mt:
-            col_custom.tenants.update(
-                Tenant(name="tenant1", activity_status=TenantActivityStatus.INACTIVE)
-            )
-            # ensure that update worked
-            assert (
-                col_admin.tenants.get()["tenant1"].activity_status == TenantActivityStatus.INACTIVE
-            )
 
     for permission in generate_missing_permissions(required_permissions):
         with role_wrapper(admin_client, request, permission):
@@ -161,13 +129,6 @@ def test_rbac_collection_update(
                 col_custom.config.update(description="test")
             assert e.value.status_code == 403
             assert "forbidden" in e.value.args[0]
-
-            if mt:
-                with pytest.raises(weaviate.exceptions.InsufficientPermissionsError) as e:
-                    col_custom.tenants.update(
-                        Tenant(name="tenant1", activity_status=TenantActivityStatus.INACTIVE)
-                    )
-                assert "forbidden" in e.value.args[0]
 
     admin_client.collections.delete(name)
 
@@ -204,17 +165,11 @@ def test_rbac_collection_update_with_ref(
     admin_client.collections.delete([name_target, name_source])
 
 
-@pytest.mark.parametrize("mt", [True, False])
 def test_rbac_collection_delete(
-    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest, mt: bool
+    admin_client, custom_client, role_wrapper: RoleWrapperProtocol, request: SubRequest
 ):
     name = _sanitize_role_name(request.node.name) + "col"
     admin_client.collections.delete(name)
-    col_admin = admin_client.collections.create(
-        name=name, multi_tenancy_config=wvc.config.Configure.multi_tenancy(enabled=mt)
-    )
-    if mt:
-        col_admin.tenants.create("tenant1")
 
     required_permissions = [
         Permissions.collections(collection=name, delete_collection=True, read_config=True),
@@ -227,17 +182,7 @@ def test_rbac_collection_delete(
             assert "forbidden" in e.value.args[0]
             assert admin_client.collections.get(name) is not None
 
-            if mt:
-                col_custom = custom_client.collections.get(name)
-                with pytest.raises(weaviate.exceptions.InsufficientPermissionsError) as e:
-                    col_custom.tenants.remove("tenant1")
-                assert e.value.status_code == 403
-                assert "forbidden" in e.value.args[0]
-
     with role_wrapper(admin_client, request, required_permissions):
-        if mt:
-            col_custom = custom_client.collections.get(name)
-            col_custom.tenants.remove("tenant1")
         custom_client.collections.delete(name)
         assert not admin_client.collections.exists(name)
 

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/weaviate/weaviate-python-client.git@d987ac8d8f111b27e461b4b796ad3dfa3913016c
+git+https://github.com/weaviate/weaviate-python-client.git@cf8373b6beb4fba29c8b5a33d331ed45bc654ebf
 
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -133,14 +133,6 @@ func (p *CollectionsPermission) WithCollection(collection string) *CollectionsPe
 	return p
 }
 
-func (p *CollectionsPermission) WithTenant(tenant string) *CollectionsPermission {
-	if p.Collections == nil {
-		p.Collections = &models.PermissionCollections{}
-	}
-	p.Collections.Tenant = authorization.String(tenant)
-	return p
-}
-
 func (p *CollectionsPermission) Permission() *models.Permission {
 	perm := models.Permission(*p)
 	return &perm

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -70,6 +70,15 @@ func AssignRoleToUser(t *testing.T, key, role, user string) {
 	require.Nil(t, err)
 }
 
+func RevokeRoleFromUser(t *testing.T, key, role, user string) {
+	resp, err := Client(t).Authz.RevokeRole(
+		authz.NewRevokeRoleParams().WithID(user).WithBody(authz.RevokeRoleBody{Roles: []string{role}}),
+		CreateAuth(key),
+	)
+	AssertRequestOk(t, resp, err, nil)
+	require.Nil(t, err)
+}
+
 func AddPermissions(t *testing.T, key, role string, permissions ...*models.Permission) {
 	resp, err := Client(t).Authz.AddPermissions(
 		authz.NewAddPermissionsParams().WithID(role).WithBody(authz.AddPermissionsBody{

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -70,6 +70,8 @@ var resourcePatterns = []string{
 	fmt.Sprintf(`^%s/collections/[^/]+/shards/.*$`, authorization.SchemaDomain),
 	fmt.Sprintf(`^%s/collections/[^/]+/shards/[^/]+/objects/.*$`, authorization.DataDomain),
 	fmt.Sprintf(`^%s/collections/[^/]+/shards/[^/]+/objects/[^/]+$`, authorization.DataDomain),
+	fmt.Sprintf(`^%s/collections/[^/]+$`, authorization.TenantDomain),
+	fmt.Sprintf(`^%s/collections/[^/]+/tenants/.*$`, authorization.TenantDomain),
 }
 
 func newPolicy(policy []string) *authorization.Policy {
@@ -302,6 +304,11 @@ func permission(policy []string) (*models.Permission, error) {
 			Tenant:     &splits[4],
 			Object:     &splits[6],
 		}
+	case authorization.TenantDomain:
+		permission.Tenants = &models.PermissionTenants{
+			Collection: &splits[2],
+			Tenant:     &splits[4],
+		}
 	case authorization.RolesDomain:
 		permission.Roles = &models.PermissionRoles{
 			Role: &splits[1],
@@ -328,6 +335,7 @@ func permission(policy []string) (*models.Permission, error) {
 		permission.Nodes = authorization.AllNodes
 		permission.Roles = authorization.AllRoles
 		permission.Collections = authorization.AllCollections
+		permission.Tenants = authorization.AllTenants
 	case authorization.ClusterDomain, authorization.UsersDomain:
 		// do nothing
 	default:

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -367,7 +367,7 @@ func permission(policy []string) (*models.Permission, error) {
 		return nil, fmt.Errorf("invalid domain: %s", mapped.Domain)
 	}
 
-	permission.Action = authorization.String(weaviatePermissionAction(splits[4], mapped.Verb, mapped.Domain))
+	permission.Action = authorization.String(weaviatePermissionAction(splits[len(splits)-1], mapped.Verb, mapped.Domain))
 	return permission, nil
 }
 

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -230,6 +230,16 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 			object = *permission.Data.Object
 		}
 		resource = CasbinData(collection, tenant, object)
+	case authorization.TenantDomain:
+		collection := "*"
+		tenant := "*"
+		if permission.Tenants != nil && permission.Tenants.Collection != nil {
+			collection = schema.UppercaseClassName(*permission.Tenants.Collection)
+		}
+		if permission.Tenants != nil && permission.Tenants.Tenant != nil {
+			tenant = *permission.Tenants.Tenant
+		}
+		resource = CasbinTenant(collection, tenant)
 	case authorization.BackupsDomain:
 		collection := "*"
 		if permission.Backups != nil {

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -155,6 +155,19 @@ func CasbinData(collection, shard, object string) string {
 	return fmt.Sprintf("%s/collections/%s/shards/%s/objects/%s", authorization.DataDomain, collection, shard, object)
 }
 
+func CasbinTenant(collection, tenant string) string {
+	collection = schema.UppercaseClassesNames(collection)[0]
+	if collection == "" {
+		collection = "*"
+	}
+	if tenant == "" {
+		tenant = "*"
+	}
+	collection = strings.ReplaceAll(collection, "*", ".*")
+	tenant = strings.ReplaceAll(tenant, "*", ".*")
+	return fmt.Sprintf("%s/collections/%s/tenants/%s", authorization.TenantDomain, collection, tenant)
+}
+
 func policy(permission *models.Permission) (*authorization.Policy, error) {
 	if permission.Action == nil {
 		return &authorization.Policy{Resource: InternalPlaceHolder}, nil

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -406,6 +406,70 @@ func Test_policy(t *testing.T) {
 			},
 			tests: objectsDataTests,
 		},
+		{
+			name: "a tenant",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("Foo", ""),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "all tenants in all collections",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("*", "*"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "all tenants in a collection",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("Foo", "*"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "a tenant in all collections",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Tenant: bar,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("*", "bar"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name: "a tenant in a collection",
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+					Tenant:     bar,
+				},
+			},
+			policy: &authorization.Policy{
+				Resource: CasbinTenant("Foo", "bar"),
+				Domain:   authorization.TenantDomain,
+			},
+			tests: tenantsActionTests,
+		},
 	}
 	for _, tt := range tests {
 		for _, ttt := range tt.tests {

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -73,6 +73,12 @@ var (
 		{permissionAction: authorization.UpdateData, testDescription: updateDesc, policyVerb: updateVerb},
 		{permissionAction: authorization.DeleteData, testDescription: deleteDesc, policyVerb: deleteVerb},
 	}
+	tenantsActionTests = []innerTest{
+		{permissionAction: authorization.CreateTenant, testDescription: createDesc, policyVerb: createVerb},
+		{permissionAction: authorization.ReadTenant, testDescription: readDesc, policyVerb: readVerb},
+		{permissionAction: authorization.UpdateTenant, testDescription: updateDesc, policyVerb: updateVerb},
+		{permissionAction: authorization.DeleteTenant, testDescription: deleteDesc, policyVerb: deleteVerb},
+	}
 )
 
 func Test_policy(t *testing.T) {
@@ -475,6 +481,25 @@ func Test_permission(t *testing.T) {
 				},
 			},
 			tests: nodesTests,
+		},
+		{
+			name:   "all tenants",
+			policy: []string{"p", "/collections/*/tenants/*", "", authorization.TenantDomain},
+			permission: &models.Permission{
+				Tenants: authorization.AllTenants,
+			},
+			tests: tenantsActionTests,
+		},
+		{
+			name:   "a tenant",
+			policy: []string{"p", "/collections/Foo/tenants/*", "", authorization.TenantDomain},
+			permission: &models.Permission{
+				Tenants: &models.PermissionTenants{
+					Collection: foo,
+					Tenant:     authorization.All,
+				},
+			},
+			tests: tenantsActionTests,
 		},
 		{
 			name:   "all collections",

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -68,10 +68,10 @@ var (
 		{permissionAction: authorization.DeleteData, testDescription: deleteDesc, policyVerb: deleteVerb},
 	}
 	tenantsActionTests = []innerTest{
-		{permissionAction: authorization.CreateTenant, testDescription: createDesc, policyVerb: createVerb},
-		{permissionAction: authorization.ReadTenant, testDescription: readDesc, policyVerb: readVerb},
-		{permissionAction: authorization.UpdateTenant, testDescription: updateDesc, policyVerb: updateVerb},
-		{permissionAction: authorization.DeleteTenant, testDescription: deleteDesc, policyVerb: deleteVerb},
+		{permissionAction: authorization.CreateTenants, testDescription: createDesc, policyVerb: createVerb},
+		{permissionAction: authorization.ReadTenants, testDescription: readDesc, policyVerb: readVerb},
+		{permissionAction: authorization.UpdateTenants, testDescription: updateDesc, policyVerb: updateVerb},
+		{permissionAction: authorization.DeleteTenants, testDescription: deleteDesc, policyVerb: deleteVerb},
 	}
 )
 

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -61,12 +61,6 @@ var (
 		{permissionAction: authorization.UpdateCollections, testDescription: updateDesc, policyVerb: updateVerb},
 		{permissionAction: authorization.DeleteCollections, testDescription: deleteDesc, policyVerb: deleteVerb},
 	}
-	tenantsTests = []innerTest{
-		{permissionAction: authorization.CreateCollections, testDescription: createDesc, policyVerb: createVerb},
-		{permissionAction: authorization.ReadCollections, testDescription: readDesc, policyVerb: readVerb},
-		{permissionAction: authorization.UpdateCollections, testDescription: updateDesc, policyVerb: updateVerb},
-		{permissionAction: authorization.DeleteCollections, testDescription: deleteDesc, policyVerb: deleteVerb},
-	}
 	objectsDataTests = []innerTest{
 		{permissionAction: authorization.CreateData, testDescription: createDesc, policyVerb: createVerb},
 		{permissionAction: authorization.ReadData, testDescription: readDesc, policyVerb: readVerb},
@@ -190,7 +184,7 @@ func Test_policy(t *testing.T) {
 				Collections: &models.PermissionCollections{},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinSchema("*", ""),
+				Resource: CasbinSchema("*", "#"),
 				Domain:   authorization.SchemaDomain,
 			},
 			tests: collectionsTests,
@@ -203,7 +197,7 @@ func Test_policy(t *testing.T) {
 				},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinSchema("Foo", ""),
+				Resource: CasbinSchema("Foo", "#"),
 				Domain:   authorization.SchemaDomain,
 			},
 			tests: collectionsTests,
@@ -211,18 +205,18 @@ func Test_policy(t *testing.T) {
 		{
 			name: "all tenants in all collections",
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{},
+				Tenants: &models.PermissionTenants{},
 			},
 			policy: &authorization.Policy{
 				Resource: CasbinSchema("*", "*"),
 				Domain:   authorization.SchemaDomain,
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name: "all tenants in a collection",
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{
+				Tenants: &models.PermissionTenants{
 					Collection: foo,
 				},
 			},
@@ -230,12 +224,12 @@ func Test_policy(t *testing.T) {
 				Resource: CasbinSchema("Foo", "*"),
 				Domain:   authorization.SchemaDomain,
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name: "a tenant in all collections",
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{
+				Tenants: &models.PermissionTenants{
 					Tenant: bar,
 				},
 			},
@@ -243,12 +237,12 @@ func Test_policy(t *testing.T) {
 				Resource: CasbinSchema("*", "bar"),
 				Domain:   authorization.SchemaDomain,
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name: "a tenant in a collection",
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{
+				Tenants: &models.PermissionTenants{
 					Collection: foo,
 					Tenant:     bar,
 				},
@@ -257,7 +251,7 @@ func Test_policy(t *testing.T) {
 				Resource: CasbinSchema("Foo", "bar"),
 				Domain:   authorization.SchemaDomain,
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name: "all objects in all collections ST",
@@ -414,8 +408,8 @@ func Test_policy(t *testing.T) {
 				},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinTenant("Foo", ""),
-				Domain:   authorization.TenantDomain,
+				Resource: CasbinSchema("Foo", ""),
+				Domain:   authorization.SchemaDomain,
 			},
 			tests: tenantsActionTests,
 		},
@@ -425,8 +419,8 @@ func Test_policy(t *testing.T) {
 				Tenants: &models.PermissionTenants{},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinTenant("*", "*"),
-				Domain:   authorization.TenantDomain,
+				Resource: CasbinSchema("*", "*"),
+				Domain:   authorization.SchemaDomain,
 			},
 			tests: tenantsActionTests,
 		},
@@ -438,8 +432,8 @@ func Test_policy(t *testing.T) {
 				},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinTenant("Foo", "*"),
-				Domain:   authorization.TenantDomain,
+				Resource: CasbinSchema("Foo", "*"),
+				Domain:   authorization.SchemaDomain,
 			},
 			tests: tenantsActionTests,
 		},
@@ -451,8 +445,8 @@ func Test_policy(t *testing.T) {
 				},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinTenant("*", "bar"),
-				Domain:   authorization.TenantDomain,
+				Resource: CasbinSchema("*", "bar"),
+				Domain:   authorization.SchemaDomain,
 			},
 			tests: tenantsActionTests,
 		},
@@ -465,8 +459,8 @@ func Test_policy(t *testing.T) {
 				},
 			},
 			policy: &authorization.Policy{
-				Resource: CasbinTenant("Foo", "bar"),
-				Domain:   authorization.TenantDomain,
+				Resource: CasbinSchema("Foo", "bar"),
+				Domain:   authorization.SchemaDomain,
 			},
 			tests: tenantsActionTests,
 		},
@@ -548,7 +542,7 @@ func Test_permission(t *testing.T) {
 		},
 		{
 			name:   "all tenants",
-			policy: []string{"p", "/collections/*/tenants/*", "", authorization.TenantDomain},
+			policy: []string{"p", "/collections/*/shards/*", "", authorization.SchemaDomain},
 			permission: &models.Permission{
 				Tenants: authorization.AllTenants,
 			},
@@ -556,7 +550,7 @@ func Test_permission(t *testing.T) {
 		},
 		{
 			name:   "a tenant",
-			policy: []string{"p", "/collections/Foo/tenants/*", "", authorization.TenantDomain},
+			policy: []string{"p", "/collections/Foo/shards/*", "", authorization.SchemaDomain},
 			permission: &models.Permission{
 				Tenants: &models.PermissionTenants{
 					Collection: foo,
@@ -566,7 +560,7 @@ func Test_permission(t *testing.T) {
 			tests: tenantsActionTests,
 		},
 		{
-			name:   "all collections",
+			name:   "backup all collections",
 			policy: []string{"p", "/collections/*", "", "backups"},
 			permission: &models.Permission{
 				Backups: authorization.AllBackups,
@@ -585,7 +579,7 @@ func Test_permission(t *testing.T) {
 		},
 		{
 			name:   "all collections",
-			policy: []string{"p", "/collections/*/shards/*", "", authorization.SchemaDomain},
+			policy: []string{"p", "/collections/*/shards/#", "", authorization.SchemaDomain},
 			permission: &models.Permission{
 				Collections: authorization.AllCollections,
 			},
@@ -593,11 +587,10 @@ func Test_permission(t *testing.T) {
 		},
 		{
 			name:   "a collection",
-			policy: []string{"p", "/collections/Foo/shards/*", "", authorization.SchemaDomain},
+			policy: []string{"p", "/collections/Foo/shards/#", "", authorization.SchemaDomain},
 			permission: &models.Permission{
 				Collections: &models.PermissionCollections{
 					Collection: foo,
-					Tenant:     authorization.All,
 				},
 			},
 			tests: collectionsTests,
@@ -606,42 +599,42 @@ func Test_permission(t *testing.T) {
 			name:   "all tenants in all collections",
 			policy: []string{"p", "/collections/*/shards/*", "", authorization.SchemaDomain},
 			permission: &models.Permission{
-				Collections: authorization.AllCollections,
+				Tenants: authorization.AllTenants,
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name:   "all tenants in a collection",
 			policy: []string{"p", "/collections/Foo/shards/*", "", authorization.SchemaDomain},
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{
+				Tenants: &models.PermissionTenants{
 					Collection: foo,
 					Tenant:     authorization.All,
 				},
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name:   "a tenant in all collections",
 			policy: []string{"p", "/collections/*/shards/bar", "", authorization.SchemaDomain},
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{
+				Tenants: &models.PermissionTenants{
 					Collection: authorization.All,
 					Tenant:     bar,
 				},
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name:   "a tenant in a collection",
 			policy: []string{"p", "/collections/Foo/shards/bar", "", authorization.SchemaDomain},
 			permission: &models.Permission{
-				Collections: &models.PermissionCollections{
+				Tenants: &models.PermissionTenants{
 					Collection: foo,
 					Tenant:     bar,
 				},
 			},
-			tests: tenantsTests,
+			tests: tenantsActionTests,
 		},
 		{
 			name:   "all objects in all collections ST",

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -299,8 +299,12 @@ func prettyPermissionsResources(perm *models.Permission) string {
 		if perm.Collections.Collection != nil && *perm.Collections.Collection != "" {
 			res += fmt.Sprintf(" Schema.Collection: %s,", *perm.Collections.Collection)
 		}
-		if perm.Collections.Tenant != nil && *perm.Collections.Tenant != "" {
-			res += fmt.Sprintf(" Schema.Tenant: %s,", *perm.Collections.Tenant)
+	}
+
+	if perm.Tenants != nil {
+		if perm.Tenants.Tenant != nil && *perm.Tenants.Tenant != "" {
+			res += fmt.Sprintf(" Schema.Collection: %s,", *perm.Tenants.Collection)
+			res += fmt.Sprintf(" Schema.Tenant: %s,", *perm.Tenants.Tenant)
 		}
 	}
 

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -41,8 +41,8 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Allow all shards with ABC", authorization.ShardsMetadata("ABC", "ABC")[0], "*", true},
 		{"Allow all objects", authorization.Objects("", "", ""), "*", true},
 		{"Allow all objects with Tenant1", authorization.Objects("", "Tenant1", ""), "*", true},
-		{"Allow all tenants", authorization.Tenants("")[0], "*", true},
-		{"Allow all tenants with ABC", authorization.Tenants("ABC", "ABC")[0], "*", true},
+		{"Allow all tenants", authorization.ShardsMetadata("")[0], "*", true},
+		{"Allow all tenants with ABC", authorization.ShardsMetadata("ABC", "ABC")[0], "*", true},
 
 		// Class level
 		{"Class level collections ABC", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("*", ""), true},
@@ -52,7 +52,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Class level collections Class2 mismatch", authorization.CollectionsMetadata("Class2")[0], conv.CasbinSchema("Class1", ""), false},
 		{"Class level shards ABC TenantX", authorization.ShardsMetadata("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
 		{"Class level objects ABC TenantX objectY", authorization.Objects("ABC", "TenantX", "objectY"), conv.CasbinData("ABC", "*", "*"), true},
-		{"Class level tenant ABC TenantX", authorization.Tenants("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
+		{"Class level tenant ABC TenantX", authorization.ShardsMetadata("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
 
 		// Tenants level
 		{"Tenants level shards", authorization.ShardsMetadata("")[0], conv.CasbinSchema("*", "*"), true},
@@ -78,15 +78,15 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Objects level ABC bar abcd", authorization.Objects("ABC", "bar", "abcd"), conv.CasbinData("*", "bar", ""), true},
 
 		// Tenants
-		{"Tenants level tenant", authorization.Tenants("")[0], conv.CasbinSchema("*", "*"), true},
-		{"Tenants level tenant ABC Tenant1", authorization.Tenants("ABC", "Tenant1")[0], conv.CasbinSchema("*", "*"), true},
-		{"Tenants level tenant Class1 Tenant1", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinSchema("*", "Tenant1"), true},
+		{"Tenants level tenant", authorization.ShardsMetadata("")[0], conv.CasbinSchema("*", "*"), true},
+		{"Tenants level tenant ABC Tenant1", authorization.ShardsMetadata("ABC", "Tenant1")[0], conv.CasbinSchema("*", "*"), true},
+		{"Tenants level tenant Class1 Tenant1", authorization.ShardsMetadata("Class1", "Tenant1")[0], conv.CasbinSchema("*", "Tenant1"), true},
 		{"Tenants level objects Class1 Tenant1 ObjectY", authorization.Objects("Class1", "Tenant1", "ObjectY"), conv.CasbinData("*", "Tenant1", ""), true},
-		{"Tenants level tenant Class1 Tenant2 mismatch", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinSchema("*", "Tenant1"), false},
-		{"Tenants level tenant Class1 Tenant2 mismatch 2", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinSchema("Class2", "Tenant1"), false},
-		{"Tenants level tenant mismatch", authorization.Tenants("")[0], conv.CasbinSchema("Class1", ""), false},
-		{"Tenants level collections Class1", authorization.Tenants("Class1")[0], conv.CasbinSchema("Class1", ""), true},
-		{"Tenants level tenant Class1 tenant1", authorization.Tenants("Class1", "tenant1")[0], conv.CasbinSchema("Class1", ""), true},
+		{"Tenants level tenant Class1 Tenant2 mismatch", authorization.ShardsMetadata("Class1", "Tenant2")[0], conv.CasbinSchema("*", "Tenant1"), false},
+		{"Tenants level tenant Class1 Tenant2 mismatch 2", authorization.ShardsMetadata("Class1", "Tenant2")[0], conv.CasbinSchema("Class2", "Tenant1"), false},
+		{"Tenants level tenant mismatch", authorization.ShardsMetadata("")[0], conv.CasbinSchema("Class1", ""), false},
+		{"Tenants level collections Class1", authorization.ShardsMetadata("Class1")[0], conv.CasbinSchema("Class1", ""), true},
+		{"Tenants level tenant Class1 tenant1", authorization.ShardsMetadata("Class1", "tenant1")[0], conv.CasbinSchema("Class1", ""), true},
 
 		// Regex
 		{"Regex collections ABCD", authorization.CollectionsMetadata("ABCD")[0], conv.CasbinSchema("ABC", ""), false},
@@ -95,7 +95,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Regex objects ABCD mismatch", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
 		{"Regex objects ABCD wildcard", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC.*", "*", "*"), true},
 		{"Regex objects BCD mismatch", authorization.Objects("BCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
-		{"Regex tenant ABC", authorization.Tenants("ABC", "")[0], conv.CasbinSchema("ABC", ""), true},
+		{"Regex tenant ABC", authorization.ShardsMetadata("ABC", "")[0], conv.CasbinSchema("ABC", ""), true},
 
 		{"Regex collections ABC wildcard", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
 		{"Regex collections ABC wildcard 2", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
@@ -114,7 +114,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Partial match object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Obj*"), true},
 		{"Special character mismatch", authorization.Objects("Class1", "Shard1", "Object1"), "data/collections/Class1/shards/Shard1/objects/Object1!", false},
 		{"Mismatched object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Object2"), false},
-		{"Mismatched tenant", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinSchema("Class1", "Tenant2"), false},
+		{"Mismatched tenant", authorization.ShardsMetadata("Class1", "Tenant1")[0], conv.CasbinSchema("Class1", "Tenant2"), false},
 	}
 
 	for _, tt := range tests {

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -41,6 +41,8 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Allow all shards with ABC", authorization.ShardsMetadata("ABC", "ABC")[0], "*", true},
 		{"Allow all objects", authorization.Objects("", "", ""), "*", true},
 		{"Allow all objects with Tenant1", authorization.Objects("", "Tenant1", ""), "*", true},
+		{"Allow all tenants", authorization.Tenants("")[0], "*", true},
+		{"Allow all tenants with ABC", authorization.Tenants("ABC", "ABC")[0], "*", true},
 
 		// Class level
 		{"Class level collections ABC", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("*", ""), true},
@@ -50,6 +52,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Class level collections Class2 mismatch", authorization.CollectionsMetadata("Class2")[0], conv.CasbinSchema("Class1", ""), false},
 		{"Class level shards ABC TenantX", authorization.ShardsMetadata("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
 		{"Class level objects ABC TenantX objectY", authorization.Objects("ABC", "TenantX", "objectY"), conv.CasbinData("ABC", "*", "*"), true},
+		{"Class level tenant ABC TenantX", authorization.Tenants("ABC", "TenantX")[0], conv.CasbinTenant("ABC", ""), true},
 
 		// Tenants level
 		{"Tenants level shards", authorization.ShardsMetadata("")[0], conv.CasbinSchema("*", "*"), true},
@@ -74,6 +77,17 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Objects level ABC Tenant1 abcd mismatch", authorization.Objects("ABC", "Tenant1", "abcd"), conv.CasbinData("ABC", "Tenant1", "abc"), false},
 		{"Objects level ABC bar abcd", authorization.Objects("ABC", "bar", "abcd"), conv.CasbinData("*", "bar", ""), true},
 
+		// Tenants
+		{"Tenants level tenant", authorization.Tenants("")[0], conv.CasbinTenant("*", "*"), true},
+		{"Tenants level tenant ABC Tenant1", authorization.Tenants("ABC", "Tenant1")[0], conv.CasbinTenant("*", "*"), true},
+		{"Tenants level tenant Class1 Tenant1", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinTenant("*", "Tenant1"), true},
+		{"Tenants level objects Class1 Tenant1 ObjectY", authorization.Objects("Class1", "Tenant1", "ObjectY"), conv.CasbinData("*", "Tenant1", ""), true},
+		{"Tenants level tenant Class1 Tenant2 mismatch", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinTenant("*", "Tenant1"), false},
+		{"Tenants level tenant Class1 Tenant2 mismatch 2", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinTenant("Class2", "Tenant1"), false},
+		{"Tenants level tenant mismatch", authorization.Tenants("")[0], conv.CasbinTenant("Class1", ""), false},
+		{"Tenants level collections Class1", authorization.Tenants("Class1")[0], conv.CasbinTenant("Class1", ""), true},
+		{"Tenants level tenant Class1 tenant1", authorization.Tenants("Class1", "tenant1")[0], conv.CasbinTenant("Class1", ""), true},
+
 		// Regex
 		{"Regex collections ABCD", authorization.CollectionsMetadata("ABCD")[0], conv.CasbinSchema("ABC", ""), false},
 		{"Regex shards ABC", authorization.ShardsMetadata("ABC", "")[0], conv.CasbinSchema("ABC", ""), true},
@@ -81,6 +95,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Regex objects ABCD mismatch", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
 		{"Regex objects ABCD wildcard", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC.*", "*", "*"), true},
 		{"Regex objects BCD mismatch", authorization.Objects("BCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
+		{"Regex tenant ABC", authorization.Tenants("ABC", "")[0], conv.CasbinTenant("ABC", ""), true},
 
 		{"Regex collections ABC wildcard", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
 		{"Regex collections ABC wildcard 2", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
@@ -99,6 +114,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Partial match object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Obj*"), true},
 		{"Special character mismatch", authorization.Objects("Class1", "Shard1", "Object1"), "data/collections/Class1/shards/Shard1/objects/Object1!", false},
 		{"Mismatched object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Object2"), false},
+		{"Mismatched tenant", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinTenant("Class1", "Tenant2"), false},
 	}
 
 	for _, tt := range tests {

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -52,7 +52,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Class level collections Class2 mismatch", authorization.CollectionsMetadata("Class2")[0], conv.CasbinSchema("Class1", ""), false},
 		{"Class level shards ABC TenantX", authorization.ShardsMetadata("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
 		{"Class level objects ABC TenantX objectY", authorization.Objects("ABC", "TenantX", "objectY"), conv.CasbinData("ABC", "*", "*"), true},
-		{"Class level tenant ABC TenantX", authorization.Tenants("ABC", "TenantX")[0], conv.CasbinTenant("ABC", ""), true},
+		{"Class level tenant ABC TenantX", authorization.Tenants("ABC", "TenantX")[0], conv.CasbinSchema("ABC", ""), true},
 
 		// Tenants level
 		{"Tenants level shards", authorization.ShardsMetadata("")[0], conv.CasbinSchema("*", "*"), true},
@@ -78,15 +78,15 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Objects level ABC bar abcd", authorization.Objects("ABC", "bar", "abcd"), conv.CasbinData("*", "bar", ""), true},
 
 		// Tenants
-		{"Tenants level tenant", authorization.Tenants("")[0], conv.CasbinTenant("*", "*"), true},
-		{"Tenants level tenant ABC Tenant1", authorization.Tenants("ABC", "Tenant1")[0], conv.CasbinTenant("*", "*"), true},
-		{"Tenants level tenant Class1 Tenant1", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinTenant("*", "Tenant1"), true},
+		{"Tenants level tenant", authorization.Tenants("")[0], conv.CasbinSchema("*", "*"), true},
+		{"Tenants level tenant ABC Tenant1", authorization.Tenants("ABC", "Tenant1")[0], conv.CasbinSchema("*", "*"), true},
+		{"Tenants level tenant Class1 Tenant1", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinSchema("*", "Tenant1"), true},
 		{"Tenants level objects Class1 Tenant1 ObjectY", authorization.Objects("Class1", "Tenant1", "ObjectY"), conv.CasbinData("*", "Tenant1", ""), true},
-		{"Tenants level tenant Class1 Tenant2 mismatch", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinTenant("*", "Tenant1"), false},
-		{"Tenants level tenant Class1 Tenant2 mismatch 2", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinTenant("Class2", "Tenant1"), false},
-		{"Tenants level tenant mismatch", authorization.Tenants("")[0], conv.CasbinTenant("Class1", ""), false},
-		{"Tenants level collections Class1", authorization.Tenants("Class1")[0], conv.CasbinTenant("Class1", ""), true},
-		{"Tenants level tenant Class1 tenant1", authorization.Tenants("Class1", "tenant1")[0], conv.CasbinTenant("Class1", ""), true},
+		{"Tenants level tenant Class1 Tenant2 mismatch", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinSchema("*", "Tenant1"), false},
+		{"Tenants level tenant Class1 Tenant2 mismatch 2", authorization.Tenants("Class1", "Tenant2")[0], conv.CasbinSchema("Class2", "Tenant1"), false},
+		{"Tenants level tenant mismatch", authorization.Tenants("")[0], conv.CasbinSchema("Class1", ""), false},
+		{"Tenants level collections Class1", authorization.Tenants("Class1")[0], conv.CasbinSchema("Class1", ""), true},
+		{"Tenants level tenant Class1 tenant1", authorization.Tenants("Class1", "tenant1")[0], conv.CasbinSchema("Class1", ""), true},
 
 		// Regex
 		{"Regex collections ABCD", authorization.CollectionsMetadata("ABCD")[0], conv.CasbinSchema("ABC", ""), false},
@@ -95,7 +95,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Regex objects ABCD mismatch", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
 		{"Regex objects ABCD wildcard", authorization.Objects("ABCD", "", ""), conv.CasbinData("ABC.*", "*", "*"), true},
 		{"Regex objects BCD mismatch", authorization.Objects("BCD", "", ""), conv.CasbinData("ABC", "*", "*"), false},
-		{"Regex tenant ABC", authorization.Tenants("ABC", "")[0], conv.CasbinTenant("ABC", ""), true},
+		{"Regex tenant ABC", authorization.Tenants("ABC", "")[0], conv.CasbinSchema("ABC", ""), true},
 
 		{"Regex collections ABC wildcard", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
 		{"Regex collections ABC wildcard 2", authorization.CollectionsMetadata("ABC")[0], conv.CasbinSchema("ABC*", ""), true},
@@ -114,7 +114,7 @@ func TestKeyMatch5AuthZ(t *testing.T) {
 		{"Partial match object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Obj*"), true},
 		{"Special character mismatch", authorization.Objects("Class1", "Shard1", "Object1"), "data/collections/Class1/shards/Shard1/objects/Object1!", false},
 		{"Mismatched object", authorization.Objects("Class1", "Shard1", "Object1"), conv.CasbinData("Class1", "Shard1", "Object2"), false},
-		{"Mismatched tenant", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinTenant("Class1", "Tenant2"), false},
+		{"Mismatched tenant", authorization.Tenants("Class1", "Tenant1")[0], conv.CasbinSchema("Class1", "Tenant2"), false},
 	}
 
 	for _, tt := range tests {

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -33,13 +33,15 @@ const (
 )
 
 const (
-	UsersDomain   = "users"
-	RolesDomain   = "roles"
-	ClusterDomain = "cluster"
-	NodesDomain   = "nodes"
-	BackupsDomain = "backups"
-	SchemaDomain  = "schema"
-	DataDomain    = "data"
+	UsersDomain       = "users"
+	RolesDomain       = "roles"
+	ClusterDomain     = "cluster"
+	NodesDomain       = "nodes"
+	BackupsDomain     = "backups"
+	SchemaDomain      = "schema"
+	CollectionsDomain = "collections"
+	TenantsDomain     = "tenants"
+	DataDomain        = "data"
 )
 
 var (

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -54,6 +54,10 @@ var (
 		Tenant:     All,
 		Object:     All,
 	}
+	AllTenants = &models.PermissionTenants{
+		Collection: All,
+		Tenant:     All,
+	}
 	AllNodes = &models.PermissionNodes{
 		Verbosity:  String(verbosity.OutputVerbose),
 		Collection: All,
@@ -89,6 +93,11 @@ var (
 	UpdateData = "update_data"
 	DeleteData = "delete_data"
 
+	CreateTenant = "create_tenant"
+	ReadTenant   = "read_tenant"
+	UpdateTenant = "update_tenant"
+	DeleteTenant = "delete_tenant"
+
 	availableWeaviateActions = []string{
 		// Roles domain
 		ManageRoles,
@@ -117,6 +126,12 @@ var (
 		ReadData,
 		UpdateData,
 		DeleteData,
+
+		// Tenant domain
+		CreateTenant,
+		ReadTenant,
+		UpdateTenant,
+		DeleteTenant,
 	}
 )
 
@@ -430,6 +445,7 @@ func viewerPermissions() []*models.Permission {
 			Nodes:       AllNodes,
 			Roles:       AllRoles,
 			Collections: AllCollections,
+			Tenants:     AllTenants,
 		})
 	}
 
@@ -448,6 +464,7 @@ func adminPermissions() []*models.Permission {
 			Nodes:       AllNodes,
 			Roles:       AllRoles,
 			Collections: AllCollections,
+			Tenants:     AllTenants,
 		})
 	}
 

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -39,6 +39,7 @@ const (
 	NodesDomain   = "nodes"
 	BackupsDomain = "backups"
 	SchemaDomain  = "schema"
+	TenantDomain  = "tenant"
 	DataDomain    = "data"
 )
 
@@ -315,6 +316,40 @@ func ShardsData(class string, shards ...string) []string {
 		paths = append(paths, Objects(class, shard, "*"))
 	}
 	return paths
+}
+
+// Tenants generates a list of shard resource strings for a given class and tenants.
+// If the class is an empty string, it defaults to "*". If no tenants are provided,
+// it returns a single resource string with a wildcard for tenants. If tenants are
+// provided, it returns a list of resource strings for each tenants.
+//
+// Parameters:
+//   - class: The class name for the resource. If empty, defaults to "*".
+//   - tenants: A variadic list of shard names. If empty, a wildcard is used.
+//
+// Returns:
+//
+//	A slice of strings representing the resource paths for the given class and tenants.
+func Tenants(class string, tenants ...string) []string {
+	class = schema.UppercaseClassesNames(class)[0]
+	if class == "" {
+		class = "*"
+	}
+
+	if len(tenants) == 0 || (len(tenants) == 1 && (tenants[0] == "" || tenants[0] == "*")) {
+		return []string{fmt.Sprintf("%s/collections/%s/tenants/*", TenantDomain, class)}
+	}
+
+	resources := make([]string, len(tenants))
+	for idx := range tenants {
+		if tenants[idx] == "" {
+			resources[idx] = fmt.Sprintf("%s/collections/%s/tenants/*", TenantDomain, class)
+		} else {
+			resources[idx] = fmt.Sprintf("%s/collections/%s/tenants/%s", TenantDomain, class, tenants[idx])
+		}
+	}
+
+	return resources
 }
 
 // Objects generates a string representing a path to objects within a collection and shard.

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -331,22 +331,6 @@ func ShardsData(class string, shards ...string) []string {
 	return paths
 }
 
-// Tenants generates a list of tenant resource strings for a given class and tenants.
-// If the class is an empty string, it defaults to "*". If no tenants are provided,
-// it returns a single resource string with a wildcard for tenants. If tenants are
-// provided, it returns a list of resource strings for each tenants.
-//
-// Parameters:
-//   - class: The class name for the resource. If empty, defaults to "*".
-//   - tenants: A variadic list of shard names. If empty, a wildcard is used.
-//
-// Returns:
-//
-//	A slice of strings representing the resource paths for the given class and tenants.
-func Tenants(class string, tenants ...string) []string {
-	return ShardsMetadata(class, tenants...)
-}
-
 // Objects generates a string representing a path to objects within a collection and shard.
 // The path format varies based on the provided class, shard, and id parameters.
 //

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -39,7 +39,6 @@ const (
 	NodesDomain   = "nodes"
 	BackupsDomain = "backups"
 	SchemaDomain  = "schema"
-	TenantDomain  = "tenants"
 	DataDomain    = "data"
 )
 
@@ -67,7 +66,6 @@ var (
 	}
 	AllCollections = &models.PermissionCollections{
 		Collection: All,
-		Tenant:     All,
 	}
 
 	ComponentName = "RBAC"
@@ -256,15 +254,15 @@ func CollectionsMetadata(classes ...string) []string {
 	classes = schema.UppercaseClassesNames(classes...)
 
 	if len(classes) == 0 || (len(classes) == 1 && (classes[0] == "" || classes[0] == "*")) {
-		return []string{fmt.Sprintf("%s/collections/*/shards/*", SchemaDomain)}
+		return []string{fmt.Sprintf("%s/collections/*/shards/#", SchemaDomain)}
 	}
 
 	resources := make([]string, len(classes))
 	for idx := range classes {
 		if classes[idx] == "" {
-			resources[idx] = fmt.Sprintf("%s/collections/*/shards/*", SchemaDomain)
+			resources[idx] = fmt.Sprintf("%s/collections/*/shards/#", SchemaDomain)
 		} else {
-			resources[idx] = fmt.Sprintf("%s/collections/%s/shards/*", SchemaDomain, classes[idx])
+			resources[idx] = fmt.Sprintf("%s/collections/%s/shards/#", SchemaDomain, classes[idx])
 		}
 	}
 
@@ -297,7 +295,7 @@ func Collections(classes ...string) []string {
 //
 // Parameters:
 //   - class: The class name for the resource. If empty, defaults to "*".
-//   - shards: A variadic list of shard names. If empty, a wildcard is used.
+//   - shards: A variadic list of shard names. If empty, it will replace it with '#' to mark it as collection only check
 //
 // Returns:
 //
@@ -333,7 +331,7 @@ func ShardsData(class string, shards ...string) []string {
 	return paths
 }
 
-// Tenants generates a list of shard resource strings for a given class and tenants.
+// Tenants generates a list of tenant resource strings for a given class and tenants.
 // If the class is an empty string, it defaults to "*". If no tenants are provided,
 // it returns a single resource string with a wildcard for tenants. If tenants are
 // provided, it returns a list of resource strings for each tenants.
@@ -346,25 +344,7 @@ func ShardsData(class string, shards ...string) []string {
 //
 //	A slice of strings representing the resource paths for the given class and tenants.
 func Tenants(class string, tenants ...string) []string {
-	class = schema.UppercaseClassesNames(class)[0]
-	if class == "" {
-		class = "*"
-	}
-
-	if len(tenants) == 0 || (len(tenants) == 1 && (tenants[0] == "" || tenants[0] == "*")) {
-		return []string{fmt.Sprintf("%s/collections/%s/tenants/*", TenantDomain, class)}
-	}
-
-	resources := make([]string, len(tenants))
-	for idx := range tenants {
-		if tenants[idx] == "" {
-			resources[idx] = fmt.Sprintf("%s/collections/%s/tenants/*", TenantDomain, class)
-		} else {
-			resources[idx] = fmt.Sprintf("%s/collections/%s/tenants/%s", TenantDomain, class, tenants[idx])
-		}
-	}
-
-	return resources
+	return ShardsMetadata(class, tenants...)
 }
 
 // Objects generates a string representing a path to objects within a collection and shard.

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -39,7 +39,7 @@ const (
 	NodesDomain   = "nodes"
 	BackupsDomain = "backups"
 	SchemaDomain  = "schema"
-	TenantDomain  = "tenant"
+	TenantDomain  = "tenants"
 	DataDomain    = "data"
 )
 
@@ -93,10 +93,10 @@ var (
 	UpdateData = "update_data"
 	DeleteData = "delete_data"
 
-	CreateTenant = "create_tenant"
-	ReadTenant   = "read_tenant"
-	UpdateTenant = "update_tenant"
-	DeleteTenant = "delete_tenant"
+	CreateTenant = "create_tenants"
+	ReadTenant   = "read_tenants"
+	UpdateTenant = "update_tenants"
+	DeleteTenant = "delete_tenants"
 
 	availableWeaviateActions = []string{
 		// Roles domain

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -91,10 +91,10 @@ var (
 	UpdateData = "update_data"
 	DeleteData = "delete_data"
 
-	CreateTenant = "create_tenants"
-	ReadTenant   = "read_tenants"
-	UpdateTenant = "update_tenants"
-	DeleteTenant = "delete_tenants"
+	CreateTenants = "create_tenants"
+	ReadTenants   = "read_tenants"
+	UpdateTenants = "update_tenants"
+	DeleteTenants = "delete_tenants"
 
 	availableWeaviateActions = []string{
 		// Roles domain
@@ -126,10 +126,10 @@ var (
 		DeleteData,
 
 		// Tenant domain
-		CreateTenant,
-		ReadTenant,
-		UpdateTenant,
-		DeleteTenant,
+		CreateTenants,
+		ReadTenants,
+		UpdateTenants,
+		DeleteTenants,
 	}
 )
 

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -188,7 +188,7 @@ func TestTenants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := Tenants(tt.class, tt.shards...)
+			result := ShardsMetadata(tt.class, tt.shards...)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -108,10 +108,10 @@ func TestCollections(t *testing.T) {
 		classes  []string
 		expected []string
 	}{
-		{"No classes", []string{}, []string{fmt.Sprintf("%s/collections/*/shards/*", SchemaDomain)}},
-		{"Single empty class", []string{""}, []string{fmt.Sprintf("%s/collections/*/shards/*", SchemaDomain)}},
-		{"Single class", []string{"class1"}, []string{fmt.Sprintf("%s/collections/Class1/shards/*", SchemaDomain)}},
-		{"Multiple classes", []string{"class1", "class2"}, []string{fmt.Sprintf("%s/collections/Class1/shards/*", SchemaDomain), fmt.Sprintf("%s/collections/Class2/shards/*", SchemaDomain)}},
+		{"No classes", []string{}, []string{fmt.Sprintf("%s/collections/*/shards/#", SchemaDomain)}},
+		{"Single empty class", []string{""}, []string{fmt.Sprintf("%s/collections/*/shards/#", SchemaDomain)}},
+		{"Single class", []string{"class1"}, []string{fmt.Sprintf("%s/collections/Class1/shards/#", SchemaDomain)}},
+		{"Multiple classes", []string{"class1", "class2"}, []string{fmt.Sprintf("%s/collections/Class1/shards/#", SchemaDomain), fmt.Sprintf("%s/collections/Class2/shards/#", SchemaDomain)}},
 	}
 
 	for _, tt := range tests {
@@ -178,12 +178,12 @@ func TestTenants(t *testing.T) {
 		shards   []string
 		expected []string
 	}{
-		{"No class, no tenant", "", []string{}, []string{fmt.Sprintf("%s/collections/*/tenants/*", TenantDomain)}},
-		{"Class, no tenant", "class1", []string{}, []string{fmt.Sprintf("%s/collections/Class1/tenants/*", TenantDomain)}},
-		{"No class, single tenant", "", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/*/tenants/tenant1", TenantDomain)}},
-		{"Class, single tenants", "class1", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain)}},
-		{"Class, multiple tenants", "class1", []string{"tenant1", "tenant2"}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain), fmt.Sprintf("%s/collections/Class1/tenants/tenant2", TenantDomain)}},
-		{"Class, empty tenant", "class1", []string{"tenant1", ""}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain), fmt.Sprintf("%s/collections/Class1/tenants/*", TenantDomain)}},
+		{"No class, no tenant", "", []string{}, []string{fmt.Sprintf("%s/collections/*/shards/*", SchemaDomain)}},
+		{"Class, no tenant", "class1", []string{}, []string{fmt.Sprintf("%s/collections/Class1/shards/*", SchemaDomain)}},
+		{"No class, single tenant", "", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/*/shards/tenant1", SchemaDomain)}},
+		{"Class, single tenants", "class1", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/Class1/shards/tenant1", SchemaDomain)}},
+		{"Class, multiple tenants", "class1", []string{"tenant1", "tenant2"}, []string{fmt.Sprintf("%s/collections/Class1/shards/tenant1", SchemaDomain), fmt.Sprintf("%s/collections/Class1/shards/tenant2", SchemaDomain)}},
+		{"Class, empty tenant", "class1", []string{"tenant1", ""}, []string{fmt.Sprintf("%s/collections/Class1/shards/tenant1", SchemaDomain), fmt.Sprintf("%s/collections/Class1/shards/*", SchemaDomain)}},
 	}
 
 	for _, tt := range tests {

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -170,3 +170,26 @@ func TestObjects(t *testing.T) {
 		})
 	}
 }
+
+func TestTenants(t *testing.T) {
+	tests := []struct {
+		name     string
+		class    string
+		shards   []string
+		expected []string
+	}{
+		{"No class, no tenant", "", []string{}, []string{fmt.Sprintf("%s/collections/*/tenants/*", TenantDomain)}},
+		{"Class, no tenant", "class1", []string{}, []string{fmt.Sprintf("%s/collections/Class1/tenants/*", TenantDomain)}},
+		{"No class, single tenant", "", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/*/tenants/tenant1", TenantDomain)}},
+		{"Class, single tenants", "class1", []string{"tenant1"}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain)}},
+		{"Class, multiple tenants", "class1", []string{"tenant1", "tenant2"}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain), fmt.Sprintf("%s/collections/Class1/tenants/tenant2", TenantDomain)}},
+		{"Class, empty tenant", "class1", []string{"tenant1", ""}, []string{fmt.Sprintf("%s/collections/Class1/tenants/tenant1", TenantDomain), fmt.Sprintf("%s/collections/Class1/tenants/*", TenantDomain)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Tenants(tt.class, tt.shards...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -112,7 +112,7 @@ func Test_Schema_Authorization(t *testing.T) {
 			methodName:        "AddTenants",
 			additionalArgs:    []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
 			expectedVerb:      authorization.CREATE,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 		{
 			methodName: "UpdateTenants",
@@ -120,31 +120,25 @@ func Test_Schema_Authorization(t *testing.T) {
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
 			expectedVerb:      authorization.UPDATE,
-			expectedResources: authorization.ShardsMetadata("className", "P1"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 		{
 			methodName:        "DeleteTenants",
 			additionalArgs:    []interface{}{"className", []string{"P1"}},
 			expectedVerb:      authorization.DELETE,
-			expectedResources: authorization.ShardsMetadata("className", "P1"),
-		},
-		{
-			methodName:        "GetTenants",
-			additionalArgs:    []interface{}{"className"},
-			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 		{
 			methodName:        "GetConsistentTenants",
 			additionalArgs:    []interface{}{"className", false, []string{}},
 			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className"),
 		},
 		{
 			methodName:        "ConsistentTenantExists",
 			additionalArgs:    []interface{}{"className", false, "P1"},
 			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
+			expectedResources: authorization.Tenants("className", "P1"),
 		},
 	}
 

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -112,7 +112,7 @@ func Test_Schema_Authorization(t *testing.T) {
 			methodName:        "AddTenants",
 			additionalArgs:    []interface{}{"className", []*models.Tenant{{Name: "P1"}}},
 			expectedVerb:      authorization.CREATE,
-			expectedResources: authorization.Tenants("className", "P1"),
+			expectedResources: authorization.ShardsMetadata("className", "P1"),
 		},
 		{
 			methodName: "UpdateTenants",
@@ -120,25 +120,25 @@ func Test_Schema_Authorization(t *testing.T) {
 				{Name: "P1", ActivityStatus: models.TenantActivityStatusHOT},
 			}},
 			expectedVerb:      authorization.UPDATE,
-			expectedResources: authorization.Tenants("className", "P1"),
+			expectedResources: authorization.ShardsMetadata("className", "P1"),
 		},
 		{
 			methodName:        "DeleteTenants",
 			additionalArgs:    []interface{}{"className", []string{"P1"}},
 			expectedVerb:      authorization.DELETE,
-			expectedResources: authorization.Tenants("className", "P1"),
+			expectedResources: authorization.ShardsMetadata("className", "P1"),
 		},
 		{
 			methodName:        "GetConsistentTenants",
 			additionalArgs:    []interface{}{"className", false, []string{}},
 			expectedVerb:      authorization.READ,
-			expectedResources: authorization.Tenants("className"),
+			expectedResources: authorization.ShardsMetadata("className"),
 		},
 		{
 			methodName:        "ConsistentTenantExists",
 			additionalArgs:    []interface{}{"className", false, "P1"},
 			expectedVerb:      authorization.READ,
-			expectedResources: authorization.Tenants("className", "P1"),
+			expectedResources: authorization.ShardsMetadata("className", "P1"),
 		},
 	}
 

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -49,9 +49,9 @@ func (h *Handler) AddTenants(ctx context.Context,
 	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.Tenants(class, tenantNames...)...); err != nil {
 		return 0, err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-		return 0, err
-	}
+	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
+	// 	return 0, err
+	// }
 
 	validated, err := validateTenants(tenants, true)
 	if err != nil {
@@ -165,9 +165,9 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Tenants(class, shardNames...)...); err != nil {
 		return nil, err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-		return nil, err
-	}
+	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
+	// 	return nil, err
+	// }
 
 	h.logger.WithFields(logrus.Fields{
 		"class":   class,
@@ -212,9 +212,9 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.Tenants(class, tenants...)...); err != nil {
 		return err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-		return err
-	}
+	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
+	// 	return err
+	// }
 
 	for i, name := range tenants {
 		if name == "" {
@@ -234,9 +234,9 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenants...)...); err != nil {
 		return nil, err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-		return nil, err
-	}
+	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
+	// 	return nil, err
+	// }
 
 	if consistency {
 		tenants, _, err := h.schemaManager.QueryTenants(class, tenants)
@@ -265,9 +265,9 @@ func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.
 	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenant)...); err != nil {
 		return err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-		return err
-	}
+	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
+	// 	return err
+	// }
 
 	var tenantResponses []*models.TenantResponse
 	var err error

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -46,12 +46,9 @@ func (h *Handler) AddTenants(ctx context.Context,
 	for i, tenant := range tenants {
 		tenantNames[i] = tenant.Name
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.Tenants(class, tenantNames...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.ShardsMetadata(class, tenantNames...)...); err != nil {
 		return 0, err
 	}
-	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-	// 	return 0, err
-	// }
 
 	validated, err := validateTenants(tenants, true)
 	if err != nil {
@@ -162,12 +159,9 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 		shardNames[idx] = tenants[idx].Name
 	}
 
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Tenants(class, shardNames...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsMetadata(class, shardNames...)...); err != nil {
 		return nil, err
 	}
-	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-	// 	return nil, err
-	// }
 
 	h.logger.WithFields(logrus.Fields{
 		"class":   class,
@@ -209,12 +203,9 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.Tenants(class, tenants...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.ShardsMetadata(class, tenants...)...); err != nil {
 		return err
 	}
-	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-	// 	return err
-	// }
 
 	for i, name := range tenants {
 		if name == "" {
@@ -231,12 +222,9 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 }
 
 func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.TenantResponse, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenants...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenants...)...); err != nil {
 		return nil, err
 	}
-	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-	// 	return nil, err
-	// }
 
 	if consistency {
 		tenants, _, err := h.schemaManager.QueryTenants(class, tenants)
@@ -262,12 +250,9 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenant)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
 		return err
 	}
-	// if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-	// 	return err
-	// }
 
 	var tenantResponses []*models.TenantResponse
 	var err error

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -42,7 +42,14 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.ShardsMetadata(class)...); err != nil {
+	tenantNames := make([]string, len(tenants))
+	for i, tenant := range tenants {
+		tenantNames[i] = tenant.Name
+	}
+	if err := h.Authorizer.Authorize(principal, authorization.CREATE, authorization.Tenants(class, tenantNames...)...); err != nil {
+		return 0, err
+	}
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return 0, err
 	}
 
@@ -155,10 +162,10 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 		shardNames[idx] = tenants[idx].Name
 	}
 
-	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsMetadata(class, shardNames...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.UPDATE, authorization.Tenants(class, shardNames...)...); err != nil {
 		return nil, err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, shardNames...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return nil, err
 	}
 
@@ -202,10 +209,10 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.ShardsMetadata(class, tenants...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.DELETE, authorization.Tenants(class, tenants...)...); err != nil {
 		return err
 	}
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenants...)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
 	}
 
@@ -223,18 +230,11 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 	return err
 }
 
-// GetTenants is used to get tenants of a class.
-//
-// Class must exist and has partitioning enabled
-func (h *Handler) GetTenants(ctx context.Context, principal *models.Principal, class string) ([]*models.Tenant, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class)...); err != nil {
+func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.TenantResponse, error) {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenants...)...); err != nil {
 		return nil, err
 	}
-	return h.getTenants(class)
-}
-
-func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.TenantResponse, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return nil, err
 	}
 
@@ -288,7 +288,10 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class)...); err != nil {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.Tenants(class, tenant)...); err != nil {
+		return err
+	}
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
 	}
 

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -247,32 +247,6 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	return h.getTenantsByNames(class, tenants)
 }
 
-func (h *Handler) getTenants(class string) ([]*models.Tenant, error) {
-	info, err := h.multiTenancy(class)
-	if err != nil || info.Tenants == 0 {
-		return nil, err
-	}
-
-	ts := make([]*models.Tenant, info.Tenants)
-	f := func(_ *models.Class, ss *sharding.State) error {
-		if n := len(ss.Physical); n > len(ts) {
-			ts = make([]*models.Tenant, n)
-		} else if n < len(ts) {
-			ts = ts[:n]
-		}
-		i := 0
-		for tenant := range ss.Physical {
-			ts[i] = &models.Tenant{
-				Name:           tenant,
-				ActivityStatus: schema.ActivityStatus(ss.Physical[tenant].Status),
-			}
-			i++
-		}
-		return nil
-	}
-	return ts, h.schemaReader.Read(class, f)
-}
-
 func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 	info := h.schemaReader.ClassInfo(class)
 	if !info.Exists {


### PR DESCRIPTION
### What's being changed:
this PR does separate the tenant actions from the collections actions under the same domain with overriding the collection path to end with `#` shard, so it can detect the underlying domain from the path, the `/shard/#`  can be removed later in a follow up PR, however here is supported as `#` to keep the paths as they are 

keeping `/shards/#` and the same positions as it was is crucial to avoid panics on downgrades and keep it backward compatible 
  
**Note** will have a follow up PR to migrate the released paths in RAFT to new format
follow up PR https://github.com/weaviate/weaviate/pull/6823
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
