### PR TITLE
bugfix: fix NewScalarQuantizer with loops from data first vector

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/scalar_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/scalar_quantization.go
@@ -79,7 +79,7 @@ func NewScalarQuantizer(data [][]float32, distance distancer.Provider) *ScalarQu
 		dimensions: len(data[0]),
 	}
 	sq.b = data[0][0]
-	for i := 1; i < len(data); i++ {
+	for i := 0; i < len(data); i++ {
 		vec := data[i]
 		for _, x := range vec {
 			if x < sq.b {

--- a/adapters/repos/db/vector/compressionhelpers/scalar_quantization_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/scalar_quantization_test.go
@@ -30,24 +30,24 @@ import (
 
 func Test_NoRaceSQEncode(t *testing.T) {
 	sq := compressionhelpers.NewScalarQuantizer([][]float32{
-		{0, 0, 0, 0},
-		{1, 1, 1, 1},
+		{1, 0, 0, 0},
+		{1, 1, 1, 5},
 	}, distancer.NewCosineDistanceProvider())
 	vec := []float32{0.5, 1, 0, 2}
 	code := sq.Encode(vec)
 	assert.NotNil(t, code)
-	assert.Equal(t, byte(127), code[0])
-	assert.Equal(t, byte(255), code[1])
+	assert.Equal(t, byte(25), code[0])
+	assert.Equal(t, byte(51), code[1])
 	assert.Equal(t, byte(0), code[2])
-	assert.Equal(t, byte(255), code[3])
+	assert.Equal(t, byte(102), code[3])
 }
 
 func Test_NoRaceSQDistance(t *testing.T) {
 	distancers := []distancer.Provider{distancer.NewL2SquaredProvider(), distancer.NewCosineDistanceProvider(), distancer.NewDotProductProvider()}
 	for _, distancer := range distancers {
 		sq := compressionhelpers.NewScalarQuantizer([][]float32{
-			{0, 0, 0, 0},
-			{1, 1, 1, 1},
+			{1, 0, 0, 0},
+			{1, 1, 1, 5},
 		}, distancer)
 		vec1 := []float32{0.217, 0.435, 0, 0.348}
 		vec2 := []float32{0.241, 0.202, 0.257, 0.300}
@@ -56,7 +56,7 @@ func Test_NoRaceSQDistance(t *testing.T) {
 		expectedDist, _ := distancer.SingleDist(vec1, vec2)
 		assert.Nil(t, err)
 		if err == nil {
-			assert.True(t, math.Abs(float64(expectedDist-dist)) < 0.01)
+			assert.True(t, math.Abs(float64(expectedDist-dist)) < 0.0112)
 			fmt.Println(expectedDist-dist, expectedDist, dist)
 		}
 	}


### PR DESCRIPTION
### What's being changed:

backport of: bugfix: fix NewScalarQuantizer with loops from data first vector (#6610)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
