### PR TITLE
Error if attempting to use moveTo or MoveAwayFrom with multivectors

### DIFF
--- a/usecases/modulecomponents/arguments/nearText/searcher_movements.go
+++ b/usecases/modulecomponents/arguments/nearText/searcher_movements.go
@@ -24,9 +24,22 @@ func newMovements[T dto.Embedding]() *movements[T] {
 	return &movements[T]{}
 }
 
+const (
+	moveToError   = "move to operations are not applicable for multivector embeddings"
+	moveAwayError = "move away from operations are not applicable for multivector embeddings"
+)
+
 // MoveTo moves one vector toward another
 func (v *movements[T]) MoveTo(source T, target T, weight float32,
 ) (T, error) {
+	// the type of source/target should always be the same, but check both to be sure
+	if _, sourceOk := any(source).([][]float32); sourceOk {
+		return nil, errors.New(moveToError)
+	}
+	if _, targetOk := any(target).([][]float32); targetOk {
+		return nil, errors.New(moveToError)
+	}
+
 	multiplier := float32(0.5)
 
 	if len(source) != len(target) {
@@ -54,6 +67,14 @@ func (v *movements[T]) MoveTo(source T, target T, weight float32,
 // MoveAwayFrom moves one vector away from another
 func (v *movements[T]) MoveAwayFrom(source T, target T, weight float32,
 ) (T, error) {
+	// the type of source/target should always be the same, but check both to be sure
+	if _, sourceOk := any(source).([][]float32); sourceOk {
+		return nil, errors.New(moveAwayError)
+	}
+	if _, targetOk := any(target).([][]float32); targetOk {
+		return nil, errors.New(moveAwayError)
+	}
+
 	multiplier := float32(0.5) // so the movement is fair in comparison with moveTo
 	if len(source) != len(target) {
 		return nil, fmt.Errorf("movement (moveAwayFrom): vector lengths don't match: "+

--- a/usecases/modulecomponents/arguments/nearText/searcher_movements.go
+++ b/usecases/modulecomponents/arguments/nearText/searcher_movements.go
@@ -25,8 +25,8 @@ func newMovements[T dto.Embedding]() *movements[T] {
 }
 
 var (
-	errMoveToMultiVec       = errors.New("move to operations are not applicable for multivector embeddings")
-	errMoveAwayFromMultiVec = errors.New("move away from operations are not applicable for multivector embeddings")
+	ErrMultiVectorMoveTo   = errors.New("move to operations are not applicable for multivector embeddings")
+	ErrMultiVectorMoveAway = errors.New("move away from operations are not applicable for multivector embeddings")
 )
 
 // MoveTo moves one vector toward another
@@ -34,10 +34,10 @@ func (v *movements[T]) MoveTo(source T, target T, weight float32,
 ) (T, error) {
 	// the type of source/target should always be the same, but check both to be sure
 	if _, sourceOk := any(source).([][]float32); sourceOk {
-		return nil, errMoveToMultiVec
+		return nil, ErrMultiVectorMoveTo
 	}
 	if _, targetOk := any(target).([][]float32); targetOk {
-		return nil, errMoveToMultiVec
+		return nil, ErrMultiVectorMoveTo
 	}
 
 	multiplier := float32(0.5)
@@ -69,10 +69,10 @@ func (v *movements[T]) MoveAwayFrom(source T, target T, weight float32,
 ) (T, error) {
 	// the type of source/target should always be the same, but check both to be sure
 	if _, sourceOk := any(source).([][]float32); sourceOk {
-		return nil, errMoveAwayFromMultiVec
+		return nil, ErrMultiVectorMoveAway
 	}
 	if _, targetOk := any(target).([][]float32); targetOk {
-		return nil, errMoveAwayFromMultiVec
+		return nil, ErrMultiVectorMoveAway
 	}
 
 	multiplier := float32(0.5) // so the movement is fair in comparison with moveTo

--- a/usecases/modulecomponents/arguments/nearText/searcher_movements.go
+++ b/usecases/modulecomponents/arguments/nearText/searcher_movements.go
@@ -24,9 +24,9 @@ func newMovements[T dto.Embedding]() *movements[T] {
 	return &movements[T]{}
 }
 
-const (
-	moveToError   = "move to operations are not applicable for multivector embeddings"
-	moveAwayError = "move away from operations are not applicable for multivector embeddings"
+var (
+	errMoveToMultiVec       = errors.New("move to operations are not applicable for multivector embeddings")
+	errMoveAwayFromMultiVec = errors.New("move away from operations are not applicable for multivector embeddings")
 )
 
 // MoveTo moves one vector toward another
@@ -34,10 +34,10 @@ func (v *movements[T]) MoveTo(source T, target T, weight float32,
 ) (T, error) {
 	// the type of source/target should always be the same, but check both to be sure
 	if _, sourceOk := any(source).([][]float32); sourceOk {
-		return nil, errors.New(moveToError)
+		return nil, errMoveToMultiVec
 	}
 	if _, targetOk := any(target).([][]float32); targetOk {
-		return nil, errors.New(moveToError)
+		return nil, errMoveToMultiVec
 	}
 
 	multiplier := float32(0.5)
@@ -69,10 +69,10 @@ func (v *movements[T]) MoveAwayFrom(source T, target T, weight float32,
 ) (T, error) {
 	// the type of source/target should always be the same, but check both to be sure
 	if _, sourceOk := any(source).([][]float32); sourceOk {
-		return nil, errors.New(moveAwayError)
+		return nil, errMoveAwayFromMultiVec
 	}
 	if _, targetOk := any(target).([][]float32); targetOk {
-		return nil, errors.New(moveAwayError)
+		return nil, errMoveAwayFromMultiVec
 	}
 
 	multiplier := float32(0.5) // so the movement is fair in comparison with moveTo

--- a/usecases/modulecomponents/arguments/nearText/searcher_movements_test.go
+++ b/usecases/modulecomponents/arguments/nearText/searcher_movements_test.go
@@ -155,4 +155,21 @@ func TestMoveVectorToAnother(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("should error for multivectors", func(t *testing.T) {
+		source := [][]float32{{0, 1}, {2, 3}}
+		target := [][]float32{{0, 1}, {2, 3}}
+
+		t.Run("multivectors moveTo", func(t *testing.T) {
+			v := newMovements[[][]float32]()
+			_, err := v.MoveTo(source, target, 0)
+			assert.Equal(t, err, fmt.Errorf("move to operations are not applicable for multivector embeddings"))
+		})
+
+		t.Run("multivectors moveAwayFrom", func(t *testing.T) {
+			v := newMovements[[][]float32]()
+			_, err := v.MoveAwayFrom(source, target, 0)
+			assert.Equal(t, err, fmt.Errorf("move away from operations are not applicable for multivector embeddings"))
+		})
+	})
 }


### PR DESCRIPTION
### What's being changed:

Return a useful error to the user if they attempt to use `moveTo` or `moveAwayFrom` with a multivector embedding (eg ColBERT).

I've added unit tests to cover both methods, and tested locally with the below:

```py
# using the dev/1.29 branch of the weaviate client (commit: cde7f40dda603f328f56163efedee1aac9231d9d)
# https://github.com/weaviate/weaviate-python-client/pull/1524
import weaviate
import weaviate.classes.config as wvc
from weaviate.classes.query import Move


if __name__ == "__main__":
    client = weaviate.connect_to_local(
        # api key from: https://jina.ai/api-dashboard/embedding
        headers={"X-Jinaai-Api-Key": "replace me"}
    )

    # Delete collection
    client.collections.delete("CollectionMultivector")

    vector_index_config = wvc.Configure.VectorIndex.hnsw(
        ef=512,
        multi_vector=wvc.Configure.VectorIndex.MultiVector.multi_vector(),
    )
    vectorizers = [
        wvc.Configure.NamedVectors.text2colbert_jinaai(
            name="colbert",
            vector_index_config=vector_index_config,
        ),
    ]

    collection = client.collections.create(
        name="CollectionMultivector",
        vectorizer_config=vectorizers,
        replication_config=wvc.Configure.replication(factor=1),
    )

    response = collection.query.near_text(
        query="foo",
        move_to=Move(force=0.85, concepts="haute couture"),
        move_away=Move(force=0.45, concepts="finance"),
        limit=10,
    )
    print(response)

    client.close()
```
Gives the error:
```
explorer: get class: concurrentTargetVectorSearch): explorer: get class: vectorize search vector: vectorize params: vectorize params: move to operations are not applicable for multivector embeddings
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
