### PR TITLE
chore: Refactor code to avoid checking whether target vectors are enabled

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -112,6 +112,8 @@ type ShardLike interface {
 	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) // Check if an object was deleted
 	VectorIndex() VectorIndex                                                // Get the vector index
 	VectorIndexes() map[string]VectorIndex                                   // Get the vector indexes
+	ForEachVectorIndex(f func(name string, index VectorIndex) error) error
+	ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error
 	hasTargetVectors() bool
 	// TODO tests only
 	Versioner() *shardVersioner // Get the shard versioner
@@ -353,6 +355,48 @@ func (s *Shard) ObjectCountAsync() int {
 	}
 
 	return b.CountAsync()
+}
+
+// ForEachVectorIndex iterates through each vector index configured in the shard (named and legacy).
+// Iteration stops at the first return of non-nil error.
+// TODO: add tests
+func (s *Shard) ForEachVectorIndex(f func(name string, index VectorIndex) error) error {
+	for name, idx := range s.vectorIndexes {
+		if idx == nil {
+			continue
+		}
+
+		if err := f(name, idx); err != nil {
+			return err
+		}
+	}
+	if s.vectorIndex != nil {
+		if err := f("", s.vectorIndex); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ForEachVectorQueue iterates through each vector index queue configured in the shard (named and legacy).
+// Iteration stops at the first return of non-nil error.
+// TODO: add tests
+func (s *Shard) ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error {
+	for name, q := range s.queues {
+		if q == nil {
+			continue
+		}
+
+		if err := f(name, q); err != nil {
+			return err
+		}
+	}
+	if s.queue != nil {
+		if err := f("", s.queue); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Shard) isFallbackToSearchable() bool {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -360,12 +360,12 @@ func (s *Shard) ObjectCountAsync() int {
 // ForEachVectorIndex iterates through each vector index configured in the shard (named and legacy).
 // Iteration stops at the first return of non-nil error.
 func (s *Shard) ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error {
-	for name, idx := range s.vectorIndexes {
+	for targetVector, idx := range s.vectorIndexes {
 		if idx == nil {
 			continue
 		}
 
-		if err := f(name, idx); err != nil {
+		if err := f(targetVector, idx); err != nil {
 			return err
 		}
 	}
@@ -380,12 +380,12 @@ func (s *Shard) ForEachVectorIndex(f func(targetVector string, index VectorIndex
 // ForEachVectorQueue iterates through each vector index queue configured in the shard (named and legacy).
 // Iteration stops at the first return of non-nil error.
 func (s *Shard) ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error {
-	for name, q := range s.queues {
+	for targetVector, q := range s.queues {
 		if q == nil {
 			continue
 		}
 
-		if err := f(name, q); err != nil {
+		if err := f(targetVector, q); err != nil {
 			return err
 		}
 	}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -112,8 +112,8 @@ type ShardLike interface {
 	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) // Check if an object was deleted
 	VectorIndex() VectorIndex                                                // Get the vector index
 	VectorIndexes() map[string]VectorIndex                                   // Get the vector indexes
-	ForEachVectorIndex(f func(name string, index VectorIndex) error) error
-	ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error
+	ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error
+	ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error
 	hasTargetVectors() bool
 	// TODO tests only
 	Versioner() *shardVersioner // Get the shard versioner
@@ -359,7 +359,7 @@ func (s *Shard) ObjectCountAsync() int {
 
 // ForEachVectorIndex iterates through each vector index configured in the shard (named and legacy).
 // Iteration stops at the first return of non-nil error.
-func (s *Shard) ForEachVectorIndex(f func(name string, index VectorIndex) error) error {
+func (s *Shard) ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error {
 	for name, idx := range s.vectorIndexes {
 		if idx == nil {
 			continue
@@ -379,7 +379,7 @@ func (s *Shard) ForEachVectorIndex(f func(name string, index VectorIndex) error)
 
 // ForEachVectorQueue iterates through each vector index queue configured in the shard (named and legacy).
 // Iteration stops at the first return of non-nil error.
-func (s *Shard) ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error {
+func (s *Shard) ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error {
 	for name, q := range s.queues {
 		if q == nil {
 			continue

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -359,7 +359,6 @@ func (s *Shard) ObjectCountAsync() int {
 
 // ForEachVectorIndex iterates through each vector index configured in the shard (named and legacy).
 // Iteration stops at the first return of non-nil error.
-// TODO: add tests
 func (s *Shard) ForEachVectorIndex(f func(name string, index VectorIndex) error) error {
 	for name, idx := range s.vectorIndexes {
 		if idx == nil {
@@ -380,7 +379,6 @@ func (s *Shard) ForEachVectorIndex(f func(name string, index VectorIndex) error)
 
 // ForEachVectorQueue iterates through each vector index queue configured in the shard (named and legacy).
 // Iteration stops at the first return of non-nil error.
-// TODO: add tests
 func (s *Shard) ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error {
 	for name, q := range s.queues {
 		if q == nil {

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -57,9 +57,9 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool) (err error
 		return nil
 	})
 
-	err = s.ForEachVectorIndex(func(name string, index VectorIndex) error {
+	err = s.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
 		if err = index.SwitchCommitLogs(ctx); err != nil {
-			return fmt.Errorf("switch commit logs of vector %q: %w", name, err)
+			return fmt.Errorf("switch commit logs of vector %q: %w", targetVector, err)
 		}
 		return nil
 	})
@@ -80,10 +80,10 @@ func (s *Shard) ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor
 		return err
 	}
 
-	return s.ForEachVectorIndex(func(name string, idx VectorIndex) error {
+	return s.ForEachVectorIndex(func(targetVector string, idx VectorIndex) error {
 		files, err := idx.ListFiles(ctx, s.index.Config.RootPath)
 		if err != nil {
-			return fmt.Errorf("list files of vector %q: %w", name, err)
+			return fmt.Errorf("list files of vector %q: %w", targetVector, err)
 		}
 		ret.Files = append(ret.Files, files...)
 		return nil
@@ -104,7 +104,7 @@ func (s *Shard) resumeMaintenanceCycles(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
-		return s.ForEachVectorQueue(func(name string, q *VectorIndexQueue) error {
+		return s.ForEachVectorQueue(func(_ string, q *VectorIndexQueue) error {
 			q.Resume()
 			return nil
 		})

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -52,26 +52,19 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool) (err error
 	}
 
 	// pause indexing
-	if s.hasTargetVectors() {
-		for _, q := range s.Queues() {
-			q.Pause()
-		}
-	} else {
-		if s.Queue() != nil {
-			s.Queue().Pause()
-		}
-	}
+	_ = s.ForEachVectorQueue(func(_ string, q *VectorIndexQueue) error {
+		q.Pause()
+		return nil
+	})
 
-	if s.hasTargetVectors() {
-		for targetVector, vectorIndex := range s.vectorIndexes {
-			if err = vectorIndex.SwitchCommitLogs(ctx); err != nil {
-				return fmt.Errorf("switch commit logs of vector %q: %w", targetVector, err)
-			}
+	err = s.ForEachVectorIndex(func(name string, index VectorIndex) error {
+		if err = index.SwitchCommitLogs(ctx); err != nil {
+			return fmt.Errorf("switch commit logs of vector %q: %w", name, err)
 		}
-	} else {
-		if err = s.vectorIndex.SwitchCommitLogs(ctx); err != nil {
-			return fmt.Errorf("switch commit logs: %w", err)
-		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -87,23 +80,14 @@ func (s *Shard) ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor
 		return err
 	}
 
-	if s.hasTargetVectors() {
-		for targetVector, vectorIndex := range s.vectorIndexes {
-			files, err := vectorIndex.ListFiles(ctx, s.index.Config.RootPath)
-			if err != nil {
-				return fmt.Errorf("list files of vector %q: %w", targetVector, err)
-			}
-			ret.Files = append(ret.Files, files...)
-		}
-	} else {
-		files, err := s.vectorIndex.ListFiles(ctx, s.index.Config.RootPath)
+	return s.ForEachVectorIndex(func(name string, idx VectorIndex) error {
+		files, err := idx.ListFiles(ctx, s.index.Config.RootPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("list files of vector %q: %w", name, err)
 		}
 		ret.Files = append(ret.Files, files...)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func (s *Shard) resumeMaintenanceCycles(ctx context.Context) error {
@@ -120,16 +104,10 @@ func (s *Shard) resumeMaintenanceCycles(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
-		if s.hasTargetVectors() {
-			for _, q := range s.Queues() {
-				q.Resume()
-			}
-		} else {
-			if s.Queue() != nil {
-				s.Queue().Resume()
-			}
-		}
-		return nil
+		return s.ForEachVectorQueue(func(name string, q *VectorIndexQueue) error {
+			q.Resume()
+			return nil
+		})
 	})
 
 	if err := g.Wait(); err != nil {

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -86,9 +86,9 @@ func (s *Shard) drop() (err error) {
 		return errors.Wrapf(err, "remove version at %s", s.path())
 	}
 
-	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Drop(); err != nil {
-			return fmt.Errorf("close queue of vector %q at %s: %w", name, s.path(), err)
+			return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), err)
 		}
 		return nil
 	})
@@ -96,9 +96,9 @@ func (s *Shard) drop() (err error) {
 		return err
 	}
 
-	err = s.ForEachVectorIndex(func(name string, index VectorIndex) error {
+	err = s.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
 		if err = index.Drop(ctx); err != nil {
-			return fmt.Errorf("remove vector index of vector %q at %s: %w", name, s.path(), err)
+			return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), err)
 		}
 		return nil
 	})

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -86,27 +86,24 @@ func (s *Shard) drop() (err error) {
 		return errors.Wrapf(err, "remove version at %s", s.path())
 	}
 
-	if s.hasTargetVectors() {
-		// TODO run in parallel?
-		for targetVector, queue := range s.queues {
-			if err = queue.Drop(); err != nil {
-				return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), err)
-			}
+	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err = queue.Drop(); err != nil {
+			return fmt.Errorf("close queue of vector %q at %s: %w", name, s.path(), err)
 		}
-		for targetVector, vectorIndex := range s.vectorIndexes {
-			if err = vectorIndex.Drop(ctx); err != nil {
-				return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), err)
-			}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.ForEachVectorIndex(func(name string, index VectorIndex) error {
+		if err = index.Drop(ctx); err != nil {
+			return fmt.Errorf("remove vector index of vector %q at %s: %w", name, s.path(), err)
 		}
-	} else {
-		// delete queue cursor
-		if err = s.queue.Drop(); err != nil {
-			return errors.Wrapf(err, "close queue at %s", s.path())
-		}
-		// remove vector index
-		if err = s.vectorIndex.Drop(ctx); err != nil {
-			return errors.Wrapf(err, "remove vector index at %s", s.path())
-		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// delete property length tracker

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -114,41 +114,20 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, errors.Wrapf(err, "init shard %q", s.ID())
 	}
 
-	if s.hasTargetVectors() {
-		if err := s.initTargetVectors(ctx); err != nil {
-			return nil, err
-		}
-		if err := s.initTargetQueues(); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := s.initLegacyVector(ctx); err != nil {
-			return nil, err
-		}
-		if err := s.initLegacyQueue(); err != nil {
-			return nil, err
-		}
+	if err = s.initShardVectors(ctx); err != nil {
+		return nil, fmt.Errorf("init shard vectors: %w", err)
 	}
 
 	s.initDimensionTracking()
 
 	if asyncEnabled() {
 		f := func() {
-			// convert in-memory queues to on-disk queues in the background.
-			// no-op if the queues are already on disk.
-			if s.hasTargetVectors() {
-				for targetVector, queue := range s.queues {
-					err := s.ConvertQueue(targetVector)
-					if err != nil {
-						queue.Logger.WithError(err).Errorf("preload shard for target vector: %s", targetVector)
-					}
+			_ = s.ForEachVectorQueue(func(name string, _ *VectorIndexQueue) error {
+				if err := s.ConvertQueue(name); err != nil {
+					index.logger.WithError(err).Errorf("preload shard for target vector: %s", name)
 				}
-			} else {
-				err := s.ConvertQueue("")
-				if err != nil {
-					s.queue.Logger.WithError(err).Error("preload shard")
-				}
-			}
+				return nil
+			})
 		}
 		enterrors.GoWrapper(f, s.index.logger)
 	}

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -122,9 +122,9 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 
 	if asyncEnabled() {
 		f := func() {
-			_ = s.ForEachVectorQueue(func(name string, _ *VectorIndexQueue) error {
-				if err := s.ConvertQueue(name); err != nil {
-					index.logger.WithError(err).Errorf("preload shard for target vector: %s", name)
+			_ = s.ForEachVectorQueue(func(targetVector string, _ *VectorIndexQueue) error {
+				if err := s.ConvertQueue(targetVector); err != nil {
+					index.logger.WithError(err).Errorf("preload shard for target vector: %s", targetVector)
 				}
 				return nil
 			})

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -31,6 +31,25 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+func (s *Shard) initShardVectors(ctx context.Context) error {
+	if s.hasTargetVectors() {
+		if err := s.initTargetVectors(ctx); err != nil {
+			return err
+		}
+		if err := s.initTargetQueues(); err != nil {
+			return err
+		}
+	} else {
+		if err := s.initLegacyVector(ctx); err != nil {
+			return err
+		}
+		if err := s.initLegacyQueue(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Shard) initVectorIndex(ctx context.Context,
 	targetVector string, vectorIndexUserConfig schemaConfig.VectorIndexConfig,
 ) (VectorIndex, error) {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -444,6 +444,16 @@ func (l *LazyLoadShard) Queues() map[string]*VectorIndexQueue {
 	return l.shard.Queues()
 }
 
+func (l *LazyLoadShard) ForEachVectorIndex(f func(name string, index VectorIndex) error) error {
+	l.mustLoad()
+	return l.shard.ForEachVectorIndex(f)
+}
+
+func (l *LazyLoadShard) ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error {
+	l.mustLoad()
+	return l.shard.ForEachVectorQueue(f)
+}
+
 func (l *LazyLoadShard) VectorDistanceForQuery(ctx context.Context, id uint64, searchVectors []models.Vector, targets []string) ([]float32, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -444,12 +444,12 @@ func (l *LazyLoadShard) Queues() map[string]*VectorIndexQueue {
 	return l.shard.Queues()
 }
 
-func (l *LazyLoadShard) ForEachVectorIndex(f func(name string, index VectorIndex) error) error {
+func (l *LazyLoadShard) ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error {
 	l.mustLoad()
 	return l.shard.ForEachVectorIndex(f)
 }
 
-func (l *LazyLoadShard) ForEachVectorQueue(f func(name string, queue *VectorIndexQueue) error) error {
+func (l *LazyLoadShard) ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error {
 	l.mustLoad()
 	return l.shard.ForEachVectorQueue(f)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -739,9 +739,9 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return errors.Wrap(err, "delete object from bucket")
 	}
 
-	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Delete(docID); err != nil {
-			return fmt.Errorf("delete from vector index queue of vector %q: %w", name, err)
+			return fmt.Errorf("delete from vector index queue of vector %q: %w", targetVector, err)
 		}
 		return nil
 	})

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -739,16 +739,14 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return errors.Wrap(err, "delete object from bucket")
 	}
 
-	if s.hasTargetVectors() {
-		for targetVector, queue := range s.queues {
-			if err = queue.Delete(docID); err != nil {
-				return fmt.Errorf("delete from vector index queue of vector %q: %w", targetVector, err)
-			}
+	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err = queue.Delete(docID); err != nil {
+			return fmt.Errorf("delete from vector index queue of vector %q: %w", name, err)
 		}
-	} else {
-		if err = s.queue.Delete(docID); err != nil {
-			return errors.Wrap(err, "delete from vector index queue")
-		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -332,17 +332,17 @@ func TestShard_ForEachVectorIndexAndQueue(t *testing.T) {
 			shard, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "TestClass"}, hnsw.NewDefaultUserConfig(), false, true, tt.setConfigs)
 
 			capturedIndexes := make(map[string]any)
-			err := shard.ForEachVectorIndex(func(name string, index VectorIndex) error {
+			err := shard.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
 				require.NotNil(t, index)
-				capturedIndexes[name] = index
+				capturedIndexes[targetVector] = index
 				return nil
 			})
 			require.NoError(t, err)
 
 			capturedQueues := make(map[string]any)
-			err = shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+			err = shard.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 				require.NotNil(t, queue)
-				capturedQueues[name] = queue
+				capturedQueues[targetVector] = queue
 				return nil
 			})
 			require.NoError(t, err)

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -120,21 +120,14 @@ func (b *deleteObjectsBatcher) flushWALs(ctx context.Context) {
 		}
 	}
 
-	if b.shard.hasTargetVectors() {
-		for targetVector, queue := range b.shard.Queues() {
-			if err := queue.Flush(); err != nil {
-				for i := range b.objects {
-					b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), i)
-				}
-			}
-		}
-	} else {
-		if err := b.shard.Queue().Flush(); err != nil {
+	_ = b.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err := queue.Flush(); err != nil {
 			for i := range b.objects {
-				b.setErrorAtIndex(err, i)
+				b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), i)
 			}
 		}
-	}
+		return nil
+	})
 
 	if err := b.shard.GetPropertyLengthTracker().Flush(); err != nil {
 		for i := range b.objects {

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -120,10 +120,10 @@ func (b *deleteObjectsBatcher) flushWALs(ctx context.Context) {
 		}
 	}
 
-	_ = b.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	_ = b.shard.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err := queue.Flush(); err != nil {
 			for i := range b.objects {
-				b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), i)
+				b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), i)
 			}
 		}
 		return nil

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -247,21 +247,14 @@ func (ob *objectsBatcher) markDeletedInVectorStorage(ctx context.Context) {
 		return
 	}
 
-	if ob.shard.hasTargetVectors() {
-		for targetVector, queue := range ob.shard.Queues() {
-			if err := queue.Delete(docIDsToDelete...); err != nil {
-				for _, pos := range positions {
-					ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), pos)
-				}
-			}
-		}
-	} else {
-		if err := ob.shard.Queue().Delete(docIDsToDelete...); err != nil {
+	_ = ob.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err := queue.Delete(docIDsToDelete...); err != nil {
 			for _, pos := range positions {
-				ob.setErrorAtIndex(err, pos)
+				ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), pos)
 			}
 		}
-	}
+		return nil
+	})
 }
 
 // storeAdditionalStorageWithWorkers stores the object in all non-key-value
@@ -512,21 +505,14 @@ func (ob *objectsBatcher) flushWALs(ctx context.Context) {
 		}
 	}
 
-	if ob.shard.hasTargetVectors() {
-		for targetVector, queue := range ob.shard.Queues() {
-			if err := queue.Flush(); err != nil {
-				for i := range ob.objects {
-					ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), i)
-				}
-			}
-		}
-	} else {
-		if err := ob.shard.Queue().Flush(); err != nil {
+	_ = ob.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err := queue.Flush(); err != nil {
 			for i := range ob.objects {
-				ob.setErrorAtIndex(err, i)
+				ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), i)
 			}
 		}
-	}
+		return nil
+	})
 
 	if err := ob.shard.GetPropertyLengthTracker().Flush(); err != nil {
 		for i := range ob.objects {

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -247,10 +247,10 @@ func (ob *objectsBatcher) markDeletedInVectorStorage(ctx context.Context) {
 		return
 	}
 
-	_ = ob.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	_ = ob.shard.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err := queue.Delete(docIDsToDelete...); err != nil {
 			for _, pos := range positions {
-				ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), pos)
+				ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), pos)
 			}
 		}
 		return nil
@@ -505,10 +505,10 @@ func (ob *objectsBatcher) flushWALs(ctx context.Context) {
 		}
 	}
 
-	_ = ob.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	_ = ob.shard.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err := queue.Flush(); err != nil {
 			for i := range ob.objects {
-				ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), i)
+				ob.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), i)
 			}
 		}
 		return nil

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -333,10 +333,10 @@ func (b *referencesBatcher) flushWALs(ctx context.Context) {
 		}
 	}
 
-	_ = b.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	_ = b.shard.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err := queue.Flush(); err != nil {
 			for i := range b.refs {
-				b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), i)
+				b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), i)
 			}
 		}
 		return nil

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -333,21 +333,14 @@ func (b *referencesBatcher) flushWALs(ctx context.Context) {
 		}
 	}
 
-	if b.shard.hasTargetVectors() {
-		for targetVector, queue := range b.shard.Queues() {
-			if err := queue.Flush(); err != nil {
-				for i := range b.refs {
-					b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", targetVector, err), i)
-				}
-			}
-		}
-	} else {
-		if err := b.shard.Queue().Flush(); err != nil {
+	_ = b.shard.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err := queue.Flush(); err != nil {
 			for i := range b.refs {
-				b.setErrorAtIndex(err, i)
+				b.setErrorAtIndex(fmt.Errorf("target vector %s: %w", name, err), i)
 			}
 		}
-	}
+		return nil
+	})
 }
 
 func (b *referencesBatcher) getSchemaPropsByName() (map[string]*models.Property, error) {

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -70,9 +70,9 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return fmt.Errorf("flush all buffered WALs: %w", err)
 	}
 
-	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Delete(docID); err != nil {
-			return fmt.Errorf("delete from vector index of vector %q: %w", name, err)
+			return fmt.Errorf("delete from vector index of vector %q: %w", targetVector, err)
 		}
 		return nil
 	})
@@ -80,9 +80,9 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return err
 	}
 
-	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Flush(); err != nil {
-			return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", name, err)
+			return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", targetVector, err)
 		}
 		return nil
 	})
@@ -146,9 +146,9 @@ func (s *Shard) deleteOne(ctx context.Context, bucket *lsmkv.Bucket, obj, idByte
 		return fmt.Errorf("flush all buffered WALs: %w", err)
 	}
 
-	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Delete(docID); err != nil {
-			return fmt.Errorf("delete from vector index of vector %q: %w", name, err)
+			return fmt.Errorf("delete from vector index of vector %q: %w", targetVector, err)
 		}
 		return nil
 	})
@@ -156,9 +156,9 @@ func (s *Shard) deleteOne(ctx context.Context, bucket *lsmkv.Bucket, obj, idByte
 		return err
 	}
 
-	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Flush(); err != nil {
-			return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", name, err)
+			return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", targetVector, err)
 		}
 		return nil
 	})

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -70,24 +70,24 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return fmt.Errorf("flush all buffered WALs: %w", err)
 	}
 
