### PR TITLE
fix(schema): Correct metrics handling for `Restore` schema

### DIFF
--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -518,7 +518,7 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 // and call sink.Close() when finished or call sink.Cancel() on error.
 func (s *schema) Persist(sink raft.SnapshotSink) (err error) {
 	s.mu.RLock()
-	defer s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	defer sink.Close()
 	snap := snapshot{

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -339,6 +339,8 @@ func (s *schema) deleteClass(name string) bool {
 	return true
 }
 
+// replaceClasses replaces the exising `schema.Classes` with given `classes`
+// mainly used in cases like restoring the whole schema from backup or something.
 func (s *schema) replaceClasses(classes map[string]*metaClass) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -12,11 +12,14 @@
 package schema
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
@@ -51,8 +54,10 @@ func (ci *ClassInfo) Version() uint64 {
 type schema struct {
 	nodeID      string
 	shardReader shardReader
-	sync.RWMutex
-	Classes map[string]*metaClass
+
+	// mu protects the `classes`
+	mu      sync.RWMutex
+	classes map[string]*metaClass
 
 	// metrics
 	// collectionsCount represents the number of collections on this specific node.
@@ -68,7 +73,7 @@ func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer
 
 	s := &schema{
 		nodeID:      nodeID,
-		Classes:     make(map[string]*metaClass, 128),
+		classes:     make(map[string]*metaClass, 128),
 		shardReader: shardReader,
 		collectionsCount: r.NewGauge(prometheus.GaugeOpts{
 			Namespace:   "weaviate",
@@ -88,9 +93,10 @@ func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer
 }
 
 func (s *schema) ClassInfo(class string) ClassInfo {
-	s.RLock()
-	defer s.RUnlock()
-	cl, ok := s.Classes[class]
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cl, ok := s.classes[class]
 	if !ok {
 		return ClassInfo{}
 	}
@@ -100,9 +106,10 @@ func (s *schema) ClassInfo(class string) ClassInfo {
 // ClassEqual returns the name of an existing class with a similar name, and "" otherwise
 // strings.EqualFold is used to compare classes
 func (s *schema) ClassEqual(name string) string {
-	s.RLock()
-	defer s.RUnlock()
-	for k := range s.Classes {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for k := range s.classes {
 		if strings.EqualFold(k, name) {
 			return k
 		}
@@ -125,17 +132,18 @@ func (s *schema) Read(class string, reader func(*models.Class, *sharding.State) 
 }
 
 func (s *schema) metaClass(class string) *metaClass {
-	s.RLock()
-	defer s.RUnlock()
-	return s.Classes[class]
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.classes[class]
 }
 
 // ReadOnlyClass returns a shallow copy of a class.
 // The copy is read-only and should not be modified.
 func (s *schema) ReadOnlyClass(class string) (*models.Class, uint64) {
-	s.RLock()
-	defer s.RUnlock()
-	meta := s.Classes[class]
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	meta := s.classes[class]
 	if meta == nil {
 		return nil, 0
 	}
@@ -150,11 +158,11 @@ func (s *schema) ReadOnlyClasses(classes ...string) map[string]versioned.Class {
 	}
 
 	vclasses := make(map[string]versioned.Class, len(classes))
-	s.RLock()
-	defer s.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	for _, class := range classes {
-		meta := s.Classes[class]
+		meta := s.classes[class]
 		if meta == nil {
 			continue
 		}
@@ -175,11 +183,12 @@ func (s *schema) ReadOnlyClasses(classes ...string) map[string]versioned.Class {
 // This implementation assumes that individual properties are overwritten rather than partially updated
 func (s *schema) ReadOnlySchema() models.Schema {
 	cp := models.Schema{}
-	s.RLock()
-	defer s.RUnlock()
-	cp.Classes = make([]*models.Class, len(s.Classes))
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cp.Classes = make([]*models.Class, len(s.classes))
 	i := 0
-	for _, meta := range s.Classes {
+	for _, meta := range s.classes {
 		cp.Classes[i] = meta.CloneClass()
 		i++
 	}
@@ -217,10 +226,10 @@ func (s *schema) ShardReplicas(class, shard string) ([]string, uint64, error) {
 
 // TenantsShards returns shard name for the provided tenant and its activity status
 func (s *schema) TenantsShards(class string, tenants ...string) (map[string]string, uint64) {
-	s.RLock()
-	defer s.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	meta := s.Classes[class]
+	meta := s.classes[class]
 	if meta == nil {
 		return nil, 0
 	}
@@ -246,16 +255,18 @@ type shardReader interface {
 }
 
 func (s *schema) len() int {
-	s.RLock()
-	defer s.RUnlock()
-	return len(s.Classes)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.classes)
 }
 
 func (s *schema) multiTenancyEnabled(class string) (bool, *metaClass, ClassInfo, error) {
-	s.RLock()
-	defer s.RUnlock()
-	meta := s.Classes[class]
-	info := s.Classes[class].ClassInfo()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	meta := s.classes[class]
+	info := s.classes[class].ClassInfo()
 	if meta == nil {
 		return false, nil, ClassInfo{}, ErrClassNotFound
 	}
@@ -266,14 +277,15 @@ func (s *schema) multiTenancyEnabled(class string) (bool, *metaClass, ClassInfo,
 }
 
 func (s *schema) addClass(cls *models.Class, ss *sharding.State, v uint64) error {
-	s.Lock()
-	defer s.Unlock()
-	_, exists := s.Classes[cls.Class]
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, exists := s.classes[cls.Class]
 	if exists {
 		return ErrClassExists
 	}
 
-	s.Classes[cls.Class] = &metaClass{
+	s.classes[cls.Class] = &metaClass{
 		Class: *cls, Sharding: *ss, ClassVersion: v, ShardVersion: v,
 	}
 
@@ -288,14 +300,65 @@ func (s *schema) addClass(cls *models.Class, ss *sharding.State, v uint64) error
 
 // updateClass modifies existing class based on the givin update function
 func (s *schema) updateClass(name string, f func(*metaClass) error) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	meta := s.Classes[name]
+	meta := s.classes[name]
 	if meta == nil {
 		return ErrClassNotFound
 	}
 	return meta.LockGuard(f)
+}
+
+func (s *schema) deleteClass(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// since `delete(map, key)` is no-op if `key` doesn't exist, check before deleting
+	// so that we can increment the `collectionsCount` correctly.
+	class, ok := s.classes[name]
+	if !ok {
+		return false
+	}
+
+	// sc tracks number of shards in this collection to be deleted by status.
+	sc := make(map[string]int)
+
+	// need to decrement shards count on this class.
+	for _, shard := range class.Sharding.Physical {
+		sc[shard.Status]++
+	}
+
+	delete(s.classes, name)
+
+	s.collectionsCount.Dec()
+	for status, count := range sc {
+		s.shardsCount.WithLabelValues(status).Sub(float64(count))
+	}
+
+	return true
+}
+
+func (s *schema) replaceClasses(classes map[string]*metaClass) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.collectionsCount.Sub(float64(len(s.classes)))
+	for _, ss := range s.classes {
+		for _, shard := range ss.Sharding.Physical {
+			s.shardsCount.WithLabelValues(shard.Status).Dec()
+		}
+	}
+
+	s.classes = classes
+
+	s.collectionsCount.Add(float64(len(s.classes)))
+
+	for _, ss := range s.classes {
+		for _, shard := range ss.Sharding.Physical {
+			s.shardsCount.WithLabelValues(shard.Status).Inc()
+		}
+	}
 }
 
 // replaceStatesNodeName it update the node name inside sharding states.
@@ -303,10 +366,10 @@ func (s *schema) updateClass(name string, f func(*metaClass) error) error {
 // because it will replace the shard node name if the node name got updated
 // only if the replication factor is 1, otherwise it's no-op
 func (s *schema) replaceStatesNodeName(new string) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	for _, meta := range s.Classes {
+	for _, meta := range s.classes {
 		meta.LockGuard(func(mc *metaClass) error {
 			if meta.Class.ReplicationConfig.Factor > 1 {
 				return nil
@@ -322,40 +385,11 @@ func (s *schema) replaceStatesNodeName(new string) {
 	}
 }
 
-func (s *schema) deleteClass(name string) bool {
-	s.Lock()
-	defer s.Unlock()
-
-	// since `delete(map, key)` is no-op if `key` doesn't exist, check before deleting
-	// so that we can increment the `collectionsCount` correctly.
-	class, ok := s.Classes[name]
-	if !ok {
-		return false
-	}
-
-	// sc tracks number of shards in this collection to be deleted by status.
-	sc := make(map[string]int)
-
-	// need to decrement shards count on this class.
-	for _, shard := range class.Sharding.Physical {
-		sc[shard.Status]++
-	}
-
-	delete(s.Classes, name)
-
-	s.collectionsCount.Dec()
-	for status, count := range sc {
-		s.shardsCount.WithLabelValues(status).Sub(float64(count))
-	}
-
-	return true
-}
-
 func (s *schema) addProperty(class string, v uint64, props ...*models.Property) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	meta := s.Classes[class]
+	meta := s.classes[class]
 	if meta == nil {
 		return ErrClassNotFound
 	}
@@ -443,11 +477,11 @@ func (s *schema) getTenants(class string, tenants []string) ([]*models.Tenant, e
 }
 
 func (s *schema) States() map[string]types.ClassState {
-	s.RLock()
-	defer s.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	cs := make(map[string]types.ClassState, len(s.Classes))
-	for _, c := range s.Classes {
+	cs := make(map[string]types.ClassState, len(s.classes))
+	for _, c := range s.classes {
 		cs[c.Class.Class] = types.ClassState{
 			Class:  c.Class,
 			Shards: c.Sharding,
@@ -458,11 +492,51 @@ func (s *schema) States() map[string]types.ClassState {
 }
 
 func (s *schema) MetaClasses() map[string]*metaClass {
-	s.RLock()
-	defer s.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	return s.Classes
+	return s.classes
 }
+
+func (s *schema) Restore(r io.Reader, parser Parser) error {
+	snap := snapshot{}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return fmt.Errorf("restore snapshot: decode json: %v", err)
+	}
+	for _, cls := range snap.Classes {
+		if err := parser.ParseClass(&cls.Class); err != nil { // should not fail
+			return fmt.Errorf("parsing class %q: %w", cls.Class.Class, err) // schema might be corrupted
+		}
+		cls.Sharding.SetLocalName(s.nodeID)
+	}
+
+	s.replaceClasses(snap.Classes)
+	return nil
+}
+
+// Persist should dump all necessary state to the WriteCloser 'sink',
+// and call sink.Close() when finished or call sink.Cancel() on error.
+func (s *schema) Persist(sink raft.SnapshotSink) (err error) {
+	s.mu.RLock()
+	defer s.mu.RLock()
+
+	defer sink.Close()
+	snap := snapshot{
+		NodeID:     s.nodeID,
+		SnapshotID: sink.ID(),
+		Classes:    s.classes,
+	}
+	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+
+	return nil
+}
+
+func (s *schema) Release() {
+}
+
+//
 
 func makeTenant(name, status string) *models.Tenant {
 	return &models.Tenant{

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -339,7 +339,7 @@ func (s *schema) deleteClass(name string) bool {
 	return true
 }
 
-// replaceClasses replaces the exising `schema.Classes` with given `classes`
+// replaceClasses replaces the existing `schema.Classes` with given `classes`
 // mainly used in cases like restoring the whole schema from backup or something.
 func (s *schema) replaceClasses(classes map[string]*metaClass) {
 	s.mu.Lock()

--- a/cluster/schema/snapshot.go
+++ b/cluster/schema/snapshot.go
@@ -26,47 +26,6 @@ type snapshot struct {
 	Classes    map[string]*metaClass `json:"classes"`
 }
 
-func (s *schema) Restore(r io.Reader, parser Parser) error {
-	snap := snapshot{}
-	if err := json.NewDecoder(r).Decode(&snap); err != nil {
-		return fmt.Errorf("restore snapshot: decode json: %v", err)
-	}
-	for _, cls := range snap.Classes {
-		if err := parser.ParseClass(&cls.Class); err != nil { // should not fail
-			return fmt.Errorf("parsing class %q: %w", cls.Class.Class, err) // schema might be corrupted
-		}
-		cls.Sharding.SetLocalName(s.nodeID)
-	}
-
-	s.Lock()
-	defer s.Unlock()
-	s.Classes = snap.Classes
-
-	return nil
-}
-
-// Persist should dump all necessary state to the WriteCloser 'sink',
-// and call sink.Close() when finished or call sink.Cancel() on error.
-func (s *schema) Persist(sink raft.SnapshotSink) (err error) {
-	s.Lock()
-	defer s.Unlock()
-
-	defer sink.Close()
-	snap := snapshot{
-		NodeID:     s.nodeID,
-		SnapshotID: sink.ID(),
-		Classes:    s.Classes,
-	}
-	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
-		return fmt.Errorf("encode: %w", err)
-	}
-
-	return nil
-}
-
-func (s *schema) Release() {
-}
-
 // LegacySnapshot returns a ready-to-use in-memory Raft snapshot based on the provided legacy schema
 func LegacySnapshot(nodeID string, m map[string]types.ClassState) (*raft.SnapshotMeta, io.ReadCloser, error) {
 	store := raft.NewInmemSnapshotStore()


### PR DESCRIPTION
### What's being changed:
Sometimes schema is restored directly via `schema.Restore()` method during startup. Meaning, `class` addition may not go through `schema.addClass` method.

#### Changes

1. This PR handles the metrics(`schema_collection` and `schema_shards`) correctly during `Restore()` case.
1. Also did some refactoring to keep the `schema.classes` mutation close to fewer methods (`addClass`, `deleteClass`, `updateClass`, `replaceClasses`) and also move all `schema's` methods in `schema.go` file instead in multiple files.

Also added test to lock this behaviour.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
