### PR TITLE
fix(raft): randomize shard owner to tolerate down nodes

### DIFF
--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -144,7 +145,7 @@ func TestVersionedSchemaReaderClass(t *testing.T) {
 	// ShardOwner
 	owner, err := sc.ShardOwner(ctx, "D", "S1", 1)
 	assert.Nil(t, err)
-	assert.Equal(t, owner, "N1")
+	assert.Contains(t, nodes, owner)
 
 	// TenantShard
 	shards, _, err = sc.TenantsShards(ctx, 1, "D", "S1")

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -246,7 +246,7 @@ func TestSchemaReaderClass(t *testing.T) {
 	// ShardOwner
 	owner, err := sc.ShardOwner("D", "S1")
 	assert.Nil(t, err)
-	assert.Equal(t, owner, "N1")
+	assert.Contains(t, nodes, owner)
 
 	// TenantShard
 	shards, _ := sc.TenantsShards("D", "S1")

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -13,14 +13,16 @@ package schema
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
+
+	"golang.org/x/exp/slices"
 
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	entSchema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
-	"golang.org/x/exp/slices"
 )
 
 type metaClass struct {
@@ -98,7 +100,8 @@ func (m *metaClass) ShardOwner(shard string) (string, uint64, error) {
 	if len(x.BelongsToNodes) < 1 || x.BelongsToNodes[0] == "" {
 		return "", 0, fmt.Errorf("owner node not found")
 	}
-	return x.BelongsToNodes[0], m.version(), nil
+
+	return x.BelongsToNodes[rand.Intn(len(x.BelongsToNodes))], m.version(), nil
 }
 
 // ShardFromUUID returns shard name of the provided uuid

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -89,6 +89,7 @@ func (m *metaClass) CloneClass() *models.Class {
 }
 
 // ShardOwner returns the node owner of the specified shard
+// will randomize the owner if there is more than one node
 func (m *metaClass) ShardOwner(shard string) (string, uint64, error) {
 	m.RLock()
 	defer m.RUnlock()
@@ -101,6 +102,10 @@ func (m *metaClass) ShardOwner(shard string) (string, uint64, error) {
 		return "", 0, fmt.Errorf("owner node not found")
 	}
 
+	// we randomize the owner if there is more than one node
+	// - avoid hotspots
+	// - tolerate down nodes
+	// - distribute load
 	return x.BelongsToNodes[rand.Intn(len(x.BelongsToNodes))], m.version(), nil
 }
 


### PR DESCRIPTION
### What's being changed:
this PR makes sure that we randomize the shard owner if there is more than one to 
-  avoid hotspots
- tolerate down nodes
- distribute load

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
 - [chaos engineering run](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13803730338)
 - [e2e whole test](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13803713363)
 - [recovery test run 1](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13803369278/job/38609694952)
 - [recovery test run 2](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13814660345)
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
