### PR TITLE
Add more tests for openai with missing rate limit headers

### DIFF
--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -127,10 +127,43 @@ func TestClient(t *testing.T) {
 			Dimensions: 3,
 			Errors:     []error{nil},
 		}
-		res, _, _, err := c.Vectorize(context.Background(), []string{"This is my text"}, fakeClassConfig{classConfig: map[string]interface{}{"Type": "text", "Model": "ada"}})
+		res, rl, _, err := c.Vectorize(context.Background(), []string{"This is my text"}, fakeClassConfig{classConfig: map[string]interface{}{"Type": "text", "Model": "ada"}})
 
 		assert.Nil(t, err)
 		assert.Equal(t, expected, res)
+
+		assert.Equal(t, false, rl.UpdateWithMissingValues)
+		assert.Equal(t, 100, rl.RemainingTokens)
+		assert.Equal(t, 100, rl.RemainingRequests)
+		assert.Equal(t, 100, rl.LimitTokens)
+		assert.Equal(t, 100, rl.LimitRequests)
+	})
+
+	t.Run("when rate limit values are missing", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t, noRlHeader: true})
+		defer server.Close()
+
+		c := New("apiKey", "", "", 0, nullLogger())
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+			return server.URL, nil
+		}
+
+		expected := &modulecomponents.VectorizationResult{
+			Text:       []string{"This is my text"},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
+			Dimensions: 3,
+			Errors:     []error{nil},
+		}
+		res, rl, _, err := c.Vectorize(context.Background(), []string{"This is my text"}, fakeClassConfig{classConfig: map[string]interface{}{"Type": "text", "Model": "ada"}})
+
+		assert.Nil(t, err)
+		assert.Equal(t, expected, res)
+
+		assert.Equal(t, true, rl.UpdateWithMissingValues)
+		assert.Equal(t, -1, rl.RemainingTokens)
+		assert.Equal(t, -1, rl.RemainingRequests)
+		assert.Equal(t, -1, rl.LimitTokens)
+		assert.Equal(t, -1, rl.LimitRequests)
 	})
 
 	t.Run("when the context is expired", func(t *testing.T) {
@@ -297,6 +330,7 @@ type fakeHandler struct {
 	t               *testing.T
 	serverError     error
 	headerRequestID string
+	noRlHeader      bool
 }
 
 func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -344,6 +378,13 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	outBytes, err := json.Marshal(embedding)
 	require.Nil(f.t, err)
+
+	if !f.noRlHeader {
+		w.Header().Add("x-ratelimit-limit-requests", "100")
+		w.Header().Add("x-ratelimit-limit-tokens", "100")
+		w.Header().Add("x-ratelimit-remaining-requests", "100")
+		w.Header().Add("x-ratelimit-remaining-tokens", "100")
+	}
 
 	w.Write(outBytes)
 }

--- a/usecases/modulecomponents/batch/fakes_for_test.go
+++ b/usecases/modulecomponents/batch/fakes_for_test.go
@@ -47,9 +47,15 @@ func (c *fakeBatchClientWithRL) Vectorize(ctx context.Context,
 	errors := make([]error, len(text))
 	if c.rateLimit == nil {
 		c.rateLimit = &modulecomponents.RateLimits{LastOverwrite: time.Now(), RemainingTokens: 100, RemainingRequests: 100, LimitTokens: 200, ResetTokens: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second), ResetRequests: time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)}
+	} else if c.rateLimit.UpdateWithMissingValues {
+		// return original values
+		c.rateLimit.UpdateWithMissingValues = false
+		c.rateLimit.RemainingTokens = 100
+		c.rateLimit.RemainingRequests = 100
 	} else {
 		c.rateLimit.ResetTokens = time.Now().Add(time.Duration(c.defaultResetRate) * time.Second)
 	}
+
 	for i := range text {
 		if len(text[i]) >= len("error ") && text[i][:6] == "error " {
 			errors[i] = fmt.Errorf("%s", text[i][6:])
@@ -70,6 +76,10 @@ func (c *fakeBatchClientWithRL) Vectorize(ctx context.Context,
 		} else if len(text[i]) >= len("wait ") && text[i][:5] == "wait " {
 			wait, _ := strconv.Atoi(text[i][5:])
 			time.Sleep(time.Duration(wait) * time.Millisecond)
+		} else if len(text[i]) >= len("missingValues ") && text[i][:14] == "missingValues " {
+			c.rateLimit.UpdateWithMissingValues = true
+			c.rateLimit.RemainingTokens = -1
+			c.rateLimit.RemainingRequests = -1
 		} else {
 			// refresh the remaining token
 			secondsSinceLastRefresh := time.Since(c.rateLimit.LastOverwrite)
@@ -93,13 +103,14 @@ func (c *fakeBatchClientWithRL) Vectorize(ctx context.Context,
 			Text:       text,
 			Errors:     errors,
 		}, &modulecomponents.RateLimits{
-			LastOverwrite:     c.rateLimit.LastOverwrite,
-			RemainingTokens:   c.rateLimit.RemainingTokens,
-			RemainingRequests: c.rateLimit.RemainingRequests,
-			LimitTokens:       c.rateLimit.LimitTokens,
-			ResetTokens:       c.rateLimit.ResetTokens,
-			ResetRequests:     c.rateLimit.ResetRequests,
-			LimitRequests:     c.rateLimit.LimitRequests,
+			LastOverwrite:           c.rateLimit.LastOverwrite,
+			RemainingTokens:         c.rateLimit.RemainingTokens,
+			RemainingRequests:       c.rateLimit.RemainingRequests,
+			LimitTokens:             c.rateLimit.LimitTokens,
+			ResetTokens:             c.rateLimit.ResetTokens,
+			ResetRequests:           c.rateLimit.ResetRequests,
+			LimitRequests:           c.rateLimit.LimitRequests,
+			UpdateWithMissingValues: c.rateLimit.UpdateWithMissingValues,
 		}, 0, reqError
 }
 


### PR DESCRIPTION
### What's being changed:

Adds the following tests:
- unit test for openai => correctly mark the ratelimit when the response form openai does not contain the rate limit headers
- integration tests for the batching algorithm => if the vectorizer returns a marked ratelimit, the update is skipped

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
