### PR TITLE
Add flag to disable async replication

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -676,7 +676,7 @@ func (m *Migrator) UpdateReplicationConfig(ctx context.Context, className string
 	{
 		idx.Config.ReplicationFactor.Store(cfg.Factor)
 
-		if err := idx.updateAsyncReplication(ctx, cfg.AsyncEnabled); err != nil {
+		if err := idx.updateAsyncReplicationConfig(ctx, cfg.AsyncEnabled); err != nil {
 			return fmt.Errorf("update async replication for class %q: %w", className, err)
 		}
 	}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -86,7 +86,7 @@ type ShardLike interface {
 	ObjectVectorSearch(ctx context.Context, searchVectors [][]float32, targetVectors []string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties, targetCombination *dto.TargetCombination) ([]*storobj.Object, []float32, error)
 	UpdateVectorIndexConfig(ctx context.Context, updated schemaConfig.VectorIndexConfig) error
 	UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schemaConfig.VectorIndexConfig) error
-	UpdateAsyncReplication(ctx context.Context, enabled bool) error
+	updateAsyncReplicationConfig(ctx context.Context, enabled bool) error
 	AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error
 	DeleteObjectBatch(ctx context.Context, ids []strfmt.UUID, deletionTime time.Time, dryRun bool) objects.BatchSimpleObjects // Delete many objects by id
 	DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error                                           // Delete object by id
@@ -456,7 +456,7 @@ func (s *Shard) cleanupHashTree() {
 	s.hashtreeInitialized.Store(false)
 }
 
-func (s *Shard) UpdateAsyncReplication(ctx context.Context, enabled bool) error {
+func (s *Shard) updateAsyncReplicationConfig(ctx context.Context, enabled bool) error {
 	s.hashtreeRWMux.Lock()
 	defer s.hashtreeRWMux.Unlock()
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -266,11 +266,11 @@ func (l *LazyLoadShard) UpdateVectorIndexConfigs(ctx context.Context, updated ma
 	return l.shard.UpdateVectorIndexConfigs(ctx, updated)
 }
 
-func (l *LazyLoadShard) UpdateAsyncReplication(ctx context.Context, enabled bool) error {
+func (l *LazyLoadShard) updateAsyncReplicationConfig(ctx context.Context, enabled bool) error {
 	if err := l.Load(ctx); err != nil {
 		return err
 	}
-	return l.shard.UpdateAsyncReplication(ctx, enabled)
+	return l.shard.updateAsyncReplicationConfig(ctx, enabled)
 }
 
 func (l *LazyLoadShard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {


### PR DESCRIPTION
### What's being changed:

- Add env var `ASYNC_REPLICATION_DISABLED` to disable async replication for all shards.
- Intended as a expert level recovery feature when high load or high class count is encountered. It is generally better to disable in the class configuration.
