### PR TITLE
chore(nearVector): detect vector type based of target vector

### DIFF
--- a/adapters/handlers/grpc/v1/parse_aggregate_request.go
+++ b/adapters/handlers/grpc/v1/parse_aggregate_request.go
@@ -95,7 +95,7 @@ func (p *AggregateParser) Aggregate(req *pb.AggregateRequest) (*aggregation.Para
 	switch search := req.GetSearch().(type) {
 	case *pb.AggregateRequest_NearVector:
 		if nv := search.NearVector; nv != nil {
-			params.NearVector, err = parseNearVec(nv, targetVectors)
+			params.NearVector, err = parseNearVec(nv, targetVectors, class)
 			if err != nil {
 				return nil, fmt.Errorf("parse near vector: %w", err)
 			}
@@ -240,9 +240,14 @@ func (p *AggregateParser) Aggregate(req *pb.AggregateRequest) (*aggregation.Para
 			var vector models.Vector
 			// vectors has precedent for being more efficient
 			if len(hs.Vectors) > 0 {
-				vector, err = extractVector(hs.Vectors)
-				if err != nil {
-					return nil, fmt.Errorf("hybrid: %w", err)
+				switch len(hs.Vectors) {
+				case 1:
+					vector, err = extractVector(hs.Vectors[0])
+					if err != nil {
+						return nil, fmt.Errorf("hybrid: %w", err)
+					}
+				default:
+					return nil, fmt.Errorf("hybrid: only 1 vector supported, found %d vectors", len(hs.Vectors))
 				}
 			} else if len(hs.VectorBytes) > 0 {
 				vector = byteops.Fp32SliceFromBytes(hs.VectorBytes)
@@ -284,7 +289,7 @@ func (p *AggregateParser) Aggregate(req *pb.AggregateRequest) (*aggregation.Para
 			}
 
 			if nearVec != nil {
-				params.Hybrid.NearVectorParams, err = parseNearVec(nearVec, targetVectors)
+				params.Hybrid.NearVectorParams, err = parseNearVec(nearVec, targetVectors, class)
 				if err != nil {
 					return nil, err
 				}

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
@@ -55,7 +56,9 @@ type Parser struct {
 	authorizedGetClass func(string) (*models.Class, error)
 }
 
-func NewParser(uses127Api bool, authorizedGetClass func(string) (*models.Class, error)) *Parser {
+func NewParser(uses127Api bool,
+	authorizedGetClass func(string) (*models.Class, error),
+) *Parser {
 	return &Parser{
 		generative:         generative.NewParser(uses127Api),
 		authorizedGetClass: authorizedGetClass,
@@ -101,7 +104,7 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 	}
 
 	if nv := req.NearVector; nv != nil {
-		out.NearVector, err = parseNearVec(nv, targetVectors)
+		out.NearVector, err = parseNearVec(nv, targetVectors, class)
 		if err != nil {
 			return dto.GetParams{}, err
 		}
@@ -239,9 +242,14 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		var vector models.Vector
 		// vectors has precedent for being more efficient
 		if len(hs.Vectors) > 0 {
-			vector, err = extractVector(hs.Vectors)
-			if err != nil {
-				return dto.GetParams{}, fmt.Errorf("hybrid: %w", err)
+			switch len(hs.Vectors) {
+			case 1:
+				vector, err = extractVector(hs.Vectors[0])
+				if err != nil {
+					return dto.GetParams{}, fmt.Errorf("hybrid: %w", err)
+				}
+			default:
+				return dto.GetParams{}, fmt.Errorf("hybrid: only 1 vector supported, found %d vectors", len(hs.Vectors))
 			}
 		} else if len(hs.VectorBytes) > 0 {
 			vector = byteops.Fp32SliceFromBytes(hs.VectorBytes)
@@ -279,7 +287,7 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		}
 
 		if nearVec != nil {
-			out.HybridSearch.NearVectorParams, err = parseNearVec(nearVec, targetVectors)
+			out.HybridSearch.NearVectorParams, err = parseNearVec(nearVec, targetVectors, class)
 			if err != nil {
 				return dto.GetParams{}, err
 			}
@@ -1140,14 +1148,19 @@ func parseNearIMU(n *pb.NearIMUSearch, targetVectors []string) (*nearImu.NearIMU
 	return out, nil
 }
 
-func parseNearVec(nv *pb.NearVector, targetVectors []string) (*searchparams.NearVector, error) {
+func parseNearVec(nv *pb.NearVector, targetVectors []string, class *models.Class) (*searchparams.NearVector, error) {
 	var vector models.Vector
 	var err error
 	// vectors has precedent for being more efficient
 	if len(nv.Vectors) > 0 {
-		vector, err = extractVector(nv.Vectors)
-		if err != nil {
-			return nil, fmt.Errorf("near_vector: %w", err)
+		switch len(nv.Vectors) {
+		case 1:
+			vector, err = extractVector(nv.Vectors[0])
+			if err != nil {
+				return nil, fmt.Errorf("near_vector: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("near_vector: only 1 vector supported, found %d vectors", len(nv.Vectors))
 		}
 	} else if len(nv.VectorBytes) > 0 {
 		vector = byteops.Fp32SliceFromBytes(nv.VectorBytes)
@@ -1183,7 +1196,7 @@ func parseNearVec(nv *pb.NearVector, targetVectors []string) (*searchparams.Near
 				return nil, fmt.Errorf("near_vector: vector for target %s is required. All target vectors: %v all vectors for targets %v", targetVectorsTmp[i], targetVectorsTmp, allNames)
 			}
 			if len(nv.VectorForTargets[i].Vectors) > 0 {
-				vectors[i], err = extractVector(nv.VectorForTargets[i].Vectors)
+				vectors[i], err = extractVectors(nv.VectorForTargets[i].Vectors)
 				if err != nil {
 					return nil, fmt.Errorf("near_vector: vector for targets: extract vectors[%v]: %w", i, err)
 				}
@@ -1209,6 +1222,44 @@ func parseNearVec(nv *pb.NearVector, targetVectors []string) (*searchparams.Near
 		}
 	} else {
 		return nil, fmt.Errorf("near_vector: vector is required")
+	}
+
+	if len(targetVectors) > 0 {
+		var fixedVectors []models.Vector
+		var fixedTargetVectorNames []string
+		for i, targetVector := range targetVectors {
+			switch vectorsArray := vectors[i].(type) {
+			case [][][]float32:
+				for _, multiVec := range vectorsArray {
+					if isTargetVectorMultiVector(class, targetVector) {
+						fixedVectors = append(fixedVectors, multiVec)
+						fixedTargetVectorNames = append(fixedTargetVectorNames, targetVector)
+					} else {
+						for _, vec := range multiVec {
+							fixedVectors = append(fixedVectors, vec)
+							fixedTargetVectorNames = append(fixedTargetVectorNames, targetVector)
+						}
+					}
+				}
+			case [][]float32:
+				if isTargetVectorMultiVector(class, targetVector) {
+					fixedVectors = append(fixedVectors, vectorsArray)
+					fixedTargetVectorNames = append(fixedTargetVectorNames, targetVector)
+				} else {
+					for _, vec := range vectorsArray {
+						fixedVectors = append(fixedVectors, vec)
+						fixedTargetVectorNames = append(fixedTargetVectorNames, targetVector)
+					}
+				}
+			default:
+				fixedVectors = append(fixedVectors, vectorsArray)
+				fixedTargetVectorNames = append(fixedTargetVectorNames, targetVector)
+			}
+		}
+		return &searchparams.NearVector{
+			Vectors:       fixedVectors,
+			TargetVectors: fixedTargetVectorNames,
+		}, nil
 	}
 
 	return &searchparams.NearVector{
@@ -1252,21 +1303,60 @@ OUTER:
 	}
 }
 
-func extractVector(vectors []*pb.Vectors) (models.Vector, error) {
-	if len(vectors) > 0 {
-		vec := vectors[0]
-		switch vec.Type {
+func extractVectors(vectors []*pb.Vectors) (models.Vector, error) {
+	var vecs [][]float32
+	var multiVecs [][][]float32
+	for i := range vectors {
+		vec, err := extractVector(vectors[i])
+		if err != nil {
+			return nil, fmt.Errorf("vectors[%d]: %w", i, err)
+		}
+		switch v := vec.(type) {
+		case []float32:
+			vecs = append(vecs, v)
+		case [][]float32:
+			multiVecs = append(multiVecs, v)
+		default:
+			// do nothing
+		}
+	}
+	if len(multiVecs) > 0 {
+		return multiVecs, nil
+	}
+	return vecs, nil
+}
+
+func extractVector(vector *pb.Vectors) (models.Vector, error) {
+	if vector != nil {
+		switch vector.Type {
 		case *pb.Vectors_VECTOR_TYPE_UNSPECIFIED.Enum(), *pb.Vectors_VECTOR_TYPE_SINGLE_FP32.Enum():
-			return byteops.Fp32SliceFromBytes(vec.VectorBytes), nil
+			return byteops.Fp32SliceFromBytes(vector.VectorBytes), nil
 		case *pb.Vectors_VECTOR_TYPE_MULTI_FP32.Enum():
-			out, err := byteops.Fp32SliceOfSlicesFromBytes(vec.VectorBytes)
+			out, err := byteops.Fp32SliceOfSlicesFromBytes(vector.VectorBytes)
 			if err != nil {
 				return nil, fmt.Errorf("extract vector: %w", err)
 			}
 			return out, nil
 		default:
-			return nil, fmt.Errorf("cannot extract vector: unknown vector type: %T", vec.Type)
+			return nil, fmt.Errorf("cannot extract vector: unknown vector type: %T", vector.Type)
 		}
 	}
 	return nil, fmt.Errorf("cannot extract vector: empty vectors")
+}
+
+func isTargetVectorMultiVector(class *models.Class, targetVector string) bool {
+	switch targetVector {
+	case "":
+		if vc, ok := class.VectorIndexConfig.(schemaConfig.VectorIndexConfig); ok {
+			return vc.IsMultiVector()
+		}
+		return false
+	default:
+		if vectorConfig, ok := class.VectorConfig[targetVector]; ok {
+			if vc, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig); ok {
+				return vc.IsMultiVector()
+			}
+		}
+		return false
+	}
 }

--- a/test/acceptance/grpc/grpc_search_test.go
+++ b/test/acceptance/grpc/grpc_search_test.go
@@ -1,0 +1,446 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/planets"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+func TestGRPCSearch(t *testing.T) {
+	ctx := context.Background()
+
+	host := "localhost:8080"
+	helper.SetupClient(host)
+
+	grpcClient, _ := newClient(t)
+	require.NotNil(t, grpcClient)
+
+	// Define class
+	className := "PlanetsMultiVectorSearch"
+	class := planets.BaseClass(className)
+	class.VectorConfig = map[string]models.VectorConfig{
+		"colbert": {
+			Vectorizer: map[string]interface{}{
+				"none": map[string]interface{}{},
+			},
+			VectorIndexConfig: map[string]interface{}{
+				"multivector": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			VectorIndexType: "hnsw",
+		},
+		"regular": {
+			Vectorizer: map[string]interface{}{
+				"none": map[string]interface{}{},
+			},
+			VectorIndexType: "hnsw",
+		},
+		"description": {
+			Vectorizer: map[string]interface{}{
+				"text2vec-contextionary": map[string]interface{}{
+					"properties":         []interface{}{"description"},
+					"vectorizeClassName": false,
+				},
+			},
+			VectorIndexType: "flat",
+		},
+	}
+
+	colbertVectors := [][][]float32{
+		{{0.11, 0.12}, {0.13, 0.14}, {0.15, 0.16}},
+		{{0.21, 0.22}, {0.23, 0.24}, {0.25, 0.26}},
+	}
+
+	regularVectors := [][]float32{
+		{0.11, 0.12, 0.13},
+		{0.14, 0.15, 0.16},
+	}
+
+	helper.CreateClass(t, class)
+	defer helper.DeleteClass(t, class.Class)
+
+	t.Run("insert data", func(t *testing.T) {
+		for i, planet := range planets.Planets {
+			obj := &models.Object{
+				Class: className,
+				ID:    planet.ID,
+				Properties: map[string]interface{}{
+					"name":        planet.Name,
+					"description": planet.Description,
+				},
+				Vectors: models.Vectors{
+					"colbert": colbertVectors[i],
+					"regular": regularVectors[i],
+				},
+			}
+			helper.CreateObject(t, obj)
+			helper.AssertGetObjectEventually(t, obj.Class, obj.ID)
+		}
+	})
+	t.Run("vector search", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			nearVector *protocol.NearVector
+		}{
+			{
+				name: "legacy vector",
+				nearVector: &protocol.NearVector{
+					Vector: regularVectors[0],
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular"},
+					},
+				},
+			},
+			{
+				name: "legacy vector bytes",
+				nearVector: &protocol.NearVector{
+					VectorBytes: byteops.Fp32SliceToBytes(regularVectors[0]),
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular"},
+					},
+				},
+			},
+			{
+				name: "colbert vector",
+				nearVector: &protocol.NearVector{
+					Vectors: []*protocol.Vectors{
+						{
+							Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+							VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[0]),
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"colbert"},
+					},
+				},
+			},
+			{
+				name: "regular",
+				nearVector: &protocol.NearVector{
+					Vectors: []*protocol.Vectors{
+						{
+							Type:        protocol.Vectors_VECTOR_TYPE_SINGLE_FP32,
+							VectorBytes: byteops.Fp32SliceToBytes(regularVectors[0]),
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular"},
+					},
+				},
+			},
+			{
+				name: "regular unspecified",
+				nearVector: &protocol.NearVector{
+					Vectors: []*protocol.Vectors{
+						{
+							VectorBytes: byteops.Fp32SliceToBytes(regularVectors[0]),
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular"},
+					},
+				},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+					Collection:  class.Class,
+					NearVector:  tt.nearVector,
+					Uses_123Api: true,
+					Uses_125Api: true,
+					Uses_127Api: true,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Len(t, resp.Results, 2)
+			})
+		}
+	})
+
+	t.Run("multi vector search", func(t *testing.T) {
+		t.Run("regular vectors with proper type", func(t *testing.T) {
+			tests := []struct {
+				name       string
+				vectorType protocol.Vectors_VectorType
+			}{
+				{
+					name:       "unspecified",
+					vectorType: protocol.Vectors_VECTOR_TYPE_UNSPECIFIED,
+				},
+				{
+					name:       "single_fp32",
+					vectorType: protocol.Vectors_VECTOR_TYPE_UNSPECIFIED,
+				},
+			}
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+						Collection: class.Class,
+						NearVector: &protocol.NearVector{
+							VectorForTargets: []*protocol.VectorForTarget{
+								{
+									Name: "regular",
+									Vectors: []*protocol.Vectors{
+										{
+											Type:        tt.vectorType,
+											VectorBytes: byteops.Fp32SliceToBytes(regularVectors[0]),
+										},
+										{
+											Type:        tt.vectorType,
+											VectorBytes: byteops.Fp32SliceToBytes(regularVectors[1]),
+										},
+									},
+								},
+							},
+							Targets: &protocol.Targets{
+								TargetVectors: []string{"regular"},
+							},
+						},
+						Uses_123Api: true,
+						Uses_125Api: true,
+						Uses_127Api: true,
+					})
+					require.NoError(t, err)
+					require.NotNil(t, resp)
+					assert.Len(t, resp.Results, 2)
+				})
+			}
+		})
+		t.Run("only 1", func(t *testing.T) {
+			t.Run("regular vector", func(t *testing.T) {
+				resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+					Collection: class.Class,
+					NearVector: &protocol.NearVector{
+						VectorForTargets: []*protocol.VectorForTarget{
+							{
+								Name: "regular",
+								Vectors: []*protocol.Vectors{
+									{
+										Type:        protocol.Vectors_VECTOR_TYPE_SINGLE_FP32,
+										VectorBytes: byteops.Fp32SliceToBytes(regularVectors[0]),
+									},
+								},
+							},
+						},
+						Targets: &protocol.Targets{
+							TargetVectors: []string{"regular"},
+						},
+					},
+					Uses_123Api: true,
+					Uses_125Api: true,
+					Uses_127Api: true,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Len(t, resp.Results, 2)
+			})
+			t.Run("colbert vector", func(t *testing.T) {
+				resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+					Collection: class.Class,
+					NearVector: &protocol.NearVector{
+						VectorForTargets: []*protocol.VectorForTarget{
+							{
+								Name: "colbert",
+								Vectors: []*protocol.Vectors{
+									{
+										Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+										VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[0]),
+									},
+								},
+							},
+						},
+						Targets: &protocol.Targets{
+							TargetVectors: []string{"colbert"},
+						},
+					},
+					Uses_123Api: true,
+					Uses_125Api: true,
+					Uses_127Api: true,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Len(t, resp.Results, 2)
+			})
+		})
+		t.Run("regular vectors", func(t *testing.T) {
+			resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+				Collection: class.Class,
+				NearVector: &protocol.NearVector{
+					VectorForTargets: []*protocol.VectorForTarget{
+						{
+							Name: "regular",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(regularVectors),
+								},
+							},
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular"},
+					},
+				},
+				Uses_123Api: true,
+				Uses_125Api: true,
+				Uses_127Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Len(t, resp.Results, 2)
+		})
+		t.Run("colbert vectors", func(t *testing.T) {
+			resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+				Collection: class.Class,
+				NearVector: &protocol.NearVector{
+					VectorForTargets: []*protocol.VectorForTarget{
+						{
+							Name: "colbert",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[0]),
+								},
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[1]),
+								},
+							},
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"colbert"},
+					},
+				},
+				Uses_123Api: true,
+				Uses_125Api: true,
+				Uses_127Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Len(t, resp.Results, 2)
+		})
+		t.Run("regular and colbert vectors", func(t *testing.T) {
+			resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+				Collection: class.Class,
+				NearVector: &protocol.NearVector{
+					VectorForTargets: []*protocol.VectorForTarget{
+						{
+							Name: "regular",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(regularVectors),
+								},
+							},
+						},
+						{
+							Name: "colbert",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[0]),
+								},
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[1]),
+								},
+							},
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular", "colbert"},
+					},
+				},
+				Uses_123Api: true,
+				Uses_125Api: true,
+				Uses_127Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Len(t, resp.Results, 2)
+		})
+		t.Run("regular and colbert and description vectors", func(t *testing.T) {
+			descriptionVectors := make([][]float32, len(planets.Planets))
+			for i, planet := range planets.Planets {
+				t.Run(planet.ID.String(), func(t *testing.T) {
+					obj, err := helper.GetObject(t, class.Class, planet.ID, "vector")
+					require.NoError(t, err)
+					require.NotNil(t, obj)
+					require.Len(t, obj.Vectors, 3)
+					require.IsType(t, []float32{}, obj.Vectors["description"])
+					assert.True(t, len(obj.Vectors["description"].([]float32)) > 0)
+					descriptionVectors[i] = obj.Vectors["description"].([]float32)
+				})
+			}
+			require.Len(t, descriptionVectors, 2)
+			resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
+				Collection: class.Class,
+				NearVector: &protocol.NearVector{
+					VectorForTargets: []*protocol.VectorForTarget{
+						{
+							Name: "regular",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(regularVectors),
+								},
+							},
+						},
+						{
+							Name: "colbert",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[0]),
+								},
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(colbertVectors[1]),
+								},
+							},
+						},
+						{
+							Name: "description",
+							Vectors: []*protocol.Vectors{
+								{
+									Type:        protocol.Vectors_VECTOR_TYPE_MULTI_FP32,
+									VectorBytes: byteops.Fp32SliceOfSlicesToBytes(descriptionVectors),
+								},
+							},
+						},
+					},
+					Targets: &protocol.Targets{
+						TargetVectors: []string{"regular", "colbert", "description"},
+					},
+				},
+				Uses_123Api: true,
+				Uses_125Api: true,
+				Uses_127Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Len(t, resp.Results, 2)
+		})
+	})
+}


### PR DESCRIPTION
### What's being changed:

chore(nearVector): detect vector type based of target vector

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
