### PR TITLE
chore: refactor dimension tracking to support mixed vectors

### DIFF
--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -517,7 +517,7 @@ func GetDimensionsFromRepo(ctx context.Context, repo *DB, className string) int 
 	index := repo.GetIndex(schema.ClassName(className))
 	sum := 0
 	index.ForEachShard(func(name string, shard ShardLike) error {
-		sum += shard.Dimensions(ctx)
+		sum += shard.Dimensions(ctx, "")
 		return nil
 	})
 	return sum
@@ -531,7 +531,7 @@ func GetQuantizedDimensionsFromRepo(ctx context.Context, repo *DB, className str
 	index := repo.GetIndex(schema.ClassName(className))
 	sum := 0
 	index.ForEachShard(func(name string, shard ShardLike) error {
-		sum += shard.QuantizedDimensions(ctx, segments)
+		sum += shard.QuantizedDimensions(ctx, "", segments)
 		return nil
 	})
 	return sum

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -133,12 +133,11 @@ type ShardLike interface {
 	abortReplication(context.Context, string) replica.SimpleResponse
 	filePutter(context.Context, string) (io.WriteCloser, error)
 
-	// TODO tests only
-	Dimensions(ctx context.Context) int // dim(vector)*number vectors
-	// TODO tests only
-	QuantizedDimensions(ctx context.Context, segments int) int
-	extendDimensionTrackerLSM(dimLength int, docID uint64) error
-	extendDimensionTrackerForVecLSM(dimLength int, docID uint64, vecName string) error
+	// TODO test only
+	Dimensions(ctx context.Context, targetVector string) int // dim(vector)*number vectors
+	QuantizedDimensions(ctx context.Context, targetVector string, segments int) int
+
+	extendDimensionTrackerLSM(dimLength int, docID uint64, targetVector string) error
 	publishDimensionMetrics(ctx context.Context)
 	resetDimensionsLSM() error
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -133,7 +133,7 @@ type ShardLike interface {
 	abortReplication(context.Context, string) replica.SimpleResponse
 	filePutter(context.Context, string) (io.WriteCloser, error)
 
-	// TODO test only
+	// TODO tests only
 	Dimensions(ctx context.Context, targetVector string) int // dim(vector)*number vectors
 	QuantizedDimensions(ctx context.Context, targetVector string, segments int) int
 

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -36,65 +36,22 @@ const (
 	DimensionCategoryBQ
 )
 
-func (s *Shard) Dimensions(ctx context.Context) int {
-	keyLen := 4
-	sum, _ := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) (int, int) {
-		// consider only keys of len 4, skipping ones prefixed with vector name
-		if len(k) == keyLen {
-			dimLength := binary.LittleEndian.Uint32(k)
-			return int(dimLength) * len(v), int(dimLength)
-		}
-		return 0, 0
+func (s *Shard) Dimensions(ctx context.Context, targetVector string) int {
+	sum, _ := s.calcTargetVectorDimensions(ctx, targetVector, func(dimLength int, v []lsmkv.MapPair) (int, int) {
+		return dimLength * len(v), dimLength
 	})
 	return sum
 }
 
-func (s *Shard) DimensionsForVec(ctx context.Context, vecName string) int {
-	nameLen := len(vecName)
-	keyLen := nameLen + 4
-	sum, _ := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) (int, int) {
-		// consider only keys of len vecName + 4, prefixed with vecName
-		if len(k) == keyLen && strings.HasPrefix(string(k), vecName) {
-			dimLength := binary.LittleEndian.Uint32(k[nameLen:])
-			return int(dimLength) * len(v), int(dimLength)
-		}
-		return 0, 0
-	})
-	return sum
-}
-
-func (s *Shard) QuantizedDimensions(ctx context.Context, segments int) int {
-	keyLen := 4
-	sum, dimensions := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) (int, int) {
-		// consider only keys of len 4, skipping ones prefixed with vector name
-		if len(k) == keyLen {
-			if dimLength := binary.LittleEndian.Uint32(k); dimLength > 0 {
-				return len(v), int(dimLength)
-			}
-		}
-		return 0, 0
+func (s *Shard) QuantizedDimensions(ctx context.Context, targetVector string, segments int) int {
+	sum, dimensions := s.calcTargetVectorDimensions(ctx, targetVector, func(dimLength int, v []lsmkv.MapPair) (int, int) {
+		return len(v), dimLength
 	})
 
 	return sum * correctEmptySegments(segments, dimensions)
 }
 
-func (s *Shard) QuantizedDimensionsForVec(ctx context.Context, segments int, vecName string) int {
-	nameLen := len(vecName)
-	keyLen := nameLen + 4
-	sum, dimensions := s.calcDimensions(ctx, func(k []byte, v []lsmkv.MapPair) (int, int) {
-		// consider only keys of len vecName + 4, prefixed with vecName
-		if len(k) == keyLen && strings.HasPrefix(string(k), vecName) {
-			if dimLength := binary.LittleEndian.Uint32(k[nameLen:]); dimLength > 0 {
-				return len(v), int(dimLength)
-			}
-		}
-		return 0, 0
-	})
-
-	return sum * correctEmptySegments(segments, dimensions)
-}
-
-func (s *Shard) calcDimensions(ctx context.Context, calcEntry func(k []byte, v []lsmkv.MapPair) (int, int)) (sum int, dimensions int) {
+func (s *Shard) calcTargetVectorDimensions(ctx context.Context, targetVector string, calcEntry func(dimLen int, v []lsmkv.MapPair) (int, int)) (sum int, dimensions int) {
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {
 		return 0, 0
@@ -103,8 +60,20 @@ func (s *Shard) calcDimensions(ctx context.Context, calcEntry func(k []byte, v [
 	c := b.MapCursor()
 	defer c.Close()
 
+	var (
+		nameLen        = len(targetVector)
+		expectedKeyLen = 4 + nameLen
+	)
+
 	for k, v := c.First(ctx); k != nil; k, v = c.Next(ctx) {
-		size, dim := calcEntry(k, v)
+		// for named vectors we have to additionally check if the key is prefixed with the vector name
+		keyMatches := len(k) == expectedKeyLen && (nameLen == 4 || strings.HasPrefix(string(k), targetVector))
+		if !keyMatches {
+			continue
+		}
+
+		dimLength := int(binary.LittleEndian.Uint32(k[nameLen:]))
+		size, dim := calcEntry(dimLength, v)
 		if dimensions == 0 && dim > 0 {
 			dimensions = dim
 		}
@@ -164,89 +133,60 @@ func (s *Shard) initDimensionTracking() {
 
 func (s *Shard) publishDimensionMetrics(ctx context.Context) {
 	if s.promMetrics != nil {
-		className := s.index.Config.ClassName.String()
+		var (
+			className     = s.index.Config.ClassName.String()
+			sumSegments   = 0
+			sumDimensions = 0
+		)
 
-		if !s.hasTargetVectors() {
-			// send stats for legacy vector only
-			switch category, segments := getDimensionCategory(s.index.vectorIndexUserConfig); category {
-			case DimensionCategoryPQ:
-				count := s.QuantizedDimensions(ctx, segments)
-				sendVectorSegmentsMetric(s.promMetrics, className, s.name, count)
-				sendVectorDimensionsMetric(s.promMetrics, className, s.name, 0)
-			case DimensionCategoryBQ:
-				count := s.Dimensions(ctx) / 8 // BQ has a flat 8x reduction in the dimensions metric
-				sendVectorSegmentsMetric(s.promMetrics, className, s.name, count)
-				sendVectorDimensionsMetric(s.promMetrics, className, s.name, 0)
-			default:
-				count := s.Dimensions(ctx)
-				sendVectorDimensionsMetric(s.promMetrics, className, s.name, count)
-			}
-			return
+		if s.hasLegacyVector() {
+			dimensions, segments := s.calcDimensionsAndSegments(ctx, s.index.vectorIndexUserConfig, "")
+			sumDimensions += dimensions
+			sumSegments += segments
 		}
 
-		sumSegments := 0
-		sumDimensions := 0
-
-		// send stats for each target vector
 		for vecName, vecCfg := range s.index.vectorIndexUserConfigs {
-			switch category, segments := getDimensionCategory(vecCfg); category {
-			case DimensionCategoryPQ:
-				count := s.QuantizedDimensionsForVec(ctx, segments, vecName)
-				sumSegments += count
-				sendVectorSegmentsForVecMetric(s.promMetrics, className, s.name, count, vecName)
-				sendVectorDimensionsForVecMetric(s.promMetrics, className, s.name, 0, vecName)
-			case DimensionCategoryBQ:
-				count := s.DimensionsForVec(ctx, vecName) / 8 // BQ has a flat 8x reduction in the dimensions metric
-				sumSegments += count
-				sendVectorSegmentsForVecMetric(s.promMetrics, className, s.name, count, vecName)
-				sendVectorDimensionsForVecMetric(s.promMetrics, className, s.name, 0, vecName)
-			default:
-				count := s.DimensionsForVec(ctx, vecName)
-				sumDimensions += count
-				sendVectorDimensionsForVecMetric(s.promMetrics, className, s.name, count, vecName)
-			}
+			dimensions, segments := s.calcDimensionsAndSegments(ctx, vecCfg, vecName)
+			sendVectorDimensionsForVecMetric(s.promMetrics, className, s.name, dimensions, vecName)
+			sendVectorSegmentsForVecMetric(s.promMetrics, className, s.name, segments, vecName)
+
+			sumDimensions += dimensions
+			sumSegments += segments
 		}
 
-		// send sum stats for all target vectors
 		sendVectorSegmentsMetric(s.promMetrics, className, s.name, sumSegments)
 		sendVectorDimensionsMetric(s.promMetrics, className, s.name, sumDimensions)
 	}
 }
 
+func (s *Shard) calcDimensionsAndSegments(ctx context.Context, vecCfg schemaConfig.VectorIndexConfig, vecName string) (dims int, segs int) {
+	switch category, segments := getDimensionCategory(vecCfg); category {
+	case DimensionCategoryPQ:
+		count := s.QuantizedDimensions(ctx, vecName, segments)
+		return 0, count
+	case DimensionCategoryBQ:
+		count := s.Dimensions(ctx, vecName) / 8 // BQ has a flat 8x reduction in the dimensions metric
+		return 0, count
+	default:
+		count := s.Dimensions(ctx, vecName)
+		return count, 0
+	}
+}
+
 func (s *Shard) clearDimensionMetrics() {
 	clearDimensionMetrics(s.promMetrics, s.index.Config.ClassName.String(),
-		s.name, s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs)
+		s.name, s.index.vectorIndexUserConfigs)
 }
 
 func clearDimensionMetrics(promMetrics *monitoring.PrometheusMetrics,
-	className, shardName string,
-	cfg schemaConfig.VectorIndexConfig, targetCfgs map[string]schemaConfig.VectorIndexConfig,
+	className, shardName string, targetCfgs map[string]schemaConfig.VectorIndexConfig,
 ) {
 	if promMetrics != nil {
-		if !hasTargetVectors(cfg, targetCfgs) {
-			// send stats for legacy vector only
-			switch category, _ := getDimensionCategory(cfg); category {
-			case DimensionCategoryPQ, DimensionCategoryBQ:
-				sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
-				sendVectorSegmentsMetric(promMetrics, className, shardName, 0)
-			default:
-				sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
-			}
-			return
+		for vecName := range targetCfgs {
+			sendVectorDimensionsForVecMetric(promMetrics, className, shardName, 0, vecName)
+			sendVectorSegmentsForVecMetric(promMetrics, className, shardName, 0, vecName)
 		}
 
-		// send stats for each target vector
-		for vecName, vecCfg := range targetCfgs {
-			switch category, _ := getDimensionCategory(vecCfg); category {
-			case DimensionCategoryPQ, DimensionCategoryBQ:
-				sendVectorDimensionsForVecMetric(promMetrics, className, shardName, 0, vecName)
-				sendVectorSegmentsForVecMetric(promMetrics, className, shardName, 0, vecName)
-			default:
-				sendVectorDimensionsForVecMetric(promMetrics, className, shardName, 0, vecName)
-			}
-		}
-
-		// send sum stats for all target vectors
 		sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
 		sendVectorSegmentsMetric(promMetrics, className, shardName, 0)
 	}

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -248,8 +248,8 @@ func Test_DimensionTracking(t *testing.T) {
 	t.Run("verify dimensions after initial import", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard ShardLike) error {
-			assert.Equal(t, 12800, shard.Dimensions(context.Background()))
-			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), 64))
+			assert.Equal(t, 12800, shard.Dimensions(context.Background(), ""))
+			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), "", 64))
 			return nil
 		})
 	})
@@ -271,8 +271,8 @@ func Test_DimensionTracking(t *testing.T) {
 	t.Run("verify dimensions after delete", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard ShardLike) error {
-			assert.Equal(t, 11520, shard.Dimensions(context.Background()))
-			assert.Equal(t, 5760, shard.QuantizedDimensions(context.Background(), 64))
+			assert.Equal(t, 11520, shard.Dimensions(context.Background(), ""))
+			assert.Equal(t, 5760, shard.QuantizedDimensions(context.Background(), "", 64))
 			return nil
 		})
 	})
@@ -320,10 +320,10 @@ func Test_DimensionTracking(t *testing.T) {
 	t.Run("verify dimensions after first set of updates", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard ShardLike) error {
-			assert.Equal(t, 6400, shard.Dimensions(context.Background()))
-			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), 64))
-			assert.Equal(t, 1600, shard.QuantizedDimensions(context.Background(), 32))
-			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), 0))
+			assert.Equal(t, 6400, shard.Dimensions(context.Background(), ""))
+			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), "", 64))
+			assert.Equal(t, 1600, shard.QuantizedDimensions(context.Background(), "", 32))
+			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), "", 0))
 			return nil
 		})
 	})
