### PR TITLE
linter: introduce forbidigo linter to catch fmt.Print* and cleanup 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,22 @@ linters:
     - govet
     - unused
     - nolintlint
+    - forbidigo
 linters-settings:
+  forbidigo:
+    # Forbid the following identifiers (list of regexp).
+    # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
+    forbid:
+      # Built-in bootstrapping functions.
+      - ^print(ln)?$
+      # Optional message that gets included in error reports.
+      - p: ^fmt\.Print.*$
+        msg: Do not commit print statements.      
+    # Exclude godoc examples from forbidigo checks.
+    # Default: true
+    exclude-godoc-examples: true
+
+
   exhaustive:
     # Presence of "default" case in switch statements satisfies exhaustiveness,
     # even if all enum members are not listed.
@@ -73,6 +88,22 @@ issues:
         - unused
       path: adapters/repos/db/vector/hnsw/distancer/asm/l2_inline.go
       text: "func `l2[35]`"
+    - linters: # exclude tests
+        - forbidigo
+      path: test/*
+    - linters: # exclude tools
+        - forbidigo
+      path: tools/*
+    - linters: # exclude file
+        - forbidigo
+      path: cmd/libweaviate/libweaviate.go
+    - linters: # exclude file
+        - forbidigo
+      path: adapters/repos/db/vector/hnsw/debug.go
+    - linters: # exclude file
+        - forbidigo
+      path: adapters/repos/db/vector/.*/dump.go
+
 
 run:
   timeout: 5m

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	reposdb "github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -1191,7 +1192,12 @@ func (i *indices) postShardFile() http.Handler {
 			return
 		}
 
