### PR TITLE
Rename rbacconfig ViewerRootGroups yaml struct tag

### DIFF
--- a/usecases/auth/authorization/rbac/rbacconf/config.go
+++ b/usecases/auth/authorization/rbac/rbacconf/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Enabled          bool     `json:"enabled" yaml:"enabled"`
 	RootUsers        []string `json:"admins" yaml:"admins"`
 	RootGroups       []string `json:"rootGroups" yaml:"rootGroups"`
-	ViewerRootGroups []string `json:"viewerRootGroups" yaml:"rootGroups"`
+	ViewerRootGroups []string `json:"viewerRootGroups" yaml:"viewerRootGroups"`
 }
 
 // Validate admin list config for viability, can be called from the central


### PR DESCRIPTION
### What's being changed:

Duplicate yaml tags for `RootGroups` and `ViewerRootGroups` result in pod start failure:
```
panic: Duplicated key 'rootGroups' in struct rbacconf.Config [recovered]
	panic: Duplicated key 'rootGroups' in struct rbacconf.Config
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
