### PR TITLE
validate weaviate vectorizer model

### DIFF
--- a/modules/text2vec-weaviate/config.go
+++ b/modules/text2vec-weaviate/config.go
@@ -24,7 +24,7 @@ import (
 
 func (m *WeaviateEmbedModule) ClassConfigDefaults() map[string]interface{} {
 	return map[string]interface{}{
-		"model":              ent.SnowflakeArcticEmbedM,
+		"model":              ent.DefaultWeaviateModel,
 		"truncate":           ent.DefaultTruncate,
 		"baseUrl":            ent.DefaultBaseURL,
 		"vectorizeClassName": ent.DefaultVectorizeClassName,

--- a/modules/text2vec-weaviate/ent/class_settings_test.go
+++ b/modules/text2vec-weaviate/ent/class_settings_test.go
@@ -43,6 +43,23 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "Explicit correct model",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model": "Snowflake/snowflake-arctic-embed-m-v1.5",
+				},
+			},
+		},
+		{
+			name: "Explicit wrong model",
+			cfg: &fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"model": "not-available-model",
+				},
+			},
+			wantErr: errors.New("wrong model name, available model names are: [Snowflake/snowflake-arctic-embed-l-v2.0 Snowflake/snowflake-arctic-embed-m-v1.5]"),
+		},
+		{
 			name: "Explicit correct dimensions",
 			cfg: &fakeClassConfig{
 				classConfig: map[string]interface{}{
@@ -54,10 +71,10 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "Explicit wrong dimensions",
 			cfg: &fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"dimensions": 123,
+					"dimensions": 768,
 				},
 			},
-			wantErr: errors.New("available dimensions for model Snowflake/snowflake-arctic-embed-m-v1.5 are: [256 768]. Got 123"),
+			wantErr: errors.New("wrong dimensions setting for Snowflake/snowflake-arctic-embed-l-v2.0 model, available dimensions are: [256 1024]"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What's being changed:
- validate weaviate vectorizer model
- add support for `Snowflake/snowflake-arctic-embed-l-v2.0` and make it default

Creating PR as draft for a start in case we want to wait for Weaviate Embeddings go GA before merging this.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
