### PR TITLE
Rbac roles crud migration

### DIFF
--- a/cluster/proto/api/rbac_requests.go
+++ b/cluster/proto/api/rbac_requests.go
@@ -28,6 +28,10 @@ const (
 	// old verb was (C)|(R)|(U)|(D)
 	// new verb was MATCH
 	RBACCommandPolicyVersionV1
+
+	// this version was needed because we did flatten manage_roles to C+U+D_roles
+	RBACCommandPolicyVersionV2
+
 	// RBACLatestCommandPolicyVersion represents the latest version of RBAC commands policies
 	// It's used to migrate policy changes. if we end up with a cluster having different version
 	// that won't be a problem because the version here is not about the message change but more about

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -135,60 +135,81 @@ func (m *Manager) UpsertRolesPermissions(c *cmd.ApplyRequest) error {
 	if err := json.Unmarshal(c.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
-	switch req.Version {
-	case cmd.RBACCommandPolicyVersionV0:
-		for roleName, policies := range req.Roles {
-			permissions := []*authorization.Policy{}
-			for _, p := range policies {
-				permissions = append(permissions, &p)
-			}
-			// remove old permissions
-			if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
-				return err
-			}
 
-			// create new permissions
-			for idx := range policies {
-				if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
-					parts := strings.Split(req.Roles[roleName][idx].Resource, "/")
-					if len(parts) < 3 {
-						// shall never happens
-						return fmt.Errorf("invalid schema path")
+	// loop through updates until current version is reached
+UPDATE_LOOP:
+	for {
+		switch req.Version {
+		case cmd.RBACCommandPolicyVersionV0:
+			for roleName, policies := range req.Roles {
+				permissions := []*authorization.Policy{}
+				for _, p := range policies {
+					permissions = append(permissions, &p)
+				}
+				// remove old permissions
+				if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
+					return err
+				}
+
+				// create new permissions
+				for idx := range policies {
+					if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
+						parts := strings.Split(req.Roles[roleName][idx].Resource, "/")
+						if len(parts) < 3 {
+							// shall never happens
+							return fmt.Errorf("invalid schema path")
+						}
+						req.Roles[roleName][idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
 					}
-					req.Roles[roleName][idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
+
+					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
+						req.Roles[roleName][idx].Verb == conv.CRUD {
+						// this will override any role was created before 1.28
+						// to reset default to
+						req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
+					}
+				}
+			}
+		case cmd.RBACCommandPolicyVersionV1:
+			for roleName, policies := range req.Roles {
+				permissions := []*authorization.Policy{}
+				for _, p := range policies {
+					permissions = append(permissions, &p)
+				}
+				// remove old permissions
+				if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
+					return err
 				}
 
-				if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
-					req.Roles[roleName][idx].Verb == conv.CRUD {
-					// this will override any role was created before 1.28
-					// to reset default to
-					req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
+				// create new permissions
+				for idx := range policies {
+					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
+						req.Roles[roleName][idx].Verb == conv.CRUD {
+						// this will override any role was created before 1.28
+						// to reset default to
+						req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
+					}
 				}
 			}
-		}
-	case cmd.RBACCommandPolicyVersionV1:
-		for roleName, policies := range req.Roles {
-			permissions := []*authorization.Policy{}
-			for _, p := range policies {
-				permissions = append(permissions, &p)
-			}
-			// remove old permissions
-			if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
-				return err
+		case cmd.RBACCommandPolicyVersionV2:
+			for roleName, policies := range req.Roles {
+				permissions := []*authorization.Policy{}
+				for _, p := range policies {
+					permissions = append(permissions, &p)
+				}
+				// remove old permissions
+				if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
+					return err
+				}
 			}
 
-			// create new permissions
-			for idx := range policies {
-				if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
-					req.Roles[roleName][idx].Verb == conv.CRUD {
-					// this will override any role was created before 1.28
-					// to reset default to
-					req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
-				}
-			}
+			req.Roles = migrateV2(req.Roles)
+
+		default:
+			break UPDATE_LOOP
 		}
-	default:
-		// do nothing
+		req.Version += 1
+
 	}
 
 	return m.authZ.UpsertRolesPermissions(req.Roles)

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -21,7 +21,6 @@ import (
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 )
 
 var ErrBadRequest = errors.New("bad request")
@@ -149,54 +148,12 @@ func (m *Manager) UpsertRolesPermissions(c *cmd.ApplyRequest) error {
 		}
 	}
 
-	// loop through updates until current version is reached
-UPDATE_LOOP:
-	for {
-		switch req.Version {
-		case cmd.RBACCommandPolicyVersionV0:
-			for roleName, policies := range req.Roles {
-				// create new permissions
-				for idx := range policies {
-					if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
-						parts := strings.Split(req.Roles[roleName][idx].Resource, "/")
-						if len(parts) < 3 {
-							// shall never happens
-							return fmt.Errorf("invalid schema path")
-						}
-						req.Roles[roleName][idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
-					}
-
-					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
-						req.Roles[roleName][idx].Verb == conv.CRUD {
-						// this will override any role was created before 1.28
-						// to reset default to
-						req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
-					}
-				}
-			}
-		case cmd.RBACCommandPolicyVersionV1:
-			for roleName, policies := range req.Roles {
-				// create new permissions
-				for idx := range policies {
-					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
-						req.Roles[roleName][idx].Verb == conv.CRUD {
-						// this will override any role was created before 1.28
-						// to reset default to
-						req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
-					}
-				}
-			}
-		case cmd.RBACCommandPolicyVersionV2:
-			req.Roles = migrateUpsertRolesPermissionsV2(req.Roles)
-
-		default:
-			break UPDATE_LOOP
-		}
-		req.Version += 1
-
+	reqMigrated, err := migrateUpsertRolesPermissions(req)
+	if err != nil {
+		return err
 	}
 
-	return m.authZ.UpsertRolesPermissions(req.Roles)
+	return m.authZ.UpsertRolesPermissions(reqMigrated.Roles)
 }
 
 func (m *Manager) DeleteRoles(c *cmd.ApplyRequest) error {

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -136,21 +136,25 @@ func (m *Manager) UpsertRolesPermissions(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
+	if req.Version < cmd.RBACLatestCommandPolicyVersion {
+		for roleName, policies := range req.Roles {
+			permissions := []*authorization.Policy{}
+			for _, p := range policies {
+				permissions = append(permissions, &p)
+			}
+			// remove old permissions
+			if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
+				return err
+			}
+		}
+	}
+
 	// loop through updates until current version is reached
 UPDATE_LOOP:
 	for {
 		switch req.Version {
 		case cmd.RBACCommandPolicyVersionV0:
 			for roleName, policies := range req.Roles {
-				permissions := []*authorization.Policy{}
-				for _, p := range policies {
-					permissions = append(permissions, &p)
-				}
-				// remove old permissions
-				if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
-					return err
-				}
-
 				// create new permissions
 				for idx := range policies {
 					if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
@@ -172,15 +176,6 @@ UPDATE_LOOP:
 			}
 		case cmd.RBACCommandPolicyVersionV1:
 			for roleName, policies := range req.Roles {
-				permissions := []*authorization.Policy{}
-				for _, p := range policies {
-					permissions = append(permissions, &p)
-				}
-				// remove old permissions
-				if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
-					return err
-				}
-
 				// create new permissions
 				for idx := range policies {
 					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
@@ -192,18 +187,7 @@ UPDATE_LOOP:
 				}
 			}
 		case cmd.RBACCommandPolicyVersionV2:
-			for roleName, policies := range req.Roles {
-				permissions := []*authorization.Policy{}
-				for _, p := range policies {
-					permissions = append(permissions, &p)
-				}
-				// remove old permissions
-				if err := m.authZ.RemovePermissions(roleName, permissions); err != nil {
-					return err
-				}
-			}
-
-			req.Roles = migrateV2(req.Roles)
+			req.Roles = migrateUpsertRolesPermissionsV2(req.Roles)
 
 		default:
 			break UPDATE_LOOP

--- a/cluster/rbac/manager_test.go
+++ b/cluster/rbac/manager_test.go
@@ -82,7 +82,15 @@ func TestUpsertRolesPermissions(t *testing.T) {
 					"custom": {
 						{
 							Domain: authorization.RolesDomain,
-							Verb:   authorization.ROLE_SCOPE_MATCH, // new
+							Verb:   authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_MATCH), // new
+						},
+						{
+							Domain: authorization.RolesDomain,
+							Verb:   authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_MATCH), // new
+						},
+						{
+							Domain: authorization.RolesDomain,
+							Verb:   authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_MATCH), // new
 						},
 					},
 				}).Return(nil)

--- a/cluster/rbac/migration.go
+++ b/cluster/rbac/migration.go
@@ -12,9 +12,63 @@
 package rbac
 
 import (
+	"fmt"
+	"strings"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 )
+
+func migrateUpsertRolesPermissions(req *cmd.CreateRolesRequest) (*cmd.CreateRolesRequest, error) {
+	// loop through updates until current version is reached
+UPDATE_LOOP:
+	for {
+		switch req.Version {
+		case cmd.RBACCommandPolicyVersionV0:
+			for roleName, policies := range req.Roles {
+				// create new permissions
+				for idx := range policies {
+					if req.Roles[roleName][idx].Domain == authorization.SchemaDomain {
+						parts := strings.Split(req.Roles[roleName][idx].Resource, "/")
+						if len(parts) < 3 {
+							// shall never happens
+							return nil, fmt.Errorf("invalid schema path")
+						}
+						req.Roles[roleName][idx].Resource = authorization.CollectionsMetadata(parts[2])[0]
+					}
+
+					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
+						req.Roles[roleName][idx].Verb == conv.CRUD {
+						// this will override any role was created before 1.28
+						// to reset default to
+						req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
+					}
+				}
+			}
+		case cmd.RBACCommandPolicyVersionV1:
+			for roleName, policies := range req.Roles {
+				// create new permissions
+				for idx := range policies {
+					if req.Roles[roleName][idx].Domain == authorization.RolesDomain &&
+						req.Roles[roleName][idx].Verb == conv.CRUD {
+						// this will override any role was created before 1.28
+						// to reset default to
+						req.Roles[roleName][idx].Verb = authorization.ROLE_SCOPE_MATCH
+					}
+				}
+			}
+		case cmd.RBACCommandPolicyVersionV2:
+			req.Roles = migrateUpsertRolesPermissionsV2(req.Roles)
+
+		default:
+			break UPDATE_LOOP
+		}
+		req.Version += 1
+	}
+
+	return req, nil
+}
 
 func migrateUpsertRolesPermissionsV2(roles map[string][]authorization.Policy) map[string][]authorization.Policy {
 	for roleName, policies := range roles {

--- a/cluster/rbac/migration.go
+++ b/cluster/rbac/migration.go
@@ -1,0 +1,74 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rbac
+
+import (
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+)
+
+func migrateV2(roles map[string][]authorization.Policy) map[string][]authorization.Policy {
+	for roleName, policies := range roles {
+		// create new permissions
+		for idx := range policies {
+			// replace manage ALL (verb CRUD) with individual CUD permissions
+			if roles[roleName][idx].Domain == authorization.RolesDomain && roles[roleName][idx].Verb == conv.CRUD {
+				roles[roleName][idx].Verb = authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_ALL)
+				// new permissions for U+D needed
+				for _, verb := range []string{authorization.UPDATE, authorization.DELETE} {
+					newPolicy := authorization.Policy{
+						Resource: roles[roleName][idx].Resource,
+						Verb:     authorization.VerbWithScope(verb, authorization.ROLE_SCOPE_ALL),
+						Domain:   roles[roleName][idx].Domain,
+					}
+					roles[roleName] = append(roles[roleName], newPolicy)
+				}
+			}
+
+			// replace manage MATCH (verb MATCH) with individual CUD permissions
+			if roles[roleName][idx].Domain == authorization.RolesDomain && roles[roleName][idx].Verb == authorization.ROLE_SCOPE_MATCH {
+				roles[roleName][idx].Verb = authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_MATCH)
+				// new permissions for U+D needed
+				for _, verb := range []string{authorization.UPDATE, authorization.DELETE} {
+					newPolicy := authorization.Policy{
+						Resource: roles[roleName][idx].Resource,
+						Verb:     authorization.VerbWithScope(verb, authorization.ROLE_SCOPE_MATCH),
+						Domain:   roles[roleName][idx].Domain,
+					}
+					roles[roleName] = append(roles[roleName], newPolicy)
+				}
+			}
+
+			// replace manage ALL (verb CRUD) with individual CUD permissions
+			if roles[roleName][idx].Domain == authorization.RolesDomain && roles[roleName][idx].Verb == conv.CRUD {
+				if roles[roleName][idx].Verb == authorization.ROLE_SCOPE_MATCH {
+					roles[roleName][idx].Verb = authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_MATCH)
+					// new permissions for U+D needed
+					for _, verb := range []string{authorization.UPDATE, authorization.DELETE} {
+						newPolicy := authorization.Policy{
+							Resource: roles[roleName][idx].Resource,
+							Verb:     authorization.VerbWithScope(verb, authorization.ROLE_SCOPE_MATCH),
+							Domain:   roles[roleName][idx].Domain,
+						}
+						roles[roleName] = append(roles[roleName], newPolicy)
+					}
+				}
+			}
+
+			// add scope to read
+			if roles[roleName][idx].Domain == authorization.RolesDomain && roles[roleName][idx].Verb == authorization.READ {
+				roles[roleName][idx].Verb = authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH)
+			}
+		}
+	}
+	return roles
+}