@@ -371,11 +371,11 @@ func Test_DimensionTracking(t *testing.T) {
 	t.Run("verify dimensions after more updates", func(t *testing.T) {
 		idx := repo.GetIndex("Test")
 		idx.ForEachShard(func(name string, shard ShardLike) error {
-			assert.Equal(t, 12800, shard.Dimensions(context.Background()))
-			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), 64))
-			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), 32))
+			assert.Equal(t, 12800, shard.Dimensions(context.Background(), ""))
+			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), "", 64))
+			assert.Equal(t, 3200, shard.QuantizedDimensions(context.Background(), "", 32))
 			// segments = 0, will use 128/2 = 64 segments and so value should be 6400
-			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), 0))
+			assert.Equal(t, 6400, shard.QuantizedDimensions(context.Background(), "", 0))
 			return nil
 		})
 	})
@@ -756,4 +756,199 @@ func Test_MultiDimensionTrackingMetrics(t *testing.T) {
 			})
 		})
 	}
+}
+
+func Test_TotalDimensionTrackingMetrics(t *testing.T) {
+	const (
+		objectCount         = 100
+		multiVecCard        = 3
+		dimensionsPerVector = 64
+	)
+
+	for _, tt := range []struct {
+		name              string
+		vectorConfig      func() enthnsw.UserConfig
+		namedVectorConfig func() enthnsw.UserConfig
+		multiVectorConfig func() enthnsw.UserConfig
+
+		expectDimensions float64
+		expectSegments   float64
+	}{
+		{
+			name:         "legacy",
+			vectorConfig: enthnsw.NewDefaultUserConfig,
+
+			expectDimensions: dimensionsPerVector * objectCount,
+		},
+		{
+			name:              "named",
+			namedVectorConfig: enthnsw.NewDefaultUserConfig,
+
+			expectDimensions: dimensionsPerVector * objectCount,
+		},
+		{
+			name:              "multi",
+			multiVectorConfig: enthnsw.NewDefaultUserConfig,
+
+			expectDimensions: multiVecCard * dimensionsPerVector * objectCount,
+		},
+		{
+			name: "named_with_bq",
+			namedVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.BQ.Enabled = true
+				return cfg
+			},
+
+			expectSegments: (dimensionsPerVector / 8) * objectCount,
+		},
+		{
+			name: "named_with_pq",
+			namedVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.PQ.Enabled = true
+				cfg.PQ.Segments = 10
+				return cfg
+			},
+
+			expectSegments: 10 * objectCount,
+		},
+		{
+			name: "named_with_pq_zero_segments",
+			namedVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.PQ.Enabled = true
+				return cfg
+			},
+			expectSegments: (dimensionsPerVector / 2) * objectCount,
+		},
+		{
+			name: "multi_and_bq_named",
+			namedVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.BQ.Enabled = true
+				return cfg
+			},
+			multiVectorConfig: enthnsw.NewDefaultUserConfig,
+			expectDimensions:  multiVecCard * dimensionsPerVector * objectCount,
+			expectSegments:    (dimensionsPerVector / 8) * objectCount,
+		},
+
+		// TODO(faustas): add mixed vectors cases when support is added
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				class = &models.Class{
+					Class:               tt.name,
+					InvertedIndexConfig: invertedConfig(),
+					VectorConfig:        map[string]models.VectorConfig{},
+				}
+
+				namedVectorName = "namedVector"
+				multiVectorName = "multiVector"
+
+				legacyVec []float32
+				namedVecs map[string][]float32
+				multiVecs map[string][][]float32
+			)
+
+			if tt.vectorConfig != nil {
+				class.VectorIndexConfig = tt.vectorConfig()
+				legacyVec = randVector(dimensionsPerVector)
+			}
+
+			if tt.namedVectorConfig != nil {
+				class.VectorConfig[namedVectorName] = models.VectorConfig{
+					VectorIndexConfig: tt.namedVectorConfig(),
+				}
+				namedVecs = map[string][]float32{
+					namedVectorName: randVector(dimensionsPerVector),
+				}
+			}
+
+			if tt.multiVectorConfig != nil {
+				config := tt.multiVectorConfig()
+				config.Multivector = enthnsw.MultivectorConfig{Enabled: true}
+				class.VectorConfig[multiVectorName] = models.VectorConfig{
+					VectorIndexConfig: config,
+				}
+
+				multiVecs = map[string][][]float32{}
+				for range multiVecCard {
+					multiVecs[multiVectorName] = append(multiVecs[multiVectorName], randVector(dimensionsPerVector))
+				}
+			}
+
+			var (
+				db        = createTestDatabaseWithClass(t, class)
+				shardName = getSingleShardNameFromRepo(db, class.Class)
+
+				insertData = func() {
+					for i := range objectCount {
+						obj := &models.Object{
+							Class: tt.name,
+							ID:    intToUUID(i),
+						}
+						err := db.PutObject(context.Background(), obj, legacyVec, namedVecs, multiVecs, nil, 0)
+						require.Nil(t, err)
+					}
+					publishDimensionMetricsFromRepo(context.Background(), db, class.Class)
+				}
+
+				removeData = func() {
+					for i := range objectCount {
+						err := db.DeleteObject(context.Background(), class.Class, intToUUID(i), time.Now(), nil, "", 0)
+						require.NoError(t, err)
+					}
+					publishDimensionMetricsFromRepo(context.Background(), db, class.Class)
+				}
+
+				assertTotalMetrics = func(expectDims, expectSegs float64) {
+					metrics := monitoring.GetMetrics()
+					metric, err := metrics.VectorDimensionsSum.GetMetricWithLabelValues(class.Class, shardName)
+					require.NoError(t, err)
+					require.Equal(t, expectDims, testutil.ToFloat64(metric))
+
+					metric, err = metrics.VectorSegmentsSum.GetMetricWithLabelValues(class.Class, shardName)
+					require.NoError(t, err)
+					require.Equal(t, expectSegs, testutil.ToFloat64(metric))
+				}
+			)
+
+			insertData()
+			assertTotalMetrics(tt.expectDimensions, tt.expectSegments)
+			removeData()
+			assertTotalMetrics(0, 0)
+			insertData()
+			assertTotalMetrics(tt.expectDimensions, tt.expectSegments)
+			require.NoError(t, db.DeleteIndex(schema.ClassName(class.Class)))
+			assertTotalMetrics(0, 0)
+		})
+	}
+}
+
+func createTestDatabaseWithClass(t *testing.T, class *models.Class) *DB {
+	db, err := New(logrus.New(), Config{
+		RootPath:                  t.TempDir(),
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		TrackVectorDimensions:     true,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, monitoring.GetMetrics(), memwatch.NewDummyMonitor())
+	require.Nil(t, err)
+
+	db.SetSchemaGetter(&fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}},
+		shardState: singleShardState(),
+	})
+
+	require.Nil(t, db.WaitForStartup(testCtx()))
+	t.Cleanup(func() {
+		require.NoError(t, db.Shutdown(context.Background()))
+	})
+
+	return db
+}
+
+func intToUUID(i int) strfmt.UUID {
+	return strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
 }

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -758,7 +758,7 @@ func Test_MultiDimensionTrackingMetrics(t *testing.T) {
 	}
 }
 
