### PR TITLE
Rename DYNAMIC_USERS_ENABLED env var.

### DIFF
--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -873,7 +873,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	}
 
 	if d.withWeaviateDynamicUsers {
-		settings["DYNAMIC_USERS_ENABLED"] = "true"
+		settings["AUTHENTICATION_DYNAMIC_USERS_ENABLED"] = "true"
 	}
 
 	if d.withAutoschema {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -164,10 +164,8 @@ func FromEnv(config *Config) error {
 		}
 	}
 
-	if entcfg.Enabled(os.Getenv("DYNAMIC_USERS_ENABLED")) {
+	if entcfg.Enabled(os.Getenv("AUTHENTICATION_DYNAMIC_USERS_ENABLED")) {
 		config.Authentication.DynamicUsers.Enabled = true
-	} else {
-		config.Authentication.DynamicUsers.Enabled = false
 	}
 
 	if entcfg.Enabled(os.Getenv("AUTHENTICATION_APIKEY_ENABLED")) {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -727,7 +727,7 @@ func TestEnvironmentAuthentication(t *testing.T) {
 		},
 		{
 			name:         "Enabled dynamic user",
-			auth_env_var: []string{"DYNAMIC_USERS_ENABLED"},
+			auth_env_var: []string{"AUTHENTICATION_DYNAMIC_USERS_ENABLED"},
 			expected: Authentication{
 				DynamicUsers: DynamicUsers{Enabled: true},
 			},


### PR DESCRIPTION
Renames the `DYNAMIC_USERS_ENABLED` environment variable into `AUTHENTICAION_USERS_ENABLED`.
Also solves also the overriding of the DynamicUsers.Enabled when the environment variable isn't defined.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
