### PR TITLE
RBAC: Require collection and not tenant permissions for object+ref endpoints

### DIFF
--- a/test/acceptance_with_python/rbac/test_object_endpoint.py
+++ b/test/acceptance_with_python/rbac/test_object_endpoint.py
@@ -23,8 +23,8 @@ def test_obj_insert(
 
     required_permissions = [
         Permissions.data(collection=col.name, create=True),
+        Permissions.collections(collection=col.name, read_config=True),
     ]
-
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -69,8 +69,8 @@ def test_obj_insert_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, create=True),
+        Permissions.collections(collection=source.name, read_config=True),
     ]
-
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
             source.name
@@ -108,8 +108,10 @@ def test_obj_replace(
 
     uuid_to_replace = col.data.insert({})
 
-    required_permissions = [Permissions.data(collection=col.name, update=True)]
-
+    required_permissions = [
+        Permissions.data(collection=col.name, update=True),
+        Permissions.collections(collection=col.name, read_config=True),
+    ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -157,8 +159,8 @@ def test_obj_replace_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
+        Permissions.collections(collection=source.name, read_config=True),
     ]
-
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
             source.name
@@ -202,8 +204,8 @@ def test_obj_update(
 
     required_permissions = [
         Permissions.data(collection=col.name, update=True),
+        Permissions.collections(collection=col.name, read_config=True),
     ]
-
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -250,8 +252,8 @@ def test_obj_update_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
+        Permissions.collections(collection=source.name, read_config=True),
     ]
-
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
             source.name
@@ -295,8 +297,8 @@ def test_obj_delete(
 
     required_permissions = [
         Permissions.data(collection=col.name, delete=True),
+        Permissions.collections(collection=col.name, read_config=True),
     ]
-
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -338,6 +340,7 @@ def test_obj_exists(
 
     required_permissions = [
         Permissions.data(collection=col.name, read=True),
+        Permissions.collections(collection=col.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check

--- a/test/acceptance_with_python/rbac/test_object_endpoint.py
+++ b/test/acceptance_with_python/rbac/test_object_endpoint.py
@@ -23,8 +23,10 @@ def test_obj_insert(
 
     required_permissions = [
         Permissions.data(collection=col.name, create=True),
-        Permissions.tenants(collection=col.name, read=True),
     ]
+    if mt:
+        required_permissions.append(Permissions.tenants(collection=col.name, read=True))
+
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:

--- a/test/acceptance_with_python/rbac/test_object_endpoint.py
+++ b/test/acceptance_with_python/rbac/test_object_endpoint.py
@@ -24,8 +24,6 @@ def test_obj_insert(
     required_permissions = [
         Permissions.data(collection=col.name, create=True),
     ]
-    if mt:
-        required_permissions.append(Permissions.tenants(collection=col.name, read=True))
 
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -71,8 +69,8 @@ def test_obj_insert_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, create=True),
-        Permissions.tenants(collection=source.name, read=True),
     ]
+
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
             source.name
@@ -110,10 +108,8 @@ def test_obj_replace(
 
     uuid_to_replace = col.data.insert({})
 
-    required_permissions = [
-        Permissions.data(collection=col.name, update=True),
-        Permissions.tenants(collection=col.name, read=True),
-    ]
+    required_permissions = [Permissions.data(collection=col.name, update=True)]
+
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -161,8 +157,8 @@ def test_obj_replace_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
-        Permissions.tenants(collection=source.name, read=True),
     ]
+
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
             source.name
@@ -206,8 +202,8 @@ def test_obj_update(
 
     required_permissions = [
         Permissions.data(collection=col.name, update=True),
-        Permissions.tenants(collection=col.name, read=True),
     ]
+
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -254,8 +250,8 @@ def test_obj_update_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
-        Permissions.tenants(collection=source.name, read=True),
     ]
+
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
             source.name
@@ -299,8 +295,8 @@ def test_obj_delete(
 
     required_permissions = [
         Permissions.data(collection=col.name, delete=True),
-        Permissions.tenants(collection=col.name, read=True),
     ]
+
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
         if mt:
@@ -342,7 +338,6 @@ def test_obj_exists(
 
     required_permissions = [
         Permissions.data(collection=col.name, read=True),
-        Permissions.tenants(collection=col.name, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check

--- a/test/acceptance_with_python/rbac/test_rbac_refs.py
+++ b/test/acceptance_with_python/rbac/test_rbac_refs.py
@@ -42,7 +42,7 @@ def test_rbac_refs(
     admin_client.roles.delete(role_name)
 
     required_permissions = [
-        Permissions.tenants(collection=[source.name, target.name], read=True),
+        Permissions.collections(collection=[source.name, target.name], read_config=True),
         Permissions.data(collection=source.name, update=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
@@ -142,7 +142,7 @@ def test_batch_delete_with_filter(
     )
 
     required_permissions = [
-        Permissions.tenants(collection=[target.name, source.name], read=True),
+        Permissions.collections(collection=[target.name, source.name], read_config=True),
         Permissions.data(collection=source.name, delete=True, read=True),
         Permissions.data(collection=target.name, read=True),
     ]
@@ -219,7 +219,7 @@ def test_search_with_filter_and_return(
     admin_client.roles.delete(role_name)
 
     required_permissions = [
-        Permissions.tenants(collection=[target.name, source.name], read=True),
+        Permissions.collections(collection=[target.name, source.name], read_config=True),
         Permissions.data(collection=[source.name, target.name], read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
@@ -313,7 +313,7 @@ def test_batch_ref(
 
     # self reference
     required_permissions = [
-        Permissions.tenants(collection=source.name, read=True),
+        Permissions.collections(collection=source.name, read_config=True),
         Permissions.data(collection=source.name, read=True, update=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
@@ -348,7 +348,7 @@ def test_batch_ref(
 
     # ref to one target
     required_permissions = [
-        Permissions.tenants(collection=source.name, read=True),
+        Permissions.collections(collection=source.name, read_config=True),
         Permissions.data(collection=[source.name, target1.name], read=True),
         Permissions.data(collection=source.name, update=True),
         Permissions.collections(collection=target1.name, read_config=True),

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -46,7 +46,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 		return nil, err
 	}
 
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Collections(class)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -46,7 +46,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 		return nil, err
 	}
 
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Collections(class)...); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -37,7 +37,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
 	}
 

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -28,7 +28,7 @@ func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, c
 	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}
 

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -49,7 +49,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(updates.Class, updates.Tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(updates.Class)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -67,17 +67,12 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
 	class := "*"
-	tenant := "*"
 
 	if params != nil && params.Class != "" {
 		class = params.Class
 	}
 
-	if params != nil && params.Tenant != nil && *params.Tenant != "" {
-		tenant = *params.Tenant
-	}
-
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
 		return nil, &Error{err.Error(), StatusForbidden, err}
 	}
 	unlock, err := m.locks.LockConnector()

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -43,7 +43,7 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsData(input.Class, tenant)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(input.Class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(input.Class)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 
@@ -96,7 +96,7 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 			targetRef.Class = string(toClass)
 		}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(targetRef.Class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(targetRef.Class)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -48,7 +48,7 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsData(input.Class, tenant)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(input.Class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(input.Class)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 
@@ -73,7 +73,7 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 			input.Reference.Beacon = toBeacon
 		}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(input.Reference.Class.String(), tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(input.Reference.Class.String())...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -53,7 +53,7 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsData(input.Class, tenant)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(input.Class, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(input.Class)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 
@@ -106,7 +106,7 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 				parsedTargetRefs[i].Class = string(toClass)
 			}
 		}
-		if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(input.Refs[i].Class.String(), tenant)...); err != nil {
+		if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(input.Refs[i].Class.String())...); err != nil {
 			return &Error{err.Error(), StatusForbidden, err}
 		}
 

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -33,7 +33,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {
 		return nil, err
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(updates.Class, updates.Tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(updates.Class)...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
