### PR TITLE
perf: Use FromBinaryOptional when repairing index

### DIFF
--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -696,7 +696,7 @@ func TestShard_FillQueue(t *testing.T) {
 			// wait for the worker to index
 			time.Sleep(500 * time.Millisecond)
 
-			// make sure all objects except >= 100 < 300 are back in the vector index
+			// make sure all objects except >= 100 < 150 are back in the vector index
 			for i := 0; i < amount; i++ {
 				if 100 <= i && i < 150 {
 					require.Falsef(t, vidx.ContainsDoc(uint64(i)), "doc %d should not be in the vector index", i)

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	hnswindex "github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -540,6 +541,168 @@ func TestShard_RepairIndex(t *testing.T) {
 				if !vidx.ContainsDoc(uint64(i)) {
 					t.Fatalf("doc %d should be in the vector index", i)
 				}
+			}
+
+			require.Nil(t, idx.drop())
+			require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+		})
+	}
+}
+
+func TestShard_FillQueue(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+	t.Setenv("ASYNC_INDEXING_STALE_TIMEOUT", "200ms")
+
+	tests := []struct {
+		name           string
+		targetVector   string
+		multiVector    bool
+		cfg            schemaConfig.VectorIndexConfig
+		idxOpt         func(*Index)
+		getQueue       func(ShardLike) *VectorIndexQueue
+		getVectorIndex func(ShardLike) VectorIndex
+	}{
+		{
+			name: "hnsw",
+			cfg:  hnsw.UserConfig{},
+			getQueue: func(s ShardLike) *VectorIndexQueue {
+				return s.Queue()
+			},
+			getVectorIndex: func(s ShardLike) VectorIndex {
+				return s.VectorIndex()
+			},
+		},
+		{
+			name:         "hnsw with target vectors",
+			targetVector: "foo",
+			cfg:          hnsw.UserConfig{},
+			idxOpt: func(i *Index) {
+				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
+				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{}
+			},
+			getQueue: func(s ShardLike) *VectorIndexQueue {
+				return s.Queues()["foo"]
+			},
+			getVectorIndex: func(s ShardLike) VectorIndex {
+				return s.VectorIndexes()["foo"]
+			},
+		},
+		{
+			name:         "hnsw with multi vectors",
+			targetVector: "foo",
+			multiVector:  true,
+			cfg:          hnsw.UserConfig{},
+			idxOpt: func(i *Index) {
+				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
+				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{
+					Multivector: hnsw.MultivectorConfig{
+						Enabled: true,
+					},
+				}
+			},
+			getQueue: func(s ShardLike) *VectorIndexQueue {
+				return s.Queues()["foo"]
+			},
+			getVectorIndex: func(s ShardLike) VectorIndex {
+				return s.VectorIndexes()["foo"]
+			},
+		},
+		{
+			name: "flat",
+			cfg:  flat.NewDefaultUserConfig(),
+			getQueue: func(s ShardLike) *VectorIndexQueue {
+				return s.Queue()
+			},
+			getVectorIndex: func(s ShardLike) VectorIndex {
+				return s.VectorIndex()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			className := "TestClass"
+			var opts []func(*Index)
+			if test.idxOpt != nil {
+				opts = append(opts, test.idxOpt)
+			}
+			shd, idx := testShardWithSettings(t, ctx, &models.Class{Class: className}, test.cfg, false, true /* withCheckpoints */, opts...)
+
+			amount := 1000
+
+			defer func(path string) {
+				err := os.RemoveAll(path)
+				if err != nil {
+					fmt.Println(err)
+				}
+			}(shd.Index().Config.RootPath)
+
+			var objs []*storobj.Object
+			for i := 0; i < amount; i++ {
+				obj := testObject(className)
+				if test.targetVector != "" {
+					if test.multiVector {
+						obj.MultiVectors = map[string][][]float32{
+							test.targetVector: {{1, 2, 3}, {4, 5, 6}},
+						}
+					} else {
+						obj.Vectors = map[string][]float32{
+							test.targetVector: {1, 2, 3},
+						}
+					}
+				}
+				objs = append(objs, obj)
+			}
+
+			errs := shd.PutObjectBatch(ctx, objs)
+			for _, err := range errs {
+				require.Nil(t, err)
+			}
+
+			vidx := test.getVectorIndex(shd)
+			q := test.getQueue(shd)
+
+			// wait for the queue to be empty
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				assert.Zero(t, q.Size())
+			}, 5*time.Second, 100*time.Millisecond)
+
+			// remove most of the objects from the vector index
+			for i := 100; i < amount; i++ {
+				if test.multiVector {
+					err := vidx.DeleteMulti(uint64(i))
+					require.NoError(t, err)
+				} else {
+					err := vidx.Delete(uint64(i))
+					require.NoError(t, err)
+				}
+			}
+
+			// we need to delete tombstones so the vectors with the same doc ids could be inserted
+			if hnswindex.IsHNSWIndex(vidx) {
+				err := hnswindex.AsHNSWIndex(vidx).CleanUpTombstonedNodes(func() bool { return false })
+				require.NoError(t, err)
+			}
+
+			// refill only subset of the objects
+			err := shd.FillQueue(test.targetVector, 150)
+			require.NoError(t, err)
+
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				assert.Zero(t, q.Size())
+			}, 5*time.Second, 100*time.Millisecond)
+
+			// wait for the worker to index
+			time.Sleep(500 * time.Millisecond)
+
+			// make sure all objects except >= 100 < 300 are back in the vector index
+			for i := 0; i < amount; i++ {
+				if 100 <= i && i < 150 {
+					require.Falsef(t, vidx.ContainsDoc(uint64(i)), "doc %d should not be in the vector index", i)
+					continue
+				}
+				require.Truef(t, vidx.ContainsDoc(uint64(i)), "doc %d should be in the vector index", i)
 			}
 
 			require.Nil(t, idx.drop())


### PR DESCRIPTION
### What's being changed:
Another small optimization for a debug-level component: using optional object deserialization when repairing index.
Additionally, I added a test for `FIllQueue` as it was missing.

https://github.com/weaviate/weaviate/issues/7091

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
