### PR TITLE
chore(docker-compose): add MAXIMUM_ALLOWED_COLLECTIONS_COUNT to docker compose 

### DIFF
--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -27,6 +27,7 @@ services:
       CLUSTER_GOSSIP_BIND_PORT: "7100"
       CLUSTER_DATA_BIND_PORT: "7101"
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
+      MAXIMUM_ALLOWED_COLLECTIONS_COUNT: -1
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in

--- a/docker-compose-raft/docker-compose-raft.yml.j2
+++ b/docker-compose-raft/docker-compose-raft.yml.j2
@@ -35,6 +35,7 @@ services:
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
       RAFT_BOOTSTRAP_EXPECT: {{ NUMBER_VOTERS }}
       RAFT_JOIN: "{{ raft_join }}"
+      MAXIMUM_ALLOWED_COLLECTIONS_COUNT: -1
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in
       # memtables, the after run has some flushed which leads to some metrics
@@ -68,6 +69,7 @@ services:
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
       RAFT_BOOTSTRAP_EXPECT: {{ NUMBER_VOTERS }}
       RAFT_JOIN: "{{ raft_join }}"
+      MAXIMUM_ALLOWED_COLLECTIONS_COUNT: -1
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in
       # memtables, the after run has some flushed which leads to some metrics

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -33,6 +33,7 @@ services:
       DISABLE_TELEMETRY: true
       DISABLE_RECOVERY_ON_PANIC: true
       QUERY_MAXIMUM_RESULTS: 10005
+      MAXIMUM_ALLOWED_COLLECTIONS_COUNT: -1
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in


### PR DESCRIPTION
### What's being changed:
we have merged https://github.com/weaviate/weaviate/pull/7304 recently which ides limit the max allowed collections per cluster , this PR makes sure we have no cap for allowed collection creation unlimited

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
