### PR TITLE
RBAC: Remove need for read config for data methods

### DIFF
--- a/test/acceptance/authz/objects_validate_test.go
+++ b/test/acceptance/authz/objects_validate_test.go
@@ -12,11 +12,11 @@
 package authz
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/client/authz"
@@ -36,7 +36,6 @@ func TestAuthZObjectValidate(t *testing.T) {
 	customAuth := helper.CreateAuth(customKey)
 
 	readDataAction := authorization.ReadData
-	readCollectionsAction := authorization.ReadCollections
 
 	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{customUser: customKey}, nil)
 	defer down()
@@ -54,6 +53,21 @@ func TestAuthZObjectValidate(t *testing.T) {
 		},
 	}, adminAuth))
 
+	t.Run("No rights ", func(t *testing.T) {
+		paramsObj := objects.NewObjectsValidateParams().WithBody(
+			&models.Object{
+				ID:    strfmt.UUID(uuid.New().String()),
+				Class: className,
+				Properties: map[string]interface{}{
+					"prop": "test",
+				},
+			})
+		_, err := helper.Client(t).Objects.ObjectsValidate(paramsObj, customAuth)
+		require.NotNil(t, err)
+		var errNoAuth *objects.ObjectsValidateForbidden
+		require.True(t, errors.As(err, &errNoAuth))
+	})
+
 	t.Run("All rights", func(t *testing.T) {
 		deleteRole := &models.Role{
 			Name: &roleName,
@@ -61,10 +75,6 @@ func TestAuthZObjectValidate(t *testing.T) {
 				{
 					Action: &readDataAction,
 					Data:   &models.PermissionData{Collection: &className},
-				},
-				{
-					Action:      &readCollectionsAction,
-					Collections: &models.PermissionCollections{Collection: &className},
 				},
 			},
 		}
@@ -94,41 +104,4 @@ func TestAuthZObjectValidate(t *testing.T) {
 		require.Nil(t, err)
 		helper.DeleteRole(t, adminKey, roleName)
 	})
-
-	perms := []*models.Permission{{Action: &readDataAction, Data: &models.PermissionData{Collection: &className}}, {Action: &readCollectionsAction, Collections: &models.PermissionCollections{Collection: &className}}}
-	for _, perm := range perms {
-		t.Run("Only rights for "+*perm.Action, func(t *testing.T) {
-			deleteRole := &models.Role{
-				Name:        &roleName,
-				Permissions: []*models.Permission{perm},
-			}
-			helper.DeleteRole(t, adminKey, *deleteRole.Name)
-			helper.CreateRole(t, adminKey, deleteRole)
-			_, err := helper.Client(t).Authz.AssignRoleToUser(
-				authz.NewAssignRoleToUserParams().WithID(customUser).WithBody(authz.AssignRoleToUserBody{Roles: []string{roleName}}),
-				adminAuth,
-			)
-			require.Nil(t, err)
-
-			paramsObj := objects.NewObjectsValidateParams().WithBody(
-				&models.Object{
-					ID:    strfmt.UUID(uuid.New().String()),
-					Class: className,
-					Properties: map[string]interface{}{
-						"prop": "test",
-					},
-				})
-			_, err = helper.Client(t).Objects.ObjectsValidate(paramsObj, customAuth)
-			require.NotNil(t, err)
-			var errNoAuth *objects.ObjectsValidateForbidden
-			require.True(t, errors.As(err, &errNoAuth))
-
-			_, err = helper.Client(t).Authz.RevokeRoleFromUser(
-				authz.NewRevokeRoleFromUserParams().WithID(customUser).WithBody(authz.RevokeRoleFromUserBody{Roles: []string{roleName}}),
-				adminAuth,
-			)
-			require.Nil(t, err)
-			helper.DeleteRole(t, adminKey, roleName)
-		})
-	}
 }

