### PR TITLE
Reset dimensions before recount for stable/v1.27

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -686,8 +686,16 @@ func (m *Migrator) RecalculateVectorDimensions(ctx context.Context) error {
 
 	// Iterate over all indexes
 	for _, index := range m.db.indices {
+		err := index.ForEachShard(func(name string, shard ShardLike) error {
+			return shard.resetDimensionsLSM()
+		})
+		if err != nil {
+			m.logger.WithField("action", "reindex").WithError(err).Warn("could not reset vector dimensions")
+			return err
+		}
+
 		// Iterate over all shards
-		if err := index.IterateObjects(ctx, func(index *Index, shard ShardLike, object *storobj.Object) error {
+		err = index.IterateObjects(ctx, func(index *Index, shard ShardLike, object *storobj.Object) error {
 			count = count + 1
 			if shard.hasTargetVectors() {
 				for vecName, vec := range object.Vectors {
@@ -701,7 +709,9 @@ func (m *Migrator) RecalculateVectorDimensions(ctx context.Context) error {
 				}
 			}
 			return nil
-		}); err != nil {
+		})
+		if err != nil {
+			m.logger.WithField("action", "reindex").WithError(err).Warn("could not extend vector dimensions")
 			return err
 		}
 	}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -134,6 +134,7 @@ type ShardLike interface {
 	extendDimensionTrackerLSM(dimLength int, docID uint64) error
 	extendDimensionTrackerForVecLSM(dimLength int, docID uint64, vecName string) error
 	publishDimensionMetrics(ctx context.Context)
+	resetDimensionsLSM() error
 
 	addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -213,15 +213,14 @@ func (s *Shard) addIDProperty(ctx context.Context) error {
 	return nil
 }
 
-func (s *Shard) addDimensionsProperty(ctx context.Context) error {
+func (s *Shard) createDimensionsBucket(ctx context.Context, name string) error {
 	if err := s.isReadOnly(); err != nil {
 		return err
 	}
 
-	// Note: this data would fit the "Set" type better, but since the "Map" type
-	// is currently optimized better, it is more efficient to use a Map here.
 	err := s.store.CreateOrLoadBucket(ctx,
-		helpers.DimensionsBucketLSM,
+		name,
+		s.memtableDirtyConfig(),
 		lsmkv.WithStrategy(lsmkv.StrategyMapCollection),
 		lsmkv.WithPread(s.index.Config.AvoidMMap),
 		lsmkv.WithAllocChecker(s.index.allocChecker),
@@ -229,6 +228,20 @@ func (s *Shard) addDimensionsProperty(ctx context.Context) error {
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		s.segmentCleanupConfig(),
 	)
+	if err != nil {
+		return fmt.Errorf("create dimensions bucket: %w", err)
+	}
+	return nil
+}
+
+func (s *Shard) addDimensionsProperty(ctx context.Context) error {
+	if err := s.isReadOnly(); err != nil {
+		return err
+	}
+
+	// Note: this data would fit the "Set" type better, but since the "Map" type
+	// is currently optimized better, it is more efficient to use a Map here.
+	err := s.createDimensionsBucket(ctx, helpers.DimensionsBucketLSM)
 	if err != nil {
 		return fmt.Errorf("create dimensions tracking property: %w", err)
 	}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -411,6 +411,11 @@ func (l *LazyLoadShard) publishDimensionMetrics(ctx context.Context) {
 	l.shard.publishDimensionMetrics(ctx)
 }
 
+func (l *LazyLoadShard) resetDimensionsLSM() error {
+	l.mustLoad()
+	return l.shard.resetDimensionsLSM()
+}
+
 func (l *LazyLoadShard) Aggregate(ctx context.Context, params aggregation.Params, modules *modules.Provider) (*aggregation.Result, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"os"
 	"sync"
 
 	"github.com/pkg/errors"

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -14,10 +14,8 @@ package db
 import (
 	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"math"
-	"sync"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -277,7 +275,7 @@ var (
 
 // GenerateUniqueString generates a random string of the specified length
 func GenerateUniqueString(length int) (string, error) {
-	uniqueCounter.Inc()
+	uniqueCounter.Add(1)
 	return fmt.Sprintf("%v", uniqueCounter.Load()), nil
 }
 

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -12,9 +12,14 @@
 package db
 
 import (
+	"context"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math"
+	"os"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -265,6 +270,73 @@ func (s *Shard) extendDimensionTrackerForVecLSM(
 	return s.addToDimensionBucket(dimLength, docID, vecName, false)
 }
 
+var (
+	uniqueCounter    int
+	uniqueNumberLock = &sync.Mutex{}
+)
+
+func uniqueNumber() int {
+	uniqueNumberLock.Lock()
+	defer uniqueNumberLock.Unlock()
+	uniqueCounter = uniqueCounter + 1
+	return uniqueCounter
+}
+
+// GenerateRandomString generates a random string of the specified length
+func GenerateRandomString(length int) (string, error) {
+	// Allocate a byte slice with half the desired length (each byte will convert to 2 hex chars)
+	bytes := make([]byte, length/2)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+	// Convert the bytes to a hex string
+	return fmt.Sprintf("%v%v", hex.EncodeToString(bytes), uniqueNumber()), nil
+}
+
+// Empty the dimensions bucket, quickly and efficiently
+func (s *Shard) resetDimensionsLSM() error {
+	// Load the current one, or an empty one if it doesn't exist
+	err := s.store.CreateOrLoadBucket(context.Background(),
+		helpers.DimensionsBucketLSM,
+		s.memtableDirtyConfig(),
+		lsmkv.WithStrategy(lsmkv.StrategyMapCollection),
+		lsmkv.WithPread(s.index.Config.AvoidMMap),
+		lsmkv.WithAllocChecker(s.index.allocChecker),
+		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
+		s.segmentCleanupConfig(),
+	)
+	if err != nil {
+		return fmt.Errorf("create dimensions bucket: %w", err)
+	}
+
+	// Fetch the actual bucket
+	b := s.store.Bucket(helpers.DimensionsBucketLSM)
+	if b == nil {
+		return errors.Errorf("resetDimensionsLSM: no bucket dimensions")
+	}
+
+	// Create random bucket name
+	name, err := GenerateRandomString(32)
+	if err != nil {
+		return errors.Wrap(err, "generate random bucket name")
+	}
+
+	// Create a new bucket with the random name
+	err = s.createDimensionsBucket(context.Background(), name)
+	if err != nil {
+		return errors.Wrap(err, "create temporary dimensions bucket")
+	}
+
+	// Replace the old bucket with the new one
+	err = s.store.ReplaceBuckets(context.Background(), helpers.DimensionsBucketLSM, name)
+	if err != nil {
+		return errors.Wrap(err, "replace dimensions bucket")
+	}
+
+	return nil
+}
+
 // Key (dimensionality) | Value Doc IDs
 // 128 | 1,2,4,5,17
 // 128 | 1,2,4,5,17, Tombstone 4,
@@ -287,9 +359,13 @@ func (s *Shard) removeDimensionsForVecLSM(
 func (s *Shard) addToDimensionBucket(
 	dimLength int, docID uint64, vecName string, tombstone bool,
 ) error {
+	err := s.addDimensionsProperty(context.Background())
+	if err != nil {
+		return errors.Wrap(err, "add dimensions property")
+	}
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {
-		return errors.Errorf("no bucket dimensions")
+		return errors.Errorf("add dimension bucket: no bucket dimensions")
 	}
 
 	tv := []byte(vecName)

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -267,11 +267,7 @@ func (s *Shard) extendDimensionTrackerForVecLSM(
 	return s.addToDimensionBucket(dimLength, docID, vecName, false)
 }
 
-var (
-	uniqueCounter    atomic.Uint64
-)
-
-
+var uniqueCounter atomic.Uint64
 
 // GenerateUniqueString generates a random string of the specified length
 func GenerateUniqueString(length int) (string, error) {

--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -150,6 +150,9 @@ func TestMappings(t *testing.T) {
 	})
 
 	t.Run("check mappings, by open many file mappings and close them only after the test is done", func(t *testing.T) {
+		if runtime.GOOS == "darwin" {
+			t.Skip("macOS does not have a limit on mappings")
+		}
 		currentMappings := getCurrentMappings()
 		addMappings := 15
 		t.Setenv("MAX_MEMORY_MAPPINGS", strconv.FormatInt(currentMappings+int64(addMappings), 10))


### PR DESCRIPTION
### What's being changed:

Correctly reset the dimensions bucket before starting a recount

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
