### PR TITLE
RBAC: Remove path validation for printing of paths

### DIFF
--- a/usecases/auth/authorization/conv/casbin_converter.go
+++ b/usecases/auth/authorization/conv/casbin_converter.go
@@ -55,7 +55,7 @@ func PathToPermission(verb, path string) (*models.Permission, error) {
 		return nil, fmt.Errorf("invalid path")
 	}
 
-	return permission([]string{"", path, verb, parts[0]})
+	return permission([]string{"", path, verb, parts[0]}, false)
 }
 
 func PoliciesToPermission(policies ...authorization.Policy) ([]*models.Permission, error) {
@@ -64,7 +64,7 @@ func PoliciesToPermission(policies ...authorization.Policy) ([]*models.Permissio
 		// 1st empty string to replace casbin pattern of having policy name as 1st place
 		// e.g.  tester, roles/.*, (C)|(R)|(U)|(D), roles
 		// see newPolicy()
-		perm, err := permission([]string{"", policies[idx].Resource, policies[idx].Verb, policies[idx].Domain})
+		perm, err := permission([]string{"", policies[idx].Resource, policies[idx].Verb, policies[idx].Domain}, true)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func CasbinPolicies(casbinPolicies ...[][]string) (map[string][]authorization.Po
 					rolesPermissions[name] = append(rolesPermissions[name], *perm)
 				}
 			} else {
-				perm, err := permission(policyParts)
+				perm, err := permission(policyParts, true)
 				if err != nil {
 					return nil, err
 				}

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -298,7 +298,7 @@ func weaviatePermissionAction(pathLastPart, verb, domain string) string {
 	}
 }
 
-func permission(policy []string) (*models.Permission, error) {
+func permission(policy []string, validatePath bool) (*models.Permission, error) {
 	mapped := newPolicy(policy)
 
 	if mapped.Resource == InternalPlaceHolder {
@@ -312,7 +312,9 @@ func permission(policy []string) (*models.Permission, error) {
 	permission := &models.Permission{}
 
 	splits := strings.Split(mapped.Resource, "/")
-	if !validResource(mapped.Resource) {
+
+	// validating the resource can be expensive (regexp!)
+	if validatePath && !validResource(mapped.Resource) {
 		return nil, fmt.Errorf("invalid resource: %s", mapped.Resource)
 	}
 

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -782,7 +782,7 @@ func Test_permission(t *testing.T) {
 			t.Run(fmt.Sprintf("%s %s", ttt.testDescription, tt.name), func(t *testing.T) {
 				tt.permission.Action = authorization.String(ttt.permissionAction)
 				tt.policy[2] = ttt.policyVerb
-				permission, err := permission(tt.policy, false)
+				permission, err := permission(tt.policy, true)
 				require.Nil(t, err)
 				require.Equal(t, permission, tt.permission)
 			})

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -782,7 +782,7 @@ func Test_permission(t *testing.T) {
 			t.Run(fmt.Sprintf("%s %s", ttt.testDescription, tt.name), func(t *testing.T) {
 				tt.permission.Action = authorization.String(ttt.permissionAction)
 				tt.policy[2] = ttt.policyVerb
-				permission, err := permission(tt.policy)
+				permission, err := permission(tt.policy, false)
 				require.Nil(t, err)
 				require.Equal(t, permission, tt.permission)
 			})


### PR DESCRIPTION
### What's being changed:

Dont validate paths that are only used for printing because regexp is slow as hell

```
rbac old: 6,5s
rbac without validation 3s
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
