### PR TITLE
refact:(shutdown) improve db and shard dropping shutdown performance 

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2234,7 +2234,6 @@ func (i *Index) Shutdown(ctx context.Context) error {
 // stopCycleManagers stops all cycle managers concurrently
 func (i *Index) stopCycleManagers(ctx context.Context, usecase string) error {
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
-	eg.SetLimit(_NUMCPU)
 
 	eg.Go(func() error {
 		if err := i.cycleCallbacks.compactionCycle.StopAndWait(ctx); err != nil {

--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -22,18 +22,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	entcfg "github.com/weaviate/weaviate/entities/config"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-	"github.com/weaviate/weaviate/usecases/monitoring"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // IndexQueue is an in-memory queue of vectors to index.
@@ -379,6 +379,9 @@ func (q *IndexQueue) Delete(ids ...uint64) error {
 // It does not remove the index.
 // It should be called only when the index is dropped.
 func (q *IndexQueue) Drop() error {
+	q.indexLock.Lock()
+	defer q.indexLock.Unlock()
+
 	_ = q.Close()
 
 	if q.Checkpoints != nil {

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -101,6 +101,11 @@ func (s *Shard) drop() (err error) {
 			})
 		}
 
+		// we have to close queue before index for versions before 1.28
+		if err = eg.Wait(); err != nil {
+			return err
+		}
+
 		for targetVector, vectorIndex := range s.vectorIndexes {
 			targetVector, vectorIndex := targetVector, vectorIndex // capture loop variables
 			eg.Go(func() error {

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -79,6 +79,11 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 			})
 		}
 
+		// we have to close queue before index for versions before 1.28
+		if err = eg.Wait(); err != nil {
+			return err
+		}
+
 		for targetVector, vectorIndex := range s.vectorIndexes {
 			if vectorIndex == nil {
 				// a nil-vector index during shutdown would indicate that the shard was not

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -69,7 +69,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.mayCloseAndStoreHashTree()
 
 	if s.hasTargetVectors() {
-		eg, ctx := enterrors.NewErrorGroupWithContextWrapper(s.Index().logger, ctx)
+		eg := enterrors.NewErrorGroupWrapper(s.Index().logger)
 		eg.SetLimit(_NUMCPU)
 		for targetVector, queue := range s.queues {
 			targetVector, queue := targetVector, queue // capture loop variables

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -83,7 +83,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 
 		// we have to close queue before index for versions before 1.28
 		if err = eg.Wait(); err != nil {
-			return err
+			ec.Add(err)
 		}
 
 		for targetVector, vectorIndex := range s.vectorIndexes {
@@ -107,7 +107,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		}
 
 		if err = eg.Wait(); err != nil {
-			return err
+			ec.Add(err)
 		}
 	} else {
 		err = s.queue.Close()

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -104,7 +104,9 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 			})
 		}
 
-		_ = eg.Wait()
+		if err = eg.Wait(); err != nil {
+			return err
+		}
 	} else {
 		err = s.queue.Close()
 		ec.AddWrap(err, "shut down vector index queue")

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -565,6 +566,9 @@ func (l *hnswCommitLogger) combineLogs() (bool, error) {
 }
 
 func (l *hnswCommitLogger) Drop(ctx context.Context) error {
+	l.Lock()
+	defer l.Unlock()
+
 	if err := l.commitLogger.Close(); err != nil {
 		return errors.Wrap(err, "close hnsw commit logger prior to delete")
 	}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
@@ -594,6 +595,9 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 }
 
 func (h *hnsw) Drop(ctx context.Context) error {
+	h.Lock()
+	defer h.Unlock()
+
 	// cancel tombstone cleanup goroutine
 	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
@@ -620,6 +624,9 @@ func (h *hnsw) Drop(ctx context.Context) error {
 }
 
 func (h *hnsw) Shutdown(ctx context.Context) error {
+	h.Lock()
+	defer h.Unlock()
+
 	h.shutdownCtxCancel()
 
 	if err := h.commitLog.Shutdown(ctx); err != nil {


### PR DESCRIPTION
### What's being changed:
in order to improve the shutdown process, this PR run indexes shutdown concurrently  

**Note** needs to be handled differently in propagation to `1.28` 
- close the queue [scheduler](https://github.com/weaviate/weaviate/blob/494730349ae0c4cefe24a08f99d94b5f6a6c3da0/adapters/repos/db/repo.go#L181-L184) first
- then you can close the queues and the vector indexes in any order

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
  - [e2e pipeline](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14710173203)
  - [chaos pipeline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14710169142)
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
