### PR TITLE
Fix cross-reference from multi-tenant collection to single-tenant collection

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1163,6 +1163,11 @@ func (i *Index) IncomingMultiGetObjects(ctx context.Context, shardName string,
 func (i *Index) multiObjectByID(ctx context.Context,
 	query []multi.Identifier, tenant string,
 ) ([]*storobj.Object, error) {
+	// if this is reference search and tenant is given (as origin class is MT)
+	// but searched class is non-MT, then skip tenant to pass validation
+	if !i.partitioningEnabled {
+		tenant = ""
+	}
 	if err := i.validateMultiTenancy(tenant); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

Fix #7281. The issue is caused by the fact that, after completing the search, the resolver/cacher is used to retrieve the reference object from the response. When the resolver/cacher queries the reference object, the original tenant is still passed as an argument, which leads to the object search failing in single-tenant (non-partitioned shard) environments. A similar situation was addressed in #3679 but during a different phase. Therefore, we have added a check before performing the search for the reference object, using a solution similar to #3679.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

