### PR TITLE
refact(raft): concurrent DB updates and GQL rebuild on db reload

### DIFF
--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -102,6 +102,8 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	srv = NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	// Ensure raft starts and a leader is elected
 	m.indexer.On("Open", Anything).Return(nil)
+	// shall be called because of restoring from snapshot
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return().Once()
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -363,15 +363,15 @@ func (s *SchemaManager) apply(op applyOp) error {
 		return fmt.Errorf("%w: %s: %w", ErrSchema, op.op, err)
 	}
 
+	if op.enableSchemaCallback {
+		s.db.TriggerSchemaUpdateCallbacks()
+	}
+
 	if !op.schemaOnly {
 		if err := op.updateStore(); err != nil {
 			return fmt.Errorf("%w: %s: %w", errDB, op.op, err)
 		}
 	}
 
-	// Always trigger the schema callback last
-	if op.enableSchemaCallback {
-		s.db.TriggerSchemaUpdateCallbacks()
-	}
 	return nil
 }

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -365,6 +365,8 @@ func (s *SchemaManager) apply(op applyOp) error {
 	}
 
 	if op.enableSchemaCallback {
+		// TriggerSchemaUpdateCallbacks it concurrent and at
+		// this point of time schema shall be up to date.
 		s.db.TriggerSchemaUpdateCallbacks()
 	}
 

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -123,7 +123,7 @@ func (s *SchemaManager) ReloadDBFromSchema() {
 		cs[i] = command.UpdateClassRequest{Class: &v.Class, State: shardingState}
 		i++
 	}
-
+	s.db.TriggerSchemaUpdateCallbacks()
 	s.log.Info("reload local db: update schema ...")
 	s.db.ReloadLocalDB(context.Background(), cs)
 }

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -374,6 +374,5 @@ func (s *SchemaManager) apply(op applyOp) error {
 	if op.enableSchemaCallback {
 		s.db.TriggerSchemaUpdateCallbacks()
 	}
-
 	return nil
 }

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -21,9 +21,10 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	gproto "google.golang.org/protobuf/proto"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 var (
@@ -363,14 +364,15 @@ func (s *SchemaManager) apply(op applyOp) error {
 		return fmt.Errorf("%w: %s: %w", ErrSchema, op.op, err)
 	}
 
-	if op.enableSchemaCallback {
-		s.db.TriggerSchemaUpdateCallbacks()
-	}
-
 	if !op.schemaOnly {
 		if err := op.updateStore(); err != nil {
 			return fmt.Errorf("%w: %s: %w", errDB, op.op, err)
 		}
+	}
+
+	// Always trigger the schema callback last
+	if op.enableSchemaCallback {
+		s.db.TriggerSchemaUpdateCallbacks()
 	}
 
 	return nil

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -365,7 +365,7 @@ func (s *SchemaManager) apply(op applyOp) error {
 	}
 
 	if op.enableSchemaCallback {
-		// TriggerSchemaUpdateCallbacks it concurrent and at
+		// TriggerSchemaUpdateCallbacks is concurrent and at
 		// this point of time schema shall be up to date.
 		s.db.TriggerSchemaUpdateCallbacks()
 	}

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -364,15 +364,15 @@ func (s *SchemaManager) apply(op applyOp) error {
 		return fmt.Errorf("%w: %s: %w", ErrSchema, op.op, err)
 	}
 
+	if op.enableSchemaCallback {
+		s.db.TriggerSchemaUpdateCallbacks()
+	}
+
 	if !op.schemaOnly {
 		if err := op.updateStore(); err != nil {
 			return fmt.Errorf("%w: %s: %w", errDB, op.op, err)
 		}
 	}
 
-	// Always trigger the schema callback last
-	if op.enableSchemaCallback {
-		s.db.TriggerSchemaUpdateCallbacks()
-	}
 	return nil
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -57,12 +57,16 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 
 	var errList error
 	for i, u := range all {
-		e.logger.WithField("index", u.Class.Class).Info("reload local index")
-		cs[i] = u.Class
-		if err := e.migrator.UpdateIndex(ctx, u.Class, u.State); err != nil {
-			e.logger.WithField("index", u.Class.Class).WithError(err).Error("failed to reload local index")
-			errList = errors.Join(fmt.Errorf("failed to reload local index %q: %w", i, err))
-		}
+		i := i
+		u := u
+		enterrors.GoWrapper(func() {
+			e.logger.WithField("index", u.Class.Class).Info("reload local index")
+			cs[i] = u.Class
+			if err := e.migrator.UpdateIndex(ctx, u.Class, u.State); err != nil {
+				e.logger.WithField("index", u.Class.Class).WithError(err).Error("failed to reload local index")
+				errList = errors.Join(fmt.Errorf("failed to reload local index %q: %w", i, err))
+			}
+		}, e.logger)
 	}
 	e.TriggerSchemaUpdateCallbacks()
 	return errList

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -64,9 +64,7 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 			errList = errors.Join(fmt.Errorf("failed to reload local index %q: %w", i, err))
 		}
 	}
