### PR TITLE
fix(raft): data races on schema.Classes

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -117,9 +117,7 @@ func (s *SchemaManager) ReloadDBFromSchema() {
 	cs := make([]command.UpdateClassRequest, len(classes))
 	i := 0
 	for _, v := range classes {
-		// an immutable copy of the sharding state has to be used to avoid conflicts
-		shardingState, _ := v.CopyShardingState()
-		cs[i] = command.UpdateClassRequest{Class: &v.Class, State: shardingState}
+		cs[i] = command.UpdateClassRequest{Class: &v.Class, State: &v.Sharding}
 		i++
 	}
 	s.db.TriggerSchemaUpdateCallbacks()

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/entities/models"
@@ -479,25 +480,35 @@ func (s *schema) getTenants(class string, tenants []string) ([]*models.Tenant, e
 }
 
 func (s *schema) States() map[string]types.ClassState {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	cs := make(map[string]types.ClassState, len(s.classes))
-	for _, c := range s.classes {
+	classesCopy := s.MetaClasses()
+	cs := make(map[string]types.ClassState, len(classesCopy))
+	for _, c := range classesCopy {
 		cs[c.Class.Class] = types.ClassState{
 			Class:  c.Class,
 			Shards: c.Sharding,
 		}
 	}
-
 	return cs
 }
 
+// MetaClasses is thread-safe and returns a deep copy of the meta classes and sharding states
 func (s *schema) MetaClasses() map[string]*metaClass {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.classes
+	classesCopy := make(map[string]*metaClass, len(s.classes))
+	for k, v := range s.classes {
+		v.RLock()
+		classesCopy[k] = &metaClass{
+			Class:        v.Class,
+			ClassVersion: v.ClassVersion,
+			Sharding:     v.Sharding.DeepCopy(),
+			ShardVersion: v.ShardVersion,
+		}
+		v.RUnlock()
+	}
+
+	return classesCopy
 }
 
 func (s *schema) Restore(r io.Reader, parser Parser) error {
@@ -519,14 +530,11 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 // Persist should dump all necessary state to the WriteCloser 'sink',
 // and call sink.Close() when finished or call sink.Cancel() on error.
 func (s *schema) Persist(sink raft.SnapshotSink) (err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	defer sink.Close()
 	snap := snapshot{
 		NodeID:     s.nodeID,
 		SnapshotID: sink.ID(),
-		Classes:    s.classes,
+		Classes:    s.MetaClasses(),
 	}
 	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
 		return fmt.Errorf("encode: %w", err)

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -480,14 +480,17 @@ func (s *schema) getTenants(class string, tenants []string) ([]*models.Tenant, e
 }
 
 func (s *schema) States() map[string]types.ClassState {
-	classesCopy := s.MetaClasses()
-	cs := make(map[string]types.ClassState, len(classesCopy))
-	for _, c := range classesCopy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cs := make(map[string]types.ClassState, len(s.classes))
+	for _, c := range s.classes {
 		cs[c.Class.Class] = types.ClassState{
 			Class:  c.Class,
 			Shards: c.Sharding,
 		}
 	}
+
 	return cs
 }
 

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -533,6 +533,7 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 // Persist should dump all necessary state to the WriteCloser 'sink',
 // and call sink.Close() when finished or call sink.Cancel() on error.
 func (s *schema) Persist(sink raft.SnapshotSink) (err error) {
+	// we don't need to lock here because, we call MetaClasses() which is thread-safe
 	defer sink.Close()
 	snap := snapshot{
 		NodeID:     s.nodeID,

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -12,12 +12,14 @@
 package schema
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -153,4 +155,78 @@ func Test_schemaShardMetrics(t *testing.T) {
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("")))
 	require.NoError(t, s.addClass(c2, ss, 0))
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("")))
+}
+
+func Test_schemaDeepCopy(t *testing.T) {
+	r := prometheus.NewPedanticRegistry()
+	s := NewSchema("testNode", nil, r)
+
+	class := &models.Class{
+		Class: "test",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+	shardState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"shard1": {
+				Name:           "shard1",
+				Status:         "HOT",
+				BelongsToNodes: []string{"node1"},
+			},
+		},
+	}
+
+	require.NoError(t, s.addClass(class, shardState, 1))
+
+	t.Run("MetaClasses deep copy", func(t *testing.T) {
+		copied := s.MetaClasses()
+
+		original := s.classes["test"]
+		copiedClass := copied["test"]
+
+		copiedClass.Class.Class = "modified"
+		physical := copiedClass.Sharding.Physical["shard1"]
+		physical.Status = "COLD"
+		copiedClass.Sharding.Physical["shard1"] = physical
+
+		assert.Equal(t, "test", original.Class.Class)
+		assert.Equal(t, "HOT", original.Sharding.Physical["shard1"].Status)
+
+		assert.Equal(t, original.ClassVersion, copiedClass.ClassVersion)
+		assert.Equal(t, original.ShardVersion, copiedClass.ShardVersion)
+	})
+
+	t.Run("States deep copy", func(t *testing.T) {
+		states := s.States()
+
+		original := s.classes["test"]
+		copiedState := states["test"]
+
+		copiedState.Class.Class = "modified"
+		physical := copiedState.Shards.Physical["shard1"]
+		physical.Status = "COLD"
+		copiedState.Shards.Physical["shard1"] = physical
+
+		// Verify original is unchanged
+		assert.Equal(t, "test", original.Class.Class)
+		assert.Equal(t, "HOT", original.Sharding.Physical["shard1"].Status)
+	})
+
+	t.Run("Concurrent access", func(t *testing.T) {
+		done := make(chan bool)
+		go func() {
+			for i := 0; i < 100; i++ {
+				s.MetaClasses()
+				s.States()
+			}
+			done <- true
+		}()
+
+		for i := 0; i < 100; i++ {
+			t.Logf("adding class %d", i)
+			s.addClass(&models.Class{Class: fmt.Sprintf("concurrent%d", i)}, shardState, uint64(i))
+		}
+		<-done
+	})
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -197,22 +197,6 @@ func Test_schemaDeepCopy(t *testing.T) {
 		assert.Equal(t, original.ShardVersion, copiedClass.ShardVersion)
 	})
 
-	t.Run("States deep copy", func(t *testing.T) {
-		states := s.States()
-
-		original := s.classes["test"]
-		copiedState := states["test"]
-
-		copiedState.Class.Class = "modified"
-		physical := copiedState.Shards.Physical["shard1"]
-		physical.Status = "COLD"
-		copiedState.Shards.Physical["shard1"] = physical
-
-		// Verify original is unchanged
-		assert.Equal(t, "test", original.Class.Class)
-		assert.Equal(t, "HOT", original.Sharding.Physical["shard1"].Status)
-	})
-
 	t.Run("Concurrent access", func(t *testing.T) {
 		done := make(chan bool)
 		go func() {
@@ -224,7 +208,6 @@ func Test_schemaDeepCopy(t *testing.T) {
 		}()
 
 		for i := 0; i < 100; i++ {
-			t.Logf("adding class %d", i)
 			s.addClass(&models.Class{Class: fmt.Sprintf("concurrent%d", i)}, shardState, uint64(i))
 		}
 		<-done


### PR DESCRIPTION
### What's being changed:
this PR makes sure that the returned meta classes are deep copy to avoid any concurrent writes to classes, we encountered  `fatal error: concurrent map iteration and map write` in some places and this because despite the lock on the schema, there could be some writes on classes themselves inside the schema
![image (6)](https://github.com/user-attachments/assets/5ae1eca8-9c65-402a-b4c5-ec4e71fc1c1a)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
  - 1st run 
    - ~~[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13793969242)~~
    - ~~[e2e test](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13794005044)~~
  - 2nd run after rebase
    - ~~[chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13799163571)~~
    - ~~[e2e test](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13799157416)~~
  - 3rd run after un-touch State() **latest**
    - [chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13800404062)
    - [e2e test](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13800402955)
    
  
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
