### PR TITLE
shutdown before replacing buckets to avoid race condition

### DIFF
--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -453,8 +453,6 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 
 
 	replacementBucket.flushLock.Lock()
-	replacementBucket.disk.maintenanceLock.Lock()
-
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
 		replacementBucket.disk.maintenanceLock.Unlock()
 		replacementBucket.flushLock.Unlock()
@@ -467,9 +465,8 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		s.bucketAccessLock.Unlock()
 		return errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
 	}
-	replacementBucket.disk.maintenanceLock.Unlock()
 	replacementBucket.flushLock.Unlock()
-	
+
 
 	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
 	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -430,7 +430,6 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	s.bucketAccessLock.Lock()
 	defer s.bucketAccessLock.Unlock()
 
-
 	bucket := s.bucketsByName[bucketName]
 	if bucket == nil {
 		return fmt.Errorf("bucket '%s' not found", bucketName)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -412,6 +412,39 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 	return nil
 }
 
+func (s *Store) doRename(ctx context.Context,replacementBucket *Bucket, replacementBucketName string,  bucket *Bucket, bucketName string) (string, string, string, error) {
+	replacementBucket.disk.maintenanceLock.Lock()
+	defer replacementBucket.disk.maintenanceLock.Unlock()
+
+	currBucketDir := bucket.dir
+	newBucketDir := bucket.dir + "___del"
+	currReplacementBucketDir := replacementBucket.dir
+	newReplacementBucketDir := currBucketDir
+
+	if err := bucket.Shutdown(ctx); err != nil {
+
+		replacementBucket.disk.maintenanceLock.Unlock()
+		return "","", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
+	}
+
+	s.logger.WithField("action", "lsm_replace_bucket").
+		WithField("bucket", bucketName).
+		WithField("replacement_bucket", replacementBucketName).
+		WithField("dir", s.dir).
+		Info("replacing bucket")
+
+	replacementBucket.flushLock.Lock()
+	defer replacementBucket.flushLock.Unlock()
+	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
+		return "","", "", errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
+	}
+	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
+		return "","", "", errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
+	}
+
+	return currBucketDir, newBucketDir, currReplacementBucketDir, nil
+}
+
 // Replaces 1st bucket with 2nd one. Both buckets have to registered in bucketsByName.
 // 2nd bucket swaps the 1st one in bucketsByName using 1st one's name, 2nd one's name is deleted.
 // Dir path of 2nd bucket is changed to dir of 1st bucket as well as all other related paths of
@@ -442,39 +475,12 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	s.bucketsByName[bucketName] = replacementBucket
 	delete(s.bucketsByName, replacementBucketName)
 
-	replacementBucket.disk.maintenanceLock.Lock()
-
-	currBucketDir := bucket.dir
-	newBucketDir := bucket.dir + "___del"
-	currReplacementBucketDir := replacementBucket.dir
-	newReplacementBucketDir := currBucketDir
-
-	if err := bucket.Shutdown(ctx); err != nil {
-
-		replacementBucket.disk.maintenanceLock.Unlock()
-		return errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
+	var currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir string
+	var err error
+	currBucketDir, newBucketDir, currReplacementBucketDir, err = s.doRename(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
+	if err != nil {
+		return errors.Wrapf(err, "failed renaming bucket '%s' to '%s'", bucketName, replacementBucketName)
 	}
-
-	s.logger.WithField("action", "lsm_replace_bucket").
-		WithField("bucket", bucketName).
-		WithField("replacement_bucket", replacementBucketName).
-		WithField("dir", s.dir).
-		Info("replacing bucket")
-
-	replacementBucket.flushLock.Lock()
-	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
-		replacementBucket.disk.maintenanceLock.Unlock()
-		replacementBucket.flushLock.Unlock()
-		return errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
-	}
-	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
-		replacementBucket.disk.maintenanceLock.Unlock()
-		replacementBucket.flushLock.Unlock()
-		return errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
-	}
-
-	replacementBucket.flushLock.Unlock()
-	replacementBucket.disk.maintenanceLock.Unlock()
 
 	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
 	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -412,7 +412,7 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 	return nil
 }
 
