### PR TITLE
fix: updates segment version to v1 for rangeable filters

### DIFF
--- a/adapters/repos/db/lsmkv/memtable_flush_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_roaring_set_range.go
@@ -25,7 +25,7 @@ func (m *Memtable) flushDataRoaringSetRange(f *segmentindex.SegmentFile) ([]segm
 	header := &segmentindex.Header{
 		IndexStart:       uint64(totalDataLength + segmentindex.HeaderSize),
 		Level:            0, // always level zero on a new one
-		Version:          0, // always version 0 for now
+		Version:          segmentindex.ChooseHeaderVersion(m.enableChecksumValidation),
 		SecondaryIndices: 0,
 		Strategy:         segmentindex.StrategyRoaringSetRange,
 	}

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -133,7 +133,7 @@ func (c *Compactor) Do() error {
 	}
 
 	if _, err := segmentFile.WriteChecksum(); err != nil {
-		return fmt.Errorf("write compactorSet segment checksum: %w", err)
+		return fmt.Errorf("write compactorRoaringSet segment checksum: %w", err)
 	}
 
 	return nil

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -115,6 +115,10 @@ func (c *Compactor) Do() error {
 		return fmt.Errorf("write header: %w", err)
 	}
 
+	if _, err := segmentFile.WriteChecksum(); err != nil {
+		return fmt.Errorf("write compactorRoaringSetRange segment checksum: %w", err)
+	}
+
 	return nil
 }
 
@@ -158,7 +162,7 @@ func (c *Compactor) writeHeader(f *segmentindex.SegmentFile,
 
 	h := &segmentindex.Header{
 		Level:            c.currentLevel,
-		Version:          0,
+		Version:          segmentindex.ChooseHeaderVersion(c.enableChecksumValidation),
 		SecondaryIndices: 0,
 		Strategy:         segmentindex.StrategyRoaringSetRange,
 		IndexStart:       startOfIndex,


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/12772587078
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
