### PR TITLE
Add validation on multivector config

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
@@ -449,6 +449,58 @@ func testColBERT(host string) func(t *testing.T) {
 				require.True(t, ok)
 				assert.True(t, mv["enabled"].(bool))
 			})
+			t.Run("multi vector index with flat vector index type", func(t *testing.T) {
+				cleanup()
+				class := &models.Class{
+					Class: "NamedVectorVectorizerWithMultiVectorIndex",
+					Properties: []*models.Property{
+						{
+							Name: "name", DataType: []string{schema.DataTypeText.String()},
+						},
+					},
+					VectorConfig: map[string]models.VectorConfig{
+						"colbert": {
+							Vectorizer: map[string]interface{}{
+								"text2colbert-jinaai": map[string]interface{}{
+									"vectorizeClassName": false,
+								},
+							},
+							VectorIndexType: "flat",
+						},
+					},
+				}
+				err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+				// Weaviate overrides the multivector setting if it finds that someone has enabled
+				// multi vector vectorizer
+				require.Error(t, err)
+				assert.ErrorContains(t, err, `parse vector index config: multi vector index is not supported for vector index type: \"flat\", only supported type is hnsw`)
+			})
+			t.Run("multi vector index with dynamic vector index type", func(t *testing.T) {
+				cleanup()
+				class := &models.Class{
+					Class: "NamedVectorVectorizerWithMultiVectorIndex",
+					Properties: []*models.Property{
+						{
+							Name: "name", DataType: []string{schema.DataTypeText.String()},
+						},
+					},
+					VectorConfig: map[string]models.VectorConfig{
+						"colbert": {
+							Vectorizer: map[string]interface{}{
+								"text2colbert-jinaai": map[string]interface{}{
+									"vectorizeClassName": false,
+								},
+							},
+							VectorIndexType: "dynamic",
+						},
+					},
+				}
+				err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+				// Weaviate overrides the multivector setting if it finds that someone has enabled
+				// multi vector vectorizer
+				require.Error(t, err)
+				assert.ErrorContains(t, err, `parse vector index config: multi vector index is not supported for vector index type: \"dynamic\", only supported type is hnsw`)
+			})
 		})
 
 		t.Run("validate multi vector dimensions", func(t *testing.T) {

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -215,6 +215,12 @@ func (p *Parser) parseGivenVectorIndexConfig(vectorIndexType string,
 			vectorIndexType)
 	}
 
+	if vectorIndexType != vectorindex.VectorIndexTypeHNSW && isMultiVector {
+		return nil, errors.Errorf(
+			"parse vector index config: multi vector index is not supported for vector index type: %q, only supported type is hnsw",
+			vectorIndexType)
+	}
+
 	parsed, err := p.configParser(vectorIndexConfig, vectorIndexType, isMultiVector)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse vector index config")


### PR DESCRIPTION
### What's being changed:
This PR adds a validation on configs for multivector index. If the user tries to create a multivector index using `flat` or `dynamic` index an error will be returned.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
