### PR TITLE
fix: close allowlist after using; pv:mergeDocIDs if single child

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -138,7 +138,7 @@ func (pv *propValuePair) mergeDocIDs() (*docBitmap, error) {
 	case 0:
 		return nil, fmt.Errorf("no children for operator: %s", pv.operator.Name())
 	case 1:
-		return &pv.children[0].docIDs, nil
+		return pv.children[0].mergeDocIDs()
 	}
 
 	var err error

--- a/adapters/repos/db/inverted/prop_value_pairs_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_test.go
@@ -22,67 +22,67 @@ import (
 )
 
 func TestPropValuePairs_Merging(t *testing.T) {
+	type testCase struct {
+		name string
+
+		bitmaps  []*sroar.Bitmap
+		operator filters.Operator
+
+		expectedIds []uint64
+	}
+
+	testCases := []testCase{
+		{
+			name: "AND; different sets",
+
+			bitmaps: []*sroar.Bitmap{
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+				roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
+				roaringset.NewBitmap(1, 3, 5, 7, 9),
+			},
+			operator: filters.OperatorAnd,
+
+			expectedIds: []uint64{7, 9},
+		},
+		{
+			name: "OR; different sets",
+
+			bitmaps: []*sroar.Bitmap{
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+				roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
+				roaringset.NewBitmap(1, 3, 5, 7, 9),
+			},
+			operator: filters.OperatorOr,
+
+			expectedIds: []uint64{1, 3, 5, 7, 8, 9, 10, 11},
+		},
+		{
+			name: "AND; same sets",
+
+			bitmaps: []*sroar.Bitmap{
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+			},
+			operator: filters.OperatorAnd,
+
+			expectedIds: []uint64{7, 8, 9, 10, 11},
+		},
+		{
+			name: "OR; same sets",
+
+			bitmaps: []*sroar.Bitmap{
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+				roaringset.NewBitmap(7, 8, 9, 10, 11),
+			},
+			operator: filters.OperatorOr,
+
+			expectedIds: []uint64{7, 8, 9, 10, 11},
+		},
+	}
+
 	t.Run("reuses one of underlying bitmaps", func(t *testing.T) {
-		type testCase struct {
-			name string
-
-			bitmaps  []*sroar.Bitmap
-			operator filters.Operator
-
-			expectedIds []uint64
-		}
-
-		testCases := []testCase{
-			{
-				name: "AND; different sets",
-
-				bitmaps: []*sroar.Bitmap{
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-					roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
-					roaringset.NewBitmap(1, 3, 5, 7, 9),
-				},
-				operator: filters.OperatorAnd,
-
-				expectedIds: []uint64{7, 9},
-			},
-			{
-				name: "OR; different sets",
-
-				bitmaps: []*sroar.Bitmap{
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-					roaringset.NewBitmap(1, 3, 5, 7, 9, 11),
-					roaringset.NewBitmap(1, 3, 5, 7, 9),
-				},
-				operator: filters.OperatorOr,
-
-				expectedIds: []uint64{1, 3, 5, 7, 8, 9, 10, 11},
-			},
-			{
-				name: "AND; same sets",
-
-				bitmaps: []*sroar.Bitmap{
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-				},
-				operator: filters.OperatorAnd,
-
-				expectedIds: []uint64{7, 8, 9, 10, 11},
-			},
-			{
-				name: "OR; same sets",
-
-				bitmaps: []*sroar.Bitmap{
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-					roaringset.NewBitmap(7, 8, 9, 10, 11),
-				},
-				operator: filters.OperatorOr,
-
-				expectedIds: []uint64{7, 8, 9, 10, 11},
-			},
-		}
-
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				pv := &propValuePair{
@@ -111,6 +111,44 @@ func TestPropValuePairs_Merging(t *testing.T) {
 					}
 				}
 				assert.Equal(t, 1, sameCounter)
+			})
+		}
+	})
+
+	t.Run("merges multilevel pairs with single child", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				operatorOpposite := filters.OperatorAnd
+				if tc.operator == filters.OperatorAnd {
+					operatorOpposite = filters.OperatorOr
+				}
+
+				pv3 := &propValuePair{
+					operator: tc.operator,
+					children: make([]*propValuePair, len(tc.bitmaps)),
+				}
+				for i := range tc.bitmaps {
+					pv3.children[i] = &propValuePair{
+						operator: filters.OperatorEqual,
+						docIDs: docBitmap{
+							docIDs:  tc.bitmaps[i],
+							release: noopRelease,
+						},
+					}
+				}
+				pv2 := &propValuePair{
+					operator: tc.operator,
+					children: []*propValuePair{pv3},
+				}
+				pv1 := &propValuePair{
+					operator: operatorOpposite,
+					children: []*propValuePair{pv2},
+				}
+
+				dbm, err := pv1.mergeDocIDs()
+
+				require.Nil(t, err)
+				assert.ElementsMatch(t, tc.expectedIds, dbm.IDs())
 			})
 		}
 	})

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -426,10 +426,6 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors [][]float3
 			dists []float32
 		)
 		eg.Go(func() error {
-			if allowList != nil {
-				defer allowList.Close()
-			}
-
 			queue, err := s.getIndexQueue(targetVector)
 			if err != nil {
 				return err
@@ -471,6 +467,9 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors [][]float3
 
 	if err := eg.Wait(); err != nil {
 		return nil, nil, err
+	}
+	if allowList != nil {
+		defer allowList.Close()
 	}
 
 	idsCombined, distCombined, err := CombineMultiTargetResults(ctx, s, s.index.logger, idss, distss, targetVectors, searchVectors, targetCombination, limit, targetDist)


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
