### PR TITLE
chore: concurrent object propagation

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/interval"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -39,19 +40,34 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
-const maxHashtreeHeight = 20
-
 const (
 	defaultHashtreeHeight              = 16
 	defaultFrequency                   = 30 * time.Second
 	defaultFrequencyWhilePropagating   = 10 * time.Millisecond
 	defaultAliveNodesCheckingFrequency = 1 * time.Second
 	defaultLoggingFrequency            = 5 * time.Second
+	defaultDiffBatchSize               = 1_000
 	defaultDiffPerNodeTimeout          = 10 * time.Second
 	defaultPropagationTimeout          = 30 * time.Second
 	defaultPropagationLimit            = 10_000
 	defaultPropagationDelay            = 30 * time.Second
-	defaultBatchSize                   = 100
+	defaultPropagationConcurrency      = 5
+	defaultPropagationBatchSize        = 100
+
+	minHashtreeHeight = 0
+	maxHashtreeHeight = 20
+
+	minDiffBatchSize = 1
+	maxDiffBatchSize = 10_000
+
+	minPropagationLimit = 1
+	maxPropagationLimit = 1_000_000
+
+	minPropgationConcurrency  = 1
+	maxPropagationConcurrency = 20
+
+	minPropagationBatchSize = 1
+	maxPropagationBatchSize = 1_000
 )
 
 type asyncReplicationConfig struct {
@@ -60,83 +76,104 @@ type asyncReplicationConfig struct {
 	frequencyWhilePropagating   time.Duration
 	aliveNodesCheckingFrequency time.Duration
 	loggingFrequency            time.Duration
+	diffBatchSize               int
 	diffPerNodeTimeout          time.Duration
 	propagationTimeout          time.Duration
 	propagationLimit            int
 	propagationDelay            time.Duration
-	batchSize                   int
+	propagationConcurrency      int
+	propagationBatchSize        int
 }
 
 func (s *Shard) getAsyncReplicationConfig() (config asyncReplicationConfig, err error) {
 	config.hashtreeHeight, err = optParseInt(
-		os.Getenv("ASYNC_REPLICATION_HASHTREE_HEIGHT"), defaultHashtreeHeight)
+		os.Getenv("ASYNC_REPLICATION_HASHTREE_HEIGHT"), defaultHashtreeHeight, minHashtreeHeight, maxHashtreeHeight)
 	if err != nil {
-		return
-	}
-	if config.hashtreeHeight < 0 || config.hashtreeHeight > maxHashtreeHeight {
-		return asyncReplicationConfig{}, fmt.Errorf("hashtree height out of range: min height 0, max height %d", maxHashtreeHeight)
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_HASHTREE_HEIGHT", err)
 	}
 
 	config.frequency, err = optParseDuration(os.Getenv("ASYNC_REPLICATION_FREQUENCY"), defaultFrequency)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_FREQUENCY", err)
 	}
 
 	config.frequencyWhilePropagating, err = optParseDuration(os.Getenv("ASYNC_REPLICATION_FREQUENCY_WHILE_PROPAGATING"), defaultFrequencyWhilePropagating)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_FREQUENCY_WHILE_PROPAGATING", err)
 	}
 
 	config.aliveNodesCheckingFrequency, err = optParseDuration(
 		os.Getenv("ASYNC_REPLICATION_ALIVE_NODES_CHECKING_FREQUENCY"), defaultAliveNodesCheckingFrequency)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_ALIVE_NODES_CHECKING_FREQUENCY", err)
 	}
 
 	config.loggingFrequency, err = optParseDuration(
 		os.Getenv("ASYNC_REPLICATION_LOGGING_FREQUENCY"), defaultLoggingFrequency)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_LOGGING_FREQUENCY", err)
