### PR TITLE
feat/Store average instead of sum for proplen

### DIFF
--- a/adapters/repos/db/lsmkv/memtable_flush_inverted.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted.go
@@ -164,7 +164,9 @@ func (m *Memtable) flushDataInverted(f *bufio.Writer, ff *os.File) ([]segmentind
 
 	b := new(bytes.Buffer)
 
-	binary.LittleEndian.PutUint64(buf, propLengthSum)
+	propLengthAvg := float64(propLengthSum) / float64(propLengthCount)
+
+	binary.LittleEndian.PutUint64(buf, math.Float64bits(propLengthAvg))
 	if _, err := f.Write(buf); err != nil {
 		return nil, nil, err
 	}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -16,6 +16,7 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/weaviate/sroar"
@@ -32,7 +33,7 @@ type segmentInvertedData struct {
 	propertyLengths       map[uint64]uint32
 	propertyLengthsLoaded bool
 
-	avgPropertyLengthsSum   uint64
+	avgPropertyLengthsAvg   float64
 	avgPropertyLengthsCount uint64
 }
 
@@ -75,7 +76,7 @@ func (s *segment) loadPropertyLengths() (map[uint64]uint32, error) {
 		return s.invertedData.propertyLengths, nil
 	}
 
-	s.invertedData.avgPropertyLengthsSum = binary.LittleEndian.Uint64(s.contents[s.invertedHeader.PropertyLengthsOffset : s.invertedHeader.PropertyLengthsOffset+8])
+	s.invertedData.avgPropertyLengthsAvg = math.Float64frombits(binary.LittleEndian.Uint64(s.contents[s.invertedHeader.PropertyLengthsOffset : s.invertedHeader.PropertyLengthsOffset+8]))
 	s.invertedData.avgPropertyLengthsCount = binary.LittleEndian.Uint64(s.contents[s.invertedHeader.PropertyLengthsOffset+8 : s.invertedHeader.PropertyLengthsOffset+16])
 
 	// read property lengths, the first 16 bytes are the propLengthCount and sum, the 8 bytes are the size of the gob encoded map


### PR DESCRIPTION
### What's being changed:

Store the average instead of the sum, to avoid overflowing the sum of prop lengths for all docs in the segment.
The proper value can be recombined with minimal precision loss by doing a weighted sum of the averages.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
