### PR TITLE
Use `oneof` in `AggregateReply` to unionise single/grouped results

### DIFF
--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
@@ -40,7 +40,7 @@ func NewAggregateReplier(authorizedGetClass func(string) (*models.Class, error),
 	}
 }
 
-func (r *AggregateReplier) Aggregate(res interface{}) (*pb.AggregateReply, error) {
+func (r *AggregateReplier) Aggregate(res interface{}, isGroupby bool) (*pb.AggregateReply, error) {
 	var groups []*pb.AggregateReply_Group
 
 	if res != nil {
@@ -49,7 +49,10 @@ func (r *AggregateReplier) Aggregate(res interface{}) (*pb.AggregateReply, error
 			return nil, fmt.Errorf("unexpected aggregate result type: %T", res)
 		}
 
-		if len(result.Groups) == 1 {
+		if !isGroupby {
+			if len(result.Groups) == 0 {
+				return &pb.AggregateReply{}, fmt.Errorf("no groups found in aggregate result")
+			}
 			group := result.Groups[0]
 			count := int64(group.Count)
 			aggregations, err := r.parseAggregatedProperties(group.Properties)

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
@@ -52,7 +52,7 @@ func TestGRPCAggregateReply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			replier := NewAggregateReplier(nil, nil)
-			result, err := replier.Aggregate(tt.res)
+			result, err := replier.Aggregate(tt.res, true)
 			if tt.wantError != nil {
 				require.Error(t, err)
 				assert.EqualError(t, tt.wantError, err.Error())

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
@@ -24,7 +24,7 @@ func TestGRPCAggregateReply(t *testing.T) {
 	tests := []struct {
 		name      string
 		res       interface{}
-		outRes    *pb.AggregateReply_Result
+		outRes    *pb.AggregateReply
 		wantError error
 	}{
 		{
@@ -36,10 +36,14 @@ func TestGRPCAggregateReply(t *testing.T) {
 					},
 				},
 			},
-			outRes: &pb.AggregateReply_Result{
-				Groups: []*pb.AggregateGroup{
-					{
-						ObjectsCount: ptInt64(11),
+			outRes: &pb.AggregateReply{
+				Result: &pb.AggregateReply_GroupedResults{
+					GroupedResults: &pb.AggregateReply_Grouped{
+						Groups: []*pb.AggregateReply_Group{
+							{
+								ObjectsCount: ptInt64(11),
+							},
+						},
 					},
 				},
 			},

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -107,7 +107,7 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 		s.classGetterWithAuthzFunc(principal),
 		params,
 	)
-	reply, err := replier.Aggregate(res)
+	reply, err := replier.Aggregate(res, params.GroupBy != nil)
 	if err != nil {
 		return nil, fmt.Errorf("prepare reply: %w", err)
 	}

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -107,15 +107,12 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 		s.classGetterWithAuthzFunc(principal),
 		params,
 	)
-	result, err := replier.Aggregate(res)
+	reply, err := replier.Aggregate(res)
 	if err != nil {
 		return nil, fmt.Errorf("prepare reply: %w", err)
 	}
 
-	reply := &pb.AggregateReply{
-		Took:   float32(time.Since(before).Seconds()),
-		Result: result,
-	}
+	reply.Took = float32(time.Since(before).Seconds())
 	return reply, nil
 }
 

--- a/grpc/generated/protocol/v1/aggregate.pb.go
+++ b/grpc/generated/protocol/v1/aggregate.pb.go
@@ -36,6 +36,7 @@ type AggregateRequest struct {
 	// matches/searches for objects
 	Filters *Filters `protobuf:"bytes,40,opt,name=filters,proto3,oneof" json:"filters,omitempty"`
 	// Types that are assignable to Search:
+	//
 	//	*AggregateRequest_Hybrid
 	//	*AggregateRequest_NearVector
 	//	*AggregateRequest_NearObject
@@ -283,8 +284,12 @@ type AggregateReply struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Took   float32                `protobuf:"fixed32,1,opt,name=took,proto3" json:"took,omitempty"`
-	Result *AggregateReply_Result `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
+	Took float32 `protobuf:"fixed32,1,opt,name=took,proto3" json:"took,omitempty"`
+	// Types that are assignable to Result:
+	//
+	//	*AggregateReply_SingleResult
+	//	*AggregateReply_GroupedResults
+	Result isAggregateReply_Result `protobuf_oneof:"result"`
 }
 
 func (x *AggregateReply) Reset() {
@@ -326,75 +331,42 @@ func (x *AggregateReply) GetTook() float32 {
 	return 0
 }
 
-func (x *AggregateReply) GetResult() *AggregateReply_Result {
-	if x != nil {
-		return x.Result
+func (m *AggregateReply) GetResult() isAggregateReply_Result {
+	if m != nil {
+		return m.Result
 	}
 	return nil
 }
 
-type AggregateGroup struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	ObjectsCount *int64                       `protobuf:"varint,1,opt,name=objects_count,json=objectsCount,proto3,oneof" json:"objects_count,omitempty"`
-	Aggregations *AggregateGroup_Aggregations `protobuf:"bytes,2,opt,name=aggregations,proto3,oneof" json:"aggregations,omitempty"`
-	GroupedBy    *AggregateGroup_GroupedBy    `protobuf:"bytes,3,opt,name=grouped_by,json=groupedBy,proto3,oneof" json:"grouped_by,omitempty"`
-}
-
-func (x *AggregateGroup) Reset() {
-	*x = AggregateGroup{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[2]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *AggregateGroup) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AggregateGroup) ProtoMessage() {}
-
-func (x *AggregateGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[2]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use AggregateGroup.ProtoReflect.Descriptor instead.
-func (*AggregateGroup) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *AggregateGroup) GetObjectsCount() int64 {
-	if x != nil && x.ObjectsCount != nil {
-		return *x.ObjectsCount
-	}
-	return 0
-}
-
-func (x *AggregateGroup) GetAggregations() *AggregateGroup_Aggregations {
-	if x != nil {
-		return x.Aggregations
+func (x *AggregateReply) GetSingleResult() *AggregateReply_Single {
+	if x, ok := x.GetResult().(*AggregateReply_SingleResult); ok {
+		return x.SingleResult
 	}
 	return nil
 }
 
-func (x *AggregateGroup) GetGroupedBy() *AggregateGroup_GroupedBy {
-	if x != nil {
-		return x.GroupedBy
+func (x *AggregateReply) GetGroupedResults() *AggregateReply_Grouped {
+	if x, ok := x.GetResult().(*AggregateReply_GroupedResults); ok {
+		return x.GroupedResults
 	}
 	return nil
 }
+
+type isAggregateReply_Result interface {
+	isAggregateReply_Result()
+}
+
+type AggregateReply_SingleResult struct {
+	SingleResult *AggregateReply_Single `protobuf:"bytes,2,opt,name=single_result,json=singleResult,proto3,oneof"`
+}
+
+type AggregateReply_GroupedResults struct {
+	GroupedResults *AggregateReply_Grouped `protobuf:"bytes,3,opt,name=grouped_results,json=groupedResults,proto3,oneof"`
+}
+
+func (*AggregateReply_SingleResult) isAggregateReply_Result() {}
+
+func (*AggregateReply_GroupedResults) isAggregateReply_Result() {}
 
 type AggregateRequest_Aggregation struct {
 	state         protoimpl.MessageState
@@ -403,6 +375,7 @@ type AggregateRequest_Aggregation struct {
 
 	Property string `protobuf:"bytes,1,opt,name=property,proto3" json:"property,omitempty"`
 	// Types that are assignable to Aggregation:
+	//
 	//	*AggregateRequest_Aggregation_Int
 	//	*AggregateRequest_Aggregation_Number_
 	//	*AggregateRequest_Aggregation_Text_
@@ -415,7 +388,7 @@ type AggregateRequest_Aggregation struct {
 func (x *AggregateRequest_Aggregation) Reset() {
 	*x = AggregateRequest_Aggregation{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[3]
+		mi := &file_v1_aggregate_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -428,7 +401,7 @@ func (x *AggregateRequest_Aggregation) String() string {
 func (*AggregateRequest_Aggregation) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[3]
+	mi := &file_v1_aggregate_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -552,7 +525,7 @@ type AggregateRequest_GroupBy struct {
 func (x *AggregateRequest_GroupBy) Reset() {
 	*x = AggregateRequest_GroupBy{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[4]
+		mi := &file_v1_aggregate_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -565,7 +538,7 @@ func (x *AggregateRequest_GroupBy) String() string {
 func (*AggregateRequest_GroupBy) ProtoMessage() {}
 
 func (x *AggregateRequest_GroupBy) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[4]
+	mi := &file_v1_aggregate_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -613,7 +586,7 @@ type AggregateRequest_Aggregation_Integer struct {
 func (x *AggregateRequest_Aggregation_Integer) Reset() {
 	*x = AggregateRequest_Aggregation_Integer{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[5]
+		mi := &file_v1_aggregate_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -626,7 +599,7 @@ func (x *AggregateRequest_Aggregation_Integer) String() string {
 func (*AggregateRequest_Aggregation_Integer) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation_Integer) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[5]
+	mi := &file_v1_aggregate_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -716,7 +689,7 @@ type AggregateRequest_Aggregation_Number struct {
 func (x *AggregateRequest_Aggregation_Number) Reset() {
 	*x = AggregateRequest_Aggregation_Number{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[6]
+		mi := &file_v1_aggregate_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -729,7 +702,7 @@ func (x *AggregateRequest_Aggregation_Number) String() string {
 func (*AggregateRequest_Aggregation_Number) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation_Number) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[6]
+	mi := &file_v1_aggregate_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -815,7 +788,7 @@ type AggregateRequest_Aggregation_Text struct {
 func (x *AggregateRequest_Aggregation_Text) Reset() {
 	*x = AggregateRequest_Aggregation_Text{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[7]
+		mi := &file_v1_aggregate_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -828,7 +801,7 @@ func (x *AggregateRequest_Aggregation_Text) String() string {
 func (*AggregateRequest_Aggregation_Text) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation_Text) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[7]
+	mi := &file_v1_aggregate_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -888,7 +861,7 @@ type AggregateRequest_Aggregation_Boolean struct {
 func (x *AggregateRequest_Aggregation_Boolean) Reset() {
 	*x = AggregateRequest_Aggregation_Boolean{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[8]
+		mi := &file_v1_aggregate_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -901,7 +874,7 @@ func (x *AggregateRequest_Aggregation_Boolean) String() string {
 func (*AggregateRequest_Aggregation_Boolean) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation_Boolean) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[8]
+	mi := &file_v1_aggregate_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -975,7 +948,7 @@ type AggregateRequest_Aggregation_Date struct {
 func (x *AggregateRequest_Aggregation_Date) Reset() {
 	*x = AggregateRequest_Aggregation_Date{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[9]
+		mi := &file_v1_aggregate_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -988,7 +961,7 @@ func (x *AggregateRequest_Aggregation_Date) String() string {
 func (*AggregateRequest_Aggregation_Date) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation_Date) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[9]
+	mi := &file_v1_aggregate_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1058,7 +1031,7 @@ type AggregateRequest_Aggregation_Reference struct {
 func (x *AggregateRequest_Aggregation_Reference) Reset() {
 	*x = AggregateRequest_Aggregation_Reference{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_v1_aggregate_proto_msgTypes[10]
+		mi := &file_v1_aggregate_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1071,7 +1044,7 @@ func (x *AggregateRequest_Aggregation_Reference) String() string {
 func (*AggregateRequest_Aggregation_Reference) ProtoMessage() {}
 
 func (x *AggregateRequest_Aggregation_Reference) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_aggregate_proto_msgTypes[10]
+	mi := &file_v1_aggregate_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1101,16 +1074,64 @@ func (x *AggregateRequest_Aggregation_Reference) GetPointingTo() bool {
 	return false
 }
 
-type AggregateReply_Result struct {
+type AggregateReply_Aggregations struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Groups []*AggregateGroup `protobuf:"bytes,1,rep,name=groups,proto3" json:"groups,omitempty"`
+	Aggregations []*AggregateReply_Aggregations_Aggregation `protobuf:"bytes,1,rep,name=aggregations,proto3" json:"aggregations,omitempty"`
 }
 
-func (x *AggregateReply_Result) Reset() {
-	*x = AggregateReply_Result{}
+func (x *AggregateReply_Aggregations) Reset() {
+	*x = AggregateReply_Aggregations{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_v1_aggregate_proto_msgTypes[10]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *AggregateReply_Aggregations) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AggregateReply_Aggregations) ProtoMessage() {}
+
+func (x *AggregateReply_Aggregations) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_aggregate_proto_msgTypes[10]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AggregateReply_Aggregations.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0}
+}
+
+func (x *AggregateReply_Aggregations) GetAggregations() []*AggregateReply_Aggregations_Aggregation {
+	if x != nil {
+		return x.Aggregations
+	}
+	return nil
+}
+
+type AggregateReply_Single struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ObjectsCount *int64                       `protobuf:"varint,1,opt,name=objects_count,json=objectsCount,proto3,oneof" json:"objects_count,omitempty"`
+	Aggregations *AggregateReply_Aggregations `protobuf:"bytes,2,opt,name=aggregations,proto3,oneof" json:"aggregations,omitempty"`
+}
+
+func (x *AggregateReply_Single) Reset() {
+	*x = AggregateReply_Single{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1118,13 +1139,13 @@ func (x *AggregateReply_Result) Reset() {
 	}
 }
 
-func (x *AggregateReply_Result) String() string {
+func (x *AggregateReply_Single) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateReply_Result) ProtoMessage() {}
+func (*AggregateReply_Single) ProtoMessage() {}
 
-func (x *AggregateReply_Result) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Single) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1136,28 +1157,37 @@ func (x *AggregateReply_Result) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateReply_Result.ProtoReflect.Descriptor instead.
-func (*AggregateReply_Result) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0}
+// Deprecated: Use AggregateReply_Single.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Single) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 1}
 }
 
-func (x *AggregateReply_Result) GetGroups() []*AggregateGroup {
+func (x *AggregateReply_Single) GetObjectsCount() int64 {
+	if x != nil && x.ObjectsCount != nil {
+		return *x.ObjectsCount
+	}
+	return 0
+}
+
+func (x *AggregateReply_Single) GetAggregations() *AggregateReply_Aggregations {
 	if x != nil {
-		return x.Groups
+		return x.Aggregations
 	}
 	return nil
 }
 
-type AggregateGroup_Aggregations struct {
+type AggregateReply_Group struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Aggregations []*AggregateGroup_Aggregations_Aggregation `protobuf:"bytes,1,rep,name=aggregations,proto3" json:"aggregations,omitempty"`
+	ObjectsCount *int64                          `protobuf:"varint,1,opt,name=objects_count,json=objectsCount,proto3,oneof" json:"objects_count,omitempty"`
+	Aggregations *AggregateReply_Aggregations    `protobuf:"bytes,2,opt,name=aggregations,proto3,oneof" json:"aggregations,omitempty"`
+	GroupedBy    *AggregateReply_Group_GroupedBy `protobuf:"bytes,3,opt,name=grouped_by,json=groupedBy,proto3,oneof" json:"grouped_by,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations) Reset() {
-	*x = AggregateGroup_Aggregations{}
+func (x *AggregateReply_Group) Reset() {
+	*x = AggregateReply_Group{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1165,13 +1195,13 @@ func (x *AggregateGroup_Aggregations) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations) String() string {
+func (x *AggregateReply_Group) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations) ProtoMessage() {}
+func (*AggregateReply_Group) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Group) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1183,40 +1213,42 @@ func (x *AggregateGroup_Aggregations) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0}
+// Deprecated: Use AggregateReply_Group.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Group) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 2}
 }
 
-func (x *AggregateGroup_Aggregations) GetAggregations() []*AggregateGroup_Aggregations_Aggregation {
+func (x *AggregateReply_Group) GetObjectsCount() int64 {
+	if x != nil && x.ObjectsCount != nil {
+		return *x.ObjectsCount
+	}
+	return 0
+}
+
+func (x *AggregateReply_Group) GetAggregations() *AggregateReply_Aggregations {
 	if x != nil {
 		return x.Aggregations
 	}
 	return nil
 }
 
-type AggregateGroup_GroupedBy struct {
+func (x *AggregateReply_Group) GetGroupedBy() *AggregateReply_Group_GroupedBy {
+	if x != nil {
+		return x.GroupedBy
+	}
+	return nil
+}
+
+type AggregateReply_Grouped struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-	Path []string `protobuf:"bytes,1,rep,name=path,proto3" json:"path,omitempty"`
-	// Types that are assignable to Value:
-	//	*AggregateGroup_GroupedBy_Text
-	//	*AggregateGroup_GroupedBy_Int
-	//	*AggregateGroup_GroupedBy_Boolean
-	//	*AggregateGroup_GroupedBy_Number
-	//	*AggregateGroup_GroupedBy_Texts
-	//	*AggregateGroup_GroupedBy_Ints
-	//	*AggregateGroup_GroupedBy_Booleans
-	//	*AggregateGroup_GroupedBy_Numbers
-	//	*AggregateGroup_GroupedBy_Geo
-	Value isAggregateGroup_GroupedBy_Value `protobuf_oneof:"value"`
+	Groups []*AggregateReply_Group `protobuf:"bytes,1,rep,name=groups,proto3" json:"groups,omitempty"`
 }
 
-func (x *AggregateGroup_GroupedBy) Reset() {
-	*x = AggregateGroup_GroupedBy{}
+func (x *AggregateReply_Grouped) Reset() {
+	*x = AggregateReply_Grouped{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1224,13 +1256,13 @@ func (x *AggregateGroup_GroupedBy) Reset() {
 	}
 }
 
-func (x *AggregateGroup_GroupedBy) String() string {
+func (x *AggregateReply_Grouped) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_GroupedBy) ProtoMessage() {}
+func (*AggregateReply_Grouped) ProtoMessage() {}
 
-func (x *AggregateGroup_GroupedBy) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Grouped) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1242,164 +1274,37 @@ func (x *AggregateGroup_GroupedBy) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_GroupedBy.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_GroupedBy) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 1}
+// Deprecated: Use AggregateReply_Grouped.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Grouped) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 3}
 }
 
-func (x *AggregateGroup_GroupedBy) GetPath() []string {
+func (x *AggregateReply_Grouped) GetGroups() []*AggregateReply_Group {
 	if x != nil {
-		return x.Path
+		return x.Groups
 	}
 	return nil
 }
 
-func (m *AggregateGroup_GroupedBy) GetValue() isAggregateGroup_GroupedBy_Value {
-	if m != nil {
-		return m.Value
-	}
-	return nil
-}
-
-func (x *AggregateGroup_GroupedBy) GetText() string {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Text); ok {
-		return x.Text
-	}
-	return ""
-}
-
-func (x *AggregateGroup_GroupedBy) GetInt() int64 {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Int); ok {
-		return x.Int
-	}
-	return 0
-}
-
-func (x *AggregateGroup_GroupedBy) GetBoolean() bool {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Boolean); ok {
-		return x.Boolean
-	}
-	return false
-}
-
-func (x *AggregateGroup_GroupedBy) GetNumber() float64 {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Number); ok {
-		return x.Number
-	}
-	return 0
-}
-
-func (x *AggregateGroup_GroupedBy) GetTexts() *TextArray {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Texts); ok {
-		return x.Texts
-	}
-	return nil
-}
-
-func (x *AggregateGroup_GroupedBy) GetInts() *IntArray {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Ints); ok {
-		return x.Ints
-	}
-	return nil
-}
-
-func (x *AggregateGroup_GroupedBy) GetBooleans() *BooleanArray {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Booleans); ok {
-		return x.Booleans
-	}
-	return nil
-}
-
-func (x *AggregateGroup_GroupedBy) GetNumbers() *NumberArray {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Numbers); ok {
-		return x.Numbers
-	}
-	return nil
-}
-
-func (x *AggregateGroup_GroupedBy) GetGeo() *GeoCoordinatesFilter {
-	if x, ok := x.GetValue().(*AggregateGroup_GroupedBy_Geo); ok {
-		return x.Geo
-	}
-	return nil
-}
-
-type isAggregateGroup_GroupedBy_Value interface {
-	isAggregateGroup_GroupedBy_Value()
-}
-
-type AggregateGroup_GroupedBy_Text struct {
-	Text string `protobuf:"bytes,2,opt,name=text,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Int struct {
-	Int int64 `protobuf:"varint,3,opt,name=int,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Boolean struct {
-	Boolean bool `protobuf:"varint,4,opt,name=boolean,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Number struct {
-	Number float64 `protobuf:"fixed64,5,opt,name=number,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Texts struct {
-	Texts *TextArray `protobuf:"bytes,6,opt,name=texts,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Ints struct {
-	Ints *IntArray `protobuf:"bytes,7,opt,name=ints,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Booleans struct {
-	Booleans *BooleanArray `protobuf:"bytes,8,opt,name=booleans,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Numbers struct {
-	Numbers *NumberArray `protobuf:"bytes,9,opt,name=numbers,proto3,oneof"`
-}
-
-type AggregateGroup_GroupedBy_Geo struct {
-	Geo *GeoCoordinatesFilter `protobuf:"bytes,10,opt,name=geo,proto3,oneof"`
-}
-
-func (*AggregateGroup_GroupedBy_Text) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Int) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Boolean) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Number) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Texts) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Ints) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Booleans) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Numbers) isAggregateGroup_GroupedBy_Value() {}
-
-func (*AggregateGroup_GroupedBy_Geo) isAggregateGroup_GroupedBy_Value() {}
-
-type AggregateGroup_Aggregations_Aggregation struct {
+type AggregateReply_Aggregations_Aggregation struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
 	Property string `protobuf:"bytes,1,opt,name=property,proto3" json:"property,omitempty"`
 	// Types that are assignable to Aggregation:
-	//	*AggregateGroup_Aggregations_Aggregation_Int
-	//	*AggregateGroup_Aggregations_Aggregation_Number_
-	//	*AggregateGroup_Aggregations_Aggregation_Text_
-	//	*AggregateGroup_Aggregations_Aggregation_Boolean_
-	//	*AggregateGroup_Aggregations_Aggregation_Date_
-	//	*AggregateGroup_Aggregations_Aggregation_Reference_
-	Aggregation isAggregateGroup_Aggregations_Aggregation_Aggregation `protobuf_oneof:"aggregation"`
+	//
+	//	*AggregateReply_Aggregations_Aggregation_Int
+	//	*AggregateReply_Aggregations_Aggregation_Number_
+	//	*AggregateReply_Aggregations_Aggregation_Text_
+	//	*AggregateReply_Aggregations_Aggregation_Boolean_
+	//	*AggregateReply_Aggregations_Aggregation_Date_
+	//	*AggregateReply_Aggregations_Aggregation_Reference_
+	Aggregation isAggregateReply_Aggregations_Aggregation_Aggregation `protobuf_oneof:"aggregation"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation{}
+func (x *AggregateReply_Aggregations_Aggregation) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1407,13 +1312,13 @@ func (x *AggregateGroup_Aggregations_Aggregation) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) String() string {
+func (x *AggregateReply_Aggregations_Aggregation) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1425,114 +1330,114 @@ func (x *AggregateGroup_Aggregations_Aggregation) ProtoReflect() protoreflect.Me
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetProperty() string {
+func (x *AggregateReply_Aggregations_Aggregation) GetProperty() string {
 	if x != nil {
 		return x.Property
 	}
 	return ""
 }
 
-func (m *AggregateGroup_Aggregations_Aggregation) GetAggregation() isAggregateGroup_Aggregations_Aggregation_Aggregation {
+func (m *AggregateReply_Aggregations_Aggregation) GetAggregation() isAggregateReply_Aggregations_Aggregation_Aggregation {
 	if m != nil {
 		return m.Aggregation
 	}
 	return nil
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetInt() *AggregateGroup_Aggregations_Aggregation_Integer {
-	if x, ok := x.GetAggregation().(*AggregateGroup_Aggregations_Aggregation_Int); ok {
+func (x *AggregateReply_Aggregations_Aggregation) GetInt() *AggregateReply_Aggregations_Aggregation_Integer {
+	if x, ok := x.GetAggregation().(*AggregateReply_Aggregations_Aggregation_Int); ok {
 		return x.Int
 	}
 	return nil
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetNumber() *AggregateGroup_Aggregations_Aggregation_Number {
-	if x, ok := x.GetAggregation().(*AggregateGroup_Aggregations_Aggregation_Number_); ok {
+func (x *AggregateReply_Aggregations_Aggregation) GetNumber() *AggregateReply_Aggregations_Aggregation_Number {
+	if x, ok := x.GetAggregation().(*AggregateReply_Aggregations_Aggregation_Number_); ok {
 		return x.Number
 	}
 	return nil
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetText() *AggregateGroup_Aggregations_Aggregation_Text {
-	if x, ok := x.GetAggregation().(*AggregateGroup_Aggregations_Aggregation_Text_); ok {
+func (x *AggregateReply_Aggregations_Aggregation) GetText() *AggregateReply_Aggregations_Aggregation_Text {
+	if x, ok := x.GetAggregation().(*AggregateReply_Aggregations_Aggregation_Text_); ok {
 		return x.Text
 	}
 	return nil
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetBoolean() *AggregateGroup_Aggregations_Aggregation_Boolean {
-	if x, ok := x.GetAggregation().(*AggregateGroup_Aggregations_Aggregation_Boolean_); ok {
+func (x *AggregateReply_Aggregations_Aggregation) GetBoolean() *AggregateReply_Aggregations_Aggregation_Boolean {
+	if x, ok := x.GetAggregation().(*AggregateReply_Aggregations_Aggregation_Boolean_); ok {
 		return x.Boolean
 	}
 	return nil
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetDate() *AggregateGroup_Aggregations_Aggregation_Date {
-	if x, ok := x.GetAggregation().(*AggregateGroup_Aggregations_Aggregation_Date_); ok {
+func (x *AggregateReply_Aggregations_Aggregation) GetDate() *AggregateReply_Aggregations_Aggregation_Date {
+	if x, ok := x.GetAggregation().(*AggregateReply_Aggregations_Aggregation_Date_); ok {
 		return x.Date
 	}
 	return nil
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation) GetReference() *AggregateGroup_Aggregations_Aggregation_Reference {
-	if x, ok := x.GetAggregation().(*AggregateGroup_Aggregations_Aggregation_Reference_); ok {
+func (x *AggregateReply_Aggregations_Aggregation) GetReference() *AggregateReply_Aggregations_Aggregation_Reference {
+	if x, ok := x.GetAggregation().(*AggregateReply_Aggregations_Aggregation_Reference_); ok {
 		return x.Reference
 	}
 	return nil
 }
 
-type isAggregateGroup_Aggregations_Aggregation_Aggregation interface {
-	isAggregateGroup_Aggregations_Aggregation_Aggregation()
+type isAggregateReply_Aggregations_Aggregation_Aggregation interface {
+	isAggregateReply_Aggregations_Aggregation_Aggregation()
 }
 
-type AggregateGroup_Aggregations_Aggregation_Int struct {
-	Int *AggregateGroup_Aggregations_Aggregation_Integer `protobuf:"bytes,2,opt,name=int,proto3,oneof"`
+type AggregateReply_Aggregations_Aggregation_Int struct {
+	Int *AggregateReply_Aggregations_Aggregation_Integer `protobuf:"bytes,2,opt,name=int,proto3,oneof"`
 }
 
-type AggregateGroup_Aggregations_Aggregation_Number_ struct {
-	Number *AggregateGroup_Aggregations_Aggregation_Number `protobuf:"bytes,3,opt,name=number,proto3,oneof"`
+type AggregateReply_Aggregations_Aggregation_Number_ struct {
+	Number *AggregateReply_Aggregations_Aggregation_Number `protobuf:"bytes,3,opt,name=number,proto3,oneof"`
 }
 
-type AggregateGroup_Aggregations_Aggregation_Text_ struct {
-	Text *AggregateGroup_Aggregations_Aggregation_Text `protobuf:"bytes,4,opt,name=text,proto3,oneof"`
+type AggregateReply_Aggregations_Aggregation_Text_ struct {
+	Text *AggregateReply_Aggregations_Aggregation_Text `protobuf:"bytes,4,opt,name=text,proto3,oneof"`
 }
 
-type AggregateGroup_Aggregations_Aggregation_Boolean_ struct {
-	Boolean *AggregateGroup_Aggregations_Aggregation_Boolean `protobuf:"bytes,5,opt,name=boolean,proto3,oneof"`
+type AggregateReply_Aggregations_Aggregation_Boolean_ struct {
+	Boolean *AggregateReply_Aggregations_Aggregation_Boolean `protobuf:"bytes,5,opt,name=boolean,proto3,oneof"`
 }
 
-type AggregateGroup_Aggregations_Aggregation_Date_ struct {
-	Date *AggregateGroup_Aggregations_Aggregation_Date `protobuf:"bytes,6,opt,name=date,proto3,oneof"`
+type AggregateReply_Aggregations_Aggregation_Date_ struct {
+	Date *AggregateReply_Aggregations_Aggregation_Date `protobuf:"bytes,6,opt,name=date,proto3,oneof"`
 }
 
-type AggregateGroup_Aggregations_Aggregation_Reference_ struct {
-	Reference *AggregateGroup_Aggregations_Aggregation_Reference `protobuf:"bytes,7,opt,name=reference,proto3,oneof"`
+type AggregateReply_Aggregations_Aggregation_Reference_ struct {
+	Reference *AggregateReply_Aggregations_Aggregation_Reference `protobuf:"bytes,7,opt,name=reference,proto3,oneof"`
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Int) isAggregateGroup_Aggregations_Aggregation_Aggregation() {
+func (*AggregateReply_Aggregations_Aggregation_Int) isAggregateReply_Aggregations_Aggregation_Aggregation() {
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Number_) isAggregateGroup_Aggregations_Aggregation_Aggregation() {
+func (*AggregateReply_Aggregations_Aggregation_Number_) isAggregateReply_Aggregations_Aggregation_Aggregation() {
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Text_) isAggregateGroup_Aggregations_Aggregation_Aggregation() {
+func (*AggregateReply_Aggregations_Aggregation_Text_) isAggregateReply_Aggregations_Aggregation_Aggregation() {
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Boolean_) isAggregateGroup_Aggregations_Aggregation_Aggregation() {
+func (*AggregateReply_Aggregations_Aggregation_Boolean_) isAggregateReply_Aggregations_Aggregation_Aggregation() {
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Date_) isAggregateGroup_Aggregations_Aggregation_Aggregation() {
+func (*AggregateReply_Aggregations_Aggregation_Date_) isAggregateReply_Aggregations_Aggregation_Aggregation() {
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Reference_) isAggregateGroup_Aggregations_Aggregation_Aggregation() {
+func (*AggregateReply_Aggregations_Aggregation_Reference_) isAggregateReply_Aggregations_Aggregation_Aggregation() {
 }
 
-type AggregateGroup_Aggregations_Aggregation_Integer struct {
+type AggregateReply_Aggregations_Aggregation_Integer struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -1547,8 +1452,8 @@ type AggregateGroup_Aggregations_Aggregation_Integer struct {
 	Sum     *int64   `protobuf:"varint,8,opt,name=sum,proto3,oneof" json:"sum,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Integer{}
+func (x *AggregateReply_Aggregations_Aggregation_Integer) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Integer{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1556,13 +1461,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Integer) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Integer) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Integer) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1574,68 +1479,68 @@ func (x *AggregateGroup_Aggregations_Aggregation_Integer) ProtoReflect() protore
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Integer.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Integer) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 0}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Integer.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Integer) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 0}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetCount() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetCount() int64 {
 	if x != nil && x.Count != nil {
 		return *x.Count
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetType() string {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetType() string {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetMean() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetMean() float64 {
 	if x != nil && x.Mean != nil {
 		return *x.Mean
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetMedian() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetMedian() float64 {
 	if x != nil && x.Median != nil {
 		return *x.Median
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetMode() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetMode() int64 {
 	if x != nil && x.Mode != nil {
 		return *x.Mode
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetMaximum() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetMaximum() int64 {
 	if x != nil && x.Maximum != nil {
 		return *x.Maximum
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetMinimum() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetMinimum() int64 {
 	if x != nil && x.Minimum != nil {
 		return *x.Minimum
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Integer) GetSum() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Integer) GetSum() int64 {
 	if x != nil && x.Sum != nil {
 		return *x.Sum
 	}
 	return 0
 }
 
-type AggregateGroup_Aggregations_Aggregation_Number struct {
+type AggregateReply_Aggregations_Aggregation_Number struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -1650,8 +1555,8 @@ type AggregateGroup_Aggregations_Aggregation_Number struct {
 	Sum     *float64 `protobuf:"fixed64,8,opt,name=sum,proto3,oneof" json:"sum,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Number{}
+func (x *AggregateReply_Aggregations_Aggregation_Number) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Number{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1659,13 +1564,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Number) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Number) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Number) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Number) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Number) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1677,79 +1582,79 @@ func (x *AggregateGroup_Aggregations_Aggregation_Number) ProtoReflect() protoref
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Number.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Number) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 1}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Number.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Number) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 1}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetCount() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetCount() int64 {
 	if x != nil && x.Count != nil {
 		return *x.Count
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetType() string {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetType() string {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetMean() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetMean() float64 {
 	if x != nil && x.Mean != nil {
 		return *x.Mean
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetMedian() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetMedian() float64 {
 	if x != nil && x.Median != nil {
 		return *x.Median
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetMode() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetMode() float64 {
 	if x != nil && x.Mode != nil {
 		return *x.Mode
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetMaximum() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetMaximum() float64 {
 	if x != nil && x.Maximum != nil {
 		return *x.Maximum
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetMinimum() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetMinimum() float64 {
 	if x != nil && x.Minimum != nil {
 		return *x.Minimum
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Number) GetSum() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Number) GetSum() float64 {
 	if x != nil && x.Sum != nil {
 		return *x.Sum
 	}
 	return 0
 }
 
-type AggregateGroup_Aggregations_Aggregation_Text struct {
+type AggregateReply_Aggregations_Aggregation_Text struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
 	Count         *int64                                                       `protobuf:"varint,1,opt,name=count,proto3,oneof" json:"count,omitempty"`
 	Type          *string                                                      `protobuf:"bytes,2,opt,name=type,proto3,oneof" json:"type,omitempty"`
-	TopOccurences *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences `protobuf:"bytes,3,opt,name=top_occurences,json=topOccurences,proto3,oneof" json:"top_occurences,omitempty"`
+	TopOccurences *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences `protobuf:"bytes,3,opt,name=top_occurences,json=topOccurences,proto3,oneof" json:"top_occurences,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Text{}
+func (x *AggregateReply_Aggregations_Aggregation_Text) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Text{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1757,13 +1662,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Text) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Text) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Text) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Text) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Text) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1775,33 +1680,33 @@ func (x *AggregateGroup_Aggregations_Aggregation_Text) ProtoReflect() protorefle
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Text.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Text) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 2}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Text.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Text) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 2}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text) GetCount() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Text) GetCount() int64 {
 	if x != nil && x.Count != nil {
 		return *x.Count
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text) GetType() string {
+func (x *AggregateReply_Aggregations_Aggregation_Text) GetType() string {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text) GetTopOccurences() *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences {
+func (x *AggregateReply_Aggregations_Aggregation_Text) GetTopOccurences() *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences {
 	if x != nil {
 		return x.TopOccurences
 	}
 	return nil
 }
 
-type AggregateGroup_Aggregations_Aggregation_Boolean struct {
+type AggregateReply_Aggregations_Aggregation_Boolean struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -1814,8 +1719,8 @@ type AggregateGroup_Aggregations_Aggregation_Boolean struct {
 	PercentageFalse *float64 `protobuf:"fixed64,6,opt,name=percentage_false,json=percentageFalse,proto3,oneof" json:"percentage_false,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Boolean{}
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Boolean{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[18]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1823,13 +1728,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Boolean) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Boolean) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Boolean) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[18]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1841,54 +1746,54 @@ func (x *AggregateGroup_Aggregations_Aggregation_Boolean) ProtoReflect() protore
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Boolean.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Boolean) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 3}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Boolean.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Boolean) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 3}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) GetCount() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) GetCount() int64 {
 	if x != nil && x.Count != nil {
 		return *x.Count
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) GetType() string {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) GetType() string {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) GetTotalTrue() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) GetTotalTrue() int64 {
 	if x != nil && x.TotalTrue != nil {
 		return *x.TotalTrue
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) GetTotalFalse() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) GetTotalFalse() int64 {
 	if x != nil && x.TotalFalse != nil {
 		return *x.TotalFalse
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) GetPercentageTrue() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) GetPercentageTrue() float64 {
 	if x != nil && x.PercentageTrue != nil {
 		return *x.PercentageTrue
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Boolean) GetPercentageFalse() float64 {
+func (x *AggregateReply_Aggregations_Aggregation_Boolean) GetPercentageFalse() float64 {
 	if x != nil && x.PercentageFalse != nil {
 		return *x.PercentageFalse
 	}
 	return 0
 }
 
-type AggregateGroup_Aggregations_Aggregation_Date struct {
+type AggregateReply_Aggregations_Aggregation_Date struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -1901,8 +1806,8 @@ type AggregateGroup_Aggregations_Aggregation_Date struct {
 	Minimum *string `protobuf:"bytes,6,opt,name=minimum,proto3,oneof" json:"minimum,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Date{}
+func (x *AggregateReply_Aggregations_Aggregation_Date) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Date{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[19]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1910,13 +1815,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Date) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Date) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Date) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Date) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Date) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[19]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1928,54 +1833,54 @@ func (x *AggregateGroup_Aggregations_Aggregation_Date) ProtoReflect() protorefle
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Date.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Date) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 4}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Date.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Date) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 4}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) GetCount() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Date) GetCount() int64 {
 	if x != nil && x.Count != nil {
 		return *x.Count
 	}
 	return 0
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) GetType() string {
+func (x *AggregateReply_Aggregations_Aggregation_Date) GetType() string {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) GetMedian() string {
+func (x *AggregateReply_Aggregations_Aggregation_Date) GetMedian() string {
 	if x != nil && x.Median != nil {
 		return *x.Median
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) GetMode() string {
+func (x *AggregateReply_Aggregations_Aggregation_Date) GetMode() string {
 	if x != nil && x.Mode != nil {
 		return *x.Mode
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) GetMaximum() string {
+func (x *AggregateReply_Aggregations_Aggregation_Date) GetMaximum() string {
 	if x != nil && x.Maximum != nil {
 		return *x.Maximum
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Date) GetMinimum() string {
+func (x *AggregateReply_Aggregations_Aggregation_Date) GetMinimum() string {
 	if x != nil && x.Minimum != nil {
 		return *x.Minimum
 	}
 	return ""
 }
 
-type AggregateGroup_Aggregations_Aggregation_Reference struct {
+type AggregateReply_Aggregations_Aggregation_Reference struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -1985,8 +1890,8 @@ type AggregateGroup_Aggregations_Aggregation_Reference struct {
 	PointingTo []string `protobuf:"bytes,2,rep,name=pointing_to,json=pointingTo,proto3" json:"pointing_to,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Reference) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Reference{}
+func (x *AggregateReply_Aggregations_Aggregation_Reference) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Reference{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1994,13 +1899,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Reference) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Reference) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Reference) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Reference) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Reference) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Reference) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Reference) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2012,35 +1917,35 @@ func (x *AggregateGroup_Aggregations_Aggregation_Reference) ProtoReflect() proto
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Reference.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Reference) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 5}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Reference.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Reference) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 5}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Reference) GetType() string {
+func (x *AggregateReply_Aggregations_Aggregation_Reference) GetType() string {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Reference) GetPointingTo() []string {
+func (x *AggregateReply_Aggregations_Aggregation_Reference) GetPointingTo() []string {
 	if x != nil {
 		return x.PointingTo
 	}
 	return nil
 }
 
-type AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences struct {
+type AggregateReply_Aggregations_Aggregation_Text_TopOccurrences struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Items []*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	Items []*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences{}
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Text_TopOccurrences{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2048,13 +1953,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) Reset() {
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2066,19 +1971,19 @@ func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) ProtoRefle
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 2, 0}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Text_TopOccurrences.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 2, 0}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences) GetItems() []*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences) GetItems() []*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence {
 	if x != nil {
 		return x.Items
 	}
 	return nil
 }
 
-type AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence struct {
+type AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -2087,8 +1992,8 @@ type AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence s
 	Occurs int64  `protobuf:"varint,2,opt,name=occurs,proto3" json:"occurs,omitempty"`
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) Reset() {
-	*x = AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence{}
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) Reset() {
+	*x = AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_v1_aggregate_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2096,13 +2001,13 @@ func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurren
 	}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) String() string {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) ProtoMessage() {}
+func (*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) ProtoMessage() {}
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) ProtoReflect() protoreflect.Message {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_aggregate_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2114,24 +2019,212 @@ func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurren
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence.ProtoReflect.Descriptor instead.
-func (*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) Descriptor() ([]byte, []int) {
-	return file_v1_aggregate_proto_rawDescGZIP(), []int{2, 0, 0, 2, 0, 0}
+// Deprecated: Use AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 0, 0, 2, 0, 0}
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) GetValue() string {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) GetValue() string {
 	if x != nil {
 		return x.Value
 	}
 	return ""
 }
 
-func (x *AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) GetOccurs() int64 {
+func (x *AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence) GetOccurs() int64 {
 	if x != nil {
 		return x.Occurs
 	}
 	return 0
 }
+
+type AggregateReply_Group_GroupedBy struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
+	Path []string `protobuf:"bytes,1,rep,name=path,proto3" json:"path,omitempty"`
+	// Types that are assignable to Value:
+	//
+	//	*AggregateReply_Group_GroupedBy_Text
+	//	*AggregateReply_Group_GroupedBy_Int
+	//	*AggregateReply_Group_GroupedBy_Boolean
+	//	*AggregateReply_Group_GroupedBy_Number
+	//	*AggregateReply_Group_GroupedBy_Texts
+	//	*AggregateReply_Group_GroupedBy_Ints
+	//	*AggregateReply_Group_GroupedBy_Booleans
+	//	*AggregateReply_Group_GroupedBy_Numbers
+	//	*AggregateReply_Group_GroupedBy_Geo
+	Value isAggregateReply_Group_GroupedBy_Value `protobuf_oneof:"value"`
+}
+
+func (x *AggregateReply_Group_GroupedBy) Reset() {
+	*x = AggregateReply_Group_GroupedBy{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_v1_aggregate_proto_msgTypes[23]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *AggregateReply_Group_GroupedBy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AggregateReply_Group_GroupedBy) ProtoMessage() {}
+
+func (x *AggregateReply_Group_GroupedBy) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_aggregate_proto_msgTypes[23]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AggregateReply_Group_GroupedBy.ProtoReflect.Descriptor instead.
+func (*AggregateReply_Group_GroupedBy) Descriptor() ([]byte, []int) {
+	return file_v1_aggregate_proto_rawDescGZIP(), []int{1, 2, 0}
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetPath() []string {
+	if x != nil {
+		return x.Path
+	}
+	return nil
+}
+
+func (m *AggregateReply_Group_GroupedBy) GetValue() isAggregateReply_Group_GroupedBy_Value {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetText() string {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Text); ok {
+		return x.Text
+	}
+	return ""
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetInt() int64 {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Int); ok {
+		return x.Int
+	}
+	return 0
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetBoolean() bool {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Boolean); ok {
+		return x.Boolean
+	}
+	return false
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetNumber() float64 {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Number); ok {
+		return x.Number
+	}
+	return 0
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetTexts() *TextArray {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Texts); ok {
+		return x.Texts
+	}
+	return nil
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetInts() *IntArray {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Ints); ok {
+		return x.Ints
+	}
+	return nil
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetBooleans() *BooleanArray {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Booleans); ok {
+		return x.Booleans
+	}
+	return nil
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetNumbers() *NumberArray {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Numbers); ok {
+		return x.Numbers
+	}
+	return nil
+}
+
+func (x *AggregateReply_Group_GroupedBy) GetGeo() *GeoCoordinatesFilter {
+	if x, ok := x.GetValue().(*AggregateReply_Group_GroupedBy_Geo); ok {
+		return x.Geo
+	}
+	return nil
+}
+
+type isAggregateReply_Group_GroupedBy_Value interface {
+	isAggregateReply_Group_GroupedBy_Value()
+}
+
+type AggregateReply_Group_GroupedBy_Text struct {
+	Text string `protobuf:"bytes,2,opt,name=text,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Int struct {
+	Int int64 `protobuf:"varint,3,opt,name=int,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Boolean struct {
+	Boolean bool `protobuf:"varint,4,opt,name=boolean,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Number struct {
+	Number float64 `protobuf:"fixed64,5,opt,name=number,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Texts struct {
+	Texts *TextArray `protobuf:"bytes,6,opt,name=texts,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Ints struct {
+	Ints *IntArray `protobuf:"bytes,7,opt,name=ints,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Booleans struct {
+	Booleans *BooleanArray `protobuf:"bytes,8,opt,name=booleans,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Numbers struct {
+	Numbers *NumberArray `protobuf:"bytes,9,opt,name=numbers,proto3,oneof"`
+}
+
+type AggregateReply_Group_GroupedBy_Geo struct {
+	Geo *GeoCoordinatesFilter `protobuf:"bytes,10,opt,name=geo,proto3,oneof"`
+}
+
+func (*AggregateReply_Group_GroupedBy_Text) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Int) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Boolean) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Number) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Texts) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Ints) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Booleans) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Numbers) isAggregateReply_Group_GroupedBy_Value() {}
+
+func (*AggregateReply_Group_GroupedBy_Geo) isAggregateReply_Group_GroupedBy_Value() {}
 
 var File_v1_aggregate_proto protoreflect.FileDescriptor
 
@@ -2302,213 +2395,231 @@ var file_v1_aggregate_proto_rawDesc = []byte{
 	0x63, 0x68, 0x42, 0x0f, 0x0a, 0x0d, 0x5f, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x5f, 0x6c, 0x69,
 	0x6d, 0x69, 0x74, 0x42, 0x0b, 0x0a, 0x09, 0x5f, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x5f, 0x62, 0x79,
 	0x42, 0x08, 0x0a, 0x06, 0x5f, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x66,
-	0x69, 0x6c, 0x74, 0x65, 0x72, 0x73, 0x22, 0x9f, 0x01, 0x0a, 0x0e, 0x41, 0x67, 0x67, 0x72, 0x65,
+	0x69, 0x6c, 0x74, 0x65, 0x72, 0x73, 0x22, 0x80, 0x1b, 0x0a, 0x0e, 0x41, 0x67, 0x67, 0x72, 0x65,
 	0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x6f, 0x6f,
-	0x6b, 0x18, 0x01, 0x20, 0x01, 0x28, 0x02, 0x52, 0x04, 0x74, 0x6f, 0x6f, 0x6b, 0x12, 0x3a, 0x0a,
-	0x06, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e,
-	0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72,
-	0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x52, 0x65, 0x73, 0x75, 0x6c,
-	0x74, 0x52, 0x06, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x1a, 0x3d, 0x0a, 0x06, 0x52, 0x65, 0x73,
-	0x75, 0x6c, 0x74, 0x12, 0x33, 0x0a, 0x06, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x18, 0x01, 0x20,
-	0x03, 0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76,
-	0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70,
-	0x52, 0x06, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x22, 0xc6, 0x17, 0x0a, 0x0e, 0x41, 0x67, 0x67,
-	0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x12, 0x28, 0x0a, 0x0d, 0x6f,
+	0x6b, 0x18, 0x01, 0x20, 0x01, 0x28, 0x02, 0x52, 0x04, 0x74, 0x6f, 0x6f, 0x6b, 0x12, 0x49, 0x0a,
+	0x0d, 0x73, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x5f, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e,
+	0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c,
+	0x79, 0x2e, 0x53, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x48, 0x00, 0x52, 0x0c, 0x73, 0x69, 0x6e, 0x67,
+	0x6c, 0x65, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x12, 0x4e, 0x0a, 0x0f, 0x67, 0x72, 0x6f, 0x75,
+	0x70, 0x65, 0x64, 0x5f, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x23, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e,
+	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x47,
+	0x72, 0x6f, 0x75, 0x70, 0x65, 0x64, 0x48, 0x00, 0x52, 0x0e, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x65,
+	0x64, 0x52, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x73, 0x1a, 0xab, 0x12, 0x0a, 0x0c, 0x41, 0x67, 0x67,
+	0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x0c, 0x61, 0x67, 0x67,
+	0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x34, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67,
+	0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67, 0x67,
+	0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0c, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x73, 0x1a, 0xc0, 0x11, 0x0a, 0x0b, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x12, 0x1a, 0x0a, 0x08, 0x70, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x79, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x70, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x79, 0x12,
+	0x50, 0x0a, 0x03, 0x69, 0x6e, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x77,
+	0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65,
+	0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x2e, 0x49, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x48, 0x00, 0x52, 0x03, 0x69, 0x6e,
+	0x74, 0x12, 0x55, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x3b, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e,
+	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72,
+	0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x48, 0x00,
+	0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x4f, 0x0a, 0x04, 0x74, 0x65, 0x78, 0x74,
+	0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x39, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74,
+	0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65,
+	0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73,
+	0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x54, 0x65, 0x78,
+	0x74, 0x48, 0x00, 0x52, 0x04, 0x74, 0x65, 0x78, 0x74, 0x12, 0x58, 0x0a, 0x07, 0x62, 0x6f, 0x6f,
+	0x6c, 0x65, 0x61, 0x6e, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x77, 0x65, 0x61,
+	0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
+	0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x48, 0x00, 0x52, 0x07, 0x62, 0x6f, 0x6f, 0x6c,
+	0x65, 0x61, 0x6e, 0x12, 0x4f, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x39, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e,
+	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72,
+	0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x44, 0x61, 0x74, 0x65, 0x48, 0x00, 0x52, 0x04,
+	0x64, 0x61, 0x74, 0x65, 0x12, 0x5e, 0x0a, 0x09, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63,
+	0x65, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3e, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61,
+	0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52,
+	0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x52, 0x65,
+	0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x48, 0x00, 0x52, 0x09, 0x72, 0x65, 0x66, 0x65, 0x72,
+	0x65, 0x6e, 0x63, 0x65, 0x1a, 0xb1, 0x02, 0x0a, 0x07, 0x49, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72,
+	0x12, 0x19, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48,
+	0x00, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74,
+	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70,
+	0x65, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x18, 0x03, 0x20, 0x01,
+	0x28, 0x01, 0x48, 0x02, 0x52, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x1b, 0x0a,
+	0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x01, 0x48, 0x03, 0x52,
+	0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x6f,
+	0x64, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x03, 0x48, 0x04, 0x52, 0x04, 0x6d, 0x6f, 0x64, 0x65,
+	0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x06,
+	0x20, 0x01, 0x28, 0x03, 0x48, 0x05, 0x52, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x88,
+	0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x07, 0x20,
+	0x01, 0x28, 0x03, 0x48, 0x06, 0x52, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01,
+	0x01, 0x12, 0x15, 0x0a, 0x03, 0x73, 0x75, 0x6d, 0x18, 0x08, 0x20, 0x01, 0x28, 0x03, 0x48, 0x07,
+	0x52, 0x03, 0x73, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75,
+	0x6e, 0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x07, 0x0a, 0x05, 0x5f,
+	0x6d, 0x65, 0x61, 0x6e, 0x42, 0x09, 0x0a, 0x07, 0x5f, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x42,
+	0x07, 0x0a, 0x05, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x61, 0x78,
+	0x69, 0x6d, 0x75, 0x6d, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d,
+	0x42, 0x06, 0x0a, 0x04, 0x5f, 0x73, 0x75, 0x6d, 0x1a, 0xb0, 0x02, 0x0a, 0x06, 0x4e, 0x75, 0x6d,
+	0x62, 0x65, 0x72, 0x12, 0x19, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x03, 0x48, 0x00, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17,
+	0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04,
+	0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x01, 0x48, 0x02, 0x52, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x88, 0x01, 0x01,
+	0x12, 0x1b, 0x0a, 0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x01,
+	0x48, 0x03, 0x52, 0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a,
+	0x04, 0x6d, 0x6f, 0x64, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x01, 0x48, 0x04, 0x52, 0x04, 0x6d,
+	0x6f, 0x64, 0x65, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75,
+	0x6d, 0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x48, 0x05, 0x52, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d,
+	0x75, 0x6d, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d,
+	0x18, 0x07, 0x20, 0x01, 0x28, 0x01, 0x48, 0x06, 0x52, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75,
+	0x6d, 0x88, 0x01, 0x01, 0x12, 0x15, 0x0a, 0x03, 0x73, 0x75, 0x6d, 0x18, 0x08, 0x20, 0x01, 0x28,
+	0x01, 0x48, 0x07, 0x52, 0x03, 0x73, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f,
+	0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x07,
+	0x0a, 0x05, 0x5f, 0x6d, 0x65, 0x61, 0x6e, 0x42, 0x09, 0x0a, 0x07, 0x5f, 0x6d, 0x65, 0x64, 0x69,
+	0x61, 0x6e, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x42, 0x0a, 0x0a, 0x08, 0x5f,
+	0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x69, 0x6e, 0x69,
+	0x6d, 0x75, 0x6d, 0x42, 0x06, 0x0a, 0x04, 0x5f, 0x73, 0x75, 0x6d, 0x1a, 0x96, 0x03, 0x0a, 0x04,
+	0x54, 0x65, 0x78, 0x74, 0x12, 0x19, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12,
+	0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52,
+	0x04, 0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12, 0x74, 0x0a, 0x0e, 0x74, 0x6f, 0x70, 0x5f,
+	0x6f, 0x63, 0x63, 0x75, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x48, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67,
+	0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65,
+	0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x54, 0x65, 0x78, 0x74, 0x2e, 0x54, 0x6f, 0x70, 0x4f,
+	0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x48, 0x02, 0x52, 0x0d, 0x74, 0x6f,
+	0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x88, 0x01, 0x01, 0x1a, 0xbd,
+	0x01, 0x0a, 0x0e, 0x54, 0x6f, 0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65,
+	0x73, 0x12, 0x6c, 0x0a, 0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x56, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67,
+	0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65,
+	0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x54, 0x65, 0x78, 0x74, 0x2e, 0x54, 0x6f, 0x70, 0x4f,
+	0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x2e, 0x54, 0x6f, 0x70, 0x4f, 0x63,
+	0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x52, 0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x1a,
+	0x3d, 0x0a, 0x0d, 0x54, 0x6f, 0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65,
+	0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x73,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x03, 0x52, 0x06, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x73, 0x42, 0x08,
+	0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70,
+	0x65, 0x42, 0x11, 0x0a, 0x0f, 0x5f, 0x74, 0x6f, 0x70, 0x5f, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x65,
+	0x6e, 0x63, 0x65, 0x73, 0x1a, 0xc0, 0x02, 0x0a, 0x07, 0x42, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e,
+	0x12, 0x19, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48,
+	0x00, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74,
+	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70,
+	0x65, 0x88, 0x01, 0x01, 0x12, 0x22, 0x0a, 0x0a, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x74, 0x72,
+	0x75, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x48, 0x02, 0x52, 0x09, 0x74, 0x6f, 0x74, 0x61,
+	0x6c, 0x54, 0x72, 0x75, 0x65, 0x88, 0x01, 0x01, 0x12, 0x24, 0x0a, 0x0b, 0x74, 0x6f, 0x74, 0x61,
+	0x6c, 0x5f, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x48, 0x03, 0x52,
+	0x0a, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x46, 0x61, 0x6c, 0x73, 0x65, 0x88, 0x01, 0x01, 0x12, 0x2c,
+	0x0a, 0x0f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x72, 0x75,
+	0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x01, 0x48, 0x04, 0x52, 0x0e, 0x70, 0x65, 0x72, 0x63, 0x65,
+	0x6e, 0x74, 0x61, 0x67, 0x65, 0x54, 0x72, 0x75, 0x65, 0x88, 0x01, 0x01, 0x12, 0x2e, 0x0a, 0x10,
+	0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x66, 0x61, 0x6c, 0x73, 0x65,
+	0x18, 0x06, 0x20, 0x01, 0x28, 0x01, 0x48, 0x05, 0x52, 0x0f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e,
+	0x74, 0x61, 0x67, 0x65, 0x46, 0x61, 0x6c, 0x73, 0x65, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06,
+	0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42,
+	0x0d, 0x0a, 0x0b, 0x5f, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x74, 0x72, 0x75, 0x65, 0x42, 0x0e,
+	0x0a, 0x0c, 0x5f, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x42, 0x12,
+	0x0a, 0x10, 0x5f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x72,
+	0x75, 0x65, 0x42, 0x13, 0x0a, 0x11, 0x5f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67,
+	0x65, 0x5f, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x1a, 0xed, 0x01, 0x0a, 0x04, 0x44, 0x61, 0x74, 0x65,
+	0x12, 0x19, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48,
+	0x00, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74,
+	0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70,
+	0x65, 0x88, 0x01, 0x01, 0x12, 0x1b, 0x0a, 0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x09, 0x48, 0x02, 0x52, 0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x88, 0x01,
+	0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x6f, 0x64, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x48,
+	0x03, 0x52, 0x04, 0x6d, 0x6f, 0x64, 0x65, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x61,
+	0x78, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x48, 0x04, 0x52, 0x07, 0x6d,
+	0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x69, 0x6e,
+	0x69, 0x6d, 0x75, 0x6d, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09, 0x48, 0x05, 0x52, 0x07, 0x6d, 0x69,
+	0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75,
+	0x6e, 0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x09, 0x0a, 0x07, 0x5f,
+	0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x42,
+	0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x42, 0x0a, 0x0a, 0x08, 0x5f,
+	0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x1a, 0x4e, 0x0a, 0x09, 0x52, 0x65, 0x66, 0x65, 0x72,
+	0x65, 0x6e, 0x63, 0x65, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x48, 0x00, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12, 0x1f, 0x0a,
+	0x0b, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x6f, 0x18, 0x02, 0x20, 0x03,
+	0x28, 0x09, 0x52, 0x0a, 0x70, 0x6f, 0x69, 0x6e, 0x74, 0x69, 0x6e, 0x67, 0x54, 0x6f, 0x42, 0x07,
+	0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x0d, 0x0a, 0x0b, 0x61, 0x67, 0x67, 0x72, 0x65,
+	0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x1a, 0xa8, 0x01, 0x0a, 0x06, 0x53, 0x69, 0x6e, 0x67, 0x6c,
+	0x65, 0x12, 0x28, 0x0a, 0x0d, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75,
+	0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x0c, 0x6f, 0x62, 0x6a, 0x65,
+	0x63, 0x74, 0x73, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x51, 0x0a, 0x0c, 0x61,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x28, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e,
+	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x48, 0x01, 0x52, 0x0c, 0x61,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x88, 0x01, 0x01, 0x42, 0x10,
+	0x0a, 0x0e, 0x5f, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74,
+	0x42, 0x0f, 0x0a, 0x0d, 0x5f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x73, 0x1a, 0x95, 0x05, 0x0a, 0x05, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x12, 0x28, 0x0a, 0x0d, 0x6f,
 	0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x03, 0x48, 0x00, 0x52, 0x0c, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x43, 0x6f, 0x75,
 	0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x51, 0x0a, 0x0c, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
 	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x28, 0x2e, 0x77, 0x65,
 	0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
-	0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
+	0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
 	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x48, 0x01, 0x52, 0x0c, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x88, 0x01, 0x01, 0x12, 0x49, 0x0a, 0x0a, 0x67, 0x72, 0x6f, 0x75,
-	0x70, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x25, 0x2e, 0x77,
+	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x88, 0x01, 0x01, 0x12, 0x4f, 0x0a, 0x0a, 0x67, 0x72, 0x6f, 0x75,
+	0x70, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2b, 0x2e, 0x77,
 	0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65,
-	0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x65,
-	0x64, 0x42, 0x79, 0x48, 0x02, 0x52, 0x09, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x65, 0x64, 0x42, 0x79,
-	0x88, 0x01, 0x01, 0x1a, 0xab, 0x12, 0x0a, 0x0c, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74,
-	0x69, 0x6f, 0x6e, 0x73, 0x12, 0x58, 0x0a, 0x0c, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74,
-	0x69, 0x6f, 0x6e, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x34, 0x2e, 0x77, 0x65, 0x61,
-	0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
-	0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74,
-	0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e,
-	0x52, 0x0c, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x1a, 0xc0,
-	0x11, 0x0a, 0x0b, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x1a,
-	0x0a, 0x08, 0x70, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
-	0x52, 0x08, 0x70, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x79, 0x12, 0x50, 0x0a, 0x03, 0x69, 0x6e,
-	0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61,
-	0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x47,
-	0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e,
-	0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x49, 0x6e,
-	0x74, 0x65, 0x67, 0x65, 0x72, 0x48, 0x00, 0x52, 0x03, 0x69, 0x6e, 0x74, 0x12, 0x55, 0x0a, 0x06,
-	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3b, 0x2e, 0x77,
-	0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65,
-	0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69,
-	0x6f, 0x6e, 0x2e, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x48, 0x00, 0x52, 0x06, 0x6e, 0x75, 0x6d,
-	0x62, 0x65, 0x72, 0x12, 0x4f, 0x0a, 0x04, 0x74, 0x65, 0x78, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28,
-	0x0b, 0x32, 0x39, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e,
-	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41,
-	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72,
-	0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x54, 0x65, 0x78, 0x74, 0x48, 0x00, 0x52, 0x04,
-	0x74, 0x65, 0x78, 0x74, 0x12, 0x58, 0x0a, 0x07, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x18,
-	0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3c, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65,
-	0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f,
-	0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
-	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x42, 0x6f, 0x6f, 0x6c,
-	0x65, 0x61, 0x6e, 0x48, 0x00, 0x52, 0x07, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x12, 0x4f,
-	0x0a, 0x04, 0x64, 0x61, 0x74, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x39, 0x2e, 0x77,
-	0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65,
-	0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
-	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69,
-	0x6f, 0x6e, 0x2e, 0x44, 0x61, 0x74, 0x65, 0x48, 0x00, 0x52, 0x04, 0x64, 0x61, 0x74, 0x65, 0x12,
-	0x5e, 0x0a, 0x09, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x18, 0x07, 0x20, 0x01,
-	0x28, 0x0b, 0x32, 0x3e, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31,
-	0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e,
-	0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67,
-	0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x52, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e,
-	0x63, 0x65, 0x48, 0x00, 0x52, 0x09, 0x72, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x1a,
-	0xb1, 0x02, 0x0a, 0x07, 0x49, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0x12, 0x19, 0x0a, 0x05, 0x63,
-	0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x05, 0x63, 0x6f,
-	0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02,
-	0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12,
-	0x17, 0x0a, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x01, 0x48, 0x02, 0x52,
-	0x04, 0x6d, 0x65, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x1b, 0x0a, 0x06, 0x6d, 0x65, 0x64, 0x69,
-	0x61, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x01, 0x48, 0x03, 0x52, 0x06, 0x6d, 0x65, 0x64, 0x69,
-	0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x6f, 0x64, 0x65, 0x18, 0x05, 0x20,
-	0x01, 0x28, 0x03, 0x48, 0x04, 0x52, 0x04, 0x6d, 0x6f, 0x64, 0x65, 0x88, 0x01, 0x01, 0x12, 0x1d,
-	0x0a, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x06, 0x20, 0x01, 0x28, 0x03, 0x48,
-	0x05, 0x52, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a,
-	0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x07, 0x20, 0x01, 0x28, 0x03, 0x48, 0x06,
-	0x52, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x12, 0x15, 0x0a, 0x03,
-	0x73, 0x75, 0x6d, 0x18, 0x08, 0x20, 0x01, 0x28, 0x03, 0x48, 0x07, 0x52, 0x03, 0x73, 0x75, 0x6d,
-	0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x07, 0x0a,
-	0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6d, 0x65, 0x61, 0x6e, 0x42,
-	0x09, 0x0a, 0x07, 0x5f, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6d,
-	0x6f, 0x64, 0x65, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x42,
-	0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x42, 0x06, 0x0a, 0x04, 0x5f,
-	0x73, 0x75, 0x6d, 0x1a, 0xb0, 0x02, 0x0a, 0x06, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x19,
-	0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52,
-	0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79, 0x70,
-	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x88,
-	0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x01,
-	0x48, 0x02, 0x52, 0x04, 0x6d, 0x65, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x1b, 0x0a, 0x06, 0x6d,
-	0x65, 0x64, 0x69, 0x61, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x01, 0x48, 0x03, 0x52, 0x06, 0x6d,
-	0x65, 0x64, 0x69, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x6d, 0x6f, 0x64, 0x65,
-	0x18, 0x05, 0x20, 0x01, 0x28, 0x01, 0x48, 0x04, 0x52, 0x04, 0x6d, 0x6f, 0x64, 0x65, 0x88, 0x01,
-	0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x06, 0x20, 0x01,
-	0x28, 0x01, 0x48, 0x05, 0x52, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01, 0x01,
-	0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x18, 0x07, 0x20, 0x01, 0x28,
-	0x01, 0x48, 0x06, 0x52, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x12,
-	0x15, 0x0a, 0x03, 0x73, 0x75, 0x6d, 0x18, 0x08, 0x20, 0x01, 0x28, 0x01, 0x48, 0x07, 0x52, 0x03,
-	0x73, 0x75, 0x6d, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74,
-	0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6d, 0x65,
-	0x61, 0x6e, 0x42, 0x09, 0x0a, 0x07, 0x5f, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x42, 0x07, 0x0a,
-	0x05, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x61, 0x78, 0x69, 0x6d,
-	0x75, 0x6d, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x42, 0x06,
-	0x0a, 0x04, 0x5f, 0x73, 0x75, 0x6d, 0x1a, 0x96, 0x03, 0x0a, 0x04, 0x54, 0x65, 0x78, 0x74, 0x12,
-	0x19, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00,
-	0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79,
-	0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65,
-	0x88, 0x01, 0x01, 0x12, 0x74, 0x0a, 0x0e, 0x74, 0x6f, 0x70, 0x5f, 0x6f, 0x63, 0x63, 0x75, 0x72,
-	0x65, 0x6e, 0x63, 0x65, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x48, 0x2e, 0x77, 0x65,
-	0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
-	0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f,
-	0x6e, 0x2e, 0x54, 0x65, 0x78, 0x74, 0x2e, 0x54, 0x6f, 0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72,
-	0x65, 0x6e, 0x63, 0x65, 0x73, 0x48, 0x02, 0x52, 0x0d, 0x74, 0x6f, 0x70, 0x4f, 0x63, 0x63, 0x75,
-	0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x88, 0x01, 0x01, 0x1a, 0xbd, 0x01, 0x0a, 0x0e, 0x54, 0x6f,
-	0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x12, 0x6c, 0x0a, 0x05,
-	0x69, 0x74, 0x65, 0x6d, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x56, 0x2e, 0x77, 0x65,
-	0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67,
-	0x61, 0x74, 0x65, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61,
-	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f,
-	0x6e, 0x2e, 0x54, 0x65, 0x78, 0x74, 0x2e, 0x54, 0x6f, 0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72,
-	0x65, 0x6e, 0x63, 0x65, 0x73, 0x2e, 0x54, 0x6f, 0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72, 0x65,
-	0x6e, 0x63, 0x65, 0x52, 0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x1a, 0x3d, 0x0a, 0x0d, 0x54, 0x6f,
-	0x70, 0x4f, 0x63, 0x63, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x76,
-	0x61, 0x6c, 0x75, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75,
-	0x65, 0x12, 0x16, 0x0a, 0x06, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28,
-	0x03, 0x52, 0x06, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x73, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f,
-	0x75, 0x6e, 0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x11, 0x0a, 0x0f,
-	0x5f, 0x74, 0x6f, 0x70, 0x5f, 0x6f, 0x63, 0x63, 0x75, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x73, 0x1a,
-	0xc0, 0x02, 0x0a, 0x07, 0x42, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x12, 0x19, 0x0a, 0x05, 0x63,
-	0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x05, 0x63, 0x6f,
-	0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02,
-	0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12,
-	0x22, 0x0a, 0x0a, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x74, 0x72, 0x75, 0x65, 0x18, 0x03, 0x20,
-	0x01, 0x28, 0x03, 0x48, 0x02, 0x52, 0x09, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x54, 0x72, 0x75, 0x65,
-	0x88, 0x01, 0x01, 0x12, 0x24, 0x0a, 0x0b, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x66, 0x61, 0x6c,
-	0x73, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x48, 0x03, 0x52, 0x0a, 0x74, 0x6f, 0x74, 0x61,
-	0x6c, 0x46, 0x61, 0x6c, 0x73, 0x65, 0x88, 0x01, 0x01, 0x12, 0x2c, 0x0a, 0x0f, 0x70, 0x65, 0x72,
-	0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x72, 0x75, 0x65, 0x18, 0x05, 0x20, 0x01,
-	0x28, 0x01, 0x48, 0x04, 0x52, 0x0e, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65,
-	0x54, 0x72, 0x75, 0x65, 0x88, 0x01, 0x01, 0x12, 0x2e, 0x0a, 0x10, 0x70, 0x65, 0x72, 0x63, 0x65,
-	0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x18, 0x06, 0x20, 0x01, 0x28,
-	0x01, 0x48, 0x05, 0x52, 0x0f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x46,
-	0x61, 0x6c, 0x73, 0x65, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75, 0x6e,
-	0x74, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x0d, 0x0a, 0x0b, 0x5f, 0x74,
-	0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x74, 0x72, 0x75, 0x65, 0x42, 0x0e, 0x0a, 0x0c, 0x5f, 0x74, 0x6f,
-	0x74, 0x61, 0x6c, 0x5f, 0x66, 0x61, 0x6c, 0x73, 0x65, 0x42, 0x12, 0x0a, 0x10, 0x5f, 0x70, 0x65,
-	0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x74, 0x72, 0x75, 0x65, 0x42, 0x13, 0x0a,
-	0x11, 0x5f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x5f, 0x66, 0x61, 0x6c,
-	0x73, 0x65, 0x1a, 0xed, 0x01, 0x0a, 0x04, 0x44, 0x61, 0x74, 0x65, 0x12, 0x19, 0x0a, 0x05, 0x63,
-	0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x05, 0x63, 0x6f,
-	0x75, 0x6e, 0x74, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02,
-	0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12,
-	0x1b, 0x0a, 0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x48,
-	0x02, 0x52, 0x06, 0x6d, 0x65, 0x64, 0x69, 0x61, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x17, 0x0a, 0x04,
-	0x6d, 0x6f, 0x64, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x48, 0x03, 0x52, 0x04, 0x6d, 0x6f,
-	0x64, 0x65, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d,
-	0x18, 0x05, 0x20, 0x01, 0x28, 0x09, 0x48, 0x04, 0x52, 0x07, 0x6d, 0x61, 0x78, 0x69, 0x6d, 0x75,
-	0x6d, 0x88, 0x01, 0x01, 0x12, 0x1d, 0x0a, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d, 0x18,
-	0x06, 0x20, 0x01, 0x28, 0x09, 0x48, 0x05, 0x52, 0x07, 0x6d, 0x69, 0x6e, 0x69, 0x6d, 0x75, 0x6d,
-	0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x07, 0x0a,
-	0x05, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x42, 0x09, 0x0a, 0x07, 0x5f, 0x6d, 0x65, 0x64, 0x69, 0x61,
-	0x6e, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d,
-	0x61, 0x78, 0x69, 0x6d, 0x75, 0x6d, 0x42, 0x0a, 0x0a, 0x08, 0x5f, 0x6d, 0x69, 0x6e, 0x69, 0x6d,
-	0x75, 0x6d, 0x1a, 0x4e, 0x0a, 0x09, 0x52, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12,
-	0x17, 0x0a, 0x04, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52,
-	0x04, 0x74, 0x79, 0x70, 0x65, 0x88, 0x01, 0x01, 0x12, 0x1f, 0x0a, 0x0b, 0x70, 0x6f, 0x69, 0x6e,
-	0x74, 0x69, 0x6e, 0x67, 0x5f, 0x74, 0x6f, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0a, 0x70,
-	0x6f, 0x69, 0x6e, 0x74, 0x69, 0x6e, 0x67, 0x54, 0x6f, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x74, 0x79,
-	0x70, 0x65, 0x42, 0x0d, 0x0a, 0x0b, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f,
-	0x6e, 0x1a, 0x8b, 0x03, 0x0a, 0x09, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x65, 0x64, 0x42, 0x79, 0x12,
-	0x12, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x03, 0x28, 0x09, 0x52, 0x04, 0x70,
-	0x61, 0x74, 0x68, 0x12, 0x14, 0x0a, 0x04, 0x74, 0x65, 0x78, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28,
-	0x09, 0x48, 0x00, 0x52, 0x04, 0x74, 0x65, 0x78, 0x74, 0x12, 0x12, 0x0a, 0x03, 0x69, 0x6e, 0x74,
-	0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x03, 0x69, 0x6e, 0x74, 0x12, 0x1a, 0x0a,
-	0x07, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x48, 0x00,
-	0x52, 0x07, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x12, 0x18, 0x0a, 0x06, 0x6e, 0x75, 0x6d,
-	0x62, 0x65, 0x72, 0x18, 0x05, 0x20, 0x01, 0x28, 0x01, 0x48, 0x00, 0x52, 0x06, 0x6e, 0x75, 0x6d,
-	0x62, 0x65, 0x72, 0x12, 0x2e, 0x0a, 0x05, 0x74, 0x65, 0x78, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01,
-	0x28, 0x0b, 0x32, 0x16, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31,
-	0x2e, 0x54, 0x65, 0x78, 0x74, 0x41, 0x72, 0x72, 0x61, 0x79, 0x48, 0x00, 0x52, 0x05, 0x74, 0x65,
-	0x78, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x04, 0x69, 0x6e, 0x74, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28,
-	0x0b, 0x32, 0x15, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e,
-	0x49, 0x6e, 0x74, 0x41, 0x72, 0x72, 0x61, 0x79, 0x48, 0x00, 0x52, 0x04, 0x69, 0x6e, 0x74, 0x73,
-	0x12, 0x37, 0x0a, 0x08, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01,
-	0x28, 0x0b, 0x32, 0x19, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31,
-	0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x41, 0x72, 0x72, 0x61, 0x79, 0x48, 0x00, 0x52,
-	0x08, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x73, 0x12, 0x34, 0x0a, 0x07, 0x6e, 0x75, 0x6d,
-	0x62, 0x65, 0x72, 0x73, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x18, 0x2e, 0x77, 0x65, 0x61,
-	0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x41,
-	0x72, 0x72, 0x61, 0x79, 0x48, 0x00, 0x52, 0x07, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x73, 0x12,
-	0x35, 0x0a, 0x03, 0x67, 0x65, 0x6f, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x77,
-	0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x6f, 0x43, 0x6f,
-	0x6f, 0x72, 0x64, 0x69, 0x6e, 0x61, 0x74, 0x65, 0x73, 0x46, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x48,
-	0x00, 0x52, 0x03, 0x67, 0x65, 0x6f, 0x42, 0x07, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x42,
-	0x10, 0x0a, 0x0e, 0x5f, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75, 0x6e,
-	0x74, 0x42, 0x0f, 0x0a, 0x0d, 0x5f, 0x61, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f,
-	0x6e, 0x73, 0x42, 0x0d, 0x0a, 0x0b, 0x5f, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x65, 0x64, 0x5f, 0x62,
-	0x79, 0x42, 0x73, 0x0a, 0x23, 0x69, 0x6f, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65,
-	0x2e, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2e, 0x67, 0x72, 0x70, 0x63, 0x2e, 0x70, 0x72, 0x6f,
-	0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2e, 0x76, 0x31, 0x42, 0x16, 0x57, 0x65, 0x61, 0x76, 0x69, 0x61,
-	0x74, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65,
-	0x5a, 0x34, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x77, 0x65, 0x61,
-	0x76, 0x69, 0x61, 0x74, 0x65, 0x2f, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2f, 0x67,
-	0x72, 0x70, 0x63, 0x2f, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65, 0x64, 0x3b, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c, 0x79, 0x2e, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x2e,
+	0x47, 0x72, 0x6f, 0x75, 0x70, 0x65, 0x64, 0x42, 0x79, 0x48, 0x02, 0x52, 0x09, 0x67, 0x72, 0x6f,
+	0x75, 0x70, 0x65, 0x64, 0x42, 0x79, 0x88, 0x01, 0x01, 0x1a, 0x8b, 0x03, 0x0a, 0x09, 0x47, 0x72,
+	0x6f, 0x75, 0x70, 0x65, 0x64, 0x42, 0x79, 0x12, 0x12, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18,
+	0x01, 0x20, 0x03, 0x28, 0x09, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x12, 0x14, 0x0a, 0x04, 0x74,
+	0x65, 0x78, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x04, 0x74, 0x65, 0x78,
+	0x74, 0x12, 0x12, 0x0a, 0x03, 0x69, 0x6e, 0x74, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00,
+	0x52, 0x03, 0x69, 0x6e, 0x74, 0x12, 0x1a, 0x0a, 0x07, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e,
+	0x18, 0x04, 0x20, 0x01, 0x28, 0x08, 0x48, 0x00, 0x52, 0x07, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61,
+	0x6e, 0x12, 0x18, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18, 0x05, 0x20, 0x01, 0x28,
+	0x01, 0x48, 0x00, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x2e, 0x0a, 0x05, 0x74,
+	0x65, 0x78, 0x74, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x16, 0x2e, 0x77, 0x65, 0x61,
+	0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x54, 0x65, 0x78, 0x74, 0x41, 0x72, 0x72,
+	0x61, 0x79, 0x48, 0x00, 0x52, 0x05, 0x74, 0x65, 0x78, 0x74, 0x73, 0x12, 0x2b, 0x0a, 0x04, 0x69,
+	0x6e, 0x74, 0x73, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x15, 0x2e, 0x77, 0x65, 0x61, 0x76,
+	0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x49, 0x6e, 0x74, 0x41, 0x72, 0x72, 0x61, 0x79,
+	0x48, 0x00, 0x52, 0x04, 0x69, 0x6e, 0x74, 0x73, 0x12, 0x37, 0x0a, 0x08, 0x62, 0x6f, 0x6f, 0x6c,
+	0x65, 0x61, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x19, 0x2e, 0x77, 0x65, 0x61,
+	0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x42, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e,
+	0x41, 0x72, 0x72, 0x61, 0x79, 0x48, 0x00, 0x52, 0x08, 0x62, 0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e,
+	0x73, 0x12, 0x34, 0x0a, 0x07, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x73, 0x18, 0x09, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x18, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x76, 0x31,
+	0x2e, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x41, 0x72, 0x72, 0x61, 0x79, 0x48, 0x00, 0x52, 0x07,
+	0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x73, 0x12, 0x35, 0x0a, 0x03, 0x67, 0x65, 0x6f, 0x18, 0x0a,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e,
+	0x76, 0x31, 0x2e, 0x47, 0x65, 0x6f, 0x43, 0x6f, 0x6f, 0x72, 0x64, 0x69, 0x6e, 0x61, 0x74, 0x65,
+	0x73, 0x46, 0x69, 0x6c, 0x74, 0x65, 0x72, 0x48, 0x00, 0x52, 0x03, 0x67, 0x65, 0x6f, 0x42, 0x07,
+	0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x42, 0x10, 0x0a, 0x0e, 0x5f, 0x6f, 0x62, 0x6a, 0x65,
+	0x63, 0x74, 0x73, 0x5f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x0f, 0x0a, 0x0d, 0x5f, 0x61, 0x67,
+	0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x42, 0x0d, 0x0a, 0x0b, 0x5f, 0x67,
+	0x72, 0x6f, 0x75, 0x70, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x1a, 0x44, 0x0a, 0x07, 0x47, 0x72, 0x6f,
+	0x75, 0x70, 0x65, 0x64, 0x12, 0x39, 0x0a, 0x06, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x18, 0x01,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e,
+	0x76, 0x31, 0x2e, 0x41, 0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x52, 0x65, 0x70, 0x6c,
+	0x79, 0x2e, 0x47, 0x72, 0x6f, 0x75, 0x70, 0x52, 0x06, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x73, 0x42,
+	0x08, 0x0a, 0x06, 0x72, 0x65, 0x73, 0x75, 0x6c, 0x74, 0x42, 0x73, 0x0a, 0x23, 0x69, 0x6f, 0x2e,
+	0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2e, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2e,
+	0x67, 0x72, 0x70, 0x63, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2e, 0x76, 0x31,
+	0x42, 0x16, 0x57, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x41,
+	0x67, 0x67, 0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x5a, 0x34, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
+	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x77, 0x65, 0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2f, 0x77, 0x65,
+	0x61, 0x76, 0x69, 0x61, 0x74, 0x65, 0x2f, 0x67, 0x72, 0x70, 0x63, 0x2f, 0x67, 0x65, 0x6e, 0x65,
+	0x72, 0x61, 0x74, 0x65, 0x64, 0x3b, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x62, 0x06,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2523,91 +2634,94 @@ func file_v1_aggregate_proto_rawDescGZIP() []byte {
 	return file_v1_aggregate_proto_rawDescData
 }
 
-var file_v1_aggregate_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_v1_aggregate_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_v1_aggregate_proto_goTypes = []interface{}{
 	(*AggregateRequest)(nil),                                                          // 0: weaviate.v1.AggregateRequest
 	(*AggregateReply)(nil),                                                            // 1: weaviate.v1.AggregateReply
-	(*AggregateGroup)(nil),                                                            // 2: weaviate.v1.AggregateGroup
-	(*AggregateRequest_Aggregation)(nil),                                              // 3: weaviate.v1.AggregateRequest.Aggregation
-	(*AggregateRequest_GroupBy)(nil),                                                  // 4: weaviate.v1.AggregateRequest.GroupBy
-	(*AggregateRequest_Aggregation_Integer)(nil),                                      // 5: weaviate.v1.AggregateRequest.Aggregation.Integer
-	(*AggregateRequest_Aggregation_Number)(nil),                                       // 6: weaviate.v1.AggregateRequest.Aggregation.Number
-	(*AggregateRequest_Aggregation_Text)(nil),                                         // 7: weaviate.v1.AggregateRequest.Aggregation.Text
-	(*AggregateRequest_Aggregation_Boolean)(nil),                                      // 8: weaviate.v1.AggregateRequest.Aggregation.Boolean
-	(*AggregateRequest_Aggregation_Date)(nil),                                         // 9: weaviate.v1.AggregateRequest.Aggregation.Date
-	(*AggregateRequest_Aggregation_Reference)(nil),                                    // 10: weaviate.v1.AggregateRequest.Aggregation.Reference
-	(*AggregateReply_Result)(nil),                                                     // 11: weaviate.v1.AggregateReply.Result
-	(*AggregateGroup_Aggregations)(nil),                                               // 12: weaviate.v1.AggregateGroup.Aggregations
-	(*AggregateGroup_GroupedBy)(nil),                                                  // 13: weaviate.v1.AggregateGroup.GroupedBy
-	(*AggregateGroup_Aggregations_Aggregation)(nil),                                   // 14: weaviate.v1.AggregateGroup.Aggregations.Aggregation
-	(*AggregateGroup_Aggregations_Aggregation_Integer)(nil),                           // 15: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Integer
-	(*AggregateGroup_Aggregations_Aggregation_Number)(nil),                            // 16: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Number
-	(*AggregateGroup_Aggregations_Aggregation_Text)(nil),                              // 17: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text
-	(*AggregateGroup_Aggregations_Aggregation_Boolean)(nil),                           // 18: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Boolean
-	(*AggregateGroup_Aggregations_Aggregation_Date)(nil),                              // 19: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Date
-	(*AggregateGroup_Aggregations_Aggregation_Reference)(nil),                         // 20: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Reference
-	(*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences)(nil),               // 21: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text.TopOccurrences
-	(*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence)(nil), // 22: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text.TopOccurrences.TopOccurrence
-	(*Filters)(nil),              // 23: weaviate.v1.Filters
-	(*Hybrid)(nil),               // 24: weaviate.v1.Hybrid
-	(*NearVector)(nil),           // 25: weaviate.v1.NearVector
-	(*NearObject)(nil),           // 26: weaviate.v1.NearObject
-	(*NearTextSearch)(nil),       // 27: weaviate.v1.NearTextSearch
-	(*NearImageSearch)(nil),      // 28: weaviate.v1.NearImageSearch
-	(*NearAudioSearch)(nil),      // 29: weaviate.v1.NearAudioSearch
-	(*NearVideoSearch)(nil),      // 30: weaviate.v1.NearVideoSearch
-	(*NearDepthSearch)(nil),      // 31: weaviate.v1.NearDepthSearch
-	(*NearThermalSearch)(nil),    // 32: weaviate.v1.NearThermalSearch
-	(*NearIMUSearch)(nil),        // 33: weaviate.v1.NearIMUSearch
-	(*TextArray)(nil),            // 34: weaviate.v1.TextArray
-	(*IntArray)(nil),             // 35: weaviate.v1.IntArray
-	(*BooleanArray)(nil),         // 36: weaviate.v1.BooleanArray
-	(*NumberArray)(nil),          // 37: weaviate.v1.NumberArray
-	(*GeoCoordinatesFilter)(nil), // 38: weaviate.v1.GeoCoordinatesFilter
+	(*AggregateRequest_Aggregation)(nil),                                              // 2: weaviate.v1.AggregateRequest.Aggregation
+	(*AggregateRequest_GroupBy)(nil),                                                  // 3: weaviate.v1.AggregateRequest.GroupBy
+	(*AggregateRequest_Aggregation_Integer)(nil),                                      // 4: weaviate.v1.AggregateRequest.Aggregation.Integer
+	(*AggregateRequest_Aggregation_Number)(nil),                                       // 5: weaviate.v1.AggregateRequest.Aggregation.Number
+	(*AggregateRequest_Aggregation_Text)(nil),                                         // 6: weaviate.v1.AggregateRequest.Aggregation.Text
+	(*AggregateRequest_Aggregation_Boolean)(nil),                                      // 7: weaviate.v1.AggregateRequest.Aggregation.Boolean
+	(*AggregateRequest_Aggregation_Date)(nil),                                         // 8: weaviate.v1.AggregateRequest.Aggregation.Date
+	(*AggregateRequest_Aggregation_Reference)(nil),                                    // 9: weaviate.v1.AggregateRequest.Aggregation.Reference
+	(*AggregateReply_Aggregations)(nil),                                               // 10: weaviate.v1.AggregateReply.Aggregations
+	(*AggregateReply_Single)(nil),                                                     // 11: weaviate.v1.AggregateReply.Single
+	(*AggregateReply_Group)(nil),                                                      // 12: weaviate.v1.AggregateReply.Group
+	(*AggregateReply_Grouped)(nil),                                                    // 13: weaviate.v1.AggregateReply.Grouped
+	(*AggregateReply_Aggregations_Aggregation)(nil),                                   // 14: weaviate.v1.AggregateReply.Aggregations.Aggregation
+	(*AggregateReply_Aggregations_Aggregation_Integer)(nil),                           // 15: weaviate.v1.AggregateReply.Aggregations.Aggregation.Integer
+	(*AggregateReply_Aggregations_Aggregation_Number)(nil),                            // 16: weaviate.v1.AggregateReply.Aggregations.Aggregation.Number
+	(*AggregateReply_Aggregations_Aggregation_Text)(nil),                              // 17: weaviate.v1.AggregateReply.Aggregations.Aggregation.Text
+	(*AggregateReply_Aggregations_Aggregation_Boolean)(nil),                           // 18: weaviate.v1.AggregateReply.Aggregations.Aggregation.Boolean
+	(*AggregateReply_Aggregations_Aggregation_Date)(nil),                              // 19: weaviate.v1.AggregateReply.Aggregations.Aggregation.Date
+	(*AggregateReply_Aggregations_Aggregation_Reference)(nil),                         // 20: weaviate.v1.AggregateReply.Aggregations.Aggregation.Reference
+	(*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences)(nil),               // 21: weaviate.v1.AggregateReply.Aggregations.Aggregation.Text.TopOccurrences
+	(*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence)(nil), // 22: weaviate.v1.AggregateReply.Aggregations.Aggregation.Text.TopOccurrences.TopOccurrence
+	(*AggregateReply_Group_GroupedBy)(nil),                                            // 23: weaviate.v1.AggregateReply.Group.GroupedBy
+	(*Filters)(nil),                                                                   // 24: weaviate.v1.Filters
+	(*Hybrid)(nil),                                                                    // 25: weaviate.v1.Hybrid
+	(*NearVector)(nil),                                                                // 26: weaviate.v1.NearVector
+	(*NearObject)(nil),                                                                // 27: weaviate.v1.NearObject
+	(*NearTextSearch)(nil),                                                            // 28: weaviate.v1.NearTextSearch
+	(*NearImageSearch)(nil),                                                           // 29: weaviate.v1.NearImageSearch
+	(*NearAudioSearch)(nil),                                                           // 30: weaviate.v1.NearAudioSearch
+	(*NearVideoSearch)(nil),                                                           // 31: weaviate.v1.NearVideoSearch
+	(*NearDepthSearch)(nil),                                                           // 32: weaviate.v1.NearDepthSearch
+	(*NearThermalSearch)(nil),                                                         // 33: weaviate.v1.NearThermalSearch
+	(*NearIMUSearch)(nil),                                                             // 34: weaviate.v1.NearIMUSearch
+	(*TextArray)(nil),                                                                 // 35: weaviate.v1.TextArray
+	(*IntArray)(nil),                                                                  // 36: weaviate.v1.IntArray
+	(*BooleanArray)(nil),                                                              // 37: weaviate.v1.BooleanArray
+	(*NumberArray)(nil),                                                               // 38: weaviate.v1.NumberArray
+	(*GeoCoordinatesFilter)(nil),                                                      // 39: weaviate.v1.GeoCoordinatesFilter
 }
 var file_v1_aggregate_proto_depIdxs = []int32{
-	3,  // 0: weaviate.v1.AggregateRequest.aggregations:type_name -> weaviate.v1.AggregateRequest.Aggregation
-	4,  // 1: weaviate.v1.AggregateRequest.group_by:type_name -> weaviate.v1.AggregateRequest.GroupBy
-	23, // 2: weaviate.v1.AggregateRequest.filters:type_name -> weaviate.v1.Filters
-	24, // 3: weaviate.v1.AggregateRequest.hybrid:type_name -> weaviate.v1.Hybrid
-	25, // 4: weaviate.v1.AggregateRequest.near_vector:type_name -> weaviate.v1.NearVector
-	26, // 5: weaviate.v1.AggregateRequest.near_object:type_name -> weaviate.v1.NearObject
-	27, // 6: weaviate.v1.AggregateRequest.near_text:type_name -> weaviate.v1.NearTextSearch
-	28, // 7: weaviate.v1.AggregateRequest.near_image:type_name -> weaviate.v1.NearImageSearch
-	29, // 8: weaviate.v1.AggregateRequest.near_audio:type_name -> weaviate.v1.NearAudioSearch
-	30, // 9: weaviate.v1.AggregateRequest.near_video:type_name -> weaviate.v1.NearVideoSearch
-	31, // 10: weaviate.v1.AggregateRequest.near_depth:type_name -> weaviate.v1.NearDepthSearch
-	32, // 11: weaviate.v1.AggregateRequest.near_thermal:type_name -> weaviate.v1.NearThermalSearch
-	33, // 12: weaviate.v1.AggregateRequest.near_imu:type_name -> weaviate.v1.NearIMUSearch
-	11, // 13: weaviate.v1.AggregateReply.result:type_name -> weaviate.v1.AggregateReply.Result
-	12, // 14: weaviate.v1.AggregateGroup.aggregations:type_name -> weaviate.v1.AggregateGroup.Aggregations
-	13, // 15: weaviate.v1.AggregateGroup.grouped_by:type_name -> weaviate.v1.AggregateGroup.GroupedBy
-	5,  // 16: weaviate.v1.AggregateRequest.Aggregation.int:type_name -> weaviate.v1.AggregateRequest.Aggregation.Integer
-	6,  // 17: weaviate.v1.AggregateRequest.Aggregation.number:type_name -> weaviate.v1.AggregateRequest.Aggregation.Number
-	7,  // 18: weaviate.v1.AggregateRequest.Aggregation.text:type_name -> weaviate.v1.AggregateRequest.Aggregation.Text
-	8,  // 19: weaviate.v1.AggregateRequest.Aggregation.boolean:type_name -> weaviate.v1.AggregateRequest.Aggregation.Boolean
-	9,  // 20: weaviate.v1.AggregateRequest.Aggregation.date:type_name -> weaviate.v1.AggregateRequest.Aggregation.Date
-	10, // 21: weaviate.v1.AggregateRequest.Aggregation.reference:type_name -> weaviate.v1.AggregateRequest.Aggregation.Reference
-	2,  // 22: weaviate.v1.AggregateReply.Result.groups:type_name -> weaviate.v1.AggregateGroup
-	14, // 23: weaviate.v1.AggregateGroup.Aggregations.aggregations:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation
-	34, // 24: weaviate.v1.AggregateGroup.GroupedBy.texts:type_name -> weaviate.v1.TextArray
-	35, // 25: weaviate.v1.AggregateGroup.GroupedBy.ints:type_name -> weaviate.v1.IntArray
-	36, // 26: weaviate.v1.AggregateGroup.GroupedBy.booleans:type_name -> weaviate.v1.BooleanArray
-	37, // 27: weaviate.v1.AggregateGroup.GroupedBy.numbers:type_name -> weaviate.v1.NumberArray
-	38, // 28: weaviate.v1.AggregateGroup.GroupedBy.geo:type_name -> weaviate.v1.GeoCoordinatesFilter
-	15, // 29: weaviate.v1.AggregateGroup.Aggregations.Aggregation.int:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Integer
-	16, // 30: weaviate.v1.AggregateGroup.Aggregations.Aggregation.number:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Number
-	17, // 31: weaviate.v1.AggregateGroup.Aggregations.Aggregation.text:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text
-	18, // 32: weaviate.v1.AggregateGroup.Aggregations.Aggregation.boolean:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Boolean
-	19, // 33: weaviate.v1.AggregateGroup.Aggregations.Aggregation.date:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Date
-	20, // 34: weaviate.v1.AggregateGroup.Aggregations.Aggregation.reference:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Reference
-	21, // 35: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text.top_occurences:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text.TopOccurrences
-	22, // 36: weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text.TopOccurrences.items:type_name -> weaviate.v1.AggregateGroup.Aggregations.Aggregation.Text.TopOccurrences.TopOccurrence
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	2,  // 0: weaviate.v1.AggregateRequest.aggregations:type_name -> weaviate.v1.AggregateRequest.Aggregation
+	3,  // 1: weaviate.v1.AggregateRequest.group_by:type_name -> weaviate.v1.AggregateRequest.GroupBy
+	24, // 2: weaviate.v1.AggregateRequest.filters:type_name -> weaviate.v1.Filters
+	25, // 3: weaviate.v1.AggregateRequest.hybrid:type_name -> weaviate.v1.Hybrid
+	26, // 4: weaviate.v1.AggregateRequest.near_vector:type_name -> weaviate.v1.NearVector
+	27, // 5: weaviate.v1.AggregateRequest.near_object:type_name -> weaviate.v1.NearObject
+	28, // 6: weaviate.v1.AggregateRequest.near_text:type_name -> weaviate.v1.NearTextSearch
+	29, // 7: weaviate.v1.AggregateRequest.near_image:type_name -> weaviate.v1.NearImageSearch
+	30, // 8: weaviate.v1.AggregateRequest.near_audio:type_name -> weaviate.v1.NearAudioSearch
+	31, // 9: weaviate.v1.AggregateRequest.near_video:type_name -> weaviate.v1.NearVideoSearch
+	32, // 10: weaviate.v1.AggregateRequest.near_depth:type_name -> weaviate.v1.NearDepthSearch
+	33, // 11: weaviate.v1.AggregateRequest.near_thermal:type_name -> weaviate.v1.NearThermalSearch
+	34, // 12: weaviate.v1.AggregateRequest.near_imu:type_name -> weaviate.v1.NearIMUSearch
+	11, // 13: weaviate.v1.AggregateReply.single_result:type_name -> weaviate.v1.AggregateReply.Single
+	13, // 14: weaviate.v1.AggregateReply.grouped_results:type_name -> weaviate.v1.AggregateReply.Grouped
+	4,  // 15: weaviate.v1.AggregateRequest.Aggregation.int:type_name -> weaviate.v1.AggregateRequest.Aggregation.Integer
+	5,  // 16: weaviate.v1.AggregateRequest.Aggregation.number:type_name -> weaviate.v1.AggregateRequest.Aggregation.Number
+	6,  // 17: weaviate.v1.AggregateRequest.Aggregation.text:type_name -> weaviate.v1.AggregateRequest.Aggregation.Text
+	7,  // 18: weaviate.v1.AggregateRequest.Aggregation.boolean:type_name -> weaviate.v1.AggregateRequest.Aggregation.Boolean
+	8,  // 19: weaviate.v1.AggregateRequest.Aggregation.date:type_name -> weaviate.v1.AggregateRequest.Aggregation.Date
+	9,  // 20: weaviate.v1.AggregateRequest.Aggregation.reference:type_name -> weaviate.v1.AggregateRequest.Aggregation.Reference
+	14, // 21: weaviate.v1.AggregateReply.Aggregations.aggregations:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation
+	10, // 22: weaviate.v1.AggregateReply.Single.aggregations:type_name -> weaviate.v1.AggregateReply.Aggregations
+	10, // 23: weaviate.v1.AggregateReply.Group.aggregations:type_name -> weaviate.v1.AggregateReply.Aggregations
+	23, // 24: weaviate.v1.AggregateReply.Group.grouped_by:type_name -> weaviate.v1.AggregateReply.Group.GroupedBy
+	12, // 25: weaviate.v1.AggregateReply.Grouped.groups:type_name -> weaviate.v1.AggregateReply.Group
+	15, // 26: weaviate.v1.AggregateReply.Aggregations.Aggregation.int:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Integer
+	16, // 27: weaviate.v1.AggregateReply.Aggregations.Aggregation.number:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Number
+	17, // 28: weaviate.v1.AggregateReply.Aggregations.Aggregation.text:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Text
+	18, // 29: weaviate.v1.AggregateReply.Aggregations.Aggregation.boolean:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Boolean
+	19, // 30: weaviate.v1.AggregateReply.Aggregations.Aggregation.date:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Date
+	20, // 31: weaviate.v1.AggregateReply.Aggregations.Aggregation.reference:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Reference
+	21, // 32: weaviate.v1.AggregateReply.Aggregations.Aggregation.Text.top_occurences:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Text.TopOccurrences
+	22, // 33: weaviate.v1.AggregateReply.Aggregations.Aggregation.Text.TopOccurrences.items:type_name -> weaviate.v1.AggregateReply.Aggregations.Aggregation.Text.TopOccurrences.TopOccurrence
+	35, // 34: weaviate.v1.AggregateReply.Group.GroupedBy.texts:type_name -> weaviate.v1.TextArray
+	36, // 35: weaviate.v1.AggregateReply.Group.GroupedBy.ints:type_name -> weaviate.v1.IntArray
+	37, // 36: weaviate.v1.AggregateReply.Group.GroupedBy.booleans:type_name -> weaviate.v1.BooleanArray
+	38, // 37: weaviate.v1.AggregateReply.Group.GroupedBy.numbers:type_name -> weaviate.v1.NumberArray
+	39, // 38: weaviate.v1.AggregateReply.Group.GroupedBy.geo:type_name -> weaviate.v1.GeoCoordinatesFilter
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_v1_aggregate_proto_init() }
@@ -2643,18 +2757,6 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_v1_aggregate_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation); i {
 			case 0:
 				return &v.state
@@ -2666,7 +2768,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_GroupBy); i {
 			case 0:
 				return &v.state
@@ -2678,7 +2780,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation_Integer); i {
 			case 0:
 				return &v.state
@@ -2690,7 +2792,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation_Number); i {
 			case 0:
 				return &v.state
@@ -2702,7 +2804,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation_Text); i {
 			case 0:
 				return &v.state
@@ -2714,7 +2816,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation_Boolean); i {
 			case 0:
 				return &v.state
@@ -2726,7 +2828,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation_Date); i {
 			case 0:
 				return &v.state
@@ -2738,7 +2840,7 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
-		file_v1_aggregate_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+		file_v1_aggregate_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*AggregateRequest_Aggregation_Reference); i {
 			case 0:
 				return &v.state
@@ -2750,8 +2852,20 @@ func file_v1_aggregate_proto_init() {
 				return nil
 			}
 		}
+		file_v1_aggregate_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*AggregateReply_Aggregations); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 		file_v1_aggregate_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateReply_Result); i {
+			switch v := v.(*AggregateReply_Single); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2763,7 +2877,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations); i {
+			switch v := v.(*AggregateReply_Group); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2775,7 +2889,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_GroupedBy); i {
+			switch v := v.(*AggregateReply_Grouped); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2787,7 +2901,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2799,7 +2913,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Integer); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Integer); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2811,7 +2925,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Number); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Number); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2823,7 +2937,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Text); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Text); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2835,7 +2949,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Boolean); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Boolean); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2847,7 +2961,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Date); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Date); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2859,7 +2973,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Reference); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Reference); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2871,7 +2985,7 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2883,7 +2997,19 @@ func file_v1_aggregate_proto_init() {
 			}
 		}
 		file_v1_aggregate_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*AggregateGroup_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence); i {
+			switch v := v.(*AggregateReply_Aggregations_Aggregation_Text_TopOccurrences_TopOccurrence); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_v1_aggregate_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*AggregateReply_Group_GroupedBy); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2907,8 +3033,11 @@ func file_v1_aggregate_proto_init() {
 		(*AggregateRequest_NearThermal)(nil),
 		(*AggregateRequest_NearImu)(nil),
 	}
-	file_v1_aggregate_proto_msgTypes[2].OneofWrappers = []interface{}{}
-	file_v1_aggregate_proto_msgTypes[3].OneofWrappers = []interface{}{
+	file_v1_aggregate_proto_msgTypes[1].OneofWrappers = []interface{}{
+		(*AggregateReply_SingleResult)(nil),
+		(*AggregateReply_GroupedResults)(nil),
+	}
+	file_v1_aggregate_proto_msgTypes[2].OneofWrappers = []interface{}{
 		(*AggregateRequest_Aggregation_Int)(nil),
 		(*AggregateRequest_Aggregation_Number_)(nil),
 		(*AggregateRequest_Aggregation_Text_)(nil),
@@ -2916,25 +3045,16 @@ func file_v1_aggregate_proto_init() {
 		(*AggregateRequest_Aggregation_Date_)(nil),
 		(*AggregateRequest_Aggregation_Reference_)(nil),
 	}
-	file_v1_aggregate_proto_msgTypes[7].OneofWrappers = []interface{}{}
-	file_v1_aggregate_proto_msgTypes[13].OneofWrappers = []interface{}{
-		(*AggregateGroup_GroupedBy_Text)(nil),
-		(*AggregateGroup_GroupedBy_Int)(nil),
-		(*AggregateGroup_GroupedBy_Boolean)(nil),
-		(*AggregateGroup_GroupedBy_Number)(nil),
-		(*AggregateGroup_GroupedBy_Texts)(nil),
-		(*AggregateGroup_GroupedBy_Ints)(nil),
-		(*AggregateGroup_GroupedBy_Booleans)(nil),
-		(*AggregateGroup_GroupedBy_Numbers)(nil),
-		(*AggregateGroup_GroupedBy_Geo)(nil),
-	}
+	file_v1_aggregate_proto_msgTypes[6].OneofWrappers = []interface{}{}
+	file_v1_aggregate_proto_msgTypes[11].OneofWrappers = []interface{}{}
+	file_v1_aggregate_proto_msgTypes[12].OneofWrappers = []interface{}{}
 	file_v1_aggregate_proto_msgTypes[14].OneofWrappers = []interface{}{
-		(*AggregateGroup_Aggregations_Aggregation_Int)(nil),
-		(*AggregateGroup_Aggregations_Aggregation_Number_)(nil),
-		(*AggregateGroup_Aggregations_Aggregation_Text_)(nil),
-		(*AggregateGroup_Aggregations_Aggregation_Boolean_)(nil),
-		(*AggregateGroup_Aggregations_Aggregation_Date_)(nil),
-		(*AggregateGroup_Aggregations_Aggregation_Reference_)(nil),
+		(*AggregateReply_Aggregations_Aggregation_Int)(nil),
+		(*AggregateReply_Aggregations_Aggregation_Number_)(nil),
+		(*AggregateReply_Aggregations_Aggregation_Text_)(nil),
+		(*AggregateReply_Aggregations_Aggregation_Boolean_)(nil),
+		(*AggregateReply_Aggregations_Aggregation_Date_)(nil),
+		(*AggregateReply_Aggregations_Aggregation_Reference_)(nil),
 	}
 	file_v1_aggregate_proto_msgTypes[15].OneofWrappers = []interface{}{}
 	file_v1_aggregate_proto_msgTypes[16].OneofWrappers = []interface{}{}
@@ -2942,13 +3062,24 @@ func file_v1_aggregate_proto_init() {
 	file_v1_aggregate_proto_msgTypes[18].OneofWrappers = []interface{}{}
 	file_v1_aggregate_proto_msgTypes[19].OneofWrappers = []interface{}{}
 	file_v1_aggregate_proto_msgTypes[20].OneofWrappers = []interface{}{}
+	file_v1_aggregate_proto_msgTypes[23].OneofWrappers = []interface{}{
+		(*AggregateReply_Group_GroupedBy_Text)(nil),
+		(*AggregateReply_Group_GroupedBy_Int)(nil),
+		(*AggregateReply_Group_GroupedBy_Boolean)(nil),
+		(*AggregateReply_Group_GroupedBy_Number)(nil),
+		(*AggregateReply_Group_GroupedBy_Texts)(nil),
+		(*AggregateReply_Group_GroupedBy_Ints)(nil),
+		(*AggregateReply_Group_GroupedBy_Booleans)(nil),
+		(*AggregateReply_Group_GroupedBy_Numbers)(nil),
+		(*AggregateReply_Group_GroupedBy_Geo)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_v1_aggregate_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   23,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/grpc/generated/protocol/v1/base.pb.go
+++ b/grpc/generated/protocol/v1/base.pb.go
@@ -157,7 +157,7 @@ type NumberArrayProperties struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base.proto.
 	Values      []float64 `protobuf:"fixed64,1,rep,packed,name=values,proto3" json:"values,omitempty"` // will be removed in the future, use vector_bytes
 	PropName    string    `protobuf:"bytes,2,opt,name=prop_name,json=propName,proto3" json:"prop_name,omitempty"`
 	ValuesBytes []byte    `protobuf:"bytes,3,opt,name=values_bytes,json=valuesBytes,proto3" json:"values_bytes,omitempty"`
@@ -195,7 +195,7 @@ func (*NumberArrayProperties) Descriptor() ([]byte, []int) {
 	return file_v1_base_proto_rawDescGZIP(), []int{0}
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base.proto.
 func (x *NumberArrayProperties) GetValues() []float64 {
 	if x != nil {
 		return x.Values
@@ -791,10 +791,11 @@ type Filters struct {
 	Operator Filters_Operator `protobuf:"varint,1,opt,name=operator,proto3,enum=weaviate.v1.Filters_Operator" json:"operator,omitempty"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	//
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base.proto.
 	On      []string   `protobuf:"bytes,2,rep,name=on,proto3" json:"on,omitempty"` // will be removed in the future, use path
 	Filters []*Filters `protobuf:"bytes,3,rep,name=filters,proto3" json:"filters,omitempty"`
 	// Types that are assignable to TestValue:
+	//
 	//	*Filters_ValueText
 	//	*Filters_ValueInt
 	//	*Filters_ValueBoolean
@@ -847,7 +848,7 @@ func (x *Filters) GetOperator() Filters_Operator {
 	return Filters_OPERATOR_UNSPECIFIED
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base.proto.
 func (x *Filters) GetOn() []string {
 	if x != nil {
 		return x.On
@@ -1168,6 +1169,7 @@ type FilterTarget struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Target:
+	//
 	//	*FilterTarget_Property
 	//	*FilterTarget_SingleTarget
 	//	*FilterTarget_MultiTarget

--- a/grpc/generated/protocol/v1/base_search.pb.go
+++ b/grpc/generated/protocol/v1/base_search.pb.go
@@ -186,7 +186,7 @@ type Targets struct {
 
 	TargetVectors []string          `protobuf:"bytes,1,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"`
 	Combination   CombinationMethod `protobuf:"varint,2,opt,name=combination,proto3,enum=weaviate.v1.CombinationMethod" json:"combination,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	Weights           map[string]float32  `protobuf:"bytes,3,rep,name=weights,proto3" json:"weights,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed32,2,opt,name=value,proto3"` // deprecated in 1.26.2 - use weights_for_targets
 	WeightsForTargets []*WeightsForTarget `protobuf:"bytes,4,rep,name=weights_for_targets,json=weightsForTargets,proto3" json:"weights_for_targets,omitempty"`
 }
@@ -237,7 +237,7 @@ func (x *Targets) GetCombination() CombinationMethod {
 	return CombinationMethod_COMBINATION_METHOD_UNSPECIFIED
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *Targets) GetWeights() map[string]float32 {
 	if x != nil {
 		return x.Weights
@@ -316,12 +316,12 @@ type Hybrid struct {
 	Properties []string `protobuf:"bytes,2,rep,name=properties,proto3" json:"properties,omitempty"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	//
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	Vector      []float32         `protobuf:"fixed32,3,rep,packed,name=vector,proto3" json:"vector,omitempty"` // will be removed in the future, use vector_bytes
 	Alpha       float32           `protobuf:"fixed32,4,opt,name=alpha,proto3" json:"alpha,omitempty"`
 	FusionType  Hybrid_FusionType `protobuf:"varint,5,opt,name=fusion_type,json=fusionType,proto3,enum=weaviate.v1.Hybrid_FusionType" json:"fusion_type,omitempty"`
 	VectorBytes []byte            `protobuf:"bytes,6,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string        `protobuf:"bytes,7,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	NearText      *NearTextSearch `protobuf:"bytes,8,opt,name=near_text,json=nearText,proto3" json:"near_text,omitempty"`                // targets in msg is ignored and should not be set for hybrid
 	NearVector    *NearVector     `protobuf:"bytes,9,opt,name=near_vector,json=nearVector,proto3" json:"near_vector,omitempty"`          // same as above. Use the target vector in the hybrid message
@@ -329,6 +329,7 @@ type Hybrid struct {
 	// only vector distance, but keep it extendable
 	//
 	// Types that are assignable to Threshold:
+	//
 	//	*Hybrid_VectorDistance
 	Threshold isHybrid_Threshold `protobuf_oneof:"threshold"`
 }
@@ -379,7 +380,7 @@ func (x *Hybrid) GetProperties() []string {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *Hybrid) GetVector() []float32 {
 	if x != nil {
 		return x.Vector
@@ -408,7 +409,7 @@ func (x *Hybrid) GetVectorBytes() []byte {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *Hybrid) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -468,15 +469,15 @@ type NearVector struct {
 
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	//
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	Vector      []float32 `protobuf:"fixed32,1,rep,packed,name=vector,proto3" json:"vector,omitempty"` // will be removed in the future, use vector_bytes
 	Certainty   *float64  `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance    *float64  `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
 	VectorBytes []byte    `protobuf:"bytes,4,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,5,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,6,opt,name=targets,proto3" json:"targets,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	VectorPerTarget  map[string][]byte  `protobuf:"bytes,7,rep,name=vector_per_target,json=vectorPerTarget,proto3" json:"vector_per_target,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // deprecated in 1.26.2 - use vector_for_targets
 	VectorForTargets []*VectorForTarget `protobuf:"bytes,8,rep,name=vector_for_targets,json=vectorForTargets,proto3" json:"vector_for_targets,omitempty"`
 }
@@ -513,7 +514,7 @@ func (*NearVector) Descriptor() ([]byte, []int) {
 	return file_v1_base_search_proto_rawDescGZIP(), []int{4}
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearVector) GetVector() []float32 {
 	if x != nil {
 		return x.Vector
@@ -542,7 +543,7 @@ func (x *NearVector) GetVectorBytes() []byte {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearVector) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -557,7 +558,7 @@ func (x *NearVector) GetTargets() *Targets {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearVector) GetVectorPerTarget() map[string][]byte {
 	if x != nil {
 		return x.VectorPerTarget
@@ -580,7 +581,7 @@ type NearObject struct {
 	Id        string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -638,7 +639,7 @@ func (x *NearObject) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearObject) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -664,7 +665,7 @@ type NearTextSearch struct {
 	Distance  *float64             `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
 	MoveTo    *NearTextSearch_Move `protobuf:"bytes,4,opt,name=move_to,json=moveTo,proto3,oneof" json:"move_to,omitempty"`
 	MoveAway  *NearTextSearch_Move `protobuf:"bytes,5,opt,name=move_away,json=moveAway,proto3,oneof" json:"move_away,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,6,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,7,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -736,7 +737,7 @@ func (x *NearTextSearch) GetMoveAway() *NearTextSearch_Move {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearTextSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -759,7 +760,7 @@ type NearImageSearch struct {
 	Image     string   `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -817,7 +818,7 @@ func (x *NearImageSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearImageSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -840,7 +841,7 @@ type NearAudioSearch struct {
 	Audio     string   `protobuf:"bytes,1,opt,name=audio,proto3" json:"audio,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -898,7 +899,7 @@ func (x *NearAudioSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearAudioSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -921,7 +922,7 @@ type NearVideoSearch struct {
 	Video     string   `protobuf:"bytes,1,opt,name=video,proto3" json:"video,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -979,7 +980,7 @@ func (x *NearVideoSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearVideoSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -1002,7 +1003,7 @@ type NearDepthSearch struct {
 	Depth     string   `protobuf:"bytes,1,opt,name=depth,proto3" json:"depth,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -1060,7 +1061,7 @@ func (x *NearDepthSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearDepthSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -1083,7 +1084,7 @@ type NearThermalSearch struct {
 	Thermal   string   `protobuf:"bytes,1,opt,name=thermal,proto3" json:"thermal,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -1141,7 +1142,7 @@ func (x *NearThermalSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearThermalSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors
@@ -1164,7 +1165,7 @@ type NearIMUSearch struct {
 	Imu       string   `protobuf:"bytes,1,opt,name=imu,proto3" json:"imu,omitempty"`
 	Certainty *float64 `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64 `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/base_search.proto.
 	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
 	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 }
@@ -1222,7 +1223,7 @@ func (x *NearIMUSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/base_search.proto.
 func (x *NearIMUSearch) GetTargetVectors() []string {
 	if x != nil {
 		return x.TargetVectors

--- a/grpc/generated/protocol/v1/batch.pb.go
+++ b/grpc/generated/protocol/v1/batch.pb.go
@@ -81,7 +81,7 @@ type BatchObject struct {
 	Uuid string `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	//
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/batch.proto.
 	Vector      []float32               `protobuf:"fixed32,2,rep,packed,name=vector,proto3" json:"vector,omitempty"` // deprecated, will be removed
 	Properties  *BatchObject_Properties `protobuf:"bytes,3,opt,name=properties,proto3" json:"properties,omitempty"`
 	Collection  string                  `protobuf:"bytes,4,opt,name=collection,proto3" json:"collection,omitempty"`
@@ -130,7 +130,7 @@ func (x *BatchObject) GetUuid() string {
 	return ""
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/batch.proto.
 func (x *BatchObject) GetVector() []float32 {
 	if x != nil {
 		return x.Vector

--- a/grpc/generated/protocol/v1/generative.pb.go
+++ b/grpc/generated/protocol/v1/generative.pb.go
@@ -22,11 +22,11 @@ type GenerativeSearch struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/generative.proto.
 	SingleResponsePrompt string `protobuf:"bytes,1,opt,name=single_response_prompt,json=singleResponsePrompt,proto3" json:"single_response_prompt,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/generative.proto.
 	GroupedResponseTask string `protobuf:"bytes,2,opt,name=grouped_response_task,json=groupedResponseTask,proto3" json:"grouped_response_task,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/generative.proto.
 	GroupedProperties []string                  `protobuf:"bytes,3,rep,name=grouped_properties,json=groupedProperties,proto3" json:"grouped_properties,omitempty"`
 	Single            *GenerativeSearch_Single  `protobuf:"bytes,4,opt,name=single,proto3" json:"single,omitempty"`
 	Grouped           *GenerativeSearch_Grouped `protobuf:"bytes,5,opt,name=grouped,proto3" json:"grouped,omitempty"`
@@ -64,7 +64,7 @@ func (*GenerativeSearch) Descriptor() ([]byte, []int) {
 	return file_v1_generative_proto_rawDescGZIP(), []int{0}
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/generative.proto.
 func (x *GenerativeSearch) GetSingleResponsePrompt() string {
 	if x != nil {
 		return x.SingleResponsePrompt
@@ -72,7 +72,7 @@ func (x *GenerativeSearch) GetSingleResponsePrompt() string {
 	return ""
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/generative.proto.
 func (x *GenerativeSearch) GetGroupedResponseTask() string {
 	if x != nil {
 		return x.GroupedResponseTask
@@ -80,7 +80,7 @@ func (x *GenerativeSearch) GetGroupedResponseTask() string {
 	return ""
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/generative.proto.
 func (x *GenerativeSearch) GetGroupedProperties() []string {
 	if x != nil {
 		return x.GroupedProperties
@@ -109,6 +109,7 @@ type GenerativeProvider struct {
 
 	ReturnMetadata bool `protobuf:"varint,1,opt,name=return_metadata,json=returnMetadata,proto3" json:"return_metadata,omitempty"`
 	// Types that are assignable to Kind:
+	//
 	//	*GenerativeProvider_Anthropic
 	//	*GenerativeProvider_Anyscale
 	//	*GenerativeProvider_Aws
@@ -1871,6 +1872,7 @@ type GenerativeMetadata struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Kind:
+	//
 	//	*GenerativeMetadata_Anthropic
 	//	*GenerativeMetadata_Anyscale
 	//	*GenerativeMetadata_Aws

--- a/grpc/generated/protocol/v1/properties.pb.go
+++ b/grpc/generated/protocol/v1/properties.pb.go
@@ -71,6 +71,7 @@ type Value struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Kind:
+	//
 	//	*Value_NumberValue
 	//	*Value_StringValue
 	//	*Value_BoolValue
@@ -133,7 +134,7 @@ func (x *Value) GetNumberValue() float64 {
 	return 0
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/properties.proto.
 func (x *Value) GetStringValue() string {
 	if x, ok := x.GetKind().(*Value_StringValue); ok {
 		return x.StringValue
@@ -208,7 +209,7 @@ func (x *Value) GetNullValue() structpb.NullValue {
 	if x, ok := x.GetKind().(*Value_NullValue); ok {
 		return x.NullValue
 	}
-	return structpb.NullValue_NULL_VALUE
+	return structpb.NullValue(0)
 }
 
 func (x *Value) GetTextValue() string {
@@ -227,7 +228,7 @@ type Value_NumberValue struct {
 }
 
 type Value_StringValue struct {
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/properties.proto.
 	StringValue string `protobuf:"bytes,2,opt,name=string_value,json=stringValue,proto3,oneof"`
 }
 
@@ -306,9 +307,10 @@ type ListValue struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/properties.proto.
 	Values []*Value `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
 	// Types that are assignable to Kind:
+	//
 	//	*ListValue_NumberValues
 	//	*ListValue_BoolValues
 	//	*ListValue_ObjectValues
@@ -351,7 +353,7 @@ func (*ListValue) Descriptor() ([]byte, []int) {
 	return file_v1_properties_proto_rawDescGZIP(), []int{2}
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/properties.proto.
 func (x *ListValue) GetValues() []*Value {
 	if x != nil {
 		return x.Values
@@ -466,7 +468,7 @@ type NumberValues struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//*
+	// *
 	// The values are stored as a byte array, where each 8 bytes represent a single float64 value.
 	// The byte array is stored in little-endian order using uint64 encoding.
 	Values []byte `protobuf:"bytes,1,opt,name=values,proto3" json:"values,omitempty"`
@@ -751,7 +753,7 @@ type IntValues struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//*
+	// *
 	// The values are stored as a byte array, where each 8 bytes represent a single int64 value.
 	// The byte array is stored in little-endian order using uint64 encoding.
 	Values []byte `protobuf:"bytes,1,opt,name=values,proto3" json:"values,omitempty"`

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -23,7 +23,7 @@ type SearchRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//required
+	// required
 	Collection string `protobuf:"bytes,1,opt,name=collection,proto3" json:"collection,omitempty"`
 	// parameters
 	Tenant           string            `protobuf:"bytes,10,opt,name=tenant,proto3" json:"tenant,omitempty"`
@@ -54,9 +54,9 @@ type SearchRequest struct {
 	NearImu      *NearIMUSearch     `protobuf:"bytes,51,opt,name=near_imu,json=nearImu,proto3,oneof" json:"near_imu,omitempty"`
 	Generative   *GenerativeSearch  `protobuf:"bytes,60,opt,name=generative,proto3,oneof" json:"generative,omitempty"`
 	Rerank       *Rerank            `protobuf:"bytes,61,opt,name=rerank,proto3,oneof" json:"rerank,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Uses_123Api bool `protobuf:"varint,100,opt,name=uses_123_api,json=uses123Api,proto3" json:"uses_123_api,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Uses_125Api bool `protobuf:"varint,101,opt,name=uses_125_api,json=uses125Api,proto3" json:"uses_125_api,omitempty"`
 	Uses_127Api bool `protobuf:"varint,102,opt,name=uses_127_api,json=uses127Api,proto3" json:"uses_127_api,omitempty"`
 }
@@ -268,7 +268,7 @@ func (x *SearchRequest) GetRerank() *Rerank {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *SearchRequest) GetUses_123Api() bool {
 	if x != nil {
 		return x.Uses_123Api
@@ -276,7 +276,7 @@ func (x *SearchRequest) GetUses_123Api() bool {
 	return false
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *SearchRequest) GetUses_125Api() bool {
 	if x != nil {
 		return x.Uses_125Api
@@ -802,7 +802,7 @@ type SearchReply struct {
 
 	Took    float32         `protobuf:"fixed32,1,opt,name=took,proto3" json:"took,omitempty"`
 	Results []*SearchResult `protobuf:"bytes,2,rep,name=results,proto3" json:"results,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	GenerativeGroupedResult  *string           `protobuf:"bytes,3,opt,name=generative_grouped_result,json=generativeGroupedResult,proto3,oneof" json:"generative_grouped_result,omitempty"`
 	GroupByResults           []*GroupByResult  `protobuf:"bytes,4,rep,name=group_by_results,json=groupByResults,proto3" json:"group_by_results,omitempty"`
 	GenerativeGroupedResults *GenerativeResult `protobuf:"bytes,5,opt,name=generative_grouped_results,json=generativeGroupedResults,proto3,oneof" json:"generative_grouped_results,omitempty"`
@@ -854,7 +854,7 @@ func (x *SearchReply) GetResults() []*SearchResult {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *SearchReply) GetGenerativeGroupedResult() string {
 	if x != nil && x.GenerativeGroupedResult != nil {
 		return *x.GenerativeGroupedResult
@@ -934,7 +934,7 @@ type GroupByResult struct {
 	NumberOfObjects int64           `protobuf:"varint,4,opt,name=number_of_objects,json=numberOfObjects,proto3" json:"number_of_objects,omitempty"`
 	Objects         []*SearchResult `protobuf:"bytes,5,rep,name=objects,proto3" json:"objects,omitempty"`
 	Rerank          *RerankReply    `protobuf:"bytes,6,opt,name=rerank,proto3,oneof" json:"rerank,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Generative       *GenerativeReply  `protobuf:"bytes,7,opt,name=generative,proto3,oneof" json:"generative,omitempty"`
 	GenerativeResult *GenerativeResult `protobuf:"bytes,8,opt,name=generative_result,json=generativeResult,proto3,oneof" json:"generative_result,omitempty"`
 }
@@ -1013,7 +1013,7 @@ func (x *GroupByResult) GetRerank() *RerankReply {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *GroupByResult) GetGenerative() *GenerativeReply {
 	if x != nil {
 		return x.Generative
@@ -1099,7 +1099,7 @@ type MetadataResult struct {
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	//
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Vector                    []float32 `protobuf:"fixed32,2,rep,packed,name=vector,proto3" json:"vector,omitempty"`
 	CreationTimeUnix          int64     `protobuf:"varint,3,opt,name=creation_time_unix,json=creationTimeUnix,proto3" json:"creation_time_unix,omitempty"`
 	CreationTimeUnixPresent   bool      `protobuf:"varint,4,opt,name=creation_time_unix_present,json=creationTimeUnixPresent,proto3" json:"creation_time_unix_present,omitempty"`
@@ -1114,9 +1114,9 @@ type MetadataResult struct {
 	ExplainScore              string    `protobuf:"bytes,13,opt,name=explain_score,json=explainScore,proto3" json:"explain_score,omitempty"`
 	ExplainScorePresent       bool      `protobuf:"varint,14,opt,name=explain_score_present,json=explainScorePresent,proto3" json:"explain_score_present,omitempty"`
 	IsConsistent              *bool     `protobuf:"varint,15,opt,name=is_consistent,json=isConsistent,proto3,oneof" json:"is_consistent,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Generative string `protobuf:"bytes,16,opt,name=generative,proto3" json:"generative,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	GenerativePresent   bool       `protobuf:"varint,17,opt,name=generative_present,json=generativePresent,proto3" json:"generative_present,omitempty"`
 	IsConsistentPresent bool       `protobuf:"varint,18,opt,name=is_consistent_present,json=isConsistentPresent,proto3" json:"is_consistent_present,omitempty"`
 	VectorBytes         []byte     `protobuf:"bytes,19,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"`
@@ -1165,7 +1165,7 @@ func (x *MetadataResult) GetId() string {
 	return ""
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *MetadataResult) GetVector() []float32 {
 	if x != nil {
 		return x.Vector
@@ -1264,7 +1264,7 @@ func (x *MetadataResult) GetIsConsistent() bool {
 	return false
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *MetadataResult) GetGenerative() string {
 	if x != nil {
 		return x.Generative
@@ -1272,7 +1272,7 @@ func (x *MetadataResult) GetGenerative() string {
 	return ""
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *MetadataResult) GetGenerativePresent() bool {
 	if x != nil {
 		return x.GenerativePresent
@@ -1327,22 +1327,22 @@ type PropertiesResult struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	NonRefProperties *structpb.Struct       `protobuf:"bytes,1,opt,name=non_ref_properties,json=nonRefProperties,proto3" json:"non_ref_properties,omitempty"`
 	RefProps         []*RefPropertiesResult `protobuf:"bytes,2,rep,name=ref_props,json=refProps,proto3" json:"ref_props,omitempty"`
 	TargetCollection string                 `protobuf:"bytes,3,opt,name=target_collection,json=targetCollection,proto3" json:"target_collection,omitempty"`
 	Metadata         *MetadataResult        `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	NumberArrayProperties []*NumberArrayProperties `protobuf:"bytes,5,rep,name=number_array_properties,json=numberArrayProperties,proto3" json:"number_array_properties,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	IntArrayProperties []*IntArrayProperties `protobuf:"bytes,6,rep,name=int_array_properties,json=intArrayProperties,proto3" json:"int_array_properties,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	TextArrayProperties []*TextArrayProperties `protobuf:"bytes,7,rep,name=text_array_properties,json=textArrayProperties,proto3" json:"text_array_properties,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	BooleanArrayProperties []*BooleanArrayProperties `protobuf:"bytes,8,rep,name=boolean_array_properties,json=booleanArrayProperties,proto3" json:"boolean_array_properties,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	ObjectProperties []*ObjectProperties `protobuf:"bytes,9,rep,name=object_properties,json=objectProperties,proto3" json:"object_properties,omitempty"`
-	// Deprecated: Do not use.
+	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	ObjectArrayProperties []*ObjectArrayProperties `protobuf:"bytes,10,rep,name=object_array_properties,json=objectArrayProperties,proto3" json:"object_array_properties,omitempty"`
 	NonRefProps           *Properties              `protobuf:"bytes,11,opt,name=non_ref_props,json=nonRefProps,proto3" json:"non_ref_props,omitempty"`
 	RefPropsRequested     bool                     `protobuf:"varint,12,opt,name=ref_props_requested,json=refPropsRequested,proto3" json:"ref_props_requested,omitempty"`
@@ -1380,7 +1380,7 @@ func (*PropertiesResult) Descriptor() ([]byte, []int) {
 	return file_v1_search_get_proto_rawDescGZIP(), []int{13}
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetNonRefProperties() *structpb.Struct {
 	if x != nil {
 		return x.NonRefProperties
@@ -1409,7 +1409,7 @@ func (x *PropertiesResult) GetMetadata() *MetadataResult {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetNumberArrayProperties() []*NumberArrayProperties {
 	if x != nil {
 		return x.NumberArrayProperties
@@ -1417,7 +1417,7 @@ func (x *PropertiesResult) GetNumberArrayProperties() []*NumberArrayProperties {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetIntArrayProperties() []*IntArrayProperties {
 	if x != nil {
 		return x.IntArrayProperties
@@ -1425,7 +1425,7 @@ func (x *PropertiesResult) GetIntArrayProperties() []*IntArrayProperties {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetTextArrayProperties() []*TextArrayProperties {
 	if x != nil {
 		return x.TextArrayProperties
@@ -1433,7 +1433,7 @@ func (x *PropertiesResult) GetTextArrayProperties() []*TextArrayProperties {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetBooleanArrayProperties() []*BooleanArrayProperties {
 	if x != nil {
 		return x.BooleanArrayProperties
@@ -1441,7 +1441,7 @@ func (x *PropertiesResult) GetBooleanArrayProperties() []*BooleanArrayProperties
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetObjectProperties() []*ObjectProperties {
 	if x != nil {
 		return x.ObjectProperties
@@ -1449,7 +1449,7 @@ func (x *PropertiesResult) GetObjectProperties() []*ObjectProperties {
 	return nil
 }
 
-// Deprecated: Do not use.
+// Deprecated: Marked as deprecated in v1/search_get.proto.
 func (x *PropertiesResult) GetObjectArrayProperties() []*ObjectArrayProperties {
 	if x != nil {
 		return x.ObjectArrayProperties

--- a/grpc/generated/protocol/v1/tenants.pb.go
+++ b/grpc/generated/protocol/v1/tenants.pb.go
@@ -100,6 +100,7 @@ type TenantsGetRequest struct {
 	// we might need to add a tenant-cursor api at some point, make this easily extendable
 	//
 	// Types that are assignable to Params:
+	//
 	//	*TenantsGetRequest_Names
 	Params isTenantsGetRequest_Params `protobuf_oneof:"params"`
 }

--- a/grpc/proto/v1/aggregate.proto
+++ b/grpc/proto/v1/aggregate.proto
@@ -103,14 +103,6 @@ message AggregateRequest {
 }
 
 message AggregateReply {
-  message Result {
-    repeated AggregateGroup groups = 1;
-  }
-  float took = 1;
-  Result result = 2;
-}
-
-message AggregateGroup {
   message Aggregations {
     message Aggregation {
       message Integer {
@@ -178,22 +170,36 @@ message AggregateGroup {
     }
     repeated Aggregation aggregations = 1;
   }
-  message GroupedBy {
-    // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-    repeated string path = 1;
-    oneof value {
-      string text = 2;
-      int64 int = 3;
-      bool boolean = 4;
-      double number = 5;
-      TextArray texts = 6;
-      IntArray ints = 7;
-      BooleanArray booleans = 8;
-      NumberArray numbers = 9;
-      GeoCoordinatesFilter geo = 10;
-    };
+  message Single {
+    optional int64 objects_count = 1;
+    optional Aggregations aggregations = 2;
   }
-  optional int64 objects_count = 1;
-  optional Aggregations aggregations = 2;
-  optional GroupedBy grouped_by = 3;
+  message Group {
+    message GroupedBy {
+      // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
+      repeated string path = 1;
+      oneof value {
+        string text = 2;
+        int64 int = 3;
+        bool boolean = 4;
+        double number = 5;
+        TextArray texts = 6;
+        IntArray ints = 7;
+        BooleanArray booleans = 8;
+        NumberArray numbers = 9;
+        GeoCoordinatesFilter geo = 10;
+      };
+    }
+    optional int64 objects_count = 1;
+    optional Aggregations aggregations = 2;
+    optional GroupedBy grouped_by = 3;
+  }
+  message Grouped {
+    repeated Group groups = 1;
+  }
+  float took = 1;
+  oneof result {
+    Single single_result = 2;
+    Grouped grouped_results = 3;
+  };
 }

--- a/test/acceptance/grpc/grpc_aggregate_test.go
+++ b/test/acceptance/grpc/grpc_aggregate_test.go
@@ -222,7 +222,6 @@ func TestGRPC_Aggregate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Result)
-			require.Len(t, resp.GetSingleResult(), 1)
 			require.NotNil(t, resp.GetSingleResult().Aggregations)
 			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
 			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {

--- a/test/acceptance/grpc/grpc_aggregate_test.go
+++ b/test/acceptance/grpc/grpc_aggregate_test.go
@@ -55,9 +55,8 @@ func TestGRPC_Aggregate(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.NotNil(t, resp)
-				require.NotNil(t, resp.Result)
-				require.Len(t, resp.Result.Groups, 1)
-				require.Equal(t, tt.count, resp.Result.Groups[0].GetObjectsCount())
+				require.NotNil(t, resp.GetSingleResult())
+				require.Equal(t, tt.count, resp.GetSingleResult().GetObjectsCount())
 			})
 		}
 	})
@@ -83,11 +82,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 1)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.NotNil(t, resp.GetSingleResult())
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				assert.Equal(t, "population", aggregation.Property)
 				numerical := aggregation.GetInt()
 				require.NotNil(t, numerical)
@@ -116,11 +114,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 1)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.NotNil(t, resp.GetSingleResult())
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				assert.Equal(t, "name", aggregation.Property)
 				textAggregation := aggregation.GetText()
 				topOccurrencesResults := map[string]int64{}
@@ -158,11 +155,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 1)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.NotNil(t, resp.GetSingleResult())
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				assert.Equal(t, "isCapital", aggregation.Property)
 				booleanAggregation := aggregation.GetBoolean()
 				assert.Equal(t, int64(5), booleanAggregation.GetCount())
@@ -194,11 +190,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 1)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.NotNil(t, resp.GetSingleResult())
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				assert.Equal(t, "cityRights", aggregation.Property)
 				dateProps := aggregation.GetDate()
 				assert.Equal(t, "1984-07-21T21:34:33.709551616Z", dateProps.GetMaximum())
@@ -227,10 +222,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 1)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.Len(t, resp.GetSingleResult(), 1)
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				assert.Equal(t, "inCountry", aggregation.Property)
 				referenceAggregation := aggregation.GetReference()
 				assert.ElementsMatch(t, referenceAggregation.PointingTo, []string{"Country"})
@@ -261,11 +256,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 1)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.NotNil(t, resp.GetSingleResult())
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 1)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				assert.Equal(t, "inCountry", aggregation.Property)
 				referenceAggregation := aggregation.GetReference()
 				assert.ElementsMatch(t, referenceAggregation.GetPointingTo(), []string{"Country"})
@@ -319,11 +313,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 1)
-			require.NotNil(t, resp.Result.Groups[0].Aggregations)
-			require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 3)
-			for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+			require.NotNil(t, resp.GetSingleResult())
+			require.NotNil(t, resp.GetSingleResult().Aggregations)
+			require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 3)
+			for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 				switch aggregation.Property {
 				case "inCountry":
 					assert.Equal(t, "inCountry", aggregation.Property)
@@ -407,11 +400,11 @@ func TestGRPC_Aggregate(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.NotNil(t, resp.Result)
-			require.Len(t, resp.Result.Groups, 3)
+			require.NotNil(t, resp.GetGroupedResults())
+			require.Len(t, resp.GetGroupedResults().GetGroups(), 3)
 
 			checkProperties := func(t *testing.T,
-				aggregations []*pb.AggregateGroup_Aggregations_Aggregation,
+				aggregations []*pb.AggregateReply_Aggregations_Aggregation,
 				cityRightsCount int64,
 				cityRightsMedian string,
 				nameCount int64,
@@ -447,7 +440,7 @@ func TestGRPC_Aggregate(t *testing.T) {
 					}
 				}
 			}
-			for _, group := range resp.Result.Groups {
+			for _, group := range resp.GetGroupedResults().GetGroups() {
 				assert.ElementsMatch(t, []string{"cityRights"}, group.GroupedBy.Path)
 				require.NotNil(t, group.Aggregations)
 				require.Len(t, group.Aggregations.GetAggregations(), 3)
@@ -586,11 +579,10 @@ func TestGRPC_Aggregate(t *testing.T) {
 				resp, err := grpcClient.Aggregate(ctx, aggregateRequest)
 				require.NoError(t, err)
 				require.NotNil(t, resp)
-				require.NotNil(t, resp.Result)
-				require.Len(t, resp.Result.Groups, 1)
-				require.NotNil(t, resp.Result.Groups[0].Aggregations)
-				require.Len(t, resp.Result.Groups[0].Aggregations.GetAggregations(), 4)
-				for _, aggregation := range resp.Result.Groups[0].Aggregations.GetAggregations() {
+				require.NotNil(t, resp.GetSingleResult())
+				require.NotNil(t, resp.GetSingleResult().Aggregations)
+				require.Len(t, resp.GetSingleResult().Aggregations.GetAggregations(), 4)
+				for _, aggregation := range resp.GetSingleResult().Aggregations.GetAggregations() {
 					switch aggregation.Property {
 					case "inCountry":
 						assert.Equal(t, "inCountry", aggregation.Property)

--- a/test/acceptance/grpc/grpc_test.go
+++ b/test/acceptance/grpc/grpc_test.go
@@ -264,9 +264,8 @@ func TestGRPC(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		require.NotNil(t, resp.Result)
-		require.Len(t, resp.Result.Groups, 1)
-		require.Equal(t, int64(3), resp.Result.Groups[0].GetObjectsCount())
+		require.NotNil(t, resp.GetSingleResult())
+		require.Equal(t, int64(3), resp.GetSingleResult().GetObjectsCount())
 	})
 
 	t.Run("Batch delete", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Previously, the result of an aggregate request would always be returned in the `groups` field of the `AggregateReply` proto even if no group by request was made, e.g. `params.GroupBy == nil`. This change makes this distinction explicit in the gRPC API by using `oneof` between `Single` and `Grouped` messages. By baking this into the API, clients do not have to perform their own custom logic to determine whether it was a group by aggregate request or not. This aspect of business logic is now handled in the gRPC API itself.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
