### PR TITLE
Fix class capitalisation in batch with autoschema

### DIFF
--- a/adapters/handlers/grpc/v1/batch_parse_request.go
+++ b/adapters/handlers/grpc/v1/batch_parse_request.go
@@ -43,6 +43,7 @@ func BatchFromProto(req *pb.BatchObjectsRequest, authorizedGetClass func(string,
 	for i, obj := range objectsBatch {
 		var props map[string]interface{}
 
+		obj.Collection = schema.UppercaseClassName(obj.Collection)
 		class, err := authorizedGetClass(obj.Collection, obj.Tenant)
 		if err != nil {
 			objectErrors[insertCounter] = err
@@ -139,6 +140,7 @@ func extractMultiRefTarget(class *models.Class, properties []*pb.BatchObject_Mul
 			return fmt.Errorf("target is a single-target reference, need multi-target %v", prop.DataType)
 		}
 		beacons := make([]interface{}, len(refMulti.Uuids))
+		refMulti.TargetCollection = schema.UppercaseClassName(refMulti.TargetCollection)
 		for j, uid := range refMulti.Uuids {
 			beacons[j] = map[string]interface{}{"beacon": BEACON_START + refMulti.TargetCollection + "/" + uid}
 		}

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -77,8 +77,6 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 			return 0, ErrInvalidUserInput{validation.ErrorMissingClass}
 		}
 
-		object.Class = schema.UppercaseClassName(object.Class)
-
 		vclass := classes[object.Class]
 
 		schemaClass := vclass.Class
@@ -104,7 +102,7 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 				return 0, err
 			}
 
-			classes[schema.UppercaseClassName(object.Class)] = versioned.Class{Class: schemaClass, Version: schemaVersion}
+			classes[object.Class] = versioned.Class{Class: schemaClass, Version: schemaVersion}
 			classcache.RemoveClassFromContext(ctx, object.Class)
 		} else {
 			if newProperties := schema.DedupProperties(schemaClass.Properties, properties); len(newProperties) > 0 {
@@ -117,7 +115,7 @@ func (m *autoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 				if err != nil {
 					return 0, err
 				}
-				classes[schema.UppercaseClassName(object.Class)] = versioned.Class{Class: schemaClass, Version: schemaVersion}
+				classes[object.Class] = versioned.Class{Class: schemaClass, Version: schemaVersion}
 				classcache.RemoveClassFromContext(ctx, object.Class)
 			}
 		}
@@ -507,7 +505,7 @@ func (m *autoSchemaManager) autoTenants(ctx context.Context,
 	// skip invalid classes, non-MT classes, no auto tenant creation classes
 	var maxSchemaVersion uint64
 	for className, tenantNames := range classTenants {
-		vclass, exists := fetchedClasses[schema.UppercaseClassName(className)]
+		vclass, exists := fetchedClasses[className]
 		if !exists || // invalid class
 			vclass.Class == nil { // class is nil
 			continue

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/versioned"
 
 	"github.com/google/uuid"
@@ -37,6 +38,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
+		obj.Class = schema.UppercaseClassName(obj.Class)
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
 	}
 	knownClasses := map[string]versioned.Class{}


### PR DESCRIPTION
### What's being changed:

Currently there is a bug when batch inserting using autoschema of objects with uncapitalised collection names, e.g. `test_class`, when the collection already exists. This PR fixes this by ensuring that all object collection names are capitalised as high as possible in the stack before arriving at the autoschema logic

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
