### PR TITLE
fix: add locks around vector index configuration access

### DIFF
--- a/adapters/repos/db/index_cyclecallbacks.go
+++ b/adapters/repos/db/index_cyclecallbacks.go
@@ -45,7 +45,7 @@ func (index *Index) initCycleCallbacks() {
 	routinesN := concurrency.TimesNUMCPU(index.Config.CycleManagerRoutinesFactor)
 
 	vectorTombstoneCleanupIntervalSeconds := hnsw.DefaultCleanupIntervalSeconds
-	if hnswUserConfig, ok := index.vectorIndexUserConfig.(hnsw.UserConfig); ok {
+	if hnswUserConfig, ok := index.GetVectorIndexConfig("").(hnsw.UserConfig); ok {
 		vectorTombstoneCleanupIntervalSeconds = hnswUserConfig.CleanupIntervalSeconds
 	}
 

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -227,13 +227,13 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 	require.Nil(t, err)
 
 	// update the index vectorIndexUserConfig
-	beforeVectorConfig, ok := index.vectorIndexUserConfig.(hnsw.UserConfig)
+	beforeVectorConfig, ok := index.GetVectorIndexConfig("").(hnsw.UserConfig)
 	require.Equal(t, -1, beforeVectorConfig.EF)
 	require.True(t, ok)
 	beforeVectorConfig.EF = 99
 	err = index.updateVectorIndexConfig(context.TODO(), beforeVectorConfig)
 	require.Nil(t, err)
-	afterVectorConfig, ok := index.vectorIndexUserConfig.(hnsw.UserConfig)
+	afterVectorConfig, ok := index.GetVectorIndexConfig("").(hnsw.UserConfig)
 	require.True(t, ok)
 	require.Equal(t, 99, afterVectorConfig.EF)
 

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -134,19 +134,15 @@ func (s *Shard) initDimensionTracking() {
 func (s *Shard) publishDimensionMetrics(ctx context.Context) {
 	if s.promMetrics != nil {
 		var (
-			className     = s.index.Config.ClassName.String()
+			className = s.index.Config.ClassName.String()
+			configs   = s.index.GetVectorIndexConfigs()
+
 			sumSegments   = 0
 			sumDimensions = 0
 		)
 
-		if s.hasLegacyVectorIndex() {
-			dimensions, segments := s.calcDimensionsAndSegments(ctx, s.index.vectorIndexUserConfig, "")
-			sumDimensions += dimensions
-			sumSegments += segments
-		}
-
-		for vecName, vecCfg := range s.index.vectorIndexUserConfigs {
-			dimensions, segments := s.calcDimensionsAndSegments(ctx, vecCfg, vecName)
+		for targetVector, config := range configs {
+			dimensions, segments := s.calcDimensionsAndSegments(ctx, config, targetVector)
 			sumDimensions += dimensions
 			sumSegments += segments
 		}


### PR DESCRIPTION
### What's being changed:
Noticed that we have places where we mutate the vector index configuration:
https://github.com/weaviate/weaviate/blob/b7fd20db492e5befbcc060db181fd7c711fce522/adapters/repos/db/index.go#L563

However, we access this map without protection:
https://github.com/weaviate/weaviate/blob/a3ceb546a134757f5c7e0451b802a712aabbc4a5/adapters/repos/db/shard_dimension_tracking.go#L148-L152

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
