### PR TITLE
fix: getting default maxTokens value in generative anthropic module

### DIFF
--- a/modules/generative-anthropic/clients/anthropic.go
+++ b/modules/generative-anthropic/clients/anthropic.go
@@ -195,8 +195,13 @@ func (a *anthropic) getParameters(cfg moduletools.ClassConfig, options interface
 		params.StopSequences = settings.StopSequences()
 	}
 	if params.MaxTokens == nil {
-		maxTokens := settings.GetMaxTokensForModel(params.Model)
-		params.MaxTokens = &maxTokens
+		// respect module config settings
+		maxTokens := settings.MaxTokens()
+		if maxTokens == nil {
+			// fallback to default values
+			maxTokens = settings.GetMaxTokensForModel(params.Model)
+		}
+		params.MaxTokens = maxTokens
 	}
 
 	params.Images = generative.ParseImageProperties(params.Images, params.ImageProperties, imagePropertiesArray)

--- a/modules/generative-anthropic/config/class_settings.go
+++ b/modules/generative-anthropic/config/class_settings.go
@@ -103,8 +103,11 @@ func (ic *classSettings) getListOfStringsProperty(name string, defaultValue []st
 	return &defaultValue
 }
 
-func (ic *classSettings) GetMaxTokensForModel(model string) int {
-	return defaultMaxTokens[model]
+func (ic *classSettings) GetMaxTokensForModel(model string) *int {
+	if maxTokens, ok := defaultMaxTokens[model]; ok {
+		return &maxTokens
+	}
+	return &DefaultAnthropicMaxTokens
 }
 
 func (ic *classSettings) BaseURL() string {
@@ -115,8 +118,8 @@ func (ic *classSettings) Model() string {
 	return *ic.getStringProperty(modelProperty, DefaultAnthropicModel)
 }
 
-func (ic *classSettings) MaxTokens() int {
-	return *ic.getIntProperty(maxTokensProperty, &DefaultAnthropicMaxTokens)
+func (ic *classSettings) MaxTokens() *int {
+	return ic.getIntProperty(maxTokensProperty, nil)
 }
 
 func (ic *classSettings) Temperature() float64 {

--- a/modules/generative-anthropic/config/class_settings_test.go
+++ b/modules/generative-anthropic/config/class_settings_test.go
@@ -24,7 +24,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		name              string
 		cfg               moduletools.ClassConfig
 		wantModel         string
-		wantMaxTokens     int
+		wantMaxTokens     *int
 		wantTemperature   float64
 		wantTopK          int
 		wantTopP          float64
@@ -38,7 +38,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				classConfig: map[string]interface{}{},
 			},
 			wantModel:         "claude-3-5-sonnet-20240620",
-			wantMaxTokens:     4096,
+			wantMaxTokens:     nil,
 			wantTemperature:   1.0,
 			wantTopK:          0,
 			wantTopP:          0.0,
@@ -60,7 +60,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantModel:         "claude-3-opus-20240229",
-			wantMaxTokens:     3000,
+			wantMaxTokens:     ptrInt(3000),
 			wantTemperature:   0.7,
 			wantTopK:          5,
 			wantTopP:          0.9,
@@ -76,7 +76,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantModel:         "some-new-model-name",
-			wantMaxTokens:     4096,
+			wantMaxTokens:     nil,
 			wantTemperature:   1.0,
 			wantTopK:          0,
 			wantTopP:          0.0,
@@ -92,7 +92,7 @@ func Test_classSettings_Validate(t *testing.T) {
 				},
 			},
 			wantModel:         "claude-3-haiku-20240307",
-			wantMaxTokens:     4096,
+			wantMaxTokens:     nil,
 			wantTemperature:   1.0,
 			wantTopK:          0,
 			wantTopP:          0.0,
@@ -146,4 +146,8 @@ func (f fakeClassConfig) TargetVector() string {
 
 func (f fakeClassConfig) PropertiesDataTypes() map[string]schema.DataType {
 	return nil
+}
+
+func ptrInt(in int) *int {
+	return &in
 }


### PR DESCRIPTION
### What's being changed:

This PR fixes getting of `maxTokens` value in `generative-anthropic` module:
- respects module config `maxTokens` settings
- fallbacks to a default value in case if `maxTokens` is undefined

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
