### PR TITLE
fix(backup): memory control consumption by setting minio specific part size

### DIFF
--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -29,6 +29,12 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
+const (
+	// source : https://github.com/minio/minio-go/blob/master/api-put-object-common.go#L69
+	// minio has min part size of 16MB
+	MINIO_MIN_PART_SIZE = 16 * 1024 * 1024
+)
+
 type s3Client struct {
 	client   *minio.Client
 	config   *clientConfig
@@ -130,7 +136,7 @@ func (s *s3Client) PutFile(ctx context.Context, backupID, key string, srcPath st
 
 func (s *s3Client) PutObject(ctx context.Context, backupID, key string, byes []byte) error {
 	objectName := s.makeObjectName(backupID, key)
-	opt := minio.PutObjectOptions{ContentType: "application/octet-stream", PartSize: 16 * 1024 * 1024}
+	opt := minio.PutObjectOptions{ContentType: "application/octet-stream", PartSize: MINIO_MIN_PART_SIZE}
 	reader := bytes.NewReader(byes)
 	objectSize := int64(len(byes))
 
@@ -186,7 +192,7 @@ func (s *s3Client) Write(ctx context.Context, backupID, key string, r io.ReadClo
 	opt := minio.PutObjectOptions{
 		ContentType:      "application/octet-stream",
 		DisableMultipart: false,
-		PartSize:         16 * 1024 * 1024, // 16MB
+		PartSize:         MINIO_MIN_PART_SIZE,
 	}
 
 	info, err := s.client.PutObject(ctx, s.config.Bucket, path, r, -1, opt)

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
@@ -129,7 +130,7 @@ func (s *s3Client) PutFile(ctx context.Context, backupID, key string, srcPath st
 
 func (s *s3Client) PutObject(ctx context.Context, backupID, key string, byes []byte) error {
 	objectName := s.makeObjectName(backupID, key)
-	opt := minio.PutObjectOptions{ContentType: "application/octet-stream"}
+	opt := minio.PutObjectOptions{ContentType: "application/octet-stream", PartSize: 16 * 1024 * 1024}
 	reader := bytes.NewReader(byes)
 	objectSize := int64(len(byes))
 
@@ -185,6 +186,7 @@ func (s *s3Client) Write(ctx context.Context, backupID, key string, r io.ReadClo
 	opt := minio.PutObjectOptions{
 		ContentType:      "application/octet-stream",
 		DisableMultipart: false,
+		PartSize:         16 * 1024 * 1024, // 16MB
 	}
 
 	info, err := s.client.PutObject(ctx, s.config.Bucket, path, r, -1, opt)


### PR DESCRIPTION
### What's being changed:
this PR configure the backup multi parts upload `part size` to. `16MB` as this is the min. for `minio-go` 
if we look [here](https://github.com/minio/minio-go/blob/master/api-put-object-common.go#L72), we will see that if there is config part size the use the max which is `5TiB` and the returned partSize they use it [here](https://github.com/minio/minio-go/blob/master/api-put-object-multipart.go#L109) to create memory buffer. we have seen always memory increase when backup gets trigger and this could explain it because we don't configure any `partSize` in our minio requests.

**Profiles for 3 instance without part size limitation** 

![weaviate-2-no-fix](https://github.com/user-attachments/assets/6110f68d-68d3-4302-b082-be754e9076ce)
![weaviate-1-no-fix](https://github.com/user-attachments/assets/457ffcc7-5d74-43d5-a281-eaa5dd014301)
![weaviate-0-no-fix](https://github.com/user-attachments/assets/d8ac8cdd-f90d-4742-b8e8-8d4889accd20)



**Profiles for 3 instance with part size limitation** 

![weaviate-2-with-fix](https://github.com/user-attachments/assets/93a474b3-b55d-4927-96bd-968b03060d74)
![weaviate-1-with-fix](https://github.com/user-attachments/assets/c95dcbe7-7547-4743-a98e-6156ec480f11)
![weaviate-0-with-fix](https://github.com/user-attachments/assets/20f444a4-f1a8-478f-99a2-47fb202a1a54)


There is also extra tests was executed by @jfrancoa to confirm the findings, correctness and performance of this change which ended up a success.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
