### PR TITLE
Add new option --arm64-only into push-docker script.

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -499,7 +499,19 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref, 'refs/tags') && !startsWith(github.head_ref, 'build')  && !(github.head_ref == '') }} # no PRs from fork    
     name: push-docker-fast
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      preview-tags-amd64: ${{ steps.set-outputs.outputs.preview-tags-amd64 }}
+      semver-tags-amd64: ${{ steps.set-outputs.outputs.semver-tags-amd64 }}
+      preview-tags-arm64: ${{ steps.set-outputs.outputs.preview-tags-arm64 }}
+      semver-tags-arm64: ${{ steps.set-outputs.outputs.semver-tags-arm64 }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
@@ -509,11 +521,36 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Push container
         id: push-container
-        run: ./ci/push_docker.sh --amd64-only
+        run: ./ci/push_docker.sh --${{ matrix.arch }}-only
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
-      - name: Generate Report
-        env:
-          PREVIEW_TAG: "${{ steps.push-container.outputs.PREVIEW_TAG }}"
-          PREVIEW_SEMVER_TAG: "${{ steps.push-container.outputs.PREVIEW_SEMVER_TAG }}"
-        run: ./ci/generate_docker_report.sh
+      - name: Set architecture-specific outputs
+        id: set-outputs
+        run: |
+          # Unique output names per architecture
+          echo "preview-tags-${{ matrix.arch }}=${{ steps.push-container.outputs.PREVIEW_TAG }}" >> $GITHUB_OUTPUT
+          echo "semver-tags-${{ matrix.arch }}=${{ steps.push-container.outputs.PREVIEW_SEMVER_TAG }}" >> $GITHUB_OUTPUT
+  Generate-Docker-Report:
+    needs: [Push-Docker-Fast]
+    name: generate-docker-report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Combine tags
+        run: |
+          # Collect all architecture-specific outputs
+          ALL_PREVIEW_TAGS="${{ needs.Push-Docker-Fast.outputs.preview-tags-amd64 }}"
+          ALL_PREVIEW_TAGS+="\n${{ needs.Push-Docker-Fast.outputs.preview-tags-arm64 }}"
+          
+          ALL_SEMVER_TAGS="${{ needs.Push-Docker-Fast.outputs.semver-tags-amd64 }}"
+          ALL_SEMVER_TAGS+="\n${{ needs.Push-Docker-Fast.outputs.semver-tags-arm64 }}"
+
+          # Write to environment variables
+          echo "PREVIEW_TAG<<EOF" >> $GITHUB_ENV
+          echo -e "$ALL_PREVIEW_TAGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          echo "PREVIEW_SEMVER_TAG<<EOF" >> $GITHUB_ENV
+          echo -e "$ALL_SEMVER_TAGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: ./ci/generate_docker_report.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ ARG TARGETARCH
 ARG GITHASH="unknown"
 ARG DOCKER_IMAGE_TAG="unknown"
 ARG EXTRA_BUILD_ARGS=""
+ARG CGO_ENABLED=1
+# Allow disabling CGO when compiling for arm64
+ENV CGO_ENABLED=$CGO_ENABLED
 COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH go build $EXTRA_BUILD_ARGS \
       -ldflags '-w -extldflags "-static" \

--- a/ci/docker_report.md.tpl
+++ b/ci/docker_report.md.tpl
@@ -20,12 +20,12 @@ Preview builds make no promises about stability or feature completeness.  Use th
 
 ### Docker-compose
 
-You can obtain a [docker-compose.yaml here](https://weaviate.io/developers/weaviate/current/installation/docker-compose.html#configurator) and configure it to your liking. Then make sure to set `services.weaviate.image` to `$PREVIEW_TAG`. For example, like so:
+You can obtain a [docker-compose.yaml here](https://weaviate.io/developers/weaviate/current/installation/docker-compose.html#configurator) and configure it to your liking. Then make sure to set `services.weaviate.image` to `$FIRST_TAG`. For example, like so:
 
 ```yaml
 services:
   weaviate:
-    image: $PREVIEW_TAG
+    image: $FIRST_TAG
 ```
 
 ### Helm / Kubernetes

--- a/ci/generate_docker_report.sh
+++ b/ci/generate_docker_report.sh
@@ -3,16 +3,24 @@ set -e
 cd "${0%/*}"
 
 function generate_report() {
+  # Handle both single-line and multi-line tags
   echo "PREVIEW_TAG=$PREVIEW_TAG"
   if [ -z "$PREVIEW_TAG" ]; then
-    return
-  fi
-  echo "PREVIEW_SEMVER_TAG=$PREVIEW_SEMVER_TAG"
-  if [ -z "$PREVIEW_SEMVER_TAG" ]; then
+    echo "No preview tags found"
     return
   fi
 
-  export TAG_ONLY="$(echo "$PREVIEW_TAG" | cut -d ':' -f 2)"
+  echo "PREVIEW_SEMVER_TAG=$PREVIEW_SEMVER_TAG"
+  if [ -z "$PREVIEW_SEMVER_TAG" ]; then
+    echo "No semver tags found"
+    return
+  fi
+
+  # Extract first tag for examples (works for both single and multi-line)
+  export FIRST_TAG=$(echo "$PREVIEW_TAG" | head -n 1)
+  export TAG_ONLY="$(echo "$FIRST_TAG" | cut -d ':' -f 2)"
+
+  # Generate report using the template
   envsubst < docker_report.md.tpl >> "$GITHUB_STEP_SUMMARY"
 }
 


### PR DESCRIPTION
### What's being changed:

This commit adds a new option to build docker images and push then to Dockerhub.
Also, changes the behavior when a pull-request is created to leverage the matrix-strategy to run both, amd and arm build jobs. This way, if somebody needs an Intel based image the job will take less time to build and won't be blocked if the ARM build fails. ARM images will be build in ARM runners, removing the need for virtualization and to keep one tag for both images, we push each tag to an tag-arch (for example, 1.30.0-dev-92b06bf-arm64 and 1.30.0-dev-92b06bf-amd64) tag.

Also, it fixes the segmentation fault caused during multi-arch docker builds. The cause was a cross-platform issue when building musl on Alpine, requiring CGO_ENABLED=0:
https://docs.docker.com/docker-hub/image-library/trusted-content/#alpine-images

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
