### PR TITLE
Add new option --arm64-only into push-docker script.

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -505,7 +505,15 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' && !startsWith(github.ref, 'refs/tags') && !startsWith(github.head_ref, 'build') && !(github.head_ref == '') }} # no PRs from fork
     name: push-docker-fast
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_platform: "--amd64-only"
+            runner: "ubuntu-latest"
+          - build_platform: "--arm64-only"
+            runner: "ubuntu-24.04-arm" # ARM64 runner
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
@@ -515,7 +523,7 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Push container
         id: push-container
-        run: ./ci/push_docker.sh --amd64-only
+        run: ./ci/push_docker.sh ${{ matrix.build_platform }}
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
       - name: Generate Report

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -5,12 +5,15 @@ set -euo pipefail
 DOCKER_REPO_WEAVIATE="semitechnologies/weaviate"
 
 only_build_amd64=false
+only_build_arm64=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --amd64-only) only_build_amd64=true;;
+    --arm64-only) only_build_arm64=true;;
     --help|-h) printf '%s\n' \
       "Options:"\
       "--amd64-only"\
+      "--arm64-only"\
       "--help | -h"; exit 1;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
@@ -20,9 +23,26 @@ done
 function release() {
   DOCKER_REPO=$DOCKER_REPO_WEAVIATE
 
-  # for multi-platform build
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-  docker buildx create --use
+  # Only set up QEMU if we're doing a multi-arch build or cross-architecture build
+  need_qemu=false
+  
+  # Determine if we need QEMU based on current architecture and build target
+  current_arch=$(uname -m)
+  if [[ "$current_arch" == "x86_64" && "$only_build_arm64" == "true" ]]; then
+    need_qemu=true
+  elif [[ "$current_arch" == "aarch64" && "$only_build_amd64" == "true" ]]; then
+    need_qemu=true
+  elif [[ "$only_build_amd64" == "false" && "$only_build_arm64" == "false" ]]; then
+    # Multi-arch build always needs QEMU
+    need_qemu=true
+  fi
+  
+  if [[ "$need_qemu" == "true" ]]; then
+    echo "Setting up QEMU for cross-architecture builds"
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  else
+    echo "Native build detected, skipping QEMU setup"
+  fi
 
   # nightly tag was added to be pushed on merges to main branch, latest tag is used to get latest released version
   tag_latest="${DOCKER_REPO}:latest"
@@ -62,30 +82,156 @@ function release() {
     fi
   fi
 
+  # Create list of final tags
+  final_tags=()
+  if [ -n "$tag_exact" ]; then
+    final_tags+=("$tag_exact")
+    final_tags+=("$tag_latest")
+  fi
+  if [ -n "$tag_preview" ]; then
+    final_tags+=("$tag_preview")
+  fi
+  if [ -n "$tag_preview_semver" ]; then
+    final_tags+=("$tag_preview_semver")
+  fi
+  if [ -n "$tag_nightly" ]; then
+    final_tags+=("$tag_nightly")
+  fi
+
+  # Determine architecture and platform
   if $only_build_amd64; then
     build_platform="linux/amd64"
+    arch="amd64"
+  elif $only_build_arm64; then
+    build_platform="linux/arm64"
+    arch="arm64"
   else
     build_platform="linux/amd64,linux/arm64"
   fi
 
-  args=("--build-arg=GIT_REVISION=$git_revision" "--build-arg=GIT_BRANCH=$git_branch" "--build-arg=BUILD_USER=$build_user" "--build-arg=BUILD_DATE=$build_date" "--platform=$build_platform" "--target=weaviate" "--push")
+  # For multi-architecture builds, use standard buildx approach with all tags
+  if [ "$only_build_amd64" == "false" ] && [ "$only_build_arm64" == "false" ]; then
+    # Always create buildx builder
+    docker buildx create --use
+    
+    echo "Building multi-architecture image for $build_platform"
+    args=("--build-arg=GIT_REVISION=$git_revision" "--build-arg=GIT_BRANCH=$git_branch" "--build-arg=BUILD_USER=$build_user" "--build-arg=BUILD_DATE=$build_date" "--platform=$build_platform" "--target=weaviate" "--push")
+    
+    for tag in "${final_tags[@]}"; do
+      args+=("-t=$tag")
+    done
 
-  if [ -n "$tag_exact" ]; then
-    # exact tag on main
-    args+=("-t=$tag_exact")
-    args+=("-t=$tag_latest")
-  fi
-  if [ -n "$tag_preview" ]; then
-    # preview tag on PR builds
-    args+=("-t=$tag_preview")
-    args+=("-t=$tag_preview_semver")
-    if [ -n "$tag_nightly" ]; then
-      args+=("-t=$tag_nightly")
+    docker buildx build "${args[@]}" . || exit 1
+  else
+    # For single architecture builds
+    echo "Building single-architecture image for $build_platform"
+    
+    # Sanity check
+    if [ ${#final_tags[@]} -eq 0 ]; then
+      echo "No tags to build for"
+      exit 1
     fi
+
+    # Create a dedicated builder for this architecture with a clean cache
+    builder_name="$arch-builder-$(date +%s)"
+    docker buildx create --name="$builder_name" --use
+    
+    # Create a single temporary tag for this architecture
+    temp_tag="${DOCKER_REPO}:temp-${git_revision}-${arch}"
+    
+    # Build once with the temporary tag
+    echo "Building $arch architecture once with temporary tag: $temp_tag"
+    docker buildx build \
+      --build-arg="GIT_REVISION=$git_revision" \
+      --build-arg="GIT_BRANCH=$git_branch" \
+      --build-arg="BUILD_USER=$build_user" \
+      --build-arg="BUILD_DATE=$build_date" \
+      --platform="$build_platform" \
+      --target=weaviate \
+      --provenance=false \
+      -t="$temp_tag" \
+      --push \
+      . || exit 1
+    
+    # Enable experimental features for manifest command
+    export DOCKER_CLI_EXPERIMENTAL=enabled
+    
+    # Wait briefly to ensure tag is available
+    sleep 3
+    
+    # Determine other architecture
+    other_arch="amd64"
+    [ "$arch" = "amd64" ] && other_arch="arm64"
+    other_temp_tag="${DOCKER_REPO}:temp-${git_revision}-${other_arch}"
+    
+    # For each final tag, create/update manifest with temporary tags
+    for tag in "${final_tags[@]}"; do
+      echo "Creating/updating manifest for $tag with $temp_tag"
+      
+      # Check if other architecture's temp tag exists
+      other_arch_exists=false
+      if docker manifest inspect "$other_temp_tag" > /dev/null 2>&1; then
+        echo "Found temporary tag for $other_arch architecture"
+        other_arch_exists=true
+      fi
+      
+      # Create or update manifest accordingly
+      if docker manifest inspect "$tag" > /dev/null 2>&1; then
+        echo "Existing manifest found for $tag, updating it"
+        
+        # Check for other architecture in existing manifest
+        manifest_json=$(docker manifest inspect "$tag")
+        if ! $other_arch_exists && echo "$manifest_json" | grep -q "$other_arch"; then
+          echo "Found $other_arch in existing manifest"
+          
+          # Extract the digest for the other architecture
+          other_digest=$(echo "$manifest_json" | grep -A 10 "$other_arch" | grep -o "sha256:[a-f0-9]*" | head -1)
+          if [ -n "$other_digest" ]; then
+            echo "Using digest from existing manifest for $other_arch"
+            other_arch_exists=true
+            other_temp_tag="${DOCKER_REPO}@${other_digest}"
+          fi
+        fi
+        
+        if $other_arch_exists; then
+          # Create manifest with both architectures
+          docker manifest create "$tag" "$temp_tag" "$other_temp_tag" --amend
+          docker manifest annotate "$tag" "$temp_tag" --arch "$arch" --os linux
+          docker manifest annotate "$tag" "$other_temp_tag" --arch "$other_arch" --os linux
+        else
+          # Create manifest with just this architecture
+          docker manifest create "$tag" "$temp_tag" --amend
+          docker manifest annotate "$tag" "$temp_tag" --arch "$arch" --os linux
+        fi
+      else
+        # No existing manifest, create new one
+        echo "Creating new manifest for $tag"
+        docker manifest create "$tag" "$temp_tag"
+        docker manifest annotate "$tag" "$temp_tag" --arch "$arch" --os linux
+      fi
+      
+      # Push manifest with retries
+      for i in {1..3}; do
+        if docker manifest push --purge "$tag"; then
+          echo "Successfully pushed manifest for $tag"
+          break
+        fi
+        
+        if [ $i -eq 3 ]; then
+          echo "Failed to push manifest after 3 attempts"
+          exit 1
+        fi
+        
+        echo "Retrying manifest push (attempt $i)..."
+        sleep 5
+      done
+    done
+    
+    # Clean up builder
+    docker buildx rm "$builder_name" || true
   fi
 
-  docker buildx build "${args[@]}" . || exit 1
-
+  # Set output variables for GitHub Actions
   if [ -n "$tag_preview" ]; then
     echo "PREVIEW_TAG=$tag_preview" >> "$GITHUB_OUTPUT"
     echo "PREVIEW_SEMVER_TAG=$tag_preview_semver" >> "$GITHUB_OUTPUT"
@@ -96,3 +242,4 @@ function release() {
 }
 
 release
+


### PR DESCRIPTION
This commit adds a new option to build docker images and push then to Dockerhub.
Also, changes the behavior when a pull-request is created to leverage the matrix-strategy to run both, amd and arm build jobs. This way, if somebody needs an Intel based image the job will take less time to build and won't be blocked if the ARM build fails.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
