### PR TITLE
Add env var to enable dynamic user management

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -50,7 +50,7 @@ type authZHandlers struct {
 	schemaReader   schemaUC.SchemaGetter
 	logger         logrus.FieldLogger
 	metrics        *monitoring.PrometheusMetrics
-	apiKeysConfigs config.APIKey
+	apiKeysConfigs config.StaticAPIKey
 	oidcConfigs    config.OIDC
 	rbacconfig     rbacconf.Config
 }
@@ -61,7 +61,7 @@ type ControllerAndGetUsers interface {
 }
 
 func SetupHandlers(api *operations.WeaviateAPI, controller ControllerAndGetUsers, schemaReader schemaUC.SchemaGetter,
-	apiKeysConfigs config.APIKey, oidcConfigs config.OIDC, rconfig rbacconf.Config, metrics *monitoring.PrometheusMetrics, authorizer authorization.Authorizer, logger logrus.FieldLogger,
+	apiKeysConfigs config.StaticAPIKey, oidcConfigs config.OIDC, rconfig rbacconf.Config, metrics *monitoring.PrometheusMetrics, authorizer authorization.Authorizer, logger logrus.FieldLogger,
 ) {
 	h := &authZHandlers{
 		controller:     controller,

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -53,7 +53,7 @@ func TestAssignRoleToUserSuccess(t *testing.T) {
 	h := &authZHandlers{
 		authorizer:     authorizer,
 		controller:     controller,
-		apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
+		apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user1"}},
 		logger:         logger,
 	}
 	res := h.assignRoleToUser(params, principal)
@@ -82,7 +82,7 @@ func TestAssignRoleToGroupSuccess(t *testing.T) {
 	h := &authZHandlers{
 		authorizer:     authorizer,
 		controller:     controller,
-		apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
+		apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user1"}},
 		logger:         logger,
 		rbacconfig: rbacconf.Config{
 			RootUsers: []string{"root-user"},
@@ -149,7 +149,7 @@ func TestAssignRoleToUserOrUserNotFound(t *testing.T) {
 			h := &authZHandlers{
 				authorizer:     authorizer,
 				controller:     controller,
-				apiKeysConfigs: config.APIKey{Enabled: true, Users: tt.existedUsers},
+				apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: tt.existedUsers},
 				logger:         logger,
 			}
 			res := h.assignRoleToUser(tt.params, tt.principal)

--- a/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
@@ -90,7 +90,7 @@ func TestRevokeRoleFromUserSuccess(t *testing.T) {
 			h := &authZHandlers{
 				authorizer:     authorizer,
 				controller:     controller,
-				apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
+				apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user1"}},
 				logger:         logger,
 			}
 			res := h.revokeRoleFromUser(tt.params, tt.principal)
@@ -166,7 +166,7 @@ func TestRevokeRoleFromGroupSuccess(t *testing.T) {
 			h := &authZHandlers{
 				authorizer:     authorizer,
 				controller:     controller,
-				apiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user1"}},
+				apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user1"}},
 				logger:         logger,
 				rbacconfig: rbacconf.Config{
 					RootUsers: []string{"root-user"}, RootGroups: []string{"root-group"},
@@ -337,7 +337,7 @@ func TestRevokeRoleFromUserOrUserNotFound(t *testing.T) {
 			h := &authZHandlers{
 				authorizer:     authorizer,
 				controller:     controller,
-				apiKeysConfigs: config.APIKey{Enabled: true, Users: tt.existedUsers},
+				apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: tt.existedUsers},
 				logger:         logger,
 			}
 			res := h.revokeRoleFromUser(tt.params, tt.principal)
@@ -389,7 +389,7 @@ func TestRevokeRoleFromGroupOrUserNotFound(t *testing.T) {
 			h := &authZHandlers{
 				authorizer:     authorizer,
 				controller:     controller,
-				apiKeysConfigs: config.APIKey{Enabled: true, Users: tt.existedUsers},
+				apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: tt.existedUsers},
 				logger:         logger,
 				rbacconfig: rbacconf.Config{
 					RootUsers: []string{"root-user"},

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -719,14 +719,14 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	authz.SetupHandlers(api,
 		appState.ClusterService.Raft,
 		appState.SchemaManager,
-		appState.ServerConfig.Config.Authentication.DB.StaticApiKeys,
+		appState.ServerConfig.Config.Authentication.APIKey,
 		appState.ServerConfig.Config.Authentication.OIDC,
 		appState.ServerConfig.Config.Authorization.Rbac,
 		appState.Metrics,
 		appState.Authorizer,
 		appState.Logger)
 
-	dynamic_user.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication.DB, appState.ServerConfig.Config.Authorization.Rbac, appState.Logger)
+	dynamic_user.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication, appState.ServerConfig.Config.Authorization.Rbac, appState.Logger)
 
 	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)
 	objectsManager := objects.NewManager(appState.SchemaManager, appState.ServerConfig, appState.Logger,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -719,14 +719,14 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	authz.SetupHandlers(api,
 		appState.ClusterService.Raft,
 		appState.SchemaManager,
-		appState.ServerConfig.Config.Authentication.APIKey,
+		appState.ServerConfig.Config.Authentication.DB.StaticApiKeys,
 		appState.ServerConfig.Config.Authentication.OIDC,
 		appState.ServerConfig.Config.Authorization.Rbac,
 		appState.Metrics,
 		appState.Authorizer,
 		appState.Logger)
 
-	dynamic_user.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication.APIKey, appState.ServerConfig.Config.Authorization.Rbac, appState.Logger)
+	dynamic_user.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication.DB, appState.ServerConfig.Config.Authorization.Rbac, appState.Logger)
 
 	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)
 	objectsManager := objects.NewManager(appState.SchemaManager, appState.ServerConfig, appState.Logger,

--- a/adapters/handlers/rest/dynamic_user/activate_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/activate_user_test.go
@@ -85,7 +85,7 @@ func TestActivateBadParameters(t *testing.T) {
 			h := dynUserHandler{
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
-				staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"static-user"}},
+				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static-user"}},
 				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}},
 			}
 
@@ -94,4 +94,20 @@ func TestActivateBadParameters(t *testing.T) {
 			assert.True(t, ok)
 		})
 	}
+}
+
+func TestActivateNoDynamic(t *testing.T) {
+	principal := &models.Principal{}
+	authorizer := authzMocks.NewAuthorizer(t)
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
+
+	h := dynUserHandler{
+		dynamicUser:    mocks.NewDynamicUserAndRolesGetter(t),
+		authorizer:     authorizer,
+		dynUserEnabled: false,
+	}
+
+	res := h.activateUser(users.ActivateUserParams{UserID: "user"}, principal)
+	_, ok := res.(*users.ActivateUserUnprocessableEntity)
+	assert.True(t, ok)
 }

--- a/adapters/handlers/rest/dynamic_user/activate_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/activate_user_test.go
@@ -36,7 +36,7 @@ func TestSuccessActivate(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.activateUser(users.ActivateUserParams{UserID: "user"}, principal)
@@ -53,7 +53,7 @@ func TestActivateNotFound(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.activateUser(users.ActivateUserParams{UserID: "user"}, principal)
@@ -86,7 +86,7 @@ func TestActivateBadParameters(t *testing.T) {
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
 				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static-user"}},
-				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}},
+				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}}, dynUserEnabled: true,
 			}
 
 			res := h.activateUser(users.ActivateUserParams{UserID: test.user}, principal)

