### PR TITLE
feat(rbac): filter based authz for READ ALL (schema, tenants, roles, getObjects)

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/helpers_for_test.go
+++ b/adapters/handlers/graphql/local/aggregate/helpers_for_test.go
@@ -40,6 +40,10 @@ func (m *mockAuthorizer) AuthorizeSilent(principal *models.Principal, action str
 	return nil
 }
 
+func (m *mockAuthorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	return resources, nil
+}
+
 func newMockResolver(cfg config.Config) *mockResolver {
 	field, err := Build(&testhelper.CarSchema, cfg, nil, &mockAuthorizer{})
 	if err != nil {

--- a/adapters/handlers/graphql/local/explore/concepts_resolver.go
+++ b/adapters/handlers/graphql/local/explore/concepts_resolver.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/tailor-inc/graphql"
 	"github.com/tailor-inc/graphql/language/ast"
+
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	restCtx "github.com/weaviate/weaviate/adapters/handlers/rest/context"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -80,6 +81,7 @@ func (r *resolver) resolve(p graphql.ResolveParams) (interface{}, error) {
 func (r *resolver) resolveExplore(p graphql.ResolveParams) (interface{}, error) {
 	principal := restCtx.GetPrincipalFromContext(p.Context)
 
+	// TODO-RBAC: filter response instead of gating it
 	err := r.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsData()...)
 	if err != nil {
 		return nil, err

--- a/adapters/handlers/graphql/local/explore/concepts_resolver.go
+++ b/adapters/handlers/graphql/local/explore/concepts_resolver.go
@@ -81,7 +81,6 @@ func (r *resolver) resolve(p graphql.ResolveParams) (interface{}, error) {
 func (r *resolver) resolveExplore(p graphql.ResolveParams) (interface{}, error) {
 	principal := restCtx.GetPrincipalFromContext(p.Context)
 
-	// TODO-RBAC: filter response instead of gating it
 	err := r.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsData()...)
 	if err != nil {
 		return nil, err

--- a/adapters/handlers/graphql/local/explore/helpers_for_test.go
+++ b/adapters/handlers/graphql/local/explore/helpers_for_test.go
@@ -50,6 +50,10 @@ func (a *fakeAuthorizer) AuthorizeSilent(principal *models.Principal, verb strin
 	return nil
 }
 
+func (a *fakeAuthorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	return resources, nil
+}
+
 func getFakeAuthorizer() authorization.Authorizer {
 	return &fakeAuthorizer{}
 }

--- a/adapters/handlers/graphql/local/get/helper_test.go
+++ b/adapters/handlers/graphql/local/get/helper_test.go
@@ -639,6 +639,10 @@ func (f *fakeAuthorizer) AuthorizeSilent(principal *models.Principal, action str
 	return nil
 }
 
+func (f *fakeAuthorizer) FilterAuthorizedResources(principal *models.Principal, action string, resources ...string) ([]string, error) {
+	return resources, nil
+}
+
 func getFakeAuthorizer() authorization.Authorizer {
 	return &fakeAuthorizer{}
 }

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
@@ -281,17 +282,12 @@ func (h *authZHandlers) hasPermission(params authz.HasPermissionParams, principa
 }
 
 func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.Principal) middleware.Responder {
-	if err := h.authorizeRoleScopes(principal, authorization.READ, nil, ""); err != nil {
-		return authz.NewGetRolesForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
-	}
-
 	roles, err := h.controller.GetRoles()
 	if err != nil {
 		return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
 	var response []*models.Role
-
 	for roleName, policies := range roles {
 		if roleName == authorization.Root && !slices.Contains(h.rbacconfig.RootUsers, principal.Username) {
 			continue
@@ -306,7 +302,30 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 			Permissions: perms,
 		})
 	}
-	sortByName(response)
+
+	// Filter roles based on authorization
+	resourceFilter := filter.New[*models.Role](h.authorizer, config.Config{Authorization: config.Authorization{Rbac: h.rbacconfig}})
+	filteredRoles := resourceFilter.Filter(
+		principal,
+		response,
+		authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_ALL),
+		func(role *models.Role) []string {
+			return authorization.Roles(*role.Name)
+		},
+	)
+	if len(filteredRoles) == 0 {
+		// try match if all was none
+		filteredRoles = resourceFilter.Filter(
+			principal,
+			response,
+			authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH),
+			func(role *models.Role) []string {
+				return authorization.Roles(*role.Name)
+			},
+		)
+	}
+
+	sortByName(filteredRoles)
 
 	h.logger.WithFields(logrus.Fields{
 		"action":    "read_all_roles",
@@ -314,7 +333,7 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 		"user":      principal.Username,
 	}).Info("roles requested")
 
-	return authz.NewGetRolesOK().WithPayload(response)
+	return authz.NewGetRolesOK().WithPayload(filteredRoles)
 }
 
 func (h *authZHandlers) getRole(params authz.GetRoleParams, principal *models.Principal) middleware.Responder {

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -306,6 +306,7 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 	// Filter roles based on authorization
 	resourceFilter := filter.New[*models.Role](h.authorizer, config.Config{Authorization: config.Authorization{Rbac: h.rbacconfig}})
 	filteredRoles := resourceFilter.Filter(
+		h.logger,
 		principal,
 		response,
 		authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_ALL),
@@ -316,6 +317,7 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 	if len(filteredRoles) == 0 {
 		// try match if all was none
 		filteredRoles = resourceFilter.Filter(
+			h.logger,
 			principal,
 			response,
 			authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH),

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -309,8 +309,8 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 		principal,
 		response,
 		authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_ALL),
-		func(role *models.Role) []string {
-			return authorization.Roles(*role.Name)
+		func(role *models.Role) string {
+			return authorization.Roles(*role.Name)[0]
 		},
 	)
 	if len(filteredRoles) == 0 {
@@ -319,8 +319,8 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 			principal,
 			response,
 			authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH),
-			func(role *models.Role) []string {
-				return authorization.Roles(*role.Name)
+			func(role *models.Role) string {
+				return authorization.Roles(*role.Name)[0]
 			},
 		)
 	}

--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -60,7 +60,7 @@ func setupGraphQLHandlers(
 	api.GraphqlGraphqlPostHandler = graphql.GraphqlPostHandlerFunc(func(params graphql.GraphqlPostParams, principal *models.Principal) middleware.Responder {
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
 		// authorization requirements.
-
+		// TODO-RBAC: filter response instead of gating it
 		err := m.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata()...)
 		if err != nil {
 			metricRequestsTotal.logUserError()
@@ -156,6 +156,7 @@ func setupGraphQLHandlers(
 
 	api.GraphqlGraphqlBatchHandler = graphql.GraphqlBatchHandlerFunc(func(params graphql.GraphqlBatchParams, principal *models.Principal) middleware.Responder {
 		// this is barely used (if at all) - so require read access to all collections for data and metadata
+		// TODO-RBAC: filter response instead of gating it
 		err := m.Authorizer.Authorize(principal, authorization.READ, authorization.Collections()...)
 		if err != nil {
 			return graphql.NewGraphqlBatchForbidden().WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -60,7 +60,6 @@ func setupGraphQLHandlers(
 	api.GraphqlGraphqlPostHandler = graphql.GraphqlPostHandlerFunc(func(params graphql.GraphqlPostParams, principal *models.Principal) middleware.Responder {
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
 		// authorization requirements.
-		// TODO-RBAC: filter response instead of gating it
 		err := m.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata()...)
 		if err != nil {
 			metricRequestsTotal.logUserError()
@@ -156,7 +155,6 @@ func setupGraphQLHandlers(
 
 	api.GraphqlGraphqlBatchHandler = graphql.GraphqlBatchHandlerFunc(func(params graphql.GraphqlBatchParams, principal *models.Principal) middleware.Responder {
 		// this is barely used (if at all) - so require read access to all collections for data and metadata
-		// TODO-RBAC: filter response instead of gating it
 		err := m.Authorizer.Authorize(principal, authorization.READ, authorization.Collections()...)
 		if err != nil {
 			return graphql.NewGraphqlBatchForbidden().WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -457,3 +457,7 @@ func (f *fakeAuthorizer) Authorize(_ *models.Principal, _ string, _ ...string) e
 func (f *fakeAuthorizer) AuthorizeSilent(_ *models.Principal, _ string, _ ...string) error {
 	return nil
 }
+
+func (f *fakeAuthorizer) FilterAuthorizedResources(_ *models.Principal, _ string, resources ...string) ([]string, error) {
+	return resources, nil
+}

--- a/modules/text2vec-contextionary/helpers_test.go
+++ b/modules/text2vec-contextionary/helpers_test.go
@@ -333,6 +333,10 @@ func (f *fakeAuthorizer) AuthorizeSilent(principal *models.Principal, action str
 	return nil
 }
 
+func (a *fakeAuthorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	return resources, nil
+}
+
 func getFakeAuthorizer() *fakeAuthorizer {
 	return &fakeAuthorizer{}
 }

--- a/test/acceptance/authz/adminlist_test.go
+++ b/test/acceptance/authz/adminlist_test.go
@@ -80,5 +80,5 @@ func TestAdminlistWithRBACEndpoints(t *testing.T) {
 
 	// if you are not admin or readonly you also cannot do anything
 	_, err = helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), helper.CreateAuth(customKey))
-	require.Error(t, err)
+	require.NoError(t, err)
 }

--- a/test/acceptance/authz/adminlist_test.go
+++ b/test/acceptance/authz/adminlist_test.go
@@ -13,11 +13,11 @@ package authz
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/client/authz"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/docker"
@@ -73,11 +73,7 @@ func TestAdminlistWithRBACEndpoints(t *testing.T) {
 
 	// as read only user you can cannot do anything
 	_, err = helper.Client(t).Authz.GetRoles(authz.NewGetRolesParams(), helper.CreateAuth(readonlyKey))
-	require.Error(t, err)
-	var parsed *authz.GetRolesForbidden
-	if !errors.As(err, &parsed) {
-		helper.AssertRequestOk(t, nil, err, nil)
-	}
+	require.NoError(t, err)
 
 	_, err = helper.Client(t).Authz.CreateRole(authz.NewCreateRoleParams().WithBody(testRole), helper.CreateAuth(readonlyKey))
 	require.Error(t, err)

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -927,6 +927,7 @@ func TestAuthzRoleFilteredTenantPermissions(t *testing.T) {
 
 	filteredRole := "filtered-role"
 	className := "FilteredTenantTestClass"
+	className2 := "FilteredTenantTestClass2"
 	allowedTenant := "tenant1"
 	restrictedTenant := "tenant2"
 
@@ -944,12 +945,19 @@ func TestAuthzRoleFilteredTenantPermissions(t *testing.T) {
 				Enabled: true,
 			},
 		}, "admin-key")
+		helper.CreateClassAuth(t, &models.Class{
+			Class: className2,
+			MultiTenancyConfig: &models.MultiTenancyConfig{
+				Enabled: true,
+			},
+		}, "admin-key")
 
 		tenants := []*models.Tenant{
 			{Name: allowedTenant, ActivityStatus: models.TenantActivityStatusHOT},
 			{Name: restrictedTenant, ActivityStatus: models.TenantActivityStatusHOT},
 		}
 		helper.CreateTenantsAuth(t, className, tenants, "admin-key")
+		helper.CreateTenantsAuth(t, className2, tenants, "admin-key")
 	})
 
 	defer func() {

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -915,3 +915,72 @@ func TestAuthzRoleScopeMatching(t *testing.T) {
 		)
 	})
 }
+
+func TestAuthzRoleFilteredTenantPermissions(t *testing.T) {
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	adminAuth := helper.CreateAuth(adminKey)
+
+	limitedUser := "custom-user"
+	limitedKey := "custom-key"
+	limitedAuth := helper.CreateAuth(limitedKey)
+
+	filteredRole := "filtered-role"
+	className := "FilteredTenantTestClass"
+	allowedTenant := "tenant1"
+	restrictedTenant := "tenant2"
+
+	_, down := composeUp(t,
+		map[string]string{adminUser: adminKey},
+		map[string]string{limitedUser: limitedKey},
+		nil,
+	)
+	defer down()
+
+	t.Run("setup collection with tenants", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{
+			Class: className,
+			MultiTenancyConfig: &models.MultiTenancyConfig{
+				Enabled: true,
+			},
+		}, "admin-key")
+
+		tenants := []*models.Tenant{
+			{Name: allowedTenant, ActivityStatus: models.TenantActivityStatusHOT},
+			{Name: restrictedTenant, ActivityStatus: models.TenantActivityStatusHOT},
+		}
+		helper.CreateTenantsAuth(t, className, tenants, "admin-key")
+	})
+
+	defer func() {
+		helper.DeleteClassWithAuthz(t, className, adminAuth)
+	}()
+
+	t.Run("create filtered role", func(t *testing.T) {
+		_, err := helper.Client(t).Authz.CreateRole(
+			authz.NewCreateRoleParams().WithBody(&models.Role{
+				Name: &filteredRole,
+				Permissions: []*models.Permission{
+					{
+						Action: String(authorization.ReadTenants),
+						Tenants: &models.PermissionTenants{
+							Collection: String(className),
+							Tenant:     String(allowedTenant),
+						},
+					},
+				},
+			}),
+			adminAuth,
+		)
+		require.NoError(t, err)
+
+		helper.AssignRoleToUser(t, adminKey, filteredRole, limitedUser)
+	})
+
+	t.Run("verify filtered tenant permissions", func(t *testing.T) {
+		tenants, err := helper.GetTenantsWithAuthz(t, className, limitedAuth)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(tenants.Payload))
+		require.Equal(t, allowedTenant, tenants.Payload[0].Name)
+	})
+}

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/go-openapi/runtime"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 
@@ -71,6 +70,14 @@ func GetClass(t *testing.T, class string) *models.Class {
 	resp, err := Client(t).Schema.SchemaObjectsGet(params, nil)
 	AssertRequestOk(t, resp, err, nil)
 	return resp.Payload
+}
+
+func GetSchemaAuth(t *testing.T, class string, authInfo runtime.ClientAuthInfoWriter) []*models.Class {
+	t.Helper()
+	params := schema.NewSchemaDumpParams()
+	resp, err := Client(t).Schema.SchemaDump(params, authInfo)
+	AssertRequestOk(t, resp, err, nil)
+	return resp.Payload.Classes
 }
 
 func GetClassWithoutAssert(t *testing.T, class string) (*models.Class, error) {
@@ -365,6 +372,12 @@ func GetTenants(t *testing.T, class string) (*schema.TenantsGetOK, error) {
 	t.Helper()
 	params := schema.NewTenantsGetParams().WithClassName(class)
 	resp, err := Client(t).Schema.TenantsGet(params, nil)
+	return resp, err
+}
+func GetTenantsWithAuthz(t *testing.T, class string, authInfo runtime.ClientAuthInfoWriter) (*schema.TenantsGetOK, error) {
+	t.Helper()
+	params := schema.NewTenantsGetParams().WithClassName(class)
+	resp, err := Client(t).Schema.TenantsGet(params, authInfo)
 	return resp, err
 }
 

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -374,6 +374,7 @@ func GetTenants(t *testing.T, class string) (*schema.TenantsGetOK, error) {
 	resp, err := Client(t).Schema.TenantsGet(params, nil)
 	return resp, err
 }
+
 func GetTenantsWithAuthz(t *testing.T, class string, authInfo runtime.ClientAuthInfoWriter) (*schema.TenantsGetOK, error) {
 	t.Helper()
 	params := schema.NewTenantsGetParams().WithClassName(class)

--- a/usecases/auth/authorization/adminlist/authorizer.go
+++ b/usecases/auth/authorization/adminlist/authorizer.go
@@ -73,6 +73,14 @@ func (a *Authorizer) AuthorizeSilent(principal *models.Principal, verb string, r
 	return a.Authorize(principal, verb, resources...)
 }
 
+func (a *Authorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	if err := a.Authorize(principal, verb, resources...); err != nil {
+		return nil, err
+	}
+
+	return resources, nil
+}
+
 func (a *Authorizer) addAdminUserList(users []string) {
 	// build a map for more efficient lookup on long lists
 	if a.adminUsers == nil {

--- a/usecases/auth/authorization/authorizer.go
+++ b/usecases/auth/authorization/authorizer.go
@@ -22,6 +22,9 @@ type Authorizer interface {
 	Authorize(principal *models.Principal, verb string, resources ...string) error
 	// AuthorizeSilent Silent authorization without audit logs
 	AuthorizeSilent(principal *models.Principal, verb string, resources ...string) error
+	// FilterAuthorizedResources authorize the passed resources with best effort approach, it will return
+	// list of allowed resources, if none, it will return an empty slice
+	FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error)
 }
 
 // DummyAuthorizer is a pluggable Authorizer which can be used if no specific
@@ -37,4 +40,8 @@ func (d *DummyAuthorizer) Authorize(principal *models.Principal, verb string, re
 
 func (d *DummyAuthorizer) AuthorizeSilent(principal *models.Principal, verb string, resources ...string) error {
 	return nil
+}
+
+func (d *DummyAuthorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	return resources, nil
 }

--- a/usecases/auth/authorization/filter/filter.go
+++ b/usecases/auth/authorization/filter/filter.go
@@ -1,0 +1,52 @@
+package filter
+
+import (
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// ResourceFilter handles filtering resources based on authorization
+type ResourceFilter[T any] struct {
+	authorizer authorization.Authorizer
+	config     config.Config
+}
+
+func New[T any](authorizer authorization.Authorizer, config config.Config) *ResourceFilter[T] {
+	return &ResourceFilter[T]{
+		authorizer: authorizer,
+		config:     config,
+	}
+}
+
+// FilterFn defines a function that generates authorization resources for an item
+type FilterFn[T any] func(item T) []string
+
+// Filter filters a slice of items based on authorization
+func (f *ResourceFilter[T]) Filter(
+	principal *models.Principal,
+	items []T,
+	verb string,
+	resourceFn FilterFn[T],
+) []T {
+	if !f.config.Authorization.Rbac.Enabled {
+		if len(items) == 0 {
+			return items
+		}
+		// here it's either you have the permissions or not so 1 check is enough
+		if err := f.authorizer.Authorize(principal, verb, resourceFn(items[0])...); err != nil {
+			return nil
+		}
+		return items
+	}
+
+	// For RBAC, filter based on per-item authorization
+	filtered := make([]T, 0, len(items))
+	for _, item := range items {
+		// TODO-RBAC: we need non silent authorizer with best effort enforcer
+		if err := f.authorizer.Authorize(principal, verb, resourceFn(item)...); err == nil {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}

--- a/usecases/auth/authorization/filter/filter.go
+++ b/usecases/auth/authorization/filter/filter.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package filter
 
 import (

--- a/usecases/auth/authorization/filter/filter.go
+++ b/usecases/auth/authorization/filter/filter.go
@@ -12,6 +12,10 @@
 package filter
 
 import (
+	"slices"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -35,6 +39,7 @@ type FilterFn[T any] func(item T) string
 
 // Filter filters a slice of items based on authorization
 func (f *ResourceFilter[T]) Filter(
+	logger logrus.FieldLogger,
 	principal *models.Principal,
 	items []T,
 	verb string,
@@ -46,18 +51,69 @@ func (f *ResourceFilter[T]) Filter(
 		}
 		// here it's either you have the permissions or not so 1 check is enough
 		if err := f.authorizer.Authorize(principal, verb, resourceFn(items[0])); err != nil {
+			logger.WithFields(logrus.Fields{
+				"username":  principal.Username,
+				"verb":      verb,
+				"resources": items,
+			}).Error(err)
 			return nil
 		}
 		return items
 	}
 
+	// For RBAC, first check if all items have the same parent resource
+	firstResource := resourceFn(items[0])
+	allSameParent := true
+
+	for i := 1; i < len(items); i++ {
+		if authorization.WildcardPath(resourceFn(items[i])) != authorization.WildcardPath(firstResource) {
+			allSameParent = false
+		}
+	}
+
+	// If all items have the same parent, we can do a single authorization check
+	if allSameParent {
+		err := f.authorizer.Authorize(principal, verb, authorization.WildcardPath(firstResource))
+		if err != nil {
+			logger.WithFields(logrus.Fields{
+				"username": principal.Username,
+				"verb":     verb,
+				"resource": authorization.WildcardPath(firstResource),
+			}).Error(err)
+		}
+
+		if err == nil {
+			// user is authorized
+			return items
+		}
+	}
+
 	// For RBAC, filter based on per-item authorization
 	filtered := make([]T, 0, len(items))
+	resources := make([]string, 0, len(items))
 	for _, item := range items {
-		// TODO-RBAC: we need non silent authorizer with best effort enforcer
-		if err := f.authorizer.Authorize(principal, verb, resourceFn(item)); err == nil {
+		resources = append(resources, resourceFn(item))
+	}
+
+	allowedList, err := f.authorizer.FilterAuthorizedResources(principal, verb, resources...)
+	if err != nil {
+		logger.WithFields(logrus.Fields{
+			"username":  principal.Username,
+			"verb":      verb,
+			"resources": resources,
+		}).Error(err)
+	}
+
+	if len(allowedList) == len(resources) {
+		// has permissions to all
+		return items
+	}
+
+	for _, item := range items {
+		if slices.Contains(allowedList, resourceFn(item)) {
 			filtered = append(filtered, item)
 		}
 	}
+
 	return filtered
 }

--- a/usecases/auth/authorization/filter/filter.go
+++ b/usecases/auth/authorization/filter/filter.go
@@ -31,7 +31,7 @@ func New[T any](authorizer authorization.Authorizer, config config.Config) *Reso
 }
 
 // FilterFn defines a function that generates authorization resources for an item
-type FilterFn[T any] func(item T) []string
+type FilterFn[T any] func(item T) string
 
 // Filter filters a slice of items based on authorization
 func (f *ResourceFilter[T]) Filter(
@@ -45,7 +45,7 @@ func (f *ResourceFilter[T]) Filter(
 			return items
 		}
 		// here it's either you have the permissions or not so 1 check is enough
-		if err := f.authorizer.Authorize(principal, verb, resourceFn(items[0])...); err != nil {
+		if err := f.authorizer.Authorize(principal, verb, resourceFn(items[0])); err != nil {
 			return nil
 		}
 		return items
@@ -55,7 +55,7 @@ func (f *ResourceFilter[T]) Filter(
 	filtered := make([]T, 0, len(items))
 	for _, item := range items {
 		// TODO-RBAC: we need non silent authorizer with best effort enforcer
-		if err := f.authorizer.Authorize(principal, verb, resourceFn(item)...); err == nil {
+		if err := f.authorizer.Authorize(principal, verb, resourceFn(item)); err == nil {
 			filtered = append(filtered, item)
 		}
 	}

--- a/usecases/auth/authorization/mocks/AuthorizerMock.go
+++ b/usecases/auth/authorization/mocks/AuthorizerMock.go
@@ -72,6 +72,43 @@ func (_m *Authorizer) AuthorizeSilent(principal *models.Principal, verb string, 
 	return r0
 }
 
+// FilterAuthorizedResources provides a mock function with given fields: principal, verb, resources
+func (_m *Authorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	_va := make([]interface{}, len(resources))
+	for _i := range resources {
+		_va[_i] = resources[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, principal, verb)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FilterAuthorizedResources")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*models.Principal, string, ...string) ([]string, error)); ok {
+		return rf(principal, verb, resources...)
+	}
+	if rf, ok := ret.Get(0).(func(*models.Principal, string, ...string) []string); ok {
+		r0 = rf(principal, verb, resources...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*models.Principal, string, ...string) error); ok {
+		r1 = rf(principal, verb, resources...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewAuthorizer creates a new instance of Authorizer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewAuthorizer(t interface {

--- a/usecases/auth/authorization/mocks/authorizer.go
+++ b/usecases/auth/authorization/mocks/authorizer.go
@@ -47,6 +47,13 @@ func (a *FakeAuthorizer) AuthorizeSilent(principal *models.Principal, verb strin
 	return a.Authorize(principal, verb, resources...)
 }
 
+func (a *FakeAuthorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	if err := a.Authorize(principal, verb, resources...); err != nil {
+		return nil, err
+	}
+	return resources, nil
+}
+
 func (a *FakeAuthorizer) Calls() []AuthZReq {
 	return a.requests
 }

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -27,6 +27,10 @@ func (m *manager) authorize(principal *models.Principal, verb string, skipAudit 
 		return errors.NewUnauthenticated()
 	}
 
+	if len(resources) == 0 {
+		return fmt.Errorf("at least 1 resource is required")
+	}
+
 	logger := m.logger.WithFields(logrus.Fields{
 		"action":         "authorize",
 		"user":           principal.Username,
@@ -34,8 +38,11 @@ func (m *manager) authorize(principal *models.Principal, verb string, skipAudit 
 		"request_action": verb,
 	})
 	if len(principal.Groups) > 0 {
-		logger.WithFields(logrus.Fields{"groups": principal.Groups})
+		logger = logger.WithField("groups", principal.Groups)
 	}
+
+	// Create a slice to store all permission results
+	permResults := make([]logrus.Fields, 0, len(resources))
 
 	for _, resource := range resources {
 		allowed, err := m.checkPermissions(principal, resource, verb)
@@ -51,19 +58,26 @@ func (m *manager) authorize(principal *models.Principal, verb string, skipAudit 
 			return err
 		}
 
-		logger.WithFields(logrus.Fields{
-			"resources": prettyPermissionsResources(perm),
-			"results":   prettyStatus(allowed),
-		})
-
-		if !skipAudit {
-			logger.Info()
+		if allowed {
+			permResults = append(permResults, logrus.Fields{
+				"resource": prettyPermissionsResources(perm),
+				"results":  prettyStatus(allowed),
+			})
 		}
 
 		if !allowed {
+			if !skipAudit {
+				logger.WithField("permissions", permResults).Error("authorization denied")
+			}
 			return fmt.Errorf("rbac: %w", errors.NewForbidden(principal, prettyPermissionsActions(perm), prettyPermissionsResources(perm)))
 		}
 	}
+
+	// Log all results at once if audit is enabled
+	if !skipAudit {
+		logger.WithField("permissions", permResults).Info()
+	}
+
 	return nil
 }
 
@@ -76,4 +90,54 @@ func (m *manager) Authorize(principal *models.Principal, verb string, resources 
 // to be used internally
 func (m *manager) AuthorizeSilent(principal *models.Principal, verb string, resources ...string) error {
 	return m.authorize(principal, verb, true, resources...)
+}
+
+// FilterAuthorizedResources authorize the passed resources with best effort approach, it will return
+// list of allowed resources, if none, it will return an empty slice
+func (m *manager) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	if principal == nil {
+		return nil, errors.NewUnauthenticated()
+	}
+
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("at least 1 resource is required")
+	}
+
+	logger := m.logger.WithFields(logrus.Fields{
+		"action":         "authorize",
+		"user":           principal.Username,
+		"component":      authorization.ComponentName,
+		"request_action": verb,
+	})
+
+	if len(principal.Groups) > 0 {
+		logger = logger.WithField("groups", principal.Groups)
+	}
+
+	permResults := make([]logrus.Fields, 0, len(resources))
+	allowedResources := make([]string, 0, len(resources))
+
+	for _, resource := range resources {
+		allowed, err := m.checkPermissions(principal, resource, verb)
+		if err != nil {
+			logger.WithError(err).WithField("resource", resource).Error("failed to enforce policy")
+			return nil, err
+		}
+
+		if allowed {
+			perm, err := conv.PathToPermission(verb, resource)
+			if err != nil {
+				return nil, err
+			}
+
+			permResults = append(permResults, logrus.Fields{
+				"resource": prettyPermissionsResources(perm),
+				"results":  prettyStatus(allowed),
+			})
+			allowedResources = append(allowedResources, resource)
+		}
+	}
+
+	logger.WithField("permissions", permResults).Info()
+	return allowedResources, nil
 }

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -12,6 +12,7 @@
 package rbac
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,65 +25,438 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+	authzErrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
 )
 
-func TestAuthorization(t *testing.T) {
-	t.Run("audit logging behavior", func(t *testing.T) {
-		// Setup
-		logger, hook := test.NewNullLogger()
-		m, err := setupTestManager(t, logger)
-		require.NoError(t, err)
-
-		principal := &models.Principal{
-			Username: "test-user",
-		}
-
-		// Add a test policy
-		_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", "*", "*")
-		require.NoError(t, err)
-
-		_, err = m.casbin.AddRoleForUser(conv.PrefixUserName("test-user"), conv.PrefixRoleName("admin"))
-		require.NoError(t, err)
-
-		tests := []struct {
-			name           string
-			authFunc       func() error
-			expectLogEntry bool
-		}{
-			{
-				name: "regular authorize should produce audit logs",
-				authFunc: func() error {
-					return m.Authorize(principal, authorization.READ, authorization.CollectionsMetadata()...)
-				},
-				expectLogEntry: true,
+func TestAuthorize(t *testing.T) {
+	tests := []struct {
+		name          string
+		principal     *models.Principal
+		verb          string
+		resources     []string
+		skipAudit     bool
+		setupPolicies func(*manager) error
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name:      "nil principal returns unauthenticated error",
+			principal: nil,
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test"),
+			wantErr:   true,
+		},
+		{
+			name: "empty resources returns error",
+			principal: &models.Principal{
+				Username: "test-user",
+				Groups:   []string{},
 			},
-			{
-				name: "silent authorize should not produce audit logs",
-				authFunc: func() error {
-					return m.AuthorizeSilent(principal, authorization.READ, authorization.CollectionsMetadata()...)
-				},
-				expectLogEntry: false,
+			verb:        authorization.READ,
+			resources:   []string{},
+			wantErr:     true,
+			errContains: "at least 1 resource is required",
+		},
+		{
+			name: "authorized user with correct permissions",
+			principal: &models.Principal{
+				Username: "admin-user",
+				Groups:   []string{"admin-group"},
 			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				hook.Reset()
-				require.NoError(t, tt.authFunc())
-
-				hasAuditLog := false
-				for _, entry := range hook.AllEntries() {
-					if entry.Data["action"] == "authorize" {
-						hasAuditLog = true
-						break
-					}
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1", "Test2"),
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", authorization.SchemaDomain, authorization.READ)
+				if err != nil {
+					return err
 				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("admin-user"),
+					conv.PrefixRoleName("admin"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+		},
+		{
+			name: "unauthorized user returns forbidden error",
+			principal: &models.Principal{
+				Username: "regular-user",
+				Groups:   []string{},
+			},
+			verb:        authorization.UPDATE,
+			resources:   authorization.CollectionsMetadata("Test1"),
+			wantErr:     true,
+			errContains: "forbidden",
+		},
+		{
+			name: "partial authorization fails completely",
+			principal: &models.Principal{
+				Username: "partial-user",
+				Groups:   []string{},
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1", "Test2"),
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("partial"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("partial-user"),
+					conv.PrefixRoleName("partial"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantErr:     true,
+			errContains: "Test2",
+		},
+		{
+			name: "group-based authorization",
+			principal: &models.Principal{
+				Username: "group-user",
+				Groups:   []string{"authorized-group"},
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1"),
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("group-role"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixGroupName("authorized-group"),
+					conv.PrefixRoleName("group-role"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for group")
+				}
+				return nil
+			},
+		},
+		{
+			name: "audit logging can be skipped",
+			principal: &models.Principal{
+				Username: "audit-test-user",
+				Groups:   []string{},
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1"),
+			skipAudit: true,
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("audit-role"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("audit-test-user"),
+					conv.PrefixRoleName("audit-role"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+		},
+	}
 
-				assert.Equal(t, tt.expectLogEntry, hasAuditLog, "unexpected audit log behavior")
-			})
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup logger with hook for testing
+			logger, hook := test.NewNullLogger()
+			m, err := setupTestManager(t, logger)
+			require.NoError(t, err)
+
+			// Setup policies if needed
+			if tt.setupPolicies != nil {
+				err := tt.setupPolicies(m)
+				require.NoError(t, err)
+			}
+
+			// Execute
+			err = m.authorize(tt.principal, tt.verb, tt.skipAudit, tt.resources...)
+
+			// Assert error conditions
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify logging behavior
+			if !tt.skipAudit {
+				require.NotEmpty(t, hook.AllEntries())
+				lastEntry := hook.LastEntry()
+				require.NotNil(t, lastEntry)
+
+				// Verify log fields
+				assert.Equal(t, "authorize", lastEntry.Data["action"])
+				assert.Equal(t, tt.principal.Username, lastEntry.Data["user"])
+				assert.Equal(t, authorization.ComponentName, lastEntry.Data["component"])
+				assert.Equal(t, tt.verb, lastEntry.Data["request_action"])
+
+				if len(tt.principal.Groups) > 0 {
+					assert.Contains(t, lastEntry.Data, "groups")
+					assert.ElementsMatch(t, tt.principal.Groups, lastEntry.Data["groups"])
+				}
+			} else {
+				// Verify no info logs when audit is skipped
+				for _, entry := range hook.AllEntries() {
+					assert.NotEqual(t, logrus.InfoLevel, entry.Level)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterAuthorizedResources(t *testing.T) {
+	tests := []struct {
+		name          string
+		principal     *models.Principal
+		verb          string
+		resources     []string
+		setupPolicies func(*manager) error
+		wantResources []string
+		wantErr       bool
+		errType       error
+	}{
+		{
+			name:      "nil principal returns unauthenticated error",
+			principal: nil,
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test"),
+			wantErr:   true,
+			errType:   authzErrors.Unauthenticated{},
+		},
+		{
+			name: "wildcard permission allows all resources",
+			principal: &models.Principal{
+				Username: "admin-user",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1", "Test2"),
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"),
+					"*", authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("admin-user"),
+					conv.PrefixRoleName("admin"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantResources: authorization.CollectionsMetadata("Test1", "Test2"),
+		},
+		{
+			name: "specific permission allows only matching resource",
+			principal: &models.Principal{
+				Username: "limited-user",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1", "Test2"),
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("limited"),
+					authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("limited-user"),
+					conv.PrefixRoleName("limited"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantResources: authorization.CollectionsMetadata("Test1"),
+		},
+		{
+			name: "no permissions returns empty list",
+			principal: &models.Principal{
+				Username: "no-perm-user",
+			},
+			verb:          authorization.READ,
+			resources:     authorization.CollectionsMetadata("Test1", "Test2"),
+			wantResources: []string{},
+		},
+		{
+			name: "wildcard collection permission allows all collections",
+			principal: &models.Principal{
+				Username: "collections-admin",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1", "Test2"),
+			setupPolicies: func(m *manager) error {
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("collections-admin"),
+					authorization.CollectionsMetadata()[0], authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("collections-admin"),
+					conv.PrefixRoleName("collections-admin"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantResources: authorization.CollectionsMetadata("Test1", "Test2"),
+		},
+		{
+			name: "empty resources list returns empty result",
+			principal: &models.Principal{
+				Username: "test-user",
+			},
+			verb:          authorization.READ,
+			resources:     []string{},
+			wantResources: []string{},
+			wantErr:       true,
+			errType:       fmt.Errorf("at least 1 resource is required"),
+		},
+		{
+			name: "user with multiple roles",
+			principal: &models.Principal{
+				Username: "multi-role-user",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("Test1", "Test2", "Test3"),
+			setupPolicies: func(m *manager) error {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("role1"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+					return err
+				}
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("role2"), authorization.CollectionsMetadata("Test2")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+					return err
+				}
+				if ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("multi-role-user"), conv.PrefixRoleName("role1")); err != nil {
+					return err
+				} else if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				if ok, err := m.casbin.AddRoleForUser(conv.PrefixUserName("multi-role-user"), conv.PrefixRoleName("role2")); err != nil {
+					return err
+				} else if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantResources: authorization.CollectionsMetadata("Test1", "Test2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			logger, _ := test.NewNullLogger()
+			m, err := setupTestManager(t, logger)
+			require.NoError(t, err)
+
+			// Setup policies if needed
+			if tt.setupPolicies != nil {
+				err := tt.setupPolicies(m)
+				require.NoError(t, err)
+			}
+
+			// Execute
+			got, err := m.FilterAuthorizedResources(tt.principal, tt.verb, tt.resources...)
+
+			// Assert
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.wantResources, got)
+		})
+	}
+}
+
+func TestFilterAuthorizedResourcesLogging(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	m, err := setupTestManager(t, logger)
+	require.NoError(t, err)
+
+	principal := &models.Principal{
+		Username: "test-user",
+		Groups:   []string{"group1"},
+	}
+
+	testResources := authorization.CollectionsMetadata("Test1", "Test2")
+
+	// Setup a policy
+	_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", "*", authorization.RolesDomain)
+	require.NoError(t, err)
+	_, err = m.casbin.AddRoleForUser(conv.PrefixUserName("test-user"), conv.PrefixRoleName("admin"))
+	require.NoError(t, err)
+
+	// Call the function
+	allowedResources, err := m.FilterAuthorizedResources(principal, authorization.READ, testResources...)
+	require.NoError(t, err)
+
+	// Verify logging
+	require.NotEmpty(t, hook.AllEntries())
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+
+	// Check the permissions array exists and has the correct structure
+	permissions, ok := entry.Data["permissions"].([]logrus.Fields)
+	require.True(t, ok, "permissions should be []logrus.Fields")
+	require.NotEmpty(t, permissions, "permissions should not be empty")
+
+	// Check that we have entries for both resources
+	require.Len(t, permissions, 2, "Should have permissions entries for both resources")
+
+	// Check the first permission entry
+	firstPerm := permissions[0]
+	assert.Contains(t, firstPerm, "resource", "First permission entry should contain resource field")
+	assert.Contains(t, firstPerm, "results", "First permission entry should contain results field")
+	assert.Equal(t, "Collection: Test1", firstPerm["resource"])
+	assert.Equal(t, "success", firstPerm["results"])
+
+	// Check the second permission entry
+	secondPerm := permissions[1]
+	assert.Contains(t, secondPerm, "resource", "Second permission entry should contain resource field")
+	assert.Contains(t, secondPerm, "results", "Second permission entry should contain results field")
+	assert.Equal(t, "Collection: Test2", secondPerm["resource"])
+	assert.Equal(t, "success", secondPerm["results"])
+
+	// Check other required fields
+	assert.Equal(t, "authorize", entry.Data["action"])
+	assert.Equal(t, principal.Username, entry.Data["user"])
+	assert.Equal(t, principal.Groups, entry.Data["groups"])
+	assert.Equal(t, authorization.ComponentName, entry.Data["component"])
+	assert.Equal(t, authorization.READ, entry.Data["request_action"])
+
+	// Verify the final result matches the logged permissions
+	assert.ElementsMatch(t, testResources, allowedResources,
+		"Allowed resources should match input resources")
 }
 
 func setupTestManager(t *testing.T, logger *logrus.Logger) (*manager, error) {

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -408,6 +408,14 @@ func Backups(classes ...string) []string {
 	return resources
 }
 
+// WildcardPath returns the appropriate wildcard path based on the domain and original resource path.
+// The domain is expected to be the first part of the resource path.
+func WildcardPath(resource string) string {
+	parts := strings.Split(resource, "/")
+	parts[len(parts)-1] = "*"
+	return strings.Join(parts, "/")
+}
+
 func String(s string) *string {
 	return &s
 }

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -193,3 +193,74 @@ func TestTenants(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWildcardPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		expected string
+	}{
+		// Data domain tests
+		{
+			name:     "data domain full path",
+			resource: "data/collections/Class1/shards/Tenant1/objects/123",
+			expected: "data/collections/Class1/shards/Tenant1/objects/*",
+		},
+		{
+			name:     "data domain incomplete path",
+			resource: "data/collections/Class1/shards/Tenant1",
+			expected: "data/collections/Class1/shards/*",
+		},
+
+		// Schema domain tests
+		{
+			name:     "schema domain full path",
+			resource: "schema/collections/Class1/shards/Tenant1",
+			expected: "schema/collections/Class1/shards/*",
+		},
+		{
+			name:     "schema domain full path",
+			resource: "schema/collections/Class1/shards/Tenant1",
+			expected: "schema/collections/Class1/shards/*",
+		},
+		{
+			name:     "schema domain incomplete path",
+			resource: "schema/collections/Class1",
+			expected: "schema/collections/*",
+		},
+
+		// Backups domain tests
+		{
+			name:     "backups domain full path",
+			resource: "backups/collections/Class1",
+			expected: "backups/collections/*",
+		},
+		{
+			name:     "backups domain incomplete path",
+			resource: "backups/collections",
+			expected: "backups/*",
+		},
+
+		// Users domain tests
+		{
+			name:     "users domain",
+			resource: "users/user1",
+			expected: "users/*",
+		},
+
+		// Roles domain tests
+		{
+			name:     "roles domain",
+			resource: "roles/role1",
+			expected: "roles/*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WildcardPath(tt.resource)
+			assert.Equal(t, tt.expected, result, "WildcardPath(%q) = %q, want %q",
+				tt.resource, result, tt.expected)
+		})
+	}
+}

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	cmocks "github.com/weaviate/weaviate/entities/modulecapabilities/mocks"

--- a/usecases/objects/auto_schema_test.go
+++ b/usecases/objects/auto_schema_test.go
@@ -1700,3 +1700,7 @@ func (f fakeAuthorizer) Authorize(_ *models.Principal, _ string, _ ...string) er
 func (f fakeAuthorizer) AuthorizeSilent(_ *models.Principal, _ string, _ ...string) error {
 	return nil
 }
+
+func (f fakeAuthorizer) FilterAuthorizedResources(principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	return resources, nil
+}

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -81,6 +81,7 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	// Filter objects based on authorization
 	resourceFilter := filter.New[*models.Object](m.authorizer, m.config.Config)
 	filteredObjects := resourceFilter.Filter(
+		m.logger,
 		principal,
 		objects,
 		authorization.READ,

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 )
 
 // GetObject Class from the connected DB
@@ -63,11 +64,6 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	offset *int64, limit *int64, sort *string, order *string, after *string,
 	addl additional.Properties, tenant string,
 ) ([]*models.Object, error) {
-	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects("", tenant, ""))
-	if err != nil {
-		return nil, err
-	}
-
 	unlock, err := m.locks.LockConnector()
 	if err != nil {
 		return nil, NewErrInternal("could not acquire lock: %v", err)
@@ -76,17 +72,29 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 
 	m.metrics.GetObjectInc()
 	defer m.metrics.GetObjectDec()
-	return m.getObjectsFromRepo(ctx, offset, limit, sort, order, after, addl, tenant)
+
+	objects, err := m.getObjectsFromRepo(ctx, offset, limit, sort, order, after, addl, tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter objects based on authorization
+	resourceFilter := filter.New[*models.Object](m.authorizer, m.config.Config)
+	filteredObjects := resourceFilter.Filter(
+		principal,
+		objects,
+		authorization.READ,
+		func(obj *models.Object) []string {
+			return []string{authorization.Objects(obj.Class, tenant, obj.ID)}
+		},
+	)
+
+	return filteredObjects, nil
 }
 
 func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Principal,
 	id strfmt.UUID,
 ) (*models.Class, error) {
-	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects("", "", id))
-	if err != nil {
-		return nil, err
-	}
-
 	unlock, err := m.locks.LockConnector()
 	if err != nil {
 		return nil, NewErrInternal("could not acquire lock: %v", err)
@@ -98,6 +106,20 @@ func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Princip
 	res, err := m.getObjectFromRepo(ctx, "", id, additional.Properties{}, nil, "")
 	if err != nil {
 		return nil, err
+	}
+
+	resourceFilter := filter.New[*models.Object](m.authorizer, m.config.Config)
+	filteredObjects := resourceFilter.Filter(
+		principal,
+		[]*models.Object{res.Object()},
+		authorization.READ,
+		func(obj *models.Object) []string {
+			return []string{authorization.Objects(obj.Class, obj.Tenant, obj.ID)}
+		},
+	)
+
+	if len(filteredObjects) == 0 {
+		return nil, NewErrNotFound("no object with id '%s' or unauthorized", id)
 	}
 
 	class, err := m.schemaManager.GetClass(ctx, principal, res.ClassName)

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -108,20 +108,6 @@ func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Princip
 		return nil, err
 	}
 
-	resourceFilter := filter.New[*models.Object](m.authorizer, m.config.Config)
-	filteredObjects := resourceFilter.Filter(
-		principal,
-		[]*models.Object{res.Object()},
-		authorization.READ,
-		func(obj *models.Object) string {
-			return authorization.Objects(obj.Class, obj.Tenant, obj.ID)
-		},
-	)
-
-	if len(filteredObjects) == 0 {
-		return nil, NewErrNotFound("no object with id '%s' or unauthorized", id)
-	}
-
 	class, err := m.schemaManager.GetClass(ctx, principal, res.ClassName)
 	return class, err
 }

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -84,8 +84,8 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 		principal,
 		objects,
 		authorization.READ,
-		func(obj *models.Object) []string {
-			return []string{authorization.Objects(obj.Class, tenant, obj.ID)}
+		func(obj *models.Object) string {
+			return authorization.Objects(obj.Class, tenant, obj.ID)
 		},
 	)
 
@@ -113,8 +113,8 @@ func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Princip
 		principal,
 		[]*models.Object{res.Object()},
 		authorization.READ,
-		func(obj *models.Object) []string {
-			return []string{authorization.Objects(obj.Class, obj.Tenant, obj.ID)}
+		func(obj *models.Object) string {
+			return authorization.Objects(obj.Class, obj.Tenant, obj.ID)
 		},
 	)
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -91,10 +91,8 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 		},
 	)
 	if len(filteredQuery) == 0 {
-		return nil, &Error{
-			"unauthorized to access any collection", StatusForbidden,
-			fmt.Errorf("unauthorized to access collection %s", q.Class),
-		}
+		err = fmt.Errorf("unauthorized to access collection %s", q.Class)
+		return nil, &Error{err.Error(), StatusForbidden, err}
 	}
 
 	res, rerr := m.vectorRepo.Query(ctx, filteredQuery[0])

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -13,11 +13,13 @@ package objects
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 )
 
 type QueryInput struct {
@@ -66,15 +68,6 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
-	class := "*"
-
-	if params != nil && params.Class != "" {
-		class = params.Class
-	}
-
-	if err := m.authorizer.Authorize(principal, authorization.READ, authorization.CollectionsData(class)...); err != nil {
-		return nil, &Error{err.Error(), StatusForbidden, err}
-	}
 	unlock, err := m.locks.LockConnector()
 	if err != nil {
 		return nil, &Error{"cannot lock", StatusInternalServerError, err}
@@ -88,7 +81,21 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	if err != nil {
 		return nil, &Error{"offset or limit", StatusBadRequest, err}
 	}
-	res, rerr := m.vectorRepo.Query(ctx, q)
+
+	filteredQuery := filter.New[*QueryInput](m.authorizer, m.config.Config).Filter(
+		principal,
+		[]*QueryInput{q},
+		authorization.READ,
+		func(qi *QueryInput) []string {
+			return authorization.CollectionsData(qi.Class)
+		},
+	)
+	if len(filteredQuery) == 0 {
+		return nil, &Error{"unauthorized to access any collection", StatusForbidden,
+			fmt.Errorf("unauthorized to access collection %s", q.Class)}
+	}
+
+	res, rerr := m.vectorRepo.Query(ctx, filteredQuery[0])
 	if rerr != nil {
 		return nil, rerr
 	}

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -86,8 +86,8 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 		principal,
 		[]*QueryInput{q},
 		authorization.READ,
-		func(qi *QueryInput) []string {
-			return authorization.CollectionsData(qi.Class)
+		func(qi *QueryInput) string {
+			return authorization.CollectionsData(qi.Class)[0]
 		},
 	)
 	if len(filteredQuery) == 0 {

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -83,6 +83,7 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	}
 
 	filteredQuery := filter.New[*QueryInput](m.authorizer, m.config.Config).Filter(
+		m.logger,
 		principal,
 		[]*QueryInput{q},
 		authorization.READ,

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -91,8 +91,10 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 		},
 	)
 	if len(filteredQuery) == 0 {
-		return nil, &Error{"unauthorized to access any collection", StatusForbidden,
-			fmt.Errorf("unauthorized to access collection %s", q.Class)}
+		return nil, &Error{
+			"unauthorized to access any collection", StatusForbidden,
+			fmt.Errorf("unauthorized to access collection %s", q.Class),
+		}
 	}
 
 	res, rerr := m.vectorRepo.Query(ctx, filteredQuery[0])

--- a/usecases/objects/query_test.go
+++ b/usecases/objects/query_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -148,7 +149,9 @@ func TestQuery(t *testing.T) {
 				m.metrics.On("AddUsageDimensions", cls, "get_rest", "list_include_vector",
 					tc.mockedDBResponse[0].Dims)
 			}
-			res, err := m.Manager.Query(context.Background(), nil, &tc.param)
+			res, err := m.Manager.Query(context.Background(), &models.Principal{
+				Username: "testuser",
+			}, &tc.param)
 			code := 0
 			if err != nil {
 				code = err.Code

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
@@ -37,17 +38,6 @@ func Test_Schema_Authorization(t *testing.T) {
 	}
 
 	tests := []testCase{
-		{
-			methodName:        "GetSchema",
-			expectedVerb:      authorization.READ,
-			expectedResources: authorization.CollectionsMetadata(),
-		},
-		{
-			methodName:        "GetConsistentSchema",
-			expectedVerb:      authorization.READ,
-			additionalArgs:    []interface{}{false},
-			expectedResources: authorization.CollectionsMetadata(),
-		},
 		{
 			methodName:        "GetClass",
 			additionalArgs:    []interface{}{"classname"},
@@ -129,12 +119,6 @@ func Test_Schema_Authorization(t *testing.T) {
 			expectedResources: authorization.ShardsMetadata("className", "P1"),
 		},
 		{
-			methodName:        "GetConsistentTenants",
-			additionalArgs:    []interface{}{"className", false, []string{}},
-			expectedVerb:      authorization.READ,
-			expectedResources: authorization.ShardsMetadata("className"),
-		},
-		{
 			methodName:        "ConsistentTenantExists",
 			additionalArgs:    []interface{}{"className", false, "P1"},
 			expectedVerb:      authorization.READ,
@@ -159,7 +143,9 @@ func Test_Schema_Authorization(t *testing.T) {
 				"StartServing", "Shutdown", "Statistics",
 				// Cluster/nodes related endpoint
 				"JoinNode", "RemoveNode", "Nodes", "NodeName", "ClusterHealthScore", "ClusterStatus", "ResolveParentNodes",
-				// revert to schema v0 (non raft)
+				// revert to schema v0 (non raft),
+				"GetConsistentSchema", "GetConsistentTenants",
+				// ignored because it will check if schema has collections otherwise returns nothing
 				"StoreSchemaV1":
 				// don't require auth on methods which are exported because other
 				// packages need to call them for maintenance and other regular jobs,

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/backup"
@@ -33,17 +34,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 	shardingConfig "github.com/weaviate/weaviate/usecases/sharding/config"
 )
-
-func Test_GetSchema(t *testing.T) {
-	t.Parallel()
-	handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
-	fakeSchemaManager.On("ReadOnlySchema").Return(models.Schema{})
-
-	sch, err := handler.GetSchema(nil)
-	assert.Nil(t, err)
-	assert.NotNil(t, sch)
-	fakeSchemaManager.AssertExpectations(t)
-}
 
 func Test_AddClass(t *testing.T) {
 	t.Parallel()

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -190,8 +190,8 @@ func (h *Handler) GetConsistentSchema(principal *models.Principal, consistency b
 		principal,
 		fullSchema.Objects.Classes,
 		authorization.READ,
-		func(class *models.Class) []string {
-			return authorization.CollectionsMetadata(class.Class)
+		func(class *models.Class) string {
+			return authorization.CollectionsMetadata(class.Class)[0]
 		},
 	)
 

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -187,6 +187,7 @@ func (h *Handler) GetConsistentSchema(principal *models.Principal, consistency b
 	}
 
 	filteredClasses := filter.New[*models.Class](h.Authorizer, h.config).Filter(
+		h.logger,
 		principal,
 		fullSchema.Objects.Classes,
 		authorization.READ,

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -133,7 +133,6 @@ type Handler struct {
 	scaleOut                scaleOut
 	parser                  Parser
 	classGetter             *ClassGetter
-	authFilter              *filter.ResourceFilter[*models.Class]
 }
 
 // NewHandler creates a new handler
@@ -149,7 +148,6 @@ func NewHandler(
 	cloud modulecapabilities.OffloadCloud,
 	parser Parser, classGetter *ClassGetter,
 ) (Handler, error) {
-	authFilter := filter.New[*models.Class](authorizer, config)
 	handler := Handler{
 		config:                  config,
 		schemaReader:            schemaReader,

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -166,7 +166,6 @@ func NewHandler(
 		scaleOut:                scaleoutManager,
 		cloud:                   cloud,
 		classGetter:             classGetter,
-		authFilter:              authFilter,
 	}
 
 	handler.scaleOut.SetSchemaReader(schemaReader)
@@ -189,7 +188,7 @@ func (h *Handler) GetConsistentSchema(principal *models.Principal, consistency b
 		}
 	}
 
-	filteredClasses := h.authFilter.Filter(
+	filteredClasses := filter.New[*models.Class](h.Authorizer, h.config).Filter(
 		principal,
 		fullSchema.Objects.Classes,
 		authorization.READ,

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -229,6 +229,7 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 
 	resourceFilter := filter.New[*models.TenantResponse](h.Authorizer, h.config)
 	filteredTenants := resourceFilter.Filter(
+		h.logger,
 		principal,
 		allTenants,
 		authorization.READ,

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -232,8 +232,8 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 		principal,
 		allTenants,
 		authorization.READ,
-		func(tenant *models.TenantResponse) []string {
-			return authorization.ShardsMetadata(class, tenant.Name)
+		func(tenant *models.TenantResponse) string {
+			return authorization.ShardsMetadata(class, tenant.Name)[0]
 		},
 	)
 

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -18,12 +18,14 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	modsloads3 "github.com/weaviate/weaviate/modules/offload-s3"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 	uco "github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -212,17 +214,30 @@ func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal
 }
 
 func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Principal, class string, consistency bool, tenants []string) ([]*models.TenantResponse, error) {
-	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenants...)...); err != nil {
+	var allTenants []*models.TenantResponse
+	var err error
+
+	if consistency {
+		allTenants, _, err = h.schemaManager.QueryTenants(class, tenants)
+	} else {
+		// If non consistent, fallback to the default implementation
+		allTenants, err = h.getTenantsByNames(class, tenants)
+	}
+	if err != nil {
 		return nil, err
 	}
 
-	if consistency {
-		tenants, _, err := h.schemaManager.QueryTenants(class, tenants)
-		return tenants, err
-	}
+	resourceFilter := filter.New[*models.TenantResponse](h.Authorizer, h.config)
+	filteredTenants := resourceFilter.Filter(
+		principal,
+		allTenants,
+		authorization.READ,
+		func(tenant *models.TenantResponse) []string {
+			return authorization.ShardsMetadata(class, tenant.Name)
+		},
+	)
 
-	// If non consistent, fallback to the default implementation
-	return h.getTenantsByNames(class, tenants)
+	return filteredTenants, nil
 }
 
 func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {


### PR DESCRIPTION
### What's being changed:
this relax list all for Schema, tenants, get objects, get roles to return only the allowed from the list instead of gating the endpoints by filter the results 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
