### PR TITLE
fix: pass initialPages argument to constructor

### DIFF
--- a/adapters/repos/db/vector/common/paged_cache.go
+++ b/adapters/repos/db/vector/common/paged_cache.go
@@ -27,10 +27,10 @@ func NewPagedCache[T any](pageSize int) *PagedCache[T] {
 }
 
 // NewPagedCacheWith creates a new PagedCache with the given page size and initial number of pages.
-func NewPagedCacheWith[T any](pageSize int, initalPages int) *PagedCache[T] {
+func NewPagedCacheWith[T any](pageSize int, initialPages int) *PagedCache[T] {
 	return &PagedCache[T]{
 		pageSize: pageSize,
-		cache:    make([][]*T, 10),
+		cache:    make([][]*T, initialPages),
 	}
 }
 

--- a/adapters/repos/db/vector/common/paged_cache_test.go
+++ b/adapters/repos/db/vector/common/paged_cache_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestPagedCache(t *testing.T) {
 	cache := NewPagedCacheWith[int](10, 2)
+	require.Len(t, cache.cache, 2, "wrong initial number of pages")
 
 	setN := func(n int) {
 		for i := 0; i < n; i++ {


### PR DESCRIPTION
`NewPagedCacheWith` from #7303 does not use `initialPages` argument and always creates 10 pages. 

Fixed a typo 'inital' -> 'initial'.

### What's being changed:

`NewPagedCacheWith` passes the initialPages parameter to `make()`.

### Review checklist

- [ ] ~~Documentation has been updated, if necessary. Link to changed documentation:~~
- [ ] ~~Chaos pipeline run or not necessary. Link to pipeline:~~
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
