### PR TITLE
feat(rbac): scope based actions for roles permissions

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/authz"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -237,6 +238,9 @@ func TestAddPermissionsForbidden(t *testing.T) {
 			logger, _ := test.NewNullLogger()
 
 			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.ID)[0]).Return(tt.authorizeErr)
+			if tt.authorizeErr != nil {
+				authorizer.On("Authorize", tt.principal, authorization.ROLE_SCOPE_MATCH, authorization.Roles(tt.params.ID)[0]).Return(tt.authorizeErr)
+			}
 
 			h := &authZHandlers{
 				authorizer: authorizer,

--- a/adapters/handlers/rest/authz/handlers_authz_create_role_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_create_role_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/authz"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -297,6 +298,9 @@ func TestCreateRoleForbidden(t *testing.T) {
 			logger, _ := test.NewNullLogger()
 
 			authorizer.On("Authorize", tt.principal, authorization.CREATE, authorization.Roles(*tt.params.Body.Name)[0]).Return(tt.authorizeErr)
+			if tt.authorizeErr != nil {
+				authorizer.On("Authorize", tt.principal, authorization.ROLE_SCOPE_MATCH, authorization.Roles(*tt.params.Body.Name)[0]).Return(tt.authorizeErr)
+			}
 
 			h := &authZHandlers{
 				authorizer: authorizer,

--- a/adapters/handlers/rest/authz/handlers_authz_remove_permission_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_remove_permission_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/authz"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -172,6 +173,10 @@ func TestRemovePermissionsForbidden(t *testing.T) {
 			logger, _ := test.NewNullLogger()
 
 			authorizer.On("Authorize", tt.principal, authorization.UPDATE, authorization.Roles(tt.params.ID)[0]).Return(tt.authorizeErr)
+			if tt.authorizeErr != nil {
+				// 2nd Call if update failed
+				authorizer.On("Authorize", tt.principal, authorization.ROLE_SCOPE_MATCH, authorization.Roles(tt.params.ID)[0]).Return(tt.authorizeErr)
+			}
 
 			h := &authZHandlers{
 				authorizer: authorizer,

--- a/adapters/handlers/rest/authz/handlers_authz_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_test.go
@@ -209,7 +209,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 				logger:     logger,
 			}
 
-			err := h.AuthorizeRoleScopes(tt.principal, tt.originalVerb, tt.policies, tt.roleName)
+			err := h.authorizeRoleScopes(tt.principal, tt.originalVerb, tt.policies, tt.roleName)
 
 			if tt.expectedError == "" {
 				assert.NoError(t, err)

--- a/adapters/handlers/rest/authz/handlers_authz_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_test.go
@@ -1,0 +1,223 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package authz
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
+)
+
+func TestAuthorizeRoleScopes(t *testing.T) {
+	type testCase struct {
+		name           string
+		principal      *models.Principal
+		originalVerb   string
+		policies       []authorization.Policy
+		roleName       string
+		authorizeSetup func(*mocks.Authorizer)
+		expectedError  string
+	}
+
+	tests := []testCase{
+		{
+			name:         "has full role management permissions",
+			principal:    &models.Principal{Username: "admin"},
+			originalVerb: authorization.CREATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+			},
+			roleName: "newRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call succeeds - has full permissions
+				a.On("Authorize", &models.Principal{Username: "admin"}, authorization.CREATE, authorization.Roles("newRole")[0]).
+					Return(nil).Once()
+			},
+			expectedError: "",
+		},
+		{
+			name:         "has role scope match and all required permissions",
+			principal:    &models.Principal{Username: "user"},
+			originalVerb: authorization.CREATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+			},
+			roleName: "newRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call fails - no full permissions
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.CREATE, authorization.Roles("newRole")[0]).
+					Return(errors.New("no full permissions")).Once()
+				// Second call succeeds - has role scope match
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("newRole")[0]).
+					Return(nil).Once()
+				// Third call succeeds - has required permission
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+					Return(nil).Once()
+			},
+			expectedError: "",
+		},
+		{
+			name:         "has role scope match but missing required permissions",
+			principal:    &models.Principal{Username: "user"},
+			originalVerb: authorization.CREATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collection/XYZ", Verb: authorization.UPDATE},
+			},
+			roleName: "newRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call fails - no full permissions
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.CREATE, authorization.Roles("newRole")[0]).
+					Return(errors.New("no full permissions")).Once()
+				// Second call succeeds - has role scope match
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("newRole")[0]).
+					Return(nil).Once()
+				// Third call succeeds - has first permission
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+					Return(nil).Once()
+				// Fourth call fails - missing second permission
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.UPDATE, "collection/XYZ").
+					Return(errors.New("missing write permission")).Once()
+			},
+			expectedError: "missing write permission",
+		},
+		{
+			name:         "has neither full management nor role scope match",
+			principal:    &models.Principal{Username: "user"},
+			originalVerb: authorization.CREATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+			},
+			roleName: "newRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call fails - no full permissions
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.CREATE, authorization.Roles("newRole")[0]).
+					Return(errors.New("no full permissions")).Once()
+				// Second call fails - no role scope match
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("newRole")[0]).
+					Return(errors.New("no role scope match")).Once()
+			},
+			expectedError: "can only create roles with less or equal permissions as the current user: no role scope match",
+		},
+		{
+			name:         "has full role management permissions for update",
+			principal:    &models.Principal{Username: "admin"},
+			originalVerb: authorization.UPDATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+			},
+			roleName: "existingRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call succeeds - has full permissions
+				a.On("Authorize", &models.Principal{Username: "admin"}, authorization.UPDATE, authorization.Roles("existingRole")[0]).
+					Return(nil).Once()
+			},
+			expectedError: "",
+		},
+		{
+			name:         "has role scope match and all required permissions for update",
+			principal:    &models.Principal{Username: "user"},
+			originalVerb: authorization.UPDATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+			},
+			roleName: "existingRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call fails - no full permissions
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.UPDATE, authorization.Roles("existingRole")[0]).
+					Return(errors.New("no full permissions")).Once()
+				// Second call succeeds - has role scope match
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("existingRole")[0]).
+					Return(nil).Once()
+				// Third call succeeds - has required permission
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+					Return(nil).Once()
+			},
+			expectedError: "",
+		},
+		{
+			name:         "has role scope match but missing some required permissions for update",
+			principal:    &models.Principal{Username: "user"},
+			originalVerb: authorization.UPDATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collection/XYZ", Verb: authorization.DELETE},
+			},
+			roleName: "existingRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call fails - no full permissions
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.UPDATE, authorization.Roles("existingRole")[0]).
+					Return(errors.New("no full permissions")).Once()
+				// Second call succeeds - has role scope match
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("existingRole")[0]).
+					Return(nil).Once()
+				// Third call succeeds - has first permission
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+					Return(nil).Once()
+				// Fourth call fails - missing delete permission
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.DELETE, "collection/XYZ").
+					Return(errors.New("missing delete permission")).Once()
+			},
+			expectedError: "missing delete permission",
+		},
+		{
+			name:         "has neither full management nor role scope match for update",
+			principal:    &models.Principal{Username: "user"},
+			originalVerb: authorization.UPDATE,
+			policies: []authorization.Policy{
+				{Resource: "collection/ABC", Verb: authorization.READ},
+			},
+			roleName: "existingRole",
+			authorizeSetup: func(a *mocks.Authorizer) {
+				// First call fails - no full permissions
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.UPDATE, authorization.Roles("existingRole")[0]).
+					Return(errors.New("no full permissions")).Once()
+				// Second call fails - no role scope match
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("existingRole")[0]).
+					Return(errors.New("no role scope match")).Once()
+			},
+			expectedError: "can only create roles with less or equal permissions as the current user: no role scope match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := mocks.NewAuthorizer(t)
+			logger, _ := test.NewNullLogger()
+
+			if tt.authorizeSetup != nil {
+				tt.authorizeSetup(authorizer)
+			}
+
+			h := &authZHandlers{
+				authorizer: authorizer,
+				logger:     logger,
+			}
+
+			err := h.AuthorizeRoleScopes(tt.principal, tt.originalVerb, tt.policies, tt.roleName)
+
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectedError)
+			}
+
+			authorizer.AssertExpectations(t)
+		})
+	}
+}