-		fmt.Printf("%s/%s/%s n=%d\n", index, shard, filename, n)
+		i.logger.WithFields(logrus.Fields{
+			"index":    index,
+			"shard":    shard,
+			"fileName": filename,
+			"n":        n,
+		}).Debug()
 
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -1200,7 +1206,6 @@ func (i *indices) postShardFile() http.Handler {
 func (i *indices) postShard() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		args := i.regexpShard.FindStringSubmatch(r.URL.Path)
-		fmt.Println(args)
 		if len(args) != 3 {
 			http.Error(w, "invalid URI", http.StatusBadRequest)
 			return
@@ -1221,7 +1226,6 @@ func (i *indices) postShard() http.Handler {
 func (i *indices) putShardReinit() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		args := i.regexpShardReinit.FindStringSubmatch(r.URL.Path)
-
 		if len(args) != 3 {
 			http.Error(w, "invalid URI", http.StatusBadRequest)
 			return

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -242,7 +243,6 @@ func (i *replicatedIndices) executeCommitPhase() http.Handler {
 func (i *replicatedIndices) increaseReplicationFactor() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		args := regxIncreaseRepFactor.FindStringSubmatch(r.URL.Path)
-		fmt.Printf("path: %v, args: %+v", r.URL.Path, args)
 		if len(args) != 2 {
 			http.Error(w, "invalid URI", http.StatusBadRequest)
 			return

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1245,7 +1245,7 @@ func setupGoProfiling(config config.Config, logger logrus.FieldLogger) {
 		portNumber := config.Profiling.Port
 		if portNumber == 0 {
 			if err := http.ListenAndServe(":6060", nil); err != nil {
-				logger.Error("error listinening and server :6060 : %w", err)
+				logger.Error("error listinening and serve :6060 : %w", err)
 			}
 		} else {
 			http.ListenAndServe(fmt.Sprintf(":%d", portNumber), nil)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -26,9 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weaviate/fgprof"
-
 	"github.com/KimMachineGun/automemlimit/memlimit"
+	"github.com/getsentry/sentry-go"
 	openapierrors "github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
@@ -36,6 +35,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/fgprof"
 	"github.com/weaviate/weaviate/adapters/clients"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
@@ -47,11 +48,10 @@ import (
 	modulestorage "github.com/weaviate/weaviate/adapters/repos/modules"
 	schemarepo "github.com/weaviate/weaviate/adapters/repos/schema"
 	rCluster "github.com/weaviate/weaviate/cluster"
-	vectorIndex "github.com/weaviate/weaviate/entities/vectorindex"
-
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/entities/replication"
+	vectorIndex "github.com/weaviate/weaviate/entities/vectorindex"
 	modstgazure "github.com/weaviate/weaviate/modules/backup-azure"
 	modstgfs "github.com/weaviate/weaviate/modules/backup-filesystem"
 	modstggcs "github.com/weaviate/weaviate/modules/backup-gcs"
@@ -111,8 +111,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/telemetry"
 	"github.com/weaviate/weaviate/usecases/traverser"
-
-	"github.com/getsentry/sentry-go"
 )
 
 const MinimumRequiredContextionaryVersion = "1.0.2"
@@ -1246,7 +1244,9 @@ func setupGoProfiling(config config.Config, logger logrus.FieldLogger) {
 	enterrors.GoWrapper(func() {
 		portNumber := config.Profiling.Port
 		if portNumber == 0 {
-			fmt.Println(http.ListenAndServe(":6060", nil))
+			if err := http.ListenAndServe(":6060", nil); err != nil {
+				logger.Error("error listinening and server :6060 : %w", err)
+			}
 		} else {
 			http.ListenAndServe(fmt.Sprintf(":%d", portNumber), nil)
 		}

--- a/adapters/repos/db/helpers/slow_queries.go
+++ b/adapters/repos/db/helpers/slow_queries.go
@@ -38,16 +38,10 @@ type BaseSlowReporter struct {
 }
 
 func NewSlowQueryReporterFromEnv(logger logrus.FieldLogger) SlowQueryReporter {
-	if logger == nil {
-		fmt.Println("Unexpected nil logger for SlowQueryReporter. Reporter disabled.")
-		return &NoopSlowReporter{}
-	}
-
 	enabled := false
 	if enabledStr, ok := os.LookupEnv(enabledEnvVar); ok {
 		// TODO: Log warning if bool can't be parsed
 		enabled, _ = strconv.ParseBool(enabledStr)
-		fmt.Println("en", enabledStr, enabled)
 	}
 	if !enabled {
 		return &NoopSlowReporter{}

--- a/adapters/repos/db/vector/dynamic/dump.go
+++ b/adapters/repos/db/vector/dynamic/dump.go
@@ -1,0 +1,27 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package dynamic
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (dynamic *dynamic) Dump(labels ...string) {
+	if len(labels) > 0 {
+		fmt.Printf("--------------------------------------------------\n")
+		fmt.Printf("--  %s\n", strings.Join(labels, ", "))
+	}
+	fmt.Printf("--------------------------------------------------\n")
+	fmt.Printf("ID: %s\n", dynamic.id)
+	fmt.Printf("--------------------------------------------------\n")
+}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -14,18 +14,18 @@ package dynamic
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"math"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 
+	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
@@ -39,7 +39,6 @@ import (
 	ent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/monitoring"
-	bolt "go.etcd.io/bbolt"
 )
 
 const composerUpgradedKey = "upgraded"
@@ -315,16 +314,6 @@ func (dynamic *dynamic) PostStartup() {
 	dynamic.Lock()
 	defer dynamic.Unlock()
 	dynamic.index.PostStartup()
-}
-
-func (dynamic *dynamic) Dump(labels ...string) {
-	if len(labels) > 0 {
-		fmt.Printf("--------------------------------------------------\n")
-		fmt.Printf("--  %s\n", strings.Join(labels, ", "))
-	}
-	fmt.Printf("--------------------------------------------------\n")
-	fmt.Printf("ID: %s\n", dynamic.id)
-	fmt.Printf("--------------------------------------------------\n")
 }
 
 func (dynamic *dynamic) DistanceBetweenVectors(x, y []float32) (float32, error) {

--- a/adapters/repos/db/vector/flat/dump.go
+++ b/adapters/repos/db/vector/flat/dump.go
@@ -1,0 +1,27 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (index *flat) Dump(labels ...string) {
+	if len(labels) > 0 {
+		fmt.Printf("--------------------------------------------------\n")
+		fmt.Printf("--  %s\n", strings.Join(labels, ", "))
+	}
+	fmt.Printf("--------------------------------------------------\n")
+	fmt.Printf("ID: %s\n", index.id)
+	fmt.Printf("--------------------------------------------------\n")
+}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -19,13 +19,13 @@ import (
 	"math"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
@@ -768,16 +768,6 @@ func (index *flat) PostStartup() {
 		"took":     took,
 		"index_id": index.id,
 	}).Debugf("pre-loaded %d vectors in %s", count, took)
-}
-
-func (index *flat) Dump(labels ...string) {
-	if len(labels) > 0 {
-		fmt.Printf("--------------------------------------------------\n")
-		fmt.Printf("--  %s\n", strings.Join(labels, ", "))
-	}
-	fmt.Printf("--------------------------------------------------\n")
-	fmt.Printf("ID: %s\n", index.id)
-	fmt.Printf("--------------------------------------------------\n")
 }
 
 func (index *flat) DistanceBetweenVectors(x, y []float32) (float32, error) {

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/qna-openai/config"
 	"github.com/weaviate/weaviate/modules/qna-openai/ent"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
 )
 
 func buildUrl(baseURL, resourceName, deploymentID string) (string, error) {
@@ -88,7 +88,8 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 	if err != nil {
 		return nil, errors.Wrap(err, "join OpenAI API host and path")
 	}
-	fmt.Printf("using the OpenAI URL: %v\n", oaiUrl)
+	v.logger.WithField("URL", oaiUrl).Info("using OpenAI")
+
 	req, err := http.NewRequestWithContext(ctx, "POST", oaiUrl,
 		bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
### What's being changed:
- Use of [forbidigo](https://golangci-lint.run/usage/linters/#forbidigo) linter to detect any `fmt.Print()` or `fmt.Println()` on PRs 
- Clean up existed code 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
