### PR TITLE
Add Flush() to dynamic integration test

### DIFF
--- a/adapters/repos/db/vector/dynamic/restore_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_integration_test.go
@@ -13,7 +13,6 @@ package dynamic_test
 
 import (
 	"context"
-	"math"
 	"os"
 	"sync"
 	"testing"
@@ -108,11 +107,12 @@ func TestBackup_Integration(t *testing.T) {
 	recall1, _ := recallAndLatency(ctx, queries, k, idx, truths)
 	assert.True(t, recall1 > 0.9)
 
+	assert.Nil(t, idx.Flush())
 	assert.Nil(t, idx.Shutdown(context.Background()))
 	idx, err = dynamic.New(config, uc, store)
 	require.Nil(t, err)
 	idx.PostStartup()
 
 	recall2, _ := recallAndLatency(ctx, queries, k, idx, truths)
-	assert.True(t, math.Abs(float64(recall1-recall2)) <= 0.1)
+	assert.Equal(t, recall1, recall2)
 }


### PR DESCRIPTION
### What's being changed:

Fixes a flaky test that didn't flush the vector index after writing vectors. Normally a shard after each request will flush with `batcher.flushWALs`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