--- a/adapters/handlers/rest/authz/handlers_authz_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_test.go
@@ -40,7 +40,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "admin"},
 			originalVerb: authorization.CREATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collections/ABC", Verb: authorization.READ},
 			},
 			roleName: "newRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -55,7 +55,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "user"},
 			originalVerb: authorization.CREATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collections/ABC", Verb: authorization.READ},
 			},
 			roleName: "newRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -66,7 +66,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("newRole")[0]).
 					Return(nil).Once()
 				// Third call succeeds - has required permission
-				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collections/ABC").
 					Return(nil).Once()
 			},
 			expectedError: "",
@@ -76,8 +76,8 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "user"},
 			originalVerb: authorization.CREATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
-				{Resource: "collection/XYZ", Verb: authorization.UPDATE},
+				{Resource: "collections/ABC", Verb: authorization.READ},
+				{Resource: "collections/XYZ", Verb: authorization.UPDATE},
 			},
 			roleName: "newRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -88,10 +88,10 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("newRole")[0]).
 					Return(nil).Once()
 				// Third call succeeds - has first permission
-				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collections/ABC").
 					Return(nil).Once()
 				// Fourth call fails - missing second permission
-				a.On("Authorize", &models.Principal{Username: "user"}, authorization.UPDATE, "collection/XYZ").
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.UPDATE, "collections/XYZ").
 					Return(errors.New("missing write permission")).Once()
 			},
 			expectedError: "missing write permission",
