### PR TITLE
chore: refactor shard metrics to capture more use cases

### DIFF
--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -31,7 +31,7 @@ import (
 // method to keep drop behaviour consistent.
 func (s *Shard) drop() (err error) {
 	s.metrics.DeleteShardLabels(s.index.Config.ClassName.String(), s.name)
-	s.metrics.baseMetrics.StartUnloadingShard(s.index.Config.ClassName.String())
+	s.metrics.baseMetrics.StartUnloadingShard()
 	s.replicationMap.clear()
 
 	if s.index.Config.TrackVectorDimensions {
@@ -127,7 +127,7 @@ func (s *Shard) drop() (err error) {
 		return fmt.Errorf("delete shard dir: %w", err)
 	}
 
-	s.metrics.baseMetrics.FinishUnloadingShard(s.index.Config.ClassName.String())
+	s.metrics.baseMetrics.FinishUnloadingShard()
 
 	s.index.logger.WithFields(logrus.Fields{
 		"action": "drop_shard",

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -35,6 +35,9 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	scheduler *queue.Scheduler,
 	indexCheckpoints *indexcheckpoint.Checkpoints,
 ) (_ *Shard, err error) {
+	promMetrics.StartLoadingShard(class.Class)
+	defer promMetrics.FinishLoadingShard(class.Class)
+
 	before := time.Now()
 
 	index.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -35,8 +35,8 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	scheduler *queue.Scheduler,
 	indexCheckpoints *indexcheckpoint.Checkpoints,
 ) (_ *Shard, err error) {
-	promMetrics.StartLoadingShard(class.Class)
-	defer promMetrics.FinishLoadingShard(class.Class)
+	promMetrics.StartLoadingShard()
+	defer promMetrics.FinishLoadingShard()
 
 	before := time.Now()
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -119,11 +119,6 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	}
 	defer l.shardLoadLimiter.Release()
 
-	if l.shardOpts.class == nil {
-		l.shardOpts.promMetrics.StartLoadingShard("unknown class")
-	} else {
-		l.shardOpts.promMetrics.StartLoadingShard(l.shardOpts.class.Class)
-	}
 	shard, err := NewShard(ctx, l.shardOpts.promMetrics, l.shardOpts.name, l.shardOpts.index,
 		l.shardOpts.class, l.shardOpts.jobQueueCh, l.shardOpts.scheduler, l.shardOpts.indexCheckpoints)
 	if err != nil {
@@ -133,11 +128,6 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	}
 	l.shard = shard
 	l.loaded = true
-	if l.shardOpts.class == nil {
-		l.shardOpts.promMetrics.FinishLoadingShard("unknown class")
-	} else {
-		l.shardOpts.promMetrics.FinishLoadingShard(l.shardOpts.class.Class)
-	}
 
 	return nil
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -66,7 +66,7 @@ func NewLazyLoadShard(ctx context.Context, promMetrics *monitoring.PrometheusMet
 	if memMonitor == nil {
 		memMonitor = memwatch.NewDummyMonitor()
 	}
-	promMetrics.NewUnloadedshard(class.Class)
+	promMetrics.NewUnloadedshard()
 	return &LazyLoadShard{
 		shardOpts: &deferredShardOpts{
 			promMetrics:      promMetrics,

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -101,10 +101,10 @@ type PrometheusMetrics struct {
 	StartupDurations *prometheus.SummaryVec
 	StartupDiskIO    *prometheus.SummaryVec
 
-	ShardsLoaded    *prometheus.GaugeVec
-	ShardsUnloaded  *prometheus.GaugeVec
-	ShardsLoading   *prometheus.GaugeVec
-	ShardsUnloading *prometheus.GaugeVec
+	ShardsLoaded    prometheus.Gauge
+	ShardsUnloaded  prometheus.Gauge
+	ShardsLoading   prometheus.Gauge
+	ShardsUnloading prometheus.Gauge
 
 	// RAFT-based schema metrics
 	SchemaWrites         *prometheus.SummaryVec
@@ -618,22 +618,22 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		}, []string{"backend_name", "class_name"}),
 
 		// Shard metrics
-		ShardsLoaded: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		ShardsLoaded: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "shards_loaded",
 			Help: "Number of shards loaded",
-		}, []string{"class_name"}),
-		ShardsUnloaded: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		}),
+		ShardsUnloaded: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "shards_unloaded",
 			Help: "Number of shards on not loaded",
-		}, []string{"class_name"}),
-		ShardsLoading: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		}),
+		ShardsLoading: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "shards_loading",
 			Help: "Number of shards in process of loading",
