### PR TITLE
Remove unused field in indices_payloads

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -24,8 +24,6 @@ import (
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
 
-	"github.com/weaviate/weaviate/usecases/byteops"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 
@@ -48,8 +46,6 @@ type indicesPayloads struct {
 	VersionedObjectList       versionedObjectListPayload
 	SearchResults             searchResultsPayload
 	SearchParams              searchParamsPayload
-	VectorDistanceParams      vectorDistanceParamsPayload
-	VectorDistanceResults     vectorDistanceResultsPayload
 	ReferenceList             referenceListPayload
 	AggregationParams         aggregationParamsPayload
 	AggregationResult         aggregationResultPayload
@@ -348,90 +344,6 @@ func (p mergeDocPayload) Unmarshal(in []byte) (objects.MergeDocument, error) {
 	var mergeDoc objects.MergeDocument
 	err := json.Unmarshal(in, &mergeDoc)
 	return mergeDoc, err
-}
-
-type vectorDistanceParamsPayload struct{}
-
-func (p vectorDistanceParamsPayload) Marshal(id strfmt.UUID, targets []string, searchVectors [][]float32,
-) ([]byte, error) {
-	type params struct {
-		Id            strfmt.UUID `json:"id"`
-		Targets       []string    `json:"targets"`
-		SearchVectors [][]float32 `json:"searchVectors"`
-	}
-
-	par := params{id, targets, searchVectors}
-	return json.Marshal(par)
-}
-
-func (p vectorDistanceParamsPayload) Unmarshal(in []byte) (strfmt.UUID, []string, [][]float32, error,
-) {
-	type params struct {
-		Id            strfmt.UUID `json:"id"`
-		Targets       []string    `json:"targets"`
-		SearchVectors [][]float32 `json:"searchVectors"`
-	}
-	var par params
-	err := json.Unmarshal(in, &par)
-	return par.Id, par.Targets, par.SearchVectors, err
-}
-
-func (p vectorDistanceParamsPayload) MIME() string {
-	return "vnd.weaviate.vectordistanceparams+json"
-}
-
-func (p vectorDistanceParamsPayload) CheckContentTypeHeaderReq(r *http.Request) (string, bool) {
-	ct := r.Header.Get("content-type")
-	return ct, ct == p.MIME()
-}
-
-func (p vectorDistanceParamsPayload) SetContentTypeHeaderReq(r *http.Request) {
-	r.Header.Set("content-type", p.MIME())
-}
-
-type vectorDistanceResultsPayload struct{}
-
-func (p vectorDistanceResultsPayload) Unmarshal(in []byte) ([]float32, error) {
-	read := uint64(0)
-
-	distsLength := binary.LittleEndian.Uint64(in[read : read+8])
-	read += 8
-
-	dists := make([]float32, distsLength)
-	for i := range dists {
-		dists[i] = math.Float32frombits(binary.LittleEndian.Uint32(in[read : read+4]))
-		read += 4
-	}
-
-	if read != uint64(len(in)) {
-		return nil, errors.Errorf("corrupt read: %d != %d", read, len(in))
-	}
-
-	return dists, nil
-}
-
-func (p vectorDistanceResultsPayload) Marshal(dists []float32) ([]byte, error) {
-	buf := byteops.NewReadWriter(make([]byte, 8+len(dists)*4))
-	buf.WriteUint64(uint64(len(dists)))
-
-	for _, dist := range dists {
-		buf.WriteUint32(math.Float32bits(dist))
-	}
-
-	return buf.Buffer, nil
-}
-
-func (p vectorDistanceResultsPayload) MIME() string {
-	return "application/vnd.weaviate.vectordistanceresults+octet-stream"
-}
-
-func (p vectorDistanceResultsPayload) SetContentTypeHeader(w http.ResponseWriter) {
-	w.Header().Set("content-type", p.MIME())
-}
-
-func (p vectorDistanceResultsPayload) CheckContentTypeHeader(r *http.Response) (string, bool) {
-	ct := r.Header.Get("content-type")
-	return ct, ct == p.MIME()
 }
 
 type searchParametersPayload struct {


### PR DESCRIPTION
### What's being changed:
Since distances are computed during the  shard level after #5190, those two fields in `indicesPayload` can be removed.
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
