### PR TITLE
Fix nodes api with collection name on multi node

### DIFF
--- a/adapters/handlers/rest/clusterapi/nodes.go
+++ b/adapters/handlers/rest/clusterapi/nodes.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
@@ -82,9 +83,10 @@ func (s *nodes) incomingNodeStatus() http.Handler {
 
 		var className string
 
-		args := regxNodesClass.FindStringSubmatch(r.URL.Path)
-		if len(args) == 3 {
-			className = args[2]
+		// url is /nodes/status[/className], where /className is optional
+		args := strings.Split(r.URL.Path, "/")
+		if len(args) == 4 {
+			className = args[3]
 		}
 
 		output := verbosity.OutputMinimal
@@ -92,7 +94,6 @@ func (s *nodes) incomingNodeStatus() http.Handler {
 		if found && len(out) > 0 {
 			output = out[0]
 		}
-
 		nodeStatus, err := s.nodesManager.GetNodeStatus(r.Context(), className, output)
 		if err != nil {
 			http.Error(w, "/nodes fulfill request: "+err.Error(),

--- a/test/acceptance/multi_node/nodes_api_test.go
+++ b/test/acceptance/multi_node/nodes_api_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package multi_node
 
 import (

--- a/test/acceptance/multi_node/nodes_api_test.go
+++ b/test/acceptance/multi_node/nodes_api_test.go
@@ -36,9 +36,8 @@ func TestNodesMultiNode(t *testing.T) {
 			t.Fatalf("failed to terminate test containers: %s", err.Error())
 		}
 	}()
-
 	helper.SetupClient(compose.GetWeaviate().URI())
-	// helper.SetupClient("127.0.0.1:8080")
+
 	paragraphClass := articles.ParagraphsClass()
 	helper.DeleteClass(t, paragraphClass.Class)
 	helper.CreateClass(t, paragraphClass)

--- a/test/acceptance/multi_node/nodes_api_test.go
+++ b/test/acceptance/multi_node/nodes_api_test.go
@@ -1,0 +1,88 @@
+package multi_node
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+func TestNodesMultiNode(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		With3NodeCluster().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	// helper.SetupClient("127.0.0.1:8080")
+	paragraphClass := articles.ParagraphsClass()
+	helper.DeleteClass(t, paragraphClass.Class)
+	helper.CreateClass(t, paragraphClass)
+	articleClass := articles.ArticlesClass()
+	helper.DeleteClass(t, articleClass.Class)
+	helper.CreateClass(t, articleClass)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, helper.CreateObject(t, articles.NewArticle().Object()))
+		require.NoError(t, helper.CreateObject(t, articles.NewParagraph().Object()))
+	}
+
+	minimal, verbose := verbosity.OutputMinimal, verbosity.OutputVerbose
+
+	t.Run("output without class minimal", func(t *testing.T) {
+		payload := getNodesPayload(t, minimal, "")
+		for _, node := range payload.Nodes {
+			require.Nil(t, node.Shards)
+		}
+	})
+
+	t.Run("output without class verbose", func(t *testing.T) {
+		payload := getNodesPayload(t, verbose, "")
+		for _, node := range payload.Nodes {
+			require.NotNil(t, node.Shards)
+			require.Len(t, node.Shards, 2)
+		}
+	})
+
+	t.Run("output with class minimal", func(t *testing.T) {
+		payload := getNodesPayload(t, minimal, articleClass.Class)
+		for _, node := range payload.Nodes {
+			require.Nil(t, node.Shards)
+		}
+	})
+
+	t.Run("output with class verbose", func(t *testing.T) {
+		payload := getNodesPayload(t, verbose, articleClass.Class)
+		for _, node := range payload.Nodes {
+			require.NotNil(t, node.Shards)
+			require.Len(t, node.Shards, 1)
+		}
+	})
+}
+
+func getNodesPayload(t *testing.T, verbosity string, class string) *models.NodesStatusResponse {
+	params := nodes.NewNodesGetClassParams().WithOutput(&verbosity)
+	if class != "" {
+		params.WithClassName(class)
+	}
+	body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+	require.NoError(t, clientErr)
+	payload, err := body.Payload, clientErr
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	require.Len(t, payload.Nodes, 3)
+	return payload
+}


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/weaviate/issues/6866

`args := regxNodesClass.FindStringSubmatch(r.URL.Path)` would not actually get the different entries of the path and the class name was always "". Switched it to a simpler method to get the different parts and detect if there is a class name for the request

Output of MRE in issue:

```
Display nodes info
[Node(git_hash='66d3819c0d', name='weaviate-0', shards=[Shard(collection='Paragraph', name='TeKYyMwYZWLF', node='weaviate-0', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Article', name='s0RSDyDsOsk5', node='weaviate-0', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Movies1', name='gMoZOoMOgHXK', node='weaviate-0', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Movies2', name='xQ7SVjrbNH4e', node='weaviate-0', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=4), status='HEALTHY', version='1.28.3'), Node(git_hash='66d3819c0d', name='weaviate-1', shards=[Shard(collection='Movies2', name='JVpAOLz9FKSj', node='weaviate-1', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Article', name='ENQPzCGlBTDk', node='weaviate-1', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Paragraph', name='FCaCAOrQVV3Y', node='weaviate-1', object_count=4, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Movies1', name='imzFBajCQeHR', node='weaviate-1', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=4, shard_count=4), status='HEALTHY', version='1.28.3'), Node(git_hash='66d3819c0d', name='weaviate-2', shards=[Shard(collection='Movies2', name='Z0iJlaEvYyGP', node='weaviate-2', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Article', name='MHDUTtlF8h3m', node='weaviate-2', object_count=4, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Paragraph', name='gT2qn50rKos9', node='weaviate-2', object_count=2, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True), Shard(collection='Movies1', name='LLoxFUleaYXk', node='weaviate-2', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=6, shard_count=4), status='HEALTHY', version='1.28.3')]
Display nodes info for collection Movies1
[Node(git_hash='66d3819c0d', name='weaviate-0', shards=[Shard(collection='Movies1', name='gMoZOoMOgHXK', node='weaviate-0', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=1), status='HEALTHY', version='1.28.3'), Node(git_hash='66d3819c0d', name='weaviate-1', shards=[Shard(collection='Movies1', name='imzFBajCQeHR', node='weaviate-1', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=1), status='HEALTHY', version='1.28.3'), Node(git_hash='66d3819c0d', name='weaviate-2', shards=[Shard(collection='Movies1', name='LLoxFUleaYXk', node='weaviate-2', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=1), status='HEALTHY', version='1.28.3')]
Display nodes info for collection Movies2
[Node(git_hash='66d3819c0d', name='weaviate-0', shards=[Shard(collection='Movies2', name='xQ7SVjrbNH4e', node='weaviate-0', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=1), status='HEALTHY', version='1.28.3'), Node(git_hash='66d3819c0d', name='weaviate-1', shards=[Shard(collection='Movies2', name='JVpAOLz9FKSj', node='weaviate-1', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=1), status='HEALTHY', version='1.28.3'), Node(git_hash='66d3819c0d', name='weaviate-2', shards=[Shard(collection='Movies2', name='Z0iJlaEvYyGP', node='weaviate-2', object_count=0, vector_indexing_status='READY', vector_queue_length=0, compressed=False, loaded=True)], stats=Stats(object_count=0, shard_count=1), status='HEALTHY', version='1.28.3')]
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
