### PR TITLE
chore: add an option of falling back to ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX env variable

### DIFF
--- a/usecases/modulecomponents/additional/generate/generate.go
+++ b/usecases/modulecomponents/additional/generate/generate.go
@@ -49,7 +49,7 @@ func NewGeneric(
 		defaultProviderName:            defaultProviderName,
 		maximumNumberOfGoroutines:      maximumNumberOfGoroutines,
 		logger:                         logger,
-		isDynamicRAGSyntaxEnabled:      entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG")),
+		isDynamicRAGSyntaxEnabled:      isDynamicRAGSyntaxEnabled(),
 	}
 }
 
@@ -80,4 +80,11 @@ func (p *GenerateProvider) AdditionalPropertyFn(ctx context.Context,
 		return p.generateResult(ctx, in, parameters, limit, argumentModuleParams, cfg)
 	}
 	return nil, errors.New("wrong parameters")
+}
+
+func isDynamicRAGSyntaxEnabled() bool {
+	if entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_RUNTIME_RAG_CONFIG")) {
+		return true
+	}
+	return entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX"))
 }


### PR DESCRIPTION
…

### What's being changed:

Add an option of falling back to to ENABLE_EXPERIMENTAL_DYNAMIC_RAG_SYNTAX env variable

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