+	}
+
+	config.diffBatchSize, err = optParseInt(
+		os.Getenv("ASYNC_REPLICATION_DIFF_BATCH_SIZE"), defaultDiffBatchSize, minDiffBatchSize, maxDiffBatchSize)
+	if err != nil {
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_DIFF_BATCH_SIZE", err)
 	}
 
 	config.diffPerNodeTimeout, err = optParseDuration(
 		os.Getenv("ASYNC_REPLICATION_DIFF_PER_NODE_TIMEOUT"), defaultDiffPerNodeTimeout)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_DIFF_PER_NODE_TIMEOUT", err)
 	}
 
 	config.propagationTimeout, err = optParseDuration(
 		os.Getenv("ASYNC_REPLICATION_PROPAGATION_TIMEOUT"), defaultPropagationTimeout)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_TIMEOUT", err)
 	}
 
 	config.propagationLimit, err = optParseInt(
-		os.Getenv("ASYNC_REPLICATION_PROPAGATION_LIMIT"), defaultPropagationLimit)
+		os.Getenv("ASYNC_REPLICATION_PROPAGATION_LIMIT"), defaultPropagationLimit, minPropagationLimit, maxPropagationLimit)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_LIMIT", err)
 	}
 
 	config.propagationDelay, err = optParseDuration(
 		os.Getenv("ASYNC_REPLICATION_PROPAGATION_DELAY"), defaultPropagationDelay)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_DELAY", err)
 	}
 
-	config.batchSize, err = optParseInt(
-		os.Getenv("ASYNC_REPLICATION_BATCH_SIZE"), defaultBatchSize)
+	config.propagationConcurrency, err = optParseInt(
+		os.Getenv("ASYNC_REPLICATION_PROPAGATION_CONCURRENCY"), defaultPropagationConcurrency, minPropgationConcurrency, maxPropagationConcurrency)
 	if err != nil {
-		return
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_CONCURRENCY", err)
+	}
+
+	config.propagationBatchSize, err = optParseInt(
+		os.Getenv("ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE"), defaultPropagationBatchSize, minPropagationBatchSize, maxPropagationBatchSize)
+	if err != nil {
+		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE", err)
 	}
 
 	return
 }
 
-func optParseInt(s string, defaultInt int) (int, error) {
+func optParseInt(s string, defaultVal, minVal, maxVal int) (val int, err error) {
 	if s == "" {
-		return defaultInt, nil
+		val = defaultVal
+	} else {
+		val, err = strconv.Atoi(s)
+		if err != nil {
+			return 0, err
+		}
 	}
-	return strconv.Atoi(s)
+
+	if val < minVal || val > maxVal {
+		return 0, fmt.Errorf("value %d out of range: min %d, max %d", val, minVal, maxVal)
+	}
+
+	return val, nil
 }
 
 func optParseDuration(s string, defaultDuration time.Duration) (time.Duration, error) {
@@ -659,14 +696,13 @@ func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (st
 		localObjs, remoteObjs, propagations, err := s.stepsTowardsShardConsistency(
 			ctx,
 			config,
-			s.name,
 			shardDiffReader.Host,
 			initialLeaf,
 			finalLeaf,
 			config.propagationLimit-objectsPropagated,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("achieving shard consistency : %w", err)
+			return nil, fmt.Errorf("achieving shard consistency: %w", err)
 		}
 
 		localObjects += localObjs
@@ -712,7 +748,7 @@ func incToNextLexValue(b []byte) bool {
 }
 
 func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncReplicationConfig,
-	shardName string, host string, initialLeaf, finalLeaf uint64, limit int,
+	host string, initialLeaf, finalLeaf uint64, limit int,
 ) (localObjects, remoteObjects, propagations int, err error) {
 	hashtreeHeight := config.hashtreeHeight
 
@@ -740,7 +776,7 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncRe
 			return localObjects, remoteObjects, propagations, err
 		}
 
-		allLocalDigests, err := s.index.DigestObjectsInRange(ctx, shardName, currLocalUUID, finalUUID, config.batchSize)
+		allLocalDigests, err := s.index.DigestObjectsInRange(ctx, s.name, currLocalUUID, finalUUID, config.diffBatchSize)
 		if err != nil {
 			return localObjects, remoteObjects, propagations, fmt.Errorf("fetching local object digests: %w", err)
 		}
@@ -762,7 +798,7 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncRe
 		}
 
 		// iteration should stop when all local digests within the range has been read
-		shouldContinueFetchingLocalData = len(localDigests) == config.batchSize
+		shouldContinueFetchingLocalData = len(localDigests) == config.diffBatchSize
 
 		lastLocalUUID := strfmt.UUID(localDigests[len(localDigests)-1].ID)
 
@@ -793,7 +829,7 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncRe
 			}
 
 			remoteDigests, err := s.index.replicator.DigestObjectsInRange(ctx,
-				shardName, host, currRemoteUUID, lastLocalUUID, config.batchSize)
+				s.name, host, currRemoteUUID, lastLocalUUID, config.diffBatchSize)
 			if err != nil {
 				return localObjects, remoteObjects, propagations, fmt.Errorf("fetching remote object digests: %w", err)
 			}
