### PR TITLE
Fix incorrect message warning about number of replicas

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1741,10 +1741,6 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors [][]float3
 		if remoteSearches != remoteResponses.Load() {
 			i.logger.Warnf("remote search count does not match remote response count: searches=%d responses=%d", remoteSearches, remoteResponses.Load())
 		}
-
-		if localSearches+remoteSearches != int64(len(shardNames)) {
-			i.logger.Warnf("full replicas search response does not match replica count: response=%d replicas=%d", len(out), len(shardNames))
-		}
 		out, dists, err = searchResultDedup(out, dists)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not deduplicate result after full replicas search: %w", err)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1736,10 +1736,10 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors [][]float3
 	// If we are force querying all replicas, we need to run deduplication on the result.
 	if i.Config.ForceFullReplicasSearch {
 		if localSearches != localResponses.Load() {
-			i.logger.Warnf("local search count does not match local response count: searches=%d responses=%d", localSearches, localResponses.Load())
+			i.logger.Warnf("(in full replica search) local search count does not match local response count: searches=%d responses=%d", localSearches, localResponses.Load())
 		}
 		if remoteSearches != remoteResponses.Load() {
-			i.logger.Warnf("remote search count does not match remote response count: searches=%d responses=%d", remoteSearches, remoteResponses.Load())
+			i.logger.Warnf("(in full replica search) remote search count does not match remote response count: searches=%d responses=%d", remoteSearches, remoteResponses.Load())
 		}
 		out, dists, err = searchResultDedup(out, dists)
 		if err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1736,10 +1736,10 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors [][]float3
 	// If we are force querying all replicas, we need to run deduplication on the result.
 	if i.Config.ForceFullReplicasSearch {
 		if localSearches != localResponses.Load() {
-			i.logger.Warnf("local searches do not match local responses: searches=%d responses=%d", localSearches, localResponses.Load())
+			i.logger.Warnf("local search count does not match local response count: searches=%d responses=%d", localSearches, localResponses.Load())
 		}
 		if remoteSearches != remoteResponses.Load() {
-			i.logger.Warnf("remote searches do not match remote responses: searches=%d responses=%d", remoteSearches, remoteResponses.Load())
+			i.logger.Warnf("remote search count does not match remote response count: searches=%d responses=%d", remoteSearches, remoteResponses.Load())
 		}
 
 		if localSearches+remoteSearches != int64(len(shardNames)) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1742,9 +1742,8 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors [][]float3
 			i.logger.Warnf("remote searches do not match remote responses: searches=%d responses=%d", remoteSearches, remoteResponses.Load())
 		}
 
-		if localSearches + remoteSearches != int64(len(shardNames)) {
+		if localSearches+remoteSearches != int64(len(shardNames)) {
 			i.logger.Warnf("full replicas search response does not match replica count: response=%d replicas=%d", len(out), len(shardNames))
-
 		}
 		out, dists, err = searchResultDedup(out, dists)
 		if err != nil {

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -474,8 +474,8 @@ func (ri *RemoteIndex) queryAllReplicas(
 		if len(resp) == 0 {
 			return nil, errList
 		}
-		if len(resp) != len(replicas)-1 {
-			log.Warnf("full replicas search has less results than the count of replicas: have=%d want=%d", len(resp), len(replicas)-1)
+		if len(resp) != len(replicas)-1  && len(resp) != len(replicas) {
+			log.Warnf("full replicas search response does not match replica count: response=%d replicas=%d", len(resp), len(replicas))
 		}
 		return resp, nil
 	}

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -474,7 +474,7 @@ func (ri *RemoteIndex) queryAllReplicas(
 		if len(resp) == 0 {
 			return nil, errList
 		}
-		if len(resp) != len(replicas)-1  && len(resp) != len(replicas) {
+		if len(resp) != len(replicas)-1 && len(resp) != len(replicas) {
 			log.Warnf("full replicas search response does not match replica count: response=%d replicas=%d", len(resp), len(replicas))
 		}
 		return resp, nil

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/dto"
@@ -428,6 +429,8 @@ func (ri *RemoteIndex) queryAllReplicas(
 		return do(replica, host)
 	}
 
+	var queriesSent atomic.Int64
+
 	queryAll := func(replicas []string) (resp []ReplicasSearchResult, err error) {
 		var mu sync.Mutex // protect resp + errlist
 		var searchResult ReplicasSearchResult
@@ -452,6 +455,7 @@ func (ri *RemoteIndex) queryAllReplicas(
 					return
 				}
 
+				queriesSent.Add(1)
 				if searchResult, err = queryOne(node); err != nil {
 					mu.Lock()
 					errList = errors.Join(errList, fmt.Errorf("error while searching shard=%s replica node=%s: %w", shard, node, err))
@@ -474,7 +478,7 @@ func (ri *RemoteIndex) queryAllReplicas(
 		if len(resp) == 0 {
 			return nil, errList
 		}
-		if len(resp) != len(replicas)-1 && len(resp) != len(replicas) {
+		if len(resp) != int(queriesSent.Load()) {
 			log.Warnf("full replicas search response does not match replica count: response=%d replicas=%d", len(resp), len(replicas))
 		}
 		return resp, nil


### PR DESCRIPTION
### What's being changed:

I suspect this is caused by local search happening when one of the replicas is on the machine starting the full replica search

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
