### PR TITLE
Add new workflow to build ARM image with a comment.

### DIFF
--- a/.github/workflows/build_arm_on_comment.yaml
+++ b/.github/workflows/build_arm_on_comment.yaml
@@ -1,0 +1,121 @@
+name: Build ARM on Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/build_arm' }}
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+      pr_head_sha: ${{ steps.get-pr-info.outputs.pr_head_sha }}
+      pr_title: ${{ steps.get-pr-info.outputs.pr_title }}
+    steps:
+      - name: Get PR info
+        id: get-pr-info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            
+            // Get the PR details to find the head SHA and title
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issue_number
+            });
+            
+            console.log(`PR head SHA: ${pullRequest.head.sha}`);
+            console.log(`PR title: ${pullRequest.title}`);
+            core.setOutput('pr_head_sha', pullRequest.head.sha);
+            core.setOutput('pr_title', pullRequest.title);
+      
+      - name: Check if tests have run
+        id: check
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = '${{ steps.get-pr-info.outputs.pr_head_sha }}';
+            
+            // Get workflow runs for this PR
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              head_sha: sha
+            });
+            
+            // Check if the main workflow has completed successfully
+            const mainWorkflow = runs.workflow_runs.find(run => 
+              run.name === 'Tests' && 
+              run.head_sha === sha && 
+              run.conclusion === 'success'
+            );
+            
+            if (mainWorkflow) {
+              console.log('Main workflow has completed successfully');
+              core.setOutput('should_build', 'true');
+              
+              // Add a comment to the PR
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: '🚀 Starting ARM build based on your request...'
+              });
+            } else {
+              console.log('Main workflow has not completed successfully yet');
+              core.setOutput('should_build', 'false');
+              
+              // Add a comment to the PR
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.issue.number,
+                body: '⚠️ Cannot start ARM build because the required tests have not completed successfully yet.'
+              });
+            }
+
+  push-docker-arm:
+    needs: check-comment
+    if: ${{ needs.check-comment.outputs.should_build == 'true' }}
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.check-comment.outputs.pr_head_sha }}
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      
+      - name: Push container
+        id: push-container
+        run: ./ci/push_docker.sh
+        env:
+          PR_TITLE: "${{ needs.check-comment.outputs.pr_title }}"
+      
+      - name: Generate Report
+        env:
+          PREVIEW_TAG: "${{ steps.push-container.outputs.PREVIEW_TAG }}"
+          PREVIEW_SEMVER_TAG: "${{ steps.push-container.outputs.PREVIEW_SEMVER_TAG }}"
+        run: ./ci/generate_docker_report.sh
+      
+      - name: Add completion comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: context.issue.number,
+              body: '✅ ARM build completed successfully! Docker image is available with tags:\n' +
+                    '- `${{ steps.push-container.outputs.PREVIEW_TAG }}`\n' +
+                    '- `${{ steps.push-container.outputs.PREVIEW_SEMVER_TAG }}`'
+            });


### PR DESCRIPTION
One limitation with the current approach is that, to save time, we are not building ARM images. However, for testing purposes this adds some extra steps if we want to test an image from a colleague on MacOS. Having to clone the branch into antoher starting with build* and wait for all the CI jobs to finish.

This new workflow would get trigger upon the comment /build_arm and if all the workflows have passed, then it will trigger the Push-Docker job. Leaving the decission of building it at will.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