--- a/test/acceptance_with_python/rbac/conftest.py
+++ b/test/acceptance_with_python/rbac/conftest.py
@@ -63,7 +63,7 @@ def role_wrapper() -> RoleWrapperProtocol:
         yield
 
         if not isinstance(permissions, list) or len(permissions) > 0:
-            admin_client.roles.revoke_roles(user_id=user, role_names=name)
+            admin_client.users.revoke_roles(user_id=user, role_names=name)
             admin_client.roles.delete(name)
 
     return contextmanager(wrapper)

--- a/test/acceptance_with_python/rbac/conftest.py
+++ b/test/acceptance_with_python/rbac/conftest.py
@@ -58,12 +58,12 @@ def role_wrapper() -> RoleWrapperProtocol:
         admin_client.roles.delete(name)
         if not isinstance(permissions, list) or len(permissions) > 0:
             admin_client.roles.create(role_name=name, permissions=permissions)
-            admin_client.roles.assign_to_user(user=user, role_names=name)
+            admin_client.users.assign_roles(user_id=user, role_names=name)
 
         yield
 
         if not isinstance(permissions, list) or len(permissions) > 0:
-            admin_client.roles.revoke_from_user(user=user, role_names=name)
+            admin_client.roles.revoke_roles(user_id=user, role_names=name)
             admin_client.roles.delete(name)
 
     return contextmanager(wrapper)

--- a/test/acceptance_with_python/rbac/test_casing.py
+++ b/test/acceptance_with_python/rbac/test_casing.py
@@ -25,11 +25,11 @@ def test_rbac_refs(request: SubRequest, admin_client, custom_client, to_upper: b
             Permissions.data(collection=name, read=True),
         ],
     )
-    admin_client.roles.assign_to_user(user="custom-user", role_names=name)
+    admin_client.users.assign_roles(user_id="custom-user", role_names=name)
     collection_no_rights = custom_client.collections.get(collection.name)
     collection_no_rights.query.fetch_objects()
 
-    admin_client.roles.revoke_from_user(user="custom-user", role_names=name)
+    admin_client.users.revoke_roles(user_id="custom-user", role_names=name)
     admin_client.roles.delete(name)
 
     admin_client.collections.delete(name)
@@ -52,9 +52,9 @@ def test_role_name_case_sensitivity(request: SubRequest, admin_client):
         role_name=u_name, permissions=Permissions.collections(collection="upper", read_config=True)
     )
 
-    admin_client.roles.assign_to_user(user="custom-user", role_names=[l_name, u_name])
+    admin_client.users.assign_roles(user_id="custom-user", role_names=[l_name, u_name])
 
-    roles = admin_client.roles.by_user("custom-user")
+    roles = admin_client.users.get_assigned_roles("custom-user")
     assert sorted(roles.keys()) == sorted([l_name, u_name])
 
     admin_client.roles.delete(l_name)

