### PR TITLE
Refactor: clean up Inverted/BlockMax and map/WAND interactions

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -115,15 +115,17 @@ func (b *BM25Searcher) GetPropertyLengthTracker() *JsonShardMetaData {
 	return b.propLenTracker.(*JsonShardMetaData)
 }
 
-func (b *BM25Searcher) generateQueryTermsAndStats(class *models.Class, params searchparams.KeywordRanking) (float64, map[string][]string, map[string][]string, map[string][]int, map[string]float32, float64, error) {
+func (b *BM25Searcher) generateQueryTermsAndStats(class *models.Class, params searchparams.KeywordRanking) (bool, float64, map[string][]string, map[string][]string, map[string][]int, map[string]float32, float64, error) {
 	N := float64(b.store.Bucket(helpers.ObjectsBucketLSM).Count())
+
+	allSegmentsAreBlockMax := true
 
 	var stopWordDetector *stopwords.Detector
 	if class.InvertedIndexConfig != nil && class.InvertedIndexConfig.Stopwords != nil {
 		var err error
 		stopWordDetector, err = stopwords.NewDetectorFromConfig(*(class.InvertedIndexConfig.Stopwords))
 		if err != nil {
-			return 0, nil, nil, nil, nil, 0, err
+			return false, 0, nil, nil, nil, nil, 0, err
 		}
 	}
 
@@ -166,7 +168,16 @@ func (b *BM25Searcher) generateQueryTermsAndStats(class *models.Class, params se
 
 		propMean, err := b.GetPropertyLengthTracker().PropertyMean(property)
 		if err != nil {
-			return 0, nil, nil, nil, nil, 0, err
+			return false, 0, nil, nil, nil, nil, 0, err
+		}
+
+		bucket := b.GetBucket(property)
+		if bucket == nil {
+			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("could not find bucket for property %v", property)
+		}
+
+		if bucket.Strategy() != lsmkv.StrategyInverted {
+			allSegmentsAreBlockMax = false
 		}
 
 		// A NaN here is the results of a corrupted prop length tracker.
@@ -180,18 +191,18 @@ func (b *BM25Searcher) generateQueryTermsAndStats(class *models.Class, params se
 
 		prop, err := schema.GetPropertyByName(class, property)
 		if err != nil {
-			return 0, nil, nil, nil, nil, 0, err
+			return false, 0, nil, nil, nil, nil, 0, err
 		}
 
 		switch dt, _ := schema.AsPrimitive(prop.DataType); dt {
 		case schema.DataTypeText, schema.DataTypeTextArray:
 			if _, exists := propNamesByTokenization[prop.Tokenization]; !exists {
-				return 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle tokenization '%v' of property '%s'",
+				return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle tokenization '%v' of property '%s'",
 					prop.Tokenization, prop.Name)
 			}
 			propNamesByTokenization[prop.Tokenization] = append(propNamesByTokenization[prop.Tokenization], property)
 		default:
-			return 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle datatype '%v' of property '%s'", dt, prop.Name)
+			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle datatype '%v' of property '%s'", dt, prop.Name)
 		}
 	}
 
@@ -204,13 +215,13 @@ func (b *BM25Searcher) generateQueryTermsAndStats(class *models.Class, params se
 	if math.IsNaN(averagePropLength) || averagePropLength == 0 {
 		averagePropLength = 40.0
 	}
-	return N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, nil
+	return allSegmentsAreBlockMax, N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, nil
 }
 
 func (b *BM25Searcher) wand(
 	ctx context.Context, filterDocIds helpers.AllowList, class *models.Class, params searchparams.KeywordRanking, limit int, additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
-	N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, err := b.generateQueryTermsAndStats(class, params)
+	_, N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, err := b.generateQueryTermsAndStats(class, params)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -37,9 +37,13 @@ func (b *BM25Searcher) createBlockTerm(N float64, filterDocIds helpers.AllowList
 func (b *BM25Searcher) wandBlock(
 	ctx context.Context, filterDocIds helpers.AllowList, class *models.Class, params searchparams.KeywordRanking, limit int, additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
-	N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, err := b.generateQueryTermsAndStats(class, params)
+	allSegmentsAreBlockMax, N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, err := b.generateQueryTermsAndStats(class, params)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if !allSegmentsAreBlockMax {
+		return b.wand(ctx, filterDocIds, class, params, limit, additional)
 	}
 
 	allResults := make([][][]*lsmkv.SegmentBlockMax, 0, len(params.Properties))

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -36,6 +36,7 @@ const (
 	className = "TestClass"
 )
 
+// TODO amourao, check if this is needed for SegmentInverted as well
 func Test_Filters_String(t *testing.T) {
 	dirName := t.TempDir()
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -63,6 +63,8 @@ func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
 		bm, err = s.docBitmapInvertedRoaringSetRange(ctx, b, pv)
 	case lsmkv.StrategyMapCollection:
 		bm, err = s.docBitmapInvertedMap(ctx, b, limit, pv)
+	case lsmkv.StrategyInverted: // TODO amourao, check
+		bm, err = s.docBitmapInvertedMap(ctx, b, limit, pv)
 	default:
 		return docBitmap{}, fmt.Errorf("property '%s' is neither filterable nor searchable nor rangeable", pv.prop)
 	}

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -104,9 +104,8 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 				Error(errors.Wrap(err, "write-ahead-log ended abruptly, some elements may not have been recovered"))
 		}
 
-		if strings.Contains(mt.path, "_searchable") && os.Getenv("USE_INVERTED_SEARCHABLE") == "true" {
-			b.desiredStrategy = StrategyInverted
-			mt.flushStrategy = StrategyInverted
+		if strings.Contains(mt.path, "_searchable") {
+			b.desiredStrategy = DefaultSearchableStrategy()
 		}
 		if err := mt.flush(); err != nil {
 			return errors.Wrap(err, "flush memtable after WAL recovery")

--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -46,7 +46,7 @@ func (p *commitloggerParser) Do() error {
 	switch p.strategy {
 	case StrategyReplace:
 		return p.doReplace()
-	case StrategyMapCollection, StrategySetCollection:
+	case StrategyMapCollection, StrategySetCollection, StrategyInverted:
 		return p.doCollection()
 	case StrategyRoaringSet:
 		return p.doRoaringSet()

--- a/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
@@ -83,7 +83,8 @@ func (p *commitloggerParser) parseCollectionNode(reader io.Reader) error {
 		return err
 	}
 
-	if p.strategy == StrategyMapCollection {
+	// Commit log nodes are the same for MapCollection and Inverted strategies
+	if p.strategy == StrategyMapCollection || p.strategy == StrategyInverted {
 		return p.parseMapNode(n)
 	}
 

--- a/adapters/repos/db/lsmkv/entities/strategies.go
+++ b/adapters/repos/db/lsmkv/entities/strategies.go
@@ -17,6 +17,7 @@ const (
 	StrategySetCollection = "setcollection"
 	StrategyMapCollection = "mapcollection"
 	StrategyRoaringSet    = "roaringset"
+	StrategyInverted      = "inverted"
 )
 
 type SegmentStrategy uint16
@@ -26,6 +27,7 @@ const (
 	SegmentStrategySetCollection
 	SegmentStrategyMapCollection
 	SegmentStrategyRoaringSet
+	SegmentStrategyInverted
 )
 
 func SegmentStrategyFromString(in string) SegmentStrategy {
@@ -38,6 +40,8 @@ func SegmentStrategyFromString(in string) SegmentStrategy {
 		return SegmentStrategyMapCollection
 	case StrategyRoaringSet:
 		return SegmentStrategyRoaringSet
+	case StrategyInverted:
+		return SegmentStrategyInverted
 	default:
 		panic("unsupported strategy")
 	}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -38,7 +38,6 @@ type Memtable struct {
 	size               uint64
 	path               string
 	strategy           string
-	flushStrategy      string
 	secondaryIndices   uint16
 	secondaryToPrimary []map[string][]byte
 	// stores time memtable got dirty to determine when flush is needed
@@ -55,10 +54,6 @@ func newMemtable(path string, strategy string, secondaryIndices uint16,
 	cl *commitLogger, metrics *Metrics, logger logrus.FieldLogger,
 	enableChecksumValidation bool,
 ) (*Memtable, error) {
-	flushStrategy := strategy
-	if strategy == StrategyInverted {
-		strategy = StrategyMapCollection
-	}
 	m := &Memtable{
 		key:                      &binarySearchTree{},
 		keyMulti:                 &binarySearchTreeMulti{},
@@ -69,7 +64,6 @@ func newMemtable(path string, strategy string, secondaryIndices uint16,
 		commitlog:                cl,
 		path:                     path,
 		strategy:                 strategy,
-		flushStrategy:            flushStrategy,
 		secondaryIndices:         secondaryIndices,
 		dirtyAt:                  time.Time{},
 		createdAt:                time.Now(),
@@ -86,7 +80,7 @@ func newMemtable(path string, strategy string, secondaryIndices uint16,
 
 	m.metrics.size(m.size)
 
-	if m.strategy == StrategyMapCollection {
+	if m.strategy == StrategyInverted {
 		m.tombstones = sroar.NewBitmap()
 	}
 
@@ -283,9 +277,10 @@ func (m *Memtable) getCollection(key []byte) ([]value, error) {
 	start := time.Now()
 	defer m.metrics.getCollection(start.UnixNano())
 
-	if m.strategy != StrategySetCollection && m.strategy != StrategyMapCollection {
-		return nil, errors.Errorf("getCollection only possible with strategies %q, %q",
-			StrategySetCollection, StrategyMapCollection)
+	// TODO amourao: check if this is needed for StrategyInverted
+	if m.strategy != StrategySetCollection && m.strategy != StrategyMapCollection && m.strategy != StrategyInverted {
+		return nil, errors.Errorf("getCollection only possible with strategies %q, %q, %q",
+			StrategySetCollection, StrategyMapCollection, StrategyInverted)
 	}
 
 	m.RLock()
@@ -303,9 +298,9 @@ func (m *Memtable) getMap(key []byte) ([]MapPair, error) {
 	start := time.Now()
 	defer m.metrics.getMap(start.UnixNano())
 
-	if m.strategy != StrategyMapCollection {
-		return nil, errors.Errorf("getCollection only possible with strategy %q",
-			StrategyMapCollection)
+	if m.strategy != StrategyMapCollection && m.strategy != StrategyInverted {
+		return nil, errors.Errorf("getMap only possible with strategies %q, %q",
+			StrategyMapCollection, StrategyInverted)
 	}
 
 	m.RLock()
@@ -382,7 +377,7 @@ func (m *Memtable) appendMapSorted(key []byte, pair MapPair) error {
 	m.metrics.size(m.size)
 	m.updateDirtyAt()
 
-	if pair.Tombstone && len(pair.Key) == 8 {
+	if pair.Tombstone && len(pair.Key) == 8 && m.strategy == StrategyInverted {
 		docID := binary.BigEndian.Uint64(pair.Key)
 		m.tombstones.Set(docID)
 	}
@@ -442,8 +437,8 @@ func (m *Memtable) writeWAL() error {
 }
 
 func (m *Memtable) GetTombstones() (*sroar.Bitmap, error) {
-	if m.strategy != StrategyInverted && m.strategy != StrategyMapCollection {
-		return nil, errors.Errorf("tombstones only supported for inverted and map collection strategies")
+	if m.strategy != StrategyInverted {
+		return nil, errors.Errorf("tombstones only supported for strategy %q", StrategyInverted)
 	}
 
 	m.RLock()

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -54,7 +54,7 @@ func (m *Memtable) flush() error {
 	var keys []segmentindex.Key
 	skipIndices := false
 
-	switch m.flushStrategy {
+	switch m.strategy {
 	case StrategyReplace:
 		if keys, err = m.flushDataReplace(segmentFile); err != nil {
 			return err
@@ -98,7 +98,7 @@ func (m *Memtable) flush() error {
 		// TODO: Currently no checksum validation support for StrategyInverted.
 		//       This condition can be removed once support is added, and for
 		//       all strategies we can simply `segmentFile.WriteIndexes(indexes)`
-		if m.flushStrategy == StrategyInverted {
+		if m.strategy == StrategyInverted {
 			if _, err := indexes.WriteTo(bufw); err != nil {
 				return err
 			}
@@ -112,7 +112,7 @@ func (m *Memtable) flush() error {
 	// TODO: Currently no checksum validation support for StrategyInverted.
 	//       This condition can be removed once support is added, and for
 	//       all strategies we can simply `segmentFile.WriteChecksum()`
-	if m.flushStrategy != StrategyInverted {
+	if m.strategy != StrategyInverted {
 		if _, err := segmentFile.WriteChecksum(); err != nil {
 			return err
 		}

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -56,7 +56,8 @@ func newSegmentCleaner(sg *SegmentGroup) (segmentCleaner, error) {
 	case StrategyMapCollection,
 		StrategySetCollection,
 		StrategyRoaringSet,
-		StrategyRoaringSetRange:
+		StrategyRoaringSetRange,
+		StrategyInverted:
 		return &segmentCleanerNoop{}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized strategy %q", sg.strategy)

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -13,8 +13,10 @@ package lsmkv
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/entities/config"
 )
 
 const (
@@ -88,4 +90,11 @@ func CheckStrategyRoaringSet(strategy string) error {
 
 func CheckStrategyRoaringSetRange(strategy string) error {
 	return CheckExpectedStrategy(strategy, StrategyRoaringSetRange)
+}
+
+func DefaultSearchableStrategy() string {
+	if config.Enabled(os.Getenv("USE_INVERTED_SEARCHABLE")) {
+		return StrategyInverted
+	}
+	return StrategyMapCollection
 }

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -123,8 +123,9 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 	}
 
 	if inverted.HasSearchableIndex(prop) {
-		searchableBucketOpts := append(bucketOpts, lsmkv.WithStrategy(lsmkv.StrategyMapCollection))
-		if s.versioner.Version() < 2 {
+		strategy := lsmkv.DefaultSearchableStrategy()
+		searchableBucketOpts := append(bucketOpts, lsmkv.WithStrategy(strategy))
+		if strategy == lsmkv.StrategyMapCollection && s.versioner.Version() < 2 {
 			searchableBucketOpts = append(searchableBucketOpts, lsmkv.WithLegacyMapSorting())
 		}
 

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -181,7 +181,7 @@ func (s *Shard) pairPropertyWithFrequency(docID uint64, freq, propLen float32) l
 }
 
 func (s *Shard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {
-	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection, lsmkv.StrategyInverted)
 
 	return bucket.MapSet(key, pair)
 }

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -107,7 +107,7 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 func (s *Shard) deleteInvertedIndexItemWithFrequencyLSM(bucket *lsmkv.Bucket,
 	item inverted.Countable, docID uint64,
 ) error {
-	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection)
+	lsmkv.MustBeExpectedStrategy(bucket.Strategy(), lsmkv.StrategyMapCollection, lsmkv.StrategyInverted)
 
 	docIDBytes := make([]byte, 8)
 	// Shard Index version 2 requires BigEndian for sorting, if the shard was


### PR DESCRIPTION
### What's being changed:

Make `BlockMaxWAND` and `WAND` work properly with all combinations of `map` and `inverted` buckets and segments:
                
`USE_BLOCKMAX_WAND: "true"`
- will only use **BlockMaxWAND** if all properties are of the `inverted` type
- if there is at least a bucket using the `mapcollection` strategy, falls back to **WAND** (which also works on `inverted` segments)

`USE_INVERTED_SEARCHABLE: "true"`(only applies to `_searchable` buckets and segments
- will write incoming data in the `inverted` format ONLY if there is no data written in the `mapcollection` format
- if there exists `mapcollection` format data, keep writing on `mapcollection` format
- same conditions apply for WAL recoveries:
  - if there is no segment, WAL will be recovered and written in `inverted` format
  - if there is at least a segment in the `mapcollection` format, write in `mapcollection` format
- existing data is not converted at any time
- if the flag is disabled at any time, data for `inverted` format segments WILL STILL BE WRITTEN as `inverted`
  - this means that there shouldn't be any data mixups between formats
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
