### PR TITLE
chore: Add root level `Makefile`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,91 @@
+SHELL:=/usr/bin/env bash -o pipefail
+
+# Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
+# .PHONY: help
+help:
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := weaviate
+
+GO_VERSION         := 1.22.0
+
+# Git tags
+GIT_REVISION       := $(shell git rev-parse --short HEAD)
+GIT_BRANCH         := $(shell git rev-parse --abbrev-ref HEAD)
+
+# Golang environment
+GOOS               ?= $(shell go env GOOS)
+GOHOSTOS           ?= $(shell go env GOHOSTOS)
+GOARCH             ?= $(shell go env GOARCH)
+GOARM              ?= $(shell go env GOARM)
+GOEXPERIMENT       ?= $(shell go env GOEXPERIMENT)
+CGO_ENABLED        := 0
+GO_ENV             := GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED)
+GOTEST             ?= go test
+
+# Golang Build flags
+VPREFIX            := github.com/weaviate/weaviate/usecases/build
+GO_LDFLAGS         := -X $(VPREFIX).Branch=$(GIT_BRANCH) \
+                      -X $(VPREFIX).Revision=$(GIT_REVISION) \
+                      -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) \
+                      -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+GO_FLAGS           := -ldflags "-extldflags \"-static\" -s -w $(GO_LDFLAGS)" -tags netgo
+DYN_GO_FLAGS       := -ldflags "-s -w $(GO_LDFLAGS)" -tags netgo
+
+# Debug build flags
+DEBUG_GO_FLAGS     := -gcflags "all=-N -l" -ldflags "-extldflags \"-static\" $(GO_LDFLAGS)" -tags netgo
+DEBUG_DYN_GO_FLAGS := -gcflags "all=-N -l" -ldflags "$(GO_LDFLAGS)" -tags netgo
+
+# Docker images
+IMAGE_PREFIX           ?= semitechnologies
+IMAGE_TAG              ?= $(shell jq -r '.info.version' < openapi-specs/schema.json)
+WEAVIATE_IMAGE         ?= $(IMAGE_PREFIX)/weaviate:$(IMAGE_TAG)
+
+# OCI (Docker) setup
+OCI_PLATFORMS  := --platform=linux/amd64,linux/arm64
+OCI_BUILD_ARGS := --build-arg GO_VERSION=$(GO_VERSION) --build-arg BUILD_IMAGE=$(BUILD_IMAGE)
+OCI_PUSH_ARGS  := -o type=registry
+OCI_PUSH       := docker push
+OCI_TAG        := docker tag
+
+ifeq ($(CI),true)
+  # buildx is used on the CI for cross-platform builds
+	_               := $(shell ./tools/ensure-buildx-builder.sh)
+	OCI_BUILD       := DOCKER_BUILDKIT=1 docker buildx build $(OCI_PLATFORMS) $(OCI_BUILD_ARGS)
+else
+	OCI_BUILD       := DOCKER_BUILDKIT=1 docker build $(OCI_BUILD_ARGS)
+endif
+
+
+# Weaviate binary
+.PHONY: cmd/weaviate-server/weaviate
+
+weaviate: cmd/weaviate-server/weaviate ## Build weaviate binary (Default)
+weaviate-debug: cmd/weaviate-server/weaviate-debug ## Build weaviate-debug binary
+
+cmd/weaviate-server/weaviate:
+	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
+
+cmd/weaviate-server/weaviate-debug:
+	CGO_ENABLED=0 go build $(DEBUG_GO_FLAGS) -o $@ ./$(@D)
+
+# Weaviate OCI (Docker) images
+weaviate-image: ## Build weaviate OCI (Docker) image
+	$(OCI_BUILD) -t $(WEAVIATE_IMAGE) -f Dockerfile .
+
+# Run tests
+test: weaviate ## Run all unit test cases
+	./test/run.sh -u
+
+# ideally we need to separate everything except unit tests cases with build tags `go:build integration` or something similar. But not there yet. We can do it incrementally.
+test-integration: ## Run all the integration tests
+	./test/run.sh -i
+
+contextionary: ## Run the contextionary embedding server
+	./tools/dev/restart_dev_environment.sh
+
+monitoring: ## Run the prometheus and grafana for monitoring
+	./tools/dev/restart_dev_environment.sh --prometheus
+
+local: ## Run the local development setup with single node
+	./tools/dev/run_dev_server.sh local-single-node


### PR DESCRIPTION
### What's being changed:
Add root level makefile. Primary goal is have single way to "build", "run", "test" weaviate artifacts. Both in local, CI, etc.

This is just the simple basic targets I added that are part of my everyday workflows. Feel free to extend it.

<img width="999" alt="Screenshot 2025-01-22 at 11 26 03" src="https://github.com/user-attachments/assets/1ee72b4e-bbde-4caf-95dc-01fc2e7d46ec" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
