### PR TITLE
doc: remove duplicated blog link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Here are some popular posts:
 - [The ChatGPT Retrieval Plugin - Weaviate as a Long-term Memory Store for Generative AI](https://weaviate.io/blog/weaviate-retrieval-plugin)
 - [Combining LangChain and Weaviate](https://weaviate.io/blog/combining-langchain-and-weaviate)
 - [How to build an Image Search Application with Weaviate](https://weaviate.io/blog/how-to-build-an-image-search-application-with-weaviate)
-- [Cohere Multilingual ML Models with Weaviate](https://weaviate.io/blog/cohere-multilingual-with-weaviate)
 - [Building Multimodal AI in TypeScript](https://weaviate.io/blog/multimodal-search-in-typescript)
 - [Giving Auto-GPT Long-Term Memory with Weaviate](https://weaviate.io/blog/autogpt-and-weaviate)
 


### PR DESCRIPTION
### What's being changed:
Removed duplicate link for the blog post [Cohere Multilingual ML Models with Weaviate](https://weaviate.io/blog/cohere-multilingual-with-weaviate) in project's readme.
Blog link is already specified at [line 126](https://github.com/weaviate/weaviate/blob/35036a8239697ab32a08fb8ebc58c1f76c77b732/README.md?plain=1#L126).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
