### PR TITLE
chore: rename env variable enabling dynamic RAG syntax

### DIFF
--- a/test/modules/generative-anthropic/setup_test.go
+++ b/test/modules/generative-anthropic/setup_test.go
@@ -41,7 +41,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules(apiKey).
 		WithWeaviateWithGRPC().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", "120s").
 		Start(ctx)
 	return

--- a/test/modules/generative-aws/setup_test.go
+++ b/test/modules/generative-aws/setup_test.go
@@ -59,7 +59,7 @@ func createSingleNodeEnvironment(ctx context.Context, accessKey, secretKey, sess
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules(accessKey, secretKey, sessionToken).
 		WithWeaviateWithGRPC().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", "120s").
 		Start(ctx)
 	return

--- a/test/modules/generative-cohere/setup_test.go
+++ b/test/modules/generative-cohere/setup_test.go
@@ -41,7 +41,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules(apiKey).
 		WithWeaviateWithGRPC().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		Start(ctx)
 	return
 }

--- a/test/modules/generative-friendliai/setup_test.go
+++ b/test/modules/generative-friendliai/setup_test.go
@@ -40,7 +40,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules(apiKey).
 		WithWeaviate().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		Start(ctx)
 	return
 }

--- a/test/modules/generative-google/setup_test.go
+++ b/test/modules/generative-google/setup_test.go
@@ -46,7 +46,7 @@ func createSingleNodeEnvironment(ctx context.Context, googleApiKey string,
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules(googleApiKey).
 		WithWeaviateWithGRPC().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", "120s").
 		Start(ctx)
 	return

--- a/test/modules/generative-ollama/setup_test.go
+++ b/test/modules/generative-ollama/setup_test.go
@@ -37,7 +37,7 @@ func createSingleNodeEnvironment(ctx context.Context,
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules().
 		WithWeaviateWithGRPC().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", "120s").
 		Start(ctx)
 	return

--- a/test/modules/generative-openai/setup_test.go
+++ b/test/modules/generative-openai/setup_test.go
@@ -45,7 +45,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey, organization strin
 ) (compose *docker.DockerCompose, err error) {
 	compose, err = composeModules(apiKey, organization).
 		WithWeaviateWithGRPC().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", "120s").
 		Start(ctx)
 	return

--- a/test/modules/many-generative/setup_test.go
+++ b/test/modules/many-generative/setup_test.go
@@ -81,7 +81,7 @@ func createSingleNodeEnvironment(ctx context.Context,
 		openAIApiKey, openAIOrganization, googleApiKey, cohereApiKey,
 	).
 		WithWeaviate().
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG", "true").
 		Start(ctx)
 	return
 }

--- a/usecases/modulecomponents/additional/generate/generate.go
+++ b/usecases/modulecomponents/additional/generate/generate.go
@@ -49,7 +49,7 @@ func NewGeneric(
 		defaultProviderName:            defaultProviderName,
 		maximumNumberOfGoroutines:      maximumNumberOfGoroutines,
 		logger:                         logger,
-		isDynamicRAGSyntaxEnabled:      entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX")),
+		isDynamicRAGSyntaxEnabled:      entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG")),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

This PR renames the environment variable name that enables Dynamic RAG syntax:
- `ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX` -> `ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
