### PR TITLE
Fix updated stopwords in inverted_index not taking effect

### DIFF
--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -91,7 +91,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 
 	if a.params.Filters != nil {
 		allow, err = inverted.NewSearcher(a.logger, a.store, a.getSchema.ReadOnlyClass, nil,
-			a.classSearcher, a.stopwords, a.shardVersion, a.isFallbackToSearchable,
+			a.classSearcher, a.shardVersion, a.isFallbackToSearchable,
 			a.tenant, a.nestedCrossRefLimit, a.bitmapFactory).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},
 				a.params.ClassName)

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -304,7 +304,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		if filters != nil {
 			objs, err = inverted.NewSearcher(s.index.logger, s.store,
 				s.index.getSchema.ReadOnlyClass, s.propertyIndices,
-				s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
+				s.index.classSearcher, s.versioner.Version(),
 				s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit,
 				s.bitmapFactory).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
@@ -336,7 +336,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		return objs, nil, err
 	}
 	objs, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
-		s.propertyIndices, s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
+		s.propertyIndices, s.index.classSearcher, s.versioner.Version(),
 		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName, properties)
 	return objs, nil, err
@@ -666,7 +666,7 @@ func (s *Shard) sortDocIDsAndDists(ctx context.Context, limit int, sort []filter
 
 func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter, addl additional.Properties) (helpers.AllowList, error) {
 	list, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
-		s.propertyIndices, s.index.classSearcher, s.index.stopwords, s.versioner.Version(),
+		s.propertyIndices, s.index.classSearcher, s.versioner.Version(),
 		s.isFallbackToSearchable, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)
 	if err != nil {

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -151,7 +151,7 @@ func (b *deleteObjectsBatcher) setErrorAtIndex(err error, index int) {
 
 func (s *Shard) findDocIDs(ctx context.Context, filters *filters.LocalFilter) ([]uint64, error) {
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
-		nil, s.index.classSearcher, s.index.stopwords, s.versioner.version, s.isFallbackToSearchable,
+		nil, s.index.classSearcher, s.versioner.version, s.isFallbackToSearchable,
 		s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		DocIDs(ctx, filters, additional.Properties{}, s.index.Config.ClassName)
 	if err != nil {


### PR DESCRIPTION
fix #7214 
The issue was caused by directly using `s.index.stopwords`, which doesn't update when the `inverted_index` stopwords setting changes. This PR replaces it with `StopwordDetector`, ensuring the correct stopwords are applied, similar to BM25's implementation.
https://github.com/weaviate/weaviate/blob/bf1123fc8e5f99c78f2b32a281a57b34bf562bef/adapters/repos/db/inverted/bm25_searcher.go#L126-L133