--- a/cluster/rbac/migration.go
+++ b/cluster/rbac/migration.go
@@ -53,10 +53,10 @@ UPDATE_LOOP:
 			}
 		case cmd.RBACCommandPolicyVersionV2:
 			req.Roles = migrateUpsertRolesPermissionsV2(req.Roles)
+		case cmd.RBACLatestCommandPolicyVersion:
+			break UPDATE_LOOP
 		default:
-			if req.Version == cmd.RBACLatestCommandPolicyVersion {
-				break UPDATE_LOOP
-			}
+			continue
 		}
 		req.Version += 1
 	}
@@ -129,11 +129,10 @@ UPDATE_LOOP:
 			}
 		case cmd.RBACCommandPolicyVersionV2:
 			req.Permissions = migrateRemoveRolesPermissionsV2(req.Permissions)
-
+		case cmd.RBACLatestCommandPolicyVersion:
+			break UPDATE_LOOP
 		default:
-			if req.Version == cmd.RBACLatestCommandPolicyVersion {
-				break UPDATE_LOOP
-			}
+			continue
 		}
 		req.Version += 1
 	}

--- a/cluster/rbac/migration.go
+++ b/cluster/rbac/migration.go
@@ -16,7 +16,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 )
 
-func migrateV2(roles map[string][]authorization.Policy) map[string][]authorization.Policy {
+func migrateUpsertRolesPermissionsV2(roles map[string][]authorization.Policy) map[string][]authorization.Policy {
 	for roleName, policies := range roles {
 		// create new permissions
 		for idx := range policies {

--- a/cluster/rbac/migration_test.go
+++ b/cluster/rbac/migration_test.go
@@ -1,0 +1,74 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rbac
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+)
+
+func TestMigrationV2(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string][]authorization.Policy
+		output map[string][]authorization.Policy
+	}{
+		{
+			name: "empty policy list",
+		},
+		{
+			name: "single policy - read without scope",
+			input: map[string][]authorization.Policy{
+				"read": {{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.READ}},
+			},
+			output: map[string][]authorization.Policy{
+				"read": {{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH)}},
+			},
+		},
+		{
+			name: "single policy - manage with match",
+			input: map[string][]authorization.Policy{
+				"manage": {{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.ROLE_SCOPE_MATCH}},
+			},
+			output: map[string][]authorization.Policy{
+				"manage": {
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_MATCH)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_MATCH)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_MATCH)},
+				},
+			},
+		},
+		{
+			name: "single policy - manage with all",
+			input: map[string][]authorization.Policy{
+				"manage": {{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD}},
+			},
+			output: map[string][]authorization.Policy{
+				"manage": {
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_ALL)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_ALL)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_ALL)},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := migrateV2(test.input)
+			require.Equal(t, test.output, output)
+		})
+	}
+}

