### PR TITLE
enhance logic when checking properties is searchable or not

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -83,16 +83,16 @@ func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store,
 func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList,
 	className schema.ClassName, limit int, keywordRanking searchparams.KeywordRanking, additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
-	// WEAVIATE-471 - If a property is not searchable, return an error
-	for _, property := range keywordRanking.Properties {
-		if !PropertyHasSearchableIndex(b.getClass(className.String()), property) {
-			return nil, nil, inverted.NewMissingSearchableIndexError(property)
-		}
-	}
-
 	class := b.getClass(className.String())
 	if class == nil {
 		return nil, nil, fmt.Errorf("could not find class %s in schema", className)
+	}
+
+	// WEAVIATE-471 - If a property is not searchable, return an error
+	for _, property := range keywordRanking.Properties {
+		if !PropertyHasSearchableIndex(class, property) {
+			return nil, nil, inverted.NewMissingSearchableIndexError(property)
+		}
 	}
 
 	var objs []*storobj.Object


### PR DESCRIPTION
### What's being changed:
enhance #5888 
Notice that this issue has been solved, but the logic of code could be further enhanced.

Currently, The `for` loop makes the following `if` statement a little redundant because function `PropertyHasSearchableIndex`  will return `false` when its first argument is `nil`. What's worse, when the `Class` really does not exist, the `for` loop will make  function `BM25F` return misleading prompt("Is IndexSearchable option of property xxx enabled ?" rather than  "could not find class xxx in schema") to users.

As has been mentioned above, we had better check whether the `Class` exists or nor at first, and then check if the properties is `indexSearchable` or not
**Func PropertyHasSearchableIndex()  detail:**
<img width="549" alt="BM25F" src="https://github.com/user-attachments/assets/e97500e1-a874-4fb4-a872-15ecc3296e59" />

### Review checklist
- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
-->