### PR TITLE
metrics: Add http server metrics to main api handers in v1.27.x

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -703,7 +703,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	grpcServer := createGrpcServer(appState)
 	setupMiddlewares := makeSetupMiddlewares(appState)
-	setupGlobalMiddleware := makeSetupGlobalMiddleware(appState)
+	setupGlobalMiddleware := makeSetupGlobalMiddleware(appState, api.Context())
 
 	telemeter := telemetry.New(appState.DB, appState.SchemaManager, appState.Logger)
 	if telemetryEnabled(appState) {

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	sentryhttp "github.com/getsentry/sentry-go/http"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
@@ -108,7 +109,7 @@ func makeAddModuleHandlers(modules *modules.Provider) func(http.Handler) http.Ha
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics
 // Contains "x-api-key", "x-api-token" for legacy reasons, older interfaces might need these headers.
-func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Handler {
+func makeSetupGlobalMiddleware(appState *state.State, context *middleware.Context) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		handleCORS := cors.New(cors.Options{
 			OptionsPassthrough: true,
@@ -128,6 +129,16 @@ func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Ha
 		handler = makeAddModuleHandlers(appState.Modules)(handler)
 		handler = addInjectHeadersIntoContext(handler)
 		handler = makeCatchPanics(appState.Logger, newPanicsRequestsTotal(appState.Metrics, appState.Logger))(handler)
+		if appState.ServerConfig.Config.Monitoring.Enabled {
+			handler = monitoring.InstrumentHTTP(
+				handler,
+				context,
+				appState.ServerMetrics.InflightRequests,
+				appState.ServerMetrics.RequestDuration,
+				appState.ServerMetrics.RequestBodySize,
+				appState.ServerMetrics.ResponseBodySize,
+			)
+		}
 		// Must be the last middleware as it might skip the next handler
 		handler = addClusterHandlerMiddleware(handler, appState)
 		if appState.ServerConfig.Config.Sentry.Enabled {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -69,6 +69,7 @@ func FromEnv(config *Config) error {
 		config.Monitoring.Enabled = true
 		config.Monitoring.Tool = "prometheus"
 		config.Monitoring.Port = 2112
+		config.Monitoring.MetricsNamespace = "" // to support backward compabitlity. Metric names won't have prefix by default.
 
 		if entcfg.Enabled(os.Getenv("PROMETHEUS_MONITORING_GROUP_CLASSES")) ||
 			entcfg.Enabled(os.Getenv("PROMETHEUS_MONITORING_GROUP")) {
@@ -81,6 +82,11 @@ func FromEnv(config *Config) error {
 			// not about classes or shards.
 			config.Monitoring.Group = true
 		}
+
+		if val := strings.TrimSpace(os.Getenv("PROMETHEUS_MONITORING_METRIC_NAMESPACE")); val != "" {
+			config.Monitoring.MetricsNamespace = val
+		}
+
 		if entcfg.Enabled(os.Getenv("PROMETHEUS_MONITOR_CRITICAL_BUCKETS_ONLY")) {
 			config.Monitoring.MonitorCriticalBucketsOnly = true
 		}

--- a/usecases/monitoring/http.go
+++ b/usecases/monitoring/http.go
@@ -1,0 +1,118 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type InstrumentHandler struct {
+	inflightRequests *prometheus.GaugeVec
+	duration         *prometheus.HistogramVec
+
+	// in bytes
+	requestSize  *prometheus.HistogramVec
+	responseSize *prometheus.HistogramVec
+
+	// next is original http handler we instrument
+	next http.Handler
+
+	// context is from openapi spec. Used for routing information.
+	// for e.g: to turn dynamic routing `/api/v1/schema/Question/tenant1` to static route `/api/v1/schema/{class}/{tenant}`
+	// This is useful to create bounded cardinality value for "route" label.
+	context *middleware.Context
+}
+
+func InstrumentHTTP(
+	next http.Handler,
+	context *middleware.Context,
+	inflight *prometheus.GaugeVec,
+	duration *prometheus.HistogramVec,
+	requestSize *prometheus.HistogramVec,
+	responseSize *prometheus.HistogramVec,
+) *InstrumentHandler {
+	return &InstrumentHandler{
+		next:             next,
+		context:          context,
+		inflightRequests: inflight,
+		duration:         duration,
+		requestSize:      requestSize,
+		responseSize:     responseSize,
+	}
+}
+
+func (i *InstrumentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	route := r.URL.String()
+	matchedRoute, rr, ok := i.context.RouteInfo(r)
+	if ok {
+		// convert dynamic route to static route.
+		// `/api/v1/schema/Question/tenant1` -> `/api/v1/schema/{class}/{tenant}`
+		route = matchedRoute.PathPattern
+		r = rr
+	}
+
+	method := r.Method
+
+	inflight := i.inflightRequests.WithLabelValues(method, route)
+	inflight.Inc()
+	defer inflight.Dec()
+
+	origBody := r.Body
+	defer func() {
+		// We don't need `countingReadCloser` before this instrument handler
+		r.Body = origBody
+	}()
+
+	cr := &countingReadCloser{
+		r: r.Body,
+	}
+	r.Body = cr
+
+	// This is where we run actual upstream http.Handler
+	respWithMetrics := httpsnoop.CaptureMetricsFn(w, func(rw http.ResponseWriter) {
+		i.next.ServeHTTP(rw, r)
+	})
+
+	i.requestSize.WithLabelValues(method, route).Observe(float64(cr.read))
+	i.responseSize.WithLabelValues(method, route).Observe(float64(respWithMetrics.Written))
+
+	labelValues := []string{
+		method,
+		route,
+		strconv.Itoa(respWithMetrics.Code),
+	}
+
+	i.duration.WithLabelValues(labelValues...).Observe(respWithMetrics.Duration.Seconds())
+}
+
+type countingReadCloser struct {
+	r    io.ReadCloser
+	read int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	if n > 0 {
+		c.read += int64(n)
+	}
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error {
+	return c.r.Close()
+}

--- a/usecases/monitoring/listen.go
+++ b/usecases/monitoring/listen.go
@@ -1,0 +1,54 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"net"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type countingListener struct {
+	net.Listener
+	count prometheus.Gauge
+}
+
+func CountingListener(l net.Listener, g prometheus.Gauge) net.Listener {
+	return &countingListener{Listener: l, count: g}
+}
+
+func (c *countingListener) Accept() (net.Conn, error) {
+	conn, err := c.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	c.count.Inc()
+	return &countingConn{Conn: conn, count: c.count}, nil
+}
+
+type countingConn struct {
+	net.Conn
+	count prometheus.Gauge
+	once  sync.Once
+}
+
+func (c *countingConn) Close() error {
+	err := c.Conn.Close()
+
+	// Client can call `Close()` any number of times on a single connection. Make sure to decrement the counter only once.
+	c.once.Do(func() {
+		c.count.Dec()
+	})
+
+	return err
+}

--- a/usecases/monitoring/listen_test.go
+++ b/usecases/monitoring/listen_test.go
@@ -1,0 +1,87 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeListener struct {
+	net.Listener
+	acceptErr error
+	closeErr  error
+}
+
+type fakeConn struct {
+	net.Conn
+	closeErr error
+}
+
+func (c *fakeConn) Close() error {
+	return c.closeErr
+}
+
+func (c *fakeListener) Accept() (net.Conn, error) {
+	return &fakeConn{closeErr: c.closeErr}, c.acceptErr
+}
+
+func TestCountingListener(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	g := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		Namespace: "test",
+		Name:      "gauge",
+	})
+
+	fake := &fakeListener{}
+	l := CountingListener(fake, g)
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Accepting connections should increment the gauge.
+	c1, err := l.Accept()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(g))
+	c2, err := l.Accept()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(2), testutil.ToFloat64(g))
+
+	// Closing connections should decrement the gauge.
+	assert.NoError(t, c1.Close())
+	assert.Equal(t, float64(1), testutil.ToFloat64(g))
+	assert.NoError(t, c2.Close())
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Duplicate calls to Close should not decrement.
+	assert.NoError(t, c1.Close())
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Accept errors should not cause an increment.
+	fake.acceptErr = errors.New("accept")
+	_, err = l.Accept()
+	assert.Error(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Close errors should still decrement.
+	fake.acceptErr = nil
+	fake.closeErr = errors.New("close")
+	c3, err := l.Accept()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(g))
+	assert.Error(t, c3.Close())
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -26,7 +26,6 @@ type Config struct {
 	MonitorCriticalBucketsOnly bool   `json:"monitor_critical_buckets_only" yaml:"monitor_critical_buckets_only"`
 
 	// Metrics namespace group the metrics with common prefix.
-	// currently used only on ServerMetrics.
 	MetricsNamespace string `json:"metrics_namespace" yaml:"metrics_namespace" long:"metrics_namespace" default:""`
 }
 


### PR DESCRIPTION
### What's being changed:

These are already part of v1.28+. Just backporting it to v1.27.x
<img width="1487" alt="Screenshot 2025-02-04 at 10 14 04" src="https://github.com/user-attachments/assets/991e1449-0832-4e35-8c1d-b8d39dee9f17" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