--- a/cluster/rbac/migration_test.go
+++ b/cluster/rbac/migration_test.go
@@ -67,7 +67,7 @@ func TestMigrationV2(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			output := migrateV2(test.input)
+			output := migrateUpsertRolesPermissionsV2(test.input)
 			require.Equal(t, test.output, output)
 		})
 	}

--- a/cluster/rbac/migration_test.go
+++ b/cluster/rbac/migration_test.go
@@ -129,10 +129,9 @@ func TestMigrationsRemove(t *testing.T) {
 			}},
 			output: &cmd.RemovePermissionsRequest{
 				Version: cmd.RBACLatestCommandPolicyVersion, Permissions: []*authorization.Policy{
-					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD}, // original
-					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_ALL)},
-					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_ALL)},
-					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_ALL)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_MATCH)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_MATCH)},
+					{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_MATCH)},
 				},
 			},
 		},
@@ -161,7 +160,6 @@ func TestMigrationRemoveV2(t *testing.T) {
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.READ},
 			},
 			output: []*authorization.Policy{
-				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.READ},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH)},
 			},
 		},
@@ -171,7 +169,6 @@ func TestMigrationRemoveV2(t *testing.T) {
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.ROLE_SCOPE_MATCH},
 			},
 			output: []*authorization.Policy{
-				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.ROLE_SCOPE_MATCH},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_MATCH)},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_MATCH)},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_MATCH)},
@@ -183,7 +180,6 @@ func TestMigrationRemoveV2(t *testing.T) {
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD},
 			},
 			output: []*authorization.Policy{
-				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.CREATE, authorization.ROLE_SCOPE_ALL)},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.UPDATE, authorization.ROLE_SCOPE_ALL)},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.VerbWithScope(authorization.DELETE, authorization.ROLE_SCOPE_ALL)},
@@ -214,7 +210,6 @@ func TestMigrationRemoveV1(t *testing.T) {
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD},
 			},
 			output: []*authorization.Policy{
-				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD},
 				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.ROLE_SCOPE_MATCH},
 			},
 		},