-func Test_TotalDimensionTrackingMetrics(t *testing.T) {
+func TestTotalDimensionTrackingMetrics(t *testing.T) {
 	const (
 		objectCount         = 100
 		multiVecCard        = 3

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -224,6 +224,10 @@ func (s *Shard) hasTargetVectors() bool {
 	return hasTargetVectors(s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs)
 }
 
+func (s *Shard) hasLegacyVector() bool {
+	return s.vectorIndex != nil
+}
+
 // target vectors and legacy vector are (supposed to be) exclusive
 // method allows to distinguish which of them is configured for the class
 func hasTargetVectors(cfg schemaConfig.VectorIndexConfig, targetCfgs map[string]schemaConfig.VectorIndexConfig) bool {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -333,8 +333,7 @@ func (l *LazyLoadShard) drop() error {
 
 		// cleanup dimensions
 		if idx.Config.TrackVectorDimensions {
-			clearDimensionMetrics(l.shardOpts.promMetrics, className, shardName,
-				idx.vectorIndexUserConfig, idx.vectorIndexUserConfigs)
+			clearDimensionMetrics(l.shardOpts.promMetrics, className, shardName, idx.vectorIndexUserConfigs)
 		}
 
 		// cleanup index checkpoints
@@ -398,14 +397,14 @@ func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Proper
 	return l.shard.AnalyzeObject(object)
 }
 
-func (l *LazyLoadShard) Dimensions(ctx context.Context) int {
+func (l *LazyLoadShard) Dimensions(ctx context.Context, targetVector string) int {
 	l.mustLoad()
-	return l.shard.Dimensions(ctx)
+	return l.shard.Dimensions(ctx, targetVector)
 }
 
-func (l *LazyLoadShard) QuantizedDimensions(ctx context.Context, segments int) int {
+func (l *LazyLoadShard) QuantizedDimensions(ctx context.Context, targetVector string, segments int) int {
 	l.mustLoad()
-	return l.shard.QuantizedDimensions(ctx, segments)
+	return l.shard.QuantizedDimensions(ctx, targetVector, segments)
 }
 
 func (l *LazyLoadShard) publishDimensionMetrics(ctx context.Context) {
@@ -597,18 +596,11 @@ func (l *LazyLoadShard) filePutter(ctx context.Context, shardID string) (io.Writ
 	return l.shard.filePutter(ctx, shardID)
 }
 
-func (l *LazyLoadShard) extendDimensionTrackerLSM(dimLength int, docID uint64) error {
+func (l *LazyLoadShard) extendDimensionTrackerLSM(dimLength int, docID uint64, targetVector string) error {
 	if err := l.Load(context.Background()); err != nil {
 		return err
 	}
-	return l.shard.extendDimensionTrackerLSM(dimLength, docID)
-}
-
-func (l *LazyLoadShard) extendDimensionTrackerForVecLSM(dimLength int, docID uint64, vecName string) error {
-	if err := l.Load(context.Background()); err != nil {
-		return err
-	}
-	return l.shard.extendDimensionTrackerForVecLSM(dimLength, docID, vecName)
+	return l.shard.extendDimensionTrackerLSM(dimLength, docID, targetVector)
 }
 
 func (l *LazyLoadShard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -796,7 +796,7 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 	shd.resetDimensionsLSM()
 
 	t.Run("count dimensions before insert", func(t *testing.T) {
-		dims := shd.Dimensions(ctx)
+		dims := shd.Dimensions(ctx, "")
 		require.Equal(t, 0, dims)
 	})
 
@@ -815,7 +815,7 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 	})
 
 	t.Run("count dimensions", func(t *testing.T) {
-		dims := shd.Dimensions(ctx)
+		dims := shd.Dimensions(ctx, "")
 		require.Equal(t, 3*amount, dims)
 	})
 
@@ -825,7 +825,7 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 	})
 
 	t.Run("count dimensions after reset", func(t *testing.T) {
-		dims := shd.Dimensions(ctx)
+		dims := shd.Dimensions(ctx, "")
 		require.Equal(t, 0, dims)
 	})
 
@@ -844,7 +844,7 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 	})
 
 	t.Run("count dimensions after reset and insert", func(t *testing.T) {
-		dims := shd.Dimensions(ctx)
+		dims := shd.Dimensions(ctx, "")
 		require.Equal(t, 3*amount, dims)
 	})
 

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -194,26 +194,14 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 	}
 
 	if s.index.Config.TrackVectorDimensions {
-		if s.hasTargetVectors() {
-			for vecName, vec := range previousObject.Vectors {
-				if err = s.removeDimensionsForVecLSM(len(vec), docID, vecName); err != nil {
-					return fmt.Errorf("track dimensions of '%s' (delete): %w", vecName, err)
-				}
+		err = previousObject.IterateThroughVectorDimensions(func(targetVector string, dims int) error {
+			if err = s.removeDimensionsLSM(dims, docID, targetVector); err != nil {
+				return fmt.Errorf("remove dimension tracking for vector %q: %w", targetVector, err)
 			}
-			var dims int
-			for vecName, vec := range previousObject.MultiVectors {
-				dims = 0
-				for _, v := range vec {
-					dims += len(v)
-				}
-				if err := s.removeDimensionsForVecLSM(len(vec), docID, vecName); err != nil {
-					return fmt.Errorf("track dimensions of '%s' (delete): %w", vecName, err)
-				}
-			}
-		} else {
-			if err = s.removeDimensionsLSM(len(previousObject.Vector), docID); err != nil {
-				return fmt.Errorf("track dimensions (delete): %w", err)
-			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -320,9 +320,9 @@ func (s *Shard) resetDimensionsLSM() error {
 	return nil
 }
 
-// Key (dimensionality and target vector name) | Value Doc IDs
-// 128,targetVector | 1,2,4,5,17
-// 128,targetVector | 1,2,4,5,17, Tombstone 4,
+// Key (target vector name and dimensionality) | Value Doc IDs
+// targetVector,128 | 1,2,4,5,17
+// targetVector,128 | 1,2,4,5,17, Tombstone 4,
 func (s *Shard) removeDimensionsLSM(
 	dimLength int, docID uint64, targetVector string,
 ) error {

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -264,18 +264,9 @@ func (s *Shard) subtractPropLengths(props []inverted.Property) error {
 }
 
 func (s *Shard) extendDimensionTrackerLSM(
-	dimLength int, docID uint64,
+	dimLength int, docID uint64, targetVector string,
 ) error {
-	return s.addToDimensionBucket(dimLength, docID, "", false)
-}
-
-func (s *Shard) extendDimensionTrackerForVecLSM(
-	dimLength int, docID uint64, vecName string,
-) error {
-	if vecName == "" {
-		return fmt.Errorf("vector name can not be empty")
-	}
-	return s.addToDimensionBucket(dimLength, docID, vecName, false)
+	return s.addToDimensionBucket(dimLength, docID, targetVector, false)
 }
 
 var uniqueCounter atomic.Uint64
@@ -329,23 +320,13 @@ func (s *Shard) resetDimensionsLSM() error {
 	return nil
 }
 
-// Key (dimensionality) | Value Doc IDs
-// 128 | 1,2,4,5,17
-// 128 | 1,2,4,5,17, Tombstone 4,
-
+// Key (dimensionality and target vector name) | Value Doc IDs
+// 128,targetVector | 1,2,4,5,17
+// 128,targetVector | 1,2,4,5,17, Tombstone 4,
 func (s *Shard) removeDimensionsLSM(
-	dimLength int, docID uint64,
+	dimLength int, docID uint64, targetVector string,
 ) error {
-	return s.addToDimensionBucket(dimLength, docID, "", true)
-}
-
-func (s *Shard) removeDimensionsForVecLSM(
-	dimLength int, docID uint64, vecName string,
-) error {
-	if vecName == "" {
-		return fmt.Errorf("vector name can not be empty")
-	}
-	return s.addToDimensionBucket(dimLength, docID, vecName, true)
+	return s.addToDimensionBucket(dimLength, docID, targetVector, true)
 }
 
 func (s *Shard) addToDimensionBucket(

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -596,6 +596,33 @@ func (ko *Object) Valid() bool {
 		ko.Class().String() != ""
 }
 
+// IterateThroughVectorDimensions iterates through all vectors present on the Object and invokes
+// the callback with target name and dimensions of the vector.
+func (ko *Object) IterateThroughVectorDimensions(f func(targetVector string, dims int) error) error {
+	if len(ko.Vector) > 0 {
+		if err := f("", len(ko.Vector)); err != nil {
+			return err
+		}
+	}
+
+	for targetVector, vector := range ko.Vectors {
+		if err := f(targetVector, len(vector)); err != nil {
+			return err
+		}
+	}
+
+	for targetVector, vectors := range ko.MultiVectors {
+		var dims int
+		for _, vector := range vectors {
+			dims += len(vector)
+		}
+		if err := f(targetVector, dims); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func SearchResults(in []*Object, additional additional.Properties, tenant string) search.Results {
 	out := make(search.Results, len(in))
 


### PR DESCRIPTION
### What's being changed:

Continuation of https://github.com/weaviate/weaviate/pull/7363 to refactor code that explicitly checks whether target vectors are enabled.

In this PR dimension tracking has been refactored. I've embraced the fact that legacy vector is treated as named vector with empty name, which allows for way nicer code and avoids repetition.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