--- a/test/acceptance_with_python/rbac/test_object_endpoint.py
+++ b/test/acceptance_with_python/rbac/test_object_endpoint.py
@@ -23,7 +23,6 @@ def test_obj_insert(
 
     required_permissions = [
         Permissions.data(collection=col.name, create=True),
-        Permissions.collections(collection=col.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -69,7 +68,6 @@ def test_obj_insert_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, create=True),
-        Permissions.collections(collection=source.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
@@ -110,7 +108,6 @@ def test_obj_replace(
 
     required_permissions = [
         Permissions.data(collection=col.name, update=True),
-        Permissions.collections(collection=col.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -159,7 +156,6 @@ def test_obj_replace_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
-        Permissions.collections(collection=source.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
@@ -204,7 +200,6 @@ def test_obj_update(
 
     required_permissions = [
         Permissions.data(collection=col.name, update=True),
-        Permissions.collections(collection=col.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check
@@ -252,7 +247,6 @@ def test_obj_update_ref(
 
     required_permissions = [
         Permissions.data(collection=source.name, update=True),
-        Permissions.collections(collection=source.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         source_no_rights = custom_client.collections.get(
@@ -297,7 +291,6 @@ def test_obj_delete(
 
     required_permissions = [
         Permissions.data(collection=col.name, delete=True),
-        Permissions.collections(collection=col.name, read_config=True),
     ]
     with role_wrapper(admin_client, request, required_permissions):
         col_no_rights = custom_client.collections.get(name)  # no network call => no RBAC check

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/weaviate/weaviate-python-client.git@cf8373b6beb4fba29c8b5a33d331ed45bc654ebf
+weaviate-client==4.11.0b1
 
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -55,7 +55,8 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 	defer m.metrics.AddObjectDec()
 
 	ctx = classcache.ContextWithClassCache(ctx)
-	fetchedClasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
+	// we don't reveal any info that the end users cannot get through the structure of the data anyway
+	fetchedClasses, err := m.schemaManager.GetCachedClassNoAuth(ctx, className)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -33,10 +33,10 @@ import (
 // if class == "" it will delete all object with same id regardless of the class name.
 // This is due to backward compatibility reasons and should be removed in the future
 func (m *Manager) DeleteObject(ctx context.Context,
-	principal *models.Principal, class string, id strfmt.UUID,
+	principal *models.Principal, className string, id strfmt.UUID,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
-	err := m.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(class, tenant, id))
+	err := m.authorizer.Authorize(principal, authorization.DELETE, authorization.Objects(className, tenant, id))
 	if err != nil {
 		return err
 	}
@@ -56,20 +56,21 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	m.metrics.DeleteObjectInc()
 	defer m.metrics.DeleteObjectDec()
 
-	if class == "" { // deprecated
+	if className == "" { // deprecated
 		return m.deleteObjectFromRepo(ctx, id, time.UnixMilli(m.timeSource.Now()))
 	}
 
-	vclasses, err := m.schemaManager.GetCachedClass(ctx, principal, class)
+	// we don't reveal any info that the end users and only use the version in this endpoint
+	fetchedClasses, err := m.schemaManager.GetCachedClassNoAuth(ctx, className)
 	if err != nil {
-		return fmt.Errorf("could not get class %s: %w", class, err)
+		return fmt.Errorf("could not get class %s: %w", className, err)
 	}
 
 	// Ensure that the local schema has caught up to the version we used to validate
-	if err := m.schemaManager.WaitForUpdate(ctx, vclasses[class].Version); err != nil {
-		return fmt.Errorf("error waiting for local schema to catch up to version %d: %w", vclasses[class].Version, err)
+	if err := m.schemaManager.WaitForUpdate(ctx, fetchedClasses[className].Version); err != nil {
+		return fmt.Errorf("error waiting for local schema to catch up to version %d: %w", fetchedClasses[className].Version, err)
 	}
-	if err = m.vectorRepo.DeleteObject(ctx, class, id, time.UnixMilli(m.timeSource.Now()), repl, tenant, vclasses[class].Version); err != nil {
+	if err = m.vectorRepo.DeleteObject(ctx, className, id, time.UnixMilli(m.timeSource.Now()), repl, tenant, fetchedClasses[className].Version); err != nil {
 		var e1 ErrMultiTenancy
 		if errors.As(err, &e1) {
 			return NewErrMultiTenancy(fmt.Errorf("delete object from vector repo: %w", err))

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -60,7 +60,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 		return m.deleteObjectFromRepo(ctx, id, time.UnixMilli(m.timeSource.Now()))
 	}
 
-	// we don't reveal any info that the end users and only use the version in this endpoint
+	// we only use the schemaVersion in this endpoint
 	fetchedClasses, err := m.schemaManager.GetCachedClassNoAuth(ctx, className)
 	if err != nil {
 		return fmt.Errorf("could not get class %s: %w", className, err)

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -115,6 +115,19 @@ func (f *fakeSchemaManager) GetCachedClass(ctx context.Context,
 	return res, nil
 }
 
+func (f *fakeSchemaManager) GetCachedClassNoAuth(ctx context.Context, names ...string,
+) (map[string]versioned.Class, error) {
+	res := map[string]versioned.Class{}
+	for _, name := range names {
+		cls, err := f.GetClass(ctx, nil, name)
+		if err != nil {
+			return res, err
+		}
+		res[name] = versioned.Class{Class: cls}
+	}
+	return f.GetCachedClass(ctx, nil, names...)
+}
+
 func (f *fakeSchemaManager) ReadOnlyClass(name string) *models.Class {
 	c, err := f.GetClass(context.TODO(), nil, name)
 	if err != nil {

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -59,6 +59,8 @@ type schemaManager interface {
 	GetCachedClass(ctx context.Context, principal *models.Principal, names ...string,
 	) (map[string]versioned.Class, error)
 
+	GetCachedClassNoAuth(ctx context.Context, names ...string) (map[string]versioned.Class, error)
+
 	// WaitForUpdate ensures that the local schema has caught up to schemaVersion
 	WaitForUpdate(ctx context.Context, schemaVersion uint64) error
 

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -57,7 +57,9 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	updates.Class = className
 
 	ctx = classcache.ContextWithClassCache(ctx)
-	fetchedClass, err := m.schemaManager.GetCachedClass(ctx, principal, className)
+
+	// we don't reveal any info that the end users cannot get through the structure of the data anyway
+	fetchedClass, err := m.schemaManager.GetCachedClassNoAuth(ctx, className)
 	if err != nil {
 		if errors.As(err, &authzerrs.Forbidden{}) {
 			return &Error{err.Error(), StatusForbidden, err}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -42,7 +42,8 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	}
 
 	ctx = classcache.ContextWithClassCache(ctx)
-	fetchedClasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
+	// we don't reveal any info that the end users cannot get through the structure of the data anyway
+	fetchedClasses, err := m.schemaManager.GetCachedClassNoAuth(ctx, className)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -39,7 +39,9 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	}
 
 	ctx = classcache.ContextWithClassCache(ctx)
-	fetchedClasses, err := m.schemaManager.GetCachedClass(ctx, principal, className)
+
+	// we don't reveal any info that the end users cannot get through the structure of the data anyway
+	fetchedClasses, err := m.schemaManager.GetCachedClassNoAuth(ctx, className)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -139,6 +139,7 @@ func Test_Schema_Authorization(t *testing.T) {
 				"UpdateMeta", "GetSchemaSkipAuth", "IndexedInverted", "RLock", "RUnlock", "Lock", "Unlock",
 				"TryLock", "RLocker", "TryRLock", "CopyShardingState", "TxManager", "RestoreClass",
 				"ShardOwner", "TenantShard", "ShardFromUUID", "LockGuard", "RLockGuard", "ShardReplicas",
+				"GetCachedClassNoAuth",
 				// internal methods to indicate readiness state
 				"StartServing", "Shutdown", "Statistics",
 				// Cluster/nodes related endpoint

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -81,6 +81,15 @@ func (h *Handler) GetCachedClass(ctxWithClassCache context.Context,
 	}, names...)
 }
 
+// GetCachedClassNoAuth will return the class from the cache if it exists. Note that the context cache
+// will likely be at the "request" or "operation" level and not be shared between requests.
+// Uses the Handler's getClassMethod to determine how to get the class data.
+func (h *Handler) GetCachedClassNoAuth(ctxWithClassCache context.Context, names ...string) (map[string]versioned.Class, error) {
+	return classcache.ClassesFromContext(ctxWithClassCache, func(names ...string) (map[string]versioned.Class, error) {
+		return h.classGetter.getClasses(names)
+	}, names...)
+}
+
 // AddClass to the schema
 func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	cls *models.Class,


### PR DESCRIPTION
### What's being changed:

chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13307735611
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13307749256

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
