### PR TITLE
chore: download gRPC health probe instead of building it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,11 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 
 ###############################################################################
 # This image gets grpc health check probe
-FROM golang:1.23-alpine AS grpc_health_probe_builder
-RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.37
-RUN GOBIN=/go/bin && chmod +x ${GOBIN}/grpc-health-probe && mv ${GOBIN}/grpc-health-probe /bin/grpc_health_probe
+FROM build_base AS grpc_health_probe_builder
+ARG TARGETARCH
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.37 && \
+      wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
+      chmod +x /bin/grpc_health_probe
 
 ###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)


### PR DESCRIPTION
### What's being changed:

Download gRPC health probe instead of building it

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
