### PR TITLE
Fetch classes only once for batch endpoint

### DIFF
--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -77,7 +77,12 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	}
 	object.ID = id
 
-	schemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, true, object)
+	vclasses, err := m.schemaManager.GetCachedClass(ctx, principal, object.Class)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, true, vclasses, object)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid object")
 	}
@@ -98,10 +103,6 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 		object.Properties = map[string]interface{}{}
 	}
 
-	vclasses, err := m.schemaManager.GetCachedClass(ctx, principal, object.Class)
-	if err != nil {
-		return nil, err
-	}
 	err = m.modulesProvider.UpdateVector(ctx, object, vclasses[object.Class].Class, m.findObject, m.logger)
 	if err != nil {
 		return nil, err

--- a/usecases/objects/authorization_test.go
+++ b/usecases/objects/authorization_test.go
@@ -220,8 +220,8 @@ func Test_BatchKinds_Authorization(t *testing.T) {
 				[]*string{},
 				&additional.ReplicationProperties{},
 			},
-			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("", ""),
+			expectedVerb:      authorization.UPDATE,
+			expectedResources: authorization.ShardsData("", ""),
 		},
 		{
 			methodName: "AddReferences",

--- a/usecases/objects/auto_schema_test.go
+++ b/usecases/objects/auto_schema_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/weaviate/weaviate/entities/versioned"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -605,7 +607,9 @@ func Test_autoSchemaManager_autoSchema_emptyRequest(t *testing.T) {
 
 	var obj *models.Object
 
-	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
+	knownClasses := map[string]versioned.Class{}
+
+	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, knownClasses, obj)
 	assert.EqualError(t, fmt.Errorf(validation.ErrorMissingObject), err.Error())
 }
 
@@ -638,9 +642,11 @@ func Test_autoSchemaManager_autoSchema_create(t *testing.T) {
 			"numberArray":     []interface{}{json.Number("30")},
 		},
 	}
+	knownClasses := map[string]versioned.Class{}
+
 	// when
 	schemaBefore := schemaManager.GetSchemaResponse
-	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
+	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, knownClasses, obj)
 	schemaAfter := schemaManager.GetSchemaResponse
 
 	// then
@@ -673,20 +679,20 @@ func Test_autoSchemaManager_autoSchema_update(t *testing.T) {
 	vectorRepo.On("ObjectByID", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(&search.Result{ClassName: "Publication"}, nil).Once()
 	logger, _ := test.NewNullLogger()
+
+	class := &models.Class{
+		Class: "Publication",
+		Properties: []*models.Property{
+			{
+				Name:     "age",
+				DataType: []string{"int"},
+			},
+		},
+	}
 	schemaManager := &fakeSchemaManager{
 		GetSchemaResponse: schema.Schema{
 			Objects: &models.Schema{
-				Classes: []*models.Class{
-					{
-						Class: "Publication",
-						Properties: []*models.Property{
-							{
-								Name:     "age",
-								DataType: []string{"int"},
-							},
-						},
-					},
-				},
+				Classes: []*models.Class{class},
 			},
 		},
 	}
@@ -722,7 +728,11 @@ func Test_autoSchemaManager_autoSchema_update(t *testing.T) {
 	assert.Equal(t, "age", (schemaBefore.Objects.Classes)[0].Properties[0].Name)
 	assert.Equal(t, "int", (schemaBefore.Objects.Classes)[0].Properties[0].DataType[0])
 
-	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, obj)
+	knownClasses := map[string]versioned.Class{
+		class.Class: {Version: 0, Class: class},
+	}
+
+	_, err := autoSchemaManager.autoSchema(context.Background(), &models.Principal{}, true, knownClasses, obj)
 	require.Nil(t, err)
 
 	schemaAfter := schemaManager.GetSchemaResponse
@@ -1640,7 +1650,11 @@ func Test_autoSchemaManager_perform_withNested(t *testing.T) {
 		authorizer: fakeAuthorizer{},
 	}
 
-	_, err := manager.autoSchema(context.Background(), &models.Principal{}, true, object)
+	knownClasses := map[string]versioned.Class{
+		class.Class: {Version: 0, Class: class},
+	}
+
+	_, err := manager.autoSchema(context.Background(), &models.Principal{}, true, knownClasses, object)
 	require.NoError(t, err)
 
 	schemaAfter := schemaManager.GetSchemaResponse

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -149,12 +149,6 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 			maxSchemaVersion = schemaVersion
 		}
 
-		if len(fetchedClasses) == 0 || fetchedClasses[obj.Class].Class == nil {
-			batchObjects[i].Err = fmt.Errorf("class '%v' not present in schema", obj.Class)
-			continue
-		}
-		class := fetchedClasses[obj.Class].Class
-
 		if obj.ID == "" {
 			// Generate UUID for the new object
 			uid, err := generateUUID()
@@ -175,6 +169,12 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 		if batchObjects[i].Err != nil {
 			continue
 		}
+
+		if len(fetchedClasses) == 0 || fetchedClasses[obj.Class].Class == nil {
+			batchObjects[i].Err = fmt.Errorf("class '%v' not present in schema", obj.Class)
+			continue
+		}
+		class := fetchedClasses[obj.Class].Class
 
 		if err := validator.Object(ctx, class, obj, nil); err != nil {
 			batchObjects[i].Err = err

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/weaviate/weaviate/entities/versioned"
+
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
@@ -31,16 +33,21 @@ var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be
 func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
 ) (BatchObjects, error) {
+	ctx = classcache.ContextWithClassCache(ctx)
+
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
 	}
+	knownClasses := map[string]versioned.Class{}
 
 	// whole request fails if permissions for any collection are not present
 	for class, shards := range classesShards {
-		if err := b.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, shards...)...); err != nil {
+		vClass, err := b.schemaManager.GetCachedClass(ctx, principal, class)
+		if err != nil {
 			return nil, err
 		}
+		knownClasses[class] = vClass[class]
 
 		if err := b.authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsData(class, shards...)...); err != nil {
 			return nil, err
@@ -51,18 +58,18 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 		}
 	}
 
