### PR TITLE
log: Fix `hcLogLogrus` adapter logger to avoid merging log lines.

### DIFF
--- a/cluster/log/logger.go
+++ b/cluster/log/logger.go
@@ -38,6 +38,7 @@ type hclogLogrus struct {
 	// logger is underlying `logrus.Logger` that is used to create `logrus.Entry`
 	// for each log lines logged by `hclog.Logger`.
 	// we need this otherwise using *global* entry can duplicate fields from previous log lines.
+	// https://github.com/weaviate/weaviate/pull/6830
 	logger *logrus.Logger
 	name   string
 }

--- a/cluster/log/logger.go
+++ b/cluster/log/logger.go
@@ -195,9 +195,10 @@ func (hclogger *hclogLogrus) Named(name string) hclog.Logger {
 
 func (hclogger *hclogLogrus) ResetNamed(name string) hclog.Logger {
 	return &hclogLogrus{
-		name:   name,
-		entry:  hclogger.entry,
-		logger: hclogger.logger,
+		name:       name,
+		entry:      hclogger.entry,
+		logger:     hclogger.logger,
+		withFields: hclogger.withFields,
 	}
 }
 

--- a/cluster/log/logger.go
+++ b/cluster/log/logger.go
@@ -32,7 +32,7 @@ func NewHCLogrusLogger(name string, logger *logrus.Logger) hclog.Logger {
 
 // hclogLogrus is an adapter logger between `logrus.Logger` and `hclog.Logger`.
 type hclogLogrus struct {
-	// entry is single log line entry
+	// entry is global set of fields shared by single logger
 	entry *logrus.Entry
 
 	// logger is underlying `logrus.Logger` that is used to create `logrus.Entry`
@@ -113,6 +113,7 @@ func (hclogger *hclogLogrus) Error(msg string, args ...interface{}) {
 }
 
 func (hclogger *hclogLogrus) logToLogrus(level logrus.Level, msg string, args ...interface{}) {
+	// we create new log entry merging per-logger `fields` (hclogger.entry)
 	entry := logrus.NewEntry(hclogger.logger)
 	entry = entry.WithFields(hclogger.loggerWith(args).WithField("action", strings.TrimSpace(hclogger.name)).Data)
 	entry.Log(level, msg)

--- a/cluster/log/logger_test.go
+++ b/cluster/log/logger_test.go
@@ -28,7 +28,6 @@ func Test_hclogger(t *testing.T) {
 	v := NewHCLogrusLogger("test", r)
 
 	v.Warn("Election time out")
-	// fmt.Println(strings.Contains("Election time out", buf.String()))
 	assert.Contains(t, buf.String(), "Election time out")
 	buf.Reset()
 

--- a/cluster/log/logger_test.go
+++ b/cluster/log/logger_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package log
 
 import (

--- a/cluster/log/logger_test.go
+++ b/cluster/log/logger_test.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_hclogger(t *testing.T) {
+	buf := bytes.Buffer{}
+
+	r := logrus.New()
+	r.SetOutput(&buf)
+
+	v := NewHCLogrusLogger("test", r)
+
+	v.Warn("Election time out")
+	// fmt.Println(strings.Contains("Election time out", buf.String()))
+	assert.Contains(t, buf.String(), "Election time out")
+	buf.Reset()
+
+	v.Warn("heartbeat timeout reached", "last-leader-addr", "fake", "last-leader-id", "fake")
+	assert.NotContains(t, buf.String(), "Election time out")
+	assert.Contains(t, buf.String(), "heartbeat timeout reached")
+	assert.Contains(t, buf.String(), "last-leader-addr=fake")
+	assert.Contains(t, buf.String(), "last-leader-id=fake")
+	buf.Reset()
+
+	v.Warn("Election time out")
+	assert.Contains(t, buf.String(), "Election time out")
+	assert.NotContains(t, buf.String(), "heartbeat timeout reached")
+	assert.NotContains(t, buf.String(), "last-leader-addr=fake")
+	assert.NotContains(t, buf.String(), "last-leader-id=fake")
+	buf.Reset()
+
+	// check if any fields added to it later should be available in future log lines
+	v = v.With("oh-new", "oh-new-value")
+	v.Warn("Election time out")
+	assert.Contains(t, buf.String(), "Election time out")
+	assert.NotContains(t, buf.String(), "heartbeat timeout reached")
+	assert.NotContains(t, buf.String(), "last-leader-addr=fake")
+	assert.NotContains(t, buf.String(), "last-leader-id=fake")
+	buf.Reset()
+}

--- a/cluster/log/logger_test.go
+++ b/cluster/log/logger_test.go
@@ -49,6 +49,7 @@ func Test_hclogger(t *testing.T) {
 	v = v.With("oh-new", "oh-new-value")
 	v.Warn("Election time out")
 	assert.Contains(t, buf.String(), "Election time out")
+	assert.Contains(t, buf.String(), "oh-new=oh-new-value")
 	assert.NotContains(t, buf.String(), "heartbeat timeout reached")
 	assert.NotContains(t, buf.String(), "last-leader-addr=fake")
 	assert.NotContains(t, buf.String(), "last-leader-id=fake")


### PR DESCRIPTION
### What's being changed:
Currently we use global `logrus.Entry` to append fields to **every** logline from raft package. This creates problem of merging fields from multiple log entries.

This PR fixes it by creating fresh `logrus.Entry` for every log line.

given these logging code,
```go
	v.Warn("Election time out")
        v.Warn("heartbeat timeout reached", "last-leader-addr", "fake", "last-leader-id", "fake")
	v.Warn("Election time out")
```

### Before

```bash
time="2025-01-06T11:01:36+01:00" level=warning msg="Election time out" action=test
time="2025-01-06T11:01:36+01:00" level=warning msg="heartbeat timeout reached" action=test last-leader-addr=fake last-leader-id=fake
time="2025-01-06T11:01:36+01:00" level=warning msg="Election time out" action=test last-leader-addr=fake last-leader-id=fake
```

### After
```bash
time="2025-01-06T11:01:02+01:00" level=warning msg="Election time out" action=test
time="2025-01-06T11:01:02+01:00" level=warning msg="heartbeat timeout reached" action=test last-leader-addr=fake last-leader-id=fake
time="2025-01-06T11:01:02+01:00" level=warning msg="Election time out" action=test
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
