### PR TITLE
fix: linter errors in TestUpdatePropertyDescription test

### DIFF
--- a/test/acceptance/schema/update_class_test.go
+++ b/test/acceptance/schema/update_class_test.go
@@ -12,6 +12,7 @@
 package test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,9 +157,11 @@ func TestUpdatePropertyDescription(t *testing.T) {
 			})
 		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
 		assert.NotNil(t, err)
-		parsed, ok := err.(*clschema.SchemaObjectsUpdateUnprocessableEntity)
-		require.True(t, ok)
-		require.Contains(t, parsed.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
+		var parsed *clschema.SchemaObjectsUpdateUnprocessableEntity
+		require.ErrorAs(t, err, &parsed)
+		if errors.As(err, &parsed) {
+			require.Contains(t, parsed.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
+		}
 	})
 
 	t.Run("update field other than description in nested", func(t *testing.T) {
@@ -178,8 +181,10 @@ func TestUpdatePropertyDescription(t *testing.T) {
 			})
 		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
 		assert.NotNil(t, err)
-		parsed, ok := err.(*clschema.SchemaObjectsUpdateUnprocessableEntity)
-		require.True(t, ok)
-		require.Contains(t, parsed.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
+		var parsed *clschema.SchemaObjectsUpdateUnprocessableEntity
+		require.ErrorAs(t, err, &parsed)
+		if errors.As(err, &parsed) {
+			require.Contains(t, parsed.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
+		}
 	})
 }


### PR DESCRIPTION
### What's being changed:

fix: linter errors in TestUpdatePropertyDescription test

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
