### PR TITLE
chore: pin alpine gcc to 3.21 gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,16 @@
 ###############################################################################
 # Base build image
 FROM golang:1.22-alpine AS build_base
-RUN apk add bash ca-certificates git gcc g++ libc-dev
+
+# Install specific gcc version from Alpine 3.19 repository
+RUN apk add --no-cache \
+    bash \ 
+    libc-dev \
+    git \
+    ca-certificates \
+    gcc=14.2.0-r4 \
+    g++=14.2.0-r4
+
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on
 # Populate the module cache based on the go.{mod,sum} files.


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
