### PR TITLE
Rbac: less calls to authorizer for object endpoint

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -89,8 +89,7 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 	className := getClassName(params.Body)
 
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
-	object, err := h.manager.AddObject(ctx,
-		principal, params.Body, repl)
+	object, err := h.manager.AddObject(ctx, principal, params.Body, repl)
 	if err != nil {
 		h.metricRequestsTotal.logError(className, err)
 		if errors.As(err, &uco.ErrInvalidUserInput{}) {

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -40,12 +40,8 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(object.Class)
 	object.Class = className
-	tenant := "*"
-	if object.Tenant != "" {
-		tenant = object.Tenant
-	}
 
-	if err := m.authorizer.Authorize(principal, authorization.CREATE, authorization.ShardsData(className, tenant)...); err != nil {
+	if err := m.authorizer.Authorize(principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -17,10 +17,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/weaviate/weaviate/entities/classcache"
+
 	"github.com/go-openapi/strfmt"
 
 	"github.com/weaviate/weaviate/entities/additional"
-	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
@@ -39,10 +40,6 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(class)...); err != nil {
-		return err
-	}
-
 	ctx = classcache.ContextWithClassCache(ctx)
 
 	unlock, err := m.locks.LockConnector()

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -16,10 +16,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/weaviate/weaviate/entities/classcache"
+
 	"github.com/go-openapi/strfmt"
 
 	"github.com/weaviate/weaviate/entities/additional"
-	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
@@ -55,6 +56,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	className := schema.UppercaseClassName(updates.Class)
 	updates.Class = className
 
+	ctx = classcache.ContextWithClassCache(ctx)
 	fetchedClass, err := m.schemaManager.GetCachedClass(ctx, principal, className)
 	if err != nil {
 		if errors.As(err, &authzerrs.Forbidden{}) {
@@ -72,7 +74,6 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{err.Error(), StatusInternalServerError, err}
 	}
 
-	ctx = classcache.ContextWithClassCache(ctx)
 	obj, err := m.vectorRepo.Object(ctx, cls, id, nil, additional.Properties{}, repl, updates.Tenant)
 	if err != nil {
 		switch {

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -15,12 +15,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/weaviate/weaviate/entities/classcache"
+
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/versioned"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/additional"
-	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -40,6 +41,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	className := schema.UppercaseClassName(updates.Class)
 	updates.Class = className
 
+	ctx = classcache.ContextWithClassCache(ctx)
 	fetchedClasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
 	if err != nil {
 		return nil, err
@@ -47,8 +49,6 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 
 	m.metrics.UpdateObjectInc()
 	defer m.metrics.UpdateObjectDec()
-
-	ctx = classcache.ContextWithClassCache(ctx)
 
 	unlock, err := m.locks.LockSchema()
 	if err != nil {

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -15,10 +15,11 @@ import (
 	"context"
 	"errors"
 
+	"github.com/weaviate/weaviate/entities/classcache"
+
 	"github.com/weaviate/weaviate/entities/schema"
 
 	"github.com/weaviate/weaviate/entities/additional"
-	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
@@ -36,6 +37,8 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	if err != nil {
 		return err
 	}
+
+	ctx = classcache.ContextWithClassCache(ctx)
 	fetchedClasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
 	if err != nil {
 		return err
@@ -47,7 +50,6 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	}
 	defer unlock()
 
-	ctx = classcache.ContextWithClassCache(ctx)
 	err = m.validateObjectAndNormalizeNames(ctx, repl, obj, nil, fetchedClasses)
 	if err != nil {
 		var forbidden autherrs.Forbidden


### PR DESCRIPTION
### What's being changed:

Same as the other PRs: Get the class definition once (which includes the authz check) and reuse it afterwards

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
  - chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/12904171710
  - e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/12904163418
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
