### PR TITLE
Rename UserInfo definition to UserOwnInfo 

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4086,7 +4086,7 @@ func init() {
           "200": {
             "description": "Info about the user",
             "schema": {
-              "$ref": "#/definitions/UserInfo"
+              "$ref": "#/definitions/UserOwnInfo"
             }
           },
           "401": {
@@ -6305,7 +6305,7 @@ func init() {
         }
       ]
     },
-    "UserInfo": {
+    "UserOwnInfo": {
       "type": "object",
       "required": [
         "username"
@@ -10844,7 +10844,7 @@ func init() {
           "200": {
             "description": "Info about the user",
             "schema": {
-              "$ref": "#/definitions/UserInfo"
+              "$ref": "#/definitions/UserOwnInfo"
             }
           },
           "401": {
@@ -13351,7 +13351,7 @@ func init() {
         }
       ]
     },
-    "UserInfo": {
+    "UserOwnInfo": {
       "type": "object",
       "required": [
         "username"

--- a/adapters/handlers/rest/handlers_authn.go
+++ b/adapters/handlers/rest/handlers_authn.go
@@ -66,7 +66,7 @@ func (h *authNHandlers) getOwnInfo(_ users.GetOwnInfoParams, principal *models.P
 		"user":      principal.Username,
 	}).Info("own info requested")
 
-	return users.NewGetOwnInfoOK().WithPayload(&models.UserInfo{
+	return users.NewGetOwnInfoOK().WithPayload(&models.UserOwnInfo{
 		Groups:   principal.Groups,
 		Roles:    roles,
 		Username: &principal.Username,

--- a/adapters/handlers/rest/operations/users/get_own_info_responses.go
+++ b/adapters/handlers/rest/operations/users/get_own_info_responses.go
@@ -33,7 +33,6 @@ GetOwnInfoOK Info about the user
 swagger:response getOwnInfoOK
 */
 type GetOwnInfoOK struct {
-
 	/*
 	  In: Body
 	*/
@@ -42,7 +41,6 @@ type GetOwnInfoOK struct {
 
 // NewGetOwnInfoOK creates GetOwnInfoOK with default headers values
 func NewGetOwnInfoOK() *GetOwnInfoOK {
-
 	return &GetOwnInfoOK{}
 }
 
@@ -59,7 +57,6 @@ func (o *GetOwnInfoOK) SetPayload(payload *models.UserOwnInfo) {
 
 // WriteResponse to the client
 func (o *GetOwnInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(200)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -77,19 +74,16 @@ GetOwnInfoUnauthorized Unauthorized or invalid credentials.
 
 swagger:response getOwnInfoUnauthorized
 */
-type GetOwnInfoUnauthorized struct {
-}
+type GetOwnInfoUnauthorized struct{}
 
 // NewGetOwnInfoUnauthorized creates GetOwnInfoUnauthorized with default headers values
 func NewGetOwnInfoUnauthorized() *GetOwnInfoUnauthorized {
-
 	return &GetOwnInfoUnauthorized{}
 }
 
 // WriteResponse to the client
 func (o *GetOwnInfoUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+	rw.Header().Del(runtime.HeaderContentType) // Remove Content-Type on empty responses
 
 	rw.WriteHeader(401)
 }
@@ -103,7 +97,6 @@ GetOwnInfoInternalServerError An error has occurred while trying to fulfill the 
 swagger:response getOwnInfoInternalServerError
 */
 type GetOwnInfoInternalServerError struct {
-
 	/*
 	  In: Body
 	*/
@@ -112,7 +105,6 @@ type GetOwnInfoInternalServerError struct {
 
 // NewGetOwnInfoInternalServerError creates GetOwnInfoInternalServerError with default headers values
 func NewGetOwnInfoInternalServerError() *GetOwnInfoInternalServerError {
-
 	return &GetOwnInfoInternalServerError{}
 }
 
@@ -129,7 +121,6 @@ func (o *GetOwnInfoInternalServerError) SetPayload(payload *models.ErrorResponse
 
 // WriteResponse to the client
 func (o *GetOwnInfoInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(500)
 	if o.Payload != nil {
 		payload := o.Payload

--- a/adapters/handlers/rest/operations/users/get_own_info_responses.go
+++ b/adapters/handlers/rest/operations/users/get_own_info_responses.go
@@ -37,7 +37,7 @@ type GetOwnInfoOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.UserInfo `json:"body,omitempty"`
+	Payload *models.UserOwnInfo `json:"body,omitempty"`
 }
 
 // NewGetOwnInfoOK creates GetOwnInfoOK with default headers values
@@ -47,13 +47,13 @@ func NewGetOwnInfoOK() *GetOwnInfoOK {
 }
 
 // WithPayload adds the payload to the get own info o k response
-func (o *GetOwnInfoOK) WithPayload(payload *models.UserInfo) *GetOwnInfoOK {
+func (o *GetOwnInfoOK) WithPayload(payload *models.UserOwnInfo) *GetOwnInfoOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get own info o k response
-func (o *GetOwnInfoOK) SetPayload(payload *models.UserInfo) {
+func (o *GetOwnInfoOK) SetPayload(payload *models.UserOwnInfo) {
 	o.Payload = payload
 }
 

--- a/adapters/handlers/rest/operations/users/get_own_info_responses.go
+++ b/adapters/handlers/rest/operations/users/get_own_info_responses.go
@@ -33,6 +33,7 @@ GetOwnInfoOK Info about the user
 swagger:response getOwnInfoOK
 */
 type GetOwnInfoOK struct {
+
 	/*
 	  In: Body
 	*/
@@ -41,6 +42,7 @@ type GetOwnInfoOK struct {
 
 // NewGetOwnInfoOK creates GetOwnInfoOK with default headers values
 func NewGetOwnInfoOK() *GetOwnInfoOK {
+
 	return &GetOwnInfoOK{}
 }
 
@@ -57,6 +59,7 @@ func (o *GetOwnInfoOK) SetPayload(payload *models.UserOwnInfo) {
 
 // WriteResponse to the client
 func (o *GetOwnInfoOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(200)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -74,16 +77,19 @@ GetOwnInfoUnauthorized Unauthorized or invalid credentials.
 
 swagger:response getOwnInfoUnauthorized
 */
-type GetOwnInfoUnauthorized struct{}
+type GetOwnInfoUnauthorized struct {
+}
 
 // NewGetOwnInfoUnauthorized creates GetOwnInfoUnauthorized with default headers values
 func NewGetOwnInfoUnauthorized() *GetOwnInfoUnauthorized {
+
 	return &GetOwnInfoUnauthorized{}
 }
 
 // WriteResponse to the client
 func (o *GetOwnInfoUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-	rw.Header().Del(runtime.HeaderContentType) // Remove Content-Type on empty responses
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
 	rw.WriteHeader(401)
 }
@@ -97,6 +103,7 @@ GetOwnInfoInternalServerError An error has occurred while trying to fulfill the 
 swagger:response getOwnInfoInternalServerError
 */
 type GetOwnInfoInternalServerError struct {
+
 	/*
 	  In: Body
 	*/
@@ -105,6 +112,7 @@ type GetOwnInfoInternalServerError struct {
 
 // NewGetOwnInfoInternalServerError creates GetOwnInfoInternalServerError with default headers values
 func NewGetOwnInfoInternalServerError() *GetOwnInfoInternalServerError {
+
 	return &GetOwnInfoInternalServerError{}
 }
 
@@ -121,6 +129,7 @@ func (o *GetOwnInfoInternalServerError) SetPayload(payload *models.ErrorResponse
 
 // WriteResponse to the client
 func (o *GetOwnInfoInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(500)
 	if o.Payload != nil {
 		payload := o.Payload

--- a/client/users/get_own_info_responses.go
+++ b/client/users/get_own_info_responses.go
@@ -68,7 +68,7 @@ GetOwnInfoOK describes a response with status code 200, with default header valu
 Info about the user
 */
 type GetOwnInfoOK struct {
-	Payload *models.UserInfo
+	Payload *models.UserOwnInfo
 }
 
 // IsSuccess returns true when this get own info o k response has a 2xx status code
@@ -109,13 +109,13 @@ func (o *GetOwnInfoOK) String() string {
 	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoOK  %+v", 200, o.Payload)
 }
 
-func (o *GetOwnInfoOK) GetPayload() *models.UserInfo {
+func (o *GetOwnInfoOK) GetPayload() *models.UserOwnInfo {
 	return o.Payload
 }
 
 func (o *GetOwnInfoOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.UserInfo)
+	o.Payload = new(models.UserOwnInfo)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/users/get_own_info_responses.go
+++ b/client/users/get_own_info_responses.go
@@ -114,6 +114,7 @@ func (o *GetOwnInfoOK) GetPayload() *models.UserOwnInfo {
 }
 
 func (o *GetOwnInfoOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.UserOwnInfo)
 
 	// response payload
@@ -134,7 +135,8 @@ GetOwnInfoUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type GetOwnInfoUnauthorized struct{}
+type GetOwnInfoUnauthorized struct {
+}
 
 // IsSuccess returns true when this get own info unauthorized response has a 2xx status code
 func (o *GetOwnInfoUnauthorized) IsSuccess() bool {
@@ -175,6 +177,7 @@ func (o *GetOwnInfoUnauthorized) String() string {
 }
 
 func (o *GetOwnInfoUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	return nil
 }
 
@@ -235,6 +238,7 @@ func (o *GetOwnInfoInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetOwnInfoInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/get_own_info_responses.go
+++ b/client/users/get_own_info_responses.go
@@ -114,7 +114,6 @@ func (o *GetOwnInfoOK) GetPayload() *models.UserOwnInfo {
 }
 
 func (o *GetOwnInfoOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.UserOwnInfo)
 
 	// response payload
@@ -135,8 +134,7 @@ GetOwnInfoUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type GetOwnInfoUnauthorized struct {
-}
+type GetOwnInfoUnauthorized struct{}
 
 // IsSuccess returns true when this get own info unauthorized response has a 2xx status code
 func (o *GetOwnInfoUnauthorized) IsSuccess() bool {
@@ -177,7 +175,6 @@ func (o *GetOwnInfoUnauthorized) String() string {
 }
 
 func (o *GetOwnInfoUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,7 +235,6 @@ func (o *GetOwnInfoInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetOwnInfoInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/entities/models/user_own_info.go
+++ b/entities/models/user_own_info.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model UserOwnInfo
 type UserOwnInfo struct {
-
 	// The groups associated to the user
 	Groups []string `json:"groups"`
 
@@ -87,7 +86,6 @@ func (m *UserOwnInfo) validateRoles(formats strfmt.Registry) error {
 }
 
 func (m *UserOwnInfo) validateUsername(formats strfmt.Registry) error {
-
 	if err := validate.Required("username", "body", m.Username); err != nil {
 		return err
 	}
@@ -110,9 +108,7 @@ func (m *UserOwnInfo) ContextValidate(ctx context.Context, formats strfmt.Regist
 }
 
 func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Roles); i++ {
-
 		if m.Roles[i] != nil {
 			if err := m.Roles[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
@@ -123,7 +119,6 @@ func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/user_own_info.go
+++ b/entities/models/user_own_info.go
@@ -26,10 +26,10 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// UserInfo user info
+// UserOwnInfo user own info
 //
-// swagger:model UserInfo
-type UserInfo struct {
+// swagger:model UserOwnInfo
+type UserOwnInfo struct {
 
 	// The groups associated to the user
 	Groups []string `json:"groups"`
@@ -42,8 +42,8 @@ type UserInfo struct {
 	Username *string `json:"username"`
 }
 
-// Validate validates this user info
-func (m *UserInfo) Validate(formats strfmt.Registry) error {
+// Validate validates this user own info
+func (m *UserOwnInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateRoles(formats); err != nil {
@@ -60,7 +60,7 @@ func (m *UserInfo) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *UserInfo) validateRoles(formats strfmt.Registry) error {
+func (m *UserOwnInfo) validateRoles(formats strfmt.Registry) error {
 	if swag.IsZero(m.Roles) { // not required
 		return nil
 	}
@@ -86,7 +86,7 @@ func (m *UserInfo) validateRoles(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *UserInfo) validateUsername(formats strfmt.Registry) error {
+func (m *UserOwnInfo) validateUsername(formats strfmt.Registry) error {
 
 	if err := validate.Required("username", "body", m.Username); err != nil {
 		return err
@@ -95,8 +95,8 @@ func (m *UserInfo) validateUsername(formats strfmt.Registry) error {
 	return nil
 }
 
-// ContextValidate validate this user info based on the context it is used
-func (m *UserInfo) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+// ContextValidate validate this user own info based on the context it is used
+func (m *UserOwnInfo) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.contextValidateRoles(ctx, formats); err != nil {
@@ -109,7 +109,7 @@ func (m *UserInfo) ContextValidate(ctx context.Context, formats strfmt.Registry)
 	return nil
 }
 
-func (m *UserInfo) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
+func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Roles); i++ {
 
@@ -130,7 +130,7 @@ func (m *UserInfo) contextValidateRoles(ctx context.Context, formats strfmt.Regi
 }
 
 // MarshalBinary interface implementation
-func (m *UserInfo) MarshalBinary() ([]byte, error) {
+func (m *UserOwnInfo) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -138,8 +138,8 @@ func (m *UserInfo) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *UserInfo) UnmarshalBinary(b []byte) error {
-	var res UserInfo
+func (m *UserOwnInfo) UnmarshalBinary(b []byte) error {
+	var res UserOwnInfo
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/entities/models/user_own_info.go
+++ b/entities/models/user_own_info.go
@@ -30,6 +30,7 @@ import (
 //
 // swagger:model UserOwnInfo
 type UserOwnInfo struct {
+
 	// The groups associated to the user
 	Groups []string `json:"groups"`
 
@@ -86,6 +87,7 @@ func (m *UserOwnInfo) validateRoles(formats strfmt.Registry) error {
 }
 
 func (m *UserOwnInfo) validateUsername(formats strfmt.Registry) error {
+
 	if err := validate.Required("username", "body", m.Username); err != nil {
 		return err
 	}
@@ -108,7 +110,9 @@ func (m *UserOwnInfo) ContextValidate(ctx context.Context, formats strfmt.Regist
 }
 
 func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
+
 	for i := 0; i < len(m.Roles); i++ {
+
 		if m.Roles[i] != nil {
 			if err := m.Roles[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
@@ -119,6 +123,7 @@ func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.R
 				return err
 			}
 		}
+
 	}
 
 	return nil

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -5,7 +5,7 @@
     "application/json"
   ],
   "definitions": {
-    "UserInfo": {
+    "UserOwnInfo": {
       "type": "object",
       "properties": {
         "groups": {
@@ -2656,7 +2656,7 @@
           "200": {
             "description": "Info about the user",
             "schema": {
-              "$ref": "#/definitions/UserInfo"
+              "$ref": "#/definitions/UserOwnInfo"
             }
           },
           "401": {

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -44,7 +44,7 @@ func GetRolesForUser(t *testing.T, user, key string) []*models.Role {
 	return resp.Payload
 }
 
-func GetInfoForOwnUser(t *testing.T, key string) *models.UserInfo {
+func GetInfoForOwnUser(t *testing.T, key string) *models.UserOwnInfo {
 	resp, err := Client(t).Users.GetOwnInfo(users.NewGetOwnInfoParams(), CreateAuth(key))
 	AssertRequestOk(t, resp, err, nil)
 	require.Nil(t, err)


### PR DESCRIPTION
### What's being changed:

Free name for dynamic user management (Just definition name, has no effect)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
