### PR TITLE
Fix Shard VectorDistanceForQuery for Multivectors

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -374,10 +374,13 @@ func (s *Shard) VectorDistanceForQuery(ctx context.Context, docId uint64, search
 			return nil, fmt.Errorf("index %s not found", target)
 		}
 		var distancer common.QueryVectorDistancer
-		if index.Multivector() {
-			distancer = index.QueryMultiVectorDistancer(searchVectors[j].([][]float32))
-		} else {
-			distancer = index.QueryVectorDistancer(searchVectors[j].([]float32))
+		switch v := searchVectors[j].(type) {
+		case []float32:
+			distancer = index.QueryVectorDistancer(v)
+		case [][]float32:
+			distancer = index.QueryMultiVectorDistancer(v)
+		default:
+			return nil, fmt.Errorf("unsupported vector type: %T", v)
 		}
 		dist, err := distancer.DistanceToNode(docId)
 		if err != nil {


### PR DESCRIPTION
### What's being changed:

We should use the actual type of each of the search vectors to decide which distancer to use instead of using the index's Multivector method to decide (eg to avoid a panic if there is a mismatch).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
