### PR TITLE
Remove `ai21.j2-mid-v1` from `generative-aws` module tests

### DIFF
--- a/test/helper/graphql/graphql_helper.go
+++ b/test/helper/graphql/graphql_helper.go
@@ -73,9 +73,10 @@ func getGraphQLResponseOrFatal(t *testing.T, response *models.GraphQLResponse, e
 	if err != nil {
 		parsedErr, ok := err.(*graphql.GraphqlPostUnprocessableEntity)
 		if !ok {
-			t.Fatalf("Expected the query to succeed, but failed due to: %#v", err)
+			t.Fatalf("Expected the query to succeed, but failed due to: %#v, with message: %s", err, err.Error())
 		}
-		t.Fatalf("Expected the query to succeed, but failed with unprocessable entity: %v", parsedErr.Payload.Error[0])
+		innerErr := parsedErr.Payload.Error[0]
+		t.Fatalf("Expected the query to succeed, but failed with unprocessable entity: %v, with message: %s", innerErr, innerErr.Message)
 	}
 	return response
 }

--- a/test/modules/generative-aws/generative_aws_test.go
+++ b/test/modules/generative-aws/generative_aws_test.go
@@ -116,6 +116,11 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 				name:            "meta.llama3-70b-instruct-v1:0",
 				generativeModel: "meta.llama3-70b-instruct-v1:0",
 			},
+			{
+				name:               "absent module config",
+				generativeModel:    "meta.llama3-70b-instruct-v1:0",
+				absentModuleConfig: true,
+			},
 			// Mistral AI
 			{
 				name:            "mistral.mistral-7b-instruct-v0:2",
@@ -128,11 +133,6 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 			{
 				name:            "mistral.mistral-large-2402-v1:0",
 				generativeModel: "mistral.mistral-large-2402-v1:0",
-			},
-			{
-				name:               "absent module config",
-				generativeModel:    "ai21.j2-mid-v1",
-				absentModuleConfig: true,
 			},
 		}
 		for _, tt := range tests {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
