### PR TITLE
[api] Double timeouts over GQL and gRPC for generative module tests

### DIFF
--- a/test/helper/sample-schema/planets/planets.go
+++ b/test/helper/sample-schema/planets/planets.go
@@ -134,7 +134,7 @@ func CreatePromptTestWithParams(t *testing.T, className, prompt, params string) 
 				}
 			}
 		`, className, prompt, params)
-	result := graphqlhelper.AssertGraphQLWithTimeout(t, helper.RootAuth, 5*time.Minute, query)
+	result := graphqlhelper.AssertGraphQLWithTimeout(t, helper.RootAuth, 10*time.Minute, query)
 	objs := result.Get("Get", className).AsSlice()
 	require.Len(t, objs, 2)
 	for i, obj := range objs {
@@ -185,7 +185,7 @@ func CreatePromptTestWithParamsGRPC(t *testing.T, className, singlePrompt, group
 		},
 		Uses_127Api: true,
 	}
-	resp := grpchelper.AssertSearchWithTimeout(t, req, 5*time.Minute)
+	resp := grpchelper.AssertSearchWithTimeout(t, req, 10*time.Minute)
 	require.NotNil(t, resp)
 	require.Len(t, resp.Results, 2)
 	for i, res := range resp.Results {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
