### PR TITLE
perf: Improve filtered group-by performance by avoiding memory allocations 

### DIFF
--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -91,10 +91,13 @@ func (os *objectScannerLSM) scan() error {
 
 		// used for extraction from json
 		propertiesTyped = make(map[string]interface{}, len(os.properties))
+
+		buf = make([]byte, 10*1024)
 	)
 	for _, id := range os.pointers {
 		binary.LittleEndian.PutUint64(docIDBytes, id)
-		res, err := os.objectsBucket.GetBySecondary(0, docIDBytes)
+		res, b, err := os.objectsBucket.GetBySecondaryIntoMemory(0, docIDBytes, buf)
+		buf = b
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/lsmkv/entities/strategies.go
+++ b/adapters/repos/db/lsmkv/entities/strategies.go
@@ -12,7 +12,7 @@
 package entities
 
 const (
-	// StrategyReplace allows for idem-potent PUT where the latest takes presence
+	// StrategyReplace allows for idem-potent PUT where the latest takes precedence
 	StrategyReplace       = "replace"
 	StrategySetCollection = "setcollection"
 	StrategyMapCollection = "mapcollection"

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -507,7 +507,7 @@ func (sg *SegmentGroup) getWithUpperSegmentBoundary(key []byte, segments []*segm
 				return nil, nil
 			}
 
-			panic(fmt.Sprintf("unsupported error in segmentGroup.get(): %v", err))
+			return nil, fmt.Errorf("segment[%d].get(): %w", i, err)
 		}
 
 		return v, nil
@@ -556,7 +556,7 @@ func (sg *SegmentGroup) existsWithUpperSegmentBoundary(key []byte, segments []*s
 				return false, nil
 			}
 
-			panic(fmt.Sprintf("unsupported error in segmentGroup.exists(): %v", err))
+			return false, fmt.Errorf("segment[%d].exists(): %w", i, err)
 		}
 
 		return true, nil

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -487,7 +487,7 @@ func (sg *SegmentGroup) getWithUpperSegmentBoundary(key []byte, segments []*segm
 	// assumes "replace" strategy
 
 	// start with latest and exit as soon as something is found, thus making sure
-	// the latest takes presence
+	// the latest takes precedence
 	for i := len(segments) - 1; i >= 0; i-- {
 		beforeSegment := time.Now()
 		v, err := segments[i].get(key)
@@ -536,7 +536,7 @@ func (sg *SegmentGroup) existsWithUpperSegmentBoundary(key []byte, segments []*s
 	// assumes "replace" strategy
 
 	// start with latest and exit as soon as something is found, thus making sure
-	// the latest takes presence
+	// the latest takes precedence
 	for i := len(segments) - 1; i >= 0; i-- {
 		beforeSegment := time.Now()
 		_, err := segments[i].exists(key)
@@ -576,7 +576,7 @@ func (sg *SegmentGroup) getWithUpperSegmentBoundaryErrDeleted(key []byte, segmen
 	// assumes "replace" strategy
 
 	// start with latest and exit as soon as something is found, thus making sure
-	// the latest takes presence
+	// the latest takes precedence
 	for i := len(segments) - 1; i >= 0; i-- {
 		v, err := segments[i].get(key)
 		if err != nil {
@@ -604,7 +604,7 @@ func (sg *SegmentGroup) getBySecondaryIntoMemory(pos int, key []byte, buffer []b
 	// assumes "replace" strategy
 
 	// start with latest and exit as soon as something is found, thus making sure
-	// the latest takes presence
+	// the latest takes precedence
 	for i := len(segments) - 1; i >= 0; i-- {
 		k, v, allocatedBuff, err := segments[i].getBySecondaryIntoMemory(pos, key, buffer)
 		if err != nil {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -531,7 +531,7 @@ func (sg *SegmentGroup) exists(key []byte) (bool, error) {
 }
 
 // not thread-safe on its own, as the assumption is that this is called from a
-// lockholder, e.g. within .get()
+// lockholder, e.g. within .exists()
 func (sg *SegmentGroup) existsWithUpperSegmentBoundary(key []byte, segments []*segment) (bool, error) {
 	// assumes "replace" strategy
 

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	// StrategyReplace allows for idem-potent PUT where the latest takes presence
+	// StrategyReplace allows for idem-potent PUT where the latest takes precedence
 	StrategyReplace         = "replace"
 	StrategySetCollection   = "setcollection"
 	StrategyMapCollection   = "mapcollection"


### PR DESCRIPTION
### What's being changed:

Removing some unnecessary allocations from the filtered group-by aggregation.

--- 
Benchmarking was performed by continuously running a filtered group-by query on the Sphere1m dataset with filter selectivity of 1M documents.

Query latency on a warm single-node cluster dropped **from ~22s to ~2.5s**  compared to `main` build.

`main`:
![image](https://github.com/user-attachments/assets/dfccffc4-0ec5-40de-8ecc-b95fb414b1bf)

this branch:
![image](https://github.com/user-attachments/assets/21de61ad-4e27-454f-b552-321b2708b520)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
