### PR TITLE
Fix concurrent access to multicache

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -587,7 +587,6 @@ func (s *shardedMultipleLockCache[T]) MultiGet(ctx context.Context, ids []uint64
 }
 
 func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
-
 	if int(id) >= len(s.vectorDocID) {
 		return
 	}

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -547,15 +547,16 @@ func (s *shardedMultipleLockCache[T]) GetKeysNoLock(id uint64) (uint64, uint64) 
 }
 
 func (s *shardedMultipleLockCache[T]) Get(ctx context.Context, id uint64) ([]T, error) {
-	s.shardedLocks.RLock(id)
-	docID, relativeID := s.GetKeysNoLock(id)
+	docID, relativeID := s.GetKeys(id)
+	s.shardedLocks.RLock(docID)
 	docVecs := s.cache[docID]
-	s.shardedLocks.RUnlock(id)
 
 	if len(docVecs) <= int(relativeID) || docVecs[relativeID] == nil || len(docVecs[relativeID]) == 0 {
-		return s.handleMultipleCacheMiss(ctx, id, docID, relativeID)
+		s.shardedLocks.RUnlock(docID)
+		return s.handleMultipleCacheMiss(ctx, docID, relativeID)
 	}
 
+	s.shardedLocks.RUnlock(docID)
 	return docVecs[relativeID], nil
 }
 
@@ -564,17 +565,18 @@ func (s *shardedMultipleLockCache[T]) MultiGet(ctx context.Context, ids []uint64
 	errs := make([]error, len(ids))
 
 	for i, id := range ids {
-		s.shardedLocks.RLock(id)
-		docID, relativeID := s.GetKeysNoLock(id)
+		docID, relativeID := s.GetKeys(id)
+		s.shardedLocks.RLock(docID)
 		docVecs := s.cache[docID]
-		s.shardedLocks.RUnlock(id)
 
 		var vec []T
 		if len(docVecs) <= int(relativeID) || docVecs[relativeID] == nil || len(docVecs[relativeID]) == 0 {
-			vecFromDisk, err := s.handleMultipleCacheMiss(ctx, id, docID, relativeID)
+			s.shardedLocks.RUnlock(docID)
+			vecFromDisk, err := s.handleMultipleCacheMiss(ctx, docID, relativeID)
 			errs[i] = err
 			vec = vecFromDisk
 		} else {
+			s.shardedLocks.RUnlock(docID)
 			vec = docVecs[relativeID]
 		}
 
@@ -585,14 +587,14 @@ func (s *shardedMultipleLockCache[T]) MultiGet(ctx context.Context, ids []uint64
 }
 
 func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
-	s.shardedLocks.Lock(id)
-	defer s.shardedLocks.Unlock(id)
 
 	if int(id) >= len(s.vectorDocID) {
 		return
 	}
 
-	docID, relativeID := s.GetKeysNoLock(id)
+	docID, relativeID := s.GetKeys(id)
+	s.shardedLocks.RLock(docID)
+	defer s.shardedLocks.RUnlock(docID)
 
 	if s.cache[docID][relativeID] == nil {
 		return
@@ -602,7 +604,7 @@ func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
 	atomic.AddInt64(&s.count, -1)
 }
 
-func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Context, id uint64, docID uint64, relativeID uint64) ([]T, error) {
+func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Context, docID uint64, relativeID uint64) ([]T, error) {
 	if s.allocChecker != nil {
 		// we don't really know the exact size here, but we don't have to be
 		// accurate. If mem pressure is this high, we basically want to prevent any
@@ -630,14 +632,14 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 	}
 
 	atomic.AddInt64(&s.count, 1)
-	s.shardedLocks.Lock(id)
+	s.shardedLocks.Lock(docID)
 	if len(s.cache[docID]) <= int(relativeID) {
 		newCacheLine := make([][]T, relativeID+MinimumIndexGrowthDelta)
 		copy(newCacheLine, s.cache[docID])
 		s.cache[docID] = newCacheLine
 	}
-	s.cache[docID][relativeID] = vec
-	s.shardedLocks.Unlock(id)
+	copy(s.cache[docID][relativeID], vec)
+	s.shardedLocks.Unlock(docID)
 
 	return vec, nil
 }


### PR DESCRIPTION
### What's being changed:
This PR fixes a bug when trying to access the multicache. The previous implementation was not concurrent-safe, indeed data race were happening.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
