### PR TITLE
Gate assigning/revoking roles to/from groups behind root users only

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -453,7 +453,7 @@ func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, 
 	}
 
 	if !h.isRootUser(principal.Username) {
-		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("only root users can assign roles to groups")))
+		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("assigning: only root users can assign roles to groups")))
 	}
 
 	if err := h.validateRootGroup(params.ID); err != nil {
@@ -625,7 +625,7 @@ func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupPara
 	}
 
 	if !h.isRootUser(principal.Username) {
-		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("only root users can revoke roles from groups")))
+		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("revoking: only root users can revoke roles from groups")))
 	}
 
 	if err := h.validateRootGroup(params.ID); err != nil {

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -434,10 +434,6 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 }
 
 func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, principal *models.Principal) middleware.Responder {
-	if !h.isRootUser(principal.Username) {
-		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("only root users can assign roles to groups")))
-	}
-
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
 			return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to assign is empty")))
@@ -454,6 +450,10 @@ func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, 
 
 	if err := h.authorizer.Authorize(principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)...); err != nil {
 		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	if !h.isRootUser(principal.Username) {
+		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("only root users can assign roles to groups")))
 	}
 
 	if err := h.validateRootGroup(params.ID); err != nil {
@@ -606,10 +606,6 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 }
 
 func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupParams, principal *models.Principal) middleware.Responder {
-	if !h.isRootUser(principal.Username) {
-		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("only root users can revoke roles from groups")))
-	}
-
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
 			return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
