### PR TITLE
fix(raft): stop retrying in case of error in applies

### DIFF
--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -14,18 +14,21 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/sharding"
-	"google.golang.org/protobuf/proto"
 )
 
 func (s *Raft) AddClass(ctx context.Context, cls *models.Class, ss *sharding.State) (uint64, error) {
@@ -202,7 +205,10 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		if s.store.IsLeader() {
 			schemaVersion, err = s.store.Execute(req)
 			// We might fail due to leader not found as we are losing or transferring leadership, retry
-			return err
+			if errors.Is(err, raft.ErrNotLeader) || errors.Is(err, raft.ErrLeadershipLost) {
+				return err
+			}
+			return backoff.Permanent(err)
 		}
 
 		leader := s.store.Leader()

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -12,14 +12,12 @@
 package cluster
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/cluster/proto/api"
-	"github.com/weaviate/weaviate/cluster/types"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"google.golang.org/protobuf/proto"
 	gproto "google.golang.org/protobuf/proto"
@@ -48,11 +46,6 @@ func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 
 	// Always call Error first otherwise the response can't  be read from the future
 	if err := fut.Error(); err != nil {
-		// If the current node is not the leader (it might have changed recently) return ErrNotLeader to ensure that we
-		// will retry the apply to the leader
-		if errors.Is(err, raft.ErrNotLeader) {
-			return 0, types.ErrNotLeader
-		}
 		return 0, err
 	}
 


### PR DESCRIPTION
### What's being changed:
we found that we have retries even for invalid requests, for example if request fails in `PreApplyFilter()` previously it was retried, however it should have not been retried 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13635298414
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
