### PR TITLE
fix: remove empty wal upon start

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -279,6 +279,8 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 }
 
 func (b *Bucket) GetDir() string {
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
 	return b.dir
 }
 
@@ -1046,7 +1048,7 @@ func (b *Bucket) DeleteWith(key []byte, deletionTime time.Time, opts ...Secondar
 func (b *Bucket) setNewActiveMemtable() error {
 	path := filepath.Join(b.dir, fmt.Sprintf("segment-%d", time.Now().UnixNano()))
 
-	cl, err := newCommitLogger(path)
+	cl, err := newLazyCommitLogger(path)
 	if err != nil {
 		return errors.Wrap(err, "init commit logger")
 	}
@@ -1131,7 +1133,7 @@ func (b *Bucket) existsOnDiskAndPreviousMemtable(previous *countStats, key []byt
 }
 
 func (b *Bucket) Shutdown(ctx context.Context) error {
-	defer GlobalBucketRegistry.Remove(b.dir)
+	defer GlobalBucketRegistry.Remove(b.GetDir())
 
 	if err := b.disk.shutdown(ctx); err != nil {
 		return err
@@ -1171,7 +1173,7 @@ func (b *Bucket) Shutdown(ctx context.Context) error {
 // flushAndSwitchIfThresholdsMet is part of flush callbacks of the bucket.
 func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAbortCallback) bool {
 	b.flushLock.RLock()
-	commitLogSize := b.active.commitlog.Size()
+	commitLogSize := b.active.commitlog.size()
 	memtableTooLarge := b.active.Size() >= b.memtableThreshold
 	walTooLarge := uint64(commitLogSize) >= b.walThreshold
 	dirtyTooLong := b.active.DirtyDuration() >= b.flushDirtyAfter
@@ -1199,7 +1201,7 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 		cycleLength := b.active.ActiveDuration()
 		if err := b.FlushAndSwitch(); err != nil {
 			b.logger.WithField("action", "lsm_memtable_flush").
-				WithField("path", b.dir).
+				WithField("path", b.GetDir()).
 				WithError(err).
 				Errorf("flush and switch failed")
 			return false
@@ -1284,11 +1286,24 @@ func (b *Bucket) isReadOnly() bool {
 func (b *Bucket) FlushAndSwitch() error {
 	before := time.Now()
 
+	bucketPath := b.GetDir()
+
 	b.logger.WithField("action", "lsm_memtable_flush_start").
-		WithField("path", b.dir).
+		WithField("path", bucketPath).
 		Trace("start flush and switch")
-	if err := b.atomicallySwitchMemtable(); err != nil {
-		return fmt.Errorf("switch active memtable: %w", err)
+
+	switched, err := b.atomicallySwitchMemtable()
+	if err != nil {
+		b.logger.WithField("action", "lsm_memtable_flush_start").
+			WithField("path", bucketPath).
+			Error(err)
+		return fmt.Errorf("flush and switch: %w", err)
+	}
+	if !switched {
+		b.logger.WithField("action", "lsm_memtable_flush_start").
+			WithField("path", bucketPath).
+			Trace("flush and switch not needed")
+		return nil
 	}
 
 	if err := b.flushing.flush(); err != nil {
@@ -1327,15 +1342,34 @@ func (b *Bucket) FlushAndSwitch() error {
 
 	took := time.Since(before)
 	b.logger.WithField("action", "lsm_memtable_flush_complete").
-		WithField("path", b.dir).
+		WithField("path", bucketPath).
 		Trace("finish flush and switch")
 
 	b.logger.WithField("action", "lsm_memtable_flush_complete").
-		WithField("path", b.dir).
+		WithField("path", bucketPath).
 		WithField("took", took).
 		Debugf("flush and switch took %s\n", took)
 
 	return nil
+}
+
+func (b *Bucket) atomicallySwitchMemtable() (bool, error) {
+	b.flushLock.Lock()
+	defer b.flushLock.Unlock()
+
+	if b.active.size == 0 {
+		return false, nil
+	}
+
+	flushing := b.active
+
+	err := b.setNewActiveMemtable()
+	if err != nil {
+		return false, fmt.Errorf("switch active memtable: %w", err)
+	}
+	b.flushing = flushing
+
+	return true, nil
 }
 
 func (b *Bucket) initAndPrecomputeNewSegment() (*segment, error) {
@@ -1372,14 +1406,6 @@ func (b *Bucket) atomicallyAddDiskSegmentAndRemoveFlushing(seg *segment) error {
 	}
 
 	return nil
-}
-
-func (b *Bucket) atomicallySwitchMemtable() error {
-	b.flushLock.Lock()
-	defer b.flushLock.Unlock()
-
-	b.flushing = b.active
-	return b.setNewActiveMemtable()
 }
 
 func (b *Bucket) Strategy() string {

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -184,7 +184,7 @@ func bucketReadsIntoMemory(ctx context.Context, t *testing.T, opts []BucketOptio
 		WithSecondaryKey(0, []byte("bonjour"))))
 	require.Nil(t, b.FlushMemtable())
 
-	files, err := os.ReadDir(b.dir)
+	files, err := os.ReadDir(b.GetDir())
 	require.Nil(t, err)
 
 	_, ok := findFileWithExt(files, ".bloom")
@@ -194,7 +194,7 @@ func bucketReadsIntoMemory(ctx context.Context, t *testing.T, opts []BucketOptio
 	assert.True(t, ok)
 	b.Shutdown(ctx)
 
-	b2, err := NewBucketCreator().NewBucket(ctx, b.dir, "", logger, nil,
+	b2, err := NewBucketCreator().NewBucket(ctx, b.GetDir(), "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -99,8 +99,8 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 			}
 
 			bucket.flushLock.RLock()
-			walFile := bucket.active.commitlog.path
-			walSize := bucket.active.commitlog.Size()
+			walFile := bucket.active.commitlog.walPath()
+			walSize := bucket.active.commitlog.size()
 			bucket.flushLock.RUnlock()
 
 			if firstWalFile == "" {

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -17,11 +17,140 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/usecases/integrity"
 )
+
+type memtableCommitLogger interface {
+	writeEntry(commitType CommitType, nodeBytes []byte) error
+	put(node segmentReplaceNode) error
+	append(node segmentCollectionNode) error
+	add(node *roaringset.SegmentNodeList) error
+	walPath() string
+	size() int64
+	flushBuffers() error
+	close() error
+	delete() error
+}
+
+var (
+	_ memtableCommitLogger = (*lazyCommitLogger)(nil)
+	_ memtableCommitLogger = (*commitLogger)(nil)
+)
+
+type lazyCommitLogger struct {
+	path         string
+	commitLogger *commitLogger
+	mux          sync.Mutex
+}
+
+func (cl *lazyCommitLogger) mayInitCommitLogger() error {
+	cl.mux.Lock()
+	defer cl.mux.Unlock()
+
+	if cl.commitLogger != nil {
+		return nil
+	}
+
+	commitLogger, err := newCommitLogger(cl.path)
+	if err != nil {
+		return err
+	}
+
+	cl.commitLogger = commitLogger
+	return nil
+}
+
+func walPath(path string) string {
+	return path + ".wal"
+}
+
+func (cl *lazyCommitLogger) walPath() string {
+	return walPath(cl.path)
+}
+
+func (cl *lazyCommitLogger) writeEntry(commitType CommitType, nodeBytes []byte) error {
+	err := cl.mayInitCommitLogger()
+	if err != nil {
+		return err
+	}
+
+	return cl.commitLogger.writeEntry(commitType, nodeBytes)
+}
+
+func (cl *lazyCommitLogger) put(node segmentReplaceNode) error {
+	err := cl.mayInitCommitLogger()
+	if err != nil {
+		return err
+	}
+
+	return cl.commitLogger.put(node)
+}
+
+func (cl *lazyCommitLogger) append(node segmentCollectionNode) error {
+	err := cl.mayInitCommitLogger()
+	if err != nil {
+		return err
+	}
+
+	return cl.commitLogger.append(node)
+}
+
+func (cl *lazyCommitLogger) add(node *roaringset.SegmentNodeList) error {
+	err := cl.mayInitCommitLogger()
+	if err != nil {
+		return err
+	}
+
+	return cl.commitLogger.add(node)
+}
+
+func (cl *lazyCommitLogger) size() int64 {
+	cl.mux.Lock()
+	defer cl.mux.Unlock()
+
+	if cl.commitLogger == nil {
+		return 0
+	}
+
+	return cl.commitLogger.size()
+}
+
+func (cl *lazyCommitLogger) flushBuffers() error {
+	cl.mux.Lock()
+	defer cl.mux.Unlock()
+
+	if cl.commitLogger == nil {
+		return nil
+	}
+
+	return cl.commitLogger.flushBuffers()
+}
+
+func (cl *lazyCommitLogger) close() error {
+	cl.mux.Lock()
+	defer cl.mux.Unlock()
+
+	if cl.commitLogger == nil {
+		return nil
+	}
+
+	return cl.commitLogger.close()
+}
+
+func (cl *lazyCommitLogger) delete() error {
+	cl.mux.Lock()
+	defer cl.mux.Unlock()
+
+	if cl.commitLogger == nil {
+		return nil
+	}
+
+	return cl.commitLogger.delete()
+}
 
 type commitLogger struct {
 	file   *os.File
@@ -87,9 +216,15 @@ func (ct CommitType) Is(checkedCommitType CommitType) bool {
 	return ct == checkedCommitType
 }
 
+func newLazyCommitLogger(path string) (*lazyCommitLogger, error) {
+	return &lazyCommitLogger{
+		path: path,
+	}, nil
+}
+
 func newCommitLogger(path string) (*commitLogger, error) {
 	out := &commitLogger{
-		path: path + ".wal",
+		path: walPath(path),
 	}
 
 	f, err := os.OpenFile(out.path, os.O_CREATE|os.O_RDWR, 0o666)
@@ -105,6 +240,10 @@ func newCommitLogger(path string) (*commitLogger, error) {
 	out.bufNode = bytes.NewBuffer(nil)
 
 	return out, nil
+}
+
+func (cl *commitLogger) walPath() string {
+	return cl.path
 }
 
 func (cl *commitLogger) writeEntry(commitType CommitType, nodeBytes []byte) error {
@@ -199,7 +338,7 @@ func (cl *commitLogger) add(node *roaringset.SegmentNodeList) error {
 // Size returns the amount of data that has been written since the commit
 // logger was initialized. After a flush a new logger is initialized which
 // automatically resets the logger.
-func (cl *commitLogger) Size() int64 {
+func (cl *commitLogger) size() int64 {
 	return cl.n.Load()
 }
 

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -34,7 +34,7 @@ type Memtable struct {
 	primaryIndex       *binarySearchTree
 	roaringSet         *roaringset.BinarySearchTree
 	roaringSetRange    *roaringsetrange.Memtable
-	commitlog          *commitLogger
+	commitlog          memtableCommitLogger
 	size               uint64
 	path               string
 	strategy           string
@@ -51,7 +51,7 @@ type Memtable struct {
 }
 
 func newMemtable(path string, strategy string, secondaryIndices uint16,
-	cl *commitLogger, metrics *Metrics, logger logrus.FieldLogger,
+	cl memtableCommitLogger, metrics *Metrics, logger logrus.FieldLogger,
 	enableChecksumValidation bool,
 ) (*Memtable, error) {
 	m := &Memtable{

--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -38,7 +38,7 @@ func (s *Store) PauseCompaction(ctx context.Context) error {
 
 	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
 	for _, b := range s.bucketsByName {
-		label := b.dir
+		label := b.GetDir()
 		if monitoring.GetMetrics().Group {
 			label = "n/a"
 		}


### PR DESCRIPTION
### What's being changed:

- lazy LSM WAL file creation
- remove empty wal files during recovery

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13631747092
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
