### PR TITLE
Add new option --arm64-only into push-docker script.

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -500,7 +500,19 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork && !startsWith(github.ref, 'refs/tags') && !startsWith(github.head_ref, 'build')  && !(github.head_ref == '') }} # no PRs from fork    
     name: push-docker-fast
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      preview-tags-amd64: ${{ steps.set-outputs.outputs.preview-tags-amd64 }}
+      semver-tags-amd64: ${{ steps.set-outputs.outputs.semver-tags-amd64 }}
+      preview-tags-arm64: ${{ steps.set-outputs.outputs.preview-tags-arm64 }}
+      semver-tags-arm64: ${{ steps.set-outputs.outputs.semver-tags-arm64 }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
@@ -510,11 +522,36 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Push container
         id: push-container
-        run: ./ci/push_docker.sh --amd64-only
+        run: ./ci/push_docker.sh --${{ matrix.arch }}-only
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
-      - name: Generate Report
-        env:
-          PREVIEW_TAG: "${{ steps.push-container.outputs.PREVIEW_TAG }}"
-          PREVIEW_SEMVER_TAG: "${{ steps.push-container.outputs.PREVIEW_SEMVER_TAG }}"
-        run: ./ci/generate_docker_report.sh
+      - name: Set architecture-specific outputs
+        id: set-outputs
+        run: |
+          # Unique output names per architecture
+          echo "preview-tags-${{ matrix.arch }}=${{ steps.push-container.outputs.PREVIEW_TAG }}" >> $GITHUB_OUTPUT
+          echo "semver-tags-${{ matrix.arch }}=${{ steps.push-container.outputs.PREVIEW_SEMVER_TAG }}" >> $GITHUB_OUTPUT
+  Generate-Docker-Report:
+    needs: [Push-Docker-Fast]
+    name: generate-docker-report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Combine tags
+        run: |
+          # Collect all architecture-specific outputs
+          ALL_PREVIEW_TAGS="${{ needs.Push-Docker-Fast.outputs.preview-tags-amd64 }}"
+          ALL_PREVIEW_TAGS+="\n${{ needs.Push-Docker-Fast.outputs.preview-tags-arm64 }}"
+          
+          ALL_SEMVER_TAGS="${{ needs.Push-Docker-Fast.outputs.semver-tags-amd64 }}"
+          ALL_SEMVER_TAGS+="\n${{ needs.Push-Docker-Fast.outputs.semver-tags-arm64 }}"
+
+          # Write to environment variables
+          echo "PREVIEW_TAG<<EOF" >> $GITHUB_ENV
+          echo -e "$ALL_PREVIEW_TAGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          echo "PREVIEW_SEMVER_TAG<<EOF" >> $GITHUB_ENV
+          echo -e "$ALL_SEMVER_TAGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: ./ci/generate_docker_report.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ARG GIT_REVISION="unknown"
 ARG BUILD_USER="unknown"
 ARG BUILD_DATE="unknown"
 ARG EXTRA_BUILD_ARGS=""
+ARG CGO_ENABLED=1
+# Allow disabling CGO when compiling for arm64
+ENV CGO_ENABLED=$CGO_ENABLED
 COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH go build $EXTRA_BUILD_ARGS \
       -ldflags '-w -extldflags "-static" \

--- a/ci/docker_report.md.tpl
+++ b/ci/docker_report.md.tpl
@@ -20,12 +20,12 @@ Preview builds make no promises about stability or feature completeness.  Use th
 
 ### Docker-compose
 
-You can obtain a [docker-compose.yaml here](https://weaviate.io/developers/weaviate/current/installation/docker-compose.html#configurator) and configure it to your liking. Then make sure to set `services.weaviate.image` to `$PREVIEW_TAG`. For example, like so:
+You can obtain a [docker-compose.yaml here](https://weaviate.io/developers/weaviate/current/installation/docker-compose.html#configurator) and configure it to your liking. Then make sure to set `services.weaviate.image` to `$FIRST_TAG`. For example, like so:
 
 ```yaml
 services:
   weaviate:
-    image: $PREVIEW_TAG
+    image: $FIRST_TAG
 ```
 
 ### Helm / Kubernetes

--- a/ci/generate_docker_report.sh
+++ b/ci/generate_docker_report.sh
@@ -3,16 +3,24 @@ set -e
 cd "${0%/*}"
 
 function generate_report() {
+  # Handle both single-line and multi-line tags
   echo "PREVIEW_TAG=$PREVIEW_TAG"
   if [ -z "$PREVIEW_TAG" ]; then
-    return
-  fi
-  echo "PREVIEW_SEMVER_TAG=$PREVIEW_SEMVER_TAG"
-  if [ -z "$PREVIEW_SEMVER_TAG" ]; then
+    echo "No preview tags found"
     return
   fi
 
-  export TAG_ONLY="$(echo "$PREVIEW_TAG" | cut -d ':' -f 2)"
+  echo "PREVIEW_SEMVER_TAG=$PREVIEW_SEMVER_TAG"
+  if [ -z "$PREVIEW_SEMVER_TAG" ]; then
+    echo "No semver tags found"
+    return
+  fi
+
+  # Extract first tag for examples (works for both single and multi-line)
+  export FIRST_TAG=$(echo "$PREVIEW_TAG" | head -n 1)
+  export TAG_ONLY="$(echo "$FIRST_TAG" | cut -d ':' -f 2)"
+
+  # Generate report using the template
   envsubst < docker_report.md.tpl >> "$GITHUB_STEP_SUMMARY"
 }
 

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -3,12 +3,15 @@
 DOCKER_REPO="semitechnologies/weaviate"
 
 only_build_amd64=false
+only_build_arm64=false
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --amd64-only) only_build_amd64=true;;
+    --arm64-only) only_build_arm64=true;;
     --help|-h) printf '%s\n' \
       "Options:"\
       "--amd64-only"\
