### PR TITLE
fix(raft-EC): TriggerSchemaUpdateCallbacks sequentially

### DIFF
--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -260,14 +260,11 @@ func (e *executor) TriggerSchemaUpdateCallbacks() {
 	e.callbacksLock.RLock()
 	defer e.callbacksLock.RUnlock()
 
-	// execute callbacks asynchronously in a single goroutine
-	enterrors.GoWrapper(func() {
-		s := e.schemaReader.ReadOnlySchema()
-		schema := schema.Schema{Objects: &s}
-		for _, cb := range e.callbacks {
-			cb(schema)
-		}
-	}, e.logger)
+	s := e.schemaReader.ReadOnlySchema()
+	schema := schema.Schema{Objects: &s}
+	for _, cb := range e.callbacks {
+		cb(schema)
+	}
 }
 
 // RegisterSchemaUpdateCallback allows other usecases to register a primitive


### PR DESCRIPTION
### What's being changed:
always run schema callbacks sequentially to avoid in EC for GQL

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
