### PR TITLE
test: add test case to handle deleting tenants with misconfigured offload

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -20,9 +20,10 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
+	gproto "google.golang.org/protobuf/proto"
+
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 var (
@@ -342,11 +343,24 @@ func (s *SchemaManager) DeleteTenants(cmd *command.ApplyRequest, schemaOnly bool
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
+	tenants, err := s.schema.getTenants(cmd.Class, req.Tenants)
+	if err != nil {
+		// error are handled by the updateSchema, so they are ignored here.
+		// Instead, we log the error to detect tenant status before deleting
+		// them from the schema. this allows the database layer to decide whether
+		// to send the delete request to the cloud provider.
+		s.log.WithFields(logrus.Fields{
+			"class":   cmd.Class,
+			"tenants": req.Tenants,
+			"error":   err.Error(),
+		}).Error("error getting tenants")
+	}
+
 	return s.apply(
 		applyOp{
 			op:           cmd.GetType().String(),
 			updateSchema: func() error { return s.schema.deleteTenants(cmd.Class, cmd.Version, req) },
-			updateStore:  func() error { return s.db.DeleteTenants(cmd.Class, req) },
+			updateStore:  func() error { return s.db.DeleteTenants(cmd.Class, tenants) },
 			schemaOnly:   schemaOnly,
 		},
 	)

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -35,7 +35,7 @@ type Indexer interface {
 	AddProperty(class string, req api.AddPropertyRequest) error
 	AddTenants(class string, req *api.AddTenantsRequest) error
 	UpdateTenants(class string, req *api.UpdateTenantsRequest) error
-	DeleteTenants(class string, req *api.DeleteTenantsRequest) error
+	DeleteTenants(class string, tenants []*models.Tenant) error
 	UpdateTenantsProcess(class string, req *api.TenantProcessRequest) error
 	UpdateShardStatus(*api.UpdateShardStatusRequest) error
 	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -146,6 +146,12 @@ func (d *DockerCompose) GetMinIO() *DockerContainer {
 	return d.getContainerByName(MinIO)
 }
 
+func (d *DockerCompose) StopMinIO(ctx context.Context) error {
+	minio := d.getContainerByName(MinIO)
+
+	return minio.container.Stop(ctx, nil)
+}
+
 func (d *DockerCompose) GetGCS() *DockerContainer {
 	return d.getContainerByName(GCS)
 }

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/weaviate/weaviate/client/batch"
 	"github.com/weaviate/weaviate/client/meta"
 	"github.com/weaviate/weaviate/client/objects"
@@ -329,6 +330,13 @@ func TenantExists(t *testing.T, class string, tenant string) (*schema.TenantExis
 func DeleteTenants(t *testing.T, class string, tenants []string) error {
 	t.Helper()
 	params := schema.NewTenantsDeleteParams().WithClassName(class).WithTenants(tenants)
+	_, err := Client(t).Schema.TenantsDelete(params, nil)
+	return err
+}
+
+func DeleteTenantsWithContext(t *testing.T, ctx context.Context, class string, tenants []string) error {
+	t.Helper()
+	params := schema.NewTenantsDeleteParams().WithContext(ctx).WithClassName(class).WithTenants(tenants)
 	_, err := Client(t).Schema.TenantsDelete(params, nil)
 	return err
 }

--- a/test/modules/offload-s3/misocnfigured_test.go
+++ b/test/modules/offload-s3/misocnfigured_test.go
@@ -1,0 +1,201 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func Test_DeleteTenantsWhileMisconfigured(t *testing.T) {
+	t.Run("misconfigure offload, create tenant, delete tenant", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, "the_wrong_Key")
+		t.Setenv(envS3SecretKey, "the_wrong_Key")
+
+		compose, err := docker.New().
+			WithOffloadS3("not-existing-bucket", "us-west-1").
+			WithWeaviateEnv("OFFLOAD_TIMEOUT", "120").
+			WithWeaviateEnv("OFFLOAD_S3_ENDPOINT", "http://test-minio:0000"). // wrong port configured
+			WithoutWeaviateEnvs("OFFLOAD_S3_BUCKET_AUTO_CREATE").
+			With3NodeCluster().
+			Start(ctx)
+		require.Nil(t, err)
+
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminate test containers: %s", err.Error())
+			}
+		}()
+
+		helper.SetupClient(compose.GetWeaviate().URI())
+
+		className := "MultiTenantClass"
+		testClass := models.Class{
+			Class:             className,
+			ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+			MultiTenancyConfig: &models.MultiTenancyConfig{
+				Enabled: true,
+			},
+		}
+		t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+			helper.CreateClass(t, &testClass)
+		})
+
+		defer func() {
+			helper.DeleteClass(t, className)
+		}()
+
+		tenantNames := []string{
+			"Tenant1", "Tenant2", "Tenant3",
+		}
+		t.Run("create tenants", func(t *testing.T) {
+			tenants := make([]*models.Tenant, len(tenantNames))
+			for i := range tenants {
+				tenants[i] = &models.Tenant{Name: tenantNames[i], ActivityStatus: models.TenantActivityStatusACTIVE}
+			}
+			helper.CreateTenants(t, className, tenants)
+		})
+
+		t.Run("delete tenant 1 in time manner", func(t *testing.T) {
+			customCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- helper.DeleteTenantsWithContext(t, customCtx, className, []string{tenantNames[0]})
+			}()
+
+			select {
+			case err := <-errChan:
+				if err != nil {
+					t.Fatalf("expected no error, but got: %v", err)
+				}
+
+			case <-customCtx.Done():
+				t.Fatalf("operation took longer than timeout: %v", customCtx.Err())
+			}
+		})
+
+		t.Run("get tenants after deletion", func(t *testing.T) {
+			response, err := helper.GetTenants(t, className)
+			require.NoError(t, err)
+			returnedTenantsNames := []string{}
+			for _, tn := range response.Payload {
+				returnedTenantsNames = append(returnedTenantsNames, tn.Name)
+			}
+
+			slices.Sort(tenantNames[1:])
+			slices.Sort(returnedTenantsNames)
+			require.Equal(t, tenantNames[1:], returnedTenantsNames, "expected tenant to be deleted but it's not")
+		})
+	})
+}
+
+func Test_DeleteTenantsWhileProviderIsDown(t *testing.T) {
+	t.Run("offload, create tenant, minio down, delete tenant", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+		t.Log("pre-instance env setup")
+		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
+		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
+
+		compose, err := docker.New().
+			WithOffloadS3("not-existing-bucket", "us-west-1").
+			WithWeaviateEnv("OFFLOAD_TIMEOUT", "120").
+			WithoutWeaviateEnvs("OFFLOAD_S3_BUCKET_AUTO_CREATE").
+			With3NodeCluster().
+			Start(ctx)
+		require.Nil(t, err)
+
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminate test containers: %s", err.Error())
+			}
+		}()
+
+		helper.SetupClient(compose.GetWeaviate().URI())
+
+		className := "MultiTenantClass"
+		testClass := models.Class{
+			Class:             className,
+			ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+			MultiTenancyConfig: &models.MultiTenancyConfig{
+				Enabled: true,
+			},
+		}
+		t.Run("create class with multi-tenancy enabled", func(t *testing.T) {
+			helper.CreateClass(t, &testClass)
+		})
+
+		defer func() {
+			helper.DeleteClass(t, className)
+		}()
+
+		tenantNames := []string{
+			"Tenant1", "Tenant2", "Tenant3",
+		}
+		t.Run("create tenants", func(t *testing.T) {
+			tenants := make([]*models.Tenant, len(tenantNames))
+			for i := range tenants {
+				tenants[i] = &models.Tenant{Name: tenantNames[i], ActivityStatus: models.TenantActivityStatusACTIVE}
+			}
+			helper.CreateTenants(t, className, tenants)
+		})
+		t.Run("stop minio", func(t *testing.T) {
+			require.NoError(t, compose.StopMinIO(ctx))
+		})
+
+		t.Run("delete tenant 1 in time manner", func(t *testing.T) {
+			customCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- helper.DeleteTenantsWithContext(t, customCtx, className, []string{tenantNames[0]})
+			}()
+
+			select {
+			case err := <-errChan:
+				if err != nil {
+					t.Fatalf("expected no error, but got: %v", err)
+				}
+
+			case <-customCtx.Done():
+				t.Fatalf("operation took longer than timeout: %v", customCtx.Err())
+			}
+		})
+
+		t.Run("get tenants after deletion", func(t *testing.T) {
+			response, err := helper.GetTenants(t, className)
+			require.NoError(t, err)
+			returnedTenantsNames := []string{}
+			for _, tn := range response.Payload {
+				returnedTenantsNames = append(returnedTenantsNames, tn.Name)
+			}
+
+			slices.Sort(tenantNames[1:])
+			slices.Sort(returnedTenantsNames)
+			require.Equal(t, tenantNames[1:], returnedTenantsNames, "expected tenant to be deleted but it's not")
+		})
+	})
+}

