### PR TITLE
chore: refactor module config to support mixed vectors

### DIFF
--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -24,14 +24,13 @@ import (
 // SetClassDefaults sets the module-specific defaults for the class itself, but
 // also for each prop
 func (p *Provider) SetClassDefaults(class *models.Class) {
-	if !p.hasTargetVectors(class) {
+	if p.hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 		p.setClassDefaults(class, class.Vectorizer, "", func(vectorizerConfig map[string]interface{}) {
 			if class.ModuleConfig == nil {
 				class.ModuleConfig = map[string]interface{}{}
 			}
 			class.ModuleConfig.(map[string]interface{})[class.Vectorizer] = vectorizerConfig
 		})
-		return
 	}
 
 	for targetVector, vectorConfig := range class.VectorConfig {
@@ -94,9 +93,8 @@ func (p *Provider) SetSinglePropertyDefaults(class *models.Class,
 	props ...*models.Property,
 ) {
 	for _, prop := range props {
-		if !p.hasTargetVectors(class) {
+		if p.hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 			p.setSinglePropertyDefaults(prop, class.Vectorizer)
-			continue
 		}
 
 		for _, vectorConfig := range class.VectorConfig {
@@ -298,6 +296,6 @@ func (p *Provider) validateVectorConfig(class *models.Class, moduleName string, 
 	}
 }
 
-func (p *Provider) hasTargetVectors(class *models.Class) bool {
-	return len(class.VectorConfig) > 0
+func (p *Provider) hasLegacyVectorIndex(class *models.Class) bool {
+	return class.VectorIndexConfig != nil
 }


### PR DESCRIPTION
### What's being changed:
Continuation of https://github.com/weaviate/weaviate/pull/7433 to refactor code that explicitly checks whether target vectors are enabled.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
