### PR TITLE
Propagate the varint encoders and fix buffer reuse

### DIFF
--- a/adapters/repos/db/inverted/terms/terms_block.go
+++ b/adapters/repos/db/inverted/terms/terms_block.go
@@ -29,7 +29,7 @@ type BlockEntry struct {
 	MaxImpactPropLength uint32
 }
 
-func (b *BlockEntry) Size() int {
+func (b BlockEntry) Size() int {
 	return 20
 }
 

--- a/adapters/repos/db/lsmkv/memtable_flush_inverted.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted.go
@@ -94,6 +94,11 @@ func (m *Memtable) flushDataInverted(f *bufio.Writer, ff *os.File) ([]segmentind
 		DataFields:            []varenc.VarEncDataType{varenc.DeltaVarIntUint64, varenc.VarIntUint64},
 	}
 
+	docIdEncoder := varenc.GetVarEncEncoder64(headerInverted.DataFields[0])
+	tfEncoder := varenc.GetVarEncEncoder64(headerInverted.DataFields[1])
+	docIdEncoder.Init(segmentindex.SegmentInvertedDefaultBlockSize)
+	tfEncoder.Init(segmentindex.SegmentInvertedDefaultBlockSize)
+
 	n, err := header.WriteTo(f)
 	if err != nil {
 		return nil, nil, err
@@ -120,7 +125,7 @@ func (m *Memtable) flushDataInverted(f *bufio.Writer, ff *os.File) ([]segmentind
 				ValueStart: totalWritten,
 			}
 
-			blocksEncoded, _ := createAndEncodeBlocksWithLengths(mapNode.values)
+			blocksEncoded, _ := createAndEncodeBlocksWithLengths(mapNode.values, docIdEncoder, tfEncoder)
 
 			if _, err := f.Write(blocksEncoded); err != nil {
 				return nil, nil, err

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -145,8 +145,12 @@ type VarIntEncoder struct {
 }
 
 func (e *VarIntEncoder) Init(expectedCount int) {
-	e.values = make([]uint64, expectedCount)
-	e.buf = make([]byte, 8+8*expectedCount)
+	if len(e.values) < expectedCount {
+		e.values = make([]uint64, expectedCount)
+	}
+	if len(e.buf) < 8+8*expectedCount {
+		e.buf = make([]byte, 8+8*expectedCount)
+	}
 }
 
 func (e VarIntEncoder) EncodeReusable(values []uint64, buf []byte) {
@@ -159,7 +163,9 @@ func (e VarIntEncoder) DecodeReusable(data []byte, values []uint64) {
 
 func (e *VarIntEncoder) Encode(values []uint64) []byte {
 	n := encodeReusable(values, e.buf, false)
-	return e.buf[:n]
+	output := make([]byte, n)
+	copy(output, e.buf[:n])
+	return output
 }
 
 func (e *VarIntEncoder) Decode(data []byte) []uint64 {
@@ -173,8 +179,12 @@ type VarIntDeltaEncoder struct {
 }
 
 func (e *VarIntDeltaEncoder) Init(expectedCount int) {
-	e.values = make([]uint64, expectedCount)
-	e.buf = make([]byte, 8+8*expectedCount)
+	if len(e.values) < expectedCount {
+		e.values = make([]uint64, expectedCount)
+	}
+	if len(e.buf) < 8+8*expectedCount {
+		e.buf = make([]byte, 8+8*expectedCount)
+	}
 }
 
 func (e VarIntDeltaEncoder) EncodeReusable(values []uint64, buf []byte) {
@@ -187,7 +197,9 @@ func (e VarIntDeltaEncoder) DecodeReusable(data []byte, values []uint64) {
 
 func (e *VarIntDeltaEncoder) Encode(values []uint64) []byte {
 	n := encodeReusable(values, e.buf, true)
-	return e.buf[:n]
+	output := make([]byte, n)
+	copy(output, e.buf[:n])
+	return output
 }
 
 func (e *VarIntDeltaEncoder) Decode(data []byte) []uint64 {


### PR DESCRIPTION
### What's being changed:

- Copy encoded ids/tfs to new buffer so that we don't overwrite output on flush or compaction
- Propagate the proper docId and Tf encoders during flushing and compaction of Inverted segments

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
