### PR TITLE
bug: When flush is failed increase retry interval 

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1057,6 +1057,7 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 				WithField("path", b.dir).
 				WithError(err).
 				Errorf("flush and switch failed")
+			return false
 		}
 
 		if b.memtableResizer != nil {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1024,6 +1024,7 @@ func (b *Bucket) Shutdown(ctx context.Context) error {
 	}
 }
 
+// flushAndSwitchIfThresholdsMet is part of flush callbacks of the bucket.
 func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAbortCallback) bool {
 	b.flushLock.RLock()
 	commitLogSize := b.active.commitlog.Size()


### PR DESCRIPTION
### What's being changed:

Currently if `FlushAndSwitch` failed for any underlying issues (say disk failures, no disk space left), we don't report any failure to the flushcallback manager. So it will be retried with current interval (100ms).

By returning `false`, we [increase the interval](https://github.com/weaviate/weaviate/blob/kavirajk%2Fbucket-flush-failure-backoff/entities/cyclemanager/cyclecallbackgroup.go#L155-L159) up to 5s. So less retry, thus less error logs during unrecoverable errors.

myself and @aliszka tested this manually. We agreed we can merge the PR as is if it's passing the existing test suite and chaos tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
