### PR TITLE
remove text2vec-weaviate rate limit

### DIFF
--- a/modules/text2vec-weaviate/module.go
+++ b/modules/text2vec-weaviate/module.go
@@ -35,11 +35,11 @@ import (
 const Name = "text2vec-weaviate"
 
 var batchSettings = batch.Settings{
-	TokenMultiplier:    1,
+	TokenMultiplier:    0,
 	MaxTimePerBatch:    float64(10),
 	MaxObjectsPerBatch: 200,
-	MaxTokensPerBatch:  func(cfg moduletools.ClassConfig) int { return 512 * 200 },
-	HasTokenLimit:      true,
+	MaxTokensPerBatch:  func(cfg moduletools.ClassConfig) int { return 500000 },
+	HasTokenLimit:      false,
 	ReturnsRateLimit:   false,
 }
 


### PR DESCRIPTION
### What's being changed:

remove `text2vec-weaviate` rate limit a it currently unnecessarily reduces module's throughput/latency ~3x.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
