### PR TITLE
[storobj] Remove unnecessary complexity from object unmarshaling

### DIFF
--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -80,10 +80,10 @@ func (os *objectScannerLSM) scan() error {
 	// each object is scanned one after the other, so we can reuse the same memory allocations for all objects
 	docIDBytes := make([]byte, 8)
 
-	// Preallocate strings needed for json unmarshalling
-	propStrings := make([][]string, len(os.properties))
+	// Preallocate property paths needed for json unmarshalling
+	propertyPaths := make([][]string, len(os.properties))
 	for i := range os.properties {
-		propStrings[i] = []string{os.properties[i]}
+		propertyPaths[i] = []string{os.properties[i]}
 	}
 
 	var (
@@ -103,8 +103,8 @@ func (os *objectScannerLSM) scan() error {
 			continue
 		}
 
-		if len(os.properties) > 0 {
-			err = storobj.UnmarshalPropertiesFromObject(res, propertiesTyped, os.properties, propStrings)
+		if len(propertyPaths) > 0 {
+			err = storobj.UnmarshalPropertiesFromObject(res, propertiesTyped, propertyPaths)
 			if err != nil {
 				return errors.Wrapf(err, "unmarshal data object")
 			}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -129,16 +129,13 @@ func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
 	out := make([]*storobj.Object, outlen)
 	docIDBytes := make([]byte, 8)
 
-	propStrings := make([]string, len(properties))
-	propStringsList := make([][]string, len(properties))
+	propertyPaths := make([][]string, len(properties))
 	for j := range properties {
-		propStrings[j] = properties[j]
-		propStringsList[j] = []string{properties[j]}
+		propertyPaths[j] = []string{properties[j]}
 	}
 
 	props := &storobj.PropertyExtraction{
-		PropStrings:     propStrings,
-		PropStringsList: propStringsList,
+		PropertyPaths: propertyPaths,
 	}
 
 	i := 0

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -122,16 +122,13 @@ func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLik
 		return nil
 	}
 
-	propStrings := make([]string, 0, len(props))
-	propStringsList := make([][]string, 0, len(props))
+	propertyPaths := make([][]string, 0, len(props))
 	for prop := range props {
-		propStrings = append(propStrings, prop)
-		propStringsList = append(propStringsList, []string{prop})
+		propertyPaths = append(propertyPaths, []string{prop})
 	}
 
 	propsExtraction := &storobj.PropertyExtraction{
-		PropStrings:     propStrings,
-		PropStringsList: propStringsList,
+		PropertyPaths: propertyPaths,
 	}
 
 	objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)

--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -88,16 +88,13 @@ func (g *grouper) Do(ctx context.Context) ([]*storobj.Object, []float32, error) 
 	docIDObject := map[uint64]*storobj.Object{}
 	docIDDistance := map[uint64]float32{}
 
-	propStrings := make([]string, len(g.properties))
-	propStringsList := make([][]string, len(g.properties))
+	propertyPaths := make([][]string, len(g.properties))
 	for j := range g.properties {
-		propStrings[j] = g.properties[j]
-		propStringsList[j] = []string{g.properties[j]}
+		propertyPaths[j] = []string{g.properties[j]}
 	}
 
 	props := &storobj.PropertyExtraction{
-		PropStrings:     propStrings,
-		PropStringsList: propStringsList,
+		PropertyPaths: propertyPaths,
 	}
 
 DOCS_LOOP:

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -287,8 +287,7 @@ func FromBinaryOptional(data []byte,
 }
 
 type PropertyExtraction struct {
-	PropStrings     []string
-	PropStringsList [][]string
+	PropertyPaths [][]string
 }
 
 type bucket interface {
@@ -379,16 +378,13 @@ func objectsByDocIDSequential(bucket bucket, ids []uint64,
 	var props *PropertyExtraction = nil
 	// not all code paths forward the list of properties that should be extracted - if nil is passed fall back
 	if properties != nil {
-		propStrings := make([]string, len(properties))
-		propStringsList := make([][]string, len(properties))
+		propertyPaths := make([][]string, len(properties))
 		for j := range properties {
-			propStrings[j] = properties[j]
-			propStringsList[j] = []string{properties[j]}
+			propertyPaths[j] = []string{properties[j]}
 		}
 
 		props = &PropertyExtraction{
-			PropStrings:     propStrings,
-			PropStringsList: propStringsList,
+			PropertyPaths: propertyPaths,
 		}
 	}
 
@@ -942,41 +938,43 @@ func (ko *Object) MarshalBinary() ([]byte, error) {
 	return byteBuffer, nil
 }
 
-// UnmarshalPropertiesFromObject only unmarshals and returns the properties part of the object
+// UnmarshalPropertiesFromObject accepts marshaled object as data and populates resultProperties map with the properties specified by propertyPaths.
 //
 // Check MarshalBinary for the order of elements in the input array
-func UnmarshalPropertiesFromObject(data []byte, properties map[string]interface{}, aggregationProperties []string, propStrings [][]string) error {
+func UnmarshalPropertiesFromObject(data []byte, resultProperties map[string]interface{}, propertyPaths [][]string) error {
 	if data[0] != uint8(1) {
 		return errors.Errorf("unsupported binary marshaller version %d", data[0])
 	}
 
 	// clear out old values in case an object misses values. This should NOT shrink the capacity of the map, eg there
-	// are no allocations when adding the properties of the next object again
-	clear(properties)
+	// are no allocations when adding the resultProperties of the next object again
+	clear(resultProperties)
 
 	startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
 	rw := byteops.NewReadWriter(data, byteops.WithPosition(startPos))
 	// get the length of the vector, each element is a float32 (4 bytes)
 	vectorLength := uint64(rw.ReadUint16())
 	rw.MoveBufferPositionForward(vectorLength * 4)
-
 	classnameLength := uint64(rw.ReadUint16())
 	rw.MoveBufferPositionForward(classnameLength)
 	propertyLength := uint64(rw.ReadUint32())
 
-	return UnmarshalProperties(rw.Buffer[rw.Position:rw.Position+propertyLength], properties, aggregationProperties, propStrings)
+	return UnmarshalProperties(rw.Buffer[rw.Position:rw.Position+propertyLength], resultProperties, propertyPaths)
 }
 
-func UnmarshalProperties(data []byte, properties map[string]interface{}, aggregationProperties []string, propStrings [][]string) error {
+// UnmarshalProperties accepts serialized properties as data and populates resultProperties map with the properties specified by propertyPaths.
+func UnmarshalProperties(data []byte, properties map[string]interface{}, propertyPaths [][]string) error {
 	var returnError error
 	jsonparser.EachKey(data, func(idx int, value []byte, dataType jsonparser.ValueType, err error) {
+		propertyName := propertyPaths[idx][len(propertyPaths[idx])-1]
+
 		switch dataType {
 		case jsonparser.Number, jsonparser.String, jsonparser.Boolean:
 			val, err := parseValues(dataType, value)
 			if err != nil {
 				returnError = err
 			}
-			properties[aggregationProperties[idx]] = val
+			properties[propertyName] = val
 		case jsonparser.Array: // can be a beacon or an actual array
 			arrayEntries := value[1 : len(value)-1] // without leading and trailing []
 			// this checks if refs are present - the return points to the underlying memory, dont use without copying
@@ -990,7 +988,7 @@ func UnmarshalProperties(data []byte, properties map[string]interface{}, aggrega
 					beacons = append(beacons, map[string]interface{}{"beacon": beaconVal})
 				}
 				_, returnError = jsonparser.ArrayEach(value, handler)
-				properties[aggregationProperties[idx]] = beacons
+				properties[propertyName] = beacons
 			} else {
 				// check how many entries there are in the array by counting the ",". This allows us to allocate an
 				// array with the right size without extending it with every append.
@@ -1030,7 +1028,7 @@ func UnmarshalProperties(data []byte, properties map[string]interface{}, aggrega
 				if err != nil {
 					returnError = err
 				}
-				properties[aggregationProperties[idx]] = array
+				properties[propertyName] = array
 
 			}
 		case jsonparser.Object:
@@ -1047,11 +1045,11 @@ func UnmarshalProperties(data []byte, properties map[string]interface{}, aggrega
 			if err != nil {
 				returnError = err
 			}
-			properties[aggregationProperties[idx]] = nestedProps
+			properties[propertyName] = nestedProps
 		default:
 			returnError = fmt.Errorf("unknown data type %v", dataType)
 		}
-	}, propStrings...)
+	}, propertyPaths...)
 
 	return returnError
 }
@@ -1381,8 +1379,8 @@ func (ko *Object) parseObject(uuid strfmt.UUID, create, update int64, className 
 		}
 	} else if len(propsB) >= int(propLength) {
 		// the properties are not read in all cases, skip if not needed
-		returnProps = make(map[string]interface{}, len(properties.PropStrings))
-		if err := UnmarshalProperties(propsB[:propLength], returnProps, properties.PropStrings, properties.PropStringsList); err != nil {
+		returnProps = make(map[string]interface{}, len(properties.PropertyPaths))
+		if err := UnmarshalProperties(propsB[:propLength], returnProps, properties.PropertyPaths); err != nil {
 			return err
 		}
 	}

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -714,10 +714,8 @@ func TestExtractionOfSingleProperties(t *testing.T) {
 	byteObject, err := before.MarshalBinary()
 	require.Nil(t, err)
 
-	var propertyNames []string
 	var propStrings [][]string
 	for key := range properties {
-		propertyNames = append(propertyNames, key)
 		propStrings = append(propStrings, []string{key})
 	}
 
@@ -725,7 +723,7 @@ func TestExtractionOfSingleProperties(t *testing.T) {
 
 	// test with reused property map
 	for i := 0; i < 2; i++ {
-		require.Nil(t, UnmarshalPropertiesFromObject(byteObject, extractedProperties, propertyNames, propStrings))
+		require.Nil(t, UnmarshalPropertiesFromObject(byteObject, extractedProperties, propStrings))
 		for key := range expected {
 			require.Equal(t, expected[key], extractedProperties[key])
 		}
@@ -950,7 +948,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 
 				t.Run("with explicit properties", func(t *testing.T) {
 					after, err := FromBinaryOptional(asBinary, additional.Properties{},
-						&PropertyExtraction{PropStrings: []string{"name"}, PropStringsList: [][]string{{"name"}}},
+						&PropertyExtraction{PropertyPaths: [][]string{{"name"}}},
 					)
 					require.Nil(t, err)
 
@@ -964,7 +962,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 						NoProps:      true,
 						ModuleParams: map[string]interface{}{"foo": "bar"}, // this causes the property extraction code to run
 					},
-						&PropertyExtraction{PropStrings: nil, PropStringsList: nil},
+						&PropertyExtraction{PropertyPaths: nil},
 					)
 					require.Nil(t, err)
 
@@ -1252,12 +1250,9 @@ func TestMemoryReuse(t *testing.T) {
 			Properties: beforeProp,
 		}
 
-		propStrings := make([]string, 0, len(beforeProp))
-		propStringsList := make([][]string, 0, len(beforeProp))
-
+		propertyPaths := make([][]string, 0, len(beforeProp))
 		for j := range beforeProp {
-			propStrings = append(propStrings, j)
-			propStringsList = append(propStringsList, []string{j})
+			propertyPaths = append(propertyPaths, []string{j})
 		}
 
 		before := FromObject(&obj, nil, nil, nil)
@@ -1267,7 +1262,7 @@ func TestMemoryReuse(t *testing.T) {
 		copy(reuseableBuff, asBinary)
 
 		afterProp := map[string]interface{}{}
-		require.Nil(t, UnmarshalProperties(reuseableBuff, afterProp, propStrings, propStringsList))
+		require.Nil(t, UnmarshalProperties(reuseableBuff, afterProp, propertyPaths))
 		afterProps = append(afterProps, afterProp)
 	}
 
@@ -1311,14 +1306,13 @@ func benchmarkExtraction(b *testing.B, propStrings []string) {
 	var props *PropertyExtraction
 
 	if len(propStrings) > 0 {
-		propStringsList := make([][]string, len(propStrings))
+		propertyPaths := make([][]string, len(propStrings))
 		for i, prop := range propStrings {
-			propStringsList[i] = []string{prop}
+			propertyPaths[i] = []string{prop}
 		}
 
 		props = &PropertyExtraction{
-			PropStrings:     propStrings,
-			PropStringsList: propStringsList,
+			PropertyPaths: propertyPaths,
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:
For some reason, duplicate information was constructed and passed around in `propStrings` and `propStringsList` all the time, so simplified.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
