### PR TITLE
Change default NVIDIA generative model to nvidia/llama-3.1-nemotron-51b-instruct

### DIFF
--- a/modules/generative-nvidia/config/class_settings.go
+++ b/modules/generative-nvidia/config/class_settings.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	DefaultBaseURL     = "https://integrate.api.nvidia.com"
-	DefaultNvidiaModel = "meta/llama-3.2-3b-instruct"
+	DefaultNvidiaModel = "nvidia/llama-3.1-nemotron-51b-instruct"
 )
 
 type classSettings struct {

--- a/modules/generative-nvidia/config/class_settings_test.go
+++ b/modules/generative-nvidia/config/class_settings_test.go
@@ -35,7 +35,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				classConfig: map[string]interface{}{},
 			},
 			wantBaseURL: "https://integrate.api.nvidia.com",
-			wantModel:   "meta/llama-3.2-3b-instruct",
+			wantModel:   "nvidia/llama-3.1-nemotron-51b-instruct",
 			wantErr:     nil,
 		},
 		{


### PR DESCRIPTION
### What's being changed:

Change default NVIDIA generative model to nvidia/llama-3.1-nemotron-51b-instruct

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