-	if s.hasTargetVectors() {
-		for targetVector, queue := range s.queues {
-			if err = queue.Delete(docID); err != nil {
-				return fmt.Errorf("delete from vector index of vector %q: %w", targetVector, err)
-			}
+	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err = queue.Delete(docID); err != nil {
+			return fmt.Errorf("delete from vector index of vector %q: %w", name, err)
 		}
-		for targetVector, queue := range s.Queues() {
-			if err = queue.Flush(); err != nil {
-				return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", targetVector, err)
-			}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err = queue.Flush(); err != nil {
+			return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", name, err)
 		}
-	} else {
-		if err = s.queue.Delete(docID); err != nil {
-			return fmt.Errorf("delete from vector index: %w", err)
-		}
-		if err = s.queue.Flush(); err != nil {
-			return fmt.Errorf("flush all vector index buffered WALs: %w", err)
-		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
@@ -146,24 +146,24 @@ func (s *Shard) deleteOne(ctx context.Context, bucket *lsmkv.Bucket, obj, idByte
 		return fmt.Errorf("flush all buffered WALs: %w", err)
 	}
 
-	if s.hasTargetVectors() {
-		for targetVector, queue := range s.queues {
-			if err = queue.Delete(docID); err != nil {
-				return fmt.Errorf("delete from vector index of vector %q: %w", targetVector, err)
-			}
+	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err = queue.Delete(docID); err != nil {
+			return fmt.Errorf("delete from vector index of vector %q: %w", name, err)
 		}
-		for targetVector, queue := range s.queues {
-			if err = queue.Flush(); err != nil {
-				return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", targetVector, err)
-			}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = s.ForEachVectorQueue(func(name string, queue *VectorIndexQueue) error {
+		if err = queue.Flush(); err != nil {
+			return fmt.Errorf("flush all vector index buffered WALs of vector %q: %w", name, err)
 		}
-	} else {
-		if err = s.queue.Delete(docID); err != nil {
-			return fmt.Errorf("delete from vector index: %w", err)
-		}
-		if err = s.queue.Flush(); err != nil {
-			return fmt.Errorf("flush all vector index buffered WALs: %w", err)
-		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	if err = s.mayDeleteObjectHashTree(idBytes, currentUpdateTime); err != nil {


### PR DESCRIPTION
### What's being changed:
We are refactoring the database code to support legacy and named vectors simultaneously for the same collection.

---

This is the first step to the unifying of application logic so it would not care whether the vector is legacy or named and act on them uniformly. 

As of this PR:
1. **There are no functional changes in the validation and mixed vectors are not yet supported.**
2. Introduced functions to iterate through vectors and queues no matter their type.
3. Use these new functions instead of explicit `if s.hasTargetVectors() {` checks in noncomplex places. 

There are various other places where more consideration will have to be made and changes will come in future PRs.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
