### PR TITLE
Update schema handler to exclude synthetic data

### DIFF
--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -43,7 +43,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		{
 			methodName:       "GetConsistentSchema",
 			expectedVerb:     "list",
-			additionalArgs:   []interface{}{false},
+			additionalArgs:   []interface{}{false, false},
 			expectedResource: "schema/*",
 		},
 		{


### PR DESCRIPTION
Minimal implementation of https://github.com/weaviate/weaviate/issues/6722 for further review, will update the checklist below when it comes out of draft (this should require a public doc change).

### What's being changed:

Adds an `includeWellknown` boolean input to `GetConsistentSchema()` and a filter function to optionally include synthetic data in schema dumps.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
