### PR TITLE
Add Support for Multivectors in GraphQL vectorPerTarget queries

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/near_filters.go
+++ b/adapters/handlers/graphql/local/common_filters/near_filters.go
@@ -161,7 +161,11 @@ func vectorPerTargetParseLiteral(valueAST ast.Value) interface{} {
 func getNormalVector(values []ast.Value) ([]float32, error) {
 	normalVector := make([]float32, len(values))
 	for i, value := range values {
-		floatValue, err := strconv.ParseFloat(value.GetValue().(string), 64)
+		vStr, ok := value.GetValue().(string)
+		if !ok {
+			return nil, fmt.Errorf("value is not a string: %T", value)
+		}
+		floatValue, err := strconv.ParseFloat(vStr, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +177,10 @@ func getNormalVector(values []ast.Value) ([]float32, error) {
 func getListOfNormalVectors(values []ast.Value) ([][]float32, error) {
 	normalVectors := make([][]float32, len(values))
 	for i, value := range values {
-		vector := value.(*ast.ListValue)
+		vector, ok := value.(*ast.ListValue)
+		if !ok {
+			return nil, fmt.Errorf("value is not a list: %T", value)
+		}
 		v, err := getNormalVector(vector.Values)
 		if err != nil {
 			return nil, err
@@ -186,7 +193,10 @@ func getListOfNormalVectors(values []ast.Value) ([][]float32, error) {
 func getListOfMultiVectors(values []ast.Value) ([][][]float32, error) {
 	multiVectors := make([][][]float32, len(values))
 	for i, value := range values {
-		multiVector := value.(*ast.ListValue)
+		multiVector, ok := value.(*ast.ListValue)
+		if !ok {
+			return nil, fmt.Errorf("value is not a multivector list: %T", value)
+		}
 		mv, err := getListOfNormalVectors(multiVector.Values)
 		if err != nil {
 			return nil, err

--- a/adapters/handlers/graphql/local/common_filters/near_filters.go
+++ b/adapters/handlers/graphql/local/common_filters/near_filters.go
@@ -12,12 +12,12 @@
 package common_filters
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
-	"github.com/tailor-inc/graphql/language/ast"
-
 	"github.com/tailor-inc/graphql"
+	"github.com/tailor-inc/graphql/language/ast"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/descriptions"
 )
 
@@ -109,52 +109,118 @@ var vectorPerTarget = graphql.NewScalar(graphql.ScalarConfig{
 	ParseValue: func(value interface{}) interface{} {
 		return value
 	},
-	ParseLiteral: func(valueAST ast.Value) interface{} {
-		switch v := valueAST.(type) {
-		case *ast.ObjectValue:
-			result := make(map[string]interface{})
-			for _, field := range v.Fields {
-				key := field.Name.Value
-				switch value := field.Value.(type) {
-				case *ast.ListValue:
-					if len(value.Values) > 0 {
-						switch value.Values[0].(type) {
-						case *ast.ListValue:
-							// Handle list of lists of floats
-							listOfLists := make([][]float32, len(value.Values))
-							for i, listValue := range value.Values {
-								innerList := listValue.(*ast.ListValue)
-								floatValues := make([]float32, len(innerList.Values))
-								for j, innerValue := range innerList.Values {
-									floatValue, err := strconv.ParseFloat(innerValue.GetValue().(string), 64)
-									if err != nil {
-										return nil
-									}
-									floatValues[j] = float32(floatValue)
-								}
-								listOfLists[i] = floatValues
-							}
-							result[key] = listOfLists
-						default:
-							// Handle list of floats
-							floatValues := make([]float32, len(value.Values))
-							for i, value := range value.Values {
-								floatValue, err := strconv.ParseFloat(value.GetValue().(string), 64)
-								if err != nil {
-									return nil
-								}
-								floatValues[i] = float32(floatValue)
-							}
-							result[key] = floatValues
-						}
-					}
-				default:
-					return nil
-				}
-			}
-			return result
-		default:
-			return nil
-		}
-	},
+	ParseLiteral: vectorPerTargetParseLiteral,
 })
+
+func vectorPerTargetParseLiteral(valueAST ast.Value) interface{} {
+	switch v := valueAST.(type) {
+	case *ast.ObjectValue:
+		result := make(map[string]interface{})
+		for _, field := range v.Fields {
+			key := field.Name.Value
+			switch value := field.Value.(type) {
+			case *ast.ListValue:
+				if len(value.Values) > 0 {
+					switch value.Values[0].(type) {
+					case *ast.ListValue:
+						areMultiVectors, err := valuesAreMultiVectors(value.Values)
+						if err != nil {
+							return nil
+						}
+						if areMultiVectors {
+							r, err := getListOfMultiVectors(value.Values)
+							if err != nil {
+								return nil
+							}
+							result[key] = r
+						} else {
+							r, err := getListOfNormalVectors(value.Values)
+							if err != nil {
+								return nil
+							}
+							result[key] = r
+						}
+					default:
+						normalVector, err := getNormalVector(value.Values)
+						if err != nil {
+							return nil
+						}
+						result[key] = normalVector
+					}
+				}
+			default:
+				return nil
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func getNormalVector(values []ast.Value) ([]float32, error) {
+	normalVector := make([]float32, len(values))
+	for i, value := range values {
+		floatValue, err := strconv.ParseFloat(value.GetValue().(string), 64)
+		if err != nil {
+			return nil, err
+		}
+		normalVector[i] = float32(floatValue)
+	}
+	return normalVector, nil
+}
+
+func getListOfNormalVectors(values []ast.Value) ([][]float32, error) {
+	normalVectors := make([][]float32, len(values))
+	for i, value := range values {
+		vector := value.(*ast.ListValue)
+		v, err := getNormalVector(vector.Values)
+		if err != nil {
+			return nil, err
+		}
+		normalVectors[i] = v
+	}
+	return normalVectors, nil
+}
+
+func getListOfMultiVectors(values []ast.Value) ([][][]float32, error) {
+	multiVectors := make([][][]float32, len(values))
+	for i, value := range values {
+		multiVector := value.(*ast.ListValue)
+		mv, err := getListOfNormalVectors(multiVector.Values)
+		if err != nil {
+			return nil, err
+		}
+		multiVectors[i] = mv
+	}
+	return multiVectors, nil
+}
+
+func valuesAreMultiVectors(values []ast.Value) (bool, error) {
+	if len(values) == 0 {
+		return false, errors.New(("values are empty"))
+	}
+	firstValue := values[0]
+	switch firstValue.(type) {
+	case *ast.ListValue:
+		switch firstValue.(type) {
+		case *ast.ListValue:
+			vList := firstValue.(*ast.ListValue)
+			if len(vList.Values) == 0 {
+				return false, errors.New("empty list")
+			}
+			vv := vList.Values[0]
+			if _, vvIsList := vv.(*ast.ListValue); vvIsList {
+				return true, nil
+			}
+			// TODO test intvalue, etc
+			if _, vvIsFloat := vv.(*ast.FloatValue); vvIsFloat {
+				return false, nil
+			}
+			return false, errors.New("unknown type")
+		}
+	default:
+		return false, errors.New("not list value")
+	}
+	return false, errors.New("failed to determine")
+}

--- a/adapters/handlers/graphql/local/common_filters/near_filters.go
+++ b/adapters/handlers/graphql/local/common_filters/near_filters.go
@@ -213,11 +213,13 @@ func valuesAreMultiVectors(values []ast.Value) (bool, error) {
 			if _, vvIsList := vv.(*ast.ListValue); vvIsList {
 				return true, nil
 			}
-			// TODO test intvalue, etc
 			if _, vvIsFloat := vv.(*ast.FloatValue); vvIsFloat {
 				return false, nil
 			}
-			return false, errors.New("unknown type")
+			if _, vvIsInt := vv.(*ast.IntValue); vvIsInt {
+				return false, nil
+			}
+			return false, fmt.Errorf("unknown type: %T", vv)
 		}
 	default:
 		return false, errors.New("not list value")

--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -1404,6 +1404,45 @@ func TestNearVectorRanker(t *testing.T) {
 		resolver.AssertResolve(t, query)
 	})
 
+	t.Run("with targetvector list", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [[1, 0]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+							}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[]float32{1., 0}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
+				TargetVectors: []string{"title1", "title2", "title3"},
+			},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+	t.Run("with target multivector", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [[[1, 0]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+							}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[][]float32{{1., 0}}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
+				TargetVectors: []string{"title1", "title2", "title3"},
+			},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+
 	t.Run("with targetvector and multiple entries for a vector", func(t *testing.T) {
 		query := `{ Get { SomeThing(
 						nearVector: {
@@ -1415,6 +1454,26 @@ func TestNearVectorRanker(t *testing.T) {
 			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
 			NearVector: &searchparams.NearVector{
 				Vectors:       []models.Vector{[]float32{1., 0}, []float32{0, 1}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
+				TargetVectors: []string{"title1", "title1", "title2", "title3"},
+			},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+
+	t.Run("with target multivector and multiple entries for multivector", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [[[1, 0]], [[0,1]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+							}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[][]float32{{1., 0}}, [][]float32{{0, 1}}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
 				TargetVectors: []string{"title1", "title1", "title2", "title3"},
 			},
 		}
@@ -1436,6 +1495,28 @@ func TestNearVectorRanker(t *testing.T) {
 			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
 			NearVector: &searchparams.NearVector{
 				Vectors:       []models.Vector{[]float32{1., 0}, []float32{0, 1}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
+				TargetVectors: []string{"title1", "title1", "title2", "title3"},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.Sum, Weights: []float32{1, 1, 1, 1}},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+
+	t.Run("with target multivector and multiple entries for multivector and targets", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [[[1, 0]], [[0,1]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+						targets: {targetVectors: ["title1", "title1", "title2", "title3"], combinationMethod: sum}
+							}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[][]float32{{1., 0}}, [][]float32{{0, 1}}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
 				TargetVectors: []string{"title1", "title1", "title2", "title3"},
 			},
 			TargetVectorCombination: &dto.TargetCombination{Type: dto.Sum, Weights: []float32{1, 1, 1, 1}},
@@ -1472,6 +1553,32 @@ func TestNearVectorRanker(t *testing.T) {
 		resolver.AssertResolve(t, query)
 	})
 
+	t.Run("with target multivector and weights", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [1, 0], title2: [0, 0, 1], title3: [[[0, 0, 0, 1]]]}
+						targets: {
+							targetVectors: ["title1", "title2", "title3"], 
+							combinationMethod: manualWeights,
+							weights: {title1: 1, title2: 3, title3: 4}
+						}
+					}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[]float32{1., 0}, []float32{0, 0, 1}, [][]float32{{0, 0, 0, 1}}},
+				TargetVectors: []string{"title1", "title2", "title3"},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.ManualWeights, Weights: []float32{1, 3, 4}},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+
 	t.Run("with targetvector and multiple entries for a vector and weights", func(t *testing.T) {
 		query := `{ Get { SomeThing(
 						nearVector: {
@@ -1498,6 +1605,32 @@ func TestNearVectorRanker(t *testing.T) {
 		resolver.AssertResolve(t, query)
 	})
 
+	t.Run("with target multivector and multiple entries for multivector and weights", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [[[1, 0]], [[0,1]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+						targets: {
+							targetVectors: ["title1", "title1", "title2", "title3"], 
+							combinationMethod: manualWeights,
+							weights: {title1: [1, 2], title2: 3, title3: 4}
+						}
+					}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[][]float32{{1., 0}}, [][]float32{{0, 1}}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
+				TargetVectors: []string{"title1", "title1", "title2", "title3"},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.ManualWeights, Weights: []float32{1, 2, 3, 4}},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+
 	t.Run("with non fitting target vectors", func(t *testing.T) {
 		query := `{ Get { SomeThing(
 						nearVector: {
@@ -1509,10 +1642,32 @@ func TestNearVectorRanker(t *testing.T) {
 		resolver.AssertFailToResolve(t, query)
 	})
 
+	t.Run("with non fitting target multivectors", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1: [[[1, 0]], [[0,1]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+						targets: {
+							targetVectors: ["title1", "title2", "title3"], 
+						}
+					}) { intField } } }`
+		resolver.AssertFailToResolve(t, query)
+	})
+
 	t.Run("with non fitting target vectors 2", func(t *testing.T) {
 		query := `{ Get { SomeThing(
 						nearVector: {
 						vectorPerTarget: {title1:  [0,1], title2: [0, 0, 1], title3:[[1, 0], [0,1]]}
+						targets: {
+							targetVectors: ["title1", "title2", "title3"], 
+						}
+					}) { intField } } }`
+		resolver.AssertFailToResolve(t, query)
+	})
+
+	t.Run("with non fitting target multivectors 2", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						nearVector: {
+						vectorPerTarget: {title1:  [0,1], title2: [0, 0, 1], title3:[[[1, 0]], [[0,1]]]}
 						targets: {
 							targetVectors: ["title1", "title2", "title3"], 
 						}
@@ -2161,7 +2316,7 @@ func TestHybridWithTargets(t *testing.T) {
 		resolver.AssertResolve(t, query)
 	})
 
-	t.Run("hybrid search with near vector subsearch and multi vector", func(t *testing.T) {
+	t.Run("hybrid search with near vector subsearch and multiple vectors", func(t *testing.T) {
 		query := `{Get{SomeAction(hybrid:{
 					query:"apple", 
 					targetVectors: ["title1", "title2", "title3"],
@@ -2190,12 +2345,52 @@ func TestHybridWithTargets(t *testing.T) {
 		resolver.AssertResolve(t, query)
 	})
 
+	t.Run("hybrid search with near vector subsearch and multiple vectors with multivector", func(t *testing.T) {
+		query := `{Get{SomeAction(hybrid:{
+					query:"apple", 
+					targetVectors: ["title1", "title2", "title3"],
+					searches: {nearVector:{
+     							vectorPerTarget: {title1: [[[1, 0]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+                    }}
+					}){intField}}}`
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeAction",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			HybridSearch: &searchparams.HybridSearch{
+				Query:           "apple",
+				Alpha:           0.75,
+				Type:            "hybrid",
+				FusionAlgorithm: 1,
+				SubSearches:     emptySubsearches,
+				TargetVectors:   []string{"title1", "title2", "title3"},
+				NearVectorParams: &searchparams.NearVector{
+					Vectors: []models.Vector{[][]float32{{1.0, 0}}, []float32{0, 0, 1}, []float32{0, 0, 0, 1}},
+				},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+		resolver.AssertResolve(t, query)
+	})
+
 	t.Run("hybrid search with near vector subsearch and wrong input", func(t *testing.T) {
 		query := `{Get{SomeAction(hybrid:{
 					query:"apple", 
 					targetVectors: ["title1", "title2", "title3"],
 					searches: {nearVector:{
      							vectorPerTarget: {title1: [1, "fish"], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
+                    }}
+					}){intField}}}`
+		resolver.AssertFailToResolve(t, query)
+	})
+
+	t.Run("hybrid search with near vector subsearch and wrong input in multivector", func(t *testing.T) {
+		query := `{Get{SomeAction(hybrid:{
+					query:"apple", 
+					targetVectors: ["title1", "title2", "title3"],
+					searches: {nearVector:{
+     							vectorPerTarget: {title1: [[[1, "fish"]]], title2: [0, 0, 1], title3: [0, 0, 0, 1]}
                     }}
 					}){intField}}}`
 		resolver.AssertFailToResolve(t, query)
@@ -2230,7 +2425,36 @@ func TestHybridWithTargets(t *testing.T) {
 		resolver.AssertResolve(t, query)
 	})
 
-	t.Run("hybrid search with near vector subsearch and multi vector", func(t *testing.T) {
+	t.Run("hybrid search with near vector subsearch and multiple vectors with multivector2", func(t *testing.T) {
+		query := `{Get{SomeAction(hybrid:{
+					query:"apple", 
+					targetVectors: ["title1", "title2", "title2", "title3", "title3"],
+					searches: {nearVector:{
+     							vectorPerTarget: {title1: [1, 0], title2: [[[0, 0, 1]], [[1,0,0]]], title3: [[0, 0, 0, 1], [1, 0, 0, 1]]}
+                    }}
+					}){intField}}}`
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeAction",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			HybridSearch: &searchparams.HybridSearch{
+				Query:           "apple",
+				Alpha:           0.75,
+				Type:            "hybrid",
+				FusionAlgorithm: 1,
+				SubSearches:     emptySubsearches,
+				TargetVectors:   []string{"title1", "title2", "title2", "title3", "title3"},
+				NearVectorParams: &searchparams.NearVector{
+					Vectors: []models.Vector{[]float32{1.0, 0}, [][]float32{{0, 0, 1}}, [][]float32{{1, 0, 0}}, []float32{0, 0, 0, 1}, []float32{1, 0, 0, 1}},
+				},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+		resolver.AssertResolve(t, query)
+	})
+
+	t.Run("hybrid search with near vector subsearch and multiple vectors missing target vectors", func(t *testing.T) {
 		query := `{Get{SomeAction(hybrid:{
 					query:"apple", 
 					searches: {nearVector:{
@@ -2238,6 +2462,45 @@ func TestHybridWithTargets(t *testing.T) {
                     }}
 					}){intField}}}`
 		resolver.AssertFailToResolve(t, query)
+	})
+
+	t.Run("hybrid search with near vector subsearch and multiple vectors and multivector missing target vectors", func(t *testing.T) {
+		query := `{Get{SomeAction(hybrid:{
+					query:"apple", 
+					searches: {nearVector:{
+     							vectorPerTarget: {title1: [[[1, 0]]], title2: [[[0, 0, 1]], [[1,0,0]]], title3: [[[0, 0, 0, 1]], [[1, 0, 0, 1]]]}
+                    }}
+					}){intField}}}`
+		resolver.AssertFailToResolve(t, query)
+	})
+
+	t.Run("hybrid search with near vector subsearch and multi vector2", func(t *testing.T) {
+		query := `{Get{SomeAction(hybrid:{
+					query:"apple", 
+					targetVectors: ["title1", "title2", "title2", "title3", "title3"],
+					searches: {nearVector:{
+     							vectorPerTarget: {title1: [1, 0], title2: [[0, 0, 1], [1,0,0]], title3: [[0, 0, 0, 1], [1, 0, 0, 1]]}
+                    }}
+					}){intField}}}`
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeAction",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			HybridSearch: &searchparams.HybridSearch{
+				Query:           "apple",
+				Alpha:           0.75,
+				Type:            "hybrid",
+				FusionAlgorithm: 1,
+				SubSearches:     emptySubsearches,
+				TargetVectors:   []string{"title1", "title2", "title2", "title3", "title3"},
+				NearVectorParams: &searchparams.NearVector{
+					Vectors: []models.Vector{[]float32{1.0, 0}, []float32{0, 0, 1}, []float32{1, 0, 0}, []float32{0, 0, 0, 1}, []float32{1, 0, 0, 1}},
+				},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+		resolver.AssertResolve(t, query)
 	})
 }
 
@@ -2621,6 +2884,497 @@ func TestNearVectorNoModules(t *testing.T) {
 
 		resolver.AssertResolve(t, query)
 	})
+
+	t.Run("vectorPerTarget and targets multivector", func(t *testing.T) {
+		query := `{ Get { SomeThing(
+						limit: -1
+						nearVector: {
+							vectorPerTarget:{ test1: [[[0.123, 0.984]]], test2: [0.456, 0.789]}
+							targetVectors: ["test1", "test2"]
+								}) { intField } } }`
+
+		expectedParams := dto.GetParams{
+			ClassName:  "SomeThing",
+			Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+			Pagination: &filters.Pagination{Limit: -1},
+			NearVector: &searchparams.NearVector{
+				Vectors:       []models.Vector{[][]float32{{0.123, 0.984}}, []float32{0.456, 0.789}},
+				TargetVectors: []string{"test1", "test2"},
+			},
+			TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+		}
+		resolver.On("GetClass", expectedParams).
+			Return([]interface{}{}, nil).Once()
+
+		resolver.AssertResolve(t, query)
+	})
+}
+
+func TestNearVectorNoModulesMultiVector(t *testing.T) {
+	t.Parallel()
+
+	resolver := newMockResolverWithNoModules()
+
+	tt := []struct {
+		name           string
+		query          string
+		expectedParams *dto.GetParams
+	}{
+		// single 3x2 multi-vector => valid if no `targetVectors` is given (only 1 multi-vector)
+		{
+			name: "vectorPerTarget and targets multivector",
+			query: `{ Get { SomeThing(
+						limit: -1
+						nearVector: {
+							vectorPerTarget:{ mymultivec2d: [
+								[[0.1,0.1],[0.2,0.2],[0.3,0.3]]
+							]}
+						}) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+					},
+					TargetVectors: []string{"mymultivec2d"},
+				},
+			},
+		},
+		// 4 levels of nesting is not handled, only support 3 levels right now (eg list of 2d multi-vectors)
+		{
+			name: "4 levels too much vector nesting",
+			query: `{ Get { SomeThing(
+						limit: -1
+						nearVector: {
+							vectorPerTarget:{ mymultivec2d: [
+								[[[0.1,0.1],[0.2,0.2],[0.3,0.3]]]
+							]}
+						}) { intField } } }`,
+			// 4 levels => parse error => expect nil
+			expectedParams: nil,
+		},
+		// two multi-vectors with two targetVectors => valid
+		{
+			name: "vectorPerTarget + targetVectors for multi and normal",
+			query: `{ Get { SomeThing(
+						limit: -1
+						nearVector: {
+							vectorPerTarget:{ test1: [[[0.123, 0.984]]], test2: [0.456, 0.789]}
+							targetVectors: ["test1", "test2"]
+								}) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{
+						[][]float32{{0.123, 0.984}}, // multi-vector for "test1" (3 levels)
+						[]float32{0.456, 0.789},     // normal vector for "test2" (2 levels)
+					},
+					TargetVectors: []string{"test1", "test2"},
+				},
+				// The original example shows a minimum combination:
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+			},
+		},
+		// single 3x2 multi-vector => valid if no `targetVectors` is given (only 1 multi-vector)
+		{
+			name: "single 3x2 multi-vector with no targetVectors",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]]
+						]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+					},
+					TargetVectors: []string{"mymultivec2d"},
+				},
+			},
+		},
+		// two 3x2 multi-vectors => shape is valid, but missing `targetVectors`,
+		// so final parse must fail (multiple multi-vectors with no labels).
+		{
+			name: "two 3x2 multi-vectors with no targetVectors error)",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.4,0.4],[0.5,0.5],[0.6,0.6]]
+						]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil, // fails because multiple multi-vectors require targetVectors
+		},
+		// one 3x2 multi-vector and one 1x2 multi-vector => shape is valid,
+		// but no targetVectors => must fail for same reason (multiple MVs).
+		{
+			name: "2 multi-vectors with no targetVectors error",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.4,0.4]]
+						]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil,
+		},
+		// one 3x2 multi-vector, one 1x2 multi-vector, one 4x2 multi-vector => shape valid,
+		// but still multiple MVs with no targetVectors => error.
+		{
+			name: "3 multi-vectors, no targetVectors error",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.4,0.4]],
+							[[0.5,0.5],[0.6,0.6],[0.7,0.7],[0.8,0.8]]
+						]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil,
+		},
+		// This fails because it is interpreted as a list of normal vectors, which should require
+		// targetVectors to be specified since there are more than one.
+		{
+			name: "2 levels (multiple normal vectors), no targetVectors",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[0.1,0.1],[0.2,0.2],[0.3,0.3]
+						]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil,
+		},
+		// 3 levels but sub-vectors have inconsistent lengths, this is not a parse error, but
+		// the query layer should handle this to decide if it is an error.
+		{
+			name: "3 levels but sub-vector length mismatch => error",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2,0.2,0.2],[0.3]]
+						]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2, 0.2, 0.2}, {0.3},
+						},
+					},
+					TargetVectors: []string{"mymultivec2d"},
+				},
+			},
+		},
+		// one multi-vector with a target label
+		{
+			name: "single multi-vector + matching label",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]]
+						]
+					}
+					targetVectors: ["mymultivec2d"]
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+					},
+					TargetVectors: []string{"mymultivec2d"},
+				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+			},
+		},
+		// two multi-vectors for the same target label => we have 2 items, each of shape >=3 levels.
+		// The doc example:
+		// => valid if we parse each multi-vector separately with the same label.
+		{
+			name: "2 multi-vectors for same label",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.4,0.4]]
+						]
+					}
+					targetVectors: ["mymultivec2d", "mymultivec2d"]
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					// two multi-vectors, each a [][]float32
+					Vectors: []models.Vector{
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+						[][]float32{
+							{0.4, 0.4},
+						},
+					},
+					TargetVectors: []string{"mymultivec2d", "mymultivec2d"},
+				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+			},
+		},
+		// two multi-vectors over two labels, no target vectors => error
+		{
+			name: "2 multi-vectors, no multi-vector labels error",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+						],
+						mymultivec1d: [
+							[[0.5],[0.6]]
+						],
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil,
+		},
+		// multiple multi-vectors over multiple labels, total # must match.
+		// => 3 multi-vectors total => 3 target labels => valid
+		{
+			name: "3 multi-vectors, 3 matching labels",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.4,0.4]]
+						],
+						mymultivec1d: [
+							[[0.5],[0.6]]
+						],
+					}
+					targetVectors: ["mymultivec2d","mymultivec2d","mymultivec1d"]
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName:  "SomeThing",
+				Properties: []search.SelectProperty{{Name: "intField", IsPrimitive: true}},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{
+						// 3) 2x1
+						[][]float32{
+							{0.5},
+							{0.6},
+						},
+						// 1) 3x2
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+						// 2) 1x2
+						[][]float32{
+							{0.4, 0.4},
+						},
+					},
+					TargetVectors: []string{"mymultivec1d", "mymultivec2d", "mymultivec2d"},
+				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+			},
+		},
+		// If multiple multi-vectors appear but `targetVectors` doesn’t match the count => error
+		{
+			name: "mismatch between multi-vectors and labels error",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.4,0.4]]
+						],
+						mymultivec1d: [
+							[[0.1],[0.2]]
+						],
+						targetVectors: ["mymultivec2d","mymultivec1d"] 
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil, // we've got 3 multi-vectors but only 2 labels => error
+		},
+		// Within a single target vector, you cannot mix normal vectors (2-level) and multi-vectors (>=3-level).
+		{
+			name: "mix normal + multi in one target error",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[0.4,0.5]
+						],
+						targetVectors: ["mymultivec2d","mymultivec2d"]
+					}
+				}
+			) { intField } } }`,
+			expectedParams: nil,
+		},
+		// However, you *can* do multi-vectors for one target vector and normal vectors for another, as
+		//    long as each target is “internally consistent” and the `targetVectors` count lines up.
+		{
+			name: "multi-vector in one, normal vectors in another",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]],
+							[[0.5,0.5],[0.6,0.6],[0.7,0.7],[0.8,0.8]]
+						],
+						mymultivec3d: [
+							[0.1,0.2,0.3],
+							[0.4,0.5,0.6],
+							[0.7,0.8,0.9]
+						],
+					}
+					targetVectors: ["mymultivec2d","mymultivec2d","mymultivec3d","mymultivec3d","mymultivec3d"]
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName: "SomeThing",
+				Properties: []search.SelectProperty{
+					{Name: "intField", IsPrimitive: true},
+				},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					// two multi-vectors, each a [][]float32:
+					Vectors: []models.Vector{
+						// 1) the first multi-vector (3x2)
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+						// 2) the second multi-vector (4x2)
+						[][]float32{
+							{0.5, 0.5}, {0.6, 0.6}, {0.7, 0.7}, {0.8, 0.8},
+						},
+						// Next 3 are normal vectors of dimension 3
+						[]float32{0.1, 0.2, 0.3},
+						[]float32{0.4, 0.5, 0.6},
+						[]float32{0.7, 0.8, 0.9},
+					},
+					TargetVectors: []string{
+						"mymultivec2d", "mymultivec2d",
+						"mymultivec3d", "mymultivec3d", "mymultivec3d",
+					},
+				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+			},
+		},
+		// multi-vector in one target, single vector in another => valid
+		{
+			name: "multi-vector in one, single vector in other",
+			query: `{ Get { SomeThing(
+				limit: -1
+				nearVector: {
+					vectorPerTarget: {
+						mymultivec2d: [
+							[[0.1,0.1],[0.2,0.2],[0.3,0.3]]
+						],
+						mymultivec3d: [
+							0.1, 0.2, 0.3
+						]
+					}
+					targetVectors: ["mymultivec2d","mymultivec3d"]
+				}
+			) { intField } } }`,
+			expectedParams: &dto.GetParams{
+				ClassName: "SomeThing",
+				Properties: []search.SelectProperty{
+					{Name: "intField", IsPrimitive: true},
+				},
+				Pagination: &filters.Pagination{Limit: -1},
+				NearVector: &searchparams.NearVector{
+					// two multi-vectors, each a [][]float32:
+					Vectors: []models.Vector{
+						// the first multi-vector (3x2)
+						[][]float32{
+							{0.1, 0.1}, {0.2, 0.2}, {0.3, 0.3},
+						},
+						// 3 dimensional normal vector
+						[]float32{0.1, 0.2, 0.3},
+					},
+					TargetVectors: []string{
+						"mymultivec2d",
+						"mymultivec3d",
+					},
+				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedParams != nil {
+				// If we expect a successful parse, mock the resolver calls
+				resolver.On("GetClass", *tc.expectedParams).
+					Return([]interface{}{}, nil).Once()
+				resolver.AssertResolve(t, tc.query)
+			} else {
+				// Otherwise, we expect a parse/validation error
+				resolver.AssertFailToResolve(t, tc.query)
+			}
+		})
+	}
 }
 
 func TestSort(t *testing.T) {

--- a/test/acceptance_with_go_client/fixtures/colbert.go
+++ b/test/acceptance_with_go_client/fixtures/colbert.go
@@ -20,6 +20,10 @@ var (
 	BringYourOwnColBERTClassName       = "BringYourOwnColBERT"
 	BringYourOwnColBERTPropertyName    = "name"
 	BringYourOwnColBERTNamedVectorName = "byoc"
+	NormalVector2dName                 = "normal_2d"
+	MultiVector1dName                  = "multi_1d"
+	MultiVector2dName                  = "multi_2d"
+	MultiVector3dName                  = "multi_3d"
 )
 
 var BringYourOwnColBERTClass = func(className string) *models.Class {
@@ -32,6 +36,45 @@ var BringYourOwnColBERTClass = func(className string) *models.Class {
 		},
 		VectorConfig: map[string]models.VectorConfig{
 			BringYourOwnColBERTNamedVectorName: {
+				Vectorizer: map[string]interface{}{
+					"none": map[string]interface{}{},
+				},
+				VectorIndexConfig: map[string]interface{}{
+					"multivector": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				VectorIndexType: "hnsw",
+			},
+			NormalVector2dName: {
+				Vectorizer: map[string]interface{}{
+					"none": map[string]interface{}{},
+				},
+				VectorIndexType: "hnsw",
+			},
+			MultiVector1dName: {
+				Vectorizer: map[string]interface{}{
+					"none": map[string]interface{}{},
+				},
+				VectorIndexConfig: map[string]interface{}{
+					"multivector": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				VectorIndexType: "hnsw",
+			},
+			MultiVector2dName: {
+				Vectorizer: map[string]interface{}{
+					"none": map[string]interface{}{},
+				},
+				VectorIndexConfig: map[string]interface{}{
+					"multivector": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				VectorIndexType: "hnsw",
+			},
+			MultiVector3dName: {
 				Vectorizer: map[string]interface{}{
 					"none": map[string]interface{}{},
 				},

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
@@ -283,7 +283,7 @@ func testColBERT(host string) func(t *testing.T) {
 				performNearVector(t, client, className)
 				performNearObject(t, client, className)
 			})
-			t.Run("WithVectorPerTarget searches", func(t *testing.T) {
+			t.Run("WithVector[s]PerTarget searches", func(t *testing.T) {
 				withVectorPerTargetTests := []struct {
 					name       string
 					nearVector *graphql.NearVectorArgumentBuilder
@@ -296,20 +296,103 @@ func testColBERT(host string) func(t *testing.T) {
 							}).
 							WithTargetVectors(normalVector2dName),
 					},
-					// TODO this errors because it gets interpreted as a multivector
-					// {
-					// 	name: "NormalVector_dim3x2",
-					// 	nearVector: client.GraphQL().NearVectorArgBuilder().
-					// 		WithVectorPerTarget(map[string]models.Vector{
-					// 			normalVector2dName: [][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
-					// 		}).
-					// 		WithTargetVectors(normalVector2dName),
-					// },
+					{
+						name: "NormalVectors_dim3x2",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorsPerTarget(map[string][]models.Vector{
+								normalVector2dName: {[]float32{0.1, 0.1}, []float32{0.1, 0.1}, []float32{0.1, 0.1}},
+							}).
+							WithTargetVectors(normalVector2dName),
+					},
 					{
 						name: "MultiVector_dim3x2",
 						nearVector: client.GraphQL().NearVectorArgBuilder().
 							WithVectorPerTarget(map[string]models.Vector{
 								multiVector2dName: [][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+					{
+						name: "MultiVectors_dim1x3x2",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorsPerTarget(map[string][]models.Vector{
+								multiVector2dName: {
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+								},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+					{
+						name: "MultiVectors_dim2x3x2",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorsPerTarget(map[string][]models.Vector{
+								multiVector2dName: {
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+								},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+					{
+						name: "MultiVector_1d2d3d",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorPerTarget(map[string]models.Vector{
+								multiVector1dName: [][]float32{{0.1}, {0.1}},
+								multiVector2dName: [][]float32{{0.1, 0.1}, {0.1, 0.1}},
+								multiVector3dName: [][]float32{{0.1, 0.1, 0.1}, {0.1, 0.1, 0.1}},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+					{
+						name: "MultiVectors_1d2d3d",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorsPerTarget(map[string][]models.Vector{
+								multiVector1dName: {
+									[][]float32{{0.1}, {0.1}},
+									[][]float32{{0.1}, {0.1}},
+									[][]float32{{0.1}, {0.1}},
+								},
+								multiVector2dName: {
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}},
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}},
+								},
+								multiVector3dName: {
+									[][]float32{{0.1, 0.1, 0.1}, {0.1, 0.1, 0.1}},
+								},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+					{
+						name: "MultiVector_all",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorPerTarget(map[string]models.Vector{
+								normalVector2dName: []float32{0.1, 0.1},
+								multiVector1dName:  [][]float32{{0.1}, {0.1}},
+								multiVector2dName:  [][]float32{{0.1, 0.1}, {0.1, 0.1}},
+								multiVector3dName:  [][]float32{{0.1, 0.1, 0.1}, {0.1, 0.1, 0.1}},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+					{
+						name: "MultiVectors_all",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorsPerTarget(map[string][]models.Vector{
+								normalVector2dName: {
+									[]float32{0.1, 0.1},
+									[]float32{0.1, 0.1},
+								},
+								multiVector1dName: {
+									[][]float32{{0.1}, {0.1}},
+									[][]float32{{0.1}, {0.1}},
+								},
+								multiVector2dName: {
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}},
+									[][]float32{{0.1, 0.1}, {0.1, 0.1}},
+								},
+								multiVector3dName: {
+									[][]float32{{0.1, 0.1, 0.1}, {0.1, 0.1, 0.1}},
+									[][]float32{{0.1, 0.1, 0.1}, {0.1, 0.1, 0.1}},
+								},
 							}).
 							WithTargetVectors(multiVector2dName),
 					},
@@ -327,9 +410,6 @@ func testColBERT(host string) func(t *testing.T) {
 						assert.Len(t, ids, len(objects))
 					})
 				}
-			})
-			t.Run("WithVectorsPerTarget searches", func(t *testing.T) {
-				// TODO
 			})
 		})
 

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
@@ -45,8 +45,26 @@ func testColBERT(host string) func(t *testing.T) {
 			className := fixtures.BringYourOwnColBERTClassName
 			objects := fixtures.BringYourOwnColBERTObjects
 			byoc := fixtures.BringYourOwnColBERTNamedVectorName
+			normalVector2dName := fixtures.NormalVector2dName
+			multiVector1dName := fixtures.MultiVector1dName
+			multiVector2dName := fixtures.MultiVector2dName
+			multiVector3dName := fixtures.MultiVector3dName
+			multiVector1dFromMultiVector2d := func(mv [][]float32) [][]float32 {
+				multiVector1d := make([][]float32, len(mv))
+				for i, v := range mv {
+					multiVector1d[i] = []float32{v[0]}
+				}
+				return multiVector1d
+			}
+			multiVector3dFromMultiVector2d := func(mv [][]float32) [][]float32 {
+				multiVector3d := make([][]float32, len(mv))
+				for i, v := range mv {
+					multiVector3d[i] = []float32{v[0], v[1], v[1]}
+				}
+				return multiVector3d
+			}
 
-			_additional := graphql.Field{
+			_additional_byoc := graphql.Field{
 				Name: "_additional",
 				Fields: []graphql.Field{
 					{Name: "id"},
@@ -61,7 +79,7 @@ func testColBERT(host string) func(t *testing.T) {
 				resp, err := client.GraphQL().Get().
 					WithClassName(className).
 					WithNearVector(nearVector).
-					WithFields(_additional).
+					WithFields(_additional_byoc).
 					Do(ctx)
 				require.NoError(t, err)
 				ids := acceptance_with_go_client.GetIds(t, resp, className)
@@ -76,7 +94,7 @@ func testColBERT(host string) func(t *testing.T) {
 				resp, err := client.GraphQL().Get().
 					WithClassName(className).
 					WithNearObject(nearObject).
-					WithFields(_additional).
+					WithFields(_additional_byoc).
 					Do(ctx)
 				require.NoError(t, err)
 				ids := acceptance_with_go_client.GetIds(t, resp, className)
@@ -100,7 +118,11 @@ func testColBERT(host string) func(t *testing.T) {
 							"name": o.Name,
 						},
 						Vectors: models.Vectors{
-							byoc: o.Vector,
+							byoc:               o.Vector,
+							normalVector2dName: o.Vector[0],
+							multiVector1dName:  multiVector1dFromMultiVector2d(o.Vector),
+							multiVector2dName:  o.Vector,
+							multiVector3dName:  multiVector3dFromMultiVector2d(o.Vector),
 						},
 					}
 					objs = append(objs, obj)
@@ -123,6 +145,7 @@ func testColBERT(host string) func(t *testing.T) {
 			t.Run("vector search after insert", func(t *testing.T) {
 				performNearVector(t, client, className)
 				performNearObject(t, client, className)
+
 			})
 
 			t.Run("check existence", func(t *testing.T) {
@@ -141,7 +164,7 @@ func testColBERT(host string) func(t *testing.T) {
 					objs, err := client.Data().ObjectsGetter().WithID(o.ID).WithClassName(className).WithVector().Do(ctx)
 					require.NoError(t, err)
 					require.Len(t, objs, 1)
-					require.Len(t, objs[0].Vectors, 1)
+					require.Len(t, objs[0].Vectors, 5)
 					assert.IsType(t, [][]float32{}, objs[0].Vectors[byoc])
 					assert.Equal(t, o.Vector, objs[0].Vectors[byoc])
 				}
@@ -152,7 +175,7 @@ func testColBERT(host string) func(t *testing.T) {
 					resp, err := client.GraphQL().Get().
 						WithClassName(className).
 						WithWhere(filters.Where().WithPath([]string{"id"}).WithOperator(filters.Equal).WithValueText(o.ID)).
-						WithFields(_additional).
+						WithFields(_additional_byoc).
 						Do(ctx)
 					require.NoError(t, err)
 					vectors := acceptance_with_go_client.GetVectors(t, resp, className, false, byoc)
@@ -189,13 +212,17 @@ func testColBERT(host string) func(t *testing.T) {
 					t.Run(tt.name, func(t *testing.T) {
 						firstObj := tt.obj
 						updateVectors := models.Vectors{
-							byoc: tt.vector,
+							byoc:               tt.vector,
+							normalVector2dName: tt.vector[0],
+							multiVector1dName:  multiVector1dFromMultiVector2d(tt.vector),
+							multiVector2dName:  tt.vector,
+							multiVector3dName:  multiVector3dFromMultiVector2d(tt.vector),
 						}
 						objs, err := client.Data().ObjectsGetter().
 							WithClassName(className).WithID(firstObj.ID).WithVector().Do(ctx)
 						require.NoError(t, err)
 						require.NotEmpty(t, objs)
-						require.Len(t, objs[0].Vectors, 1)
+						require.Len(t, objs[0].Vectors, 5)
 						assert.Equal(t, firstObj.Vector, objs[0].Vectors[byoc])
 						updater := client.Data().Updater().
 							WithClassName(className).WithID(firstObj.ID).WithVectors(updateVectors)
@@ -209,12 +236,12 @@ func testColBERT(host string) func(t *testing.T) {
 							WithClassName(className).WithID(firstObj.ID).WithVector().Do(ctx)
 						require.NoError(t, err)
 						require.NotEmpty(t, objs)
-						require.Len(t, objs[0].Vectors, 1)
+						require.Len(t, objs[0].Vectors, 5)
 						assert.Equal(t, updateVectors[byoc], objs[0].Vectors[byoc])
 						resp, err := client.GraphQL().Get().
 							WithClassName(className).
 							WithWhere(filters.Where().WithPath([]string{"id"}).WithOperator(filters.Equal).WithValueText(firstObj.ID)).
-							WithFields(_additional).
+							WithFields(_additional_byoc).
 							Do(ctx)
 						require.NoError(t, err)
 						vectors := acceptance_with_go_client.GetVectors(t, resp, className, false, byoc)
@@ -238,7 +265,11 @@ func testColBERT(host string) func(t *testing.T) {
 				for _, obj := range objects {
 					err = client.Data().Updater().
 						WithClassName(className).WithID(obj.ID).WithVectors(models.Vectors{
-						byoc: obj.Vector,
+						byoc:               obj.Vector,
+						normalVector2dName: obj.Vector[0],
+						multiVector1dName:  multiVector1dFromMultiVector2d(obj.Vector),
+						multiVector2dName:  obj.Vector,
+						multiVector3dName:  multiVector3dFromMultiVector2d(obj.Vector),
 					}).Do(ctx)
 					require.NoError(t, err)
 				}
@@ -251,6 +282,54 @@ func testColBERT(host string) func(t *testing.T) {
 			t.Run("vector search after update of all objects", func(t *testing.T) {
 				performNearVector(t, client, className)
 				performNearObject(t, client, className)
+			})
+			t.Run("WithVectorPerTarget searches", func(t *testing.T) {
+				withVectorPerTargetTests := []struct {
+					name       string
+					nearVector *graphql.NearVectorArgumentBuilder
+				}{
+					{
+						name: "NormalVector_dim2",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorPerTarget(map[string]models.Vector{
+								normalVector2dName: []float32{0.1, 0.1},
+							}).
+							WithTargetVectors(normalVector2dName),
+					},
+					// TODO this errors because it gets interpreted as a multivector
+					// {
+					// 	name: "NormalVector_dim3x2",
+					// 	nearVector: client.GraphQL().NearVectorArgBuilder().
+					// 		WithVectorPerTarget(map[string]models.Vector{
+					// 			normalVector2dName: [][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+					// 		}).
+					// 		WithTargetVectors(normalVector2dName),
+					// },
+					{
+						name: "MultiVector_dim3x2",
+						nearVector: client.GraphQL().NearVectorArgBuilder().
+							WithVectorPerTarget(map[string]models.Vector{
+								multiVector2dName: [][]float32{{0.1, 0.1}, {0.1, 0.1}, {0.1, 0.1}},
+							}).
+							WithTargetVectors(multiVector2dName),
+					},
+				}
+				for _, tt := range withVectorPerTargetTests {
+					t.Run(tt.name, func(t *testing.T) {
+						resp, err := client.GraphQL().Get().
+							WithClassName(className).
+							WithNearVector(tt.nearVector).
+							WithFields(_additional_byoc).
+							Do(ctx)
+						require.NoError(t, err)
+						ids := acceptance_with_go_client.GetIds(t, resp, className)
+						require.NotEmpty(t, ids)
+						assert.Len(t, ids, len(objects))
+					})
+				}
+			})
+			t.Run("WithVectorsPerTarget searches", func(t *testing.T) {
+				// TODO
 			})
 		})
 


### PR DESCRIPTION
### What's being changed:

Adds support for multivectors in GraphQL in `vectorPerTarget` queries.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
