### PR TITLE
feat(rbac): assign and revoke groups

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -348,7 +348,7 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 		return authz.NewAssignRoleToUserNotFound()
 	}
 
-	if err := h.controller.AddRolesForUser(params.ID, params.Body.Roles); err != nil {
+	if err := h.controller.AddRolesForUser(conv.PrefixUserName(params.ID), params.Body.Roles); err != nil {
 		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
@@ -358,13 +358,48 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 		"user":                    principal.Username,
 		"user_to_assign_roles_to": params.ID,
 		"roles":                   params.Body.Roles,
-	}).Info("roles assigned")
+	}).Info("roles assigned to user")
 
 	return authz.NewAssignRoleToUserOK()
 }
 
 func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, principal *models.Principal) middleware.Responder {
-	return authz.NewAssignRoleToGroupForbidden()
+	for _, role := range params.Body.Roles {
+		if strings.TrimSpace(role) == "" {
+			return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to assign is empty")))
+		}
+	}
+
+	if len(params.Body.Roles) == 0 {
+		return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+	}
+
+	if err := h.authorizer.Authorize(principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)...); err != nil {
+		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
+	if err != nil {
+		return authz.NewAssignRoleToGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	if len(existedRoles) != len(params.Body.Roles) && len(params.Body.Roles) > 0 {
+		return authz.NewAssignRoleToGroupNotFound()
+	}
+
+	if err := h.controller.AddRolesForUser(conv.PrefixGroupName(params.ID), params.Body.Roles); err != nil {
+		return authz.NewAssignRoleToGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"action":                   "assign_roles",
+		"component":                authorization.ComponentName,
+		"user":                     principal.Username,
+		"group_to_assign_roles_to": params.ID,
+		"roles":                    params.Body.Roles,
+	}).Info("roles assigned to group")
+
+	return authz.NewAssignRoleToGroupOK()
 }
 
 func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, principal *models.Principal) middleware.Responder {
@@ -477,6 +512,10 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		}
 	}
 
+	if len(params.Body.Roles) == 0 {
+		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+	}
+
 	if err := h.authorizer.Authorize(principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)...); err != nil {
 		return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
@@ -504,7 +543,7 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		return authz.NewRevokeRoleFromUserNotFound()
 	}
 
