### PR TITLE
fix: do not back up subdirectories

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_backup.go
+++ b/adapters/repos/db/lsmkv/bucket_backup.go
@@ -13,7 +13,7 @@ package lsmkv
 
 import (
 	"context"
-	"io/fs"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -70,25 +70,27 @@ func (b *Bucket) FlushMemtable() error {
 // in a stable state if the memtable is empty, and if compactions are paused. If one
 // of those conditions is not given, it errors
 func (b *Bucket) ListFiles(ctx context.Context, basePath string) ([]string, error) {
-	var (
-		bucketRoot = b.disk.dir
-		files      []string
-	)
+	bucketRoot := b.disk.dir
 
-	err := filepath.WalkDir(bucketRoot, func(currPath string, d fs.DirEntry, err error) error {
-		if d.IsDir() {
-			return nil
-		}
-		// ignore .wal files because they are not immutable
-		if filepath.Ext(currPath) == ".wal" {
-			return nil
-		}
-		files = append(files, path.Join(basePath, path.Base(currPath)))
-		return nil
-	})
+	entries, err := os.ReadDir(bucketRoot)
 	if err != nil {
 		return nil, errors.Errorf("failed to list files for bucket: %s", err)
 	}
 
+	var files []string
+	for _, entry := range entries {
+		// Skip directories as they are used as scratch spaces (e.g. for compaction or flushing).
+		// All stable files are in the root of the bucket.
+		if entry.IsDir() {
+			continue
+		}
+
+		// ignore .wal files because they are not immutable
+		if filepath.Ext(entry.Name()) == ".wal" {
+			continue
+		}
+
+		files = append(files, path.Join(basePath, entry.Name()))
+	}
 	return files, nil
 }


### PR DESCRIPTION
### What's being changed:

Current backup implementation had a bug where we would be scanning items in subdirectories and adding them to the list as if they were in the root directory, meaning that a file at a path like this:
```
/var/lib/weaviate/city/001/lsm/property_id/.scratch.d/primary
```

was added to the list as:
```
/var/lib/weaviate/city/001/lsm/property_id/primary
``` 

This caused backups to fail if there were some leftover files in the buckets present.

---

This PR changes the logic to not scan any subdirectories and assume that all stable data is in the root of the bucket.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
