### PR TITLE
Fix/validate io read

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -210,18 +210,24 @@ func (p objectListPayload) Unmarshal(in []byte) ([]*storobj.Object, error) {
 	r := bytes.NewReader(in)
 
 	for {
-		_, err := r.Read(reusableLengthBuf)
+		n, err := r.Read(reusableLengthBuf)
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
+		if n != len(reusableLengthBuf) {
+			return nil, errors.Errorf("expected to read %d bytes, got %d", len(reusableLengthBuf), n)
+		}
 
 		payloadBytes := make([]byte, binary.LittleEndian.Uint64(reusableLengthBuf))
-		_, err = r.Read(payloadBytes)
+		n, err = r.Read(payloadBytes)
 		if err != nil {
 			return nil, err
+		}
+		if n != len(payloadBytes) {
+			return nil, errors.Errorf("expected to read %d bytes, got %d", len(payloadBytes), n)
 		}
 
 		obj, err := storobj.FromBinary(payloadBytes)
@@ -288,19 +294,25 @@ func (p versionedObjectListPayload) Unmarshal(in []byte) ([]*objects.VObject, er
 	r := bytes.NewReader(in)
 
 	for {
-		_, err := r.Read(reusableLengthBuf)
+		n, err := r.Read(reusableLengthBuf)
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
+		if n != len(reusableLengthBuf) {
+			return nil, errors.Errorf("expected to read %d bytes, got %d", len(reusableLengthBuf), n)
+		}
 
 		ln := binary.LittleEndian.Uint64(reusableLengthBuf)
 		payloadBytes := make([]byte, ln)
-		_, err = r.Read(payloadBytes)
+		n, err = r.Read(payloadBytes)
 		if err != nil {
 			return nil, err
+		}
+		if n != len(payloadBytes) {
+			return nil, errors.Errorf("expected to read %d bytes, got %d", len(payloadBytes), n)
 		}
 
 		var vobj objects.VObject

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -357,8 +357,9 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		t.Run("keep importing crossing the dirty threshold", func(t *testing.T) {
 			rounds := 12 // at least 300ms
 			data := make([]byte, rounds*4)
-			_, err := rand.Read(data)
+			n, err := rand.Read(data)
 			require.Nil(t, err)
+			require.Equal(t, rounds*4, n)
 
 			for i := 0; i < rounds; i++ {
 				key := data[(i * 4) : (i+1)*4]

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -65,9 +65,12 @@ func (s *segment) segmentNodeFromBuffer(offset nodeOffset) (*roaringset.SegmentN
 		if err != nil {
 			return nil, false, err
 		}
-		_, err = r.Read(contents)
+		n, err := r.Read(contents)
 		if err != nil {
 			return nil, false, err
+		}
+		if n != len(contents) {
+			return nil, false, fmt.Errorf("expected to read %d bytes, got %d", len(contents), n)
 		}
 		copied = true
 	}

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -426,9 +426,12 @@ func ParseInvertedNode(r io.Reader) (segmentCollectionNode, error) {
 		bufferSize := 24 + toRead
 		allBytes = make([]byte, bufferSize)
 		copy(allBytes, buffer)
-		_, err := r.Read(allBytes[24:])
+		n, err := r.Read(allBytes[24:])
 		if err != nil {
 			return out, err
+		}
+		if n != int(toRead) {
+			return out, errors.Errorf("expected to read %d bytes, got %d", toRead, n)
 		}
 		out.offset += int(toRead)
 	}
@@ -438,9 +441,13 @@ func ParseInvertedNode(r io.Reader) (segmentCollectionNode, error) {
 	keyLen := binary.LittleEndian.Uint32(allBytes[len(allBytes)-4:])
 
 	key := make([]byte, keyLen)
-	_, err := r.Read(key)
+	n, err := r.Read(key)
 	if err != nil {
 		return out, err
+	}
+
+	if n != int(keyLen) {
+		return out, errors.Errorf("expected to read %d bytes, got %d", keyLen, n)
 	}
 
 	out.offset += int(keyLen)

--- a/adapters/repos/db/lsmkv/segmentindex/segment_file.go
+++ b/adapters/repos/db/lsmkv/segmentindex/segment_file.go
@@ -217,9 +217,12 @@ func (f *SegmentFile) ValidateChecksum(info os.FileInfo) error {
 	f.checksumReader = integrity.NewCRC32Reader(f.reader)
 
 	var header [HeaderSize]byte
-	_, err := f.reader.Read(header[:])
+	n, err := f.reader.Read(header[:])
 	if err != nil {
 		return fmt.Errorf("read segment file header: %w", err)
+	}
+	if n != HeaderSize {
+		return fmt.Errorf("expected to read %d bytes, got %d", HeaderSize, n)
 	}
 
 	var (

--- a/adapters/repos/db/lsmkv/segmentindex/segment_file.go
+++ b/adapters/repos/db/lsmkv/segmentindex/segment_file.go
@@ -246,15 +246,21 @@ func (f *SegmentFile) ValidateChecksum(info os.FileInfo) error {
 	}
 
 	var checksumBytes [ChecksumSize]byte
-	_, err = f.reader.Read(checksumBytes[:])
+	n, err = f.reader.Read(checksumBytes[:])
 	if err != nil {
 		return fmt.Errorf("read segment file checksum: %w", err)
 	}
+	if n != ChecksumSize {
+		return fmt.Errorf("expected to read %d bytes, got %d", ChecksumSize, n)
+	}
 
 	f.reader.Reset(bytes.NewReader(header[:]))
-	_, err = f.checksumReader.Read(make([]byte, HeaderSize))
+	n, err = f.checksumReader.Read(make([]byte, HeaderSize))
 	if err != nil {
 		return fmt.Errorf("add header to checksum: %w", err)
+	}
+	if n != HeaderSize {
+		return fmt.Errorf("expected to read %d bytes, got %d", HeaderSize, n)
 	}
 
 	computedChecksum := f.checksumReader.Hash()

--- a/adapters/repos/db/vector/hnsw/benchmark_test.go
+++ b/adapters/repos/db/vector/hnsw/benchmark_test.go
@@ -226,13 +226,15 @@ func readBigAnnDataset(t testing.TB, file string, maxObjects int) [][]float32 {
 	// If the file is in i8bin format, the vector data needs to be converted from bytes to int8 then to float.
 
 	// The first 4 bytes are the number of vectors in the file
-	_, err = f.Read(b)
+	read, err := f.Read(b)
 	require.NoError(t, err)
+	require.Equal(t, 4, read)
 	n := int32FromBytes(b)
 
 	// The second 4 bytes are the dimensionality of the vectors in the file
-	_, err = f.Read(b)
+	read, err = f.Read(b)
 	require.NoError(t, err)
+	require.Equal(t, 4, read)
 	d := int32FromBytes(b)
 
 	var bytesPerVector int
@@ -253,11 +255,12 @@ func readBigAnnDataset(t testing.TB, file string, maxObjects int) [][]float32 {
 	}
 
 	for i := 0; i < n; i++ {
-		_, err = f.Read(vectorBytes)
+		read, err := f.Read(vectorBytes)
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
+		require.Equal(t, bytesPerVector, read)
 
 		vectorFloat := make([]float32, 0, d)
 		for j := 0; j < d; j++ {

--- a/adapters/repos/db/vector/hnsw/hnsw_stress_test.go
+++ b/adapters/repos/db/vector/hnsw/hnsw_stress_test.go
@@ -427,11 +427,14 @@ func readSiftFloat(file string, maxObjects int) [][]float32 {
 	bytesPerF := 4
 	vectorBytes := make([]byte, bytesPerF+vectorSize*bytesPerF)
 	for i := 0; i >= 0; i++ {
-		_, err = f.Read(vectorBytes)
+		read, err := f.Read(vectorBytes)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			panic(err)
+		}
+		if read != len(vectorBytes) {
+			panic("Could not read all bytes.")
 		}
 		if int32FromBytes(vectorBytes[0:bytesPerF]) != vectorSize {
 			panic("Each vector must have 128 entries.")

--- a/adapters/repos/db/vector/testinghelpers/helpers.go
+++ b/adapters/repos/db/vector/testinghelpers/helpers.go
@@ -82,11 +82,14 @@ func readSiftFloat(file string, maxObjects int, vectorLengthFloat int) [][]float
 	objects := make([][]float32, maxObjects)
 	vectorBytes := make([]byte, bytesPerF+vectorLengthFloat*bytesPerF)
 	for i := 0; i >= 0; i++ {
-		_, err = f.Read(vectorBytes)
+		read, err := f.Read(vectorBytes)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			panic(err)
+		}
+		if read != len(vectorBytes) {
+			panic("Could not read all bytes.")
 		}
 		if int32FromBytes(vectorBytes[0:bytesPerF]) != vectorLengthFloat {
 			panic("Each vector must have 128 entries.")

--- a/entities/diskio/metered_reader_test.go
+++ b/entities/diskio/metered_reader_test.go
@@ -48,8 +48,9 @@ func TestMeteredReader(t *testing.T) {
 		mr := NewMeteredReader(bytes.NewReader(data), nil)
 
 		target := make([]byte, 128)
-		_, err := mr.Read(target)
+		n, err := mr.Read(target)
 		require.Nil(t, err)
+		assert.Equal(t, 128, n)
 	})
 
 	t.Run("with an error", func(t *testing.T) {
@@ -69,9 +70,10 @@ func TestMeteredReader(t *testing.T) {
 		mr := NewMeteredReader(underlying, cb)
 
 		target := make([]byte, 128)
-		_, err := mr.Read(target)
+		n, err := mr.Read(target)
 
 		assert.Equal(t, io.EOF, err)
+		assert.Equal(t, int64(0), n)
 
 		// callback should not have been called in error cases, so we expect to
 		// read initial values

--- a/entities/diskio/metered_reader_test.go
+++ b/entities/diskio/metered_reader_test.go
@@ -73,7 +73,7 @@ func TestMeteredReader(t *testing.T) {
 		n, err := mr.Read(target)
 
 		assert.Equal(t, io.EOF, err)
-		assert.Equal(t, int64(0), n)
+		assert.Equal(t, 0, n)
 
 		// callback should not have been called in error cases, so we expect to
 		// read initial values

--- a/test/benchmark/benchmark_sift.go
+++ b/test/benchmark/benchmark_sift.go
@@ -98,11 +98,13 @@ func readSiftFloat(file string, maxObjects int) []*models.Object {
 	vectorLengthFloat := 128
 	vectorBytes := make([]byte, bytesPerF+vectorLengthFloat*bytesPerF)
 	for i := 0; i >= 0; i++ {
-		_, err = f.Read(vectorBytes)
+		read, err := f.Read(vectorBytes)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			panic(err)
+		} else if read != len(vectorBytes) {
+			panic("Could not read all bytes.")
 		}
 		if int32FromBytes(vectorBytes[0:bytesPerF]) != vectorLengthFloat {
 			panic("Each vector must have 128 entries.")


### PR DESCRIPTION
### What's being changed:

Validate the number of read byes on all io.Read() calls.
Checked for "completeness" by searching the repo for `.*,.*=.*Read\(` and not finding any call that starts with an underscore (ignored returned number of bytes)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
