### PR TITLE
fix: allows concurrent writes and search in rangeable memtable

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_memtable_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_memtable_roaring_set_range.go
@@ -19,5 +19,5 @@ func (m *Memtable) newRoaringSetRangeReader() roaringsetrange.InnerReader {
 	m.RLock()
 	defer m.RUnlock()
 
-	return roaringsetrange.NewMemtableReader(m.roaringSetRange)
+	return roaringsetrange.NewMemtableReader(m.roaringSetRange.Clone())
 }

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_range_test.go
@@ -1,0 +1,118 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"math/rand"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+func TestMemtableRoaringSetRange(t *testing.T) {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	logger, _ := test.NewNullLogger()
+	memPath := func() string {
+		return path.Join(t.TempDir(), "memtable")
+	}
+
+	t.Run("concurrent writes and search", func(t *testing.T) {
+		cl, err := newCommitLogger(memPath())
+		require.NoError(t, err)
+		m, err := newMemtable(memPath(), StrategyRoaringSetRange, 0, cl, nil, logger, false)
+		require.Nil(t, err)
+
+		addKeyVals := func(k uint64) error {
+			return m.roaringSetRangeAdd(k, k+1000, k+2000, k+3000)
+		}
+		removeKeyVals := func(k uint64) error {
+			return m.roaringSetRangeRemove(k, k+1000, k+2000, k+3000)
+		}
+		assertRead_LTE4_GT7 := func(t *testing.T, reader roaringsetrange.InnerReader) {
+			expAddLTE4 := []uint64{
+				1000, 2000, 3000,
+				1002, 2002, 3002,
+				1004, 2004, 3004,
+			}
+			expAddGT7 := []uint64{
+				1008, 2008, 3008,
+			}
+			expDel := []uint64{
+				1000, 2000, 3000,
+				1001, 2001, 3001,
+				1002, 2002, 3002,
+				1003, 2003, 3003,
+				1004, 2004, 3004,
+				1005, 2005, 3005,
+				1006, 2006, 3006,
+				1007, 2007, 3007,
+				1008, 2008, 3008,
+				1009, 2009, 3009,
+			}
+
+			layerLTE4, err := reader.Read(context.Background(), 4, filters.OperatorLessThanEqual)
+			require.NoError(t, err)
+
+			layerGT7, err := reader.Read(context.Background(), 7, filters.OperatorGreaterThan)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, expAddLTE4, layerLTE4.Additions.ToArray())
+			assert.ElementsMatch(t, expDel, layerLTE4.Deletions.ToArray())
+			assert.ElementsMatch(t, expAddGT7, layerGT7.Additions.ToArray())
+			assert.ElementsMatch(t, expDel, layerGT7.Deletions.ToArray())
+		}
+
+		// populate with initial data
+		for i := uint64(0); i < 10; i = i + 2 {
+			assert.NoError(t, addKeyVals(i))
+		}
+		for i := uint64(1); i < 10; i = i + 2 {
+			assert.NoError(t, removeKeyVals(i))
+		}
+
+		// create reader
+		reader := m.newRoaringSetRangeReader()
+
+		// assert data
+		assertRead_LTE4_GT7(t, reader)
+
+		// concurrently mutate memtable
+		chStart := make(chan struct{})
+		chFinish := make(chan struct{})
+		go func() {
+			chStart <- struct{}{}
+			for {
+				select {
+				case <-chFinish:
+					return
+				default:
+					addKeyVals(uint64(rnd.Int31n(1000)))
+					removeKeyVals(uint64(rnd.Int31n(1000)))
+				}
+			}
+		}()
+
+		// assert search results do not contain muted data
+		<-chStart
+		for i := 0; i < 256; i++ {
+			assertRead_LTE4_GT7(t, reader)
+		}
+		chFinish <- struct{}{}
+	})
+}

--- a/adapters/repos/db/roaringsetrange/memtable.go
+++ b/adapters/repos/db/roaringsetrange/memtable.go
@@ -57,6 +57,21 @@ func (m *Memtable) Delete(key uint64, values []uint64) {
 	}
 }
 
+func (m *Memtable) Clone() *Memtable {
+	clone := &Memtable{logger: m.logger}
+	clone.additions = make(map[uint64]uint64, len(m.additions))
+	clone.deletions = make(map[uint64]struct{}, len(m.deletions))
+
+	for k := range m.additions {
+		clone.additions[k] = m.additions[k]
+	}
+	for k := range m.deletions {
+		clone.deletions[k] = m.deletions[k]
+	}
+
+	return clone
+}
+
 func (m *Memtable) Nodes() []*MemtableNode {
 	if len(m.additions) == 0 && len(m.deletions) == 0 {
 		return []*MemtableNode{}


### PR DESCRIPTION
### What's being changed:
rangeable memtable is cloned before being passed to the reader, allowing concurrent writes and searches and keeping search results consistent over reader lifetime.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
