### PR TITLE
feat: raft migrate paths on request to new style

### DIFF
--- a/cluster/proto/api/rbac_requests.go
+++ b/cluster/proto/api/rbac_requests.go
@@ -15,8 +15,19 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
+const (
+	// in case changes happens to the RBAC message, add new version before the LatestCommandVersion
+	// RBACCommandPolicyVersionV0 represents the first version of RBAC commands
+	RBACCommandPolicyVersionV0 = iota
+
+	// RBACLatestCommandPolicyVersion represents the latest version of RBAC commands policies
+	// It's used to migrate policy changes
+	RBACLatestCommandPolicyVersion
+)
+
 type CreateRolesRequest struct {
-	Roles map[string][]authorization.Policy
+	Roles   map[string][]authorization.Policy
+	Version int
 }
 
 type DeleteRolesRequest struct {
@@ -26,6 +37,7 @@ type DeleteRolesRequest struct {
 type RemovePermissionsRequest struct {
 	Role        string
 	Permissions []*authorization.Policy
+	Version     int
 }
 
 type AddRolesForUsersRequest struct {

--- a/cluster/proto/api/rbac_requests.go
+++ b/cluster/proto/api/rbac_requests.go
@@ -21,7 +21,9 @@ const (
 	RBACCommandPolicyVersionV0 = iota
 
 	// RBACLatestCommandPolicyVersion represents the latest version of RBAC commands policies
-	// It's used to migrate policy changes
+	// It's used to migrate policy changes. if we end up with a cluster having different version
+	// that won't be a problem because the version here is not about the message change but more about
+	// the content of the body which will dumbed anyway in RBAC storage.
 	RBACLatestCommandPolicyVersion
 )
 

--- a/cluster/proto/api/rbac_requests.go
+++ b/cluster/proto/api/rbac_requests.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// in case changes happens to the RBAC message, add new version before the LatestCommandVersion
+	// in case changes happens to the RBAC message, add new version before the RBACLatestCommandPolicyVersion
 	// RBACCommandPolicyVersionV0 represents the first version of RBAC commands
 	RBACCommandPolicyVersionV0 = iota
 

--- a/cluster/raft_rbac_apply_endpoints.go
+++ b/cluster/raft_rbac_apply_endpoints.go
@@ -26,7 +26,7 @@ func (s *Raft) UpsertRolesPermissions(roles map[string][]authorization.Policy) e
 		return fmt.Errorf("no roles to create: %w", schema.ErrBadRequest)
 	}
 
-	req := cmd.CreateRolesRequest{Roles: roles}
+	req := cmd.CreateRolesRequest{Roles: roles, Version: cmd.RBACLatestCommandPolicyVersion}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
@@ -64,7 +64,7 @@ func (s *Raft) RemovePermissions(role string, permissions []*authorization.Polic
 	if role == "" {
 		return fmt.Errorf("no roles to remove permissions from: %w", schema.ErrBadRequest)
 	}
-	req := cmd.RemovePermissionsRequest{Role: role, Permissions: permissions}
+	req := cmd.RemovePermissionsRequest{Role: role, Permissions: permissions, Version: cmd.RBACLatestCommandPolicyVersion}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -143,7 +143,7 @@ func (m *Manager) UpsertRolesPermissions(c *cmd.ApplyRequest) error {
 			}
 		}
 	default:
-		//no thing
+		// do nothing
 	}
 
 	return m.authZ.UpsertRolesPermissions(req.Roles)

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
@@ -114,6 +115,29 @@ func (m *Manager) UpsertRolesPermissions(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
+	// remove old permissions
+	for roleName, policies := range req.Roles {
+		pol := []*authorization.Policy{}
+		for _, p := range policies {
+			pol = append(pol, &p)
+		}
+		if err := m.authZ.RemovePermissions(roleName, pol); err != nil {
+			return err
+		}
+	}
+
+	for roleName, policies := range req.Roles {
+		for idx := range policies {
+			if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
+				parts := strings.Split(req.Roles[roleName][idx].Resource, "/")
+				if len(parts) < 3 {
+					return fmt.Errorf("invalid schema path")
+				}
+				req.Roles[roleName][idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
+			}
+		}
+	}
+
 	return m.authZ.UpsertRolesPermissions(req.Roles)
 }
 
@@ -139,6 +163,22 @@ func (m *Manager) RemovePermissions(c *cmd.ApplyRequest) error {
 	req := &cmd.RemovePermissionsRequest{}
 	if err := json.Unmarshal(c.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
+	}
+
+	// keep to remove old formats
+	if err := m.authZ.RemovePermissions(req.Role, req.Permissions); err != nil {
+		return err
+	}
+
+	// remove any added with new format after migration
+	for idx := range req.Permissions {
+		if req.Permissions[idx].Domain == authorization.SchemaDomain {
+			parts := strings.Split(req.Permissions[idx].Resource, "/")
+			if len(parts) < 3 {
+				return fmt.Errorf("invalid schema path")
+			}
+			req.Permissions[idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
+		}
 	}
 
 	return m.authZ.RemovePermissions(req.Role, req.Permissions)

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -115,27 +115,35 @@ func (m *Manager) UpsertRolesPermissions(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	// remove old permissions
-	for roleName, policies := range req.Roles {
-		pol := []*authorization.Policy{}
-		for _, p := range policies {
-			pol = append(pol, &p)
-		}
-		if err := m.authZ.RemovePermissions(roleName, pol); err != nil {
-			return err
-		}
-	}
+	switch req.Version {
+	case cmd.RBACCommandPolicyVersionV0:
+		for roleName, policies := range req.Roles {
+			permissions := []*authorization.Policy{}
+			for _, p := range policies {
+				permissions = append(permissions, &p)
+			}
+			// remove old permissions
+			if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
+				return err
+			}
 
-	for roleName, policies := range req.Roles {
-		for idx := range policies {
-			if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
+			// create new permissions
+			for idx := range policies {
+				if req.Roles[roleName][idx].Domain != authorization.SchemaDomain {
+					continue
+				}
+
 				parts := strings.Split(req.Roles[roleName][idx].Resource, "/")
 				if len(parts) < 3 {
+					// shall never happens
 					return fmt.Errorf("invalid schema path")
 				}
 				req.Roles[roleName][idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
+
 			}
 		}
+	default:
+		//no thing
 	}
 
 	return m.authZ.UpsertRolesPermissions(req.Roles)
@@ -165,20 +173,26 @@ func (m *Manager) RemovePermissions(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	// keep to remove old formats
-	if err := m.authZ.RemovePermissions(req.Role, req.Permissions); err != nil {
-		return err
-	}
-
-	// remove any added with new format after migration
-	for idx := range req.Permissions {
-		if req.Permissions[idx].Domain == authorization.SchemaDomain {
+	switch req.Version {
+	case cmd.RBACCommandPolicyVersionV0:
+		// keep to remove old formats
+		if err := m.authZ.RemovePermissions(req.Role, req.Permissions); err != nil {
+			return err
+		}
+		// remove any added with new format after migration
+		for idx := range req.Permissions {
+			if req.Permissions[idx].Domain != authorization.SchemaDomain {
+				continue
+			}
 			parts := strings.Split(req.Permissions[idx].Resource, "/")
 			if len(parts) < 3 {
+				// shall never happens
 				return fmt.Errorf("invalid schema path")
 			}
 			req.Permissions[idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
 		}
+	default:
+		// do nothing
 	}
 
 	return m.authZ.RemovePermissions(req.Role, req.Permissions)


### PR DESCRIPTION
### What's being changed:
in `1.28` we introduced rbac actions `[crud]_collections` the name is misleading of the nature of the action 
because it does give permission for the whole schema(collection+tenant), however to amend this we introduced `[crud]_tenants` in https://github.com/weaviate/weaviate/pull/6800 and we limited  `[crud]_collections` by creating new path `"schema/collections/{collection_name}/shards/#"` to limit the permission to collection only

 in order to keep it backward compatible and amend those actions to limit them to collection level only and 
 - because the path included in the message of RAFT command 
 - because of nature of RAFT FSM we have to do migration for the raft affected commands body to V2 to be able to differentiate from the command level, also 
    - delete old paths from casbin 
    - add the new paths to casbin 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
