### PR TITLE
Observability: collections count

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -493,7 +493,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		appState.Logger, appState.Authorizer, appState.ServerConfig.Config,
 		vectorIndex.ParseAndValidateConfig, appState.Modules, inverted.ValidateConfig,
 		appState.Modules, appState.Cluster, scaler,
-		offloadmod,
+		offloadmod, appState.Metrics,
 	)
 	if err != nil {
 		appState.Logger.

--- a/test/acceptance/objects/setup_test.go
+++ b/test/acceptance/objects/setup_test.go
@@ -17,15 +17,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/weaviate/weaviate/test/docker"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/objects"
-
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -43,6 +43,7 @@ type PrometheusMetrics struct {
 	BatchDeleteTime                     *prometheus.SummaryVec
 	BatchCount                          *prometheus.CounterVec
 	BatchCountBytes                     *prometheus.CounterVec
+	CollectionsCount                    prometheus.Gauge
 	ObjectsTime                         *prometheus.SummaryVec
 	LSMBloomFilters                     *prometheus.SummaryVec
 	AsyncOperations                     *prometheus.GaugeVec
@@ -355,6 +356,11 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "batch_objects_processed_bytes",
 			Help: "Number of bytes processed in a batch",
 		}, []string{"class_name", "shard_name"}),
+
+		CollectionsCount: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "collections_count",
+			Help: "Number of collections in schema",
+		}),
 
 		ObjectsTime: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "objects_durations_ms",

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -288,3 +288,8 @@ func (f *fakeStore) UpdateClass(cls *models.Class) error {
 	cls.InvertedIndexConfig = u.InvertedIndexConfig
 	return nil
 }
+
+type fakeMetrics struct{}
+
+func (m *fakeMetrics) collectionsCountInc() {}
+func (m *fakeMetrics) collectionsCountDec() {}

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -128,6 +128,7 @@ type Handler struct {
 	invertedConfigValidator InvertedConfigValidator
 	scaleOut                scaleOut
 	parser                  Parser
+	metrics                 schemaMetrics
 }
 
 // NewHandler creates a new handler
@@ -141,6 +142,7 @@ func NewHandler(
 	moduleConfig ModuleConfig, clusterState clusterState,
 	scaleoutManager scaleOut,
 	cloud modulecapabilities.OffloadCloud,
+	metrics schemaMetrics,
 ) (Handler, error) {
 	handler := Handler{
 		config:                  config,
@@ -157,6 +159,7 @@ func NewHandler(
 		clusterState:            clusterState,
 		scaleOut:                scaleoutManager,
 		cloud:                   cloud,
+		metrics:                 metrics,
 	}
 
 	handler.scaleOut.SetSchemaReader(schemaReader)

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -47,7 +47,8 @@ func newTestHandler(t *testing.T, db clusterSchema.Indexer) (*Handler, *fakeSche
 	handler, err := NewHandler(
 		schemaManager, schemaManager, &fakeValidator{}, logger, mocks.NewMockAuthorizer(),
 		cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
-		&fakeModuleConfig{}, fakes.NewFakeClusterState(), &fakeScaleOutManager{}, nil)
+		&fakeModuleConfig{}, fakes.NewFakeClusterState(), &fakeScaleOutManager{},
+		nil, &fakeMetrics{})
 	require.Nil(t, err)
 	return &handler, schemaManager
 }
@@ -64,7 +65,8 @@ func newTestHandlerWithCustomAuthorizer(t *testing.T, db clusterSchema.Indexer, 
 	handler, err := NewHandler(
 		metaHandler, metaHandler, &fakeValidator{}, logger, authorizer,
 		cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
-		&fakeModuleConfig{}, fakes.NewFakeClusterState(), &fakeScaleOutManager{}, nil)
+		&fakeModuleConfig{}, fakes.NewFakeClusterState(), &fakeScaleOutManager{},
+		nil, &fakeMetrics{})
 	require.Nil(t, err)
 	return &handler, metaHandler
 }

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/scaler"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	shardingConfig "github.com/weaviate/weaviate/usecases/sharding/config"
@@ -49,6 +50,11 @@ type Manager struct {
 	Handler
 
 	SchemaReader
+}
+
+type schemaMetrics interface {
+	collectionsCountInc()
+	collectionsCountDec()
 }
 
 type VectorConfigParser func(in interface{}, vectorIndexType string) (schemaConfig.VectorIndexConfig, error)
@@ -204,6 +210,7 @@ func NewManager(validator validator,
 	moduleConfig ModuleConfig, clusterState clusterState,
 	scaleoutManager scaleOut,
 	cloud modulecapabilities.OffloadCloud,
+	prom *monitoring.PrometheusMetrics,
 ) (*Manager, error) {
 	handler, err := NewHandler(
 		schemaReader,
@@ -211,7 +218,7 @@ func NewManager(validator validator,
 		validator,
 		logger, authorizer,
 		config, configParser, vectorizerValidator, invertedConfigValidator,
-		moduleConfig, clusterState, scaleoutManager, cloud)
+		moduleConfig, clusterState, scaleoutManager, cloud, NewMetrics(prom))
 	if err != nil {
 		return nil, fmt.Errorf("cannot init handler: %w", err)
 	}

--- a/usecases/schema/metrics.go
+++ b/usecases/schema/metrics.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+type Metrics struct {
+	collectionsCount prometheus.Gauge
+}
+
+func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
+	if prom == nil {
+		return nil
+	}
+
+	return &Metrics{
+		collectionsCount: prom.CollectionsCount,
+	}
+}
+
+func (m *Metrics) collectionsCountInc() {
+	m.collectionsCount.Inc()
+}
+
+func (m *Metrics) collectionsCountDec() {
+	m.collectionsCount.Dec()
+}

--- a/usecases/schema/metrics.go
+++ b/usecases/schema/metrics.go
@@ -18,22 +18,28 @@ import (
 
 type Metrics struct {
 	collectionsCount prometheus.Gauge
+	enabled          bool
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 	if prom == nil {
-		return nil
+		return &Metrics{}
 	}
 
 	return &Metrics{
 		collectionsCount: prom.CollectionsCount,
+		enabled:          true,
 	}
 }
 
 func (m *Metrics) collectionsCountInc() {
-	m.collectionsCount.Inc()
+	if m.enabled {
+		m.collectionsCount.Inc()
+	}
 }
 
 func (m *Metrics) collectionsCountDec() {
-	m.collectionsCount.Dec()
+	if m.enabled {
+		m.collectionsCount.Dec()
+	}
 }


### PR DESCRIPTION
### What's being changed:

Introduce a new prometheus metric, `collections_count`, which measures the number of collections in a cluster's schema at any time. Also adds a telemetry field for the same thing.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
