### PR TITLE
async: add ASYNC_INDEXING_BATCH_SIZE env var

### DIFF
--- a/adapters/repos/db/vector_index_queue_test.go
+++ b/adapters/repos/db/vector_index_queue_test.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+func TestVectorIndexQueueBatchSize(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+	os.Setenv("ASYNC_INDEXING_BATCH_SIZE", "6000")
+	os.Setenv("ASYNC_INDEXING_STALE_TIMEOUT", "1ms")
+
+	ctx := context.Background()
+	className := "TestClass"
+	shd, _ := testShardWithSettings(t, ctx, &models.Class{Class: className}, hnsw.UserConfig{}, false, true)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	count := 10_000
+
+	v := make([]float32, 1000)
+
+	var vectors []common.VectorRecord
+	for i := range count {
+		vectors = append(vectors, &common.Vector[[]float32]{
+			ID:     uint64(i),
+			Vector: v,
+		})
+	}
+
+	q := shd.Queue()
+	err := q.Insert(ctx, vectors...)
+	require.NoError(t, err)
+
+	// wait for the batch to be stale
+	time.Sleep(100 * time.Millisecond)
+
+	b, err := q.DequeueBatch()
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.InEpsilon(t, 6000, len(b.Tasks), 0.4)
+	size := len(b.Tasks)
+	b.Done()
+	require.EqualValues(t, 10000-size, q.Size())
+}


### PR DESCRIPTION
### What's being changed:

This adds the ASYNC_INDEXING_BATCH_SIZE env var that allows to control the minimum number of vectors in a batch.
Useful for scenarios when it is preferred to index lots of vectors in one go (e.g. cuVS)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
