### PR TITLE
refactor(bm25_block): :recycle: Make Bitmap public in allowlist

### DIFF
--- a/adapters/repos/db/helpers/allow_list.go
+++ b/adapters/repos/db/helpers/allow_list.go
@@ -50,77 +50,77 @@ func NewAllowListFromBitmap(bm *sroar.Bitmap) AllowList {
 }
 
 func NewAllowListCloseableFromBitmap(bm *sroar.Bitmap, release func()) AllowList {
-	return &bitmapAllowList{bm: bm, release: release}
+	return &BitmapAllowList{Bm: bm, release: release}
 }
 
 func NewAllowListFromBitmapDeepCopy(bm *sroar.Bitmap) AllowList {
 	return NewAllowListFromBitmap(bm.Clone())
 }
 
-type bitmapAllowList struct {
-	bm      *sroar.Bitmap
+type BitmapAllowList struct {
+	Bm      *sroar.Bitmap
 	release func()
 }
 
-func (al *bitmapAllowList) Close() {
+func (al *BitmapAllowList) Close() {
 	al.release()
 }
 
-func (al *bitmapAllowList) Insert(ids ...uint64) {
-	al.bm.SetMany(ids)
+func (al *BitmapAllowList) Insert(ids ...uint64) {
+	al.Bm.SetMany(ids)
 }
 
-func (al *bitmapAllowList) Contains(id uint64) bool {
-	return al.bm.Contains(id)
+func (al *BitmapAllowList) Contains(id uint64) bool {
+	return al.Bm.Contains(id)
 }
 
-func (al *bitmapAllowList) DeepCopy() AllowList {
-	return NewAllowListFromBitmapDeepCopy(al.bm)
+func (al *BitmapAllowList) DeepCopy() AllowList {
+	return NewAllowListFromBitmapDeepCopy(al.Bm)
 }
 
-func (al *bitmapAllowList) WrapOnWrite() AllowList {
+func (al *BitmapAllowList) WrapOnWrite() AllowList {
 	return newWrappedAllowList(al)
 }
 
-func (al *bitmapAllowList) Slice() []uint64 {
-	return al.bm.ToArray()
+func (al *BitmapAllowList) Slice() []uint64 {
+	return al.Bm.ToArray()
 }
 
-func (al *bitmapAllowList) IsEmpty() bool {
-	return al.bm.IsEmpty()
+func (al *BitmapAllowList) IsEmpty() bool {
+	return al.Bm.IsEmpty()
 }
 
-func (al *bitmapAllowList) Len() int {
-	return al.bm.GetCardinality()
+func (al *BitmapAllowList) Len() int {
+	return al.Bm.GetCardinality()
 }
 
-func (al *bitmapAllowList) Min() uint64 {
-	return al.bm.Minimum()
+func (al *BitmapAllowList) Min() uint64 {
+	return al.Bm.Minimum()
 }
 
-func (al *bitmapAllowList) Max() uint64 {
-	return al.bm.Maximum()
+func (al *BitmapAllowList) Max() uint64 {
+	return al.Bm.Maximum()
 }
 
-func (al *bitmapAllowList) Size() uint64 {
+func (al *BitmapAllowList) Size() uint64 {
 	// TODO provide better size estimation
-	return uint64(1.5 * float64(len(al.bm.ToBuffer())))
+	return uint64(1.5 * float64(len(al.Bm.ToBuffer())))
 }
 
-func (al *bitmapAllowList) Truncate(upTo uint64) AllowList {
-	card := al.bm.GetCardinality()
+func (al *BitmapAllowList) Truncate(upTo uint64) AllowList {
+	card := al.Bm.GetCardinality()
 	if upTo < uint64(card) {
-		al.bm.RemoveRange(upTo, uint64(al.bm.GetCardinality()+1))
+		al.Bm.RemoveRange(upTo, uint64(al.Bm.GetCardinality()+1))
 	}
 	return al
 }
 
-func (al *bitmapAllowList) Iterator() AllowListIterator {
+func (al *BitmapAllowList) Iterator() AllowListIterator {
 	return al.LimitedIterator(0)
 }
 
-func (al *bitmapAllowList) LimitedIterator(limit int) AllowListIterator {
-	return newBitmapAllowListIterator(al.bm, limit)
+func (al *BitmapAllowList) LimitedIterator(limit int) AllowListIterator {
+	return newBitmapAllowListIterator(al.Bm, limit)
 }
 
 type bitmapAllowListIterator struct {

--- a/adapters/repos/db/helpers/allow_list.go
+++ b/adapters/repos/db/helpers/allow_list.go
@@ -57,6 +57,9 @@ func NewAllowListFromBitmapDeepCopy(bm *sroar.Bitmap) AllowList {
 	return NewAllowListFromBitmap(bm.Clone())
 }
 
+// this was changed to be public to allow for accessing the underlying bitmap and intersecting it with other *sroar.Bitmap for faster keyword retrieval
+// We should consider making this private again and adding a method to intersect two AllowLists, but at the same time, it would also make the interface bloated
+// and add the burden of supporting this method in all (future, if any) implementations of AllowList
 type BitmapAllowList struct {
 	Bm      *sroar.Bitmap
 	release func()


### PR DESCRIPTION
### What's being changed:

Make Bitmap public in allowlist to enable direct sroar roaringset access for faster filtering on blockmax
- during retrieval, direct roaringset access, enables merging tombstones roaringset with the allowlist filter roaringset so that we'll only need to check the doc ids on a single roaringset.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
