### PR TITLE
RBAC: unify env var naming

### DIFF
--- a/docker-compose-auth-test.yml
+++ b/docker-compose-auth-test.yml
@@ -29,8 +29,12 @@ services:
       AUTHENTICATION_APIKEY_ENABLED: "true"
       AUTHENTICATION_APIKEY_ALLOWED_KEYS: 'viewer-key,editor-key,admin-key,custom-key'
       AUTHENTICATION_APIKEY_USERS: 'viewer-user,editor-user,admin-user,custom-user'
-      AUTHORIZATION_ENABLE_RBAC: "true"
+      AUTHORIZATION_RBAC_ENABLED: "true"
       AUTHORIZATION_ADMIN_USERS: "admin-user"
       AUTHORIZATION_VIEWER_USERS: "viewer-user"
+      AUTHORIZATION_ADMINLIST_ENABLED: "false"
+      AUTHORIZATION_ADMINLIST_USERS: "admin-user"
+      AUTHORIZATION_ADMINLIST_READONLY_USERS:  "viewer-user"
+
 
 

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -787,7 +787,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	}
 
 	if d.withWeaviateRbac {
-		settings["AUTHORIZATION_ENABLE_RBAC"] = "true"
+		settings["AUTHORIZATION_RBAC_ENABLED"] = "true"
 
 		if len(d.weaviateRbacAdmins) > 0 {
 			settings["AUTHORIZATION_ADMIN_USERS"] = strings.Join(d.weaviateRbacAdmins, ",")

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -68,7 +68,7 @@ case $CONFIG in
 
   local-single-node-rbac)
     AUTHENTICATION_APIKEY_ENABLED=true \
-    AUTHORIZATION_ENABLE_RBAC=true \
+    AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
     AUTHORIZATION_ADMIN_USERS='jp-hwang' \
@@ -91,7 +91,7 @@ case $CONFIG in
   local-first-rbac)
     CONTEXTIONARY_URL=localhost:9999 \
     AUTHENTICATION_APIKEY_ENABLED=true \
-    AUTHORIZATION_ENABLE_RBAC=true \
+    AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
     AUTHORIZATION_ADMIN_USERS='jp-hwang' \
@@ -118,7 +118,7 @@ case $CONFIG in
     GRPC_PORT=50052 \
     CONTEXTIONARY_URL=localhost:9999 \
     AUTHENTICATION_APIKEY_ENABLED=true \
-    AUTHORIZATION_ENABLE_RBAC=true \
+    AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
     AUTHORIZATION_ADMIN_USERS='jp-hwang' \
@@ -149,7 +149,7 @@ case $CONFIG in
     GRPC_PORT=50053 \
     CONTEXTIONARY_URL=localhost:9999 \
     AUTHENTICATION_APIKEY_ENABLED=true \
-    AUTHORIZATION_ENABLE_RBAC=true \
+    AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
     AUTHORIZATION_ADMIN_USERS='jp-hwang' \

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -201,7 +201,7 @@ func FromEnv(config *Config) error {
 		}
 	}
 
-	if entcfg.Enabled(os.Getenv("AUTHORIZATION_ENABLE_RBAC")) {
+	if entcfg.Enabled(os.Getenv("AUTHORIZATION_ENABLE_RBAC")) || entcfg.Enabled(os.Getenv("AUTHORIZATION_RBAC_ENABLED")) {
 		config.Authorization.Rbac.Enabled = true
 
 		adminsString, ok := os.LookupEnv("AUTHORIZATION_ADMIN_USERS")


### PR DESCRIPTION
### What's being changed:

Use `AUTHORIZATION_RBAC_ENABLED` in addition of `AUTHORIZATION_ENABLE_RBAC` to make the naming consistent with our other env vars

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
