### PR TITLE
fix: include last update time during object propagation

### DIFF
--- a/adapters/repos/db/shard_hashbeater.go
+++ b/adapters/repos/db/shard_hashbeater.go
@@ -442,11 +442,12 @@ func (s *Shard) stepsTowardsShardConsistency(ctx context.Context,
 			}
 
 			obj := &objects.VObject{
-				ID:              replicaObj.ID,
-				LatestObject:    &replicaObj.Object.Object,
-				Vector:          replicaObj.Object.Vector,
-				Vectors:         vectors,
-				StaleUpdateTime: remoteStaleUpdateTime[replicaObj.ID.String()],
+				ID:                      replicaObj.ID,
+				LastUpdateTimeUnixMilli: replicaObj.LastUpdateTimeUnixMilli,
+				LatestObject:            &replicaObj.Object.Object,
+				Vector:                  replicaObj.Object.Vector,
+				Vectors:                 vectors,
+				StaleUpdateTime:         remoteStaleUpdateTime[replicaObj.ID.String()],
 			}
 
 			mergeObjs = append(mergeObjs, obj)

--- a/test/acceptance/replication/async_replication/async_repair_deletes_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_deletes_test.go
@@ -14,11 +14,9 @@ package replication
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
@@ -63,63 +61,28 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 		helper.CreateClass(t, paragraphClass)
 	})
 
-	paragraphCount := 10
-
-	// pick one node to be down during insertion
-	node := 2 + rand.Intn(clusterSize-1)
-
-	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, node)
-	})
+	paragraphCount := len(paragraphIDs)
 
 	t.Run("insert paragraphs", func(t *testing.T) {
 		batch := make([]*models.Object, paragraphCount)
-		for i, id := range paragraphIDs[:paragraphCount] {
+		for i, id := range paragraphIDs {
 			batch[i] = articles.NewParagraph().
 				WithID(id).
 				WithContents(fmt.Sprintf("paragraph#%d", i)).
 				Object()
 		}
 
-		// choose one more node to insert the objects into
-		var targetNode int
-		for {
-			targetNode = 1 + rand.Intn(clusterSize)
-			if targetNode != node {
-				break
-			}
-		}
-
-		common.CreateObjectsCL(t, compose.GetWeaviateNode(targetNode).URI(), batch, replica.One)
+		common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, replica.All)
 	})
 
-	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, node)
-		time.Sleep(time.Second)
+	node := 2
+
+	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, node)
 	})
 
-	objectNotDeletedAt := make(map[strfmt.UUID]int)
-
-	for _, id := range paragraphIDs[:paragraphCount] {
-		// pick one node to be down during upserts
-		node := 2 + rand.Intn(clusterSize-1)
-
-		t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
-			common.StopNodeAt(ctx, t, compose, node)
-		})
-
-		objectNotDeletedAt[id] = node
-
-		// choose one more node to delete the object
-		var targetNode int
-		for {
-			targetNode = 1 + rand.Intn(clusterSize)
-			if targetNode != node {
-				break
-			}
-		}
-
-		host := compose.GetWeaviateNode(targetNode).URI()
+	for _, id := range paragraphIDs {
+		host := compose.GetWeaviate().URI()
 
 		helper.SetupClient(host)
 
@@ -127,23 +90,16 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 		require.NoError(t, err)
 
 		helper.DeleteObjectCL(t, toDelete.Class, toDelete.ID, replica.Quorum)
-
-		t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
-			common.StartNodeAt(ctx, t, compose, node)
-			time.Sleep(time.Second)
-		})
 	}
 
-	// wait for some time for async replication to propagate deleted objects
-	t.Run("assert each node has all the objects at its latest version when object was not deleted", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-			for _, id := range paragraphIDs[:paragraphCount] {
-				node := objectNotDeletedAt[id]
+	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, node)
+	})
 
-				resp, err := common.ObjectExistsCL(t, compose.GetWeaviateNode(node).URI(), paragraphClass.Class, id, replica.Quorum)
-				assert.NoError(ct, err)
-				assert.False(ct, resp)
-			}
-		}, 30*time.Second, 500*time.Millisecond, "not all the objects have been asynchronously replicated")
+	t.Run("assert node has objects already deleted", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			resp := common.GQLGet(t, compose.ContainerURI(node), "Paragraph", replica.One)
+			assert.Len(ct, resp, 0)
+		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})
 }


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