-		}, []string{"class_name"}),
-		ShardsUnloading: promauto.NewGaugeVec(prometheus.GaugeOpts{
+		}),
+		ShardsUnloading: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "shards_unloading",
 			Help: "Number of shards in process of unloading",
-		}, []string{"class_name"}),
+		}),
 
 		// Schema TX-metrics. Can be removed when RAFT is ready
 		SchemaTxOpened: promauto.NewCounterVec(prometheus.CounterOpts{

--- a/usecases/monitoring/shards.go
+++ b/usecases/monitoring/shards.go
@@ -11,128 +11,51 @@
 
 package monitoring
 
-import (
-	"github.com/prometheus/client_golang/prometheus"
-)
-
 // Move the shard from unloaded to in progress
-func (pm *PrometheusMetrics) StartLoadingShard(className string) error {
+func (pm *PrometheusMetrics) StartLoadingShard() {
 	if pm == nil {
-		return nil
+		return
 	}
 
-	labels := prometheus.Labels{
-		"class_name": className,
-	}
-	suld, err := pm.ShardsUnloaded.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-	suld.Dec()
-
-	slding, err := pm.ShardsLoading.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	slding.Inc()
-	return nil
+	pm.ShardsUnloaded.Dec()
+	pm.ShardsLoading.Inc()
 }
 
 // Move the shard from in progress to loaded
-func (pm *PrometheusMetrics) FinishLoadingShard(className string) error {
+func (pm *PrometheusMetrics) FinishLoadingShard() {
 	if pm == nil {
-		return nil
+		return
 	}
 
-	labels := prometheus.Labels{
-		"class_name": className,
-	}
-
-	slding, err := pm.ShardsLoading.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	slding.Dec()
-
-	sldd, err := pm.ShardsLoaded.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	sldd.Inc()
-	return nil
+	pm.ShardsLoading.Dec()
+	pm.ShardsLoaded.Inc()
 }
 
 // Move the shard from loaded to in progress
-func (pm *PrometheusMetrics) StartUnloadingShard(className string) error {
+func (pm *PrometheusMetrics) StartUnloadingShard() {
 	if pm == nil {
-		return nil
+		return
 	}
 
-	labels := prometheus.Labels{
-		"class_name": className,
-	}
-
-	sldd, err := pm.ShardsLoaded.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	sldd.Dec()
-
-	suld, err := pm.ShardsUnloaded.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	suld.Inc()
-	return nil
+	pm.ShardsLoaded.Dec()
+	pm.ShardsUnloaded.Inc()
 }
 
 // Move the shard from in progress to unloaded
-func (pm *PrometheusMetrics) FinishUnloadingShard(className string) error {
+func (pm *PrometheusMetrics) FinishUnloadingShard() {
 	if pm == nil {
-		return nil
+		return
 	}
 
-	labels := prometheus.Labels{
-		"class_name": className,
-	}
-
-	sulding, err := pm.ShardsUnloading.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	sulding.Dec()
-
-	suld, err := pm.ShardsUnloaded.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	suld.Inc()
-
-	return nil
+	pm.ShardsUnloading.Dec()
+	pm.ShardsUnloaded.Inc()
 }
 
 // Register a new, unloaded shard
-func (pm *PrometheusMetrics) NewUnloadedshard(className string) error {
+func (pm *PrometheusMetrics) NewUnloadedshard() {
 	if pm == nil {
-		return nil
+		return
 	}
 
-	labels := prometheus.Labels{
-		"class_name": className,
-	}
-
-	suld, err := pm.ShardsUnloaded.GetMetricWith(labels)
-	if err != nil {
-		return err
-	}
-
-	suld.Inc()
-	return nil
+	pm.ShardsUnloaded.Inc()
 }


### PR DESCRIPTION
### What's being changed:
We want to have a better visibility into the progress of node bootstrapping and we already have metrics for that. Moving the reporting around a little so they would span all use cases (lazy and eagerly loaded shards).

---

I see that currently `class` is used as a label, which is a bad practice due to unbounded cardinality, however, this problem can be tackled in another PR.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