--- a/cluster/rbac/migration_test.go
+++ b/cluster/rbac/migration_test.go
@@ -198,3 +198,32 @@ func TestMigrationRemoveV2(t *testing.T) {
 		})
 	}
 }
+
+func TestMigrationRemoveV1(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []*authorization.Policy
+		output []*authorization.Policy
+	}{
+		{
+			name: "empty policy list",
+		},
+		{
+			name: "single policy - CRUD",
+			input: []*authorization.Policy{
+				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD},
+			},
+			output: []*authorization.Policy{
+				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: conv.CRUD},
+				{Resource: "roles/something", Domain: authorization.RolesDomain, Verb: authorization.ROLE_SCOPE_MATCH},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := migrateRemoveRolesPermissionsV1(test.input)
+			require.Equal(t, test.output, output)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Adds RAFT migration for CRUD roles permissions

When creating the following role on stable/v1.28:
```
    client.roles.create(
        role_name="TestManageWithRestriction",
        permissions=[
            wvc.rbac.Permissions.roles(read=True, manage=True, role="Core_*"),
            wvc.rbac.Permissions.roles(manage=wvc.rbac.RoleScope.ALL, role="Core_*"),
        ]
    )
```
Policies look like this
```
0 = TestManageWithRestriction -> len:3, cap:4
 key = {string} "TestManageWithRestriction"
 value = {[]authorization.Policy} len:3, cap:4
  0 = {authorization.Policy} 
   Resource = {string} "roles/Core_.*"
   Verb = {string} "R"
   Domain = {string} "roles"
  1 = {authorization.Policy} 
   Resource = {string} "roles/Core_.*"
   Verb = {string} "MATCH"
   Domain = {string} "roles"
  2 = {authorization.Policy} 
   Resource = {string} "roles/Core_.*"
   Verb = {string} "(C)|(R)|(U)|(D)"
   Domain = {string} "roles"
```

After the RAFT migration they look like this:
```
0 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "R_MATCH"
 Domain = {string} "roles"
1 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "C_MATCH"
 Domain = {string} "roles"
2 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "C_ALL"
 Domain = {string} "roles"
3 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "U_MATCH"
 Domain = {string} "roles"
4 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "D_MATCH"
 Domain = {string} "roles"
5 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "U_ALL"
 Domain = {string} "roles"
6 = {authorization.Policy} 
 Resource = {string} "roles/Core_.*"
 Verb = {string} "D_ALL"
 Domain = {string} "roles"
```

- old read, READ => READ_match
- old manage with match, MATCH => C_MATCH, D_MATCH, U_MATCH
-  old manage with all, CRUD => C_ALL, D_ALL, U_ALL
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
