### PR TITLE
fix: default value for segment checksum enablement

### DIFF
--- a/adapters/repos/db/lsmkv/segmentindex/segment_file.go
+++ b/adapters/repos/db/lsmkv/segmentindex/segment_file.go
@@ -93,11 +93,12 @@ func WithChecksumsDisabled(disable bool) SegmentFileOption {
 // NewSegmentFile creates a new instance of SegmentFile.
 // Be sure to include a writer or reader option depending on your needs.
 func NewSegmentFile(opts ...SegmentFileOption) *SegmentFile {
-	s := &SegmentFile{}
+	s := &SegmentFile{
+		checksumsDisabled: true,
+	}
 	for _, opt := range opts {
 		opt(s)
 	}
-	s.checksumsDisabled = true
 	return s
 }
 

--- a/test/acceptance_lsmkv/data_integrity_test.go
+++ b/test/acceptance_lsmkv/data_integrity_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestLSMKV_ChecksumRoundtrip(t *testing.T) {
+	for _, enableChecksumsInitially := range []bool{true, false} {
+		t.Run(fmt.Sprintf("enableChecksumsInitially=%v", enableChecksumsInitially), func(t *testing.T) {
+			var (
+				key     = []byte("primary_key")
+				val     = []byte("some_value")
+				dataDir = t.TempDir()
+			)
+
+			bucket, err := newTestBucket(dataDir, enableChecksumsInitially)
+			require.NoError(t, err)
+
+			require.NoError(t, bucket.Put(key, val))
+
+			// verify that you can read the value
+			res, err := bucket.Get(key)
+			require.NoError(t, err)
+			require.Equal(t, val, res)
+
+			// flush the segment to disk
+			require.NoError(t, bucket.Shutdown(context.Background()))
+
+			// verify that you can boostrap from the data on disk when checksums are enabled
+			bucket, err = newTestBucket(dataDir, true)
+			require.NoError(t, err)
+
+			res, err = bucket.Get(key)
+			require.Nil(t, err)
+			require.Equal(t, val, res)
+
+			require.NoError(t, bucket.Shutdown(context.Background()))
+		})
+	}
+}
+
+func TestLSMKV_ChecksumsCatchCorruptedFiles(t *testing.T) {
+	var (
+		key     = []byte("primary_key")
+		val     = []byte("some_value")
+		dataDir = t.TempDir()
+	)
+
+	// create a bucket with checksums enabled and flush some data to disk
+	bucket, err := newTestBucket(dataDir, true)
+	require.NoError(t, err)
+	require.NoError(t, bucket.Put(key, val))
+	require.NoError(t, bucket.Shutdown(context.Background()))
+
+	entries, err := os.ReadDir(dataDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "single segment file should be created")
+
+	segmentPath := path.Join(dataDir, entries[0].Name())
+	fileContent, err := os.ReadFile(segmentPath)
+	require.NoError(t, err)
+
+	valueOffset := bytes.Index(fileContent, val)
+	require.NotEqual(t, -1, valueOffset, "value was not find in the segment file")
+
+	// corrupt the file contents
+	fileContent[valueOffset] = 0xFF
+	require.NoError(t, os.WriteFile(segmentPath, fileContent, os.ModePerm))
+
+	_, err = newTestBucket(dataDir, true)
+	require.ErrorContains(t, err, "invalid checksum")
+}
+
+func newTestBucket(dataPath string, checkSumEnabled bool) (*lsmkv.Bucket, error) {
+	log, _ := test.NewNullLogger()
+	return lsmkv.NewBucketCreator().
+		NewBucket(context.Background(), dataPath, "", log, nil,
+			cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(),
+			lsmkv.WithSegmentsChecksumValidationEnabled(checkSumEnabled),
+		)
+}


### PR DESCRIPTION
### What's being changed:
The default value on whether to enable checksum was set _after_ applying the options to enable checksums, which resulted in checksums being always disabled at the segment level.

However, other parts of the system expected the checksums anyway, and shards failed to load.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
