### PR TITLE
[HNSW] Expose more quantization stats

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_quantization.go
@@ -45,3 +45,13 @@ func (bq BinaryQuantizer) Encode(vec []float32) []uint64 {
 func (bq BinaryQuantizer) DistanceBetweenCompressedVectors(x, y []uint64) (float32, error) {
 	return distancer.HammingBitwise(x, y)
 }
+
+type BQStats struct{}
+
+func (b BQStats) CompressionType() string {
+	return "bq"
+}
+
+func (bq *BinaryQuantizer) Stats() CompressionStats {
+	return BQStats{}
+}

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -178,6 +178,11 @@ type PQData struct {
 	TrainingLimit       int
 }
 
+type PQStats struct {
+	Ks int `json:"centroids"`
+	M  int `json:"segments"`
+}
+
 type PQEncoder interface {
 	Encode(x []float32) byte
 	Centroid(b byte) []float32
@@ -428,4 +433,15 @@ func (pq *ProductQuantizer) CenterAt(vec []float32) *DistanceLookUpTable {
 
 func (pq *ProductQuantizer) Distance(encoded []byte, lut *DistanceLookUpTable) float32 {
 	return lut.LookUp(encoded, pq)
+}
+
+func (p PQStats) CompressionType() string {
+	return "pq"
+}
+
+func (pq *ProductQuantizer) Stats() CompressionStats {
+	return PQStats{
+		Ks: pq.ks,
+		M:  pq.m,
+	}
 }

--- a/adapters/repos/db/vector/compressionhelpers/quantizer.go
+++ b/adapters/repos/db/vector/compressionhelpers/quantizer.go
@@ -27,6 +27,7 @@ type quantizer[T byte | uint64] interface {
 	CompressedBytes(compressed []T) []byte
 	FromCompressedBytes(compressed []byte) []T
 	PersistCompression(logger CommitLogger)
+	Stats() CompressionStats
 
 	// FromCompressedBytesWithSubsliceBuffer is like FromCompressedBytes, but
 	// instead of allocating a new slice you can pass in a buffer to use. It will

--- a/adapters/repos/db/vector/compressionhelpers/scalar_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/scalar_quantization.go
@@ -202,3 +202,19 @@ func (sq *ScalarQuantizer) PersistCompression(logger CommitLogger) {
 func (sq *ScalarQuantizer) norm(code []byte) uint32 {
 	return binary.BigEndian.Uint32(code[len(code)-8:])
 }
+
+type SQStats struct {
+	A float32 `json:"a"`
+	B float32 `json:"b"`
+}
+
+func (s SQStats) CompressionType() string {
+	return "sq"
+}
+
+func (sq *ScalarQuantizer) Stats() CompressionStats {
+	return SQStats{
+		A: sq.a,
+		B: sq.b,
+	}
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -898,13 +898,15 @@ func (h *hnsw) calculateUnreachablePoints() []uint64 {
 }
 
 type HnswStats struct {
-	Dimensions         int32        `json:"dimensions"`
-	EntryPointID       uint64       `json:"entryPointID"`
-	DistributionLayers map[int]uint `json:"distributionLayers"`
-	UnreachablePoints  []uint64     `json:"unreachablePoints"`
-	NumTombstones      int          `json:"numTombstones"`
-	CacheSize          int32        `json:"cacheSize"`
-	PQConfiguration    ent.PQConfig `json:"pqConfiguration"`
+	Dimensions         int32                               `json:"dimensions"`
+	EntryPointID       uint64                              `json:"entryPointID"`
+	DistributionLayers map[int]uint                        `json:"distributionLayers"`
+	UnreachablePoints  []uint64                            `json:"unreachablePoints"`
+	NumTombstones      int                                 `json:"numTombstones"`
+	CacheSize          int32                               `json:"cacheSize"`
+	Compressed         bool                                `json:"compressed"`
+	CompressorStats    compressionhelpers.CompressionStats `json:"compressionStats"`
+	CompressionType    string                              `json:"compressionType"`
 }
 
 func (s *HnswStats) IndexType() common.IndexType {
@@ -943,8 +945,16 @@ func (h *hnsw) Stats() (common.IndexStats, error) {
 		UnreachablePoints:  h.calculateUnreachablePoints(),
 		NumTombstones:      len(h.tombstones),
 		CacheSize:          h.cache.Len(),
-		PQConfiguration:    h.pqConfig,
+		Compressed:         h.compressed.Load(),
 	}
+
+	if stats.Compressed {
+		stats.CompressorStats = h.compressor.Stats()
+	} else {
+		stats.CompressorStats = compressionhelpers.UncompressedStats{}
+	}
+
+	stats.CompressionType = stats.CompressorStats.CompressionType()
 
 	return &stats, nil
 }


### PR DESCRIPTION
### What's being changed:

- Extend debug stats endpoint to also show SQ and PQ stats
- This includes the SQ range `(a, b)` and PQ `centroids` and `segments`
- No longer return the pqConfig which can instead be retrieved via the schema endpoint
- Part of fix for https://github.com/weaviate/weaviate/issues/7060, next step is to promote the debug endpoint to a regular rest endpoint

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
