### PR TITLE
fix late interaction score

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -855,7 +855,7 @@ func (h *hnsw) computeLateInteraction(queryVectors [][]float32, k int, candidate
 	for resultsQueue.Len() > 0 {
 		element := resultsQueue.Pop()
 		ids[i] = element.ID
-		distances[i] = element.Dist
+		distances[i] = -element.Dist
 		i--
 	}
 


### PR DESCRIPTION
### What's being changed:
This PR changes the sign of late interaction score for multivector indexes. 
The MaxSim score is a similarity measure, not a distance measure. So a higher value means high similarity.  But to keep the same logic as the others distance metrics (e.g. Euclidean distance), smaller values corresponds to a high similarity.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
