### PR TITLE
Remove QEMU for docker builds, use moby/buildkit instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@
 
 ###############################################################################
 # Base build image
-# NOTE using 1.22-alpine3.20 because of error similar to: https://github.com/docker/buildx/issues/2028
-# please update tag when this issue is fixed
-FROM golang:1.22-alpine3.20 AS build_base
+FROM golang:1.22-alpine AS build_base
 RUN apk add bash ca-certificates git gcc g++ libc-dev
 WORKDIR /go/src/github.com/weaviate/weaviate
 ENV GO111MODULE=on

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -8,7 +8,6 @@ function release() {
   DOCKER_REPO=$DOCKER_REPO_WEAVIATE
 
   # for multi-platform build
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   docker buildx create --use
 
   # nightly tag was added to be pushed on merges to main branch, latest tag is used to get latest released version


### PR DESCRIPTION
### What's being changed:

Upgrade QEMU to v8 version in push docker pipelines

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
