### PR TITLE
chore: cleanup gcp backup test created buckets with every test

### DIFF
--- a/test/helper/modules/modules_helper.go
+++ b/test/helper/modules/modules_helper.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
-	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
@@ -105,16 +104,7 @@ func CreateGCSBucket(ctx context.Context, t *testing.T, projectID, bucketName st
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		client, err := storage.NewClient(ctx, option.WithoutAuthentication())
 		assert.Nil(t, err)
-		err = client.Bucket(bucketName).Create(ctx, projectID, nil)
-		gcsErr, ok := err.(*googleapi.Error)
-		if ok {
-			// the bucket persists from the previous test.
-			// if the bucket already exists, we can proceed
-			if gcsErr.Code == http.StatusConflict {
-				return
-			}
-		}
-		assert.Nil(t, err)
+		assert.Nil(t, client.Bucket(bucketName).Create(ctx, projectID, nil))
 	}, 5*time.Second, 500*time.Millisecond)
 }
 
@@ -122,7 +112,22 @@ func DeleteGCSBucket(ctx context.Context, t *testing.T, bucketName string) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		client, err := storage.NewClient(ctx, option.WithoutAuthentication())
 		assert.Nil(t, err)
-		assert.Nil(t, client.Bucket(bucketName).Delete(ctx))
+
+		bucket := client.Bucket(bucketName)
+		// we do iterate over objects because GCP doesn't allow deleting non-empty buckets
+		it := bucket.Objects(ctx, nil)
+		for {
+			objAttrs, err := it.Next()
+			if err == iterator.Done {
+				break
+			}
+			assert.Nil(t, err)
+
+			obj := bucket.Object(objAttrs.Name)
+			err = obj.Delete(ctx)
+			assert.Nil(t, err)
+		}
+		assert.Nil(t, bucket.Delete(ctx))
 	}, 5*time.Second, 500*time.Millisecond)
 }
 

--- a/test/helper/modules/modules_helper.go
+++ b/test/helper/modules/modules_helper.go
@@ -118,6 +118,14 @@ func CreateGCSBucket(ctx context.Context, t *testing.T, projectID, bucketName st
 	}, 5*time.Second, 500*time.Millisecond)
 }
 
+func DeleteGCSBucket(ctx context.Context, t *testing.T, bucketName string) {
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+		assert.Nil(t, err)
+		assert.Nil(t, client.Bucket(bucketName).Delete(ctx))
+	}, 5*time.Second, 500*time.Millisecond)
+}
+
 func CreateAzureContainer(ctx context.Context, t *testing.T, endpoint, containerName string) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		connectionString := "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://%s/devstoreaccount1;"

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -72,6 +72,7 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 	t.Setenv(envGCSBucket, bucketName)
 	t.Setenv(envGCSUseAuth, gcsUseAuth)
 	moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
+	defer moduleshelper.DeleteGCSBucket(testCtx, t, bucketName)
 
 	t.Run("store backup meta in gcs", func(t *testing.T) {
 		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
@@ -154,6 +155,7 @@ func moduleLevelCopyObjects(t *testing.T) {
 	t.Setenv(envGCSBucket, bucketName)
 	t.Setenv(envGCSUseAuth, gcsUseAuth)
 	moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
+	defer moduleshelper.DeleteGCSBucket(testCtx, t, bucketName)
 
 	t.Run("copy objects", func(t *testing.T) {
 		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
@@ -193,6 +195,7 @@ func moduleLevelCopyFiles(t *testing.T) {
 	t.Setenv(envGCSBucket, bucketName)
 	t.Setenv(envGCSUseAuth, gcsUseAuth)
 	moduleshelper.CreateGCSBucket(testCtx, t, projectID, bucketName)
+	defer moduleshelper.DeleteGCSBucket(testCtx, t, bucketName)
 
 	t.Run("copy files", func(t *testing.T) {
 		fpaths := moduleshelper.CreateTestFiles(t, dataDir)

--- a/test/modules/backup-gcs/backup_journey_test.go
+++ b/test/modules/backup-gcs/backup_journey_test.go
@@ -62,6 +62,8 @@ func Test_BackupJourney(t *testing.T) {
 		t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
 		t.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI())
 		moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+		defer moduleshelper.DeleteGCSBucket(ctx, t, gcsBackupJourneyBucketName)
+
 		helper.SetupClient(compose.GetWeaviate().URI())
 
 		t.Run("backup-gcs", func(t *testing.T) {
@@ -92,6 +94,8 @@ func Test_BackupJourney(t *testing.T) {
 		t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
 		t.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI())
 		moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+		defer moduleshelper.DeleteGCSBucket(ctx, t, gcsBackupJourneyBucketName)
+
 		helper.SetupClient(compose.GetWeaviate().URI())
 
 		t.Run("backup-gcs", func(t *testing.T) {

--- a/test/modules/backup-gcs/multi_tenant_backup_test.go
+++ b/test/modules/backup-gcs/multi_tenant_backup_test.go
@@ -55,6 +55,8 @@ func Test_MultiTenantBackupJourney(t *testing.T) {
 		t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
 		t.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI())
 		moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+		defer moduleshelper.DeleteGCSBucket(ctx, t, gcsBackupJourneyBucketName)
+
 		helper.SetupClient(compose.GetWeaviate().URI())
 
 		t.Run("backup-gcs", func(t *testing.T) {
@@ -86,6 +88,8 @@ func Test_MultiTenantBackupJourney(t *testing.T) {
 		t.Setenv(envGCSEndpoint, compose.GetGCS().URI())
 		t.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI())
 		moduleshelper.CreateGCSBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+		defer moduleshelper.DeleteGCSBucket(ctx, t, gcsBackupJourneyBucketName)
+
 		helper.SetupClient(compose.GetWeaviate().URI())
 
 		t.Run("backup-gcs", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
his shall stabilize the backup GCP acceptance test flakiness, by cleaning up the tests by removing the gcp bucket and it's objects 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
