### PR TITLE
RBAC: Reduce authorizer calls for reference endpoints

### DIFF
--- a/entities/versioned/class.go
+++ b/entities/versioned/class.go
@@ -19,3 +19,5 @@ type Class struct {
 	*models.Class
 	Version uint64
 }
+
+type Classes map[string]Class

--- a/test/acceptance/authz/swagger_helper.go
+++ b/test/acceptance/authz/swagger_helper.go
@@ -233,6 +233,28 @@ func generateValidData(schema *spec.Schema, definitions map[string]spec.Schema) 
 				return jsonData, nil
 			}
 
+			if strings.Contains(itemSchema.Ref.String(), "SingleRef") {
+				ref := &models.SingleRef{
+					Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/ABC/%s", uuid.New().String())),
+				}
+				jsonData, err := json.Marshal(ref)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal mock data: %w", err)
+				}
+				return jsonData, nil
+			}
+
+			if strings.Contains(itemSchema.Ref.String(), "MultipleRef") {
+				ref := &models.MultipleRef{
+					&models.SingleRef{Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/ABC/%s", uuid.New().String()))},
+				}
+				jsonData, err := json.Marshal(ref)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal mock data: %w", err)
+				}
+				return jsonData, nil
+			}
+
 			if itemSchema.Ref.String() != "" {
 				refSchema, err := resolveReference(itemSchema.Ref.String(), definitions)
 				if err != nil {

--- a/test/acceptance/authz/swagger_helper.go
+++ b/test/acceptance/authz/swagger_helper.go
@@ -147,6 +147,18 @@ func generateValidRequestBody(param *spec.Parameter, definitions map[string]spec
 }
 
 func generateValidData(schema *spec.Schema, definitions map[string]spec.Schema) ([]byte, error) {
+	// needs to be at the top, because it contains a SingleRef
+	if strings.Contains(schema.Ref.String(), "MultipleRef") {
+		ref := &models.MultipleRef{
+			&models.SingleRef{Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/ABC/%s", uuid.New().String()))},
+		}
+		jsonData, err := json.Marshal(ref)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal mock data: %w", err)
+		}
+		return jsonData, nil
+	}
+
 	if schema.Ref.String() != "" {
 		ref := schema.Ref.String()
 
@@ -227,28 +239,6 @@ func generateValidData(schema *spec.Schema, definitions map[string]spec.Schema) 
 				array = append(array, batch)
 				mockData = array
 				jsonData, err := json.Marshal(mockData)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal mock data: %w", err)
-				}
-				return jsonData, nil
-			}
-
-			if strings.Contains(itemSchema.Ref.String(), "SingleRef") {
-				ref := &models.SingleRef{
-					Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/ABC/%s", uuid.New().String())),
-				}
-				jsonData, err := json.Marshal(ref)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal mock data: %w", err)
-				}
-				return jsonData, nil
-			}
-
-			if strings.Contains(itemSchema.Ref.String(), "MultipleRef") {
-				ref := &models.MultipleRef{
-					&models.SingleRef{Beacon: strfmt.URI(fmt.Sprintf("weaviate://localhost/ABC/%s", uuid.New().String()))},
-				}
-				jsonData, err := json.Marshal(ref)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal mock data: %w", err)
 				}

--- a/test/acceptance_with_python/rbac/test_rbac_refs.py
+++ b/test/acceptance_with_python/rbac/test_rbac_refs.py
@@ -43,7 +43,7 @@ def test_rbac_refs(
 
     required_permissions = [
         Permissions.collections(collection=[source.name, target.name], read_config=True),
-        Permissions.data(collection=source.name, update=True),
+        Permissions.data(collection=[source.name, target.name], update=True, read=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(

--- a/usecases/objects/references.go
+++ b/usecases/objects/references.go
@@ -57,3 +57,20 @@ func (m *Manager) getAuthorizedFromClass(ctx context.Context, principal *models.
 
 	return fetchedClass[className].Class, fetchedClass[className].Version, fetchedClass, nil
 }
+
+// validateNames validates class and property names
+func validateReferenceName(class, property string) error {
+	if _, err := schema.ValidateClassName(class); err != nil {
+		return err
+	}
+
+	if err := schema.ValidateReservedPropertyName(property); err != nil {
+		return err
+	}
+
+	if _, err := schema.ValidatePropertyName(property); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -65,6 +65,10 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		input.Class = objectRes.Object().Class
 	}
 
+	if err := validateReferenceName(input.Class, input.Property); err != nil {
+		return &Error{err.Error(), StatusBadRequest, err}
+	}
+
 	class, schemaVersion, fetchedClass, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
 	if typedErr != nil {
 		return typedErr
@@ -178,9 +182,6 @@ func (req *AddReferenceInput) validate(
 	v *validation.Validator,
 	class *models.Class,
 ) (*crossref.Ref, error) {
-	if err := validateReferenceName(req.Class, req.Property); err != nil {
-		return nil, err
-	}
 	ref, err := v.ValidateSingleRef(&req.Ref)
 	if err != nil {
 		return nil, err

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -65,13 +65,10 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		input.Class = objectRes.Object().Class
 	}
 
-	fetchedClass, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
+	class, schemaVersion, fetchedClass, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
 	if typedErr != nil {
 		return typedErr
 	}
-
-	schemaVersion := fetchedClass[input.Class].Version
-	class := fetchedClass[input.Class].Class
 
 	unlock, err := m.locks.LockSchema()
 	if err != nil {

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -139,7 +139,12 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		_, err = validateReferenceMultiTenancy(ctx, principal,
 			m.schemaManager, m.vectorRepo, source, target, tenant, fetchedClass)
 		if err != nil {
-			return &Error{"multi-tenancy violation", StatusInternalServerError, err}
+			switch {
+			case errors.As(err, &autherrs.Forbidden{}):
+				return &Error{"validation", StatusForbidden, err}
+			default:
+				return &Error{"multi-tenancy violation", StatusInternalServerError, err}
+			}
 		}
 	}
 

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -104,6 +104,9 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		}
 	}
 
+	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.ShardsData(targetRef.Class, tenant)...); err != nil {
+		return &Error{err.Error(), StatusForbidden, err}
+	}
 	if err := input.validateExistence(ctx, validator, tenant, targetRef); err != nil {
 		return &Error{"validate existence", StatusBadRequest, err}
 	}

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -71,13 +71,10 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	}
 	input.Class = res.ClassName
 
-	fetchedClass, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
+	class, schemaVersion, _, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
 	if typedErr != nil {
 		return typedErr
 	}
-
-	schemaVersion := fetchedClass[input.Class].Version
-	class := fetchedClass[input.Class].Class
 
 	beacon, err := crossref.Parse(input.Reference.Beacon.String())
 	if err != nil {

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -47,10 +47,6 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 	ctx = classcache.ContextWithClassCache(ctx)
 	input.Class = schema.UppercaseClassName(input.Class)
 
-	if err := validateReferenceName(input.Class, input.Property); err != nil {
-		return &Error{err.Error(), StatusBadRequest, err}
-	}
-
 	if err := m.authorizer.Authorize(principal, authorization.UPDATE, authorization.ShardsData(input.Class, tenant)...); err != nil {
 		return &Error{err.Error(), StatusForbidden, err}
 	}
@@ -74,6 +70,10 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 		return &Error{"source object", StatusInternalServerError, err}
 	}
 	input.Class = res.ClassName
+
+	if err := validateReferenceName(input.Class, input.Property); err != nil {
+		return &Error{err.Error(), StatusBadRequest, err}
+	}
 
 	class, schemaVersion, _, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
 	if typedErr != nil {

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -465,7 +465,7 @@ func Test_ReferenceDelete(t *testing.T) {
 		},
 		{
 			Name: "get schema",
-			Req:  req, Stage: 2,
+			Req:  req, Stage: 1,
 			ErrSchema: anyErr,
 			WantCode:  StatusBadRequest,
 		},
@@ -486,12 +486,12 @@ func Test_ReferenceDelete(t *testing.T) {
 		},
 		{
 			Name: "reserved property name",
-			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "_id"}, Stage: 2,
+			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "_id"}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{
 			Name: "valid property name",
-			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "-"}, Stage: 2,
+			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "-"}, Stage: 1,
 			WantCode: StatusBadRequest,
 		},
 		{

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -486,12 +486,12 @@ func Test_ReferenceDelete(t *testing.T) {
 		},
 		{
 			Name: "reserved property name",
-			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "_id"}, Stage: 1,
+			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "_id"}, Stage: 2,
 			WantCode: StatusBadRequest,
 		},
 		{
 			Name: "valid property name",
-			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "-"}, Stage: 1,
+			Req:  DeleteReferenceInput{Class: cls, ID: id, Property: "-"}, Stage: 2,
 			WantCode: StatusBadRequest,
 		},
 		{

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -76,13 +76,10 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	}
 	input.Class = res.ClassName
 