@@ -101,7 +101,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "user"},
 			originalVerb: authorization.CREATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collections/ABC", Verb: authorization.READ},
 			},
 			roleName: "newRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -119,7 +119,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "admin"},
 			originalVerb: authorization.UPDATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collections/ABC", Verb: authorization.READ},
 			},
 			roleName: "existingRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -134,7 +134,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "user"},
 			originalVerb: authorization.UPDATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collections/ABC", Verb: authorization.READ},
 			},
 			roleName: "existingRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -145,7 +145,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("existingRole")[0]).
 					Return(nil).Once()
 				// Third call succeeds - has required permission
-				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collections/ABC").
 					Return(nil).Once()
 			},
 			expectedError: "",
@@ -155,8 +155,8 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "user"},
 			originalVerb: authorization.UPDATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
-				{Resource: "collection/XYZ", Verb: authorization.DELETE},
+				{Resource: "collections/ABC", Verb: authorization.READ},
+				{Resource: "collections/XYZ", Verb: authorization.DELETE},
 			},
 			roleName: "existingRole",
 			authorizeSetup: func(a *mocks.Authorizer) {
@@ -167,10 +167,10 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 				a.On("Authorize", &models.Principal{Username: "user"}, authorization.ROLE_SCOPE_MATCH, authorization.Roles("existingRole")[0]).
 					Return(nil).Once()
 				// Third call succeeds - has first permission
-				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collection/ABC").
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.READ, "collections/ABC").
 					Return(nil).Once()
 				// Fourth call fails - missing delete permission
-				a.On("Authorize", &models.Principal{Username: "user"}, authorization.DELETE, "collection/XYZ").
+				a.On("Authorize", &models.Principal{Username: "user"}, authorization.DELETE, "collections/XYZ").
 					Return(errors.New("missing delete permission")).Once()
 			},
 			expectedError: "missing delete permission",
