### PR TITLE
Binary quantization using bit shifts.

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_quantization.go
@@ -12,8 +12,6 @@
 package compressionhelpers
 
 import (
-	"math"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
@@ -36,7 +34,7 @@ func (bq BinaryQuantizer) Encode(vec []float32) []uint64 {
 	for j := 0; j < len(vec); j++ {
 		if vec[j] < 0 {
 			segment := j / 64
-			code[segment] += uint64(math.Pow(2, float64(j%64)))
+			code[segment] |= uint64(1) << (j % 64)
 		}
 	}
 	return code

--- a/adapters/repos/db/vector/compressionhelpers/binary_quantization_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_quantization_test.go
@@ -13,6 +13,8 @@ package compressionhelpers_test
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -87,4 +89,82 @@ func TestBinaryQuantizerChecksSize(t *testing.T) {
 	bq := compressionhelpers.NewBinaryQuantizer(nil)
 	_, err := bq.DistanceBetweenCompressedVectors(make([]uint64, 3), make([]uint64, 4))
 	assert.NotNil(t, err)
+}
+
+func extractBit(code []uint64, idx int) bool {
+	return code[idx/64]&(uint64(1)<<(idx%64)) != 0
+}
+
+func TestBinaryQuantizerBitAssignmenFixedValues(t *testing.T) {
+	test_bits := []struct {
+		value           float32
+		quantized_value bool
+	}{
+		{-1.0, true},
+		{1.0, false},
+		{0.0, false},
+		{float32(math.NaN()), false},
+		{float32(math.Inf(1)), false},
+		{float32(math.Inf(-1)), true},
+	}
+
+	bq := compressionhelpers.NewBinaryQuantizer(nil)
+	for _, b := range test_bits {
+		y := []float32{b.value}
+		code := bq.Encode(y)
+		assert.True(t, extractBit(code, 0) == b.quantized_value,
+			"Unexpected quantized value: %f should quantize to %t",
+			b.value, b.quantized_value)
+	}
+}
+
+func TestBinaryQuantizerBitAssignmenRandomVector(t *testing.T) {
+	const seed = 42
+	r := rand.New(rand.NewSource(seed))
+	x := make([]float32, 1000)
+	for i := range len(x) {
+		x[i] = 2.0*r.Float32() - 1.0
+	}
+
+	bq := compressionhelpers.NewBinaryQuantizer(nil)
+	code := bq.Encode(x)
+	for i, v := range x {
+		assert.True(t, extractBit(code, i) == (v < 0),
+			"Unexpected quantized value: %f should quantize to %t", v, v < 0)
+	}
+
+	for i := 1000; i < 1024; i++ {
+		assert.True(t, extractBit(code, i) == false,
+			"Remaining bits should be set to zero.")
+	}
+}
+
+// Verify that using bit shifts produces the same results as the previous
+// approach of computing powers of floats and converting to uint64.
+func TestBinaryQuantizerBitShiftBackwardsCompatibility(t *testing.T) {
+	for j := range 64 {
+		pow_bit := uint64(math.Pow(2, float64(j%64)))
+		shift_bit := uint64(1) << (j % 64)
+		assert.True(t, pow_bit == shift_bit)
+	}
+}
+
+func BenchmarkBinaryQuantization(b *testing.B) {
+	bq := compressionhelpers.NewBinaryQuantizer(nil)
+	const seed = 42
+	r := rand.New(rand.NewSource(seed))
+	for _, d := range []int{32, 64, 100, 256, 500, 1024, 4096} {
+		x := make([]float32, d)
+		for i := range d {
+			x[i] = 2.0*r.Float32() - 1.0
+		}
+		b.Run(fmt.Sprintf("BinaryQuantization-dim-%d", d), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				// Even though we do not use the output of bq.Encode() the call
+				// does not seem to be optimized away by the compiler.
+				// TODO: Use b.Loop() instead when we move to Go 1.24.
+				bq.Encode(x)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This patch changes the Encode() function of binary quantization to set the individual bits of the quantized code using bit shifts. Prior to this patch we used the less efficient math.Pow() to produce a desired power of two as a floating point number before converting the result to an uint64 in order to set a specific bit in the quantized code.

A benchmark on random vectors of different lengths shows that using bit shifts instead of math.Pow() results in a 6-8x speedup of Encode().

This patch also includes unit tests to verify that the behavior of binary quantization has not changed with this patch, i.e. we still turn floating point values into bits in exactly the same way.

The output from benchstat for BenchmarkBinaryQuantization comparing the using math.Pow() (old.txt) vs bit shifts (new.txt):

```
goos: darwin
goarch: arm64
cpu: Apple M4 Pro

            │   old.txt    │               new.txt               │
            │    sec/op    │   sec/op     vs base                │
dim-32-14     175.50n ± 2%   20.45n ± 1%  -88.35% (p=0.000 n=10)
dim-64-14     270.60n ± 1%   42.04n ± 1%  -84.46% (p=0.000 n=10)
dim-100-14    534.20n ± 1%   70.65n ± 3%  -86.78% (p=0.000 n=10)
dim-256-14    1444.5n ± 1%   202.1n ± 0%  -86.01% (p=0.000 n=10)
dim-500-14    2746.5n ± 1%   391.0n ± 2%  -85.76% (p=0.000 n=10)
dim-1024-14   5575.0n ± 1%   828.2n ± 1%  -85.14% (p=0.000 n=10)
dim-4096-14   23.590µ ± 1%   3.418µ ± 1%  -85.51% (p=0.000 n=10)
geomean        1.446µ        201.7n       -86.05%
```

### Review checklist
* [x]  Documentation has been updated, if necessary. _Not necessary, pure (minor) performance improvement._
* [x]  Chaos pipeline run or not necessary. _Not necessary, the change is covered by unit tests._
* [x]  All new code is covered by tests where it is reasonable.
* [x]  Performance tests have been run or not necessary. _The specific change has been benchmarked._