-func (s *Store) doRename(ctx context.Context,replacementBucket *Bucket, replacementBucketName string,  bucket *Bucket, bucketName string) (string, string, string, error) {
+func (s *Store) doRename(ctx context.Context, replacementBucket *Bucket, replacementBucketName string, bucket *Bucket, bucketName string) (string, string, string, error) {
 	replacementBucket.disk.maintenanceLock.Lock()
 	defer replacementBucket.disk.maintenanceLock.Unlock()
 
@@ -422,7 +422,7 @@ func (s *Store) doRename(ctx context.Context,replacementBucket *Bucket, replacem
 	newReplacementBucketDir := currBucketDir
 
 	if err := bucket.Shutdown(ctx); err != nil {
-		return "","", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
+		return "", "", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
 	s.logger.WithField("action", "lsm_replace_bucket").
@@ -434,10 +434,10 @@ func (s *Store) doRename(ctx context.Context,replacementBucket *Bucket, replacem
 	replacementBucket.flushLock.Lock()
 	defer replacementBucket.flushLock.Unlock()
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
-		return "","", "", errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
+		return "", "", "", errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
 	}
 	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
-		return "","", "", errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
+		return "", "", "", errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
 	}
 
 	return currBucketDir, newBucketDir, currReplacementBucketDir, nil

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -422,8 +422,6 @@ func (s *Store) doRename(ctx context.Context,replacementBucket *Bucket, replacem
 	newReplacementBucketDir := currBucketDir
 
 	if err := bucket.Shutdown(ctx); err != nil {
-
-		replacementBucket.disk.maintenanceLock.Unlock()
 		return "","", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -412,7 +412,7 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 	return nil
 }
 
-func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, replacementBucketName string, bucket *Bucket, bucketName string) (string, string, string, error) {
+func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, replacementBucketName string, bucket *Bucket, bucketName string) (string, string, string, string, error) {
 	replacementBucket.disk.maintenanceLock.Lock()
 	defer replacementBucket.disk.maintenanceLock.Unlock()
 
@@ -422,7 +422,7 @@ func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, re
 	newReplacementBucketDir := currBucketDir
 
 	if err := bucket.Shutdown(ctx); err != nil {
-		return "", "", ""	, errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
+		return "", "", "", ""	, errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
 	s.logger.WithField("action", "lsm_replace_bucket").
@@ -434,13 +434,13 @@ func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, re
 	replacementBucket.flushLock.Lock()
 	defer replacementBucket.flushLock.Unlock()
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
-		return "", "", "", errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
+		return "", "", "", "", errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
 	}
 	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
-		return "", "", "", errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
+		return "", "", "", "", errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
 	}
 
-	return currBucketDir, newBucketDir, currReplacementBucketDir, nil
+	return currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir, nil
 }
 
 // Replaces 1st bucket with 2nd one. Both buckets have to registered in bucketsByName.
@@ -475,7 +475,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 
 	var currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir string
 	var err error
-	currBucketDir, newBucketDir, currReplacementBucketDir, err = s.replaceBucket(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
+	currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir, err = s.replaceBucket(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
 	if err != nil {
 		return errors.Wrapf(err, "failed renaming bucket '%s' to '%s'", bucketName, replacementBucketName)
 	}

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -451,7 +451,6 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		return errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
-
 	replacementBucket.flushLock.Lock()
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
 		replacementBucket.disk.maintenanceLock.Unlock()
@@ -466,7 +465,6 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		return errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
 	}
 	replacementBucket.flushLock.Unlock()
-
 
 	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
 	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -427,10 +427,10 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		return fmt.Errorf("%w: replacing bucket %q for %q in store %q", ErrAlreadyClosed, bucketName, replacementBucketName, s.dir)
 	}
 
-	fmt.Println("Taking bucketAccessLock")
+	//fmt.Println("Taking bucketAccessLock")
 	s.bucketAccessLock.Lock()
 	defer func () {
-		fmt.Println("Releasing bucketAccessLock")
+		//fmt.Println("Releasing bucketAccessLock")
 		s.bucketAccessLock.Unlock()
 	}()
 
@@ -445,7 +445,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	}
 	s.bucketsByName[bucketName] = replacementBucket
 	delete(s.bucketsByName, replacementBucketName)
-	fmt.Println("Taking maintenanceLock")
+	//fmt.Println("Taking maintenanceLock")
 	replacementBucket.disk.maintenanceLock.Lock()
 
 	currBucketDir := bucket.dir
@@ -454,7 +454,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	newReplacementBucketDir := currBucketDir
 
 	if err := bucket.Shutdown(ctx); err != nil {
-		fmt.Println("Releasing maintenanceLock")
+		//fmt.Println("Releasing maintenanceLock")
 		replacementBucket.disk.maintenanceLock.Lock()
 		return errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
@@ -465,25 +465,25 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		WithField("dir", s.dir).
 		Info("replacing bucket")
 
-		fmt.Println("Taking flushLock")
+	//fmt.Println("Taking flushLock")
 	replacementBucket.flushLock.Lock()
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
-		fmt.Println("Releasing maintenanceLock")
+		//fmt.Println("Releasing maintenanceLock")
 		replacementBucket.disk.maintenanceLock.Unlock()
-		fmt.Println("Releasing flushLock")
+		//fmt.Println("Releasing flushLock")
 		replacementBucket.flushLock.Unlock()
 		return errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
 	}
 	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
-		fmt.Println("Releasing maintenanceLock")
+		//fmt.Println("Releasing maintenanceLock")
 		replacementBucket.disk.maintenanceLock.Unlock()
-		fmt.Println("Releasing flushLock")
+		//fmt.Println("Releasing flushLock")
 		replacementBucket.flushLock.Unlock()
 		return errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
 	}
