### PR TITLE
RBAC: Internal admins are called root and endusers cannot touch them

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -539,8 +539,8 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
 		}
 
-		if err := isRootRole(params.ID); err != nil {
-			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		if err := isRootRole(role); err != nil {
+			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("revoking: %w", err)))
 		}
 	}
 

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -85,6 +85,10 @@ func (h *authZHandlers) createRole(params authz.CreateRoleParams, principal *mod
 		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("role name is invalid")))
 	}
 
+	if err := isRootRole(*params.Body.Name); err != nil {
+		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("role name is invalid")))
+	}
+
 	policies, err := conv.RolesToPolicies(params.Body)
 	if err != nil {
 		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permission %s", err.Error())))
@@ -337,6 +341,10 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 		if strings.TrimSpace(role) == "" {
 			return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to assign is empty")))
 		}
+
+		if err := isRootRole(role); err != nil {
+			return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		}
 	}
 
 	if len(params.Body.Roles) == 0 {
@@ -379,6 +387,10 @@ func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, 
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
 			return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to assign is empty")))
+		}
+
+		if err := isRootRole(role); err != nil {
+			return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 		}
 	}
 
@@ -500,6 +512,10 @@ func (h *authZHandlers) getUsersForRole(params authz.GetUsersForRoleParams, prin
 		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
+	if err := isRootRole(params.ID); err != nil {
+		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
 	users, err := h.controller.GetUsersForRole(params.ID)
 	if err != nil {
 		return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
@@ -522,6 +538,10 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		if strings.TrimSpace(role) == "" {
 			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
 		}
+
+		if err := isRootRole(params.ID); err != nil {
+			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		}
 	}
 
 	if len(params.Body.Roles) == 0 {
@@ -532,14 +552,9 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	adminRoles := slices.Contains(h.rbacconfig.Admins, params.ID) && slices.Contains(params.Body.Roles, authorization.Admin)
 	viewerRoles := slices.Contains(h.rbacconfig.Viewers, params.ID) && slices.Contains(params.Body.Roles, authorization.Viewer)
-	if adminRoles || viewerRoles {
-		requestedRole := authorization.Admin
-		if viewerRoles {
-			requestedRole = authorization.Viewer
-		}
-		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not revoke configured role %s", requestedRole)))
+	if viewerRoles {
+		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not revoke configured role %s", authorization.Viewer)))
 	}
 
 	if !h.userExists(params.ID) {
@@ -575,6 +590,11 @@ func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupPara
 		if strings.TrimSpace(role) == "" {
 			return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
 		}
+
+		if err := isRootRole(params.ID); err != nil {
+			return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		}
+
 	}
 
 	if len(params.Body.Roles) == 0 {
@@ -636,6 +656,14 @@ func (h *authZHandlers) userExists(user string) bool {
 		return false
 	}
 	return true
+}
+
+// isRootRole validates that enduser do not touch the internal root role
+func isRootRole(name string) error {
+	if name == authorization.Root {
+		return fmt.Errorf("using root role is not allowed")
+	}
+	return nil
 }
 
 // validateRoleName validates that this string is a valid role name (format wise)

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -255,9 +255,13 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 		return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	response := []*models.Role{}
+	var response []*models.Role
 
 	for roleName, policies := range roles {
+		if roleName == authorization.Root {
+			continue
+		}
+
 		perms, err := conv.PoliciesToPermission(policies...)
 		if err != nil {
 			return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -558,7 +558,7 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 
 	viewerRoles := slices.Contains(h.rbacconfig.Viewers, params.ID) && slices.Contains(params.Body.Roles, authorization.Viewer)
 	if viewerRoles {
-		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not revoke configured role %s", authorization.Viewer)))
+		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not revoke role %s when configured via AUTHORIZATION_VIEWER_USERS", authorization.Viewer)))
 	}
 
 	if !h.userExists(params.ID) {
@@ -660,7 +660,7 @@ func (h *authZHandlers) userExists(user string) bool {
 // isRootRole validates that enduser do not touch the internal root role
 func isRootRole(name string) error {
 	if name == authorization.Root {
-		return fmt.Errorf("using root role is not allowed")
+		return fmt.Errorf("modifying 'root' role or changing its assignments is not allowed")
 	}
 	return nil
 }

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -225,6 +225,15 @@ func TestAssignRoleToUserBadRequest(t *testing.T) {
 			principal:     &models.Principal{Username: "user1"},
 			expectedError: "roles can not be empty",
 		},
+		{
+			name: "root",
+			params: authz.AssignRoleToUserParams{
+				ID:   "testUser",
+				Body: authz.AssignRoleToUserBody{Roles: []string{"root"}},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			expectedError: "assigning: using root role is not allowed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -277,6 +286,15 @@ func TestAssignRoleToGroupBadRequest(t *testing.T) {
 			},
 			principal:     &models.Principal{Username: "user1"},
 			expectedError: "roles can not be empty",
+		},
+		{
+			name: "root",
+			params: authz.AssignRoleToGroupParams{
+				ID:   "testUser",
+				Body: authz.AssignRoleToGroupBody{Roles: []string{"root"}},
+			},
+			principal:     &models.Principal{Username: "user1"},
+			expectedError: "assigning: using root role is not allowed",
 		},
 	}
 

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -232,7 +232,7 @@ func TestAssignRoleToUserBadRequest(t *testing.T) {
 				Body: authz.AssignRoleToUserBody{Roles: []string{"root"}},
 			},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "assigning: using root role is not allowed",
+			expectedError: "assigning: modifying 'root' role or changing its assignments is not allowed",
 		},
 	}
 
@@ -294,7 +294,7 @@ func TestAssignRoleToGroupBadRequest(t *testing.T) {
 				Body: authz.AssignRoleToGroupBody{Roles: []string{"root"}},
 			},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "assigning: using root role is not allowed",
+			expectedError: "assigning: modifying 'root' role or changing its assignments is not allowed",
 		},
 	}
 

--- a/adapters/handlers/rest/authz/handlers_authz_get_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_get_roles_test.go
@@ -1,0 +1,61 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/authz"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
+)
+
+func TestGetRolesSuccess(t *testing.T) {
+	returnedPolices := map[string][]authorization.Policy{
+		"testRole": {}, "root": {},
+	}
+
+	type testCase struct {
+		name          string
+		principal     *models.Principal
+		expectedRoles int
+	}
+
+	tests := []testCase{
+		{
+			name:          "success non root user",
+			principal:     &models.Principal{Username: "user1"},
+			expectedRoles: 1,
+		},
+		{
+			name:          "success as root user",
+			principal:     &models.Principal{Username: "root"},
+			expectedRoles: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := mocks.NewAuthorizer(t)
+			controller := mocks.NewController(t)
+			logger, _ := test.NewNullLogger()
+
+			authorizer.On("Authorize", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			controller.On("GetRoles").Return(returnedPolices, nil)
+
+			h := &authZHandlers{
+				authorizer: authorizer,
+				controller: controller,
+				logger:     logger,
+				rbacconfig: rbacconf.Config{Enabled: true, Admins: []string{"root"}},
+			}
+			res := h.getRoles(authz.GetRolesParams{}, tt.principal)
+			parsed, ok := res.(*authz.GetRolesOK)
+			assert.True(t, ok)
+			assert.Len(t, parsed.Payload, tt.expectedRoles)
+		})
+	}
+}

--- a/adapters/handlers/rest/authz/handlers_authz_get_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_get_roles_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package authz
 
 import (

--- a/adapters/handlers/rest/authz/handlers_authz_get_users_for_role_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_get_users_for_role_test.go
@@ -158,7 +158,7 @@ func TestGetUsersForRoleBadRequest(t *testing.T) {
 			},
 			principal:     &models.Principal{Username: "user1"},
 			getUsersErr:   fmt.Errorf("internal server error"),
-			expectedError: "using root role is not allowed",
+			expectedError: "modifying 'root' role or changing its assignments is not allowed",
 		},
 	}
 

--- a/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
@@ -269,17 +269,17 @@ func TestRevokeRoleFromGroupBadRequest(t *testing.T) {
 			existedRoles:  map[string][]authorization.Policy{},
 		},
 		{
-			name: "revoke configured admin role",
+			name: "revoke configured root role",
 			params: authz.RevokeRoleFromGroupParams{
 				ID: "testUser",
 				Body: authz.RevokeRoleFromGroupBody{
-					Roles: []string{"admin"},
+					Roles: []string{"root"},
 				},
 			},
-			callAuthZ:     true,
+			callAuthZ:     false,
 			admins:        []string{"testUser"},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "you can not revoke configured role admin",
+			expectedError: "revoking: using root role is not allowed",
 		},
 		{
 			name: "revoke configured viewer role",

--- a/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
@@ -186,17 +186,17 @@ func TestRevokeRoleFromUserBadRequest(t *testing.T) {
 			existedRoles:  map[string][]authorization.Policy{},
 		},
 		{
-			name: "revoke configured admin role",
+			name: "revoke configured root role",
 			params: authz.RevokeRoleFromUserParams{
 				ID: "testUser",
 				Body: authz.RevokeRoleFromUserBody{
-					Roles: []string{"admin"},
+					Roles: []string{"root"},
 				},
 			},
-			callAuthZ:     true,
+			callAuthZ:     false,
 			admins:        []string{"testUser"},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "you can not revoke configured role admin",
+			expectedError: "revoking: using root role is not allowed",
 		},
 		{
 			name: "revoke configured viewer role",

--- a/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
@@ -196,7 +196,7 @@ func TestRevokeRoleFromUserBadRequest(t *testing.T) {
 			callAuthZ:     false,
 			admins:        []string{"testUser"},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "revoking: using root role is not allowed",
+			expectedError: "revoking: modifying 'root' role or changing its assignments is not allowed",
 		},
 		{
 			name: "revoke configured viewer role",
@@ -209,7 +209,7 @@ func TestRevokeRoleFromUserBadRequest(t *testing.T) {
 			callAuthZ:     true,
 			viewers:       []string{"testUser"},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "you can not revoke configured role viewer",
+			expectedError: "you can not revoke role viewer when configured via AUTHORIZATION_VIEWER_USERS",
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestRevokeRoleFromGroupBadRequest(t *testing.T) {
 			callAuthZ:     false,
 			admins:        []string{"testUser"},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "revoking: using root role is not allowed",
+			expectedError: "revoking: modifying 'root' role or changing its assignments is not allowed",
 		},
 		{
 			name: "revoke configured viewer role",

--- a/docker-compose-auth-test.yml
+++ b/docker-compose-auth-test.yml
@@ -30,7 +30,7 @@ services:
       AUTHENTICATION_APIKEY_ALLOWED_KEYS: 'viewer-key,editor-key,admin-key,custom-key'
       AUTHENTICATION_APIKEY_USERS: 'viewer-user,editor-user,admin-user,custom-user'
       AUTHORIZATION_RBAC_ENABLED: "true"
-      AUTHORIZATION_ADMIN_USERS: "admin-user"
+      AUTHORIZATION_ROOT_USERS: "admin-user"
       AUTHORIZATION_VIEWER_USERS: "viewer-user"
 
 

--- a/test/acceptance/authz/helper.go
+++ b/test/acceptance/authz/helper.go
@@ -41,7 +41,7 @@ const (
 	UUID6 = strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168246")
 )
 
-const NumBuildInRoles = 2
+const NumBuildInRoles = 3
 
 func deleteObjectClass(t *testing.T, class string, auth runtime.ClientAuthInfoWriter) {
 	delParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(class)

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -199,9 +199,9 @@ func TestAuthzBuiltInRolesJourney(t *testing.T) {
 func TestAuthzRolesJourney(t *testing.T) {
 	var err error
 
-	adminUser := "existing-user"
-	adminKey := "existing-key"
-	existingRole := "admin"
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	existingRole := "root"
 
 	testRoleName := "testRole"
 	createCollectionsAction := authorization.CreateCollections

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -27,11 +27,13 @@ func TestAuthzRolesForUsers(t *testing.T) {
 	adminUser := "admin-user"
 	adminKey := "admin-key"
 
-	anotherUser := "another-user"
-	anotherKey := "another-key"
+	customUser := "custom-user"
+	customKey := "custom-key"
 
-	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{anotherUser: anotherKey}, nil)
+	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{customUser: customKey}, nil)
 	defer down()
+
+	helper.SetupClient("127.0.0.1:8081")
 
 	t.Run("all roles", func(t *testing.T) {
 		roles := helper.GetRoles(t, adminKey)
@@ -44,7 +46,7 @@ func TestAuthzRolesForUsers(t *testing.T) {
 	})
 
 	t.Run("get empty roles for existing user without role", func(t *testing.T) {
-		roles := helper.GetRolesForUser(t, anotherUser, adminKey)
+		roles := helper.GetRolesForUser(t, customUser, adminKey)
 		require.Equal(t, 0, len(roles))
 	})
 

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -791,7 +791,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		settings["AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED"] = "false" // incompatible
 
 		if len(d.weaviateRbacAdmins) > 0 {
-			settings["AUTHORIZATION_ADMIN_USERS"] = strings.Join(d.weaviateRbacAdmins, ",")
+			settings["AUTHORIZATION_ROOT_USERS"] = strings.Join(d.weaviateRbacAdmins, ",")
 		}
 		if len(d.weaviateRbacViewers) > 0 {
 			settings["AUTHORIZATION_VIEWER_USERS"] = strings.Join(d.weaviateRbacViewers, ",")

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -71,7 +71,7 @@ case $CONFIG in
     AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
-    AUTHORIZATION_ADMIN_USERS='jp-hwang' \
+    AUTHORIZATION_ROOT_USERS='jp-hwang' \
     AUTHORIZATION_VIEWER_USERS='ian-smith' \
     PERSISTENCE_DATA_PATH="./data-weaviate-0" \
     BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
@@ -94,7 +94,7 @@ case $CONFIG in
     AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
-    AUTHORIZATION_ADMIN_USERS='jp-hwang' \
+    AUTHORIZATION_ROOT_USERS='jp-hwang' \
     AUTHORIZATION_VIEWER_USERS='ian-smith' \
     PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-0" \
     BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
@@ -121,7 +121,7 @@ case $CONFIG in
     AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
-    AUTHORIZATION_ADMIN_USERS='jp-hwang' \
+    AUTHORIZATION_ROOT_USERS='jp-hwang' \
     AUTHORIZATION_VIEWER_USERS='ian-smith' \
     PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-1" \
     BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-1" \
@@ -152,7 +152,7 @@ case $CONFIG in
     AUTHORIZATION_RBAC_ENABLED=true \
     AUTHENTICATION_APIKEY_ALLOWED_KEYS='jane-secret-key,ian-secret-key,jp-secret-key' \
     AUTHENTICATION_APIKEY_USERS='jane@doe.com,ian-smith,jp-hwang' \
-    AUTHORIZATION_ADMIN_USERS='jp-hwang' \
+    AUTHORIZATION_ROOT_USERS='jp-hwang' \
     AUTHORIZATION_VIEWER_USERS='ian-smith' \
     BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-2" \
     PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-2" \

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -44,6 +44,7 @@ var (
 	BuiltInPolicies = map[string]string{
 		authorization.Viewer: authorization.READ,
 		authorization.Admin:  CRUD,
+		authorization.Root:   CRUD,
 	}
 	actions = map[string]string{
 		CRUD:                 "manage",

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -104,6 +104,16 @@ func Init(conf rbacconf.Config, policyPath string) (*casbin.SyncedCachedEnforcer
 	enforcer.AddNamedMatchingFunc("g", "keyMatch5", casbinutil.KeyMatch5)
 	enforcer.AddNamedMatchingFunc("g", "regexMatch", casbinutil.RegexMatch)
 
+	// remove preexisting root role including assignments
+	_, err = enforcer.RemoveFilteredNamedPolicy("p", 0, conv.PrefixRoleName(authorization.Root))
+	if err != nil {
+		return nil, err
+	}
+	_, err = enforcer.RemoveFilteredGroupingPolicy(1, conv.PrefixRoleName(authorization.Root))
+	if err != nil {
+		return nil, err
+	}
+
 	// add pre existing roles
 	for name, verb := range conv.BuiltInPolicies {
 		if verb == "" {
@@ -118,7 +128,7 @@ func Init(conf rbacconf.Config, policyPath string) (*casbin.SyncedCachedEnforcer
 		if strings.TrimSpace(conf.Admins[i]) == "" {
 			continue
 		}
-		if _, err := enforcer.AddRoleForUser(conv.PrefixUserName(conf.Admins[i]), conv.PrefixRoleName(authorization.Admin)); err != nil {
+		if _, err := enforcer.AddRoleForUser(conv.PrefixUserName(conf.Admins[i]), conv.PrefixRoleName(authorization.Root)); err != nil {
 			return nil, fmt.Errorf("add role for user: %w", err)
 		}
 	}

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -138,7 +138,8 @@ var (
 var (
 	Viewer       = "viewer"
 	Admin        = "admin"
-	BuiltInRoles = []string{Viewer, Admin}
+	Root         = "root"
+	BuiltInRoles = []string{Viewer, Admin, Root}
 
 	// viewer : can view everything , roles, users, schema, data
 	// editor : can create/read/update everything , roles, users, schema, data
@@ -146,6 +147,7 @@ var (
 	BuiltInPermissions = map[string][]*models.Permission{
 		Viewer: viewerPermissions(),
 		Admin:  adminPermissions(),
+		Root:   adminPermissions(),
 	}
 )
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -204,9 +204,14 @@ func FromEnv(config *Config) error {
 	if entcfg.Enabled(os.Getenv("AUTHORIZATION_ENABLE_RBAC")) || entcfg.Enabled(os.Getenv("AUTHORIZATION_RBAC_ENABLED")) {
 		config.Authorization.Rbac.Enabled = true
 
-		adminsString, ok := os.LookupEnv("AUTHORIZATION_ADMIN_USERS")
+		adminsString, ok := os.LookupEnv("AUTHORIZATION_ROOT_USERS")
 		if ok {
 			config.Authorization.Rbac.Admins = strings.Split(adminsString, ",")
+		} else {
+			adminsString, ok := os.LookupEnv("AUTHORIZATION_ADMIN_USERS")
+			if ok {
+				config.Authorization.Rbac.Admins = strings.Split(adminsString, ",")
+			}
 		}
 
 		viewersString, ok := os.LookupEnv("AUTHORIZATION_VIEWER_USERS")


### PR DESCRIPTION
### What's being changed:

title

Before restart:
`{'root': Role(name='root', .....)}`

After restart (and removing the user from the admin list):
`{}`


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
