### PR TITLE
fix(bm25): :bug: Fix batch index to increment with each batch properly

### DIFF
--- a/test/benchmark_bm25/cmd/import.go
+++ b/test/benchmark_bm25/cmd/import.go
@@ -44,11 +44,12 @@ func init() {
 func parseData(data []lib.Corpus, datasetId string, batch *batch.ObjectsBatcher, i int) int {
 	total := 0
 	for _, corp := range data {
-		id := uuid.MustParse(fmt.Sprintf("%032x", i)).String()
+		index := i + total
+		id := uuid.MustParse(fmt.Sprintf("%032x", index)).String()
 		props := map[string]interface{}{
-			"modulo_10":   i % 10,
-			"modulo_100":  i % 100,
-			"modulo_1000": i % 1000,
+			"modulo_10":   index % 10,
+			"modulo_100":  index % 100,
+			"modulo_1000": index % 1000,
 		}
 
 		for key, value := range corp {


### PR DESCRIPTION
### What's being changed:

During the changes to load data in batches, the index was not being incremented by mistake, leading to duplicate ids per batch.

### Review checklist

- [X] Documentation has been updated, if necessary. Link to changed documentation:
- [X] Chaos pipeline run or **not necessary**. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
(There are no benchmarker tests, but it may be an interesting future change for test/automation.)
- [X] Performance tests **have been run** or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
