### PR TITLE
chore: experimental flag to reject collection creation with mixed vectors

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/cluster/cluster_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/cluster/cluster_test.go
@@ -50,6 +50,7 @@ func TestNamedVectors_Cluster_AsyncIndexing(t *testing.T) {
 func createClusterEnvironment(ctx context.Context) (compose *docker.DockerCompose, err error) {
 	compose, err = test_suits.ComposeModules().
 		WithWeaviateCluster(3).
+		WithWeaviateEnv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS", "true").
 		Start(ctx)
 	return
 }
@@ -58,6 +59,7 @@ func createClusterEnvironmentAsyncIndexing(ctx context.Context) (compose *docker
 	compose, err = test_suits.ComposeModules().
 		WithWeaviateEnv("ASYNC_INDEXING", "true").
 		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "1s").
+		WithWeaviateEnv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS", "true").
 		WithWeaviateCluster(3).
 		Start(ctx)
 	return

--- a/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"acceptance_tests_with_client/named_vectors_tests/test_suits"
+	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -57,9 +59,36 @@ func TestNamedVectors_SingleNode_Restart(t *testing.T) {
 	t.Run("restart", test_suits.TestRestart(compose))
 }
 
+func TestNamedVectors_VerifyMixedSchemaIsRejectedWithoutEnvFlag(t *testing.T) {
+	compose, err := test_suits.ComposeModules().
+		WithWeaviate().
+		Start(context.Background())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
+	require.Nil(t, err)
+
+	err = client.Schema().ClassCreator().
+		WithClass(&models.Class{
+			Class: "MixedVectors",
+			VectorConfig: map[string]models.VectorConfig{
+				"contextionary": {
+					Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+					VectorIndexType: "hnsw",
+				},
+			},
+			VectorIndexType: "hnsw",
+			Vectorizer:      "text2vec-contextionary",
+		}).
+		Do(ctx)
+	require.ErrorContains(t, err, "class MixedVectors has configuration for both class level and named vectors which is currently not supported.")
+}
+
 func createSingleNodeEnvironment(ctx context.Context) (compose *docker.DockerCompose, err error) {
 	compose, err = test_suits.ComposeModules().
 		WithWeaviate().
+		WithWeaviateEnv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS", "true").
 		Start(ctx)
 	return
 }
@@ -68,6 +97,7 @@ func createSingleNodeEnvironmentAsyncIndexing(ctx context.Context) (compose *doc
 	compose, err = test_suits.ComposeModules().
 		WithWeaviateEnv("ASYNC_INDEXING", "true").
 		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "1s").
+		WithWeaviateEnv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS", "true").
 		WithWeaviate().
 		Start(ctx)
 	return

--- a/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"acceptance_tests_with_client/named_vectors_tests/test_suits"
+
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate/entities/models"
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -908,7 +908,7 @@ func validateVectorIndexConfigImmutableFields(initial, updated *models.Class) er
 // maybeAllowSchemasWithMixedVectors is a method to disable experimental functionality to create
 // collections that have both legacy and named vectors until development is not finished.
 func (h *Handler) maybeAllowSchemasWithMixedVectors(cls *models.Class) error {
-	featureDisabled := entcfg.Enabled(os.Getenv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS"))
+	featureDisabled := !entcfg.Enabled(os.Getenv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS"))
 	isMixedSchema := len(cls.VectorConfig) > 0 && (cls.Vectorizer != "" || cls.VectorIndexConfig != nil || cls.VectorIndexType != "")
 
 	if isMixedSchema && featureDisabled {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -908,7 +908,7 @@ func validateVectorIndexConfigImmutableFields(initial, updated *models.Class) er
 // maybeAllowSchemasWithMixedVectors is a method to disable experimental functionality to create
 // collections that have both legacy and named vectors until development is not finished.
 func (h *Handler) maybeAllowSchemasWithMixedVectors(cls *models.Class) error {
-	featureDisabled := os.Getenv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS") != "true"
+	featureDisabled := entcfg.Enabled(os.Getenv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS"))
 	isMixedSchema := len(cls.VectorConfig) > 0 && (cls.Vectorizer != "" || cls.VectorIndexConfig != nil || cls.VectorIndexType != "")
 
 	if isMixedSchema && featureDisabled {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -102,6 +102,10 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 		return nil, 0, err
 	}
 
+	if err = h.maybeAllowSchemasWithMixedVectors(cls); err != nil {
+		return nil, 0, err
+	}
+
 	classGetterWithAuth := func(name string) (*models.Class, error) {
 		if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.CollectionsMetadata(name)...); err != nil {
 			return nil, err
@@ -899,4 +903,17 @@ func validateVectorIndexConfigImmutableFields(initial, updated *models.Class) er
 			accessor: func(c *models.Class) string { return c.VectorIndexType },
 		},
 	}...)
+}
+
+// maybeAllowSchemasWithMixedVectors is a method to disable experimental functionality to create
+// collections that have both legacy and named vectors until development is not finished.
+func (h *Handler) maybeAllowSchemasWithMixedVectors(cls *models.Class) error {
+	featureDisabled := os.Getenv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS") != "true"
+	isMixedSchema := len(cls.VectorConfig) > 0 && (cls.Vectorizer != "" || cls.VectorIndexConfig != nil || cls.VectorIndexType != "")
+
+	if isMixedSchema && featureDisabled {
+		return errors.Errorf("class %s has configuration for both class level and named vectors which is currently not supported.", cls.Class)
+	}
+
+	return nil
 }

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -86,6 +87,8 @@ func Test_AddClass(t *testing.T) {
 	})
 
 	t.Run("happy path, mixed vectors", func(t *testing.T) {
+		require.NoError(t, os.Setenv("EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS", "true"))
+
 		handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 
 		class := &models.Class{


### PR DESCRIPTION
### What's being changed:
As the current state of backwards compatible named vectors is not production ready, we want to disable collection creation, which has mixed vector configuration during the upcoming 1.30 release.

The functionality can be enabled by setting `EXPERIMENTAL_BACKWARDS_COMPATIBLE_NAMED_VECTORS=true` flag to true when running database node.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
