### PR TITLE
Build Alpine tag 1.22-alpine3.20 to Avoid GCC segfault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@
 
 ###############################################################################
 # Base build image
-FROM golang:1.22-alpine AS build_base
+# NOTE using 1.22-alpine3.20 because of error similar to: https://github.com/docker/buildx/issues/2028
+# please update tag when this issue is fixed
+FROM golang:1.22-alpine3.20 AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on


### PR DESCRIPTION
### What's being changed:

It appears that we're seeing a `docker buildx` error similar to that of this issue: https://github.com/docker/buildx/issues/2028 (eg `gcc seg fault`)

This PR pins the alpine build image to a previous one, and in some testing (eg [this PR](https://github.com/weaviate/weaviate/actions/runs/13020571969/job/36320110518?pr=7064)), it appears to resolve the issue.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