@@ -828,7 +864,7 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncRe
 				break
 			}
 
-			if len(remoteDigests) < config.batchSize {
+			if len(remoteDigests) < config.diffBatchSize {
 				break
 			}
 
@@ -901,7 +937,7 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncRe
 			continue
 		}
 
-		resp, err := s.index.replicator.Overwrite(ctx, host, s.class.Class, shardName, mergeObjs)
+		resp, err := s.propagateObjects(ctx, config, host, mergeObjs)
 		if err != nil {
 			return localObjects, remoteObjects, propagations, fmt.Errorf("propagating local objects: %w", err)
 		}
@@ -938,4 +974,66 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context, config asyncRe
 	// the local shard may receive recent objects when remote shard propagates them
 
 	return localObjects, remoteObjects, propagations, nil
+}
+
+func (s *Shard) propagateObjects(ctx context.Context, config asyncReplicationConfig, host string, objs []*objects.VObject) (res []replica.RepairResponse, err error) {
+	type workerResponse struct {
+		resp []replica.RepairResponse
+		err  error
+	}
+
+	var wg sync.WaitGroup
+
+	batchCh := make(chan []*objects.VObject, len(objs)/config.propagationBatchSize+1)
+	resultCh := make(chan workerResponse, len(objs)/config.propagationBatchSize+1)
+
+	for i := 0; i < config.propagationConcurrency; i++ {
+		enterrors.GoWrapper(func() {
+			for batch := range batchCh {
+				resp, err := s.index.replicator.Overwrite(ctx, host, s.class.Class, s.name, batch)
+
+				resultCh <- workerResponse{
+					resp: resp,
+					err:  err,
+				}
+
+				wg.Done()
+			}
+		}, s.index.logger)
+	}
+
+	for i := 0; i < len(objs); {
+		actualBatchSize := config.propagationBatchSize
+		if i+actualBatchSize > len(objs) {
+			actualBatchSize = len(objs) - i
+		}
+
+		wg.Add(1)
+		batchCh <- objs[i : i+actualBatchSize]
+
+		i += actualBatchSize
+	}
+
+	enterrors.GoWrapper(func() {
+		wg.Wait()
+		close(batchCh)
+		close(resultCh)
+	}, s.index.logger)
+
+	ec := errorcompounder.New()
+
+	for r := range resultCh {
+		if r.err != nil {
+			ec.Add(err)
+			continue
+		}
+
+		res = append(res, r.resp...)
+	}
+
+	if len(res) > 0 {
+		return res, nil
+	}
+
+	return nil, ec.ToError()
 }


### PR DESCRIPTION
### What's being changed:

Possibility to define the number of goroutines doing object propagation with env var `ASYNC_REPLICATION_PROPAGATION_CONCURRENCY`, default is set to 5

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
