### PR TITLE
common: add PagedCache implementation

### DIFF
--- a/adapters/repos/db/vector/common/paged_cache.go
+++ b/adapters/repos/db/vector/common/paged_cache.go
@@ -11,16 +11,22 @@
 
 package common
 
+// PagedCache is a cache that stores elements in pages of a fixed size.
+// It is optimized for cases where the cache is sparse and the number of elements is not known in advance.
+// The cache will grow as needed and will reuse pages that have been freed.
 type PagedCache[T any] struct {
 	cache     [][]*T
 	pageSize  int
 	freePages [][]*T
 }
 
+// NewPagedCache creates a new PagedCache with the given page size.
+// The cache will start with 10 pages.
 func NewPagedCache[T any](pageSize int) *PagedCache[T] {
 	return NewPagedCacheWith[T](pageSize, 10)
 }
 
+// NewPagedCacheWith creates a new PagedCache with the given page size and initial number of pages.
 func NewPagedCacheWith[T any](pageSize int, initalPages int) *PagedCache[T] {
 	return &PagedCache[T]{
 		pageSize: pageSize,
@@ -28,6 +34,8 @@ func NewPagedCacheWith[T any](pageSize int, initalPages int) *PagedCache[T] {
 	}
 }
 
+// Get returns the element at the given index.
+// If the element is not in the cache, it will return nil.
 func (p *PagedCache[T]) Get(id int) *T {
 	pageID := id / p.pageSize
 	slotID := id % p.pageSize
@@ -39,6 +47,8 @@ func (p *PagedCache[T]) Get(id int) *T {
 	return p.cache[pageID][slotID]
 }
 
+// Set sets the element at the given index.
+// If the page does not exist, it will be created.
 func (p *PagedCache[T]) Set(id int, value *T) {
 	pageID := id / p.pageSize
 	slotID := id % p.pageSize
@@ -72,6 +82,8 @@ func (p *PagedCache[T]) getPage() []*T {
 	return make([]*T, p.pageSize)
 }
 
+// Reset clears the cache and frees all pages.
+// Free pages are reused when new pages are needed.
 func (p *PagedCache[T]) Reset() {
 	for i := range p.cache {
 		if p.cache[i] != nil {
@@ -82,6 +94,7 @@ func (p *PagedCache[T]) Reset() {
 	}
 }
 
+// Cap returns the current capacity of the cache.
 func (p *PagedCache[T]) Cap() int {
 	return len(p.cache) * p.pageSize
 }

--- a/adapters/repos/db/vector/common/paged_cache.go
+++ b/adapters/repos/db/vector/common/paged_cache.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package common
 
 type PagedCache[T any] struct {

--- a/adapters/repos/db/vector/common/paged_cache.go
+++ b/adapters/repos/db/vector/common/paged_cache.go
@@ -1,0 +1,76 @@
+package common
+
+type PagedCache[T any] struct {
+	cache     [][]*T
+	pageSize  int
+	freePages [][]*T
+}
+
+func NewPagedCache[T any](pageSize int) *PagedCache[T] {
+	return NewPagedCacheWith[T](pageSize, 10)
+}
+
+func NewPagedCacheWith[T any](pageSize int, initalPages int) *PagedCache[T] {
+	return &PagedCache[T]{
+		pageSize: pageSize,
+		cache:    make([][]*T, 10),
+	}
+}
+
+func (p *PagedCache[T]) Get(id int) *T {
+	pageID := id / p.pageSize
+	slotID := id % p.pageSize
+
+	if p.cache[pageID] == nil {
+		return nil
+	}
+
+	return p.cache[pageID][slotID]
+}
+
+func (p *PagedCache[T]) Set(id int, value *T) {
+	pageID := id / p.pageSize
+	slotID := id % p.pageSize
+
+	if pageID >= len(p.cache) {
+		p.grow(pageID)
+	}
+
+	if p.cache[pageID] == nil {
+		p.cache[pageID] = p.getPage()
+	}
+
+	p.cache[pageID][slotID] = value
+}
+
+func (p *PagedCache[T]) grow(page int) {
+	newSize := max(page+10, len(p.cache)*2)
+	newCache := make([][]*T, newSize)
+	copy(newCache, p.cache)
+	p.cache = newCache
+}
+
+func (p *PagedCache[T]) getPage() []*T {
+	if len(p.freePages) > 0 {
+		lastIndex := len(p.freePages) - 1
+		page := p.freePages[lastIndex]
+		p.freePages = p.freePages[:lastIndex]
+		return page
+	}
+
+	return make([]*T, p.pageSize)
+}
+
+func (p *PagedCache[T]) Reset() {
+	for i := range p.cache {
+		if p.cache[i] != nil {
+			clear(p.cache[i])
+			p.freePages = append(p.freePages, p.cache[i])
+			p.cache[i] = nil
+		}
+	}
+}
+
+func (p *PagedCache[T]) Cap() int {
+	return len(p.cache) * p.pageSize
+}

--- a/adapters/repos/db/vector/common/paged_cache_test.go
+++ b/adapters/repos/db/vector/common/paged_cache_test.go
@@ -1,0 +1,117 @@
+package common
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPagedCache(t *testing.T) {
+	cache := NewPagedCacheWith[int](10, 2)
+
+	setN := func(n int) {
+		for i := 0; i < n; i++ {
+			cache.Set(i, &i)
+		}
+	}
+
+	checkN := func(n int) {
+		for i := 0; i < n; i++ {
+			v := cache.Get(i)
+			if *v != i {
+				t.Errorf("expected %d, got %d", i, *v)
+			}
+		}
+	}
+
+	setN(10)
+	checkN(10)
+
+	setN(1000)
+	checkN(1000)
+
+	cache.Reset()
+
+	setN(1000)
+	checkN(1000)
+
+	cache.Reset()
+
+	setN(100)
+	require.Equal(t, 10, *cache.Get(10))
+	require.Nil(t, cache.Get(140))
+
+	cache.Reset()
+	for i := 0; i < 100; i += 2 {
+		cache.Set(i, &i)
+	}
+	for i := 0; i < 100; i += 2 {
+		require.Equal(t, i, *cache.Get(i))
+	}
+	for i := 1; i < 100; i += 2 {
+		require.Nil(t, cache.Get(i))
+	}
+}
+
+func BenchmarkPagedCache(b *testing.B) {
+	pageSize := 512
+	keys := make([]int, 10000)
+	values := make([]int, 10000)
+	for i := range 10000 {
+		keys[i] = int(rand.Int31n(500_000_000))
+		values[i] = rand.Int()
+	}
+
+	b.Run("PagedCache/Set", func(b *testing.B) {
+		cache := NewPagedCacheWith[int](pageSize, 10)
+
+		for i := 0; i < b.N; i++ {
+			cache.Reset()
+
+			for j := 0; j < 10000; j++ {
+				cache.Set(keys[j], &values[j])
+			}
+		}
+	})
+
+	b.Run("FlatCache/Set", func(b *testing.B) {
+		cache := make([]*int, 500_000_000)
+
+		for i := 0; i < b.N; i++ {
+			clear(cache)
+
+			for j := 0; j < 10000; j++ {
+				cache[keys[j]] = &values[j]
+			}
+		}
+	})
+
+	b.Run("PagedCache/Get", func(b *testing.B) {
+		cache := NewPagedCacheWith[int](pageSize, 10)
+
+		for j := 0; j < 10000; j++ {
+			cache.Set(keys[j], &values[j])
+		}
+
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < 10000; j++ {
+				_ = cache.Get(keys[j])
+			}
+		}
+	})
+
+	b.Run("FlatCache/Get", func(b *testing.B) {
+		cache := make([]*int, 500_000_000)
+
+		for j := 0; j < 10000; j++ {
+			cache[keys[j]] = &values[j]
+		}
+
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < 10000; j++ {
+				_ = cache[keys[j]]
+			}
+		}
+	})
+}

--- a/adapters/repos/db/vector/common/paged_cache_test.go
+++ b/adapters/repos/db/vector/common/paged_cache_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package common
 
 import (


### PR DESCRIPTION
### What's being changed:

This adds a generic cache implementation that stores elements in pages of a fixed size.
It is optimized for cases where the cache is sparse and the number of elements is not known in advance.
The cache will grow as needed and will reuse pages that have been freed.

Related to https://github.com/weaviate/weaviate/issues/7189

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
