### PR TITLE
Improve error message for anon access when disabled

### DIFF
--- a/usecases/auth/authentication/anonymous/middleware.go
+++ b/usecases/auth/authentication/anonymous/middleware.go
@@ -63,7 +63,7 @@ func (c *Client) Middleware(next http.Handler) http.Handler {
 
 		w.Write([]byte(
 			fmt.Sprintf(
-				`{"code":401,"message": "anonymous access not enabled. Please authenticate through one of the enabled auth schemas: [%s]" }`, strings.Join(authSchemas, ", "),
+				`{"code":401,"message": "anonymous access not enabled. Please authenticate through one of the available methods: [%s]" }`, strings.Join(authSchemas, ", "),
 			),
 		))
 	})

--- a/usecases/auth/authentication/anonymous/middleware.go
+++ b/usecases/auth/authentication/anonymous/middleware.go
@@ -12,6 +12,7 @@
 package anonymous
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -21,13 +22,15 @@ import (
 
 // Client for anonymous access
 type Client struct {
-	config config.AnonymousAccess
+	config        config.AnonymousAccess
+	apiKeyEnabled bool
+	oidcEnabled   bool
 }
 
 // New anonymous access client. Client.Middleware can be used as a regular
 // golang http-middleware
 func New(cfg config.Config) *Client {
-	return &Client{config: cfg.Authentication.AnonymousAccess}
+	return &Client{config: cfg.Authentication.AnonymousAccess, apiKeyEnabled: cfg.Authentication.APIKey.Enabled, oidcEnabled: cfg.Authentication.OIDC.Enabled}
 }
 
 // Middleware will fail unauthenticated requests if anonymous access is
@@ -50,8 +53,18 @@ func (c *Client) Middleware(next http.Handler) http.Handler {
 		}
 
 		w.WriteHeader(401)
+		var authSchemas []string
+		if c.apiKeyEnabled {
+			authSchemas = append(authSchemas, "API-keys")
+		}
+		if c.oidcEnabled {
+			authSchemas = append(authSchemas, "OIDC")
+		}
+
 		w.Write([]byte(
-			`{"code":401,"message":"anonymous access not enabled, please provide an auth scheme such as OIDC"}`,
+			fmt.Sprintf(
+				`{"code":401,"message": "anonymous access not enabled. Please authenticate through one of the enabled auth schemas: [%s]" }`, strings.Join(authSchemas, ", "),
+			),
 		))
 	})
 }


### PR DESCRIPTION
### What's being changed:

Came from our RBAC UX test:

Old error message when a user tried to connect as anonymous (== no authentication method):
```
weaviate.exceptions.UnexpectedStatusCodeError: Meta endpoint! Unexpected status code: 401, with response body: 
{'code': 401, 'message': 'anonymous access not enabled, please provide an auth scheme such as OIDC'}.
```

New:

```
weaviate.exceptions.UnexpectedStatusCodeError: Meta endpoint! Unexpected status code: 401, with response body: 
{'code': 401, 'message': 'anonymous access not enabled. Please authenticate ththrough one of the enabled schemes: [API-keys]'}
```

 where the array is dynamic and contains the enabled methods, eg API-keys and/or OIDC

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