--- a/test/modules/offload-s3/misocnfigured_test.go
+++ b/test/modules/offload-s3/misocnfigured_test.go
@@ -87,12 +87,10 @@ func Test_DeleteTenantsWhileMisconfigured(t *testing.T) {
 
 			select {
 			case err := <-errChan:
-				if err != nil {
-					t.Fatalf("expected no error, but got: %v", err)
-				}
+				require.NoError(t, err, "got error while expecting none")
 
 			case <-customCtx.Done():
-				t.Fatalf("operation took longer than timeout: %v", customCtx.Err())
+				require.FailNowf(t, "operation took longer than timeout: %v", customCtx.Err().Error())
 			}
 		})
 
@@ -176,12 +174,10 @@ func Test_DeleteTenantsWhileProviderIsDown(t *testing.T) {
 
 			select {
 			case err := <-errChan:
-				if err != nil {
-					t.Fatalf("expected no error, but got: %v", err)
-				}
+				require.NoError(t, err, "got error while expecting none")
 
 			case <-customCtx.Done():
-				t.Fatalf("operation took longer than timeout: %v", customCtx.Err())
+				require.FailNowf(t, "operation took longer than timeout: %v", customCtx.Err().Error())
 			}
 		})
 

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
@@ -77,8 +78,8 @@ func (m *MockSchemaExecutor) UpdateTenantsProcess(class string, req *cmd.TenantP
 	return args.Error(0)
 }
 
