### PR TITLE
Authorization: Improve error messages for authorization errors

### DIFF
--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -47,14 +47,17 @@ func (h *batchObjectHandlers) addObjects(params batch.BatchObjectsCreateParams,
 		params.Body.Objects, params.Body.Fields, repl)
 	if err != nil {
 		h.metricRequestsTotal.logError("", err)
-		switch err.(type) {
-		case autherrs.Forbidden:
+		var forbidden autherrs.Forbidden
+		var errInvalidUserInput objects.ErrInvalidUserInput
+		var errMultiTenancy objects.ErrMultiTenancy
+		switch {
+		case errors.As(err, &forbidden):
 			return batch.NewBatchObjectsCreateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
-		case objects.ErrInvalidUserInput:
+		case errors.As(err, &errInvalidUserInput):
 			return batch.NewBatchObjectsCreateUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))
-		case objects.ErrMultiTenancy:
+		case errors.As(err, &errMultiTenancy):
 			return batch.NewBatchObjectsCreateUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -193,10 +193,12 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 		params.ClassName, params.ID, additional, replProps, tenant)
 	if err != nil {
 		h.metricRequestsTotal.logError(getClassName(object), err)
-		switch err.(type) {
-		case uco.ErrNotFound:
+		var errNotFound uco.ErrNotFound
+		var errMultiTenancy uco.ErrMultiTenancy
+		switch {
+		case errors.As(err, &errNotFound):
 			return objects.NewObjectsClassGetNotFound()
-		case uco.ErrMultiTenancy:
+		case errors.As(err, &errMultiTenancy):
 			return objects.NewObjectsClassGetUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:

--- a/adapters/repos/db/crud.go
+++ b/adapters/repos/db/crud.go
@@ -13,11 +13,11 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/refcache"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
@@ -89,7 +89,7 @@ func (db *DB) MultiGet(ctx context.Context, query []multi.Identifier,
 	for indexID, queries := range byIndex {
 		indexRes, err := db.indices[indexID].multiObjectByID(ctx, queries, tenant)
 		if err != nil {
-			return nil, errors.Wrapf(err, "index %q", indexID)
+			return nil, fmt.Errorf("index %q: %w", indexID, err)
 		}
 
 		for i, obj := range indexRes {
@@ -141,7 +141,7 @@ func (db *DB) ObjectsByID(ctx context.Context, id strfmt.UUID,
 			case objects.ErrMultiTenancy:
 				return nil, objects.NewErrMultiTenancy(fmt.Errorf("search index %s: %w", index.ID(), err))
 			default:
-				return nil, errors.Wrapf(err, "search index %s", index.ID())
+				return nil, fmt.Errorf("search index %s: %w", index.ID(), err)
 			}
 		}
 
@@ -171,11 +171,12 @@ func (db *DB) Object(ctx context.Context, class string, id strfmt.UUID,
 
 	obj, err := idx.objectByID(ctx, id, props, addl, repl, tenant)
 	if err != nil {
-		switch err.(type) {
-		case objects.ErrMultiTenancy:
+		var errMultiTenancy objects.ErrMultiTenancy
+		switch {
+		case errors.As(err, &errMultiTenancy):
 			return nil, objects.NewErrMultiTenancy(fmt.Errorf("search index %s: %w", idx.ID(), err))
 		default:
-			return nil, errors.Wrapf(err, "search index %s", idx.ID())
+			return nil, fmt.Errorf("search index %s: %w", idx.ID(), err)
 		}
 	}
 	var r *search.Result
@@ -194,7 +195,7 @@ func (db *DB) enrichRefsForSingle(ctx context.Context, obj *search.Result,
 	res, err := refcache.NewResolver(refcache.NewCacher(db, db.logger, tenant)).
 		Do(ctx, []search.Result{*obj}, props, additional)
 	if err != nil {
-		return nil, errors.Wrap(err, "resolve cross-refs")
+		return nil, fmt.Errorf("resolve cross-refs: %w", err)
 	}
 
 	return &res[0], nil
@@ -228,7 +229,7 @@ func (db *DB) anyExists(ctx context.Context, id strfmt.UUID,
 			case objects.ErrMultiTenancy:
 				return false, objects.NewErrMultiTenancy(fmt.Errorf("search index %s: %w", index.ID(), err))
 			default:
-				return false, errors.Wrapf(err, "search index %s", index.ID())
+				return false, fmt.Errorf("search index %s: %w", index.ID(), err)
 			}
 		}
 		if ok {
@@ -265,7 +266,7 @@ func (db *DB) Merge(ctx context.Context, merge objects.MergeDocument,
 
 	err := idx.mergeObject(ctx, merge, repl, tenant, schemaVersion)
 	if err != nil {
-		return errors.Wrapf(err, "merge into index %s", idx.ID())
+		return fmt.Errorf("merge into index %s: %w", idx.ID(), err)
 	}
 
 	return nil

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1056,10 +1056,12 @@ func (i *Index) objectByID(ctx context.Context, id strfmt.UUID,
 
 	shardName, err := i.determineObjectShard(ctx, id, tenant)
 	if err != nil {
-		switch err.(type) {
-		case objects.ErrMultiTenancy:
+		var errMultiTenancy objects.ErrMultiTenancy
+		var forbidden authErrs.Forbidden
+		switch {
+		case errors.As(err, &errMultiTenancy):
 			return nil, objects.NewErrMultiTenancy(fmt.Errorf("determine shard: %w", err))
-		case authErrs.Forbidden:
+		case errors.As(err, &forbidden):
 			return nil, fmt.Errorf("determine shard: %w", err)
 		default:
 			return nil, objects.NewErrInvalidUserInput("determine shard: %v", err)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1227,10 +1227,12 @@ func (i *Index) exists(ctx context.Context, id strfmt.UUID,
 
 	shardName, err := i.determineObjectShard(ctx, id, tenant)
 	if err != nil {
-		switch err.(type) {
-		case objects.ErrMultiTenancy:
+		var errMultiTenancy objects.ErrMultiTenancy
+		var forbidden authErrs.Forbidden
+		switch {
+		case errors.As(err, &errMultiTenancy):
 			return false, objects.NewErrMultiTenancy(fmt.Errorf("determine shard: %w", err))
-		case authErrs.Forbidden:
+		case errors.As(err, &forbidden):
 			return false, fmt.Errorf("determine shard: %w", err)
 		default:
 			return false, objects.NewErrInvalidUserInput("determine shard: %v", err)
@@ -1796,10 +1798,12 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 
 	shardName, err := i.determineObjectShard(ctx, id, tenant)
 	if err != nil {
-		switch err.(type) {
-		case objects.ErrMultiTenancy:
+		var errMultiTenancy objects.ErrMultiTenancy
+		var forbidden authErrs.Forbidden
+		switch {
+		case errors.As(err, &errMultiTenancy):
 			return objects.NewErrMultiTenancy(fmt.Errorf("determine shard: %w", err))
-		case authErrs.Forbidden:
+		case errors.As(err, &forbidden):
 			return fmt.Errorf("determine shard: %w", err)
 		default:
 			return objects.NewErrInvalidUserInput("determine shard: %v", err)

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -38,6 +38,8 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 	tenantNames := []string{
 		"Tenant1", "Tenant2", "Tenant3",
 	}
+
+	helper.DeleteClassWithAuthz(t, className, helper.CreateAuth(adminKey))
 	helper.CreateClassAuth(t, &models.Class{Class: className, MultiTenancyConfig: &models.MultiTenancyConfig{
 		Enabled: true,
 	}}, adminKey)

--- a/test/acceptance/multi_tenancy/batch_add_tenant_objects_test.go
+++ b/test/acceptance/multi_tenancy/batch_add_tenant_objects_test.go
@@ -277,7 +277,7 @@ func testAddNonTenantBatchToMultiClass(t *testing.T, implicitTenants bool) {
 	if implicitTenants {
 		require.Nil(t, resp)
 		require.NotNil(t, err)
-		batchErr := &batch.BatchObjectsCreateInternalServerError{}
+		batchErr := &batch.BatchObjectsCreateUnprocessableEntity{}
 		as := errors.As(err, &batchErr)
 		require.True(t, as)
 		require.NotNil(t, batchErr.Payload)

--- a/usecases/auth/authorization/adminlist/authorizer.go
+++ b/usecases/auth/authorization/adminlist/authorizer.go
@@ -12,6 +12,8 @@
 package adminlist
 
 import (
+	"fmt"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
@@ -64,7 +66,7 @@ func (a *Authorizer) Authorize(principal *models.Principal, verb string, resourc
 		}
 	}
 
-	return errors.NewForbidden(principal, verb, "adminlist", resources...)
+	return fmt.Errorf("adminlist: %w", errors.NewForbidden(principal, verb, resources...))
 }
 
 func (a *Authorizer) addAdminUserList(users []string) {

--- a/usecases/auth/authorization/adminlist/authorizer.go
+++ b/usecases/auth/authorization/adminlist/authorizer.go
@@ -64,7 +64,7 @@ func (a *Authorizer) Authorize(principal *models.Principal, verb string, resourc
 		}
 	}
 
-	return errors.NewForbidden(principal, verb, resources...)
+	return errors.NewForbidden(principal, verb, "adminlist", resources...)
 }
 
 func (a *Authorizer) addAdminUserList(users []string) {

--- a/usecases/auth/authorization/adminlist/authorizer_test.go
+++ b/usecases/auth/authorization/adminlist/authorizer_test.go
@@ -12,11 +12,12 @@
 package adminlist
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	authZErrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
 
 func Test_AdminList_Authorizer(t *testing.T) {
@@ -32,8 +33,10 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "R", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "R", "things"), err,
-				"should have the correct err msg")
+
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with a nil principal", func(t *testing.T) {
@@ -44,8 +47,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 
 			principal := (*models.Principal)(nil)
 			err := New(cfg).Authorize(principal, "R", "things")
-			assert.Equal(t, errors.NewForbidden(newAnonymousPrincipal(), "R", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "anonymous")
 		})
 
 		t.Run("with a non-configured user, it denies the request", func(t *testing.T) {
@@ -61,8 +65,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "R", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "R", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with a configured admin user, it allows the request", func(t *testing.T) {
@@ -128,8 +133,10 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			},
 		}
 		err := New(cfg).Authorize(principal, "R", "things")
-		assert.Equal(t, errors.NewForbidden(principal, "R", "things"), err,
-			"should have the correct err msg")
+		assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+		assert.Contains(t, err.Error(), "forbidden")
+		assert.Contains(t, err.Error(), "posse")
+		assert.Contains(t, err.Error(), "alice")
 	})
 
 	t.Run("with a configured admin group, it allows the request", func(t *testing.T) {
@@ -226,8 +233,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 
 			principal := (*models.Principal)(nil)
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(newAnonymousPrincipal(), "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "anonymous")
 		})
 
 		t.Run("with no users configured at all", func(t *testing.T) {
@@ -241,8 +249,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with a non-configured user, it denies the request", func(t *testing.T) {
@@ -258,8 +267,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with an empty user, it denies the request", func(t *testing.T) {
@@ -275,8 +285,8 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
 		})
 
 		t.Run("with a configured admin user, it allows the request", func(t *testing.T) {
@@ -310,8 +320,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with anonymous on the read-only list and a nil principal", func(t *testing.T) {
@@ -325,8 +336,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 
 			principal := (*models.Principal)(nil)
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(newAnonymousPrincipal(), "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "anonymous")
 		})
 
 		t.Run("with a non-configured group, it denies the request", func(t *testing.T) {
@@ -344,8 +356,10 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				},
 			}
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "posse")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with an empty group, it denies the request", func(t *testing.T) {
@@ -361,8 +375,9 @@ func Test_AdminList_Authorizer(t *testing.T) {
 				Groups:   []string{},
 			}
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
 		})
 
 		t.Run("with a configured admin group, it allows the request", func(t *testing.T) {
@@ -401,8 +416,10 @@ func Test_AdminList_Authorizer(t *testing.T) {
 			}
 
 			err := New(cfg).Authorize(principal, "create", "things")
-			assert.Equal(t, errors.NewForbidden(principal, "create", "things"), err,
-				"should have the correct err msg")
+			assert.True(t, errors.As(err, &authZErrors.Forbidden{}))
+			assert.Contains(t, err.Error(), "forbidden")
+			assert.Contains(t, err.Error(), "johndoe")
+			assert.Contains(t, err.Error(), "posse")
 		})
 
 		t.Run("with a configured admin user and non-configured group, it allows the request", func(t *testing.T) {

--- a/usecases/auth/authorization/errors/errors.go
+++ b/usecases/auth/authorization/errors/errors.go
@@ -20,9 +20,10 @@ import (
 
 // Forbidden indicates a failed authorization
 type Forbidden struct {
-	principal *models.Principal
-	verb      string
-	resources []string
+	principal           *models.Principal
+	verb                string
+	resources           []string
+	authorizationMethod string
 }
 
 type Unauthenticated struct{}
@@ -38,11 +39,12 @@ func NewUnauthenticated() Unauthenticated {
 
 // NewForbidden creates an explicit Forbidden error with details about the
 // principal and the attempted access on a specific resource
-func NewForbidden(principal *models.Principal, verb string, resources ...string) Forbidden {
+func NewForbidden(principal *models.Principal, verb string, authorization string, resources ...string) Forbidden {
 	return Forbidden{
-		principal: principal,
-		verb:      verb,
-		resources: resources,
+		principal:           principal,
+		verb:                verb,
+		resources:           resources,
+		authorizationMethod: authorization,
 	}
 }
 
@@ -56,8 +58,8 @@ func (f Forbidden) Error() string {
 		optionalGroups = fmt.Sprintf(" (of groups %s)", groupsList)
 	}
 
-	return fmt.Sprintf("forbidden: user '%s'%s has insufficient permissions to %s %s",
-		f.principal.Username, optionalGroups, f.verb, f.resources)
+	return fmt.Sprintf("%s: authorization error: user '%s'%s has insufficient permissions to %s %s",
+		f.authorizationMethod, f.principal.Username, optionalGroups, f.verb, f.resources)
 }
 
 func wrapInSingleQuotes(input []string) []string {

--- a/usecases/auth/authorization/errors/errors.go
+++ b/usecases/auth/authorization/errors/errors.go
@@ -20,10 +20,9 @@ import (
 
 // Forbidden indicates a failed authorization
 type Forbidden struct {
-	principal           *models.Principal
-	verb                string
-	resources           []string
-	authorizationMethod string
+	principal *models.Principal
+	verb      string
+	resources []string
 }
 
 type Unauthenticated struct{}
@@ -39,12 +38,11 @@ func NewUnauthenticated() Unauthenticated {
 
 // NewForbidden creates an explicit Forbidden error with details about the
 // principal and the attempted access on a specific resource
-func NewForbidden(principal *models.Principal, verb string, authorization string, resources ...string) Forbidden {
+func NewForbidden(principal *models.Principal, verb string, resources ...string) Forbidden {
 	return Forbidden{
-		principal:           principal,
-		verb:                verb,
-		resources:           resources,
-		authorizationMethod: authorization,
+		principal: principal,
+		verb:      verb,
+		resources: resources,
 	}
 }
 
@@ -58,8 +56,8 @@ func (f Forbidden) Error() string {
 		optionalGroups = fmt.Sprintf(" (of groups %s)", groupsList)
 	}
 
-	return fmt.Sprintf("%s: authorization error: user '%s'%s has insufficient permissions to %s %s",
-		f.authorizationMethod, f.principal.Username, optionalGroups, f.verb, f.resources)
+	return fmt.Sprintf("authorization error, forbidden action: user '%s'%s has insufficient permissions to %s %s",
+		f.principal.Username, optionalGroups, f.verb, f.resources)
 }
 
 func wrapInSingleQuotes(input []string) []string {

--- a/usecases/auth/authorization/errors/errors.go
+++ b/usecases/auth/authorization/errors/errors.go
@@ -56,7 +56,7 @@ func (f Forbidden) Error() string {
 		optionalGroups = fmt.Sprintf(" (of groups %s)", groupsList)
 	}
 
-	return fmt.Sprintf("authorization error, forbidden action: user '%s'%s has insufficient permissions to %s %s",
+	return fmt.Sprintf("authorization, forbidden action: user '%s'%s has insufficient permissions to %s %s",
 		f.principal.Username, optionalGroups, f.verb, f.resources)
 }
 

--- a/usecases/auth/authorization/errors/errors_test.go
+++ b/usecases/auth/authorization/errors/errors_test.go
@@ -24,7 +24,7 @@ func Test_ForbiddenError_NoGroups(t *testing.T) {
 	}
 
 	err := NewForbidden(principal, "delete", "schema/things")
-	expectedErrMsg := "forbidden: user 'john' has insufficient permissions to delete [schema/things]"
+	expectedErrMsg := "authorization, forbidden action: user 'john' has insufficient permissions to delete [schema/things]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 }
 
@@ -35,7 +35,7 @@ func Test_ForbiddenError_SingleGroup(t *testing.T) {
 	}
 
 	err := NewForbidden(principal, "delete", "schema/things")
-	expectedErrMsg := "forbidden: user 'john' (of group 'worstusers') has insufficient permissions to delete [schema/things]"
+	expectedErrMsg := "authorization, forbidden action: user 'john' (of group 'worstusers') has insufficient permissions to delete [schema/things]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 }
 
@@ -46,7 +46,7 @@ func Test_ForbiddenError_MultipleGroups(t *testing.T) {
 	}
 
 	err := NewForbidden(principal, "delete", "schema/things")
-	expectedErrMsg := "forbidden: user 'john' (of groups 'worstusers', 'fraudsters', 'evilpeople') " +
+	expectedErrMsg := "authorization, forbidden action: user 'john' (of groups 'worstusers', 'fraudsters', 'evilpeople') " +
 		"has insufficient permissions to delete [schema/things]"
 	assert.Equal(t, expectedErrMsg, err.Error())
 }

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -249,7 +249,7 @@ func (m *manager) Authorize(principal *models.Principal, verb string, resources 
 		}).Info()
 
 		if !allow {
-			return errors.NewForbidden(principal, prettyPermissionsActions(perm), prettyPermissionsResources(perm))
+			return errors.NewForbidden(principal, prettyPermissionsActions(perm), "rbac", prettyPermissionsResources(perm))
 		}
 	}
 
@@ -270,44 +270,44 @@ func prettyPermissionsResources(perm *models.Permission) string {
 	}
 
 	if perm.Backups != nil && perm.Backups.Collection != nil && *perm.Backups.Collection != "" {
-		res += fmt.Sprintf("Backups.Collection: %s,", *perm.Backups.Collection)
+		res += fmt.Sprintf(" Collection: %s,", *perm.Backups.Collection)
 	}
 
 	if perm.Data != nil {
 		if perm.Data.Collection != nil && *perm.Data.Collection != "" {
-			res += fmt.Sprintf(" Data.Collection: %s,", *perm.Data.Collection)
+			res += fmt.Sprintf(" Collection: %s,", *perm.Data.Collection)
 		}
 		if perm.Data.Tenant != nil && *perm.Data.Tenant != "" {
-			res += fmt.Sprintf(" Data.Tenant: %s,", *perm.Data.Tenant)
+			res += fmt.Sprintf(" Tenant: %s,", *perm.Data.Tenant)
 		}
 		if perm.Data.Object != nil && *perm.Data.Object != "" {
-			res += fmt.Sprintf(" Data.Object: %s,", *perm.Data.Object)
+			res += fmt.Sprintf(" Object: %s,", *perm.Data.Object)
 		}
 	}
 
 	if perm.Nodes != nil {
 		if perm.Nodes.Verbosity != nil && *perm.Nodes.Verbosity != "" {
-			res += fmt.Sprintf(" Nodes.Verbosity: %s,", *perm.Nodes.Verbosity)
+			res += fmt.Sprintf(" Verbosity: %s,", *perm.Nodes.Verbosity)
 		}
 		if perm.Nodes.Collection != nil && *perm.Nodes.Collection != "" {
-			res += fmt.Sprintf(" Nodes.Collection: %s,", *perm.Nodes.Collection)
+			res += fmt.Sprintf(" Collection: %s,", *perm.Nodes.Collection)
 		}
 	}
 
 	if perm.Roles != nil && perm.Roles.Role != nil && *perm.Roles.Role != "" {
-		res += fmt.Sprintf(" Roles.Role: %s,", *perm.Roles.Role)
+		res += fmt.Sprintf(" Role: %s,", *perm.Roles.Role)
 	}
 
 	if perm.Collections != nil {
 		if perm.Collections.Collection != nil && *perm.Collections.Collection != "" {
-			res += fmt.Sprintf(" Schema.Collection: %s,", *perm.Collections.Collection)
+			res += fmt.Sprintf(" Collection: %s,", *perm.Collections.Collection)
 		}
 	}
 
 	if perm.Tenants != nil {
 		if perm.Tenants.Tenant != nil && *perm.Tenants.Tenant != "" {
-			res += fmt.Sprintf(" Schema.Collection: %s,", *perm.Tenants.Collection)
-			res += fmt.Sprintf(" Schema.Tenant: %s,", *perm.Tenants.Tenant)
+			res += fmt.Sprintf(" Collection: %s,", *perm.Tenants.Collection)
+			res += fmt.Sprintf(" Tenant: %s,", *perm.Tenants.Tenant)
 		}
 	}
 

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -249,7 +249,7 @@ func (m *manager) Authorize(principal *models.Principal, verb string, resources 
 		}).Info()
 
 		if !allow {
-			return errors.NewForbidden(principal, prettyPermissionsActions(perm), "rbac", prettyPermissionsResources(perm))
+			return fmt.Errorf("rbac: %w", errors.NewForbidden(principal, prettyPermissionsActions(perm), prettyPermissionsResources(perm)))
 		}
 	}
 

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -144,10 +144,12 @@ func (m *Manager) checkIDOrAssignNew(ctx context.Context, principal *models.Prin
 	if exists {
 		return "", NewErrInvalidUserInput("id '%s' already exists", id)
 	} else if err != nil {
-		switch err.(type) {
-		case ErrInvalidUserInput:
+		var errInvalidUserInput ErrInvalidUserInput
+		var errMultiTenancy ErrMultiTenancy
+		switch {
+		case errors.As(err, &errInvalidUserInput):
 			return "", err
-		case ErrMultiTenancy:
+		case errors.As(err, &errMultiTenancy):
 			// This may be fine, the class is configured to create non-existing tenants.
 			// A non-existing tenant will still be detected later on
 			if enterrors.IsTenantNotFound(err) {

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -119,8 +119,9 @@ func (m *Manager) getObjectFromRepo(ctx context.Context, class string, id strfmt
 		res, err = m.vectorRepo.ObjectByID(ctx, id, search.SelectProperties{}, adds, tenant)
 	}
 	if err != nil {
-		switch err.(type) {
-		case ErrMultiTenancy:
+		var errMultiTenancy ErrMultiTenancy
+		switch {
+		case errors.As(err, &errMultiTenancy):
 			return nil, NewErrMultiTenancy(fmt.Errorf("repo: object by id: %w", err))
 		default:
 			if errors.As(err, &authzerrs.Forbidden{}) {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -65,8 +65,9 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	ctx = classcache.ContextWithClassCache(ctx)
 	obj, err := m.vectorRepo.Object(ctx, cls, id, nil, additional.Properties{}, repl, updates.Tenant)
 	if err != nil {
-		switch err.(type) {
-		case ErrMultiTenancy:
+		var errMultiTenancy ErrMultiTenancy
+		switch {
+		case errors.As(err, &errMultiTenancy):
 			return &Error{"repo.object", StatusUnprocessableEntity, err}
 		default:
 			if errors.As(err, &ErrDirtyReadOfDeletedObject{}) || errors.As(err, &ErrDirtyWriteOfDeletedObject{}) {

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -13,6 +13,7 @@ package objects
 
 import (
 	"context"
+	"errors"
 
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
@@ -40,7 +41,8 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	ctx = classcache.ContextWithClassCache(ctx)
 	err = m.validateObjectAndNormalizeNames(ctx, principal, repl, obj, nil)
 	if err != nil {
-		if _, ok := err.(autherrs.Forbidden); ok {
+		var forbidden autherrs.Forbidden
+		if errors.As(err, &forbidden) {
 			return err
 		}
 		return NewErrInvalidUserInput("invalid object: %v", err)


### PR DESCRIPTION
### What's being changed:

UX review of forbidden error:

- old: `forbidden: user 'custom-user' has insufficient permissions to delete_collections [Schema.Collection: TestingTenants]`
- new: `rbac: authorization error: user 'custom-user' has insufficient permissions to delete_collections [Collection: TestingTenants]`

Reasons: 
- added where error is coming from (rbac or adminlist), so users can search in the documentation
- `Schema.Collection` was confusing as we want to move away from the term schema. The action should be clear from `delete_collections` so we can remove the internal domain from the specific resource

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