@@ -180,7 +180,7 @@ func TestAuthorizeRoleScopes(t *testing.T) {
 			principal:    &models.Principal{Username: "user"},
 			originalVerb: authorization.UPDATE,
 			policies: []authorization.Policy{
-				{Resource: "collection/ABC", Verb: authorization.READ},
+				{Resource: "collections/ABC", Verb: authorization.READ},
 			},
 			roleName: "existingRole",
 			authorizeSetup: func(a *mocks.Authorizer) {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5696,7 +5696,7 @@ func init() {
               "default": "*"
             },
             "scope": {
-              "description": "set the scope for the manage scope permission",
+              "description": "set the scope for the manage role permission",
               "type": "string",
               "default": "match",
               "enum": [
@@ -12584,7 +12584,7 @@ func init() {
               "default": "*"
             },
             "scope": {
-              "description": "set the scope for the manage scope permission",
+              "description": "set the scope for the manage role permission",
               "type": "string",
               "default": "match",
               "enum": [
@@ -12685,7 +12685,7 @@ func init() {
           "default": "*"
         },
         "scope": {
-          "description": "set the scope for the manage scope permission",
+          "description": "set the scope for the manage role permission",
           "type": "string",
           "default": "match",
           "enum": [

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5701,8 +5701,7 @@ func init() {
               "default": "match",
               "enum": [
                 "all",
-                "match",
-                "match_no_manage"
+                "match"
               ]
             }
           }
@@ -12590,8 +12589,7 @@ func init() {
               "default": "match",
               "enum": [
                 "all",
-                "match",
-                "match_no_manage"
+                "match"
               ]
             }
           }
@@ -12692,8 +12690,7 @@ func init() {
           "default": "match",
           "enum": [
             "all",
-            "match",
-            "match_no_manage"
+            "match"
           ]
         }
       }

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5694,6 +5694,16 @@ func init() {
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
+            },
+            "scope": {
+              "description": "set the scope for the manage scope permission",
+              "type": "string",
+              "default": "match",
+              "enum": [
+                "all",
+                "match",
+                "match_no_manage"
+              ]
             }
           }
         },
@@ -12573,6 +12583,16 @@ func init() {
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
               "type": "string",
               "default": "*"
+            },
+            "scope": {
+              "description": "set the scope for the manage scope permission",
+              "type": "string",
+              "default": "match",
+              "enum": [
+                "all",
+                "match",
+                "match_no_manage"
+              ]
             }
           }
         },
@@ -12665,6 +12685,16 @@ func init() {
           "description": "string or regex. if a specific role name, if left empty it will be ALL or *",
           "type": "string",
           "default": "*"
+        },
+        "scope": {
+          "description": "set the scope for the manage scope permission",
+          "type": "string",
+          "default": "match",
+          "enum": [
+            "all",
+            "match",
+            "match_no_manage"
+          ]
         }
       }
     },

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -661,7 +661,7 @@ type PermissionRoles struct {
 	Role *string `json:"role,omitempty"`
 
 	// set the scope for the manage scope permission
-	// Enum: [all match match_no_manage]
+	// Enum: [all match]
 	Scope *string `json:"scope,omitempty"`
 }
 
@@ -683,7 +683,7 @@ var permissionRolesTypeScopePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["all","match","match_no_manage"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["all","match"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -698,9 +698,6 @@ const (
 
 	// PermissionRolesScopeMatch captures enum value "match"
 	PermissionRolesScopeMatch string = "match"
-
-	// PermissionRolesScopeMatchNoManage captures enum value "match_no_manage"
-	PermissionRolesScopeMatchNoManage string = "match_no_manage"
 )
 
 // prop value enum

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -659,10 +659,68 @@ type PermissionRoles struct {
 
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
+
+	// set the scope for the manage scope permission
+	// Enum: [all match match_no_manage]
+	Scope *string `json:"scope,omitempty"`
 }
 
 // Validate validates this permission roles
 func (m *PermissionRoles) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateScope(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+var permissionRolesTypeScopePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["all","match","match_no_manage"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		permissionRolesTypeScopePropEnum = append(permissionRolesTypeScopePropEnum, v)
+	}
+}
+
+const (
+
+	// PermissionRolesScopeAll captures enum value "all"
+	PermissionRolesScopeAll string = "all"
+
+	// PermissionRolesScopeMatch captures enum value "match"
+	PermissionRolesScopeMatch string = "match"
+
+	// PermissionRolesScopeMatchNoManage captures enum value "match_no_manage"
+	PermissionRolesScopeMatchNoManage string = "match_no_manage"
+)
+
+// prop value enum
+func (m *PermissionRoles) validateScopeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, permissionRolesTypeScopePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *PermissionRoles) validateScope(formats strfmt.Registry) error {
+	if swag.IsZero(m.Scope) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateScopeEnum("roles"+"."+"scope", "body", *m.Scope); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -660,7 +660,7 @@ type PermissionRoles struct {
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
 
-	// set the scope for the manage scope permission
+	// set the scope for the manage role permission
 	// Enum: [all match]
 	Scope *string `json:"scope,omitempty"`
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -111,7 +111,7 @@
               ],
               "type": "string",
               "default": "match",
-              "description": "set the scope for the manage scope permission"
+              "description": "set the scope for the manage role permission"
             }
           }
         },

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -103,6 +103,16 @@
               "type": "string",
               "default": "*",
               "description": "string or regex. if a specific role name, if left empty it will be ALL or *"
