### PR TITLE
chore(recovery-logging): log empty recovery wal filenames once per dir 

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -133,8 +133,8 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 
 	if emptyWALPaths.Len() > 0 {
 		b.logger.WithField("action", "lsm_recover_from_active_wal").
-			WithField("paths", strings.TrimSuffix(emptyWALPaths.String(), pathSeparator)).
-			Info("found empty write-ahead-log files during recovery")
+			WithField("path", strings.TrimSuffix(emptyWALPaths.String(), pathSeparator)).
+			Warning("empty write-ahead-log found. Did weaviate crash prior to this or the tenant on/loaded from the cloud? Nothing to recover from this file.")
 	}
 
 	return nil

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -21,10 +21,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/entities/diskio"
 )
 
 var logOnceWhenRecoveringFromWAL sync.Once
+
+const pathSeparator = ","
 
 func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 	beforeAll := time.Now()
@@ -55,6 +58,8 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		walFileNames = append(walFileNames, fileInfo.Name())
 	}
 
+	var emptyWALPaths strings.Builder
+
 	// recover from each log
 	for _, fname := range walFileNames {
 		path := filepath.Join(b.dir, strings.TrimSuffix(fname, ".wal"))
@@ -74,9 +79,8 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		}
 
 		if stat.Size() == 0 {
-			b.logger.WithField("action", "lsm_recover_from_active_wal").
-				WithField("path", path).
-				Warning("empty write-ahead-log found. Did weaviate crash prior to this or the tenant on/loaded from the cloud? Nothing to recover from this file.")
+			emptyWALPaths.WriteString(path)
+			emptyWALPaths.WriteString(pathSeparator)
 			continue
 		}
 
@@ -125,6 +129,12 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		b.logger.WithField("action", "lsm_recover_from_active_wal_success").
 			WithField("path", filepath.Join(b.dir, fname)).
 			Info("successfully recovered from write-ahead-log")
+	}
+
+	if emptyWALPaths.Len() > 0 {
+		b.logger.WithField("action", "lsm_recover_from_active_wal").
+			WithField("paths", strings.TrimSuffix(emptyWALPaths.String(), pathSeparator)).
+			Info("found empty write-ahead-log files during recovery")
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:
this PR aggregate the warning log of empty wal files to be logged once with all empty files 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
