### PR TITLE
chore: Add concurrency limit to shard loading

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -319,7 +319,8 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		// longer start up if the required minimum is now higher than 1. We want
 		// the required minimum to only apply to newly created classes - not block
 		// loading existing ones.
-		Replication: replication.GlobalConfig{MinimumFactor: 1},
+		Replication:                 replication.GlobalConfig{MinimumFactor: 1},
+		MaximumConcurrentShardLoads: appState.ServerConfig.Config.MaximumConcurrentShardLoads,
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics, appState.MemWatch) // TODO client
 	if err != nil {
 		appState.Logger.

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -33,6 +33,7 @@ import (
 	esync "github.com/weaviate/weaviate/entities/sync"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func parkingGaragesSchema() schema.Schema {
@@ -269,6 +270,7 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 		indexCheckpoints:      checkpts,
 		allocChecker:          memwatch.NewDummyMonitor(),
 		shardCreateLocks:      esync.NewKeyLocker(),
+		shardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
 	}
 	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
 	idx.initCycleCallbacksNoop()

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func TestIndex_DropIndex(t *testing.T) {
@@ -112,6 +113,7 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		RootPath:          dirName,
 		ClassName:         schema.ClassName(class.Class),
 		ReplicationFactor: NewAtomicInt64(1),
+		ShardLoadLimiter:  NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -170,6 +172,7 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		RootPath:          dirName,
 		ClassName:         schema.ClassName(class.Class),
 		ReplicationFactor: NewAtomicInt64(1),
+		ShardLoadLimiter:  NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema:     fakeSchema,
@@ -279,6 +282,7 @@ func TestIndex_DropReadOnlyIndexWithData(t *testing.T) {
 		RootPath:          dirName,
 		ClassName:         schema.ClassName(class.Class),
 		ReplicationFactor: NewAtomicInt64(1),
+		ShardLoadLimiter:  NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -426,6 +430,7 @@ func TestIndex_DropLoadedShard(t *testing.T) {
 		RootPath:          dirName,
 		ClassName:         schema.ClassName(class.Class),
 		ReplicationFactor: NewAtomicInt64(1),
+		ShardLoadLimiter:  NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
 	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			schema: fakeSchema, shardState: shardState,
@@ -480,6 +485,7 @@ func emptyIdx(t *testing.T, rootDir string, class *models.Class) *Index {
 		ClassName:             schema.ClassName(class.Class),
 		DisableLazyLoadShards: true,
 		ReplicationFactor:     NewAtomicInt64(1),
+		ShardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
 	}, shardState, inverted.ConfigFromModel(invertedConfig()),
 		hnsw.NewDefaultUserConfig(), nil, &fakeSchemaGetter{
 			shardState: shardState,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -102,6 +102,7 @@ func (db *DB) init(ctx context.Context) error {
 				ForceFullReplicasSearch:        db.config.ForceFullReplicasSearch,
 				ReplicationFactor:              NewAtomicInt64(class.ReplicationConfig.Factor),
 				DeletionStrategy:               class.ReplicationConfig.DeletionStrategy,
+				ShardLoadLimiter:               db.shardLoadLimiter,
 			}, db.schemaGetter.CopyShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -92,6 +92,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 			ForceFullReplicasSearch:        m.db.config.ForceFullReplicasSearch,
 			ReplicationFactor:              NewAtomicInt64(class.ReplicationConfig.Factor),
 			DeletionStrategy:               class.ReplicationConfig.DeletionStrategy,
+			ShardLoadLimiter:               m.db.shardLoadLimiter,
 		},
 		shardState,
 		// no backward-compatibility check required, since newly added classes will

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -20,13 +20,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/cluster/utils"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -86,6 +85,8 @@ type DB struct {
 	// in the case of metrics grouping we need to observe some metrics
 	// node-centric, rather than shard-centric
 	metricsObserver *nodeWideMetricsObserver
+
+	shardLoadLimiter ShardLoadLimiter
 }
 
 func (db *DB) GetSchemaGetter() schemaUC.SchemaGetter {
@@ -130,6 +131,11 @@ func New(logger logrus.FieldLogger, config Config,
 	if memMonitor == nil {
 		memMonitor = memwatch.NewDummyMonitor()
 	}
+	metricsRegisterer := monitoring.NoopRegisterer
+	if promMetrics != nil && promMetrics.Registerer != nil {
+		metricsRegisterer = promMetrics.Registerer
+	}
+
 	db := &DB{
 		logger:                  logger,
 		config:                  config,
@@ -144,6 +150,7 @@ func New(logger logrus.FieldLogger, config Config,
 		maxNumberGoroutines:     int(math.Round(config.MaxImportGoroutinesFactor * float64(runtime.GOMAXPROCS(0)))),
 		resourceScanState:       newResourceScanState(),
 		memMonitor:              memMonitor,
+		shardLoadLimiter:        NewShardLoadLimiter(metricsRegisterer, config.MaximumConcurrentShardLoads),
 	}
 
 	if db.maxNumberGoroutines == 0 {
@@ -197,6 +204,7 @@ type Config struct {
 	DisableLazyLoadShards          bool
 	ForceFullReplicasSearch        bool
 	Replication                    replication.GlobalConfig
+	MaximumConcurrentShardLoads    int
 	CycleManagerRoutinesFactor     int
 }
 

--- a/adapters/repos/db/shard_load_limiter.go
+++ b/adapters/repos/db/shard_load_limiter.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	defaultShardLoadingLimit = 500
+)
+
+// ShardLoadLimiter is a limiter to control how many shards are loaded concurrently.
+// If too many shards are loaded in parallel, it throttles the loading instead of rejecting.
+// The motivation of this limiter is the fact that loading a shard requires multiple syscalls
+// which create a new OS thread is there is no unused ones. In case we try to load thousands of shards in parallel,
+// we might hit internal thread count limit of Go runtime.
+type ShardLoadLimiter struct {
+	sema *semaphore.Weighted
+
+	shardsLoading          prometheus.Gauge
+	waitingForPermitToLoad prometheus.Gauge
+}
+
+func NewShardLoadLimiter(reg prometheus.Registerer, limit int) ShardLoadLimiter {
+	r := promauto.With(reg)
+	if limit == 0 {
+		limit = defaultShardLoadingLimit
+	}
+
+	return ShardLoadLimiter{
+		sema: semaphore.NewWeighted(int64(limit)),
+
+		shardsLoading: r.NewGauge(prometheus.GaugeOpts{
+			Name: "database_shards_loading",
+		}),
+		waitingForPermitToLoad: r.NewGauge(prometheus.GaugeOpts{
+			Name: "database_shards_waiting_for_permit_to_load",
+		}),
+	}
+}
+
+func (l *ShardLoadLimiter) Acquire(ctx context.Context) error {
+	l.waitingForPermitToLoad.Inc()
+	defer l.waitingForPermitToLoad.Dec()
+
+	err := l.sema.Acquire(ctx, 1)
+	if err != nil {
+		return err
+	}
+	l.shardsLoading.Inc()
+	return nil
+}
+
+func (l *ShardLoadLimiter) Release() {
+	l.shardsLoading.Dec()
+	l.sema.Release(1)
+}

--- a/adapters/repos/db/shard_load_limiter.go
+++ b/adapters/repos/db/shard_load_limiter.go
@@ -66,6 +66,6 @@ func (l *ShardLoadLimiter) Acquire(ctx context.Context) error {
 }
 
 func (l *ShardLoadLimiter) Release() {
-	l.shardsLoading.Dec()
 	l.sema.Release(1)
+	l.shardsLoading.Dec()
 }

--- a/adapters/repos/db/shard_load_limiter.go
+++ b/adapters/repos/db/shard_load_limiter.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (

--- a/adapters/repos/db/shard_load_limiter_test.go
+++ b/adapters/repos/db/shard_load_limiter_test.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+func TestNewShardLoadLimiter_DefaultLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		limit         int
+		expectedLimit int64
+	}{
+		{
+			name:          "with custom limit",
+			limit:         100,
+			expectedLimit: 100,
+		},
+		{
+			name:          "with default limit",
+			limit:         0,
+			expectedLimit: defaultShardLoadingLimit,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			limiter := NewShardLoadLimiter(monitoring.NoopRegisterer, tc.limit)
+
+			var count int64
+			for limiter.sema.TryAcquire(1) {
+				count++
+			}
+
+			require.Equal(t, tc.expectedLimit, count)
+		})
+	}
+}
+
+func TestNewShardLoadLimiter_ControlsConcurrency(t *testing.T) {
+	var (
+		limiter = NewShardLoadLimiter(monitoring.NoopRegisterer, 5)
+		start   = time.Now()
+	)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			require.NoError(t, limiter.Acquire(context.Background()))
+			defer limiter.Release()
+
+			time.Sleep(100 * time.Millisecond)
+		}()
+	}
+	wg.Wait()
+
+	require.GreaterOrEqual(t, time.Since(start), 200*time.Millisecond)
+}

--- a/adapters/repos/db/shard_load_limiter_test.go
+++ b/adapters/repos/db/shard_load_limiter_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -115,6 +115,7 @@ type Config struct {
 	ResourceUsage                       ResourceUsage            `json:"resource_usage" yaml:"resource_usage"`
 	MaxImportGoroutinesFactor           float64                  `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
 	MaximumConcurrentGetRequests        int                      `json:"maximum_concurrent_get_requests" yaml:"maximum_concurrent_get_requests"`
+	MaximumConcurrentShardLoads         int                      `json:"maximum_concurrent_shard_loads" yaml:"maximum_concurrent_shard_loads"`
 	TrackVectorDimensions               bool                     `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
 	ReindexVectorDimensionsAtStartup    bool                     `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
 	DisableLazyLoadShards               bool                     `json:"disable_lazy_load_shards" yaml:"disable_lazy_load_shards"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -399,6 +399,14 @@ func FromEnv(config *Config) error {
 		config.MaximumConcurrentGetRequests = DefaultMaxConcurrentGetRequests
 	}
 
+	if err = parsePositiveInt(
+		"MAXIMUM_CONCURRENT_SHARD_LOADS",
+		func(val int) { config.MaximumConcurrentShardLoads = val },
+		DefaultMaxConcurrentShardLoads,
+	); err != nil {
+		return err
+	}
+
 	if err := parsePositiveInt(
 		"GRPC_PORT",
 		func(val int) { config.GRPC.Port = val },
@@ -688,6 +696,7 @@ const (
 	DefaultPersistenceMemtablesMinDuration     = 15
 	DefaultPersistenceMemtablesMaxDuration     = 45
 	DefaultMaxConcurrentGetRequests            = 0
+	DefaultMaxConcurrentShardLoads             = 500
 	DefaultGRPCPort                            = 50051
 	DefaultMinimumReplicationFactor            = 1
 )

--- a/usecases/monitoring/noop.go
+++ b/usecases/monitoring/noop.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package monitoring
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/usecases/monitoring/noop.go
+++ b/usecases/monitoring/noop.go
@@ -1,0 +1,14 @@
+package monitoring
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NoopRegisterer is a no-op Prometheus register.
+var NoopRegisterer prometheus.Registerer = noopRegisterer{}
+
+type noopRegisterer struct{}
+
+func (n noopRegisterer) Register(_ prometheus.Collector) error { return nil }
+
+func (n noopRegisterer) MustRegister(_ ...prometheus.Collector) {}
+
+func (n noopRegisterer) Unregister(_ prometheus.Collector) bool { return true }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -26,6 +26,8 @@ type Config struct {
 }
 
 type PrometheusMetrics struct {
+	Registerer prometheus.Registerer
+
 	BatchTime                         *prometheus.HistogramVec
 	BatchSizeBytes                    *prometheus.SummaryVec
 	BatchSizeObjects                  prometheus.Summary


### PR DESCRIPTION
### What's being changed:

Adding a concurrency limiter for loading shards across the whole database (controlled by `MAXIMUM_CONCURRENT_SHARD_LOADS` env variable, default 500) 

We want to limit how many shards are loaded in parallel because while opening the shard we do multiple parallel syscalls (reading disk) and each of them creates a new OS thread if there are none available. 

If the cluster has thousands of collections or shards, we might get a fatal panic like this if there is no control:
```
runtime: program exceeds 10000-thread limit
 fatal error: thread exhaustion
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
