### PR TITLE
fix(bm25_block): :bug: Fix segment group strategy for Inverted and MapCollection

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -352,6 +352,14 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 	id := "segmentgroup/compaction/" + sg.dir
 	sg.compactionCallbackCtrl = compactionCallbacks.Register(id, sg.compactOrCleanup)
 
+	// if a segment exists of the map collection strategy, we need to
+	// convert the inverted strategy to a map collection strategy
+	// as it is done on the bucket level
+	if sg.strategy == StrategyInverted && len(sg.segments) > 0 &&
+		sg.segments[0].strategy == segmentindex.StrategyMapCollection {
+		sg.strategy = StrategyMapCollection
+	}
+
 	if sg.strategy == StrategyInverted {
 		// start at  len(sg.segments) - 2 as the last segment doesn't need any tombstones for now
 		for i := len(sg.segments) - 2; i >= 0; i-- {


### PR DESCRIPTION
### What's being changed:

USE_INVERTED_SEARCHABLE is set and we have Map segments as not being checked on the segment group, only on the bucket.
This PR adds the check.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
