### PR TITLE
RBAC: Reduce amount of authorizer calls for reference batch

### DIFF
--- a/test/acceptance/authz/batch_refs_test.go
+++ b/test/acceptance/authz/batch_refs_test.go
@@ -33,8 +33,6 @@ func TestAuthZBatchRefAuthZCalls(t *testing.T) {
 	containers := compose.Containers()
 	require.Len(t, containers, 1) // started only one node
 
-	// helper.SetupClient("127.0.0.1:8081")
-
 	// add classes with object
 	className1 := "AuthZBatchObjREST1"
 	className2 := "AuthZBatchObjREST2"

--- a/test/acceptance/authz/batch_refs_test.go
+++ b/test/acceptance/authz/batch_refs_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package authz
 
 import (

--- a/test/acceptance/authz/batch_refs_test.go
+++ b/test/acceptance/authz/batch_refs_test.go
@@ -76,5 +76,5 @@ func TestAuthZBatchRefAuthZCalls(t *testing.T) {
 	require.NotNil(t, res.Payload)
 
 	authZlogs := ls.GetAuthzLogs(t)
-	t.Log("batch ref created", len(authZlogs), "calls to authorizer")
+	require.LessOrEqual(t, len(authZlogs), 4)
 }

--- a/test/acceptance/authz/batch_refs_test.go
+++ b/test/acceptance/authz/batch_refs_test.go
@@ -1,0 +1,80 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestAuthZBatchRefAuthZCalls(t *testing.T) {
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	adminAuth := helper.CreateAuth(adminKey)
+
+	compose, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{}, nil)
+	defer down()
+
+	containers := compose.Containers()
+	require.Len(t, containers, 1) // started only one node
+
+	// helper.SetupClient("127.0.0.1:8081")
+
+	// add classes with object
+	className1 := "AuthZBatchObjREST1"
+	className2 := "AuthZBatchObjREST2"
+	deleteObjectClass(t, className1, adminAuth)
+	deleteObjectClass(t, className2, adminAuth)
+	defer deleteObjectClass(t, className1, adminAuth)
+	defer deleteObjectClass(t, className2, adminAuth)
+
+	c1 := &models.Class{
+		Class: className1,
+		Properties: []*models.Property{
+			{
+				Name:     "ref",
+				DataType: []string{className2},
+			},
+		},
+	}
+	c2 := &models.Class{
+		Class: className2,
+		Properties: []*models.Property{
+			{
+				Name:     "prop2",
+				DataType: schema.DataTypeText.PropString(),
+			},
+		},
+	}
+	require.Nil(t, createClass(t, c2, adminAuth))
+	require.Nil(t, createClass(t, c1, adminAuth))
+
+	// add an object to each class
+	helper.CreateObjectAuth(t, &models.Object{ID: UUID1, Class: className1}, adminKey)
+	helper.CreateObjectAuth(t, &models.Object{ID: UUID1, Class: className2}, adminKey)
+
+	ls := newLogScanner(containers[0].Container())
+	ls.GetAuthzLogs(t) // startup and object class creation logs that are irrelevant
+
+	from := beaconStart + className1 + "/" + UUID1.String() + "/ref"
+	to := beaconStart + UUID1
+
+	var refs []*models.BatchReference
+	for i := 0; i < 30; i++ {
+		refs = append(refs, &models.BatchReference{
+			From: strfmt.URI(from), To: strfmt.URI(to),
+		})
+	}
+
+	params := batch.NewBatchReferencesCreateParams().WithBody(refs)
+	res, err := helper.Client(t).Batch.BatchReferencesCreate(params, adminAuth)
+	require.NoError(t, err)
+	require.NotNil(t, res.Payload)
+
+	authZlogs := ls.GetAuthzLogs(t)
+	t.Log("batch ref created", len(authZlogs), "calls to authorizer")
+}

--- a/test/acceptance/authz/rbac_auto_admin_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_admin_permissions_test.go
@@ -12,9 +12,7 @@
 package authz
 
 import (
-	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -22,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
 )
@@ -137,40 +134,4 @@ func (e endpointStatsSlice) String() string {
 		str += e.String() + "\n"
 	}
 	return str
-}
-
-type logScanner struct {
-	container testcontainers.Container
-	pos       int
-}
-
-func newLogScanner(c testcontainers.Container) *logScanner {
-	return &logScanner{container: c}
-}
-
-func (s *logScanner) GetAuthzLogs(t *testing.T) []string {
-	t.Helper() // produces more accurate error tracebacks
-
-	logs, err := s.container.Logs(context.Background())
-	require.Nil(t, err)
-	defer logs.Close()
-
-	scanner := bufio.NewScanner(logs)
-	currentPosition := 0
-
-	var newLines []string
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-		if currentPosition >= s.pos && strings.Contains(line, `"action":"authorize"`) {
-			newLines = append(newLines, line)
-		}
-		currentPosition++
-	}
-
-	s.pos = currentPosition
-
-	return newLines
 }

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -329,7 +329,7 @@ func getReferenceClasses(ctx context.Context,
 	if !ok {
 		targetVclasses, err2 := schemaManager.GetCachedClass(ctx, principal, toClassName)
 		if err2 != nil {
-			err = fmt.Errorf("get target class %q: %w", toClassName, err)
+			err = fmt.Errorf("get target class %q: %w", toClassName, err2)
 			return
 		}
 		toClass = targetVclasses[toClassName]

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -154,7 +154,7 @@ func (req *DeleteReferenceInput) validate(
 		return nil, 0, err
 	}
 	vclass := vclasses[req.Class]
-	return vclass.Class, vclass.Version, validateReferenceSchema(sm, vclass.Class, req.Property)
+	return vclass.Class, vclass.Version, validateReferenceSchema(vclass.Class, req.Property)
 }
 
 // removeReference removes ref from object obj with property prop.

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -159,7 +159,7 @@ func (req *PutReferenceInput) validate(
 	}
 
 	vclass := vclasses[req.Class]
-	return refs, vclass.Version, validateReferenceSchema(sm, vclass.Class, req.Property)
+	return refs, vclass.Version, validateReferenceSchema(vclass.Class, req.Property)
 }
 
 func (req *PutReferenceInput) validateExistence(
@@ -186,13 +186,14 @@ func validateReferenceName(class, property string) error {
 	return nil
 }
 
-func validateReferenceSchema(sm schemaManager, c *models.Class, property string) error {
+func validateReferenceSchema(c *models.Class, property string) error {
 	prop, err := schema.GetPropertyByName(c, property)
 	if err != nil {
 		return err
 	}
 
-	dt, err := schema.FindPropertyDataTypeWithRefs(sm.ReadOnlyClass, prop.DataType, false, "")
+	classGetterFunc := func(string) *models.Class { return c }
+	dt, err := schema.FindPropertyDataTypeWithRefs(classGetterFunc, prop.DataType, false, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What's being changed:

Get the classes at the top of the call stack once and pass them down instead of re-getting them everytime we need it. Each class-get is authorized and results in a call to the authorizer. 

Before:   batch ref created 151 calls to authorizer
After:   batch ref created 4 calls to authorizer

for a batch ref request with 30 refs with different from and to classes.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
  - e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/12886578853
  - chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/12886592820
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