@@ -626,6 +622,10 @@ func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupPara
 
 	if err := h.authorizer.Authorize(principal, authorization.UPDATE, authorization.Roles(params.Body.Roles...)...); err != nil {
 		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
+	if !h.isRootUser(principal.Username) {
+		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("only root users can revoke roles from groups")))
 	}
 
 	if err := h.validateRootGroup(params.ID); err != nil {

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -62,7 +62,7 @@ func TestAssignRoleToGroupSuccess(t *testing.T) {
 	controller := mocks.NewController(t)
 	logger, _ := test.NewNullLogger()
 
-	principal := &models.Principal{Username: "user1"}
+	principal := &models.Principal{Username: "root-user"}
 	params := authz.AssignRoleToGroupParams{
 		ID: "group1",
 		Body: authz.AssignRoleToGroupBody{
@@ -79,6 +79,9 @@ func TestAssignRoleToGroupSuccess(t *testing.T) {
 		controller:     controller,
 		apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
 		logger:         logger,
+		rbacconfig: rbacconf.Config{
+			RootUsers: []string{"root-user"},
+		},
 	}
 	res := h.assignRoleToGroup(params, principal)
 	parsed, ok := res.(*authz.AssignRoleToGroupOK)
@@ -168,7 +171,7 @@ func TestAssignRoleToGroupOrUserNotFound(t *testing.T) {
 					Roles: []string{"role1"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			existedRoles:  map[string][]authorization.Policy{},
 			callToGetRole: true,
 		},
@@ -190,6 +193,9 @@ func TestAssignRoleToGroupOrUserNotFound(t *testing.T) {
 				authorizer: authorizer,
 				controller: controller,
 				logger:     logger,
+				rbacconfig: rbacconf.Config{
+					RootUsers: []string{"root-user"},
+				},
 			}
 			res := h.assignRoleToGroup(tt.params, tt.principal)
 			_, ok := res.(*authz.AssignRoleToGroupNotFound)
@@ -401,7 +407,7 @@ func TestAssignRoleToGroupForbidden(t *testing.T) {
 				ID:   "root-group",
 				Body: authz.AssignRoleToGroupBody{Roles: []string{"some-role"}},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			expectedError: "assigning: cannot assign or revoke from root group root-group",
 		},
 		{
@@ -411,7 +417,7 @@ func TestAssignRoleToGroupForbidden(t *testing.T) {
 				Body: authz.AssignRoleToGroupBody{Roles: []string{"some-role"}},
 			},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "assigning: cannot assign or revoke from root group viewer-root-group",
+			expectedError: "assigning: only root users can assign roles to groups",
 		},
 	}
 
@@ -528,7 +534,7 @@ func TestAssignRoleToGroupInternalServerError(t *testing.T) {
 					Roles: []string{"testRole"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			assignErr:     fmt.Errorf("internal server error"),
 			expectedError: "internal server error",
 		},
@@ -540,7 +546,7 @@ func TestAssignRoleToGroupInternalServerError(t *testing.T) {
 					Roles: []string{"testRole"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			getRolesErr:   fmt.Errorf("internal server error"),
 			expectedError: "internal server error",
 		},
@@ -562,6 +568,9 @@ func TestAssignRoleToGroupInternalServerError(t *testing.T) {
 				authorizer: authorizer,
 				controller: controller,
 				logger:     logger,
+				rbacconfig: rbacconf.Config{
+					RootUsers: []string{"root-user"},
+				},
 			}
 			res := h.assignRoleToGroup(tt.params, tt.principal)
 			parsed, ok := res.(*authz.AssignRoleToGroupInternalServerError)

--- a/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
@@ -104,7 +104,7 @@ func TestRevokeRoleFromGroupSuccess(t *testing.T) {
 	}{
 		{
 			name:      "successful revocation",
-			principal: &models.Principal{Username: "user1"},
+			principal: &models.Principal{Username: "root-user"},
 			params: authz.RevokeRoleFromGroupParams{
 				ID: "user1",
 				Body: authz.RevokeRoleFromGroupBody{
@@ -121,7 +121,7 @@ func TestRevokeRoleFromGroupSuccess(t *testing.T) {
 				},
 			},
 			configuredAdmins: []string{"testUser"},
-			principal:        &models.Principal{Username: "user1"},
+			principal:        &models.Principal{Username: "root-user"},
 		},
 		{
 			name: "revoke another user user not configured viewer role",
@@ -132,7 +132,7 @@ func TestRevokeRoleFromGroupSuccess(t *testing.T) {
 				},
 			},
 			configuredViewers: []string{"testUser"},
-			principal:         &models.Principal{Username: "user1"},
+			principal:         &models.Principal{Username: "root-user"},
 		},
 	}
 
@@ -151,6 +151,9 @@ func TestRevokeRoleFromGroupSuccess(t *testing.T) {
 				controller:     controller,
 				apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
 				logger:         logger,
+				rbacconfig: rbacconf.Config{
+					RootUsers: []string{"root-user"},
+				},
 			}
 			res := h.revokeRoleFromGroup(tt.params, tt.principal)
 			parsed, ok := res.(*authz.RevokeRoleFromGroupOK)
@@ -345,7 +348,7 @@ func TestRevokeRoleFromGroupOrUserNotFound(t *testing.T) {
 					Roles: []string{"role1"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			existedRoles:  map[string][]authorization.Policy{},
 			existedUsers:  []string{"user1"},
 			callToGetRole: true,
@@ -369,6 +372,9 @@ func TestRevokeRoleFromGroupOrUserNotFound(t *testing.T) {
 				controller:     controller,
 				apiKeysConfigs: config.APIKey{Enabled: true, Users: tt.existedUsers},
 				logger:         logger,
+				rbacconfig: rbacconf.Config{
+					RootUsers: []string{"root-user"},
+				},
 			}
 			res := h.revokeRoleFromGroup(tt.params, tt.principal)
 			_, ok := res.(*authz.RevokeRoleFromGroupNotFound)
@@ -467,18 +473,18 @@ func TestRevokeRoleFromGroupForbidden(t *testing.T) {
 			expectedError: "authorization error",
 		},
 		{
-			name: "revoke role from root group",
+			name: "revoke role from root group as root user",
 			params: authz.RevokeRoleFromGroupParams{
-				ID: "root-group",
+				ID: "viewer-root-group",
 				Body: authz.RevokeRoleFromGroupBody{
 					Roles: []string{"something"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			expectedError: "revoking: cannot assign or revoke from root group",
 		},
 		{
-			name: "revoke role from root group",
+			name: "revoke role from root group as non-root user",
 			params: authz.RevokeRoleFromGroupParams{
 				ID: "viewer-root-group",
 				Body: authz.RevokeRoleFromGroupBody{
@@ -486,7 +492,7 @@ func TestRevokeRoleFromGroupForbidden(t *testing.T) {
 				},
 			},
 			principal:     &models.Principal{Username: "user1"},
-			expectedError: "revoking: cannot assign or revoke from root group",
+			expectedError: "revoking: only root users can revoke roles from groups",
 		},
 		{
 			name: "revoke configured root role",
@@ -517,6 +523,7 @@ func TestRevokeRoleFromGroupForbidden(t *testing.T) {
 				controller: controller,
 				logger:     logger,
 				rbacconfig: rbacconf.Config{
+					RootUsers:        []string{"root-user"},
 					RootGroups:       []string{"root-group"},
 					ViewerRootGroups: []string{"viewer-root-group"},
 				},
@@ -616,7 +623,7 @@ func TestRevokeRoleFromGroupInternalServerError(t *testing.T) {
 					Roles: []string{"testRole"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			revokeErr:     fmt.Errorf("internal server error"),
 			expectedError: "internal server error",
 		},
@@ -628,7 +635,7 @@ func TestRevokeRoleFromGroupInternalServerError(t *testing.T) {
 					Roles: []string{"testRole"},
 				},
 			},
-			principal:     &models.Principal{Username: "user1"},
+			principal:     &models.Principal{Username: "root-user"},
 			getRolesErr:   fmt.Errorf("internal server error"),
 			expectedError: "internal server error",
 		},
@@ -650,6 +657,9 @@ func TestRevokeRoleFromGroupInternalServerError(t *testing.T) {
 				authorizer: authorizer,
 				controller: controller,
 				logger:     logger,
+				rbacconfig: rbacconf.Config{
+					RootUsers: []string{"root-user"},
+				},
 			}
 			res := h.revokeRoleFromGroup(tt.params, tt.principal)
 			parsed, ok := res.(*authz.RevokeRoleFromGroupInternalServerError)


### PR DESCRIPTION
### What's being changed:

Until `authN` and dynamic user management is in, this change ensures that assigning and revoking to and from groups is only permitted for root users

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