-	fetchedClass, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
+	class, schemaVersion, _, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
 	if typedErr != nil {
 		return typedErr
 	}
-
-	schemaVersion := fetchedClass[input.Class].Version
-	class := fetchedClass[input.Class].Class
 
 	unlock, err := m.locks.LockSchema()
 	if err != nil {

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -76,6 +76,10 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 	}
 	input.Class = res.ClassName
 
+	if err := validateReferenceName(input.Class, input.Property); err != nil {
+		return &Error{err.Error(), StatusBadRequest, err}
+	}
+
 	class, schemaVersion, _, typedErr := m.getAuthorizedFromClass(ctx, principal, input.Class)
 	if typedErr != nil {
 		return typedErr
@@ -149,9 +153,6 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 }
 
 func (req *PutReferenceInput) validate(v *validation.Validator, class *models.Class) ([]*crossref.Ref, error) {
-	if err := validateReferenceName(req.Class, req.Property); err != nil {
-		return nil, err
-	}
 	refs, err := v.ValidateMultipleRef(req.Refs)
 	if err != nil {
 		return nil, err
@@ -165,23 +166,6 @@ func (req *PutReferenceInput) validateExistence(
 	v *validation.Validator, tenant string, ref *crossref.Ref,
 ) error {
 	return v.ValidateExistence(ctx, ref, "validate reference", tenant)
-}
-
-// validateNames validates class and property names
-func validateReferenceName(class, property string) error {
-	if _, err := schema.ValidateClassName(class); err != nil {
-		return err
-	}
-
-	if err := schema.ValidateReservedPropertyName(property); err != nil {
-		return err
-	}
-
-	if _, err := schema.ValidatePropertyName(property); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func validateReferenceSchema(c *models.Class, property string) error {

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -133,9 +133,7 @@ func (v *Validator) ValidateExistence(ctx context.Context, ref *crossref.Ref, er
 	return nil
 }
 
-func (v *Validator) ValidateMultipleRef(ctx context.Context, refs models.MultipleRef,
-	errorVal string, tenant string,
-) ([]*crossref.Ref, error) {
+func (v *Validator) ValidateMultipleRef(refs models.MultipleRef) ([]*crossref.Ref, error) {
 	parsedRefs := make([]*crossref.Ref, len(refs))
 
 	if refs == nil {


### PR DESCRIPTION
### What's being changed:

Same as the other PRs: Get the class definition once (which includes the authz check) and reuse it afterwards

I changed the authZ checks for the target collection to:
- remove for reference_delete => we don't validate anything here, just loop through the existing refs
- switch from Metadata to Data for reference_add/update => we check that the referenced object exists 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