-
 	e.TriggerSchemaUpdateCallbacks()
-
 	return errList
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -56,7 +56,10 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 	cs := make([]*models.Class, len(all))
 
 	var errList error
+	wg := sync.WaitGroup{}
+	wg.Add(len(all))
 	for i, u := range all {
+		defer wg.Done()
 		i := i
 		u := u
 		enterrors.GoWrapper(func() {
@@ -69,6 +72,7 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 		}, e.logger)
 	}
 	e.TriggerSchemaUpdateCallbacks()
+	wg.Wait()
 	return errList
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
@@ -59,10 +60,10 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 	wg := sync.WaitGroup{}
 	wg.Add(len(all))
 	for i, u := range all {
-		defer wg.Done()
 		i := i
 		u := u
 		enterrors.GoWrapper(func() {
+			defer wg.Done()
 			e.logger.WithField("index", u.Class.Class).Info("reload local index")
 			cs[i] = u.Class
 			if err := e.migrator.UpdateIndex(ctx, u.Class, u.State); err != nil {

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -247,15 +247,19 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 	e.callbacksLock.RLock()
 	defer e.callbacksLock.RUnlock()
 
+	wg := sync.WaitGroup{}
+	wg.Add(len(e.callbacks))
 	for _, cb := range e.callbacks {
 		cb := cb
 		enterrors.GoWrapper(func() {
+			wg.Done()
 			s := e.schemaReader.ReadOnlySchema()
 			cb(schema.Schema{
 				Objects: &s,
 			})
 		}, e.logger)
 	}
+	wg.Wait()
 }
 
 // RegisterSchemaUpdateCallback allows other usecases to register a primitive

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -238,9 +238,10 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 	e.callbacksLock.RLock()
 	defer e.callbacksLock.RUnlock()
 
-	s := e.schemaReader.ReadOnlySchema()
 	for _, cb := range e.callbacks {
+		cb := cb
 		enterrors.GoWrapper(func() {
+			s := e.schemaReader.ReadOnlySchema()
 			cb(schema.Schema{
 				Objects: &s,
 			})

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/proto/api"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -63,7 +64,10 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 			errList = errors.Join(fmt.Errorf("failed to reload local index %q: %w", i, err))
 		}
 	}
-	e.TriggerSchemaUpdateCallbacks()
+	enterrors.GoWrapper(func() {
+		e.TriggerSchemaUpdateCallbacks()
+	}, e.logger)
+
 	return errList
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -245,7 +245,6 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 				Objects: &s,
 			})
 		}, e.logger)
-
 	}
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -87,8 +87,6 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 	if err := g.Wait(); err != nil {
 		return err
 	}
-
-	e.TriggerSchemaUpdateCallbacks()
 	return errList
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -262,11 +262,10 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 	e.callbacksLock.RLock()
 	defer e.callbacksLock.RUnlock()
 
-	s := e.schemaReader.ReadOnlySchema()
-	schema := schema.Schema{Objects: &s}
-
 	// execute callbacks asynchronously in a single goroutine
 	enterrors.GoWrapper(func() {
+		s := e.schemaReader.ReadOnlySchema()
+		schema := schema.Schema{Objects: &s}
 		for _, cb := range e.callbacks {
 			cb(schema)
 		}

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -58,7 +57,7 @@ func (e *executor) Open(ctx context.Context) error {
 func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassRequest) error {
 	cs := make([]*models.Class, len(all))
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, ctx := enterrors.NewErrorGroupWithContextWrapper(e.logger, ctx)
 	g.SetLimit(runtime.GOMAXPROCS(0) * 2)
 
 	var errList error

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -64,9 +64,8 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 			errList = errors.Join(fmt.Errorf("failed to reload local index %q: %w", i, err))
 		}
 	}
-	enterrors.GoWrapper(func() {
-		e.TriggerSchemaUpdateCallbacks()
-	}, e.logger)
+
+	e.TriggerSchemaUpdateCallbacks()
 
 	return errList
 }
@@ -243,9 +242,12 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 
 	s := e.schemaReader.ReadOnlySchema()
 	for _, cb := range e.callbacks {
-		cb(schema.Schema{
-			Objects: &s,
-		})
+		enterrors.GoWrapper(func() {
+			cb(schema.Schema{
+				Objects: &s,
+			})
+		}, e.logger)
+
 	}
 }
 


### PR DESCRIPTION
### What's being changed:
**current implementation**  
- loads the index sequentially 
- schema call backs sequentially (like rebuilding GQL)
**new with this PR change** 
- load concurrently 
- rebuild concurrently 

**Results** 
1.25 (**Current**)
- Inserting 500 classes took `116.23s`
- From live to ready after restart took `151000ms`

this PR branch  (**new**)
- Inserting 500 classes took `85.59s`
- From live to ready after restart took `9000ms`

chaos pipeline https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13138254690
e2e tests pipeline https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13138256389


another lates run 
chaos https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13176904222
e2e https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13176901854 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
