### PR TITLE
chore: refactor to use less checking for enabled named vectors IV

### DIFF
--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -973,14 +973,14 @@ func TestMerge_ObjectWithNamedVectors(t *testing.T) {
 		},
 	}, nil, 0))
 
-	var (
-		updatedNamedVec = randVector(10)
-		updatedMultiVec = [][]float32{
+	newVectors := models.Vectors{
+		namedVecName: randVector(10),
+		multiVecName: [][]float32{
 			randVector(10),
 			randVector(10),
 			randVector(10),
-		}
-	)
+		},
+	}
 
 	require.NoError(t, db.Merge(ctx, objects.MergeDocument{
 		Class: class.Class,
@@ -989,19 +989,13 @@ func TestMerge_ObjectWithNamedVectors(t *testing.T) {
 			"text":   "test2",
 			"number": 2,
 		},
-		Vectors: models.Vectors{
-			namedVecName: updatedNamedVec,
-			multiVecName: updatedMultiVec,
-		},
+		Vectors: newVectors,
 	}, nil, "", 0))
 
 	object, err := db.ObjectByID(context.Background(), objectID, nil, additional.Properties{}, "")
 	require.NoError(t, err)
 
-	require.Equal(t, models.Vectors{
-		"vec1":     updatedNamedVec,
-		"multivec": updatedMultiVec,
-	}, object.Vectors)
+	require.Equal(t, newVectors, object.Vectors)
 }
 
 func noopVectorizerConfig() any {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -116,7 +116,6 @@ type ShardLike interface {
 	ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error
 	GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool)
 	GetVectorIndex(targetVector string) (VectorIndex, bool)
-	hasTargetVectors() bool
 	// TODO tests only
 	Versioner() *shardVersioner // Get the shard versioner
 

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -139,7 +139,7 @@ func (s *Shard) publishDimensionMetrics(ctx context.Context) {
 			sumDimensions = 0
 		)
 
-		if s.hasLegacyVector() {
+		if s.hasLegacyVectorIndex() {
 			dimensions, segments := s.calcDimensionsAndSegments(ctx, s.index.vectorIndexUserConfig, "")
 			sumDimensions += dimensions
 			sumSegments += segments

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (s *Shard) initShardVectors(ctx context.Context) error {
-	if s.hasTargetVectors() {
+	if len(s.index.vectorIndexUserConfigs) > 0 {
 		if err := s.initTargetVectors(ctx); err != nil {
 			return err
 		}
@@ -220,18 +220,8 @@ func (s *Shard) getOrInitDynamicVectorIndexDB() (*bbolt.DB, error) {
 	return s.dynamicVectorIndexDB, nil
 }
 
-func (s *Shard) hasTargetVectors() bool {
-	return hasTargetVectors(s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs)
-}
-
 func (s *Shard) hasLegacyVectorIndex() bool {
 	return s.vectorIndex != nil
-}
-
-// target vectors and legacy vector are (supposed to be) exclusive
-// method allows to distinguish which of them is configured for the class
-func hasTargetVectors(cfg schemaConfig.VectorIndexConfig, targetCfgs map[string]schemaConfig.VectorIndexConfig) bool {
-	return len(targetCfgs) != 0
 }
 
 func (s *Shard) initTargetVectors(ctx context.Context) error {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -224,7 +224,7 @@ func (s *Shard) hasTargetVectors() bool {
 	return hasTargetVectors(s.index.vectorIndexUserConfig, s.index.vectorIndexUserConfigs)
 }
 
-func (s *Shard) hasLegacyVector() bool {
+func (s *Shard) hasLegacyVectorIndex() bool {
 	return s.vectorIndex != nil
 }
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -532,11 +532,6 @@ func (l *LazyLoadShard) VectorIndexes() map[string]VectorIndex {
 	return l.shard.VectorIndexes()
 }
 
-func (l *LazyLoadShard) hasTargetVectors() bool {
-	l.mustLoad()
-	return l.shard.hasTargetVectors()
-}
-
 func (l *LazyLoadShard) Versioner() *shardVersioner {
 	l.mustLoad()
 	return l.shard.Versioner()

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -47,7 +47,7 @@ func (s *Shard) GetStatus() storagestate.Status {
 		return s.status.Status
 	}
 
-	if len(s.queues) == 0 && !s.hasLegacyVector() {
+	if len(s.queues) == 0 && !s.hasLegacyVectorIndex() {
 		return s.status.Status
 	}
 

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -396,7 +396,7 @@ func (ob *objectsBatcher) storeSingleObjectInAdditionalStorage(ctx context.Conte
 		return
 	}
 
-	if object.Vector != nil || len(object.Vectors) > 0 || len(object.MultiVectors) > 0 {
+	if len(object.Vector) > 0 || len(object.Vectors) > 0 || len(object.MultiVectors) > 0 {
 		// By this time all required deletes (e.g. because of DocID changes) have
 		// already been grouped and performed in bulk. Only the insertions are
 		// left. The motivation for this change is explained in
@@ -416,25 +416,22 @@ func (ob *objectsBatcher) storeSingleObjectInAdditionalStorage(ctx context.Conte
 		// shard.updateVectorIndex which would also handle the delete as required
 		// for a non-batch update. Instead a new method has been introduced that
 		// ignores deletes.
-		if ob.shard.hasTargetVectors() {
-			if len(object.Vectors) > 0 {
-				if err := ob.shard.updateVectorIndexesIgnoreDelete(ctx, object.Vectors, status); err != nil {
-					ob.setErrorAtIndex(errors.Wrap(err, "insert to vector index"), index)
-					return
-				}
+		if len(object.Vectors) > 0 {
+			if err := ob.shard.updateVectorIndexesIgnoreDelete(ctx, object.Vectors, status); err != nil {
+				ob.setErrorAtIndex(errors.Wrap(err, "insert to vector index"), index)
+				return
 			}
-			if len(object.MultiVectors) > 0 {
-				if err := ob.shard.updateMultiVectorIndexesIgnoreDelete(ctx, object.MultiVectors, status); err != nil {
-					ob.setErrorAtIndex(errors.Wrap(err, "insert to multi vector index"), index)
-					return
-				}
+		}
+		if len(object.MultiVectors) > 0 {
+			if err := ob.shard.updateMultiVectorIndexesIgnoreDelete(ctx, object.MultiVectors, status); err != nil {
+				ob.setErrorAtIndex(errors.Wrap(err, "insert to multi vector index"), index)
+				return
 			}
-		} else {
-			if object.Vector != nil {
-				if err := ob.shard.updateVectorIndexIgnoreDelete(ctx, object.Vector, status); err != nil {
-					ob.setErrorAtIndex(errors.Wrap(err, "insert to vector index"), index)
-					return
-				}
+		}
+		if len(object.Vector) > 0 {
+			if err := ob.shard.updateVectorIndexIgnoreDelete(ctx, object.Vector, status); err != nil {
+				ob.setErrorAtIndex(errors.Wrap(err, "insert to vector index"), index)
+				return
 			}
 		}
 	}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -53,7 +53,7 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 		}
 	}
 
-	if len(merge.Vector) > 0 {
+	if len(merge.Vector) > 0 && s.hasLegacyVectorIndex() {
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
 		err := s.vectorIndex.ValidateBeforeInsert(merge.Vector)
 		if err != nil {

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -31,35 +31,33 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 		return err
 	}
 
-	if s.hasTargetVectors() {
-		for targetVector, vector := range merge.Vectors {
-			// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-			vectorIndex := s.VectorIndexForName(targetVector)
-			if vectorIndex == nil {
-				return errors.Errorf("Validate vector index for update of %v for target vector %s: vector index not found", merge.ID, targetVector)
-			}
-			switch v := vector.(type) {
-			case []float32:
-				err := vectorIndex.ValidateBeforeInsert(v)
-				if err != nil {
-					return errors.Wrapf(err, "Validate vector index for update of %v for target vector %s", merge.ID, targetVector)
-				}
-			case [][]float32:
-				err := vectorIndex.ValidateMultiBeforeInsert(v)
-				if err != nil {
-					return errors.Wrapf(err, "Validate multi vector index for update of %v for target vector %s", merge.ID, targetVector)
-				}
-			default:
-				return errors.Errorf("Validate vector index for update of %v for target vector %s: unrecongnized vector type: %T", merge.ID, targetVector, vector)
-			}
+	for targetVector, vector := range merge.Vectors {
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
+		vectorIndex := s.VectorIndexForName(targetVector)
+		if vectorIndex == nil {
+			return errors.Errorf("Validate vector index for update of %v for target vector %s: vector index not found", merge.ID, targetVector)
 		}
-	} else {
-		if merge.Vector != nil {
-			// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-			err := s.vectorIndex.ValidateBeforeInsert(merge.Vector)
+		switch v := vector.(type) {
+		case []float32:
+			err := vectorIndex.ValidateBeforeInsert(v)
 			if err != nil {
-				return errors.Wrapf(err, "Validate vector index for update of %v", merge.ID)
+				return errors.Wrapf(err, "Validate vector index for update of %v for target vector %s", merge.ID, targetVector)
 			}
+		case [][]float32:
+			err := vectorIndex.ValidateMultiBeforeInsert(v)
+			if err != nil {
+				return errors.Wrapf(err, "Validate multi vector index for update of %v for target vector %s", merge.ID, targetVector)
+			}
+		default:
+			return errors.Errorf("Validate vector index for update of %v for target vector %s: unrecongnized vector type: %T", merge.ID, targetVector, vector)
+		}
+	}
+
+	if len(merge.Vector) > 0 {
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
+		err := s.vectorIndex.ValidateBeforeInsert(merge.Vector)
+		if err != nil {
+			return errors.Wrapf(err, "Validate vector index for update of %v", merge.ID)
 		}
 	}
 
@@ -83,19 +81,19 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 		return nil
 	}
 
-	if s.hasTargetVectors() {
-		for targetVector, vector := range obj.Vectors {
-			if err := s.updateVectorIndexForName(ctx, vector, status, targetVector); err != nil {
-				return errors.Wrapf(err, "update vector index for target vector %s", targetVector)
-			}
+	for targetVector, vector := range obj.Vectors {
+		if err = s.updateVectorIndexForName(ctx, vector, status, targetVector); err != nil {
+			return errors.Wrapf(err, "update vector index for target vector %s", targetVector)
 		}
-		for targetVector, vector := range obj.MultiVectors {
-			if err := s.updateMultiVectorIndexForName(ctx, vector, status, targetVector); err != nil {
-				return errors.Wrapf(err, "update multi vector index for target vector %s", targetVector)
-			}
+	}
+	for targetVector, vector := range obj.MultiVectors {
+		if err = s.updateMultiVectorIndexForName(ctx, vector, status, targetVector); err != nil {
+			return errors.Wrapf(err, "update multi vector index for target vector %s", targetVector)
 		}
-	} else {
-		if err := s.updateVectorIndex(ctx, obj.Vector, status); err != nil {
+	}
+
+	if s.hasLegacyVectorIndex() {
+		if err = s.updateVectorIndex(ctx, obj.Vector, status); err != nil {
 			return errors.Wrap(err, "update vector index")
 		}
 	}


### PR DESCRIPTION
### What's being changed:
Continuation of https://github.com/weaviate/weaviate/pull/7425 to refactor code that explicitly checks whether target vectors are enabled.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