--- a/adapters/handlers/rest/dynamic_user/create_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/create_user_test.go
@@ -49,7 +49,7 @@ func TestCreateUnprocessableEntity(t *testing.T) {
 
 			h := dynUserHandler{
 				dynamicUser: dynUser,
-				authorizer:  authorizer,
+				authorizer:  authorizer, dynUserEnabled: true,
 			}
 
 			res := h.createUser(users.CreateUserParams{UserID: tt.userId}, principal)
@@ -91,7 +91,7 @@ func TestCreateInternalServerError(t *testing.T) {
 
 			h := dynUserHandler{
 				dynamicUser: dynUser,
-				authorizer:  authorizer,
+				authorizer:  authorizer, dynUserEnabled: true,
 			}
 
 			res := h.createUser(users.CreateUserParams{UserID: "user"}, principal)
@@ -125,7 +125,7 @@ func TestCreateConflict(t *testing.T) {
 			h := dynUserHandler{
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
-				staticApiKeysConfigs: tt.rbacConf,
+				staticApiKeysConfigs: tt.rbacConf, dynUserEnabled: true,
 			}
 
 			res := h.createUser(users.CreateUserParams{UserID: "user"}, principal)
@@ -148,7 +148,7 @@ func TestCreateSuccess(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.createUser(users.CreateUserParams{UserID: "user"}, principal)
@@ -166,7 +166,7 @@ func TestCreateForbidden(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.createUser(users.CreateUserParams{UserID: "user"}, principal)
@@ -184,7 +184,7 @@ func TestCreateUnprocessableEntityCreatingRootUser(t *testing.T) {
 	h := dynUserHandler{
 		dynamicUser: dynUser,
 		authorizer:  authorizer,
-		rbacConfig:  rbacconf.Config{RootUsers: []string{"user-root"}},
+		rbacConfig:  rbacconf.Config{RootUsers: []string{"user-root"}}, dynUserEnabled: true,
 	}
 
 	res := h.createUser(users.CreateUserParams{UserID: "user-root"}, principal)

--- a/adapters/handlers/rest/dynamic_user/delete_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/delete_user_test.go
@@ -41,7 +41,7 @@ func TestDeleteSuccess(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.deleteUser(users.DeleteUserParams{UserID: "user"}, principal)
@@ -59,7 +59,7 @@ func TestDeleteForbidden(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.deleteUser(users.DeleteUserParams{UserID: "user"}, principal)
@@ -75,8 +75,9 @@ func TestDeleteUnprocessableEntityStaticUser(t *testing.T) {
 	dynUser := mocks.NewDynamicUserAndRolesGetter(t)
 
 	h := dynUserHandler{
-		dynamicUser:          dynUser,
-		authorizer:           authorizer,
+		dynamicUser: dynUser,
+		authorizer:  authorizer, dynUserEnabled: true,
+
 		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user"}, AllowedKeys: []string{"key"}},
 	}
 
@@ -95,7 +96,7 @@ func TestDeleteUnprocessableEntityDeletingRootUser(t *testing.T) {
 	h := dynUserHandler{
 		dynamicUser: dynUser,
 		authorizer:  authorizer,
-		rbacConfig:  rbacconf.Config{RootUsers: []string{"user-root"}},
+		rbacConfig:  rbacconf.Config{RootUsers: []string{"user-root"}}, dynUserEnabled: true,
 	}
 
 	res := h.deleteUser(users.DeleteUserParams{UserID: "user-root"}, principal)

--- a/adapters/handlers/rest/dynamic_user/delete_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/delete_user_test.go
@@ -77,7 +77,7 @@ func TestDeleteUnprocessableEntityStaticUser(t *testing.T) {
 	h := dynUserHandler{
 		dynamicUser:          dynUser,
 		authorizer:           authorizer,
-		staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user"}, AllowedKeys: []string{"key"}},
+		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user"}, AllowedKeys: []string{"key"}},
 	}
 
 	res := h.deleteUser(users.DeleteUserParams{UserID: "user"}, principal)
@@ -99,6 +99,22 @@ func TestDeleteUnprocessableEntityDeletingRootUser(t *testing.T) {
 	}
 
 	res := h.deleteUser(users.DeleteUserParams{UserID: "user-root"}, principal)
+	_, ok := res.(*users.DeleteUserUnprocessableEntity)
+	assert.True(t, ok)
+}
+
+func TestDeleteNoDynamic(t *testing.T) {
+	principal := &models.Principal{}
+	authorizer := authzMocks.NewAuthorizer(t)
+	authorizer.On("Authorize", principal, authorization.DELETE, authorization.Users("user")[0]).Return(nil)
+
+	h := dynUserHandler{
+		dynamicUser:    mocks.NewDynamicUserAndRolesGetter(t),
+		authorizer:     authorizer,
+		dynUserEnabled: false,
+	}
+
+	res := h.deleteUser(users.DeleteUserParams{UserID: "user"}, principal)
 	_, ok := res.(*users.DeleteUserUnprocessableEntity)
 	assert.True(t, ok)
 }

--- a/adapters/handlers/rest/dynamic_user/get_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/get_user_test.go
@@ -54,7 +54,7 @@ func TestSuccessList(t *testing.T) {
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
 				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
-				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root"}},
+				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root"}}, dynUserEnabled: true,
 			}
 
 			res := h.getUser(users.GetUserInfoParams{UserID: test.userId}, principal)
@@ -77,8 +77,9 @@ func TestNotFound(t *testing.T) {
 	dynUser.On("GetUsers", "static").Return(map[string]*apikey.User{}, nil)
 
 	h := dynUserHandler{
-		dynamicUser:          dynUser,
-		authorizer:           authorizer,
+		dynamicUser: dynUser,
+		authorizer:  authorizer, dynUserEnabled: true,
+
 		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
 	}
 
@@ -96,7 +97,7 @@ func TestNotFoundStatic(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.getUser(users.GetUserInfoParams{UserID: "user"}, principal)
@@ -127,7 +128,7 @@ func TestGetUserInternalServerError(t *testing.T) {
 			}
 
 			h := dynUserHandler{
-				dynamicUser: dynUser, authorizer: authorizer,
+				dynamicUser: dynUser, authorizer: authorizer, dynUserEnabled: true,
 			}
 
 			res := h.getUser(users.GetUserInfoParams{UserID: "user"}, principal)
@@ -147,7 +148,7 @@ func TestListForbidden(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.getUser(users.GetUserInfoParams{UserID: "user"}, principal)

--- a/adapters/handlers/rest/dynamic_user/get_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/get_user_test.go
@@ -53,7 +53,7 @@ func TestSuccessList(t *testing.T) {
 			h := dynUserHandler{
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
-				staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
+				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
 				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root"}},
 			}
 
@@ -79,7 +79,7 @@ func TestNotFound(t *testing.T) {
 	h := dynUserHandler{
 		dynamicUser:          dynUser,
 		authorizer:           authorizer,
-		staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
+		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
 	}
 
 	res := h.getUser(users.GetUserInfoParams{UserID: "static"}, principal)

--- a/adapters/handlers/rest/dynamic_user/handlers_dynamic_users.go
+++ b/adapters/handlers/rest/dynamic_user/handlers_dynamic_users.go
@@ -60,13 +60,13 @@ const (
 
 var validateUserNameRegex = regexp.MustCompile(`^` + userNameRegexCore + `$`)
 
-func SetupHandlers(api *operations.WeaviateAPI, dynamicUser DynamicUserAndRolesGetter, authorizer authorization.Authorizer, DbAuthConfig config.DB, rbacConfig rbacconf.Config, logger logrus.FieldLogger,
+func SetupHandlers(api *operations.WeaviateAPI, dynamicUser DynamicUserAndRolesGetter, authorizer authorization.Authorizer, authConfig config.Authentication, rbacConfig rbacconf.Config, logger logrus.FieldLogger,
 ) {
 	h := &dynUserHandler{
 		authorizer:           authorizer,
 		dynamicUser:          dynamicUser,
-		staticApiKeysConfigs: DbAuthConfig.StaticApiKeys,
-		dynUserEnabled:       DbAuthConfig.DynamicApiKeys.Enabled,
+		staticApiKeysConfigs: authConfig.APIKey,
+		dynUserEnabled:       authConfig.DynamicUsers.Enabled,
 		rbacConfig:           rbacConfig,
 		logger:               logger,
 	}

--- a/adapters/handlers/rest/dynamic_user/list_all_users_test.go
+++ b/adapters/handlers/rest/dynamic_user/list_all_users_test.go
@@ -66,7 +66,7 @@ func TestSuccessListAll(t *testing.T) {
 			h := dynUserHandler{
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
-				staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{staticUser}, AllowedKeys: []string{"static"}},
+				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{staticUser}, AllowedKeys: []string{"static"}},
 				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root"}},
 			}
 

--- a/adapters/handlers/rest/dynamic_user/rotate_key_test.go
+++ b/adapters/handlers/rest/dynamic_user/rotate_key_test.go
@@ -38,8 +38,9 @@ func TestSuccessRotate(t *testing.T) {
 	dynUser.On("RotateKey", "user", mock.Anything).Return(nil)
 
 	h := dynUserHandler{
-		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		dynamicUser:    dynUser,
+		authorizer:     authorizer,
+		dynUserEnabled: true,
 	}
 
 	res := h.rotateKey(users.RotateUserAPIKeyParams{UserID: "user"}, principal)
@@ -73,7 +74,7 @@ func TestRotateInternalServerError(t *testing.T) {
 			}
 
 			h := dynUserHandler{
-				dynamicUser: dynUser, authorizer: authorizer,
+				dynamicUser: dynUser, authorizer: authorizer, dynUserEnabled: true,
 			}
 
 			res := h.rotateKey(users.RotateUserAPIKeyParams{UserID: "user"}, principal)
@@ -93,7 +94,7 @@ func TestRotateNotFound(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.rotateKey(users.RotateUserAPIKeyParams{UserID: "user"}, principal)
@@ -110,7 +111,7 @@ func TestRotateForbidden(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.rotateKey(users.RotateUserAPIKeyParams{UserID: "user"}, principal)
@@ -126,8 +127,9 @@ func TestRotateUnprocessableEntity(t *testing.T) {
 	dynUser := mocks.NewDynamicUserAndRolesGetter(t)
 
 	h := dynUserHandler{
-		dynamicUser:          dynUser,
-		authorizer:           authorizer,
+		dynamicUser: dynUser,
+		authorizer:  authorizer, dynUserEnabled: true,
+
 		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user"}, AllowedKeys: []string{"key"}},
 	}
 

--- a/adapters/handlers/rest/dynamic_user/rotate_key_test.go
+++ b/adapters/handlers/rest/dynamic_user/rotate_key_test.go
@@ -128,7 +128,23 @@ func TestRotateUnprocessableEntity(t *testing.T) {
 	h := dynUserHandler{
 		dynamicUser:          dynUser,
 		authorizer:           authorizer,
-		staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"user"}, AllowedKeys: []string{"key"}},
+		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user"}, AllowedKeys: []string{"key"}},
+	}
+
+	res := h.rotateKey(users.RotateUserAPIKeyParams{UserID: "user"}, principal)
+	_, ok := res.(*users.RotateUserAPIKeyUnprocessableEntity)
+	assert.True(t, ok)
+}
+
+func TestRotateNoDynamic(t *testing.T) {
+	principal := &models.Principal{}
+	authorizer := authzMocks.NewAuthorizer(t)
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
+
+	h := dynUserHandler{
+		dynamicUser:    mocks.NewDynamicUserAndRolesGetter(t),
+		authorizer:     authorizer,
+		dynUserEnabled: false,
 	}
 
 	res := h.rotateKey(users.RotateUserAPIKeyParams{UserID: "user"}, principal)

--- a/adapters/handlers/rest/dynamic_user/suspend_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/suspend_user_test.go
@@ -44,7 +44,7 @@ func TestSuccessDeactivate(t *testing.T) {
 
 			h := dynUserHandler{
 				dynamicUser: dynUser,
-				authorizer:  authorizer,
+				authorizer:  authorizer, dynUserEnabled: true,
 			}
 
 			res := h.deactivateUser(users.DeactivateUserParams{UserID: "user", Body: users.DeactivateUserBody{RevokeKey: &test.revokeKey}}, principal)
@@ -63,7 +63,7 @@ func TestDeactivateNotFound(t *testing.T) {
 
 	h := dynUserHandler{
 		dynamicUser: dynUser,
-		authorizer:  authorizer,
+		authorizer:  authorizer, dynUserEnabled: true,
 	}
 
 	res := h.deactivateUser(users.DeactivateUserParams{UserID: "user"}, principal)
@@ -96,7 +96,7 @@ func TestDeactivateBadParameters(t *testing.T) {
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
 				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static-user"}},
-				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}},
+				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}}, dynUserEnabled: true,
 			}
 
 			res := h.deactivateUser(users.DeactivateUserParams{UserID: test.user}, principal)

--- a/adapters/handlers/rest/dynamic_user/suspend_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/suspend_user_test.go
@@ -95,7 +95,7 @@ func TestDeactivateBadParameters(t *testing.T) {
 			h := dynUserHandler{
 				dynamicUser:          dynUser,
 				authorizer:           authorizer,
-				staticApiKeysConfigs: config.APIKey{Enabled: true, Users: []string{"static-user"}},
+				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static-user"}},
 				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}},
 			}
 
@@ -104,4 +104,20 @@ func TestDeactivateBadParameters(t *testing.T) {
 			assert.True(t, ok)
 		})
 	}
+}
+
+func TestSuspendNoDynamic(t *testing.T) {
+	principal := &models.Principal{}
+	authorizer := authzMocks.NewAuthorizer(t)
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
+
+	h := dynUserHandler{
+		dynamicUser:    mocks.NewDynamicUserAndRolesGetter(t),
+		authorizer:     authorizer,
+		dynUserEnabled: false,
+	}
+
+	res := h.deactivateUser(users.DeactivateUserParams{UserID: "user"}, principal)
+	_, ok := res.(*users.DeactivateUserUnprocessableEntity)
+	assert.True(t, ok)
 }

--- a/test/acceptance/authn/dynamic_users_test.go
+++ b/test/acceptance/authn/dynamic_users_test.go
@@ -29,7 +29,7 @@ func TestCreateUser(t *testing.T) {
 	adminUser := "admin-user"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).
+	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithDynamicUsers().
 		Start(ctx)
 	require.Nil(t, err)
 	helper.SetupClient(compose.GetWeaviate().URI())
@@ -96,7 +96,7 @@ func TestWithStaticUser(t *testing.T) {
 	otherUser := "custom-user"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(otherUser, otherKey).Start(ctx)
+	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(otherUser, otherKey).WithDynamicUsers().Start(ctx)
 	require.Nil(t, err)
 	helper.SetupClient(compose.GetWeaviate().URI())
 
@@ -136,7 +136,7 @@ func TestSuspendAndActivate(t *testing.T) {
 	adminUser := "admin-user"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).Start(ctx)
+	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithDynamicUsers().Start(ctx)
 	require.Nil(t, err)
 	helper.SetupClient(compose.GetWeaviate().URI())
 

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -504,7 +504,7 @@ func TestListAllUsers(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	compose, err := docker.New().WithWeaviate().
-		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).WithUserApiKey("editor-user", "editor-key").
+		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).WithUserApiKey(viewerUser, viewerKey).WithUserApiKey("editor-user", "editor-key").
 		WithRBAC().WithRbacAdmins(adminUser).
 		WithDynamicUsers().Start(ctx)
 	require.Nil(t, err)

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -12,11 +12,15 @@
 package authz
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/weaviate/weaviate/test/docker"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/client/users"
@@ -308,8 +312,17 @@ func TestUserEndpoint(t *testing.T) {
 	adminKey := "admin-key"
 	adminUser := "admin-user"
 
-	_, down := composeUp(t, map[string]string{adminUser: adminKey}, nil, nil)
-	defer down()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithDynamicUsers().
+		WithRBAC().WithRbacAdmins(adminUser).Start(ctx)
+	require.Nil(t, err)
+
+	defer func() {
+		helper.ResetClient()
+		require.NoError(t, compose.Terminate(ctx))
+		cancel()
+	}()
+	helper.SetupClient(compose.GetWeaviate().URI())
 
 	testUser := "test-user"
 	helper.DeleteUser(t, testUser, adminKey)
@@ -489,8 +502,19 @@ func TestListAllUsers(t *testing.T) {
 	// match what is defined in the docker-compose file to allow switching between them
 	staticUsers := map[string]string{customUser: customKey, viewerUser: viewerKey, "editor-user": "editor-key"}
 
-	_, down := composeUp(t, map[string]string{adminUser: adminKey}, staticUsers, nil)
-	defer down()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	compose, err := docker.New().WithWeaviate().
+		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).WithUserApiKey("editor-user", "editor-key").
+		WithRBAC().WithRbacAdmins(adminUser).
+		WithDynamicUsers().Start(ctx)
+	require.Nil(t, err)
+
+	defer func() {
+		helper.ResetClient()
+		require.NoError(t, compose.Terminate(ctx))
+		cancel()
+	}()
+	helper.SetupClient(compose.GetWeaviate().URI())
 
 	helper.AssignRoleToUser(t, adminKey, "viewer", viewerUser)
 	t.Run("List all users", func(t *testing.T) {

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -116,6 +116,7 @@ type Compose struct {
 	weaviateApiKeyUsers            []ApiKeyUser
 	weaviateAdminlistAdminUsers    []string
 	weaviateAdminlistReadOnlyUsers []string
+	withWeaviateDynamicUsers       bool
 	withWeaviateRbac               bool
 	weaviateRbacAdmins             []string
 	weaviateRbacRootGroups         []string
@@ -510,6 +511,11 @@ func (d *Compose) WithUserApiKey(username, key string) *Compose {
 
 func (d *Compose) WithRBAC() *Compose {
 	d.withWeaviateRbac = true
+	return d
+}
+
+func (d *Compose) WithDynamicUsers() *Compose {
+	d.withWeaviateDynamicUsers = true
 	return d
 }
 

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -872,6 +872,10 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		}
 	}
 
+	if d.withWeaviateDynamicUsers {
+		settings["DYNAMIC_USERS_ENABLED"] = "true"
+	}
+
 	if d.withAutoschema {
 		settings["AUTOSCHEMA_ENABLED"] = "true"
 	}

--- a/usecases/auth/authentication/anonymous/middleware.go
+++ b/usecases/auth/authentication/anonymous/middleware.go
@@ -30,7 +30,7 @@ type Client struct {
 // New anonymous access client. Client.Middleware can be used as a regular
 // golang http-middleware
 func New(cfg config.Config) *Client {
-	return &Client{config: cfg.Authentication.AnonymousAccess, apiKeyEnabled: cfg.Authentication.DB.AnyEnabled(), oidcEnabled: cfg.Authentication.OIDC.Enabled}
+	return &Client{config: cfg.Authentication.AnonymousAccess, apiKeyEnabled: cfg.Authentication.AnyApiKeyAvailable(), oidcEnabled: cfg.Authentication.OIDC.Enabled}
 }
 
 // Middleware will fail unauthenticated requests if anonymous access is

--- a/usecases/auth/authentication/anonymous/middleware.go
+++ b/usecases/auth/authentication/anonymous/middleware.go
@@ -30,7 +30,7 @@ type Client struct {
 // New anonymous access client. Client.Middleware can be used as a regular
 // golang http-middleware
 func New(cfg config.Config) *Client {
-	return &Client{config: cfg.Authentication.AnonymousAccess, apiKeyEnabled: cfg.Authentication.APIKey.Enabled, oidcEnabled: cfg.Authentication.OIDC.Enabled}
+	return &Client{config: cfg.Authentication.AnonymousAccess, apiKeyEnabled: cfg.Authentication.DB.AnyEnabled(), oidcEnabled: cfg.Authentication.OIDC.Enabled}
 }
 
 // Middleware will fail unauthenticated requests if anonymous access is

--- a/usecases/auth/authentication/apikey/client.go
+++ b/usecases/auth/authentication/apikey/client.go
@@ -28,7 +28,7 @@ type StaticApiKey struct {
 
 func NewStatic(cfg config.Config) (*StaticApiKey, error) {
 	c := &StaticApiKey{
-		config: cfg.Authentication.DB.StaticApiKeys,
+		config: cfg.Authentication.APIKey,
 	}
 
 	if err := c.validateConfig(); err != nil {

--- a/usecases/auth/authentication/apikey/client.go
+++ b/usecases/auth/authentication/apikey/client.go
@@ -22,13 +22,13 @@ import (
 )
 
 type StaticApiKey struct {
-	config         config.APIKey
+	config         config.StaticAPIKey
 	weakKeyStorage [][sha256.Size]byte
 }
 
 func NewStatic(cfg config.Config) (*StaticApiKey, error) {
 	c := &StaticApiKey{
-		config: cfg.Authentication.APIKey,
+		config: cfg.Authentication.DB.StaticApiKeys,
 	}
 
 	if err := c.validateConfig(); err != nil {

--- a/usecases/auth/authentication/apikey/client_test.go
+++ b/usecases/auth/authentication/apikey/client_test.go
@@ -169,9 +169,7 @@ func Test_APIKeyClient(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c, err := NewStatic(config.Config{
-				Authentication: config.Authentication{
-					DB: config.DB{StaticApiKeys: test.config},
-				},
+				Authentication: config.Authentication{APIKey: test.config},
 			})
 
 			if test.expectConfigErr {

--- a/usecases/auth/authentication/apikey/client_test.go
+++ b/usecases/auth/authentication/apikey/client_test.go
@@ -22,7 +22,7 @@ import (
 func Test_APIKeyClient(t *testing.T) {
 	type test struct {
 		name               string
-		config             config.APIKey
+		config             config.StaticAPIKey
 		expectConfigErr    bool
 		expectConfigErrMsg string
 		validate           func(t *testing.T, c *StaticApiKey)
@@ -31,14 +31,14 @@ func Test_APIKeyClient(t *testing.T) {
 	tests := []test{
 		{
 			name: "not enabled",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled: false,
 			},
 			expectConfigErr: false,
 		},
 		{
 			name: "key, but no user",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{"secret-key"},
 				Users:       []string{},
@@ -48,7 +48,7 @@ func Test_APIKeyClient(t *testing.T) {
 		},
 		{
 			name: "zero length key",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{""},
 				Users:       []string{"gooduser"},
@@ -58,7 +58,7 @@ func Test_APIKeyClient(t *testing.T) {
 		},
 		{
 			name: "user, but no key",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{},
 				Users:       []string{"johnnyBeAllowed"},
@@ -68,7 +68,7 @@ func Test_APIKeyClient(t *testing.T) {
 		},
 		{
 			name: "zero length user",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{"secret-key"},
 				Users:       []string{""},
@@ -78,7 +78,7 @@ func Test_APIKeyClient(t *testing.T) {
 		},
 		{
 			name: "one user, one key",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{"secret-key"},
 				Users:       []string{"mrRoboto"},
@@ -99,7 +99,7 @@ func Test_APIKeyClient(t *testing.T) {
 			// this is allowed, this means that all keys point to the same user for
 			// authZ purposes
 			name: "one user, multiple keys",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{"secret-key", "another-secret-key", "third-key"},
 				Users:       []string{"jane"},
@@ -128,7 +128,7 @@ func Test_APIKeyClient(t *testing.T) {
 			// this is allowed, this means that each key at pos i points to user at
 			// pos i for authZ purposes
 			name: "multiple user, multiple keys",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{"secret-key", "another-secret-key", "third-key"},
 				Users:       []string{"jane", "jessica", "jennifer"},
@@ -156,7 +156,7 @@ func Test_APIKeyClient(t *testing.T) {
 		{
 			// this is invalid, the keys cannot be mapped to the users
 			name: "2 users, 3 keys",
-			config: config.APIKey{
+			config: config.StaticAPIKey{
 				Enabled:     true,
 				AllowedKeys: []string{"secret-key", "another-secret-key", "third-key"},
 				Users:       []string{"jane", "jessica"},
@@ -170,7 +170,7 @@ func Test_APIKeyClient(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			c, err := NewStatic(config.Config{
 				Authentication: config.Authentication{
-					APIKey: test.config,
+					DB: config.DB{StaticApiKeys: test.config},
 				},
 			})
 

--- a/usecases/auth/authentication/composer/token_validation.go
+++ b/usecases/auth/authentication/composer/token_validation.go
@@ -27,11 +27,11 @@ type TokenFunc func(token string, scopes []string) (*models.Principal, error)
 func New(config config.Authentication,
 	apikey authValidator, oidc authValidator,
 ) TokenFunc {
-	if config.DB.AnyEnabled() && config.OIDC.Enabled {
+	if config.AnyApiKeyAvailable() && config.OIDC.Enabled {
 		return pickAuthSchemeDynamically(apikey, oidc)
 	}
 
-	if config.DB.AnyEnabled() {
+	if config.AnyApiKeyAvailable() {
 		return apikey.ValidateAndExtract
 	}
 

--- a/usecases/auth/authentication/composer/token_validation.go
+++ b/usecases/auth/authentication/composer/token_validation.go
@@ -27,12 +27,11 @@ type TokenFunc func(token string, scopes []string) (*models.Principal, error)
 func New(config config.Authentication,
 	apikey authValidator, oidc authValidator,
 ) TokenFunc {
-	apiKeyEnabled := config.DB.StaticApiKeys.Enabled || config.DB.DynamicApiKeys.Enabled
-	if apiKeyEnabled && config.OIDC.Enabled {
+	if config.DB.AnyEnabled() && config.OIDC.Enabled {
 		return pickAuthSchemeDynamically(apikey, oidc)
 	}
 
-	if apiKeyEnabled {
+	if config.DB.AnyEnabled() {
 		return apikey.ValidateAndExtract
 	}
 

--- a/usecases/auth/authentication/composer/token_validation.go
+++ b/usecases/auth/authentication/composer/token_validation.go
@@ -21,17 +21,18 @@ import (
 type TokenFunc func(token string, scopes []string) (*models.Principal, error)
 
 // New provides an OpenAPI compatible token validation
-// function that validates the token either as OIDC or as an APIKey token
+// function that validates the token either as OIDC or as an StaticAPIKey token
 // depending on which is configured. If both are configured, the scheme is
 // figured out at runtime.
 func New(config config.Authentication,
 	apikey authValidator, oidc authValidator,
 ) TokenFunc {
-	if config.APIKey.Enabled && config.OIDC.Enabled {
+	apiKeyEnabled := config.DB.StaticApiKeys.Enabled || config.DB.DynamicApiKeys.Enabled
+	if apiKeyEnabled && config.OIDC.Enabled {
 		return pickAuthSchemeDynamically(apikey, oidc)
 	}
 
-	if config.APIKey.Enabled {
+	if apiKeyEnabled {
 		return apikey.ValidateAndExtract
 	}
 

--- a/usecases/auth/authentication/composer/token_validation_test.go
+++ b/usecases/auth/authentication/composer/token_validation_test.go
@@ -39,9 +39,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: false,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -58,9 +58,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: false,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -78,9 +78,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: false,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -97,9 +97,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: false,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -117,9 +117,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: true,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -136,9 +136,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: true,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -156,9 +156,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: true,
-				}},
+				},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -176,9 +176,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: true,
-				}},
+				},
 			},
 			token: "",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -196,9 +196,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
+				APIKey: config.StaticAPIKey{
 					Enabled: true,
-				}},
+				},
 			},
 			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			apiKey: func(t string, s []string) (*models.Principal, error) {

--- a/usecases/auth/authentication/composer/token_validation_test.go
+++ b/usecases/auth/authentication/composer/token_validation_test.go
@@ -39,9 +39,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: false,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -58,9 +58,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: false,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -78,9 +78,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: false,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -97,9 +97,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: false,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -117,9 +117,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: true,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -136,9 +136,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: false,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: true,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -156,9 +156,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: true,
-				},
+				}},
 			},
 			token: "does not matter",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -176,9 +176,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: true,
-				},
+				}},
 			},
 			token: "",
 			apiKey: func(t string, s []string) (*models.Principal, error) {
@@ -196,9 +196,9 @@ func Test_TokenAuthComposer(t *testing.T) {
 				OIDC: config.OIDC{
 					Enabled: true,
 				},
-				APIKey: config.APIKey{
+				DB: config.DB{StaticApiKeys: config.StaticAPIKey{
 					Enabled: true,
-				},
+				}},
 			},
 			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			apiKey: func(t string, s []string) (*models.Principal, error) {

--- a/usecases/config/authentication.go
+++ b/usecases/config/authentication.go
@@ -17,7 +17,8 @@ import "fmt"
 type Authentication struct {
 	OIDC            OIDC            `json:"oidc" yaml:"oidc"`
 	AnonymousAccess AnonymousAccess `json:"anonymous_access" yaml:"anonymous_access"`
-	DB              DB              `json:"db" yaml:"db"`
+	APIKey          StaticAPIKey    // don't change name to not break yaml files
+	DynamicUsers    DynamicUsers    `json:"dynamic_users" yaml:"dynamic_users"`
 }
 
 // DefaultAuthentication is the default authentication scheme when no authentication is provided
@@ -39,7 +40,11 @@ func (a Authentication) Validate() error {
 }
 
 func (a Authentication) AnyAuthMethodSelected() bool {
-	return a.AnonymousAccess.Enabled || a.OIDC.Enabled || a.DB.StaticApiKeys.Enabled || a.DB.DynamicApiKeys.Enabled
+	return a.AnonymousAccess.Enabled || a.OIDC.Enabled || a.APIKey.Enabled || a.DynamicUsers.Enabled
+}
+
+func (a Authentication) AnyApiKeyAvailable() bool {
+	return a.APIKey.Enabled || a.DynamicUsers.Enabled
 }
 
 // AnonymousAccess considers users without any auth information as
@@ -61,21 +66,12 @@ type OIDC struct {
 	Scopes            []string `yaml:"scopes" json:"scopes"`
 }
 
-type DB struct {
-	StaticApiKeys  StaticAPIKey  `json:"static_api_keys" yaml:"static_api_keys"`
-	DynamicApiKeys DynamicAPIKey `json:"dynamic_api_keys" yaml:"dynamic_api_keys"`
-}
-
-func (d DB) AnyEnabled() bool {
-	return d.StaticApiKeys.Enabled || d.DynamicApiKeys.Enabled
-}
-
 type StaticAPIKey struct {
 	Enabled     bool     `json:"enabled" yaml:"enabled"`
 	Users       []string `json:"users" yaml:"users"`
 	AllowedKeys []string `json:"allowed_keys" yaml:"allowed_keys"`
 }
 
-type DynamicAPIKey struct {
+type DynamicUsers struct {
 	Enabled bool `json:"enabled" yaml:"enabled"`
 }

--- a/usecases/config/authentication.go
+++ b/usecases/config/authentication.go
@@ -17,7 +17,7 @@ import "fmt"
 type Authentication struct {
 	OIDC            OIDC            `json:"oidc" yaml:"oidc"`
 	AnonymousAccess AnonymousAccess `json:"anonymous_access" yaml:"anonymous_access"`
-	APIKey          APIKey
+	DB              DB              `json:"db" yaml:"db"`
 }
 
 // DefaultAuthentication is the default authentication scheme when no authentication is provided
@@ -39,7 +39,7 @@ func (a Authentication) Validate() error {
 }
 
 func (a Authentication) AnyAuthMethodSelected() bool {
-	return a.AnonymousAccess.Enabled || a.OIDC.Enabled || a.APIKey.Enabled
+	return a.AnonymousAccess.Enabled || a.OIDC.Enabled || a.DB.StaticApiKeys.Enabled || a.DB.DynamicApiKeys.Enabled
 }
 
 // AnonymousAccess considers users without any auth information as
@@ -61,8 +61,21 @@ type OIDC struct {
 	Scopes            []string `yaml:"scopes" json:"scopes"`
 }
 
-type APIKey struct {
+type DB struct {
+	StaticApiKeys  StaticAPIKey  `json:"static_api_keys" yaml:"static_api_keys"`
+	DynamicApiKeys DynamicAPIKey `json:"dynamic_api_keys" yaml:"dynamic_api_keys"`
+}
+
+func (d DB) AnyEnabled() bool {
+	return d.StaticApiKeys.Enabled || d.DynamicApiKeys.Enabled
+}
+
+type StaticAPIKey struct {
 	Enabled     bool     `json:"enabled" yaml:"enabled"`
 	Users       []string `json:"users" yaml:"users"`
 	AllowedKeys []string `json:"allowed_keys" yaml:"allowed_keys"`
+}
+
+type DynamicAPIKey struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }

--- a/usecases/config/authentication_test.go
+++ b/usecases/config/authentication_test.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,4 +72,28 @@ func TestConfig_Authentication(t *testing.T) {
 
 		assert.Nil(t, err, "should not error")
 	})
+}
+
+func TestDbUserAuth(t *testing.T) {
+	tests := []struct {
+		name           string
+		staticEnabled  bool
+		dynamicEnabled bool
+		expected       bool
+	}{
+		{"none enabled", false, false, false},
+		{"both enabled", true, true, true},
+		{"only static", true, false, true},
+		{"only dynamic", false, true, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			auth := Authentication{
+				DB: DB{StaticApiKeys: StaticAPIKey{Enabled: test.staticEnabled}, DynamicApiKeys: DynamicAPIKey{Enabled: test.dynamicEnabled}},
+			}
+
+			require.Equal(t, auth.DB.AnyEnabled(), test.expected)
+		})
+	}
 }

--- a/usecases/config/authentication_test.go
+++ b/usecases/config/authentication_test.go
@@ -90,10 +90,10 @@ func TestDbUserAuth(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			auth := Authentication{
-				DB: DB{StaticApiKeys: StaticAPIKey{Enabled: test.staticEnabled}, DynamicApiKeys: DynamicAPIKey{Enabled: test.dynamicEnabled}},
+				APIKey: StaticAPIKey{Enabled: test.staticEnabled}, DynamicUsers: DynamicUsers{Enabled: test.dynamicEnabled},
 			}
 
-			require.Equal(t, auth.DB.AnyEnabled(), test.expected)
+			require.Equal(t, auth.AnyApiKeyAvailable(), test.expected)
 		})
 	}
 }

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -112,9 +112,9 @@ func TestConfigModules(t *testing.T) {
 		config, err := weaviateConfig.parseConfigFile(file, configFileName)
 		require.Nil(t, err)
 
-		assert.True(t, config.Authentication.DB.StaticApiKeys.Enabled)
-		assert.ElementsMatch(t, []string{"api-key-1"}, config.Authentication.DB.StaticApiKeys.AllowedKeys)
-		assert.ElementsMatch(t, []string{"readonly@weaviate.io"}, config.Authentication.DB.StaticApiKeys.Users)
+		assert.True(t, config.Authentication.APIKey.Enabled)
+		assert.ElementsMatch(t, []string{"api-key-1"}, config.Authentication.APIKey.AllowedKeys)
+		assert.ElementsMatch(t, []string{"readonly@weaviate.io"}, config.Authentication.APIKey.Users)
 	})
 }
 
@@ -174,9 +174,9 @@ func TestConfigParsing(t *testing.T) {
 		config, err := weaviateConfig.parseConfigFile(file, configFileName)
 		require.Nil(t, err)
 
-		assert.True(t, config.Authentication.DB.StaticApiKeys.Enabled)
-		assert.ElementsMatch(t, []string{"api-key-1", "api-key-2", "api-key-3"}, config.Authentication.DB.StaticApiKeys.AllowedKeys)
-		assert.ElementsMatch(t, []string{"user1@weaviate.io", "user2@weaviate.io"}, config.Authentication.DB.StaticApiKeys.Users)
+		assert.True(t, config.Authentication.APIKey.Enabled)
+		assert.ElementsMatch(t, []string{"api-key-1", "api-key-2", "api-key-3"}, config.Authentication.APIKey.AllowedKeys)
+		assert.ElementsMatch(t, []string{"user1@weaviate.io", "user2@weaviate.io"}, config.Authentication.APIKey.Users)
 	})
 }
 

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -112,9 +112,9 @@ func TestConfigModules(t *testing.T) {
 		config, err := weaviateConfig.parseConfigFile(file, configFileName)
 		require.Nil(t, err)
 
-		assert.True(t, config.Authentication.APIKey.Enabled)
-		assert.ElementsMatch(t, []string{"api-key-1"}, config.Authentication.APIKey.AllowedKeys)
-		assert.ElementsMatch(t, []string{"readonly@weaviate.io"}, config.Authentication.APIKey.Users)
+		assert.True(t, config.Authentication.DB.StaticApiKeys.Enabled)
+		assert.ElementsMatch(t, []string{"api-key-1"}, config.Authentication.DB.StaticApiKeys.AllowedKeys)
+		assert.ElementsMatch(t, []string{"readonly@weaviate.io"}, config.Authentication.DB.StaticApiKeys.Users)
 	})
 }
 
@@ -174,9 +174,9 @@ func TestConfigParsing(t *testing.T) {
 		config, err := weaviateConfig.parseConfigFile(file, configFileName)
 		require.Nil(t, err)
 
-		assert.True(t, config.Authentication.APIKey.Enabled)
-		assert.ElementsMatch(t, []string{"api-key-1", "api-key-2", "api-key-3"}, config.Authentication.APIKey.AllowedKeys)
-		assert.ElementsMatch(t, []string{"user1@weaviate.io", "user2@weaviate.io"}, config.Authentication.APIKey.Users)
+		assert.True(t, config.Authentication.DB.StaticApiKeys.Enabled)
+		assert.ElementsMatch(t, []string{"api-key-1", "api-key-2", "api-key-3"}, config.Authentication.DB.StaticApiKeys.AllowedKeys)
+		assert.ElementsMatch(t, []string{"user1@weaviate.io", "user2@weaviate.io"}, config.Authentication.DB.StaticApiKeys.Users)
 	})
 }
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -163,22 +163,22 @@ func FromEnv(config *Config) error {
 	}
 
 	if entcfg.Enabled(os.Getenv("DYNAMIC_USERS_ENABLED")) {
-		config.Authentication.DB.DynamicApiKeys.Enabled = true
+		config.Authentication.DynamicUsers.Enabled = true
 	} else {
-		config.Authentication.DB.DynamicApiKeys.Enabled = false
+		config.Authentication.DynamicUsers.Enabled = false
 	}
 
 	if entcfg.Enabled(os.Getenv("AUTHENTICATION_APIKEY_ENABLED")) {
-		config.Authentication.DB.StaticApiKeys.Enabled = true
+		config.Authentication.APIKey.Enabled = true
 
 		if rawKeys, ok := os.LookupEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS"); ok {
 			keys := strings.Split(rawKeys, ",")
-			config.Authentication.DB.StaticApiKeys.AllowedKeys = keys
+			config.Authentication.APIKey.AllowedKeys = keys
 		}
 
 		if rawUsers, ok := os.LookupEnv("AUTHENTICATION_APIKEY_USERS"); ok {
 			users := strings.Split(rawUsers, ",")
-			config.Authentication.DB.StaticApiKeys.Users = users
+			config.Authentication.APIKey.Users = users
 		}
 
 	}

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -162,10 +162,10 @@ func FromEnv(config *Config) error {
 		}
 	}
 
-	if entcfg.Enabled(os.Getenv("DISABLE_DYNAMIC_USERS")) {
-		config.Authentication.DB.DynamicApiKeys.Enabled = false
-	} else {
+	if entcfg.Enabled(os.Getenv("DYNAMIC_USERS_ENABLED")) {
 		config.Authentication.DB.DynamicApiKeys.Enabled = true
+	} else {
+		config.Authentication.DB.DynamicApiKeys.Enabled = false
 	}
 
 	if entcfg.Enabled(os.Getenv("AUTHENTICATION_APIKEY_ENABLED")) {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -162,17 +162,23 @@ func FromEnv(config *Config) error {
 		}
 	}
 
+	if entcfg.Enabled(os.Getenv("DISABLE_DYNAMIC_USERS")) {
+		config.Authentication.DB.DynamicApiKeys.Enabled = false
+	} else {
+		config.Authentication.DB.DynamicApiKeys.Enabled = true
+	}
+
 	if entcfg.Enabled(os.Getenv("AUTHENTICATION_APIKEY_ENABLED")) {
-		config.Authentication.APIKey.Enabled = true
+		config.Authentication.DB.StaticApiKeys.Enabled = true
 
 		if rawKeys, ok := os.LookupEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS"); ok {
 			keys := strings.Split(rawKeys, ",")
-			config.Authentication.APIKey.AllowedKeys = keys
+			config.Authentication.DB.StaticApiKeys.AllowedKeys = keys
 		}
 
 		if rawUsers, ok := os.LookupEnv("AUTHENTICATION_APIKEY_USERS"); ok {
 			users := strings.Split(rawUsers, ",")
-			config.Authentication.APIKey.Users = users
+			config.Authentication.DB.StaticApiKeys.Users = users
 		}
 
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -726,6 +726,13 @@ func TestEnvironmentAuthentication(t *testing.T) {
 			},
 		},
 		{
+			name:         "Disable dynamic user",
+			auth_env_var: []string{"DISABLE_DYNAMIC_USERS"},
+			expected: Authentication{
+				DB: DB{DynamicApiKeys: DynamicAPIKey{Enabled: false}}, AnonymousAccess: AnonymousAccess{Enabled: true},
+			},
+		},
+		{
 			name:         "not given",
 			auth_env_var: []string{},
 			expected: Authentication{

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -702,9 +702,9 @@ func TestEnvironmentAuthentication(t *testing.T) {
 			name:         "Valid API Key",
 			auth_env_var: []string{"AUTHENTICATION_APIKEY_ENABLED"},
 			expected: Authentication{
-				APIKey: APIKey{
+				DB: DB{StaticApiKeys: StaticAPIKey{
 					Enabled: true,
-				},
+				}},
 			},
 		},
 		{

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -702,9 +702,9 @@ func TestEnvironmentAuthentication(t *testing.T) {
 			name:         "Valid API Key",
 			auth_env_var: []string{"AUTHENTICATION_APIKEY_ENABLED"},
 			expected: Authentication{
-				DB: DB{StaticApiKeys: StaticAPIKey{
+				APIKey: StaticAPIKey{
 					Enabled: true,
-				}},
+				},
 			},
 		},
 		{
@@ -729,7 +729,7 @@ func TestEnvironmentAuthentication(t *testing.T) {
 			name:         "Enabled dynamic user",
 			auth_env_var: []string{"DYNAMIC_USERS_ENABLED"},
 			expected: Authentication{
-				DB: DB{DynamicApiKeys: DynamicAPIKey{Enabled: true}},
+				DynamicUsers: DynamicUsers{Enabled: true},
 			},
 		},
 		{

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -726,10 +726,10 @@ func TestEnvironmentAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name:         "Disable dynamic user",
-			auth_env_var: []string{"DISABLE_DYNAMIC_USERS"},
+			name:         "Enabled dynamic user",
+			auth_env_var: []string{"DYNAMIC_USERS_ENABLED"},
 			expected: Authentication{
-				DB: DB{DynamicApiKeys: DynamicAPIKey{Enabled: false}}, AnonymousAccess: AnonymousAccess{Enabled: true},
+				DB: DB{DynamicApiKeys: DynamicAPIKey{Enabled: true}},
 			},
 		},
 		{


### PR DESCRIPTION
### What's being changed:

Adds `DYNAMIC_USERS_ENABLED` to enable dynamic user management.

Note that enabled by default was not possible as it would break "if no auth method is activated, use anon auth"

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
