### PR TITLE
Makefile: add `--load` flag to `buildx` to add it to local registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ OCI_TAG        := docker tag
 ifeq ($(CI),true)
   # buildx is used on the CI for cross-platform builds
 	_               := $(shell ./tools/dev/ensure-buildx-builder.sh)
-	OCI_BUILD       := DOCKER_BUILDKIT=1 docker buildx build $(OCI_PLATFORMS) $(OCI_BUILD_ARGS)
+	OCI_BUILD       := DOCKER_BUILDKIT=1 docker buildx build --load $(OCI_PLATFORMS) $(OCI_BUILD_ARGS)
 else
 	OCI_BUILD       := DOCKER_BUILDKIT=1 docker build $(OCI_BUILD_ARGS)
 endif


### PR DESCRIPTION
### What's being changed:
Currently, you can build docker image via `buildx` but won't be visible in local registry. `--load` flag helps with that.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
