### PR TITLE
fix: add mixed vector support in near queries

### DIFF
--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -400,6 +400,7 @@ func (c *RemoteIndex) MultiGetObjects(ctx context.Context, hostName, indexName,
 func (c *RemoteIndex) SearchShard(ctx context.Context, host, index, shard string,
 	vector []models.Vector,
 	targetVector []string,
+	distance float32,
 	limit int,
 	filters *filters.LocalFilter,
 	keywordRanking *searchparams.KeywordRanking,
@@ -412,7 +413,7 @@ func (c *RemoteIndex) SearchShard(ctx context.Context, host, index, shard string
 ) ([]*storobj.Object, []float32, error) {
 	// new request
 	body, err := clusterapi.IndicesPayloads.SearchParams.
-		Marshal(vector, targetVector, limit, filters, keywordRanking, sort, cursor, groupBy, additional, targetCombination, properties)
+		Marshal(vector, targetVector, distance, limit, filters, keywordRanking, sort, cursor, groupBy, additional, targetCombination, properties)
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshal request payload: %w", err)
 	}

--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
-
 	"github.com/weaviate/weaviate/usecases/byteops"
 
 	"github.com/go-openapi/strfmt"
@@ -500,26 +499,11 @@ func (p *searchParametersPayload) UnmarshalJSON(data []byte) error {
 
 type searchParamsPayload struct{}
 
-func (p searchParamsPayload) Marshal(vectors []models.Vector, targetVectors []string, limit int,
+func (p searchParamsPayload) Marshal(vectors []models.Vector, targetVectors []string, distance float32, limit int,
 	filter *filters.LocalFilter, keywordRanking *searchparams.KeywordRanking,
 	sort []filters.Sort, cursor *filters.Cursor, groupBy *searchparams.GroupBy,
 	addP additional.Properties, targetCombination *dto.TargetCombination, properties []string,
 ) ([]byte, error) {
-	type params struct {
-		SearchVector      []float32                    `json:"searchVector"`
-		TargetVector      string                       `json:"targetVector"`
-		Limit             int                          `json:"limit"`
-		Filters           *filters.LocalFilter         `json:"filters"`
-		KeywordRanking    *searchparams.KeywordRanking `json:"keywordRanking"`
-		Sort              []filters.Sort               `json:"sort"`
-		Cursor            *filters.Cursor              `json:"cursor"`
-		GroupBy           *searchparams.GroupBy        `json:"groupBy"`
-		Additional        additional.Properties        `json:"additional"`
-		SearchVectors     []models.Vector              `json:"searchVectors"`
-		TargetVectors     []string                     `json:"targetVectors"`
-		TargetCombination *dto.TargetCombination       `json:"targetCombination"`
-		Properties        []string                     `json:"properties"`
-	}
 	var vector []float32
 	var targetVector string
 	// BC with pre 1.26
@@ -531,7 +515,7 @@ func (p searchParamsPayload) Marshal(vectors []models.Vector, targetVectors []st
 		}
 	}
 
-	par := params{vector, targetVector, limit, filter, keywordRanking, sort, cursor, groupBy, addP, vectors, targetVectors, targetCombination, properties}
+	par := searchParametersPayload{vector, targetVector, distance, limit, filter, keywordRanking, sort, cursor, groupBy, addP, vectors, targetVectors, targetCombination, properties}
 	return json.Marshal(par)
 }
 

--- a/adapters/handlers/rest/clusterapi/indices_payloads_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads_test.go
@@ -167,7 +167,7 @@ func TestBackwardCompatibilitySearch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
-			b126, err := payload.Marshal(tt.SearchVectors, tt.Targets, 10, nil, nil, nil, nil, nil, additional.Properties{}, nil, nil)
+			b126, err := payload.Marshal(tt.SearchVectors, tt.Targets, 0.7, 10, nil, nil, nil, nil, nil, additional.Properties{}, nil, nil)
 			require.Nil(t, err)
 
 			vecs, targets, _, _, _, _, _, _, _, _, _, _, err := payload.Unmarshal(b126)

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -206,7 +206,7 @@ func (f *fakeRemoteClient) MultiGetObjects(ctx context.Context, hostName, indexN
 }
 
 func (f *fakeRemoteClient) SearchShard(ctx context.Context, hostName, indexName,
-	shardName string, vector []models.Vector, targetVector []string, limit int,
+	shardName string, vector []models.Vector, targetVector []string, distance float32, limit int,
 	filters *filters.LocalFilter, _ *searchparams.KeywordRanking, sort []filters.Sort,
 	cursor *filters.Cursor, groupBy *searchparams.GroupBy, additional additional.Properties, targetCombination *dto.TargetCombination,
 	properties []string,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1488,10 +1488,9 @@ func (i *Index) objectSearchByShard(ctx context.Context, limit int, filters *fil
 						"local shard object search %s: %w", shard.ID(), err)
 				}
 				nodeName = i.getSchema.NodeName()
-
 			} else {
 				objs, scores, nodeName, err = i.remote.SearchShard(
-					ctx, shardName, nil, nil, limit, filters, keywordRanking,
+					ctx, shardName, nil, nil, 0, limit, filters, keywordRanking,
 					sort, cursor, nil, addlProps, i.replicationEnabled(), nil, properties)
 				if err != nil {
 					return fmt.Errorf(
@@ -1651,7 +1650,7 @@ func (i *Index) localShardSearch(ctx context.Context, searchVectors []models.Vec
 }
 
 func (i *Index) remoteShardSearch(ctx context.Context, searchVectors []models.Vector,
-	targetVectors []string, limit int, localFilters *filters.LocalFilter,
+	targetVectors []string, distance float32, limit int, localFilters *filters.LocalFilter,
 	sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties,
 	targetCombination *dto.TargetCombination, properties []string, shardName string,
 ) ([]*storobj.Object, []float32, error) {
@@ -1669,7 +1668,7 @@ func (i *Index) remoteShardSearch(ctx context.Context, searchVectors []models.Ve
 	if i.Config.ForceFullReplicasSearch {
 		// Force a search on all the replicas for the shard
 		remoteSearchResults, err := i.remote.SearchAllReplicas(ctx,
-			i.logger, shardName, searchVectors, targetVectors, limit, localFilters,
+			i.logger, shardName, searchVectors, targetVectors, distance, limit, localFilters,
 			nil, sort, nil, groupBy, additional, i.replicationEnabled(), i.getSchema.NodeName(), targetCombination, properties)
 		// Only return an error if we failed to query remote shards AND we had no local shard to query
 		if err != nil && shard == nil {
@@ -1686,7 +1685,7 @@ func (i *Index) remoteShardSearch(ctx context.Context, searchVectors []models.Ve
 	} else {
 		// Search only what is necessary
 		remoteResult, remoteDists, nodeName, err := i.remote.SearchShard(ctx,
-			shardName, searchVectors, targetVectors, limit, localFilters,
+			shardName, searchVectors, targetVectors, distance, limit, localFilters,
 			nil, sort, nil, groupBy, additional, i.replicationEnabled(), targetCombination, properties)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "remote shard %s", shardName)
@@ -1779,7 +1778,7 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 			remoteSearches++
 			eg.Go(func() error {
 				// If we have no local shard or if we force the query to reach all replicas
-				remoteShardObject, remoteShardScores, err2 := i.remoteShardSearch(ctx, searchVectors, targetVectors, limit, localFilters, sort, groupBy, additionalProps, targetCombination, properties, shardName)
+				remoteShardObject, remoteShardScores, err2 := i.remoteShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, additionalProps, targetCombination, properties, shardName)
 				if err2 != nil {
 					return fmt.Errorf(
 						"remote shard object search %s: %w", shardName, err2)

--- a/entities/schema/checks/class.go
+++ b/entities/schema/checks/class.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package checks
 
 import "github.com/weaviate/weaviate/entities/models"

--- a/entities/schema/checks/class.go
+++ b/entities/schema/checks/class.go
@@ -1,0 +1,8 @@
+package checks
+
+import "github.com/weaviate/weaviate/entities/models"
+
+// HasLegacyVectorIndex checks whether there is a configured legacy vector index on a class.
+func HasLegacyVectorIndex(class *models.Class) bool {
+	return class.Vectorizer != "" || class.VectorIndexConfig != nil || class.VectorIndexType != ""
+}

--- a/entities/schema/checks/class_test.go
+++ b/entities/schema/checks/class_test.go
@@ -1,0 +1,51 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestHasLegacyVectorIndex(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		class *models.Class
+		want  bool
+	}{
+		{
+			name: "all fields are empty or nil",
+			class: &models.Class{
+				Vectorizer:        "",
+				VectorIndexConfig: nil,
+				VectorIndexType:   "",
+			},
+			want: false,
+		},
+		{
+			name: "Vectorizer is not empty",
+			class: &models.Class{
+				Vectorizer: "some_vectorizer",
+			},
+			want: true,
+		},
+		{
+			name: "VectorIndexConfig is not nil",
+			class: &models.Class{
+				VectorIndexConfig: map[string]interface{}{"distance": "cosine"},
+			},
+			want: true,
+		},
+		{
+			name: "VectorIndexType is not empty",
+			class: &models.Class{
+				VectorIndexType: "hnsw",
+			},
+			want: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, HasLegacyVectorIndex(tt.class))
+		})
+	}
+}

--- a/entities/schema/checks/class_test.go
+++ b/entities/schema/checks/class_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package checks
 
 import (

--- a/entities/schema/config/vector_index_config.go
+++ b/entities/schema/config/vector_index_config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 )
 
 type VectorIndexConfig interface {
@@ -25,14 +26,16 @@ type VectorIndexConfig interface {
 }
 
 func TypeAssertVectorIndex(class *models.Class, targetVectors []string) ([]VectorIndexConfig, error) {
-	if len(class.VectorConfig) == 0 {
+	if len(class.VectorConfig) == 0 || (schemachecks.HasLegacyVectorIndex(class) && len(targetVectors) == 0) {
 		vectorIndexConfig, ok := class.VectorIndexConfig.(VectorIndexConfig)
 		if !ok {
 			return nil, fmt.Errorf("class '%s' vector index: config is not schema.VectorIndexConfig: %T",
 				class.Class, class.VectorIndexConfig)
 		}
 		return []VectorIndexConfig{vectorIndexConfig}, nil
-	} else if len(class.VectorConfig) == 1 {
+	}
+
+	if len(class.VectorConfig) == 1 {
 		var vectorConfig models.VectorConfig
 		for _, v := range class.VectorConfig {
 			vectorConfig = v
@@ -44,24 +47,24 @@ func TypeAssertVectorIndex(class *models.Class, targetVectors []string) ([]Vecto
 				class.Class, class.VectorIndexConfig)
 		}
 		return []VectorIndexConfig{vectorIndexConfig}, nil
-	} else {
-		if len(targetVectors) == 0 {
-			return nil, errors.Errorf("multiple vector configs found for class '%s', but no target vector specified", class.Class)
-		}
-
-		configs := make([]VectorIndexConfig, 0, len(targetVectors))
-		for _, targetVector := range targetVectors {
-			vectorConfig, ok := class.VectorConfig[targetVector]
-			if !ok {
-				return nil, errors.Errorf("vector config not found for target vector: %s", targetVector)
-			}
-			vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(VectorIndexConfig)
-			if !ok {
-				return nil, fmt.Errorf("targetVector '%s' vector index: config is not schema.VectorIndexConfig: %T",
-					targetVector, class.VectorIndexConfig)
-			}
-			configs = append(configs, vectorIndexConfig)
-		}
-		return configs, nil
 	}
+
+	if len(targetVectors) == 0 {
+		return nil, errors.Errorf("multiple vector configs found for class '%s', but no target vector specified", class.Class)
+	}
+
+	configs := make([]VectorIndexConfig, 0, len(targetVectors))
+	for _, targetVector := range targetVectors {
+		vectorConfig, ok := class.VectorConfig[targetVector]
+		if !ok {
+			return nil, errors.Errorf("vector config not found for target vector: %s", targetVector)
+		}
+		vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(VectorIndexConfig)
+		if !ok {
+			return nil, fmt.Errorf("targetVector '%s' vector index: config is not schema.VectorIndexConfig: %T",
+				targetVector, class.VectorIndexConfig)
+		}
+		configs = append(configs, vectorIndexConfig)
+	}
+	return configs, nil
 }

--- a/test/acceptance_with_go_client/helper.go
+++ b/test/acceptance_with_go_client/helper.go
@@ -92,22 +92,20 @@ func GetVectors(t *testing.T,
 
 		for _, targetVector := range targetVectors {
 			if targetVector == "" {
-				targetVectorsMap[""] = parseVector(additional["vector"])
+				targetVectorsMap[""] = parseVector(t, additional["vector"])
 				continue
 			}
 
-			targetVectorsMap[targetVector] = parseVector(vectors[targetVector])
+			targetVectorsMap[targetVector] = parseVector(t, vectors[targetVector])
 		}
 	}
 
 	return targetVectorsMap
 }
 
-func parseVector(data interface{}) models.Vector {
+func parseVector(t *testing.T, data interface{}) models.Vector {
 	vector, ok := data.([]interface{})
-	if !ok {
-		panic(fmt.Sprintf("unexpected vector types in GraphQL response: %T", data))
-	}
+	require.Truef(t, ok, "unexpected vector types in GraphQL response: %T", data)
 
 	var multiVector [][]float32
 	var vec []float32

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors.go
@@ -18,7 +18,7 @@ import (
 func AllMixedVectorsTests(endpoint string) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("schema", testMixedVectorsCreateSchema(endpoint))
-		t.Run("object", testMixedVectorsCreateObject(endpoint))
+		t.Run("object", testMixedVectorsObject(endpoint))
 		t.Run("hybrid", testMixedVectorsHybrid(endpoint))
 		t.Run("aggregate", testMixedVectorsAggregate(endpoint))
 	}

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_aggregate.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_aggregate.go
@@ -22,76 +22,31 @@ import (
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
-	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 func testMixedVectorsAggregate(host string) func(t *testing.T) {
 	return func(t *testing.T) {
-		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
-		require.Nil(t, err)
 		ctx := context.Background()
 
-		classAggregate := "NamedAggregateTest"
-
-		// delete class if exists and cleanup after test
-		err = client.Schema().ClassDeleter().WithClassName(classAggregate).Do(ctx)
-		require.Nil(t, err)
-
-		defer client.Schema().ClassDeleter().WithClassName(classAggregate).Do(ctx)
-
-		contextionaryConfig := map[string]interface{}{
-			"text2vec-contextionary": map[string]interface{}{
-				"vectorizeClassName": false,
-				"properties":         []string{"text"},
-			},
-		}
-
-		// create class and objects
-		class := &models.Class{
-			Class: classAggregate,
-			Properties: []*models.Property{
-				{
-					Name: "text", DataType: []string{schema.DataTypeText.String()},
-				},
-				{
-					Name: "number", DataType: []string{schema.DataTypeInt.String()},
-				},
-			},
-			Vectorizer:      text2vecContextionary,
-			VectorIndexType: "hnsw",
-			ModuleConfig:    contextionaryConfig,
-			VectorConfig: map[string]models.VectorConfig{
-				"first": {
-					Vectorizer:      contextionaryConfig,
-					VectorIndexType: "hnsw",
-				},
-				"second": {
-					Vectorizer: map[string]interface{}{
-						text2vecTransformers: map[string]interface{}{},
-					},
-					VectorIndexType: "hnsw",
-				},
-			},
-		}
-		require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
-
-		_, err = client.Schema().ClassGetter().WithClassName(classAggregate).Do(ctx)
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
 		require.NoError(t, err)
 
+		require.NoError(t, client.Schema().AllDeleter().Do(ctx))
+		class := createMixedVectorsSchema(t, client)
+
 		creator := client.Data().Creator()
-		_, err = creator.WithClassName(classAggregate).WithID(id1).
+		_, err = creator.WithClassName(class.Class).WithID(id1).
 			WithProperties(map[string]any{"text": "Hello", "number": 1}).
 			Do(ctx)
 		require.NoError(t, err)
 
-		_, err = creator.WithClassName(classAggregate).WithID(id2).
+		_, err = creator.WithClassName(class.Class).WithID(id2).
 			WithProperties(map[string]any{"text": "World", "number": 2}).
 			Do(ctx)
 		require.NoError(t, err)
 
-		testAllObjectsIndexed(t, client, classAggregate)
-		for _, targetVector := range []string{"", "first"} {
+		testAllObjectsIndexed(t, client, class.Class)
+		for _, targetVector := range []string{"", contextionary} {
 			t.Run(fmt.Sprintf("vector=%q", targetVector), func(t *testing.T) {
 				no := &graphql.NearObjectArgumentBuilder{}
 				no = no.WithID(id1).WithCertainty(0.9)
@@ -101,13 +56,13 @@ func testMixedVectorsAggregate(host string) func(t *testing.T) {
 
 				agg, err := client.GraphQL().
 					Aggregate().
-					WithClassName(classAggregate).
+					WithClassName(class.Class).
 					WithNearObject(no).
 					WithFields(graphql.Field{Name: "number", Fields: []graphql.Field{{Name: "maximum"}}}).
 					Do(ctx)
 				require.NoError(t, err)
 
-				maximums := acceptance_with_go_client.ExtractGraphQLField[float64](t, agg, "Aggregate", classAggregate, "number", "maximum")
+				maximums := acceptance_with_go_client.ExtractGraphQLField[float64](t, agg, "Aggregate", class.Class, "number", "maximum")
 				assert.Equal(t, []float64{1}, maximums)
 			})
 		}

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
@@ -17,52 +17,15 @@ import (
 
 	acceptance_with_go_client "acceptance_tests_with_client"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
-	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 func testMixedVectorsHybrid(host string) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			ctx = context.Background()
-
-			class = &models.Class{
-				Class: "TestClass",
-				Properties: []*models.Property{
-					{
-						Name: "text", DataType: []string{schema.DataTypeText.String()},
-					},
-					{
-						Name: "text2", DataType: []string{schema.DataTypeText.String()},
-					},
-				},
-				Vectorizer:      text2vecContextionary,
-				VectorIndexType: "hnsw",
-				VectorConfig: map[string]models.VectorConfig{
-					transformers: {
-						Vectorizer: map[string]interface{}{
-							text2vecTransformers: map[string]interface{}{
-								"vectorizeClassName": false,
-								"sourceProperties":   []string{"text"},
-							},
-						},
-						VectorIndexType: "flat",
-					},
-					contextionary: {
-						Vectorizer: map[string]interface{}{
-							text2vecContextionary: map[string]interface{}{
-								"vectorizeClassName": false,
-								"sourceProperties":   []string{"text2"},
-							},
-						},
-						VectorIndexType: "flat",
-					},
-				},
-			}
 
 			field = graphql.Field{
 				Name: "_additional",
@@ -75,30 +38,19 @@ func testMixedVectorsHybrid(host string) func(t *testing.T) {
 		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
 		require.Nil(t, err)
 
-		cleanup := func() {
-			err := client.Schema().ClassDeleter().WithClassName(class.Class).Do(context.Background())
-			require.Nil(t, err)
-		}
-
-		// create class
-		err = client.Schema().ClassCreator().WithClass(class).Do(ctx)
-		defer cleanup()
-		require.NoError(t, err)
+		require.NoError(t, client.Schema().AllDeleter().Do(context.Background()))
+		class := createMixedVectorsSchema(t, client)
 
 		// insert objects
 		for _, id := range []string{id1, id2} {
-			objWrapper, err := client.Data().Creator().
+			_, err = client.Data().Creator().
 				WithClassName(class.Class).
 				WithID(id).
 				WithProperties(map[string]interface{}{
 					"text": "Some text goes here",
 				}).
 				Do(ctx)
-
 			require.NoError(t, err)
-			require.NotNil(t, objWrapper)
-			assert.NotEmpty(t, objWrapper.Object.Vector)
-			assert.Len(t, objWrapper.Object.Vectors, 2)
 		}
 
 		namedResp, err := client.GraphQL().Get().

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -171,7 +171,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 			}
 		})
 
-		t.Run("update object", func(t *testing.T) {
+		t.Run("update object with merge", func(t *testing.T) {
 			vectorsToCheck := []string{"", contextionary}
 			beforeUpdate := getVectors(t, client, class.Class, id1, vectorsToCheck...)
 			require.NoError(t, client.Data().Updater().

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -60,11 +60,6 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 		}
 		testAllObjectsIndexed(t, client, class.Class)
 
-		vectors := getVectors(t, client, class.Class, id1, contextionary)
-		require.Len(t, vectors, 1)
-		require.Len(t, vectors[contextionary], 300)
-		obj1C11YVector := vectors[contextionary].([]float32)
-
 		t.Run("get object", func(t *testing.T) {
 			objWrappers, err := client.Data().ObjectsGetter().
 				WithClassName(class.Class).
@@ -132,6 +127,11 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				})
 
 				t.Run("nearVector search", func(t *testing.T) {
+					vectors := getVectors(t, client, class.Class, id1, contextionary)
+					require.Len(t, vectors, 1)
+					require.Len(t, vectors[contextionary], 300)
+					obj1C11YVector := vectors[contextionary].([]float32)
+
 					nearVector := client.GraphQL().NearVectorArgBuilder().
 						WithVector(obj1C11YVector).
 						WithCertainty(0.9)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
 
@@ -59,17 +58,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				Do(context.Background())
 			require.NoError(t, err)
 		}
-
 		testAllObjectsIndexed(t, client, class.Class)
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			res, err := client.GraphQL().Get().WithClassName(class.Class).
-				WithNearText(client.GraphQL().
-					NearTextArgBuilder().
-					WithConcepts([]string{"book"})).
-				WithFields(idField).Do(ctx)
-			require.NoError(ct, err)
-			require.Len(ct, acceptance_with_go_client.GetIds(t, res, class.Class), 2)
-		}, 5*time.Second, 100*time.Millisecond)
 
 		t.Run("get object", func(t *testing.T) {
 			objWrappers, err := client.Data().ObjectsGetter().
@@ -121,17 +110,15 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				})
 
 				t.Run("nearObject search", func(t *testing.T) {
-					nearObject := client.GraphQL().NearObjectArgBuilder().
-						WithID(id1).
-						WithCertainty(0.9)
-
+					nearObject := client.GraphQL().NearObjectArgBuilder().WithID(id1)
 					if targetVector != "" {
 						nearObject = nearObject.WithTargetVectors(targetVector)
 					}
 
 					res, err := client.GraphQL().Get().WithClassName(class.Class).
 						WithNearObject(nearObject).
-						WithFields(idField).Do(ctx)
+						WithFields(idField).
+						WithLimit(1).Do(ctx)
 					require.NoError(t, err)
 
 					require.Equal(t, []string{id1}, acceptance_with_go_client.GetIds(t, res, class.Class))

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -58,6 +58,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				Do(context.Background())
 			require.NoError(t, err)
 		}
+		testAllObjectsIndexed(t, client, class.Class)
 
 		vectors := getVectors(t, client, class.Class, id1, contextionary)
 		require.Len(t, vectors, 1)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -63,9 +63,9 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 		testAllObjectsIndexed(t, client, class.Class)
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			res, err := client.GraphQL().Get().WithClassName(class.Class).
-				WithNearText(client.GraphQL().NearTextArgBuilder().
-					WithConcepts([]string{"book"}).
-					WithCertainty(0.9)).
+				WithNearText(client.GraphQL().
+					NearTextArgBuilder().
+					WithConcepts([]string{"book"})).
 				WithFields(idField).Do(ctx)
 			require.NoError(ct, err)
 			require.Len(ct, acceptance_with_go_client.GetIds(t, res, class.Class), 2)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -95,8 +95,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				t.Run("nearText search", func(t *testing.T) {
 					nearText := client.GraphQL().NearTextArgBuilder().
 						WithConcepts([]string{"book"}).
-						WithCertainty(0.9).
-						WithTargetVectors()
+						WithCertainty(0.9)
 
 					if targetVector != "" {
 						nearText = nearText.WithTargetVectors(targetVector)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -89,6 +89,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 			require.Len(t, resultVectors[""], 300)
 			require.Len(t, resultVectors[transformers], 384)
 		})
+
 		for _, targetVector := range []string{"", contextionary} {
 			t.Run(fmt.Sprintf("targetVector=%q", targetVector), func(t *testing.T) {
 				t.Run("nearText search", func(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects.go
@@ -15,9 +15,12 @@ import (
 	"context"
 	"testing"
 
+	acceptance_with_go_client "acceptance_tests_with_client"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -128,6 +131,24 @@ func testCreateObject(host string) func(t *testing.T) {
 					resultVectors := getVectorsWithNearObjectWithCertainty(t, client, className, id1, nearObject, c11y)
 					require.NotEmpty(t, resultVectors[c11y])
 				})
+			})
+
+			t.Run("nearText with certainty limit", func(t *testing.T) {
+				nearText := client.GraphQL().NearTextArgBuilder().
+					WithTargetVectors(c11y).
+					WithConcepts([]string{"book"}).
+					WithCertainty(0.9)
+
+				res, err := client.GraphQL().Get().
+					WithClassName(className).
+					WithNearText(nearText).
+					WithFields(graphql.Field{
+						Name:   "_additional",
+						Fields: []graphql.Field{{Name: "id"}},
+					}).
+					Do(ctx)
+				require.NoError(t, err)
+				require.Equal(t, []string{id1}, acceptance_with_go_client.GetIds(t, res, className))
 			})
 
 			t.Run("delete 1 object", func(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
@@ -262,9 +262,30 @@ func getVectorsWithNearArgs(t *testing.T, client *wvt.Client,
 		Name: "_additional",
 		Fields: []graphql.Field{
 			{Name: "id"},
-			{Name: fmt.Sprintf("vectors{%s}", strings.Join(targetVectors, " "))},
 		},
 	}
+
+	var (
+		requireLegacyVector   bool
+		filteredTargetVectors []string
+	)
+	for _, targetVector := range targetVectors {
+		if targetVector == "" {
+			requireLegacyVector = true
+		} else {
+			filteredTargetVectors = append(filteredTargetVectors, targetVector)
+		}
+	}
+
+	if requireLegacyVector {
+		field.Fields = append(field.Fields, graphql.Field{Name: "vector"})
+	}
+
+	if len(filteredTargetVectors) > 0 {
+		vectors := fmt.Sprintf("vectors{%s}", strings.Join(filteredTargetVectors, " "))
+		field.Fields = append(field.Fields, graphql.Field{Name: vectors})
+	}
+
 	if withCertainty {
 		field.Fields = append(field.Fields, graphql.Field{Name: "certainty"})
 	}

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -425,7 +425,7 @@ func (f *fakeRemoteClient) MergeObject(ctx context.Context, hostName, indexName,
 }
 
 func (f *fakeRemoteClient) SearchShard(ctx context.Context, hostName, indexName,
-	shardName string, vector []models.Vector, targetVector []string, limit int, filters *filters.LocalFilter,
+	shardName string, vector []models.Vector, targetVector []string, distance float32, limit int, filters *filters.LocalFilter,
 	keywordRanking *searchparams.KeywordRanking, sort []filters.Sort,
 	cursor *filters.Cursor, groupBy *searchparams.GroupBy, additional additional.Properties, targetCombination *dto.TargetCombination,
 	properties []string,

--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -19,12 +19,13 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 )
 
 // SetClassDefaults sets the module-specific defaults for the class itself, but
 // also for each prop
 func (p *Provider) SetClassDefaults(class *models.Class) {
-	if hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
+	if schemachecks.HasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 		p.setClassDefaults(class, class.Vectorizer, "", func(vectorizerConfig map[string]interface{}) {
 			if class.ModuleConfig == nil {
 				class.ModuleConfig = map[string]interface{}{}
@@ -93,7 +94,7 @@ func (p *Provider) SetSinglePropertyDefaults(class *models.Class,
 	props ...*models.Property,
 ) {
 	for _, prop := range props {
-		if hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
+		if schemachecks.HasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 			p.setSinglePropertyDefaults(prop, class.Vectorizer)
 		}
 
@@ -294,8 +295,4 @@ func (p *Provider) validateVectorConfig(class *models.Class, moduleName string, 
 		}
 		class.VectorConfig[targetVector].Vectorizer.(map[string]interface{})[moduleName].(map[string]interface{})["properties"] = propsTyped
 	}
-}
-
-func hasLegacyVectorIndex(class *models.Class) bool {
-	return class.Vectorizer != ""
 }

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/weaviate/weaviate/entities/dto"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -926,6 +927,10 @@ func (p *Provider) getTargetVector(class *models.Class, params interface{}) ([]s
 		return nearParam.GetTargetVectors(), nil
 	}
 	if class != nil {
+		if schemachecks.HasLegacyVectorIndex(class) {
+			return []string{""}, nil
+		}
+
 		if len(class.VectorConfig) > 1 {
 			return nil, fmt.Errorf("multiple vectorizers configuration found, please specify target vector name")
 		}

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
@@ -525,7 +526,7 @@ func (p *Provider) getModuleConfigs(class *models.Class) (map[string]map[string]
 		modConfigs[name] = modConfig
 	}
 
-	if hasLegacyVectorIndex(class) && class.Vectorizer != config.VectorizerModuleNone {
+	if schemachecks.HasLegacyVectorIndex(class) && class.Vectorizer != config.VectorizerModuleNone {
 		if modConfig, ok := class.ModuleConfig.(map[string]interface{}); ok {
 			modConfigs[""] = modConfig
 		} else {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/backup"
@@ -328,9 +329,8 @@ func (m *Handler) setNewClassDefaults(class *models.Class, globalCfg replication
 func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.GlobalConfig) error {
 	// set legacy vector index defaults only when:
 	// 	- no target vectors are configured
-	//  - OR, there are target vectors configured AND there are hints that legacy index is also needed
-	legacyVectorIndexConfigured := class.Vectorizer != "" || class.VectorIndexType != "" || class.VectorIndexConfig != nil
-	if !hasTargetVectors(class) || legacyVectorIndexConfigured {
+	//  - OR, there are target vectors configured AND there is a legacy vector configured
+	if !hasTargetVectors(class) || schemachecks.HasLegacyVectorIndex(class) {
 		if class.Vectorizer == "" {
 			class.Vectorizer = h.config.DefaultVectorizerModule
 		}

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -84,7 +84,7 @@ type RemoteIndexClient interface {
 	MultiGetObjects(ctx context.Context, hostname, indexName, shardName string,
 		ids []strfmt.UUID) ([]*storobj.Object, error)
 	SearchShard(ctx context.Context, hostname, indexName, shardName string,
-		searchVector []models.Vector, targetVector []string, limit int, filters *filters.LocalFilter,
+		searchVector []models.Vector, targetVector []string, distance float32, limit int, filters *filters.LocalFilter,
 		keywordRanking *searchparams.KeywordRanking, sort []filters.Sort,
 		cursor *filters.Cursor, groupBy *searchparams.GroupBy,
 		additional additional.Properties, targetCombination *dto.TargetCombination, properties []string,
@@ -258,6 +258,7 @@ func (ri *RemoteIndex) SearchAllReplicas(ctx context.Context,
 	shard string,
 	queryVec []models.Vector,
 	targetVector []string,
+	distance float32,
 	limit int,
 	filters *filters.LocalFilter,
 	keywordRanking *searchparams.KeywordRanking,
@@ -272,7 +273,7 @@ func (ri *RemoteIndex) SearchAllReplicas(ctx context.Context,
 ) ([]ReplicasSearchResult, error) {
 	remoteShardQuery := func(node, host string) (ReplicasSearchResult, error) {
 		objs, scores, err := ri.client.SearchShard(ctx, host, ri.class, shard,
-			queryVec, targetVector, limit, filters, keywordRanking, sort, cursor, groupBy, adds, targetCombination, properties)
+			queryVec, targetVector, distance, limit, filters, keywordRanking, sort, cursor, groupBy, adds, targetCombination, properties)
 		if err != nil {
 			return ReplicasSearchResult{}, err
 		}
@@ -284,6 +285,7 @@ func (ri *RemoteIndex) SearchAllReplicas(ctx context.Context,
 func (ri *RemoteIndex) SearchShard(ctx context.Context, shard string,
 	queryVec []models.Vector,
 	targetVector []string,
+	distance float32,
 	limit int,
 	filters *filters.LocalFilter,
 	keywordRanking *searchparams.KeywordRanking,
@@ -301,7 +303,7 @@ func (ri *RemoteIndex) SearchShard(ctx context.Context, shard string,
 	}
 	f := func(node, host string) (interface{}, error) {
 		objs, scores, err := ri.client.SearchShard(ctx, host, ri.class, shard,
-			queryVec, targetVector, limit, filters, keywordRanking, sort, cursor, groupBy, adds, targetCombination, properties)
+			queryVec, targetVector, distance, limit, filters, keywordRanking, sort, cursor, groupBy, adds, targetCombination, properties)
 		if err != nil {
 			return nil, err
 		}

--- a/usecases/traverser/target_vector_param_helper.go
+++ b/usecases/traverser/target_vector_param_helper.go
@@ -15,9 +15,9 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate/entities/dto"
-	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 )
 
 type TargetVectorParamHelper struct{}
@@ -32,7 +32,7 @@ func (t *TargetVectorParamHelper) GetTargetVectorOrDefault(sch schema.Schema, cl
 
 		// If no target vectors provided, check whether legacy vector is configured.
 		// For backwards compatibility, we have to return legacy vector in case no named vectors configured.
-		if hasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
+		if schemachecks.HasLegacyVectorIndex(class) || len(class.VectorConfig) == 0 {
 			return []string{""}, nil
 		}
 
@@ -68,8 +68,4 @@ func (t *TargetVectorParamHelper) GetTargetVectorsFromParams(params dto.GetParam
 		}
 	}
 	return []string{}
-}
-
-func hasLegacyVectorIndex(class *models.Class) bool {
-	return class.Vectorizer != "" || class.VectorIndexConfig != nil
 }


### PR DESCRIPTION
### What's being changed:
* Add acceptance tests for `near*` queries and fix found issues.
* Refactor tests and code a little bit.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