-	return b.addObjects(ctx, principal, objects, fields, repl)
+	return b.addObjects(ctx, principal, objects, fields, repl, knownClasses)
 }
 
 // AddObjectsGRPCAfterAuth bypasses the authentication in the REST endpoint as GRPC has its own checking
 func (b *BatchManager) AddObjectsGRPCAfterAuth(ctx context.Context, principal *models.Principal,
-	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
+	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties, fetchedClasses map[string]versioned.Class,
 ) (BatchObjects, error) {
-	return b.addObjects(ctx, principal, objects, fields, repl)
+	return b.addObjects(ctx, principal, objects, fields, repl, fetchedClasses)
 }
 
 func (b *BatchManager) addObjects(ctx context.Context, principal *models.Principal,
-	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
+	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties, fetchedClasses map[string]versioned.Class,
 ) (BatchObjects, error) {
 	ctx = classcache.ContextWithClassCache(ctx)
 
@@ -83,7 +90,7 @@ func (b *BatchManager) addObjects(ctx context.Context, principal *models.Princip
 	}
 
 	var maxSchemaVersion uint64
-	batchObjects, maxSchemaVersion := b.validateAndGetVector(ctx, principal, objects, repl)
+	batchObjects, maxSchemaVersion := b.validateAndGetVector(ctx, principal, objects, repl, fetchedClasses)
 	schemaVersion, tenantCount, err := b.autoSchemaManager.autoTenants(ctx, principal, objects)
 	if err != nil {
 		return nil, fmt.Errorf("auto create tenants: %w", err)
@@ -113,14 +120,13 @@ func (b *BatchManager) addObjects(ctx context.Context, principal *models.Princip
 }
 
 func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *models.Principal,
-	objects []*models.Object, repl *additional.ReplicationProperties,
+	objects []*models.Object, repl *additional.ReplicationProperties, fetchedClasses map[string]versioned.Class,
 ) (BatchObjects, uint64) {
 	var (
 		now          = time.Now().UnixNano() / int64(time.Millisecond)
 		batchObjects = make(BatchObjects, len(objects))
 
 		objectsPerClass       = make(map[string][]*models.Object)
-		classPerClassName     = make(map[string]*models.Class)
 		originalIndexPerClass = make(map[string][]int)
 		validator             = validation.New(b.vectorRepo.Exists, b.config, repl)
 	)
@@ -135,7 +141,7 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 			continue
 		}
 
-		schemaVersion, err := b.autoSchemaManager.autoSchema(ctx, principal, true, obj)
+		schemaVersion, err := b.autoSchemaManager.autoSchema(ctx, principal, true, fetchedClasses, obj)
 		if err != nil {
 			batchObjects[i].Err = err
 		}
@@ -164,21 +170,7 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 			continue
 		}
 
