### PR TITLE
chore: initialize mixed vector indexes in shard

### DIFF
--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -623,7 +623,7 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 		t,
 		ctx,
 		&models.Class{Class: class.Class},
-		hnsw.UserConfig{},
+		nil,
 		false,
 		true,
 		func(i *Index) {

--- a/adapters/repos/db/shard_accessors_test.go
+++ b/adapters/repos/db/shard_accessors_test.go
@@ -40,6 +40,7 @@ func TestShared_GetVectorIndexAndQueue(t *testing.T) {
 		{
 			name: "only named initialized",
 			setup: func(idx *Index) {
+				idx.vectorIndexUserConfig = nil
 				idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
 					"named": hnsw.NewDefaultUserConfig(),
 					"foo":   flat.NewDefaultUserConfig(),
@@ -48,19 +49,18 @@ func TestShared_GetVectorIndexAndQueue(t *testing.T) {
 			wantLegacyExists: false,
 			wantNamedExists:  true,
 		},
-		// TODO(faustas): uncomment this test once mixed vector support is added
-		//{
-		//	name: "mixed initialized",
-		//	setup: func(idx *Index) {
-		//		idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
-		//		idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
-		//			"named": hnsw.NewDefaultUserConfig(),
-		//			"foo":   flat.NewDefaultUserConfig(),
-		//		}
-		//	},
-		//	wantLegacyExists: true,
-		//	wantNamedExists:  true,
-		//},
+		{
+			name: "mixed initialized",
+			setup: func(idx *Index) {
+				idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
+				idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+					"named": hnsw.NewDefaultUserConfig(),
+					"foo":   flat.NewDefaultUserConfig(),
+				}
+			},
+			wantLegacyExists: true,
+			wantNamedExists:  true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			s, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "test"}, hnsw.UserConfig{}, false, true, tt.setup)

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -315,18 +315,17 @@ func TestShard_ForEachVectorIndexAndQueue(t *testing.T) {
 			},
 			expectIndexes: []string{"vector1", "vector2"},
 		},
-		// TODO(faustas): uncomment this test once mixed vector support is added
-		//{
-		//	name: "legacy and named vectors",
-		//	setConfigs: func(idx *Index) {
-		//		idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
-		//		idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
-		//			"vector1": hnsw.NewDefaultUserConfig(),
-		//			"vector2": flat.NewDefaultUserConfig(),
-		//		}
-		//	},
-		//	expectIndexes: []string{"", "vector1", "vector2"},
-		//},
+		{
+			name: "mixed vectors",
+			setConfigs: func(idx *Index) {
+				idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
+				idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+					"vector1": hnsw.NewDefaultUserConfig(),
+					"vector2": flat.NewDefaultUserConfig(),
+				}
+			},
+			expectIndexes: []string{"", "vector1", "vector2"},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			shard, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "TestClass"}, hnsw.NewDefaultUserConfig(), false, true, tt.setConfigs)


### PR DESCRIPTION
### What's being changed:

Adding an ability to configure legacy and named vector indexes in shard.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
