### PR TITLE
fix: tenant deletion while misconfigured tenant offload module enabled

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -345,10 +345,10 @@ func (s *SchemaManager) DeleteTenants(cmd *command.ApplyRequest, schemaOnly bool
 
 	tenants, err := s.schema.getTenants(cmd.Class, req.Tenants)
 	if err != nil {
-		// error will be caught by schema that's why it's ignored, instead
-		// we log it, the need to this because we have detect tenant status before
-		// deleting them from schema in order in the db layer decide if we shall
-		// send the delete request to cloud provider
+		// error are handled by the updateSchema, so they are ignored here.
+		// Instead, we log the error to detect tenant status before deleting
+		// them from the schema. this allows the database layer to decide whether
+		// to send the delete request to the cloud provider.
 		s.log.WithFields(logrus.Fields{
 			"class":   cmd.Class,
 			"tenants": req.Tenants,

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -35,7 +35,7 @@ type Indexer interface {
 	AddProperty(class string, req api.AddPropertyRequest) error
 	AddTenants(class string, req *api.AddTenantsRequest) error
 	UpdateTenants(class string, req *api.UpdateTenantsRequest) error
-	DeleteTenants(class string, req *api.DeleteTenantsRequest) error
+	DeleteTenants(class string, tenants []*models.Tenant) error
 	UpdateTenantsProcess(class string, req *api.TenantProcessRequest) error
 	UpdateShardStatus(*api.UpdateShardStatusRequest) error
 	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
@@ -77,8 +78,8 @@ func (m *MockSchemaExecutor) UpdateTenantsProcess(class string, req *cmd.TenantP
 	return args.Error(0)
 }
 
-func (m *MockSchemaExecutor) DeleteTenants(class string, req *cmd.DeleteTenantsRequest) error {
-	args := m.Called(class, req)
+func (m *MockSchemaExecutor) DeleteTenants(class string, tenants []*models.Tenant) error {
+	args := m.Called(class, tenants)
 	return args.Error(0)
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -230,9 +231,9 @@ func (e *executor) UpdateTenantsProcess(class string, req *api.TenantProcessRequ
 	return nil
 }
 
-func (e *executor) DeleteTenants(class string, req *api.DeleteTenantsRequest) error {
+func (e *executor) DeleteTenants(class string, tenants []*models.Tenant) error {
 	ctx := context.Background()
-	if err := e.migrator.DeleteTenants(ctx, class, req.Tenants); err != nil {
+	if err := e.migrator.DeleteTenants(ctx, class, tenants); err != nil {
 		e.logger.WithFields(logrus.Fields{
 			"action": "delete_tenants",
 			"class":  class,

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -125,17 +126,17 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("DeleteTenants", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		req := &api.DeleteTenantsRequest{}
-		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(nil)
+		tenants := []*models.Tenant{}
+		migrator.On("DeleteTenants", Anything, "A", tenants).Return(nil)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.DeleteTenants("A", req))
+		assert.Nil(t, x.DeleteTenants("A", tenants))
 	})
 	t.Run("DeleteTenantsWithError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		req := &api.DeleteTenantsRequest{}
-		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(ErrAny)
+		tenants := []*models.Tenant{}
+		migrator.On("DeleteTenants", Anything, "A", tenants).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.DeleteTenants("A", req))
+		assert.Nil(t, x.DeleteTenants("A", tenants))
 	})
 
 	t.Run("UpdateTenants", func(t *testing.T) {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -119,7 +120,7 @@ func (f *fakeDB) UpdateTenantsProcess(class string, req *command.TenantProcessRe
 	return nil
 }
 
-func (f *fakeDB) DeleteTenants(class string, cmd *command.DeleteTenantsRequest) error {
+func (f *fakeDB) DeleteTenants(class string, tenants []*models.Tenant) error {
 	return nil
 }
 
@@ -292,7 +293,7 @@ func (f *fakeMigrator) UpdateTenants(ctx context.Context, class *models.Class, u
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants []string) error {
+func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error {
 	args := f.Called(ctx, class, tenants)
 	return args.Error(0)
 }

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -47,7 +47,7 @@ type Migrator interface {
 
 	NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) error
 	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) error
-	DeleteTenants(ctx context.Context, class string, tenants []string) error
+	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error
 
 	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error


### PR DESCRIPTION
### What's being changed:
issue : https://github.com/weaviate/weaviate/issues/7021 

this PR addresses a fix for an issue reported when deleting tenants with the tenant offloading module enabled and misconfigured. Previously, we attempted to remove tenants from the cloud provider. With these changes, we now provide the database layer with tenant information, allowing it to decide whether a call to the cloud provider is needed to delete tenants. The call will only be made for tenants that are in a FROZEN or FREEZING state.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