+            },
+            "scope": {
+              "enum": [
+                "all",
+                "match",
+                "match_no_manage"
+              ],
+              "type": "string",
+              "default": "match",
+              "description": "set the scope for the manage scope permission"
             }
           }
         },

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -107,8 +107,7 @@
             "scope": {
               "enum": [
                 "all",
-                "match",
-                "match_no_manage"
+                "match"
               ],
               "type": "string",
               "default": "match",

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -732,12 +732,12 @@ func TestAuthzRoleScopeMatching(t *testing.T) {
 	adminKey := "admin-key"
 	adminAuth := helper.CreateAuth(adminKey)
 
-	limitedUser := "limited-user"
-	limitedKey := "limited-key"
+	limitedUser := "custom-user"
+	limitedKey := "custom-key"
 	limitedAuth := helper.CreateAuth(limitedKey)
 
 	// Setup test roles
-	limitedRole := "limited-role"
+	limitedRole := "custom-role"
 	newRole := "new-role"
 	broaderRole := "broader-role"
 
@@ -895,7 +895,7 @@ func TestAuthzRoleScopeMatching(t *testing.T) {
 		require.True(t, errors.As(err, &parsed))
 	})
 
-	t.Run("limited user can not remove permissions from role", func(t *testing.T) {
+	t.Run("limited user can remove permissions from role with their scope", func(t *testing.T) {
 		_, err = helper.Client(t).Authz.RemovePermissions(
 			authz.NewRemovePermissionsParams().WithID(newRole).WithBody(authz.RemovePermissionsBody{
 				Permissions: []*models.Permission{

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -912,6 +912,32 @@ func TestAuthzRoleScopeMatching(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("limited user can delete role within their scope", func(t *testing.T) {
+		roleToDelete := "role-to-delete"
+		_, err = helper.Client(t).Authz.CreateRole(
+			authz.NewCreateRoleParams().WithBody(&models.Role{
+				Name: &roleToDelete,
+				Permissions: []*models.Permission{
+					{
+						Action: String(authorization.CreateCollections),
+						Collections: &models.PermissionCollections{
+							Collection: String("Collection1"),
+						},
+					},
+				},
+			}),
+			limitedAuth,
+		)
+		require.NoError(t, err)
+
+		// Verify limited user can delete the role
+		_, err = helper.Client(t).Authz.DeleteRole(
+			authz.NewDeleteRoleParams().WithID(roleToDelete),
+			limitedAuth,
+		)
+		require.NoError(t, err)
+	})
+
 	t.Run("admin can still manage all roles", func(t *testing.T) {
 		// Admin can delete roles created by limited user
 		helper.DeleteRole(t, adminKey, newRole)

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -210,13 +210,16 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 		if permission.Roles != nil && permission.Roles.Role != nil {
 			role = *permission.Roles.Role
 			if verb == CRUD {
-				verb = authorization.ROLE_SCOPE_MATCH // default on manage
+				// Default verb for role management
+				verb = authorization.ROLE_SCOPE_MATCH
 				if permission.Roles.Scope != nil {
-					scope := *permission.Roles.Scope
-					if scope == models.PermissionRolesScopeAll {
+					// Determine verb based on scope
+					switch *permission.Roles.Scope {
+					case models.PermissionRolesScopeAll:
 						verb = CRUD
-					} else if scope == models.PermissionRolesScopeMatchNoManage {
+					case models.PermissionRolesScopeMatchNoManage:
 						verb = authorization.ROLE_SCOPE_MATCH_NO_MANAGE
+					default:
 					}
 				}
 			}
@@ -358,9 +361,10 @@ func permission(policy []string, validatePath bool) (*models.Permission, error) 
 
 		if mapped.Verb != authorization.READ {
 			scope := models.PermissionRolesScopeMatch // default
-			if mapped.Verb == authorization.ROLE_SCOPE_ALL {
+			switch mapped.Verb {
+			case authorization.ROLE_SCOPE_ALL:
 				scope = models.PermissionRolesScopeAll
-			} else if mapped.Verb == authorization.ROLE_SCOPE_MATCH_NO_MANAGE {
+			case authorization.ROLE_SCOPE_MATCH_NO_MANAGE:
 				scope = models.PermissionRolesScopeMatchNoManage
 			}
 			permission.Roles.Scope = &scope

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -47,12 +47,14 @@ var (
 		authorization.Root:   CRUD,
 	}
 	actions = map[string]string{
-		CRUD:                 "manage",
-		CRU:                  "manage",
-		authorization.CREATE: "create",
-		authorization.READ:   "read",
-		authorization.UPDATE: "update",
-		authorization.DELETE: "delete",
+		CRUD:                                     "manage",
+		CRU:                                      "manage",
+		authorization.ROLE_SCOPE_MATCH:           "manage",
+		authorization.ROLE_SCOPE_MATCH_NO_MANAGE: "manage",
+		authorization.CREATE:                     "create",
+		authorization.READ:                       "read",
+		authorization.UPDATE:                     "update",
+		authorization.DELETE:                     "delete",
 	}
 )
 

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -47,14 +47,13 @@ var (
 		authorization.Root:   CRUD,
 	}
 	actions = map[string]string{
-		CRUD:                                     "manage",
-		CRU:                                      "manage",
-		authorization.ROLE_SCOPE_MATCH:           "manage",
-		authorization.ROLE_SCOPE_MATCH_NO_MANAGE: "manage",
-		authorization.CREATE:                     "create",
-		authorization.READ:                       "read",
-		authorization.UPDATE:                     "update",
-		authorization.DELETE:                     "delete",
+		CRUD:                           "manage",
+		CRU:                            "manage",
+		authorization.ROLE_SCOPE_MATCH: "manage",
+		authorization.CREATE:           "create",
+		authorization.READ:             "read",
+		authorization.UPDATE:           "update",
+		authorization.DELETE:           "delete",
 	}
 )
 
@@ -217,8 +216,6 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 					switch *permission.Roles.Scope {
 					case models.PermissionRolesScopeAll:
 						verb = CRUD
-					case models.PermissionRolesScopeMatchNoManage:
-						verb = authorization.ROLE_SCOPE_MATCH_NO_MANAGE
 					default:
 					}
 				}
@@ -364,8 +361,6 @@ func permission(policy []string, validatePath bool) (*models.Permission, error) 
 			switch mapped.Verb {
 			case authorization.ROLE_SCOPE_ALL:
 				scope = models.PermissionRolesScopeAll
-			case authorization.ROLE_SCOPE_MATCH_NO_MANAGE:
-				scope = models.PermissionRolesScopeMatchNoManage
 			}
 			permission.Roles.Scope = &scope
 		}

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -46,7 +46,7 @@ var (
 		authorization.Admin:  CRUD,
 		authorization.Root:   CRUD,
 	}
-	actions = map[string]string{
+	weaviate_actions_prefixes = map[string]string{
 		CRUD:                           "manage",
 		CRU:                            "manage",
 		authorization.ROLE_SCOPE_MATCH: "manage",
@@ -295,7 +295,7 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 }
 
 func weaviatePermissionAction(pathLastPart, verb, domain string) string {
-	action := fmt.Sprintf("%s_%s", actions[verb], domain)
+	action := fmt.Sprintf("%s_%s", weaviate_actions_prefixes[verb], domain)
 	action = strings.ReplaceAll(action, "_*", "")
 	switch domain {
 	case authorization.SchemaDomain:
@@ -303,9 +303,9 @@ func weaviatePermissionAction(pathLastPart, verb, domain string) string {
 			// e.g
 			// schema/collections/ABC/shards/#    collection permission
 			// schema/collections/ABC/shards/*    tenant permission
-			action = fmt.Sprintf("%s_%s", actions[verb], authorization.CollectionsDomain)
+			action = fmt.Sprintf("%s_%s", weaviate_actions_prefixes[verb], authorization.CollectionsDomain)
 		} else {
-			action = fmt.Sprintf("%s_%s", actions[verb], authorization.TenantsDomain)
+			action = fmt.Sprintf("%s_%s", weaviate_actions_prefixes[verb], authorization.TenantsDomain)
 		}
 		return action
 	default:

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -207,6 +207,15 @@ func policy(permission *models.Permission) (*authorization.Policy, error) {
 		role := "*"
 		if permission.Roles != nil && permission.Roles.Role != nil {
 			role = *permission.Roles.Role
+			verb = authorization.ROLE_SCOPE_MATCH // default
+			if permission.Roles.Scope != nil {
+				scope := *permission.Roles.Scope
+				if scope == models.PermissionRolesScopeAll {
+					verb = CRUD
+				} else if scope == models.PermissionRolesScopeMatchNoManage {
+					verb = authorization.ROLE_SCOPE_MATCH_NO_MANAGE
+				}
+			}
 		}
 		resource = CasbinRoles(role)
 	case authorization.ClusterDomain:
@@ -339,8 +348,15 @@ func permission(policy []string, validatePath bool) (*models.Permission, error) 
 			Object:     &splits[6],
 		}
 	case authorization.RolesDomain:
+		scope := models.PermissionRolesScopeMatch // default
+		if mapped.Verb == authorization.ROLE_SCOPE_ALL {
+			scope = models.PermissionRolesScopeAll
+		} else if mapped.Verb == authorization.ROLE_SCOPE_MATCH_NO_MANAGE {
+			scope = models.PermissionRolesScopeMatchNoManage
+		}
 		permission.Roles = &models.PermissionRoles{
-			Role: &splits[1],
+			Role:  &splits[1],
+			Scope: &scope,
 		}
 	case authorization.NodesDomain:
 		verbosity := splits[2]

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -68,7 +68,8 @@ var (
 		Collection: All,
 	}
 	AllRoles = &models.PermissionRoles{
-		Role: All,
+		Role:  All,
+		Scope: String(models.PermissionRolesScopeAll),
 	}
 	AllCollections = &models.PermissionCollections{
 		Collection: All,

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/verbosity"
@@ -30,6 +31,10 @@ const (
 	UPDATE = "U"
 	// DELETE Represents the action to delete a resource.
 	DELETE = "D"
+
+	ROLE_SCOPE_ALL             = "(C)|(R)|(U)|(D)"
+	ROLE_SCOPE_MATCH           = "MATCH"
+	ROLE_SCOPE_MATCH_NO_MANAGE = "(C)|(R)"
 )
 
 const (

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -32,9 +32,8 @@ const (
 	// DELETE Represents the action to delete a resource.
 	DELETE = "D"
 
-	ROLE_SCOPE_ALL             = "(C)|(R)|(U)|(D)"
-	ROLE_SCOPE_MATCH           = "MATCH"
-	ROLE_SCOPE_MATCH_NO_MANAGE = "(C)|(R)"
+	ROLE_SCOPE_ALL   = "(C)|(R)|(U)|(D)"
+	ROLE_SCOPE_MATCH = "MATCH"
 )
 
 const (


### PR DESCRIPTION
### What's being changed:
This PR implements role scope matching functionality for role management operations. This feature ensures that users can only create or modify roles with permissions that are equal to or more restrictive than their own permissions.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
