### PR TITLE
chore: notifier workflow decorate message with labels and auto add community label

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -19,14 +19,14 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GH_ORG_Members_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/orgs/${{ github.repository_owner }}/teams/core/memberships/${{ github.actor }})
-          echo $response
+          
           if [ "$response" -eq 200 ]; then
-            echo "is_non_member=false" >> $GITHUB_ENV
+            echo "is_non_member=false" >> $GITHUB_OUTPUT
           elif [ "$response" -eq 404 ]; then
-            echo "is_non_member=true" >> $GITHUB_ENV
+            echo "is_non_member=true" >> $GITHUB_OUTPUT
           else
-            echo "error checking membership: HTTP $response"
-            exit 1
+            echo "Error: Unexpected response code: $response"
+            echo "is_non_member=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Send Slack Notification for PR (Community)
@@ -53,13 +53,15 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Add community label
+          # Add community label only for non-members
           if [ "${{ steps.check_user.outputs.is_non_member }}" = "true" ]; then
             curl -X POST \
               -H "Authorization: token $GH_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
               -d '{"labels":["community"]}'
+          fi
+
           # Send Slack notification
           curl -X POST -H 'Content-type: application/json' --data '{
             "text": "🚨 A new Issue has been opened:\n*User:* ${{ github.actor }}\n*Title:* ${{ github.event.issue.title }}\n*Labels:* ${{ join(github.event.issue.labels.*.name, ', ') }}\n*Link:* ${{ github.event.issue.html_url }}"

--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -33,16 +33,34 @@ jobs:
         if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && steps.check_user.outputs.is_non_member == 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Add community label
+          curl -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
+            -d '{"labels":["community"]}'
+
+          # Send Slack notification
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "📢 A Pull Request has been opened by a *community*:\n*User:* ${{ github.actor }}\n*Title:* ${{ github.event.pull_request.title }}\n*Link:* ${{ github.event.pull_request.html_url }}"
+            "text": "📢 A Pull Request has been opened by a *community*:\n*User:* ${{ github.actor }}\n*Title:* ${{ github.event.pull_request.title }}\n*Labels:* ${{ join(github.event.pull_request.labels.*.name, ', ') }}\n*Link:* ${{ github.event.pull_request.html_url }}"
           }' $SLACK_WEBHOOK_URL
 
       - name: Send Slack Notification for All Issues
         if: github.actor != 'dependabot[bot]' && github.event_name == 'issues'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Add community label
+          if [ "${{ steps.check_user.outputs.is_non_member }}" = "true" ]; then
+            curl -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
+              -d '{"labels":["community"]}'
+          # Send Slack notification
           curl -X POST -H 'Content-type: application/json' --data '{
-            "text": "🚨 A new Issue has been opened:\n*User:* ${{ github.actor }}\n*Title:* ${{ github.event.issue.title }}\n*Link:* ${{ github.event.issue.html_url }}"
+            "text": "🚨 A new Issue has been opened:\n*User:* ${{ github.actor }}\n*Title:* ${{ github.event.issue.title }}\n*Labels:* ${{ join(github.event.issue.labels.*.name, ', ') }}\n*Link:* ${{ github.event.issue.html_url }}"
           }' $SLACK_WEBHOOK_URL

--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -21,12 +21,12 @@ jobs:
             https://api.github.com/orgs/${{ github.repository_owner }}/teams/core/memberships/${{ github.actor }})
           
           if [ "$response" -eq 200 ]; then
-            echo "is_non_member=false" >> $GITHUB_OUTPUT
+            echo "is_non_member=false" >> $GITHUB_ENV
           elif [ "$response" -eq 404 ]; then
-            echo "is_non_member=true" >> $GITHUB_OUTPUT
+            echo "is_non_member=true" >> $GITHUB_ENV
           else
-            echo "Error: Unexpected response code: $response"
-            echo "is_non_member=true" >> $GITHUB_OUTPUT
+            echo "error checking membership: HTTP $response"
+            exit 1
           fi
 
       - name: Send Slack Notification for PR (Community)

--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -22,7 +22,7 @@ jobs:
           
           if [ "$response" -eq 200 ]; then
             echo "is_non_member=false" >> $GITHUB_ENV
-          elif [ "$response" -eq 404 ]; then
+          elif [ "$response" -eq 401 ] || [ "$response" -eq 404 ]; then
             echo "is_non_member=true" >> $GITHUB_ENV
           else
             echo "error checking membership: HTTP $response"


### PR DESCRIPTION
### What's being changed:
this change 
- makes sure that labels are included in the slack message and also decorate PRs, issues with `community` label where needed 
- fix getting detecting user not part of the org from forks

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