-	if err := h.controller.RevokeRolesForUser(params.ID, params.Body.Roles...); err != nil {
+	if err := h.controller.RevokeRolesForUser(conv.PrefixUserName(params.ID), params.Body.Roles...); err != nil {
 		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
@@ -514,13 +553,58 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		"user":                    principal.Username,
 		"user_to_assign_roles_to": params.ID,
 		"roles":                   params.Body.Roles,
-	}).Info("roles revoked")
+	}).Info("roles revoked from user")
 
 	return authz.NewRevokeRoleFromUserOK()
 }
 
 func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupParams, principal *models.Principal) middleware.Responder {
-	return authz.NewRevokeRoleFromGroupForbidden()
+	for _, role := range params.Body.Roles {
+		if strings.TrimSpace(role) == "" {
+			return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
+		}
+	}
+
+	if len(params.Body.Roles) == 0 {
+		return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+	}
+
+	if err := h.authorizer.Authorize(principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)...); err != nil {
+		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	adminRoles := slices.Contains(h.rbacconfig.Admins, params.ID) && slices.Contains(params.Body.Roles, authorization.Admin)
+	viewerRoles := slices.Contains(h.rbacconfig.Viewers, params.ID) && slices.Contains(params.Body.Roles, authorization.Viewer)
+	if adminRoles || viewerRoles {
+		requestedRole := authorization.Admin
+		if viewerRoles {
+			requestedRole = authorization.Viewer
+		}
+		return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not revoke configured role %s", requestedRole)))
+	}
+
+	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
+	if err != nil {
+		return authz.NewRevokeRoleFromGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	if len(existedRoles) != len(params.Body.Roles) {
+		return authz.NewRevokeRoleFromGroupNotFound()
+	}
+
+	if err := h.controller.RevokeRolesForUser(conv.PrefixGroupName(params.ID), params.Body.Roles...); err != nil {
+		return authz.NewRevokeRoleFromGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"action":                   "revoke_roles",
+		"component":                authorization.ComponentName,
+		"user":                     principal.Username,
+		"group_to_assign_roles_to": params.ID,
+		"roles":                    params.Body.Roles,
+	}).Info("roles revoked from group")
+
+	return authz.NewRevokeRoleFromGroupOK()
 }
 
 func (h *authZHandlers) userExists(user string) bool {

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -22,11 +22,12 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/authz"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-func TestAssignRoleSuccess(t *testing.T) {
+func TestAssignRoleToUserSuccess(t *testing.T) {
 	authorizer := mocks.NewAuthorizer(t)
 	controller := mocks.NewController(t)
 	logger, _ := test.NewNullLogger()
@@ -41,7 +42,7 @@ func TestAssignRoleSuccess(t *testing.T) {
 
 	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)[0]).Return(nil)
 	controller.On("GetRoles", params.Body.Roles[0]).Return(map[string][]authorization.Policy{params.Body.Roles[0]: {}}, nil)
-	controller.On("AddRolesForUser", params.ID, params.Body.Roles).Return(nil)
+	controller.On("AddRolesForUser", conv.PrefixUserName(params.ID), params.Body.Roles).Return(nil)
 
 	h := &authZHandlers{
 		authorizer:     authorizer,
@@ -55,7 +56,36 @@ func TestAssignRoleSuccess(t *testing.T) {
 	assert.NotNil(t, parsed)
 }
 
-func TestAssignRoleOrUserNotFound(t *testing.T) {
+func TestAssignRoleToGroupSuccess(t *testing.T) {
+	authorizer := mocks.NewAuthorizer(t)
+	controller := mocks.NewController(t)
+	logger, _ := test.NewNullLogger()
+
+	principal := &models.Principal{Username: "user1"}
+	params := authz.AssignRoleToGroupParams{
+		ID: "group1",
+		Body: authz.AssignRoleToGroupBody{
+			Roles: []string{"testRole"},
+		},
+	}
+
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)[0]).Return(nil)
+	controller.On("GetRoles", params.Body.Roles[0]).Return(map[string][]authorization.Policy{params.Body.Roles[0]: {}}, nil)
+	controller.On("AddRolesForUser", conv.PrefixGroupName(params.ID), params.Body.Roles).Return(nil)
+
+	h := &authZHandlers{
+		authorizer:     authorizer,
+		controller:     controller,
+		apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
+		logger:         logger,
+	}
+	res := h.assignRoleToGroup(params, principal)
+	parsed, ok := res.(*authz.AssignRoleToGroupOK)
+	assert.True(t, ok)
+	assert.NotNil(t, parsed)
+}
+
+func TestAssignRoleToUserOrUserNotFound(t *testing.T) {
 	type testCase struct {
 		name          string
 		params        authz.AssignRoleToUserParams
@@ -118,7 +148,55 @@ func TestAssignRoleOrUserNotFound(t *testing.T) {
 	}
 }
 
-func TestAssignRoleBadRequest(t *testing.T) {
+func TestAssignRoleToGroupOrUserNotFound(t *testing.T) {
+	type testCase struct {
+		name          string
+		params        authz.AssignRoleToGroupParams
+		principal     *models.Principal
+		existedRoles  map[string][]authorization.Policy
+		callToGetRole bool
+	}
+
+	tests := []testCase{
+		{
+			name: "role not found",
+			params: authz.AssignRoleToGroupParams{
+				ID: "group1",
+				Body: authz.AssignRoleToGroupBody{
+					Roles: []string{"role1"},
+				},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			existedRoles:  map[string][]authorization.Policy{},
+			callToGetRole: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := mocks.NewAuthorizer(t)
+			controller := mocks.NewController(t)
+			logger, _ := test.NewNullLogger()
+
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, mock.Anything, mock.Anything).Return(nil)
+
+			if tt.callToGetRole {
+				controller.On("GetRoles", tt.params.Body.Roles[0]).Return(tt.existedRoles, nil)
+			}
+
+			h := &authZHandlers{
+				authorizer: authorizer,
+				controller: controller,
+				logger:     logger,
+			}
+			res := h.assignRoleToGroup(tt.params, tt.principal)
+			_, ok := res.(*authz.AssignRoleToGroupNotFound)
+			assert.True(t, ok)
+		})
+	}
+}
+
+func TestAssignRoleToUserBadRequest(t *testing.T) {
 	type testCase struct {
 		name          string
 		params        authz.AssignRoleToUserParams
@@ -137,6 +215,15 @@ func TestAssignRoleBadRequest(t *testing.T) {
 			},
 			principal:     &models.Principal{Username: "user1"},
 			expectedError: "one or more of the roles you want to assign is empty",
+		},
+		{
+			name: "no roles",
+			params: authz.AssignRoleToUserParams{
+				ID:   "testUser",
+				Body: authz.AssignRoleToUserBody{},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			expectedError: "roles can not be empty",
 		},
 	}
 
@@ -162,7 +249,60 @@ func TestAssignRoleBadRequest(t *testing.T) {
 	}
 }
 
-func TestAssignRoleForbidden(t *testing.T) {
+func TestAssignRoleToGroupBadRequest(t *testing.T) {
+	type testCase struct {
+		name          string
+		params        authz.AssignRoleToGroupParams
+		principal     *models.Principal
+		expectedError string
+	}
+
+	tests := []testCase{
+		{
+			name: "empty role",
+			params: authz.AssignRoleToGroupParams{
+				ID: "testUser",
+				Body: authz.AssignRoleToGroupBody{
+					Roles: []string{""},
+				},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			expectedError: "one or more of the roles you want to assign is empty",
+		},
+		{
+			name: "no roles",
+			params: authz.AssignRoleToGroupParams{
+				ID:   "testUser",
+				Body: authz.AssignRoleToGroupBody{},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			expectedError: "roles can not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := mocks.NewAuthorizer(t)
+			controller := mocks.NewController(t)
+			logger, _ := test.NewNullLogger()
+
+			h := &authZHandlers{
+				authorizer: authorizer,
+				controller: controller,
+				logger:     logger,
+			}
+			res := h.assignRoleToGroup(tt.params, tt.principal)
+			parsed, ok := res.(*authz.AssignRoleToGroupBadRequest)
+			assert.True(t, ok)
+
+			if tt.expectedError != "" {
+				assert.Contains(t, parsed.Payload.Error[0].Message, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestAssignRoleToUserForbidden(t *testing.T) {
 	type testCase struct {
 		name          string
 		params        authz.AssignRoleToUserParams
@@ -210,7 +350,55 @@ func TestAssignRoleForbidden(t *testing.T) {
 	}
 }
 
-func TestAssignRoleInternalServerError(t *testing.T) {
+func TestAssignRoleToGroupForbidden(t *testing.T) {
+	type testCase struct {
+		name          string
+		params        authz.AssignRoleToGroupParams
+		principal     *models.Principal
+		authorizeErr  error
+		expectedError string
+	}
+
+	tests := []testCase{
+		{
+			name: "authorization error",
+			params: authz.AssignRoleToGroupParams{
+				ID: "testUser",
+				Body: authz.AssignRoleToGroupBody{
+					Roles: []string{"testRole"},
+				},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			authorizeErr:  fmt.Errorf("authorization error"),
+			expectedError: "authorization error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := mocks.NewAuthorizer(t)
+			controller := mocks.NewController(t)
+			logger, _ := test.NewNullLogger()
+
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(tt.authorizeErr)
+
+			h := &authZHandlers{
+				authorizer: authorizer,
+				controller: controller,
+				logger:     logger,
+			}
+			res := h.assignRoleToGroup(tt.params, tt.principal)
+			parsed, ok := res.(*authz.AssignRoleToGroupForbidden)
+			assert.True(t, ok)
+
+			if tt.expectedError != "" {
+				assert.Contains(t, parsed.Payload.Error[0].Message, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestAssignRoleToUserInternalServerError(t *testing.T) {
 	type testCase struct {
 		name          string
 		params        authz.AssignRoleToUserParams
@@ -256,7 +444,7 @@ func TestAssignRoleInternalServerError(t *testing.T) {
 			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(nil)
 			controller.On("GetRoles", tt.params.Body.Roles[0]).Return(map[string][]authorization.Policy{tt.params.Body.Roles[0]: {}}, tt.getRolesErr)
 			if tt.getRolesErr == nil {
-				controller.On("AddRolesForUser", tt.params.ID, tt.params.Body.Roles).Return(tt.assignErr)
+				controller.On("AddRolesForUser", conv.PrefixUserName(tt.params.ID), tt.params.Body.Roles).Return(tt.assignErr)
 			}
 
 			h := &authZHandlers{
@@ -266,6 +454,71 @@ func TestAssignRoleInternalServerError(t *testing.T) {
 			}
 			res := h.assignRoleToUser(tt.params, tt.principal)
 			parsed, ok := res.(*authz.AssignRoleToUserInternalServerError)
+			assert.True(t, ok)
+
+			if tt.expectedError != "" {
+				assert.Contains(t, parsed.Payload.Error[0].Message, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestAssignRoleToGroupInternalServerError(t *testing.T) {
+	type testCase struct {
+		name          string
+		params        authz.AssignRoleToGroupParams
+		principal     *models.Principal
+		getRolesErr   error
+		assignErr     error
+		expectedError string
+	}
+
+	tests := []testCase{
+		{
+			name: "internal server error from assigning",
+			params: authz.AssignRoleToGroupParams{
+				ID: "testUser",
+				Body: authz.AssignRoleToGroupBody{
+					Roles: []string{"testRole"},
+				},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			assignErr:     fmt.Errorf("internal server error"),
+			expectedError: "internal server error",
+		},
+		{
+			name: "internal server error from getting role",
+			params: authz.AssignRoleToGroupParams{
+				ID: "testUser",
+				Body: authz.AssignRoleToGroupBody{
+					Roles: []string{"testRole"},
+				},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			getRolesErr:   fmt.Errorf("internal server error"),
+			expectedError: "internal server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := mocks.NewAuthorizer(t)
+			controller := mocks.NewController(t)
+			logger, _ := test.NewNullLogger()
+
+			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.Body.Roles...)[0]).Return(nil)
+			controller.On("GetRoles", tt.params.Body.Roles[0]).Return(map[string][]authorization.Policy{tt.params.Body.Roles[0]: {}}, tt.getRolesErr)
+			if tt.getRolesErr == nil {
+				controller.On("AddRolesForUser", conv.PrefixGroupName(tt.params.ID), tt.params.Body.Roles).Return(tt.assignErr)
+			}
+
+			h := &authZHandlers{
+				authorizer: authorizer,
+				controller: controller,
+				logger:     logger,
+			}
+			res := h.assignRoleToGroup(tt.params, tt.principal)
+			parsed, ok := res.(*authz.AssignRoleToGroupInternalServerError)
 			assert.True(t, ok)
 
 			if tt.expectedError != "" {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -170,6 +170,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {
                 "roles": {
                   "description": "the roles that assigned to group",
@@ -236,6 +237,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {
                 "roles": {
                   "description": "the roles that revoked from group",
@@ -6747,6 +6749,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {
                 "roles": {
                   "description": "the roles that assigned to group",
@@ -6813,6 +6816,7 @@ func init() {
             "in": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {
                 "roles": {
                   "description": "the roles that revoked from group",

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3297,6 +3297,7 @@
             "name": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {
                 "roles": {
                   "type": "array",
@@ -3363,6 +3364,7 @@
             "name": "body",
             "required": true,
             "schema": {
+              "type": "object",
               "properties": {
                 "roles": {
                   "type": "array",

--- a/test/acceptance/authz/rbac_auto_admin_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_admin_permissions_test.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -55,9 +54,6 @@ func TestAuthzAllEndpointsAdminDynamically(t *testing.T) {
 	require.Nil(t, err)
 
 	endpoints := col.allEndpoints()
-	ignoreEndpoints := []string{
-		"/authz/groups/.*", // ignore for now
-	}
 	ls := newLogScanner(containers[0].Container())
 	ls.GetAuthzLogs(t) // startup logs that are irrelevant
 
@@ -73,16 +69,6 @@ func TestAuthzAllEndpointsAdminDynamically(t *testing.T) {
 		url = strings.ReplaceAll(url, "{propertyName}", "someProperty")
 
 		t.Run(url+"("+strings.ToUpper(endpoint.method)+")", func(t *testing.T) {
-			for _, pattern := range ignoreEndpoints {
-				matched, err := regexp.MatchString(pattern, endpoint.path)
-				if err != nil {
-					t.Fatalf("invalid regex pattern: %s", pattern)
-				}
-				if matched {
-					return
-				}
-			}
-
 			require.NotContains(t, url, "{")
 			require.NotContains(t, url, "}")
 

--- a/test/acceptance/authz/rbac_auto_no_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_no_permissions_test.go
@@ -66,10 +66,8 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		"/.well-known/openid-configuration",
 		"/.well-known/ready",
 		"/meta",
-		"/authz/users/own-roles",      // will return roles for own user
-		"/authz/groups/someId/assign", // ignore for now
-		"/authz/groups/someId/revoke", // ignore for now
-		"/backups/{backend}",          // we ignore backup because there is multiple endpoints doesn't need authZ and many validations
+		"/authz/users/own-roles", // will return roles for own user
+		"/backups/{backend}",     // we ignore backup because there is multiple endpoints doesn't need authZ and many validations
 		"/backups/{backend}/{id}",
 		"/backups/{backend}/{id}/restore",
 	}

--- a/test/acceptance/authz/rbac_viewer_test.go
+++ b/test/acceptance/authz/rbac_viewer_test.go
@@ -48,7 +48,7 @@ func TestAuthzViewerEndpoints(t *testing.T) {
 		{endpoint: "authz/roles/id/users", methods: []string{"GET"}, success: []bool{true}, arrayReq: false},
 		{endpoint: "authz/users/id/roles", methods: []string{"GET"}, success: []bool{true}, arrayReq: false},
 		{endpoint: "authz/users/id/assign", methods: []string{"POST"}, success: []bool{false}, arrayReq: false, body: map[string][]byte{"POST": []byte("{\"roles\": [\"abc\"]}")}},
-		{endpoint: "authz/users/id/revoke", methods: []string{"POST"}, success: []bool{false}, arrayReq: false},
+		{endpoint: "authz/users/id/revoke", methods: []string{"POST"}, success: []bool{false}, arrayReq: false, body: map[string][]byte{"POST": []byte("{\"roles\": [\"abc\"]}")}},
 		{endpoint: "batch/objects", methods: []string{"POST", "DELETE"}, success: []bool{false, false}, arrayReq: false, body: map[string][]byte{"POST": []byte("{\"objects\": [{\"class\": \"c\"}]}")}},
 		{endpoint: "batch/references", methods: []string{"POST"}, success: []bool{false}, arrayReq: true, body: map[string][]byte{"POST": []byte(fmt.Sprintf("[{\"from\": %q, \"to\": %q}]", uri+"/ref", uri))}},
 		{endpoint: "classifications", methods: []string{"POST"}, success: []bool{false}, arrayReq: false},

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -16,9 +16,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/weaviate/weaviate/entities/schema"
-
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
@@ -28,6 +27,8 @@ const (
 	ROLE_NAME_PREFIX = "role:"
 	// USER_NAME_PREFIX to prefix role to help casbin to distinguish on Enforcing
 	USER_NAME_PREFIX = "user:"
+	// GROUP_NAME_PREFIX to prefix role to help casbin to distinguish on Enforcing
+	GROUP_NAME_PREFIX = "group:"
 
 	// CRUD allow all actions on a resource
 	// this is internal for casbin to handle admin actions
@@ -402,6 +403,20 @@ func PrefixUserName(name string) string {
 		return name
 	}
 	return fmt.Sprintf("%s%s", USER_NAME_PREFIX, name)
+}
+
+func PrefixGroupName(name string) string {
+	if strings.HasPrefix(name, GROUP_NAME_PREFIX) {
+		return name
+	}
+	return fmt.Sprintf("%s%s", GROUP_NAME_PREFIX, name)
+}
+
+func PrefixDefaultToUser(name string) string {
+	if strings.HasPrefix(name, GROUP_NAME_PREFIX) {
+		return name
+	}
+	return PrefixUserName(name)
 }
 
 func TrimRoleNamePrefix(name string) string {


### PR DESCRIPTION
### What's being changed:
we found the need to add dynamic assignment for Groups<to>Roles, this PR 
- adds the implementation for 2 new endpoints assign, revoke groups to/from roles 
- Authorizer now check groups 1st before checking the user

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
