### PR TITLE
 chore: Add `weaviate_schema_shards` metric to track total `shards` count per node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,5 +90,8 @@ monitoring: ## Run the prometheus and grafana for monitoring
 local: ## Run the local development setup with single node
 	./tools/dev/run_dev_server.sh local-single-node
 
+debug: ## Connect local weaviate server via delv for debugging
+	./tools/dev/run_dev_server.sh debug
+
 banner: ## Add Weaviate banner with license details
 	./tools/gen-code-from-swagger.sh

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -93,7 +94,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	m.indexer.AssertExpectations(t)
 
 	// Create a new FSM that will restore from it's state from the disk (using snapshot and logs)
-	s := NewFSM(m.cfg)
+	s := NewFSM(m.cfg, prometheus.NewPedanticRegistry())
 	m.store = &s
 	// We refresh the mock schema to ensure that we can assert no calls except Open are sent to the database
 	m.indexer = fakes.NewMockSchemaExecutor()

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
@@ -285,7 +286,7 @@ func TestRaftEndpoints(t *testing.T) {
 	// restore from snapshot
 	assert.Nil(t, srv.Close(ctx))
 
-	s := NewFSM(m.cfg)
+	s := NewFSM(m.cfg, prometheus.NewPedanticRegistry())
 	m.store = &s
 	srv = NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	assert.Nil(t, srv.Open(ctx, m.indexer))
@@ -327,7 +328,7 @@ func TestRaftClose(t *testing.T) {
 	ctx := context.Background()
 	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
 	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
-	s := NewFSM(m.cfg)
+	s := NewFSM(m.cfg, prometheus.NewPedanticRegistry())
 	m.store = &s
 	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	m.indexer.On("Open", mock.Anything).Return(nil)

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
@@ -40,7 +41,7 @@ type SchemaManager struct {
 
 func NewSchemaManager(nodeId string, db Indexer, parser Parser, log *logrus.Logger) *SchemaManager {
 	return &SchemaManager{
-		schema: NewSchema(nodeId, db),
+		schema: NewSchema(nodeId, db, prometheus.DefaultRegisterer),
 		db:     db,
 		parser: parser,
 		log:    log,
@@ -127,7 +128,7 @@ func (s *SchemaManager) ReloadDBFromSchema() {
 }
 
 func (s *SchemaManager) Close(ctx context.Context) (err error) {
-	s.schema.Close()
+	s.schema.Close(prometheus.DefaultRegisterer)
 	return s.db.Close(ctx)
 }
 

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -39,9 +39,9 @@ type SchemaManager struct {
 	log    *logrus.Logger
 }
 
-func NewSchemaManager(nodeId string, db Indexer, parser Parser, log *logrus.Logger) *SchemaManager {
+func NewSchemaManager(nodeId string, db Indexer, parser Parser, reg prometheus.Registerer, log *logrus.Logger) *SchemaManager {
 	return &SchemaManager{
-		schema: NewSchema(nodeId, db, prometheus.DefaultRegisterer),
+		schema: NewSchema(nodeId, db, reg),
 		db:     db,
 		parser: parser,
 		log:    log,
@@ -128,7 +128,6 @@ func (s *SchemaManager) ReloadDBFromSchema() {
 }
 
 func (s *SchemaManager) Close(ctx context.Context) (err error) {
-	s.schema.Close(prometheus.DefaultRegisterer)
 	return s.db.Close(ctx)
 }
 

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -234,15 +234,21 @@ func (m *metaClass) AddTenants(nodeID string, req *command.AddTenantsRequest, re
 	return nil
 }
 
-func (m *metaClass) DeleteTenants(req *command.DeleteTenantsRequest, v uint64) error {
+// DeleteTenants try to delete the tenants from given request and returns
+// total number of deleted tenants.
+func (m *metaClass) DeleteTenants(req *command.DeleteTenantsRequest, v uint64) (int, error) {
 	m.Lock()
 	defer m.Unlock()
 
+	count := 0
+
 	for _, name := range req.Tenants {
-		m.Sharding.DeletePartition(name)
+		if m.Sharding.DeletePartition(name) {
+			count++
+		}
 	}
 	m.ShardVersion = v
-	return nil
+	return count, nil
 }
 
 func (m *metaClass) UpdateTenants(nodeID string, req *command.UpdateTenantsRequest, v uint64) error {

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -196,8 +196,6 @@ func (m *metaClass) AddTenants(nodeID string, req *command.AddTenantsRequest, re
 	m.Lock()
 	defer m.Unlock()
 
-	sc := make(map[string]int)
-
 	// TODO-RAFT: Optimize here and avoid iteration twice on the req.Tenants array
 	names := make([]string, len(req.Tenants))
 	for i, tenant := range req.Tenants {
@@ -208,6 +206,9 @@ func (m *metaClass) AddTenants(nodeID string, req *command.AddTenantsRequest, re
 	if err != nil {
 		return nil, fmt.Errorf("get partitions: %w", err)
 	}
+
+	// sc tracks number of shards in this collection to be added by status.
+	sc := make(map[string]int)
 
 	// Iterate over requested tenants and assign them, if found, a partition
 	for i, t := range req.Tenants {

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -285,16 +285,15 @@ func (m *metaClass) UpdateTenants(nodeID string, req *command.UpdateTenantsReque
 		// the map read
 		m.Sharding.Physical[oldTenant.Name] = newTenant
 
+		// At this point we know, we are going to change the status of a tenant from old-state to new-state.
+		sc[oldTenant.ActivityStatus()]--
+		sc[newTenant.ActivityStatus()]++
+
 		// If the shard is not stored on that node skip updating the request tenant as there will be nothing to load on
 		// the DB side
 		if !slices.Contains(oldTenant.BelongsToNodes, nodeID) {
 			continue
 		}
-
-		// At this point we know, we are going to change the status of a tenant from old-state to new-state.
-		// TODO: what happes if it's stored on `m.Sharding.Physical` but returned if nodeID not present on `oldTenant.BelongsToNodes`?
-		sc[oldTenant.ActivityStatus()]--
-		sc[newTenant.ActivityStatus()]++
 
 		// Save the "valid" tenant on writeIndex and increment. This allows us to filter in place in req.Tenants the
 		// tenants that actually have a change to process

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -425,16 +425,6 @@ func (s *schema) MetaClasses() map[string]*metaClass {
 	return s.Classes
 }
 
-// Close clean up the state of schema. Currently doesn't require to return any error.
-func (s *schema) Close(reg prometheus.Registerer) {
-	if reg == nil {
-		reg = prometheus.DefaultRegisterer
-	}
-
-	reg.Unregister(s.collectionsCount)
-	reg.Unregister(s.shardsCount)
-}
-
 func makeTenant(name, status string) *models.Tenant {
 	return &models.Tenant{
 		Name:           name,

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -278,6 +278,11 @@ func (s *schema) addClass(cls *models.Class, ss *sharding.State, v uint64) error
 	}
 
 	s.collectionsCount.Inc()
+
+	for _, shard := range ss.Physical {
+		s.shardsCount.WithLabelValues(shard.Status).Inc()
+	}
+
 	return nil
 }
 
@@ -323,7 +328,7 @@ func (s *schema) deleteClass(name string) bool {
 
 	// since `delete(map, key)` is no-op if `key` doesn't exist, check before deleting
 	// so that we can increment the `collectionsCount` correctly.
-	co, ok := s.Classes[name]
+	class, ok := s.Classes[name]
 	if !ok {
 		return false
 	}
@@ -332,8 +337,8 @@ func (s *schema) deleteClass(name string) bool {
 	sc := make(map[string]int)
 
 	// need to decrement shards count on this class.
-	for _, s := range co.Sharding.Physical {
-		sc[s.Status]++
+	for _, shard := range class.Sharding.Physical {
+		sc[shard.Status]++
 	}
 
 	delete(s.Classes, name)

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -321,15 +321,15 @@ func (s *schema) deleteClass(name string) bool {
 	s.Lock()
 	defer s.Unlock()
 
-	// sc tracks number of shards in this collection to be deleted by status.
-	sc := make(map[string]int)
-
 	// since `delete(map, key)` is no-op if `key` doesn't exist, check before deleting
 	// so that we can increment the `collectionsCount` correctly.
 	co, ok := s.Classes[name]
 	if !ok {
 		return false
 	}
+
+	// sc tracks number of shards in this collection to be deleted by status.
+	sc := make(map[string]int)
 
 	// need to decrement shards count on this class.
 	for _, s := range co.Sharding.Physical {
@@ -405,11 +405,7 @@ func (s *schema) updateTenants(class string, v uint64, req *command.UpdateTenant
 		s.shardsCount.WithLabelValues(status).Add(float64(count))
 	}
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (s *schema) getTenants(class string, tenants []string) ([]*models.Tenant, error) {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -383,9 +383,8 @@ func (s *schema) updateTenants(class string, v uint64, req *command.UpdateTenant
 	if !ok {
 		return err
 	}
-	// TODO: What happens if it returns error because of missingShards, but still some shards are updated in `s.Sharding.Physical`?
-	// Basically. Is partial error possible?
 	sc, err := meta.UpdateTenants(s.nodeID, req, v)
+	// partial update possible
 	for status, count := range sc {
 		// count can be positive or negative.
 		s.shardsCount.WithLabelValues(status).Add(float64(count))

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -136,4 +136,9 @@ func Test_schemaShardMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("FROZEN")))
+
+	// Deleting collection with non-zero shards should decrement the shards count as well.
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
+	require.True(t, s.deleteClass(c2.Class))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -128,4 +128,12 @@ func Test_schemaShardMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+
+	// update tenant status
+	err = s.updateTenants(c2.Class, 0, &api.UpdateTenantsRequest{
+		Tenants: []*api.Tenant{{Name: "tenant2", Status: "HOT"}}, // FROZEN -> HOT
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-func Test_schemaMetrics(t *testing.T) {
+func Test_schemaCollectionMetrics(t *testing.T) {
 	r := prometheus.NewPedanticRegistry()
 
 	s := NewSchema("testNode", nil, r)
@@ -47,52 +47,8 @@ func Test_schemaMetrics(t *testing.T) {
 	require.NoError(t, s.addClass(c1, ss, 0)) // adding c1 collection
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.collectionsCount))
 
-	require.NoError(t, s.addClass(c2, ss, 0))
-	assert.Equal(t, float64(2), testutil.ToFloat64(s.collectionsCount)) // adding c2 collection
-
-	// Shard metrics
-	// no shards now.
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode")))
-
-	// add shard to c1 collection
-	err := s.addTenants(c1.Class, 0, &api.AddTenantsRequest{
-		ClusterNodes: []string{"testNode"},
-		Tenants: []*api.Tenant{
-			{
-				Name: "tenant1",
-			},
-			nil, // nil tenant shouldn't be counted in the metrics
-		},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount))
-
-	// add shard to c2 collection
-	err = s.addTenants(c2.Class, 0, &api.AddTenantsRequest{
-		ClusterNodes: []string{"testNode"},
-		Tenants: []*api.Tenant{
-			{
-				Name: "tenant2",
-			},
-			nil, // nil tenant shouldn't be counted in the metrics
-		},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, float64(2), testutil.ToFloat64(s.shardsCount))
-
-	// delete "existing" tenant
-	err = s.deleteTenants(c1.Class, 0, &api.DeleteTenantsRequest{
-		Tenants: []string{"tenant1"},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount))
-
-	// delete "non-existing" tenant
-	err = s.deleteTenants(c1.Class, 0, &api.DeleteTenantsRequest{
-		Tenants: []string{"tenant1"},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount))
+	require.NoError(t, s.addClass(c2, ss, 0)) // adding c2 collection
+	assert.Equal(t, float64(2), testutil.ToFloat64(s.collectionsCount))
 
 	// delete c2
 	s.deleteClass("collection2")
@@ -101,4 +57,75 @@ func Test_schemaMetrics(t *testing.T) {
 	// delete c1
 	s.deleteClass("collection1")
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount))
+}
+
+func Test_schemaShardMetrics(t *testing.T) {
+	r := prometheus.NewPedanticRegistry()
+
+	s := NewSchema("testNode", nil, r)
+	ss := &sharding.State{}
+
+	c1 := &models.Class{
+		Class: "collection1",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+	c2 := &models.Class{
+		Class: "collection2",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	require.NoError(t, s.addClass(c1, ss, 0)) // adding c1 collection
+	require.NoError(t, s.addClass(c2, ss, 0)) // adding c2 collection
+
+	// Shard metrics
+	// no shards now.
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "")))
+
+	// add shard to c1 collection
+	err := s.addTenants(c1.Class, 0, &api.AddTenantsRequest{
+		ClusterNodes: []string{"testNode"},
+		Tenants: []*api.Tenant{
+			{
+				Name:   "tenant1",
+				Status: "HOT",
+			},
+			nil, // nil tenant shouldn't be counted in the metrics
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
+
+	// add shard to c2 collection
+	err = s.addTenants(c2.Class, 0, &api.AddTenantsRequest{
+		ClusterNodes: []string{"testNode"},
+		Tenants: []*api.Tenant{
+			{
+				Name:   "tenant2",
+				Status: "FROZEN",
+			},
+			nil, // nil tenant shouldn't be counted in the metrics
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+
+	// delete "existing" tenant
+	err = s.deleteTenants(c1.Class, 0, &api.DeleteTenantsRequest{
+		Tenants: []string{"tenant1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+
+	// delete "non-existing" tenant
+	err = s.deleteTenants(c1.Class, 0, &api.DeleteTenantsRequest{
+		Tenants: []string{"tenant1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -43,7 +43,7 @@ func Test_schemaCollectionMetrics(t *testing.T) {
 	}
 
 	// Collection metrics
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount.WithLabelValues("testNode")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount))
 	require.NoError(t, s.addClass(c1, ss, 0)) // adding c1 collection
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.collectionsCount))
 
@@ -83,7 +83,7 @@ func Test_schemaShardMetrics(t *testing.T) {
 
 	// Shard metrics
 	// no shards now.
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("")))
 
 	// add shard to c1 collection
 	err := s.addTenants(c1.Class, 0, &api.AddTenantsRequest{
@@ -97,7 +97,7 @@ func Test_schemaShardMetrics(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
 
 	// add shard to c2 collection
 	err = s.addTenants(c2.Class, 0, &api.AddTenantsRequest{
@@ -111,29 +111,29 @@ func Test_schemaShardMetrics(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("FROZEN")))
 
 	// delete "existing" tenant
 	err = s.deleteTenants(c1.Class, 0, &api.DeleteTenantsRequest{
 		Tenants: []string{"tenant1"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("FROZEN")))
 
 	// delete "non-existing" tenant
 	err = s.deleteTenants(c1.Class, 0, &api.DeleteTenantsRequest{
 		Tenants: []string{"tenant1"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("FROZEN")))
 
 	// update tenant status
 	err = s.updateTenants(c2.Class, 0, &api.UpdateTenantsRequest{
 		Tenants: []*api.Tenant{{Name: "tenant2", Status: "HOT"}}, // FROZEN -> HOT
 	})
 	require.NoError(t, err)
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "HOT")))
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("testNode", "FROZEN")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("FROZEN")))
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -89,10 +89,4 @@ func Test_schemaMetrics(t *testing.T) {
 	// delete c1
 	s.deleteClass("collection1")
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount))
-
-	// Close() should un-register the metrics. So that creating new schema with same `prometheus.Registry` shouldn't panic with duplicate metrics
-	s.Close(r)
-	assert.NotPanics(t, func() {
-		NewSchema("testNode", nil, r) // creating new schema
-	})
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -12,24 +12,35 @@
 package schema
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 func Test_schemaMetrics(t *testing.T) {
-	s := NewSchema("testNode", nil)
+	r := prometheus.NewPedanticRegistry()
+
+	s := NewSchema("testNode", nil, r)
 	ss := &sharding.State{}
 
 	c1 := &models.Class{
 		Class: "collection1",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
 	}
 	c2 := &models.Class{
 		Class: "collection2",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
 	}
 
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount.WithLabelValues("testNode")))
@@ -39,17 +50,49 @@ func Test_schemaMetrics(t *testing.T) {
 	require.NoError(t, s.addClass(c2, ss, 0))
 	assert.Equal(t, float64(2), testutil.ToFloat64(s.collectionsCount)) // adding c2 collection
 
+	// Check shard metric
+
+	// no shards now.
+	// assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount))
+
+	// add shard to c1 collection
+	err := s.addTenants(c1.Class, 0, &api.AddTenantsRequest{
+		ClusterNodes: []string{"testNode"},
+		Tenants: []*api.Tenant{
+			{
+				Name: "tenant1",
+			},
+			nil, // nil tenant shouldn't be counted in the metrics
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount))
+
+	// add shard to c2 collection
+	err = s.addTenants(c2.Class, 0, &api.AddTenantsRequest{
+		ClusterNodes: []string{"testNode"},
+		Tenants: []*api.Tenant{
+			{
+				Name: "tenant2",
+			},
+			nil, // nil tenant shouldn't be counted in the metrics
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, float64(2), testutil.ToFloat64(s.shardsCount))
+
 	// delete c2
 	s.deleteClass("collection2")
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.collectionsCount))
 
+	fmt.Println("Debug!!", s.Classes)
 	// delete c1
-	s.deleteClass("collection2")
+	s.deleteClass("collection1")
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount))
 
-	// should un-register the metrics. So that creating new schema shouldn't panic with duplicate metrics
-	s.Close()
+	// Close() should un-register the metrics. So that creating new schema with same `prometheus.Registry` shouldn't panic with duplicate metrics
+	s.Close(r)
 	assert.NotPanics(t, func() {
-		NewSchema("testNode", nil) // creating new schema
+		NewSchema("testNode", nil, r) // creating new schema
 	})
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -141,4 +141,16 @@ func Test_schemaShardMetrics(t *testing.T) {
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
 	require.True(t, s.deleteClass(c2.Class))
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")))
+
+	// Adding class with non empty shard should increase the shard count
+	ss = &sharding.State{
+		Physical: make(map[string]sharding.Physical),
+	}
+	ss.Physical["random"] = sharding.Physical{
+		Name:   "random",
+		Status: "",
+	}
+	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("")))
+	require.NoError(t, s.addClass(c2, ss, 0))
+	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("")))
 }

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/bootstrap"
 	"github.com/weaviate/weaviate/cluster/resolver"
@@ -66,7 +67,7 @@ func New(cfg Config) *Service {
 		}
 	}
 	cl := rpc.NewClient(resolver.NewRpc(cfg.IsLocalHost, cfg.RPCPort), cfg.RaftRPCMessageMaxSize, cfg.SentryEnabled, cfg.Logger)
-	fsm := NewFSM(cfg)
+	fsm := NewFSM(cfg, prometheus.DefaultRegisterer)
 	raft := NewRaft(cfg.NodeSelector, &fsm, cl)
 	return &Service{
 		Raft:              raft,

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/cluster"
 
@@ -187,7 +188,7 @@ type Store struct {
 	lastAppliedIndex atomic.Uint64
 }
 
-func NewFSM(cfg Config) Store {
+func NewFSM(cfg Config, reg prometheus.Registerer) Store {
 	// We have different resolver in raft so that depending on the environment we can resolve a node-id to an IP using
 	// different methods.
 	var raftResolver types.RaftResolver
@@ -212,7 +213,7 @@ func NewFSM(cfg Config) Store {
 		candidates:    make(map[string]string, cfg.BootstrapExpect),
 		applyTimeout:  time.Second * 20,
 		raftResolver:  raftResolver,
-		schemaManager: schema.NewSchemaManager(cfg.NodeID, cfg.DB, cfg.Parser, cfg.Logger),
+		schemaManager: schema.NewSchemaManager(cfg.NodeID, cfg.DB, cfg.Parser, reg, cfg.Logger),
 	}
 }
 

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
@@ -585,7 +586,7 @@ func NewMockStore(t *testing.T, nodeID string, raftPort int) MockStore {
 			ConsistencyWaitTimeout: time.Millisecond * 50,
 		},
 	}
-	s := NewFSM(ms.cfg)
+	s := NewFSM(ms.cfg, prometheus.NewPedanticRegistry())
 	ms.store = &s
 	return ms
 }

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -149,6 +149,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
+	fmt.Println("Debug!!!!!!!!!!!!!!!!!!! Am i here??")
 	if err := h.Authorizer.Authorize(principal, "delete", tenantsPath); err != nil {
 		return err
 	}

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -149,7 +149,6 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	fmt.Println("Debug!!!!!!!!!!!!!!!!!!! Am i here??")
 	if err := h.Authorizer.Authorize(principal, "delete", tenantsPath); err != nil {
 		return err
 	}

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -349,14 +349,14 @@ func (s *State) AddPartition(name string, nodes []string, status string) Physica
 
 // DeletePartition to physical shards. Return `true` if given partition is
 // actually deleted.
-func (s *State) DeletePartition(name string) bool {
-	_, ok := s.Physical[name]
+func (s *State) DeletePartition(name string) (string, bool) {
+	t, ok := s.Physical[name]
 	if !ok {
-		return false
+		return "", false
 	}
-
+	status := t.Status
 	delete(s.Physical, name)
-	return true
+	return status, true
 }
 
 // ApplyNodeMapping replaces node names with their new value form nodeMapping in s.

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -347,9 +347,16 @@ func (s *State) AddPartition(name string, nodes []string, status string) Physica
 	return p
 }
 
-// DeletePartition to physical shards
-func (s *State) DeletePartition(name string) {
+// DeletePartition to physical shards. Return `true` if given partition is
+// actually deleted.
+func (s *State) DeletePartition(name string) bool {
+	_, ok := s.Physical[name]
+	if !ok {
+		return false
+	}
+
 	delete(s.Physical, name)
+	return true
 }
 
 // ApplyNodeMapping replaces node names with their new value form nodeMapping in s.


### PR DESCRIPTION
### What's being changed:

Follow up to #6994 
Add `weaviate_schema_shards` guage metric to track total shards from each node point of view. This also adds label `status` (HOT, WARM, COLD, FROZEN). So that we can have count per shard's status.

eg: `localhost:2112/metrics`

```
# HELP weaviate_schema_shards Number of shards per node with corresponding status
# TYPE weaviate_schema_shards gauge
weaviate_schema_shards{nodeID="weaviate-0",status="COLD"} 1
weaviate_schema_shards{nodeID="weaviate-0",status="HOT"} 2
```

NOTE: no `collection` or `class` label because of cardinality issues (number of collections are unbounded)

This also fixes a couple of bugs from #6994 
1. Handles the deletion of `collections` correctly (before if non-exist collection is deleted, it is double-counted)
2. Registers the collection metric correctly.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
