### PR TITLE
[aggregator] Unmarshal only required property in non-filtered group by

### DIFF
--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -276,7 +276,7 @@ func (g *grouper) insertOrdered(elem group) {
 }
 
 // ScanAllLSM iterates over every row in the object buckets.
-// Caller can specify which properties are it is interested in to make the scanning more performant, or pass nil to
+// Caller can specify which properties it is interested in to make the scanning more performant, or pass nil to
 // decode everything.
 func ScanAllLSM(store *lsmkv.Store, scan docid.ObjectScanFn, properties *storobj.PropertyExtraction) error {
 	b := store.Bucket(helpers.ObjectsBucketLSM)


### PR DESCRIPTION
### What's being changed:

One of the optimizations in the series for https://github.com/weaviate/weaviate/issues/7091 .

When doing non-filtered group by, we have been unmarshalling the whole object to get a single property which is used in the group by clause. This PR optimizes this use case by decoding only the required property instead of everything.

--- 

As this does not add any new functionality, I'm relying on the existing test suite to catch any possible regressions.

---

I've tested the performance by executing 15 no-filter group-by aggregation queries on the Sphere 1M dataset.

The biggest improvement is in the amount of allocated memory which dropped from 90GB to 27GB. In addition to less work for the runtime, it kept the heap lower in total and resulted in significantly less disk activity (which I tracked during the test as well) due to more space for the page cache. **All in all, the query latency reduction on my local setup was from ~9 to ~2 seconds.**

Before:
![image](https://github.com/user-attachments/assets/4c367dbb-5754-45fb-80e9-5a5f3588d8b9)

After:
![image](https://github.com/user-attachments/assets/858de44c-f957-4015-ad2d-7089bdc6e565)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
