### PR TITLE
RBAC: Add authZ call count from logs for each method

### DIFF
--- a/test/docker/container.go
+++ b/test/docker/container.go
@@ -53,3 +53,7 @@ func (d *DockerContainer) GetEndpoint(name EndpointName) string {
 	}
 	return ""
 }
+
+func (d *DockerContainer) Container() testcontainers.Container {
+	return d.container
+}


### PR DESCRIPTION
### What's being changed:

Automatically checks for each endpoint in test/acceptance/authz/rbac_auto_admin_permissions_test.go (== succeeding request) how many new authorization requests were emitted.

The ones with 3 or more calls are:
```
        DELETE http://localhost:60655/v1/objects/73f2eb5f-5abf-447a-81ca-74b1dd168241/references/someProperty (count: 3), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"update_data","resources":" Collection: *, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: *","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_data","resources":" Collection: *, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"}]
        DELETE http://localhost:60655/v1/objects/ABC/73f2eb5f-5abf-447a-81ca-74b1dd168241 (count: 3), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"delete_data","resources":" Collection: ABC, Tenant: *, Object: 73f2eb5f-5abf-447a-81ca-74b1dd168241,","results":"success","time":"2025-01-20T07:38:45Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:45Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:45Z","user":"admin-user"}]
        PUT http://localhost:60655/v1/objects/73f2eb5f-5abf-447a-81ca-74b1dd168241/references/someProperty (count: 4), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"update_data","resources":" Collection: *, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: *","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_data","resources":" Collection: *, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: *","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"}]
        POST http://localhost:60655/v1/batch/objects (count: 4), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:43Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"update_data","resources":" Collection: ABC, Tenant: ABC, Object: *,","results":"success","time":"2025-01-20T07:38:43Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"create_data","resources":" Collection: ABC, Tenant: ABC, Object: *,","results":"success","time":"2025-01-20T07:38:43Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:43Z","user":"admin-user"}]
        POST http://localhost:60655/v1/objects/73f2eb5f-5abf-447a-81ca-74b1dd168241/references/someProperty (count: 4), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"update_data","resources":" Collection: *, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: *","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_data","resources":" Collection: *, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: *","results":"success","time":"2025-01-20T07:38:46Z","user":"admin-user"}]
        POST http://localhost:60655/v1/objects (count: 5), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"create_data","resources":" Collection: ABC, Tenant: ABC, Object: *,","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"}]
        POST http://localhost:60655/v1/batch/references (count: 5), Logs: [{"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"update_data","resources":" Collection: ABC, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_collections","resources":"Collection: ABC","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"} {"action":"authorize","build_git_commit":"8015521e9f","build_go_version":"go1.22.9","build_image_tag":"unknown","build_wv_version":"1.28.3","component":"RBAC","level":"info","msg":"","request_action":"read_data","resources":" Collection: ABC, Tenant: *, Object: *,","results":"success","time":"2025-01-20T07:38:44Z","user":"admin-user"}]
```

Keep in mind that:
- this is a simple request that is supposed to just have enough info to not fail, eg for batch requests there is only a single object
- GRPC calls are not covered
- Search calls do not have any complex setting (eg no filters or anything)

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
