### PR TITLE
fix: vector nil and empty considered equal

### DIFF
--- a/adapters/repos/db/vector/common/vector_util.go
+++ b/adapters/repos/db/vector/common/vector_util.go
@@ -21,16 +21,15 @@ func MultiVectorsEqual(vecA, vecB [][]float32) bool {
 	return vectorsEqual(vecA, vecB, VectorsEqual)
 }
 
+// vectorsEqual verifies whether provided vectors are the same
+// It considers nil vector as equal to vector of len = 0.
 func vectorsEqual[T []C, C float32 | []float32](vecA, vecB T, valuesEqual func(valueA, valueB C) bool) bool {
-	if vecA == nil && vecB != nil {
+	if lena, lenb := len(vecA), len(vecB); lena != lenb {
 		return false
+	} else if lena == 0 {
+		return true
 	}
-	if vecA != nil && vecB == nil {
-		return false
-	}
-	if len(vecA) != len(vecB) {
-		return false
-	}
+
 	for i := range vecA {
 		if !valuesEqual(vecA[i], vecB[i]) {
 			return false

--- a/adapters/repos/db/vector/common/vector_util_test.go
+++ b/adapters/repos/db/vector/common/vector_util_test.go
@@ -34,12 +34,12 @@ func TestVectorUtil_Equal(t *testing.T) {
 		{
 			vecA:          nil,
 			vecB:          []float32{},
-			expectedEqual: false,
+			expectedEqual: true,
 		},
 		{
 			vecA:          []float32{},
 			vecB:          nil,
-			expectedEqual: false,
+			expectedEqual: true,
 		},
 		{
 			vecA:          []float32{},
@@ -101,12 +101,12 @@ func TestMultiVectorUtil_Equal(t *testing.T) {
 		{
 			vecA:          nil,
 			vecB:          [][]float32{},
-			expectedEqual: false,
+			expectedEqual: true,
 		},
 		{
 			vecA:          [][]float32{},
 			vecB:          nil,
-			expectedEqual: false,
+			expectedEqual: true,
 		},
 		{
 			vecA:          [][]float32{},


### PR DESCRIPTION
### What's being changed:

`VectorsEqual` now considers vectors of length 0 as equal to vectors being nil.
This is due to vectors are unmarshalled from objects bucket as slices of len 0, while vectors of new/incoming objects are represented as nils when not set.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
