### PR TITLE
[CLU-35] store node id next to their addr to improve logging when bootstrapping raft

### DIFF
--- a/cluster/bootstrap/bootstrap.go
+++ b/cluster/bootstrap/bootstrap.go
@@ -22,7 +22,6 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/resolver"
 	entSentry "github.com/weaviate/weaviate/entities/sentry"
-	"golang.org/x/exp/slices"
 )
 
 // PeerJoiner is the interface we expect to be able to talk to the other peers to either Join or Notify them
@@ -129,7 +128,7 @@ func (b *Bootstrapper) Do(ctx context.Context, serverPortMap map[string]int, lg 
 }
 
 // notify attempts to notify all nodes in remoteNodes that this server is ready to bootstrap
-func (b *Bootstrapper) notify(ctx context.Context, remoteNodes []string) (err error) {
+func (b *Bootstrapper) notify(ctx context.Context, remoteNodes map[string]string) (err error) {
 	if entSentry.Enabled() {
 		span := sentry.StartSpan(ctx, "raft.bootstrap.notify",
 			sentry.WithOpName("notify"),
@@ -151,14 +150,13 @@ func (b *Bootstrapper) notify(ctx context.Context, remoteNodes []string) (err er
 
 // ResolveRemoteNodes returns a list of remoteNodes addresses resolved using addrResolver. The nodes id used are
 // taken from serverPortMap keys and ports from the values
-func ResolveRemoteNodes(addrResolver resolver.NodeToAddress, serverPortMap map[string]int) []string {
-	candidates := make([]string, 0, len(serverPortMap))
+func ResolveRemoteNodes(addrResolver resolver.NodeToAddress, serverPortMap map[string]int) map[string]string {
+	candidates := make(map[string]string, len(serverPortMap))
 	for name, raftPort := range serverPortMap {
 		if addr := addrResolver.NodeAddress(name); addr != "" {
-			candidates = append(candidates, fmt.Sprintf("%s:%d", addr, raftPort))
+			candidates[name] = fmt.Sprintf("%s:%d", addr, raftPort)
 		}
 	}
-	slices.Sort(candidates)
 	return candidates
 }
 

--- a/cluster/bootstrap/joiner.go
+++ b/cluster/bootstrap/joiner.go
@@ -43,7 +43,7 @@ func NewJoiner(peerJoiner PeerJoiner, localNodeID string, localRaftAddr string, 
 // Do will attempt to send to any nodes in remoteNodes a JoinPeerRequest for j.localNodeID with the address j.localRaftAddr.
 // Will join as voter if j.voter is true, non voter otherwise.
 // Returns the leader address if a cluster was joined or an error otherwise.
-func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes []string) (string, error) {
+func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes map[string]string) (string, error) {
 	if entSentry.Enabled() {
 		span := sentry.StartSpan(ctx, "raft.bootstrap.join",
 			sentry.WithOpName("join"),


### PR DESCRIPTION
### What's being changed:
Store the node-id alongside their resolved addr when running the raft bootstrap join/notify logic. This in turns makes our logline log the (node-id, addr) pair together to have clearer logs.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13589464933
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