-	fmt.Println("Releasing flushLock")
+	//fmt.Println("Releasing flushLock")
 	replacementBucket.flushLock.Unlock()
-	fmt.Println("Releasing maintenanceLock")
+	//fmt.Println("Releasing maintenanceLock")
 	replacementBucket.disk.maintenanceLock.Unlock()
 
 	s.updateBucketDir(bucket, currBucketDir, newBucketDir)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -422,7 +422,7 @@ func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, re
 	newReplacementBucketDir := currBucketDir
 
 	if err := bucket.Shutdown(ctx); err != nil {
-		return "", "", "", ""	, errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
+		return "", "", "", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
 	s.logger.WithField("action", "lsm_replace_bucket").

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -531,7 +531,6 @@ func (s *Store) updateBucketDir(bucket *Bucket, bucketDir, newBucketDir string) 
 		return strings.Replace(src, bucketDir, newBucketDir, 1)
 	}
 
-	fmt.Printf("Taking flushLock\n")
 	bucket.flushLock.Lock()
 	bucket.dir = newBucketDir
 	if bucket.active != nil {
@@ -542,15 +541,11 @@ func (s *Store) updateBucketDir(bucket *Bucket, bucketDir, newBucketDir string) 
 		bucket.flushing.path = updatePath(bucket.flushing.path)
 		bucket.flushing.commitlog.path = updatePath(bucket.flushing.commitlog.path)
 	}
-	fmt.Printf("Releasing flushLock\n")
 	bucket.flushLock.Unlock()
-
-	fmt.Println("Taking maintenanceLock")
 	bucket.disk.maintenanceLock.Lock()
 	bucket.disk.dir = newBucketDir
 	for _, segment := range bucket.disk.segments {
 		segment.path = updatePath(segment.path)
 	}
-	fmt.Println("Releasing maintenanceLock")
 	bucket.disk.maintenanceLock.Unlock()
 }

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -451,12 +451,17 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		return errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
+	replacementBucket.flushLock.Lock()
+	replacementBucket.disk.maintenanceLock.Lock()
+
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
 		return errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
 	}
 	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
 		return errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
 	}
+	replacementBucket.flushLock.Unlock()
+	replacementBucket.disk.maintenanceLock.Unlock()
 
 	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
 	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -412,7 +412,7 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 	return nil
 }
 
-func (s *Store) doRename(ctx context.Context, replacementBucket *Bucket, replacementBucketName string, bucket *Bucket, bucketName string) (string, string, string, error) {
+func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, replacementBucketName string, bucket *Bucket, bucketName string) (string, string, string, error) {
 	replacementBucket.disk.maintenanceLock.Lock()
 	defer replacementBucket.disk.maintenanceLock.Unlock()
 
@@ -422,7 +422,7 @@ func (s *Store) doRename(ctx context.Context, replacementBucket *Bucket, replace
 	newReplacementBucketDir := currBucketDir
 
 	if err := bucket.Shutdown(ctx); err != nil {
-		return "", "", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
+		return "", "", ""	, errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
 	s.logger.WithField("action", "lsm_replace_bucket").
@@ -475,7 +475,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 
 	var currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir string
 	var err error
-	currBucketDir, newBucketDir, currReplacementBucketDir, err = s.doRename(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
+	currBucketDir, newBucketDir, currReplacementBucketDir, err = s.replaceBucket(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
 	if err != nil {
 		return errors.Wrapf(err, "failed renaming bucket '%s' to '%s'", bucketName, replacementBucketName)
 	}

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -451,7 +451,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 		return errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
 	}
 
-	s.bucketAccessLock.Lock()
+
 	replacementBucket.flushLock.Lock()
 	replacementBucket.disk.maintenanceLock.Lock()
 
@@ -469,7 +469,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	}
 	replacementBucket.disk.maintenanceLock.Unlock()
 	replacementBucket.flushLock.Unlock()
-	s.bucketAccessLock.Unlock()
+	
 
 	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
 	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)


### PR DESCRIPTION
Tests are failing because a flush is happening during replaceBucket.  This moves the shutdown earlier to prevent the move happening during the flush.


### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