+      "--arm64-only"\
       "--help | -h"; exit 1;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
@@ -18,7 +21,10 @@ done
 function release() {
 
   # for multi-platform build
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  if [ "$only_build_amd64" == "false" ] && [ "$only_build_arm64" == "false" ]; then
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  fi
+
   docker buildx create --use
 
   tag_latest="${DOCKER_REPO}:latest"
@@ -31,6 +37,18 @@ function release() {
   build_user="ci"
   build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+  # Determine architecture and platform
+  arch=""
+  if $only_build_amd64; then
+    build_platform="linux/amd64"
+    arch="amd64"
+  elif $only_build_arm64; then
+    build_platform="linux/arm64"
+    arch="arm64"
+  else
+    build_platform="linux/amd64,linux/arm64"
+  fi
+
   weaviate_version="$(jq -r '.info.version' < openapi-specs/schema.json)"
   if [ "$GITHUB_REF_TYPE" == "tag" ]; then
       if [ "$GITHUB_REF_NAME" != "v$weaviate_version" ]; then
@@ -40,7 +58,11 @@ function release() {
       tag_exact="${DOCKER_REPO}:${weaviate_version}"
       git_branch="$GITHUB_REF_NAME"
   else
-    tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}"
+    if [ -n "$arch" ]; then
+      tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}-${arch}"
+    else
+      tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}"
+    fi
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
       git_branch="$GITHUB_REF_NAME"
@@ -49,18 +71,23 @@ function release() {
       weaviate_version="${branch_name}-${git_revision}"
       git_branch="$GITHUB_HEAD_REF"
     else
-      tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}"
+      if [ -n "$arch" ]; then
+        tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}-${arch}"
+      else
+        tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}"
+      fi
       weaviate_version="preview-${pr_title}-${git_revision}"
     fi
   fi
 
-  if $only_build_amd64; then
-    build_platform="linux/amd64"
-  else
-    build_platform="linux/amd64,linux/arm64"
-  fi
-
-  args=("--build-arg=GIT_REVISION=$git_revision" "--build-arg=GIT_BRANCH=$git_branch" "--build-arg=BUILD_USER=$build_user" "--build-arg=BUILD_DATE=$build_date" "--platform=$build_platform" "--target=weaviate" "--push")
+  args=("--build-arg=GIT_REVISION=$git_revision"
+        "--build-arg=GIT_BRANCH=$git_branch"
+        "--build-arg=BUILD_USER=$build_user"
+        "--build-arg=BUILD_DATE=$build_date"
+        "--build-arg=CGO_ENABLED=0" # Force-disable CGO for cross-compilation - Fixes segmentation faults on arm64 (https://docs.docker.com/docker-hub/image-library/trusted-content/#alpine-images)
+        "--platform=$build_platform"
+        "--target=weaviate"
+        "--push")
 
   if [ -n "$tag_exact" ]; then
     # exact tag on main


### PR DESCRIPTION
This commit adds a new option to build docker images and push then to Dockerhub.
Also, changes the behavior when a pull-request is created to leverage the matrix-strategy to run both, amd and arm build jobs. This way, if somebody needs an Intel based image the job will take less time to build and won't be blocked if the ARM build fails. ARM images will be build in ARM runners, removing the need for virtualization and to keep one tag for both images, we push each tag to an tag-arch (for example, 1.30.0-dev-92b06bf-arm64 and 1.30.0-dev-92b06bf-amd64) tag.

Also, it fixes the segmentation fault caused during multi-arch docker builds. The cause was a cross-platform issue when building musl on Alpine, requiring CGO_ENABLED=0:
https://docs.docker.com/docker-hub/image-library/trusted-content/#alpine-images

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
