### PR TITLE
fix: improve vector selection in queries for mixed vectors

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors.go
@@ -19,5 +19,6 @@ func AllMixedVectorsTests(endpoint string) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("schema", testMixedVectorsCreateSchema(endpoint))
 		t.Run("object", testMixedVectorsCreateObject(endpoint))
+		t.Run("hybrid", testMixedVectorsHybrid(endpoint))
 	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
@@ -1,0 +1,130 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test_suits
+
+import (
+	"context"
+	"testing"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func testMixedVectorsHybrid(host string) func(t *testing.T) {
+	return func(t *testing.T) {
+		var (
+			ctx = context.Background()
+
+			class = &models.Class{
+				Class: "TestClass",
+				Properties: []*models.Property{
+					{
+						Name: "text", DataType: []string{schema.DataTypeText.String()},
+					},
+					{
+						Name: "text2", DataType: []string{schema.DataTypeText.String()},
+					},
+				},
+				Vectorizer:      text2vecContextionary,
+				VectorIndexType: "hnsw",
+				VectorConfig: map[string]models.VectorConfig{
+					transformers: {
+						Vectorizer: map[string]interface{}{
+							text2vecTransformers: map[string]interface{}{
+								"vectorizeClassName": false,
+								"sourceProperties":   []string{"text"},
+							},
+						},
+						VectorIndexType: "flat",
+					},
+					contextionary: {
+						Vectorizer: map[string]interface{}{
+							text2vecContextionary: map[string]interface{}{
+								"vectorizeClassName": false,
+								"sourceProperties":   []string{"text2"},
+							},
+						},
+						VectorIndexType: "flat",
+					},
+				},
+			}
+
+			field = graphql.Field{
+				Name: "_additional",
+				Fields: []graphql.Field{
+					{Name: "id"},
+				},
+			}
+		)
+
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+		require.Nil(t, err)
+
+		cleanup := func() {
+			err := client.Schema().ClassDeleter().WithClassName(class.Class).Do(context.Background())
+			require.Nil(t, err)
+		}
+
+		// create class
+		err = client.Schema().ClassCreator().WithClass(class).Do(ctx)
+		defer cleanup()
+		require.NoError(t, err)
+
+		// insert objects
+		for _, id := range []string{id1, id2} {
+			objWrapper, err := client.Data().Creator().
+				WithClassName(class.Class).
+				WithID(id).
+				WithProperties(map[string]interface{}{
+					"text": "Some text goes here",
+				}).
+				Do(ctx)
+
+			require.NoError(t, err)
+			require.NotNil(t, objWrapper)
+			assert.NotEmpty(t, objWrapper.Object.Vector)
+			assert.Len(t, objWrapper.Object.Vectors, 2)
+		}
+
+		namedResp, err := client.GraphQL().Get().
+			WithClassName(class.Class).
+			WithHybrid(client.GraphQL().
+				HybridArgumentBuilder().
+				WithQuery("Some text goes here").
+				WithAlpha(0.5).
+				WithTargetVectors(contextionary)).
+			WithFields(field).
+			Do(ctx)
+		require.NoError(t, err)
+
+		namedIds := acceptance_with_go_client.GetIds(t, namedResp, class.Class)
+		require.ElementsMatch(t, namedIds, []string{id1, id2})
+
+		legacyResp, err := client.GraphQL().Get().
+			WithClassName(class.Class).
+			WithHybrid(client.GraphQL().
+				HybridArgumentBuilder().
+				WithQuery("Some text goes here").
+				WithAlpha(0.5)).
+			WithFields(field).
+			Do(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, namedResp, legacyResp)
+	}
+}

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -29,8 +30,9 @@ func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, cl
 	if len(targetVectors) == 0 {
 		class := sch.FindClassByName(schema.ClassName(className))
 
-		// If no target vectors provided, return the legacy vector
-		if len(class.VectorConfig) == 0 {
+		// If no target vectors provided, check whether legacy vector is configured.
+		// For backwards compatibility, we have to return legacy vector in case no named vectors configured.
+		if hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 			return []string{""}, nil
 		}
 
@@ -66,4 +68,8 @@ func (t *TargetVectorParamHelper) GetTargetVectorsFromParams(params dto.GetParam
 		}
 	}
 	return []string{}
+}
+
+func hasLegacyVectorIndex(class *models.Class) bool {
+	return class.Vectorizer != "" || class.VectorIndexConfig != nil
 }

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -33,7 +33,7 @@ func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, cl
 		// If no target vectors provided, check whether we have legacy index configured.
 		// Additionally, we have to return empty target vector if no named vectors are configured on
 		// the class for backwards compatibility reasons.
-		if hasLegacyVectorIndex(class) || len(targetVectors) == 0 {
+		if hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 			return []string{""}, nil
 		}
 

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate/entities/dto"
-	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -30,8 +29,8 @@ func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, cl
 	if len(targetVectors) == 0 {
 		class := sch.FindClassByName(schema.ClassName(className))
 
-		// If no target vectors provided, check whether we have legacy index configured first.
-		if hasLegacyVectorIndex(class) {
+		// If no target vectors provided, return the legacy vector
+		if len(class.VectorConfig) == 0 {
 			return []string{""}, nil
 		}
 
@@ -67,8 +66,4 @@ func (t *TargetVectorParamHelper) GetTargetVectorsFromParams(params dto.GetParam
 		}
 	}
 	return []string{}
-}
-
-func hasLegacyVectorIndex(class *models.Class) bool {
-	return class.Vectorizer != "" || class.VectorIndexConfig != nil
 }

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -30,10 +30,8 @@ func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, cl
 	if len(targetVectors) == 0 {
 		class := sch.FindClassByName(schema.ClassName(className))
 
-		// If no target vectors provided, check whether we have legacy index configured.
-		// Additionally, we have to return empty target vector if no named vectors are configured on
-		// the class for backwards compatibility reasons.
-		if hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
+		// If no target vectors provided, check whether we have legacy index configured first.
+		if hasLegacyVectorIndex(class) {
 			return []string{""}, nil
 		}
 

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -30,8 +30,10 @@ func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, cl
 	if len(targetVectors) == 0 {
 		class := sch.FindClassByName(schema.ClassName(className))
 
-		// if no target vectors provided, check whether we have legacy index configured
-		if hasLegacyVectorIndex(class) {
+		// If no target vectors provided, check whether we have legacy index configured.
+		// Additionally, we have to return empty target vector if no named vectors are configured on
+		// the class for backwards compatibility reasons.
+		if hasLegacyVectorIndex(class) || len(targetVectors) == 0 {
 			return []string{""}, nil
 		}
 


### PR DESCRIPTION
### What's being changed:

Improve the logic to select a legacy vector in case no target vectors were specified in query when the collection has mixed vector configuration.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