-		vclasses, err := b.schemaManager.GetCachedClass(ctx, principal, obj.Class)
-		if err != nil {
-			batchObjects[i].Err = err
-			continue
-		}
-		if len(vclasses) == 0 || vclasses[obj.Class].Class == nil {
-			batchObjects[i].Err = fmt.Errorf("class '%v' not present in schema", obj.Class)
-			continue
-		}
-		class := vclasses[obj.Class].Class
-		// Set most up-to-date class's schema (in case new properties were added by autoschema)
-		// If it was not changed, same class will be fetched from cache
-		classPerClassName[obj.Class] = class
-
-		if err := validator.Object(ctx, class, obj, nil); err != nil {
+		if err := validator.Object(ctx, fetchedClasses[obj.Class].Class, obj, nil); err != nil {
 			batchObjects[i].Err = err
 			continue
 		}
@@ -192,8 +184,8 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 	}
 
 	for className, objectsForClass := range objectsPerClass {
-		class := classPerClassName[className]
-		errorsPerObj, err := b.modulesProvider.BatchUpdateVector(ctx, class, objectsForClass, b.findObject, b.logger)
+		class := fetchedClasses[className]
+		errorsPerObj, err := b.modulesProvider.BatchUpdateVector(ctx, class.Class, objectsForClass, b.findObject, b.logger)
 		if err != nil {
 			for i := range objectsForClass {
 				origIndex := originalIndexPerClass[className][i]

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -149,6 +149,12 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 			maxSchemaVersion = schemaVersion
 		}
 
+		if len(fetchedClasses) == 0 || fetchedClasses[obj.Class].Class == nil {
+			batchObjects[i].Err = fmt.Errorf("class '%v' not present in schema", obj.Class)
+			continue
+		}
+		class := fetchedClasses[obj.Class].Class
+
 		if obj.ID == "" {
 			// Generate UUID for the new object
 			uid, err := generateUUID()
@@ -170,7 +176,7 @@ func (b *BatchManager) validateAndGetVector(ctx context.Context, principal *mode
 			continue
 		}
 
-		if err := validator.Object(ctx, fetchedClasses[obj.Class].Class, obj, nil); err != nil {
+		if err := validator.Object(ctx, class, obj, nil); err != nil {
 			batchObjects[i].Err = err
 			continue
 		}

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -79,9 +79,18 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{"not found", StatusNotFound, err}
 	}
 
-	var schemaVersion uint64
-	if schemaVersion, err = m.autoSchemaManager.autoSchema(ctx, principal, false, updates); err != nil {
+	vclasses, err := m.schemaManager.GetCachedClass(ctx, principal, schema.UppercaseClassName(updates.Class))
+	if err != nil {
 		return &Error{"bad request", StatusBadRequest, NewErrInvalidUserInput("invalid object: %v", err)}
+	}
+
+	maxSchemaVersion := vclasses[schema.UppercaseClassName(updates.Class)].Version
+	schemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, false, vclasses, updates)
+	if err != nil {
+		return &Error{"bad request", StatusBadRequest, NewErrInvalidUserInput("invalid object: %v", err)}
+	}
+	if schemaVersion > maxSchemaVersion {
+		maxSchemaVersion = schemaVersion
 	}
 
 	var propertiesToDelete []string
@@ -103,7 +112,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		updates.Properties = map[string]interface{}{}
 	}
 
-	return m.patchObject(ctx, principal, prevObj, updates, repl, propertiesToDelete, updates.Tenant, schemaVersion)
+	return m.patchObject(ctx, principal, prevObj, updates, repl, propertiesToDelete, updates.Tenant, maxSchemaVersion)
 }
 
 // patchObject patches an existing object obj with updates

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -69,9 +69,18 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 		return nil, err
 	}
 
-	var schemaVersion uint64
-	if schemaVersion, err = m.autoSchemaManager.autoSchema(ctx, principal, false, updates); err != nil {
+	vclasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
+	if err != nil {
+		return nil, err
+	}
+
+	maxSchemaVersion := vclasses[className].Version
+	schemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, false, vclasses, updates)
+	if err != nil {
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
+	}
+	if schemaVersion > maxSchemaVersion {
+		maxSchemaVersion = schemaVersion
 	}
 
 	m.logger.
@@ -95,22 +104,17 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 	updates.CreationTimeUnix = obj.Created
 	updates.LastUpdateTimeUnix = m.timeSource.Now()
 
-	vclasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
-	if err != nil {
-		return nil, err
-	}
-
 	vclass := vclasses[className]
 	err = m.modulesProvider.UpdateVector(ctx, updates, vclass.Class, m.findObject, m.logger)
 	if err != nil {
 		return nil, NewErrInternal("update object: %v", err)
 	}
 
-	if err := m.schemaManager.WaitForUpdate(ctx, schemaVersion); err != nil {
-		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", schemaVersion, err)
+	if err := m.schemaManager.WaitForUpdate(ctx, maxSchemaVersion); err != nil {
+		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", maxSchemaVersion, err)
 	}
 
-	err = m.vectorRepo.PutObject(ctx, updates, updates.Vector, updates.Vectors, repl, schemaVersion)
+	err = m.vectorRepo.PutObject(ctx, updates, updates.Vector, updates.Vectors, repl, maxSchemaVersion)
 	if err != nil {
 		return nil, fmt.Errorf("put object: %w", err)
 	}


### PR DESCRIPTION
### What's being changed:

Before RBAC (and probably RAFT) getting the class from the schema was basically free - however with RBAC each call to GetCachedClass means an additional authorization. Especially in batch each object can result in multiple calls to the authorizer.

This PR changes batch adds to request the classes from the getter at the top of the call stack and then pass them down so they can be reused, reducing unnecessary authorizer calls

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
