### PR TITLE
feat(rbac): raft migrate roles scope to MATCH as default

### DIFF
--- a/cluster/proto/api/rbac_requests.go
+++ b/cluster/proto/api/rbac_requests.go
@@ -27,7 +27,7 @@ const (
 	// of Role permissions and default to MATCH scope instead of ALL
 	// old verb was (C)|(R)|(U)|(D)
 	// new verb was MATCH
-	RBACCommandPolicyVersionV1 = iota
+	RBACCommandPolicyVersionV1
 	// RBACLatestCommandPolicyVersion represents the latest version of RBAC commands policies
 	// It's used to migrate policy changes. if we end up with a cluster having different version
 	// that won't be a problem because the version here is not about the message change but more about

--- a/cluster/proto/api/rbac_requests.go
+++ b/cluster/proto/api/rbac_requests.go
@@ -16,10 +16,18 @@ import (
 )
 
 const (
-	// in case changes happens to the RBAC message, add new version before the RBACLatestCommandPolicyVersion
-	// RBACCommandPolicyVersionV0 represents the first version of RBAC commands
+	// NOTE: in case changes happens to the RBAC message, add new version before the RBACLatestCommandPolicyVersion
+	// RBACCommandPolicyVersionV0 represents the first version of RBAC commands where it wasn't set and equal 0
+	// this version was needed because we did migrate paths of SchemaDomain to limit the collection
+	// old "schema/collections/{collection_name}/shards/*" all shards in collection
+	// new "schema/collections/{collection_name}/shards/#" limited to collection only
 	RBACCommandPolicyVersionV0 = iota
 
+	// this version was needed because we did migrate verbs of RolesDomain to control the scope
+	// of Role permissions and default to MATCH scope instead of ALL
+	// old verb was (C)|(R)|(U)|(D)
+	// new verb was MATCH
+	RBACCommandPolicyVersionV1 = iota
 	// RBACLatestCommandPolicyVersion represents the latest version of RBAC commands policies
 	// It's used to migrate policy changes. if we end up with a cluster having different version
 	// that won't be a problem because the version here is not about the message change but more about

--- a/cluster/rbac/manager_test.go
+++ b/cluster/rbac/manager_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package rbac
 
 import (

--- a/cluster/rbac/manager_test.go
+++ b/cluster/rbac/manager_test.go
@@ -9,7 +9,6 @@ import (
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 )
 
@@ -59,7 +58,7 @@ func TestUpsertRolesPermissions(t *testing.T) {
 						"admin": {
 							{
 								Domain: authorization.RolesDomain,
-								Verb:   conv.CRUD, // old
+								Verb:   authorization.ROLE_SCOPE_ALL, // old
 							},
 						},
 					},
@@ -72,6 +71,33 @@ func TestUpsertRolesPermissions(t *testing.T) {
 						{
 							Domain: authorization.RolesDomain,
 							Verb:   authorization.ROLE_SCOPE_MATCH, // new
+						},
+					},
+				}).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "VLatest: Successfully update roles domain permissions",
+			request: &cmd.ApplyRequest{
+				SubCommand: mustMarshal(cmd.CreateRolesRequest{
+					Version: cmd.RBACLatestCommandPolicyVersion,
+					Roles: map[string][]authorization.Policy{
+						"admin": {
+							{
+								Domain: authorization.RolesDomain,
+								Verb:   authorization.ROLE_SCOPE_ALL, // shall not be affected
+							},
+						},
+					},
+				}),
+			},
+			setup: func(m *mocks.Controller) {
+				m.On("UpsertRolesPermissions", map[string][]authorization.Policy{
+					"admin": {
+						{
+							Domain: authorization.RolesDomain,
+							Verb:   authorization.ROLE_SCOPE_ALL, // new
 						},
 					},
 				}).Return(nil)

--- a/cluster/rbac/manager_test.go
+++ b/cluster/rbac/manager_test.go
@@ -1,0 +1,130 @@
+package rbac
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
+)
+
+func TestUpsertRolesPermissions(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *cmd.ApplyRequest
+		setup   func(*mocks.Controller)
+		wantErr bool
+	}{
+		{
+			name: "V0: Successfully update schema domain permissions",
+			request: &cmd.ApplyRequest{
+				SubCommand: mustMarshal(cmd.CreateRolesRequest{
+					Version: cmd.RBACCommandPolicyVersionV0,
+					Roles: map[string][]authorization.Policy{
+						"admin": {
+							{
+								Domain:   authorization.SchemaDomain,
+								Resource: "schema/collections/ABC/shards/*", // old
+								Verb:     authorization.READ,
+							},
+						},
+					},
+				}),
+			},
+			setup: func(m *mocks.Controller) {
+				m.On("RemovePermissions", "admin", mock.Anything).Return(nil)
+				m.On("UpsertRolesPermissions", map[string][]authorization.Policy{
+					"admin": {
+						{
+							Domain:   authorization.SchemaDomain,
+							Resource: "schema/collections/ABC/shards/#", // new
+							Verb:     authorization.READ,
+						},
+					},
+				}).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "V1: Successfully update roles domain permissions",
+			request: &cmd.ApplyRequest{
+				SubCommand: mustMarshal(cmd.CreateRolesRequest{
+					Version: cmd.RBACCommandPolicyVersionV1,
+					Roles: map[string][]authorization.Policy{
+						"admin": {
+							{
+								Domain: authorization.RolesDomain,
+								Verb:   conv.CRUD, // old
+							},
+						},
+					},
+				}),
+			},
+			setup: func(m *mocks.Controller) {
+				m.On("RemovePermissions", "admin", mock.Anything).Return(nil)
+				m.On("UpsertRolesPermissions", map[string][]authorization.Policy{
+					"admin": {
+						{
+							Domain: authorization.RolesDomain,
+							Verb:   authorization.ROLE_SCOPE_MATCH, // new
+						},
+					},
+				}).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid schema path",
+			request: &cmd.ApplyRequest{
+				SubCommand: mustMarshal(cmd.CreateRolesRequest{
+					Version: cmd.RBACCommandPolicyVersionV0,
+					Roles: map[string][]authorization.Policy{
+						"admin": {
+							{
+								Domain:   authorization.SchemaDomain,
+								Resource: "invalid/path",
+								Verb:     authorization.READ,
+							},
+						},
+					},
+				}),
+			},
+			setup: func(m *mocks.Controller) {
+				m.On("RemovePermissions", "admin", mock.Anything).Return(nil)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := mocks.NewController(t)
+			if tt.setup != nil {
+				tt.setup(controller)
+			}
+
+			manager := NewManager(controller, nil)
+			err := manager.UpsertRolesPermissions(tt.request)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			controller.AssertExpectations(t)
+		})
+	}
+}
+
+func mustMarshal(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/cluster/store_query.go
+++ b/cluster/store_query.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
@@ -57,22 +58,22 @@ func (st *Store) Query(req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
 	case cmd.QueryRequest_TYPE_HAS_PERMISSION:
 		payload, err = st.authZManager.HasPermission(req)
 		if err != nil {
-			return &cmd.QueryResponse{}, fmt.Errorf("could not get sharding state: %w", err)
+			return &cmd.QueryResponse{}, fmt.Errorf("could not get RBAC permissions: %w", err)
 		}
 	case cmd.QueryRequest_TYPE_GET_ROLES:
 		payload, err = st.authZManager.GetRoles(req)
 		if err != nil {
-			return &cmd.QueryResponse{}, fmt.Errorf("could not get sharding state: %w", err)
+			return &cmd.QueryResponse{}, fmt.Errorf("could not get RBAC permissions: %w", err)
 		}
 	case cmd.QueryRequest_TYPE_GET_ROLES_FOR_USER:
 		payload, err = st.authZManager.GetRolesForUser(req)
 		if err != nil {
-			return &cmd.QueryResponse{}, fmt.Errorf("could not get sharding state: %w", err)
+			return &cmd.QueryResponse{}, fmt.Errorf("could not get RBAC permissions: %w", err)
 		}
 	case cmd.QueryRequest_TYPE_GET_USERS_FOR_ROLE:
 		payload, err = st.authZManager.GetUsersForRole(req)
 		if err != nil {
-			return &cmd.QueryResponse{}, fmt.Errorf("could not get sharding state: %w", err)
+			return &cmd.QueryResponse{}, fmt.Errorf("could not get RBAC permissions: %w", err)
 		}
 
 	default:


### PR DESCRIPTION
### What's being changed:
RBAC old roles had ALL by default as scope, with newer version we have MATCH as default. this PR makes sure that older versions are migrated

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