-func (m *MockSchemaExecutor) DeleteTenants(class string, req *cmd.DeleteTenantsRequest) error {
-	args := m.Called(class, req)
+func (m *MockSchemaExecutor) DeleteTenants(class string, tenants []*models.Tenant) error {
+	args := m.Called(class, tenants)
 	return args.Error(0)
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -230,9 +231,9 @@ func (e *executor) UpdateTenantsProcess(class string, req *api.TenantProcessRequ
 	return nil
 }
 
-func (e *executor) DeleteTenants(class string, req *api.DeleteTenantsRequest) error {
+func (e *executor) DeleteTenants(class string, tenants []*models.Tenant) error {
 	ctx := context.Background()
-	if err := e.migrator.DeleteTenants(ctx, class, req.Tenants); err != nil {
+	if err := e.migrator.DeleteTenants(ctx, class, tenants); err != nil {
 		e.logger.WithFields(logrus.Fields{
 			"action": "delete_tenants",
 			"class":  class,

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -125,17 +126,17 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("DeleteTenants", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		req := &api.DeleteTenantsRequest{}
-		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(nil)
+		tenants := []*models.Tenant{}
+		migrator.On("DeleteTenants", Anything, "A", tenants).Return(nil)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.DeleteTenants("A", req))
+		assert.Nil(t, x.DeleteTenants("A", tenants))
 	})
 	t.Run("DeleteTenantsWithError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		req := &api.DeleteTenantsRequest{}
-		migrator.On("DeleteTenants", Anything, "A", req.Tenants).Return(ErrAny)
+		tenants := []*models.Tenant{}
+		migrator.On("DeleteTenants", Anything, "A", tenants).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.DeleteTenants("A", req))
+		assert.Nil(t, x.DeleteTenants("A", tenants))
 	})
 
 	t.Run("UpdateTenants", func(t *testing.T) {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -119,7 +120,7 @@ func (f *fakeDB) UpdateTenantsProcess(class string, req *command.TenantProcessRe
 	return nil
 }
 
-func (f *fakeDB) DeleteTenants(class string, cmd *command.DeleteTenantsRequest) error {
+func (f *fakeDB) DeleteTenants(class string, tenants []*models.Tenant) error {
 	return nil
 }
 
@@ -292,7 +293,7 @@ func (f *fakeMigrator) UpdateTenants(ctx context.Context, class *models.Class, u
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants []string) error {
+func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error {
 	args := f.Called(ctx, class, tenants)
 	return args.Error(0)
 }

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -47,7 +47,7 @@ type Migrator interface {
 
 	NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) error
 	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) error
-	DeleteTenants(ctx context.Context, class string, tenants []string) error
+	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error
 
 	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error


### PR DESCRIPTION
### What's being changed:
issue : https://github.com/weaviate/weaviate/issues/7021 

When deleting tenants with the tenant offloading module enabled and misconfigured, we attempted to remove tenants from the cloud provider, which resulted in tenant deletion requests returning context deadline or cancelled errors. Although the tenants were deleted from the database, the error occurred due to a timeout in the cloud provider’s request configuration, which failed to report back properly because of the misconfiguration.


For example:
e.g.
```
2025-01-21 22:11:16 ERROR session: fetching region failed: RequestCanceled: request context canceled
2025-01-21 22:11:16 caused by: context deadline exceeded
```


this PR does replicate a scenario where the cloud provider configured for tenant offloading either `misconfigured` or `down` in this case we discovered an issue that this will block tenant deletion

**Note** offload test shall fail in this PR and pass in the fix PR
related fix https://github.com/weaviate/weaviate/pull/7011
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
