### PR TITLE
[hnsw] Add multi-vector support to ContainsNode and Iterate

### DIFF
--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -587,7 +587,7 @@ func TestIndex_DebugResetVectorIndex(t *testing.T) {
 
 	// make sure the new index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsNode(obj.DocID) {
+		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -608,7 +608,7 @@ func TestIndex_DebugResetVectorIndex(t *testing.T) {
 
 	// make sure the new index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsNode(obj.DocID) {
+		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -679,7 +679,7 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 	// make sure the new index contains all the objects
 	vidx := shard.VectorIndexes()["foo"]
 	for _, obj := range objs {
-		if !vidx.ContainsNode(obj.DocID) {
+		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -702,7 +702,7 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 	// make sure the new index contains all the objects
 	vidx = shard.VectorIndexes()["foo"]
 	for _, obj := range objs {
-		if !vidx.ContainsNode(obj.DocID) {
+		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -797,7 +797,7 @@ func TestIndex_DebugResetVectorIndexPQ(t *testing.T) {
 
 	// make sure the new index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsNode(obj.DocID) {
+		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -885,7 +885,7 @@ func TestIndex_ConvertQueue(t *testing.T) {
 
 	// make sure the index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsNode(obj.DocID) {
+		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -951,7 +951,7 @@ func TestIndex_ConvertQueueTargetVector(t *testing.T) {
 
 	// make sure the index contains all the objects
 	for _, obj := range objs {
-		if !vectorIndex.ContainsNode(obj.DocID) {
+		if !vectorIndex.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -363,19 +363,19 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 	}
 
 	// remove any indexed vector that is not in the LSM store
-	vectorIndex.Iterate(func(id uint64) bool {
-		if visited.Visited(id) {
+	vectorIndex.Iterate(func(docID uint64) bool {
+		if visited.Visited(docID) {
 			return true
 		}
 
 		deleted++
 		if vectorIndex.Multivector() {
-			if err := vectorIndex.DeleteMulti(id); err != nil {
-				s.index.logger.WithError(err).WithField("id", id).Warn("delete multi-vector from queue")
+			if err := vectorIndex.DeleteMulti(docID); err != nil {
+				s.index.logger.WithError(err).WithField("id", docID).Warn("delete multi-vector from queue")
 			}
 		} else {
-			if err := vectorIndex.Delete(id); err != nil {
-				s.index.logger.WithError(err).WithField("id", id).Warn("delete vector from queue")
+			if err := vectorIndex.Delete(docID); err != nil {
+				s.index.logger.WithError(err).WithField("id", docID).Warn("delete vector from queue")
 			}
 		}
 

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -373,47 +373,64 @@ func TestShard_RepairIndex(t *testing.T) {
 	tests := []struct {
 		name           string
 		targetVector   string
+		multiVector    bool
 		cfg            schemaConfig.VectorIndexConfig
 		idxOpt         func(*Index)
 		getQueue       func(ShardLike) *VectorIndexQueue
 		getVectorIndex func(ShardLike) VectorIndex
 	}{
 		{
-			"hnsw",
-			"",
-			hnsw.UserConfig{},
-			nil,
-			func(s ShardLike) *VectorIndexQueue {
+			name: "hnsw",
+			cfg:  hnsw.UserConfig{},
+			getQueue: func(s ShardLike) *VectorIndexQueue {
 				return s.Queue()
 			},
-			func(s ShardLike) VectorIndex {
+			getVectorIndex: func(s ShardLike) VectorIndex {
 				return s.VectorIndex()
 			},
 		},
 		{
-			"hnsw with target vectors",
-			"foo",
-			hnsw.UserConfig{},
-			func(i *Index) {
+			name:         "hnsw with target vectors",
+			targetVector: "foo",
+			cfg:          hnsw.UserConfig{},
+			idxOpt: func(i *Index) {
 				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
 				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{}
 			},
-			func(s ShardLike) *VectorIndexQueue {
+			getQueue: func(s ShardLike) *VectorIndexQueue {
 				return s.Queues()["foo"]
 			},
-			func(s ShardLike) VectorIndex {
+			getVectorIndex: func(s ShardLike) VectorIndex {
 				return s.VectorIndexes()["foo"]
 			},
 		},
 		{
-			"flat",
-			"",
-			flat.NewDefaultUserConfig(),
-			nil,
-			func(s ShardLike) *VectorIndexQueue {
+			name:         "hnsw with multi vectors",
+			targetVector: "foo",
+			multiVector:  true,
+			cfg:          hnsw.UserConfig{},
+			idxOpt: func(i *Index) {
+				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
+				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{
+					Multivector: hnsw.MultivectorConfig{
+						Enabled: true,
+					},
+				}
+			},
+			getQueue: func(s ShardLike) *VectorIndexQueue {
+				return s.Queues()["foo"]
+			},
+			getVectorIndex: func(s ShardLike) VectorIndex {
+				return s.VectorIndexes()["foo"]
+			},
+		},
+		{
+			name: "flat",
+			cfg:  flat.NewDefaultUserConfig(),
+			getQueue: func(s ShardLike) *VectorIndexQueue {
 				return s.Queue()
 			},
-			func(s ShardLike) VectorIndex {
+			getVectorIndex: func(s ShardLike) VectorIndex {
 				return s.VectorIndex()
 			},
 		},
@@ -442,8 +459,14 @@ func TestShard_RepairIndex(t *testing.T) {
 			for i := 0; i < amount; i++ {
 				obj := testObject(className)
 				if test.targetVector != "" {
-					obj.Vectors = map[string][]float32{
-						test.targetVector: {1, 2, 3},
+					if test.multiVector {
+						obj.MultiVectors = map[string][][]float32{
+							test.targetVector: {{1, 2, 3}, {4, 5, 6}},
+						}
+					} else {
+						obj.Vectors = map[string][]float32{
+							test.targetVector: {1, 2, 3},
+						}
 					}
 				}
 				objs = append(objs, obj)
@@ -467,8 +490,13 @@ func TestShard_RepairIndex(t *testing.T) {
 
 			// remove some objects from the vector index
 			for i := 400; i < 600; i++ {
-				err := vidx.Delete(uint64(i))
-				require.NoError(t, err)
+				if test.multiVector {
+					err := vidx.DeleteMulti(uint64(i))
+					require.NoError(t, err)
+				} else {
+					err := vidx.Delete(uint64(i))
+					require.NoError(t, err)
+				}
 			}
 
 			// remove some objects from the store
@@ -503,14 +531,14 @@ func TestShard_RepairIndex(t *testing.T) {
 			// make sure all objects except >= 100 < 300 are back in the vector index
 			for i := 0; i < amount; i++ {
 				if i >= 100 && i < 300 {
-					if vidx.ContainsNode(uint64(i)) {
-						t.Fatalf("node %d should not be in the vector index", i)
+					if vidx.ContainsDoc(uint64(i)) {
+						t.Fatalf("doc %d should not be in the vector index", i)
 					}
 					continue
 				}
 
-				if !vidx.ContainsNode(uint64(i)) {
-					t.Fatalf("node %d should be in the vector index", i)
+				if !vidx.ContainsDoc(uint64(i)) {
+					t.Fatalf("doc %d should be in the vector index", i)
 				}
 			}
 

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -281,7 +281,7 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 
 	// make sure the new index does not contain any of the objects
 	for _, obj := range objs {
-		if newIdx.ContainsNode(obj.DocID) {
+		if newIdx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should not be in the vector index", obj.DocID)
 		}
 	}
@@ -357,7 +357,7 @@ func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
 
 	// make sure the new index does not contain any of the objects
 	for _, obj := range objs {
-		if newIdx.ContainsNode(obj.DocID) {
+		if newIdx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should not be in the vector index", obj.DocID)
 		}
 	}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -78,7 +78,6 @@ type VectorIndex interface {
 	Multivector() bool
 	ValidateBeforeInsert(vector []float32) error
 	DistanceBetweenVectors(x, y []float32) (float32, error)
-	ContainsNode(id uint64) bool
 	ContainsDoc(docID uint64) bool
 	DistancerProvider() distancer.Provider
 	AlreadyIndexed() uint64
@@ -399,12 +398,6 @@ func (dynamic *dynamic) DistanceBetweenVectors(x, y []float32) (float32, error) 
 	dynamic.RLock()
 	defer dynamic.RUnlock()
 	return dynamic.index.DistanceBetweenVectors(x, y)
-}
-
-func (dynamic *dynamic) ContainsNode(id uint64) bool {
-	dynamic.RLock()
-	defer dynamic.RUnlock()
-	return dynamic.index.ContainsNode(id)
 }
 
 func (dynamic *dynamic) ContainsDoc(docID uint64) bool {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -79,6 +79,7 @@ type VectorIndex interface {
 	ValidateBeforeInsert(vector []float32) error
 	DistanceBetweenVectors(x, y []float32) (float32, error)
 	ContainsNode(id uint64) bool
+	ContainsDoc(docID uint64) bool
 	DistancerProvider() distancer.Provider
 	AlreadyIndexed() uint64
 	QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer
@@ -404,6 +405,12 @@ func (dynamic *dynamic) ContainsNode(id uint64) bool {
 	dynamic.RLock()
 	defer dynamic.RUnlock()
 	return dynamic.index.ContainsNode(id)
+}
+
+func (dynamic *dynamic) ContainsDoc(docID uint64) bool {
+	dynamic.RLock()
+	defer dynamic.RUnlock()
+	return dynamic.index.ContainsDoc(docID)
 }
 
 func (dynamic *dynamic) AlreadyIndexed() uint64 {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -83,11 +83,10 @@ type VectorIndex interface {
 	AlreadyIndexed() uint64
 	QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer
 	QueryMultiVectorDistancer(queryVector [][]float32) common.QueryVectorDistancer
-	// Iterate over all nodes in the index.
-	// Consistency is not guaranteed, as the
-	// index may be concurrently modified.
+	// Iterate over all indexed document ids in the index.
+	// Consistency or order is not guaranteed, as the index may be concurrently modified.
 	// If the callback returns false, the iteration will stop.
-	Iterate(fn func(id uint64) bool)
+	Iterate(fn func(docID uint64) bool)
 	Stats() (common.IndexStats, error)
 }
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -883,7 +883,7 @@ func (index *flat) ContainsDoc(id uint64) bool {
 	return true
 }
 
-func (index *flat) Iterate(fn func(id uint64) bool) {
+func (index *flat) Iterate(fn func(docID uint64) bool) {
 	var bucketName string
 
 	// logic modeled after SearchByVector which indicates that the PQ bucket is

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -883,6 +883,10 @@ func (index *flat) ContainsNode(id uint64) bool {
 	return true
 }
 
+func (index *flat) ContainsDoc(docID uint64) bool {
+	return index.ContainsNode(docID)
+}
+
 func (index *flat) Iterate(fn func(id uint64) bool) {
 	var bucketName string
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -858,7 +858,7 @@ func (index *flat) DistanceBetweenVectors(x, y []float32) (float32, error) {
 	return index.distancerProvider.SingleDist(x, y)
 }
 
-func (index *flat) ContainsNode(id uint64) bool {
+func (index *flat) ContainsDoc(id uint64) bool {
 	var bucketName string
 
 	// logic modeled after SearchByVector which indicates that the PQ bucket is
@@ -881,10 +881,6 @@ func (index *flat) ContainsNode(id uint64) bool {
 	}
 
 	return true
-}
-
-func (index *flat) ContainsDoc(docID uint64) bool {
-	return index.ContainsNode(docID)
 }
 
 func (index *flat) Iterate(fn func(id uint64) bool) {

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -791,10 +791,8 @@ func (h *hnsw) hasTombstone(id uint64) bool {
 	return ok
 }
 
-// hasMultiTombstone checks whether at least one node of multi-vector has a tombstone attached.
-// Since the nodes of multi-vector are deleted in a non-atomic fashion, sometimes you might find some
-// nodes still lingering, however, they should be cleaned up soon.
-func (h *hnsw) hasMultiTombstone(ids []uint64) bool {
+// hasTombstones checks whether at least one node of the provided ids has a tombstone attached.
+func (h *hnsw) hasTombstones(ids []uint64) bool {
 	h.tombstoneLock.RLock()
 	defer h.tombstoneLock.RUnlock()
 

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -791,6 +791,21 @@ func (h *hnsw) hasTombstone(id uint64) bool {
 	return ok
 }
 
+// hasMultiTombstone checks whether at least one node of multi-vector has a tombstone attached.
+// Since the nodes of multi-vector are deleted in a non-atomic fashion, sometimes you might find some
+// nodes still lingering, however, they should be cleaned up soon.
+func (h *hnsw) hasMultiTombstone(ids []uint64) bool {
+	h.tombstoneLock.RLock()
+	defer h.tombstoneLock.RUnlock()
+
+	var has bool
+	for _, id := range ids {
+		_, ok := h.tombstones[id]
+		has = has || ok
+	}
+	return has
+}
+
 func (h *hnsw) addTombstone(ids ...uint64) error {
 	h.tombstoneLock.Lock()
 	defer h.tombstoneLock.Unlock()

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -693,6 +693,17 @@ func (h *hnsw) ContainsNode(id uint64) bool {
 	return exists && !h.hasTombstone(id)
 }
 
+func (h *hnsw) ContainsDoc(docID uint64) bool {
+	if h.Multivector() {
+		h.RLock()
+		vecIds, exists := h.docIDVectors[docID]
+		h.RUnlock()
+		return exists && !h.hasMultiTombstone(vecIds)
+	}
+
+	return h.ContainsNode(docID)
+}
+
 func (h *hnsw) Iterate(fn func(id uint64) bool) {
 	var id uint64
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -688,7 +688,7 @@ func (h *hnsw) ContainsDoc(docID uint64) bool {
 		h.RLock()
 		vecIds, exists := h.docIDVectors[docID]
 		h.RUnlock()
-		return exists && !h.hasMultiTombstone(vecIds)
+		return exists && !h.hasTombstones(vecIds)
 	}
 
 	h.RLock()

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -196,7 +196,7 @@ func createEmptyHnswIndexForTests(t testing.TB, vecForIDFn common.VectorForID[fl
 	return index
 }
 
-func TestHnswIndexContainsNode(t *testing.T) {
+func TestHnswIndexContainsDoc(t *testing.T) {
 	ctx := context.Background()
 	t.Run("should return false if index is empty", func(t *testing.T) {
 		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
@@ -204,7 +204,7 @@ func TestHnswIndexContainsNode(t *testing.T) {
 			return nil, nil
 		}
 		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		require.False(t, index.ContainsNode(1))
+		require.False(t, index.ContainsDoc(1))
 	})
 
 	t.Run("should return true if node is in the index", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestHnswIndexContainsNode(t *testing.T) {
 			err := index.Add(ctx, uint64(i), vec)
 			require.Nil(t, err)
 		}
-		require.True(t, index.ContainsNode(5))
+		require.True(t, index.ContainsDoc(5))
 	})
 
 	t.Run("should return false if node is not in the index", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestHnswIndexContainsNode(t *testing.T) {
 			err := index.Add(ctx, uint64(i), vec)
 			require.Nil(t, err)
 		}
-		require.False(t, index.ContainsNode(100))
+		require.False(t, index.ContainsDoc(100))
 	})
 
 	t.Run("should return false if node is deleted", func(t *testing.T) {
@@ -242,9 +242,11 @@ func TestHnswIndexContainsNode(t *testing.T) {
 		}
 		err := index.Delete(5)
 		require.Nil(t, err)
-		require.False(t, index.ContainsNode(5))
+		require.False(t, index.ContainsDoc(5))
 	})
 }
+
+// TODO: add for multi-vector
 
 func TestHnswIndexIterate(t *testing.T) {
 	ctx := context.Background()

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -219,95 +219,71 @@ func createVectorHnswIndexTestConfig() Config {
 }
 
 func TestHnswIndexContainsDoc(t *testing.T) {
-	ctx := context.Background()
-	t.Run("should return false if index is empty", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
-			t.Fatalf("vecForID should not be called on empty index")
-			return nil, nil
-		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		require.False(t, index.ContainsDoc(1))
-	})
-
-	t.Run("should return true if node is in the index", func(t *testing.T) {
-		index := createEmptyHnswIndexForTests(t, testVectorForID)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
-		}
-		require.True(t, index.ContainsDoc(5))
-	})
-
-	t.Run("should return false if node is not in the index", func(t *testing.T) {
-		index := createEmptyHnswIndexForTests(t, testVectorForID)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
-		}
-		require.False(t, index.ContainsDoc(100))
-	})
-
-	t.Run("should return false if node is deleted", func(t *testing.T) {
-		index := createEmptyHnswIndexForTests(t, testVectorForID)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
-		}
-		err := index.Delete(5)
-		require.Nil(t, err)
-		require.False(t, index.ContainsDoc(5))
-	})
+	testHnswIndexContainsDoc(t, genericVecTestHelperSingle())
 }
 
 func TestHnswIndexContainsDoc_MultiVector(t *testing.T) {
+	testHnswIndexContainsDoc(t, genericVecTestHelperMulti())
+}
+
+func testHnswIndexContainsDoc[T float32 | []float32](t *testing.T, h genericVecTestHelper[T]) {
 	ctx := context.Background()
+
 	t.Run("should return false if index is empty", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([][]float32, error) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]T, error) {
 			t.Fatalf("vecForID should not be called on empty index")
 			return nil, nil
 		}
-		index := createEmptyMultiVectorHnswIndexForTests(t, vecForIDFn)
+		index := h.createIndex(t, vecForIDFn)
 		require.False(t, index.ContainsDoc(1))
 	})
 
 	t.Run("should return true if node is in the index", func(t *testing.T) {
-		index := createEmptyMultiVectorHnswIndexForTests(t, testMultiVectorForID)
-		for i, vec := range testMultiVectors {
-			err := index.AddMulti(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 		require.True(t, index.ContainsDoc(5))
 	})
 
 	t.Run("should return false if node is not in the index", func(t *testing.T) {
-		index := createEmptyMultiVectorHnswIndexForTests(t, testMultiVectorForID)
-		for i, vec := range testMultiVectors {
-			err := index.AddMulti(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 		require.False(t, index.ContainsDoc(100))
 	})
 
 	t.Run("should return false if node is deleted", func(t *testing.T) {
-		index := createEmptyMultiVectorHnswIndexForTests(t, testMultiVectorForID)
-		for i, vec := range testMultiVectors {
-			err := index.AddMulti(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
-		err := index.DeleteMulti(5)
+		err := h.deleteDocFromIndex(index, ctx, uint64(5))
 		require.Nil(t, err)
 		require.False(t, index.ContainsDoc(5))
 	})
 }
 
 func TestHnswIndexIterate(t *testing.T) {
+	testHnswIndexIterate(t, genericVecTestHelperSingle())
+}
+
+func TestHnswIndexIterate_MultiVector(t *testing.T) {
+	testHnswIndexIterate(t, genericVecTestHelperMulti())
+}
+
+func testHnswIndexIterate[T float32 | []float32](t *testing.T, h genericVecTestHelper[T]) {
 	ctx := context.Background()
 	t.Run("should not run callback on empty index", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
+		vecForIDFn := func(ctx context.Context, id uint64) ([]T, error) {
 			t.Fatalf("vecForID should not be called on empty index")
 			return nil, nil
 		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
+		index := h.createIndex(t, vecForIDFn)
 		index.Iterate(func(id uint64) bool {
 			t.Fatalf("callback should not be called on empty index")
 			return true
@@ -315,16 +291,13 @@ func TestHnswIndexIterate(t *testing.T) {
 	})
 
 	t.Run("should iterate over all nodes", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
-			return testVectors[id], nil
-		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 
-		visited := make([]bool, len(testVectors))
+		visited := make([]bool, len(h.testVectors))
 		index.Iterate(func(id uint64) bool {
 			visited[id] = true
 			return true
@@ -335,98 +308,68 @@ func TestHnswIndexIterate(t *testing.T) {
 	})
 
 	t.Run("should stop iteration when callback returns false", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
-			return testVectors[id], nil
-		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 
-		visited := make([]bool, len(testVectors))
+		counter := 0
 		index.Iterate(func(id uint64) bool {
-			visited[id] = true
-			return id < 5
+			counter++
+			return counter < 5
 		})
-		for i, v := range visited {
-			if i <= 5 {
-				assert.True(t, v, "node %d was not visited", i)
-			} else {
-				assert.False(t, v, "node %d was visited", i)
-			}
-		}
+		require.Equal(t, 5, counter)
 	})
 
 	t.Run("should stop iteration when shutdownCtx is canceled", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
-			return testVectors[id], nil
-		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 
-		visited := make([]bool, len(testVectors))
+		counter := 0
 		index.Iterate(func(id uint64) bool {
-			visited[id] = true
-			if id == 5 {
+			counter++
+			if counter == 5 {
 				err := index.Shutdown(context.Background())
 				require.NoError(t, err)
 			}
 			return true
 		})
-		for i, v := range visited {
-			if i <= 5 {
-				assert.True(t, v, "node %d was not visited", i)
-			} else {
-				assert.False(t, v, "node %d was visited", i)
-			}
-		}
+		require.Equal(t, 5, counter)
 	})
 
 	t.Run("should stop iteration when resetCtx is canceled", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
-			return testVectors[id], nil
-		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 
-		visited := make([]bool, len(testVectors))
+		counter := 0
 		index.Iterate(func(id uint64) bool {
-			visited[id] = true
-			if id == 5 {
+			counter++
+			if counter == 5 {
 				index.resetCtxCancel()
 			}
 			return true
 		})
-		for i, v := range visited {
-			if i <= 5 {
-				assert.True(t, v, "node %d was not visited", i)
-			} else {
-				assert.False(t, v, "node %d was visited", i)
-			}
-		}
+		require.Equal(t, 5, counter)
 	})
 
 	t.Run("should skip deleted nodes", func(t *testing.T) {
-		vecForIDFn := func(ctx context.Context, id uint64) ([]float32, error) {
-			return testVectors[id], nil
-		}
-		index := createEmptyHnswIndexForTests(t, vecForIDFn)
-		for i, vec := range testVectors {
-			err := index.Add(ctx, uint64(i), vec)
-			require.Nil(t, err)
+		index := h.createIndex(t, h.vecForIDFn)
+		for i, vec := range h.testVectors {
+			err := h.addDocToIndex(index, ctx, uint64(i), vec)
+			require.NoError(t, err)
 		}
 
-		err := index.Delete(uint64(5))
-		require.Nil(t, err)
+		err := h.deleteDocFromIndex(index, ctx, uint64(5))
+		require.NoError(t, err)
 
-		visited := make([]bool, len(testVectors))
+		visited := make([]bool, len(h.testVectors))
 		index.Iterate(func(id uint64) bool {
 			visited[id] = true
 			return true
@@ -439,4 +382,40 @@ func TestHnswIndexIterate(t *testing.T) {
 			}
 		}
 	})
+}
+
+type genericVecTestHelper[T float32 | []float32] struct {
+	createIndex        func(t testing.TB, vecForIDFn common.VectorForID[T]) *hnsw
+	vecForIDFn         common.VectorForID[T]
+	testVectors        [][]T
+	addDocToIndex      func(i *hnsw, ctx context.Context, docID uint64, vec []T) error
+	deleteDocFromIndex func(i *hnsw, ctx context.Context, docIDs ...uint64) error
+}
+
+func genericVecTestHelperSingle() genericVecTestHelper[float32] {
+	return genericVecTestHelper[float32]{
+		createIndex: createEmptyHnswIndexForTests,
+		vecForIDFn:  testVectorForID,
+		testVectors: testVectors,
+		addDocToIndex: func(i *hnsw, ctx context.Context, docID uint64, vec []float32) error {
+			return i.Add(ctx, docID, vec)
+		},
+		deleteDocFromIndex: func(i *hnsw, ctx context.Context, docIDs ...uint64) error {
+			return i.Delete(docIDs...)
+		},
+	}
+}
+
+func genericVecTestHelperMulti() genericVecTestHelper[[]float32] {
+	return genericVecTestHelper[[]float32]{
+		createIndex: createEmptyMultiVectorHnswIndexForTests,
+		vecForIDFn:  testMultiVectorForID,
+		testVectors: testMultiVectors,
+		addDocToIndex: func(i *hnsw, ctx context.Context, docID uint64, vec [][]float32) error {
+			return i.AddMulti(ctx, docID, vec)
+		},
+		deleteDocFromIndex: func(i *hnsw, ctx context.Context, docIDs ...uint64) error {
+			return i.DeleteMulti(docIDs...)
+		},
+	}
 }

--- a/adapters/repos/db/vector/hnsw/vectors_for_test.go
+++ b/adapters/repos/db/vector/hnsw/vectors_for_test.go
@@ -31,3 +31,55 @@ var testVectors = [][]float32{
 func testVectorForID(ctx context.Context, id uint64) ([]float32, error) {
 	return testVectors[int(id)], nil
 }
+
+var testMultiVectors = [][][]float32{
+	{
+		{0.1, 0.9},
+		{0.15, 0.8},
+		{0.13, 0.65},
+	},
+	{
+		{0.6, 0.1},
+		{0.63, 0.2},
+		{0.65, 0.08},
+	},
+	{
+		{0.8, 0.8},
+		{0.9, 0.75},
+		{0.8, 0.7},
+	},
+	{
+		{0.25, 0.45},
+		{0.28, 0.42},
+		{0.22, 0.48},
+	},
+	{
+		{0.35, 0.35},
+		{0.38, 0.32},
+		{0.33, 0.37},
+	},
+	{
+		{0.55, 0.55},
+		{0.58, 0.52},
+		{0.53, 0.57},
+	},
+	{
+		{0.7, 0.3},
+		{0.73, 0.28},
+		{0.68, 0.32},
+	},
+	{
+		{0.4, 0.85},
+		{0.43, 0.82},
+		{0.38, 0.87},
+	},
+	{
+		{0.95, 0.15},
+		{0.92, 0.18},
+		{0.97, 0.12},
+	},
+}
+
+func testMultiVectorForID(ctx context.Context, id uint64) ([][]float32, error) {
+	return testMultiVectors[int(id)], nil
+}

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -141,6 +141,10 @@ func (i *Index) ContainsNode(id uint64) bool {
 	return false
 }
 
+func (i *Index) ContainsDoc(docID uint64) bool {
+	return false
+}
+
 func (i *Index) Iterate(fn func(id uint64) bool) {}
 
 func (i *Index) DistancerProvider() distancer.Provider {

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -137,10 +137,6 @@ func (i *Index) DistanceBetweenVectors(x, y []float32) (float32, error) {
 	return 0, nil
 }
 
-func (i *Index) ContainsNode(id uint64) bool {
-	return false
-}
-
 func (i *Index) ContainsDoc(docID uint64) bool {
 	return false
 }

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -49,9 +49,6 @@ type VectorIndex interface {
 	ValidateBeforeInsert(vector []float32) error
 	ValidateMultiBeforeInsert(vector [][]float32) error
 	DistanceBetweenVectors(x, y []float32) (float32, error)
-	// ContainsNode returns true if the index contains the node with the given id.
-	// It must return false if the node does not exist, or has a tombstone.
-	ContainsNode(id uint64) bool
 	// ContainsDoc returns true if the index has indexed document with a given id.
 	// It must return false if the document does not exist, or has a tombstone.
 	ContainsDoc(docID uint64) bool

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -52,6 +52,9 @@ type VectorIndex interface {
 	// ContainsNode returns true if the index contains the node with the given id.
 	// It must return false if the node does not exist, or has a tombstone.
 	ContainsNode(id uint64) bool
+	// ContainsDoc returns true if the index has indexed document with a given id.
+	// It must return false if the document does not exist, or has a tombstone.
+	ContainsDoc(docID uint64) bool
 	AlreadyIndexed() uint64
 	// Iterate over all nodes in the index.
 	// Consistency is not guaranteed, as the

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -53,11 +53,10 @@ type VectorIndex interface {
 	// It must return false if the document does not exist, or has a tombstone.
 	ContainsDoc(docID uint64) bool
 	AlreadyIndexed() uint64
-	// Iterate over all nodes in the index.
-	// Consistency is not guaranteed, as the
-	// index may be concurrently modified.
+	// Iterate over all indexed document ids in the index.
+	// Consistency or order is not guaranteed, as the index may be concurrently modified.
 	// If the callback returns false, the iteration will stop.
-	Iterate(fn func(id uint64) bool)
+	Iterate(fn func(docID uint64) bool)
 	DistancerProvider() distancer.Provider
 	QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer
 	QueryMultiVectorDistancer(queryVector [][]float32) common.QueryVectorDistancer


### PR DESCRIPTION
### What's being changed:

I've been fiddling around in the `FillQueue` and `RepairIndex` and noticed that they have a bug due to the incorrect behavior of `ContainsNode` and `Iterate` which assume that `nodeID == docID` which is no longer the case with multi-vectors.

Things changed in this PR:
1. Renaming `ContainsNode` -> `ContainsDoc` as this is a more descriptive name because `Node` is `hnsw` internal detail.
2. Add multi-vector support for  `ContainsDoc` and `Iterate`.
3. Add new tests for multi-vectors for `ContainsDoc`, `Iterate`, and `FillQueue`/`RepairIndex` by refactoring them to utilize generics.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
