### PR TITLE
Validate all property fields besides description when updating collections

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -214,6 +214,7 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 		meta.Class.ReplicationConfig = u.ReplicationConfig
 		meta.Class.MultiTenancyConfig = u.MultiTenancyConfig
 		meta.Class.Description = u.Description
+		meta.Class.Properties = u.Properties
 		meta.ClassVersion = cmd.Version
 		if req.State != nil {
 			meta.Sharding = *req.State

--- a/test/acceptance/schema/update_class_test.go
+++ b/test/acceptance/schema/update_class_test.go
@@ -73,10 +73,15 @@ func TestUpdatePropertyDescription(t *testing.T) {
 	className := "C2"
 	propName := "p1"
 
-	t.Run("delete class if exists", func(t *testing.T) {
+	delete := func() {
 		params := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
 		_, err := helper.Client(t).Schema.SchemaObjectsDelete(params, nil)
 		assert.Nil(t, err)
+	}
+	defer delete()
+
+	t.Run("delete class if exists", func(t *testing.T) {
+		delete()
 	})
 
 	t.Run("initially creating the class", func(t *testing.T) {

--- a/test/acceptance/schema/update_class_test.go
+++ b/test/acceptance/schema/update_class_test.go
@@ -81,11 +81,9 @@ func TestUpdatePropertyDescription(t *testing.T) {
 	}
 	defer delete()
 
-	t.Run("delete class if exists", func(t *testing.T) {
+	func() {
 		delete()
-	})
 
-	t.Run("initially creating the class", func(t *testing.T) {
 		c := &models.Class{
 			Class: className,
 			Properties: []*models.Property{
@@ -103,8 +101,7 @@ func TestUpdatePropertyDescription(t *testing.T) {
 		params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
 		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
 		assert.Nil(t, err)
-	})
-
+	}()
 	newDescription := "its updated description"
 
 	t.Run("update property and nested property descriptions", func(t *testing.T) {
@@ -157,7 +154,7 @@ func TestUpdatePropertyDescription(t *testing.T) {
 		assert.NotNil(t, err)
 		parsed, ok := err.(*clschema.SchemaObjectsUpdateUnprocessableEntity)
 		require.True(t, ok)
-		require.Contains(t, parsed.Payload.Error[0].Message, "properties cannot be updated through updating the class")
+		require.Contains(t, parsed.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
 	})
 
 	t.Run("update field other than description in nested", func(t *testing.T) {
@@ -179,6 +176,6 @@ func TestUpdatePropertyDescription(t *testing.T) {
 		assert.NotNil(t, err)
 		parsed, ok := err.(*clschema.SchemaObjectsUpdateUnprocessableEntity)
 		require.True(t, ok)
-		require.Contains(t, parsed.Payload.Error[0].Message, "properties cannot be updated through updating the class")
+		require.Contains(t, parsed.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
 	})
 }

--- a/test/acceptance/schema/update_class_test.go
+++ b/test/acceptance/schema/update_class_test.go
@@ -81,27 +81,25 @@ func TestUpdatePropertyDescription(t *testing.T) {
 	}
 	defer delete()
 
-	func() {
-		delete()
-
-		c := &models.Class{
-			Class: className,
-			Properties: []*models.Property{
-				{
-					Name:     propName,
-					DataType: []string{"object"},
-					NestedProperties: []*models.NestedProperty{{
-						Name:     nestedPropName,
-						DataType: []string{"text"},
-					}},
-				},
+	delete()
+	c := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     propName,
+				DataType: []string{"object"},
+				NestedProperties: []*models.NestedProperty{{
+					Name:     nestedPropName,
+					DataType: []string{"text"},
+				}},
 			},
-		}
+		},
+	}
 
-		params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
-		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
-		assert.Nil(t, err)
-	}()
+	params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
+	_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+	assert.Nil(t, err)
+
 	newDescription := "its updated description"
 
 	t.Run("update property and nested property descriptions", func(t *testing.T) {
@@ -123,6 +121,12 @@ func TestUpdatePropertyDescription(t *testing.T) {
 			})
 		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
 		assert.Nil(t, err)
+
+		params = clschema.NewSchemaObjectsGetParams().WithClassName(className)
+		res, err = helper.Client(t).Schema.SchemaObjectsGet(params, nil)
+		require.Nil(t, err)
+		assert.Equal(t, newDescription, res.Payload.Properties[0].Description)
+		assert.Equal(t, newDescription, res.Payload.Properties[0].NestedProperties[0].Description)
 	})
 
 	t.Run("assert updated descriptions", func(t *testing.T) {

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -1090,7 +1090,7 @@ func Test_UpdateClass(t *testing.T) {
 					},
 				},
 				expectedError: fmt.Errorf(
-					"properties cannot be updated through updating the class. Use the add " +
+					"property fields other than description cannot be updated through updating the class. Use the add " +
 						"property feature (e.g. \"POST /v1/schema/{className}/properties\") " +
 						"to add additional properties"),
 			},
@@ -1141,7 +1141,7 @@ func Test_UpdateClass(t *testing.T) {
 					},
 				},
 				expectedError: fmt.Errorf(
-					"properties cannot be updated through updating the class. Use the add " +
+					"property fields other than description cannot be updated through updating the class. Use the add " +
 						"property feature (e.g. \"POST /v1/schema/{className}/properties\") " +
 						"to add additional properties"),
 			},

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -257,7 +257,7 @@ func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, e
 
 	if !p.validateProperties(class.Properties, update.Properties) {
 		return nil, errors.Errorf(
-			"properties cannot be updated through updating the class. Use the add " +
+			"property fields other than description cannot be updated through updating the class. Use the add " +
 				"property feature (e.g. \"POST /v1/schema/{className}/properties\") " +
 				"to add additional properties")
 	}

--- a/usecases/schema/parser_test.go
+++ b/usecases/schema/parser_test.go
@@ -148,42 +148,29 @@ func (m fakeModulesProvider) IsGenerative(name string) bool {
 	return strings.Contains(name, "generative")
 }
 
-func Test_immutableFromProperty(t *testing.T) {
-	prop := models.Property{
-		Name:            "name",
-		Description:     "description",
-		DataType:        []string{"text"},
-		IndexFilterable: boolToPtr(true),
-		IndexInverted:   boolToPtr(true),
-		IndexSearchable: boolToPtr(true),
-		ModuleConfig: map[string]interface{}{
-			"generative-madeup": map[string]interface{}{},
-		},
-		NestedProperties: []*models.NestedProperty{{
-			Name:            "nested",
-			Description:     "nested description",
-			DataType:        []string{"text"},
-			IndexFilterable: boolToPtr(true),
-			IndexSearchable: boolToPtr(true),
-			Tokenization:    "ngram",
-		}},
-		Tokenization: "ngram",
-	}
-	mapped := immutableFromProperty(&prop)
-	require.Equal(t, prop.Name, mapped.Name)
-	require.Equal(t, prop.DataType, mapped.DataType)
-	require.Equal(t, prop.IndexFilterable, mapped.IndexFilterable)
-	require.Equal(t, prop.IndexInverted, mapped.IndexInverted)
-	require.Equal(t, prop.IndexSearchable, mapped.IndexSearchable)
-	require.Equal(t, prop.ModuleConfig, mapped.ModuleConfig)
-	require.Equal(t, prop.Tokenization, mapped.Tokenization)
-	require.Equal(t, prop.NestedProperties[0].Name, mapped.NestedProperties[0].Name)
-	require.Equal(t, prop.NestedProperties[0].DataType, mapped.NestedProperties[0].DataType)
-	require.Equal(t, prop.NestedProperties[0].IndexFilterable, mapped.NestedProperties[0].IndexFilterable)
-	require.Equal(t, prop.NestedProperties[0].IndexSearchable, mapped.NestedProperties[0].IndexSearchable)
-	require.Equal(t, prop.NestedProperties[0].Tokenization, mapped.NestedProperties[0].Tokenization)
-}
+func Test_asMap(t *testing.T) {
+	t.Run("not nil", func(t *testing.T) {
+		m, err := propertyAsMap(&models.Property{
+			Name:        "name",
+			Description: "description",
+			DataType:    []string{"object"},
+			NestedProperties: []*models.NestedProperty{{
+				Name:        "nested",
+				Description: "nested description",
+				DataType:    []string{"text"},
+			}},
+		})
+		require.NotNil(t, m)
+		require.Nil(t, err)
 
-func boolToPtr(val bool) *bool {
-	return &val
+		_, ok := m["description"]
+		require.False(t, ok)
+
+		nps, ok := m["nestedProperties"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, nps, 1)
+
+		_, ok = nps[0]["description"]
+		require.False(t, ok)
+	})
 }

--- a/usecases/schema/parser_test.go
+++ b/usecases/schema/parser_test.go
@@ -147,3 +147,43 @@ func (m fakeModulesProvider) IsReranker(name string) bool {
 func (m fakeModulesProvider) IsGenerative(name string) bool {
 	return strings.Contains(name, "generative")
 }
+
+func Test_immutableFromProperty(t *testing.T) {
+	prop := models.Property{
+		Name:            "name",
+		Description:     "description",
+		DataType:        []string{"text"},
+		IndexFilterable: boolToPtr(true),
+		IndexInverted:   boolToPtr(true),
+		IndexSearchable: boolToPtr(true),
+		ModuleConfig: map[string]interface{}{
+			"generative-madeup": map[string]interface{}{},
+		},
+		NestedProperties: []*models.NestedProperty{{
+			Name:            "nested",
+			Description:     "nested description",
+			DataType:        []string{"text"},
+			IndexFilterable: boolToPtr(true),
+			IndexSearchable: boolToPtr(true),
+			Tokenization:    "ngram",
+		}},
+		Tokenization: "ngram",
+	}
+	mapped := immutableFromProperty(&prop)
+	require.Equal(t, prop.Name, mapped.Name)
+	require.Equal(t, prop.DataType, mapped.DataType)
+	require.Equal(t, prop.IndexFilterable, mapped.IndexFilterable)
+	require.Equal(t, prop.IndexInverted, mapped.IndexInverted)
+	require.Equal(t, prop.IndexSearchable, mapped.IndexSearchable)
+	require.Equal(t, prop.ModuleConfig, mapped.ModuleConfig)
+	require.Equal(t, prop.Tokenization, mapped.Tokenization)
+	require.Equal(t, prop.NestedProperties[0].Name, mapped.NestedProperties[0].Name)
+	require.Equal(t, prop.NestedProperties[0].DataType, mapped.NestedProperties[0].DataType)
+	require.Equal(t, prop.NestedProperties[0].IndexFilterable, mapped.NestedProperties[0].IndexFilterable)
+	require.Equal(t, prop.NestedProperties[0].IndexSearchable, mapped.NestedProperties[0].IndexSearchable)
+	require.Equal(t, prop.NestedProperties[0].Tokenization, mapped.NestedProperties[0].Tokenization)
+}
+
+func boolToPtr(val bool) *bool {
+	return &val
+}


### PR DESCRIPTION
### What's being changed:

This PR introduces the ability to update the descriptions of properties for usage by QueryAgent

https://github.com/weaviate/weaviate/issues/7453

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.


GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [x] Python (weaviate-python-client)
    - [x] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)
