### PR TITLE
Better user existence validation when assignning/revoking roles

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -435,14 +435,6 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 		return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	exists, err := h.userExists(params.ID)
-	if err != nil {
-		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user exists: %w", err)))
-	}
-	if !exists {
-		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to assign role to doesn't exist")))
-	}
-
 	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
 	if err != nil {
 		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
@@ -452,7 +444,13 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles requested doesn't exist")))
 	}
 
-	userTypes := getUserTypes(params.Body.UserType)
+	userTypes, err := h.getUserTypesAndValidateExistence(params.ID, params.Body.UserType)
+	if err != nil {
+		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user exists: %w", err)))
+	}
+	if userTypes == nil {
+		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to assign role to doesn't exist")))
+	}
 	for _, userType := range userTypes {
 		if err := h.controller.AddRolesForUser(conv.UserNameWithTypeFromId(params.ID, userType), params.Body.Roles); err != nil {
 			return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("AddRolesForUser: %w", err)))
@@ -531,7 +529,7 @@ func (h *authZHandlers) getRolesForUserDeprecated(params authz.GetRolesForUserDe
 		}
 	}
 
-	exists, err := h.userExists(params.ID)
+	exists, err := h.userExistsDeprecated(params.ID)
 	if err != nil {
 		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user existence: %w", err)))
 	}
@@ -609,7 +607,7 @@ func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, prin
 		return authz.NewGetRolesForUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("unknown userType: %v", params.UserType)))
 	}
 
-	exists, err := h.userExists(params.ID)
+	exists, err := h.userExists(params.ID, userType)
 	if err != nil {
 		return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user existence: %w", err)))
 	}
@@ -770,14 +768,6 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	exists, err := h.userExists(params.ID)
-	if err != nil {
-		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user existence: %w", err)))
-	}
-	if !exists {
-		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to revoke role from doesn't exist")))
-	}
-
 	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
 	if err != nil {
 		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
@@ -787,7 +777,13 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the request roles doesn't exist")))
 	}
 
-	userTypes := getUserTypes(params.Body.UserType)
+	userTypes, err := h.getUserTypesAndValidateExistence(params.ID, params.Body.UserType)
+	if err != nil {
+		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user exists: %w", err)))
+	}
+	if userTypes == nil {
+		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to revoke role from doesn't exist")))
+	}
 	for _, userType := range userTypes {
 		if err := h.controller.RevokeRolesForUser(conv.UserNameWithTypeFromId(params.ID, userType), params.Body.Roles...); err != nil {
 			return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("AddRolesForUser: %w", err)))
@@ -856,7 +852,37 @@ func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupPara
 	return authz.NewRevokeRoleFromGroupOK()
 }
 
-func (h *authZHandlers) userExists(user string) (bool, error) {
+func (h *authZHandlers) userExists(user string, userType models.UserType) (bool, error) {
+	switch userType {
+	case models.UserTypeOidc:
+		if !h.oidcConfigs.Enabled {
+			return false, fmt.Errorf("oidc is not enabled")
+		}
+		return true, nil
+	case models.UserTypeDb:
+		if h.apiKeysConfigs.Enabled {
+			for _, apiKey := range h.apiKeysConfigs.Users {
+				if apiKey == user {
+					return true, nil
+				}
+			}
+		}
+
+		users, err := h.controller.GetUsers(user)
+		if err != nil {
+			return false, err
+		}
+		if len(users) == 1 {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	default:
+		return false, fmt.Errorf("unknown user type")
+	}
+}
+
+func (h *authZHandlers) userExistsDeprecated(user string) (bool, error) {
 	// We are only able to check if a user is present on the system if APIKeys are the only auth method. For OIDC
 	// users are managed in an external service and there is no general way to check if a user we have not seen yet is
 	// valid.
@@ -901,6 +927,30 @@ func (h *authZHandlers) isRootUser(principal *models.Principal) bool {
 	return slices.Contains(h.rbacconfig.RootUsers, principal.Username)
 }
 
+func (h *authZHandlers) getUserTypesAndValidateExistence(id string, userTypeParam models.UserType) ([]models.UserType, error) {
+	if userTypeParam == "" {
+		exists, err := h.userExistsDeprecated(id)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+
+		return []models.UserType{models.UserTypeOidc, models.UserTypeDb}, nil
+	} else {
+		exists, err := h.userExists(id, userTypeParam)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, nil
+		}
+
+		return []models.UserType{userTypeParam}, nil
+	}
+}
+
 // validateRootRole validates that enduser do not touch the internal root role
 func validateRootRole(name string) error {
 	if name == authorization.Root {
@@ -924,16 +974,6 @@ func sortByName(roles []*models.Role) {
 	sort.Slice(roles, func(i, j int) bool {
 		return *roles[i].Name < *roles[j].Name
 	})
-}
-
-func getUserTypes(userTypeParam models.UserType) []models.UserType {
-	var userTypes []models.UserType
-	if userTypeParam == "" {
-		userTypes = []models.UserType{models.UserTypeOidc, models.UserTypeDb}
-	} else {
-		userTypes = []models.UserType{userTypeParam}
-	}
-	return userTypes
 }
 
 func validateUserTypeInput(userTypeInput string) (models.UserType, error) {

--- a/test/acceptance/authz/authz_deprecated_test.go
+++ b/test/acceptance/authz/authz_deprecated_test.go
@@ -12,7 +12,10 @@
 package authz
 
 import (
+	"context"
 	"testing"
+
+	"github.com/weaviate/weaviate/test/docker"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/authz"
@@ -29,8 +32,20 @@ func TestDeprecatedEndpoints(t *testing.T) {
 	customUser := "custom-user"
 	customKey := "custom-key"
 
-	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{customUser: customKey}, nil)
-	defer down()
+	ctx := context.Background()
+
+	// enable OIDC to be able to assign to db and oidc separately
+	compose, err := docker.New().
+		WithWeaviate().WithMockOIDC().WithRBAC().WithRbacAdmins(adminUser).
+		WithApiKey().WithUserApiKey(customUser, customKey).WithUserApiKey(adminUser, adminKey).
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
 
 	testRoleName := "testRole1"
 	createCollectionsAction := authorization.CreateCollections
@@ -59,10 +74,6 @@ func TestDeprecatedEndpoints(t *testing.T) {
 		RolesDbUser := helper.GetRolesForUser(t, customUser, adminKey)
 		require.Len(t, RolesDbUser, 1)
 		require.Equal(t, testRoleName, *RolesDbUser[0].Name)
-
-		RolesOIDCUser := helper.GetRolesForUserOIDC(t, customUser, adminKey)
-		require.Len(t, RolesOIDCUser, 1)
-		require.Equal(t, testRoleName, *RolesOIDCUser[0].Name)
 	})
 
 	// revoke without usertype should revoke from, OIDC as well as db user

--- a/test/acceptance/authz/oidc_test.go
+++ b/test/acceptance/authz/oidc_test.go
@@ -40,12 +40,14 @@ func TestRbacWithOIDC(t *testing.T) {
 		name          string
 		image         *docker.Compose
 		nameCollision bool
+		onlyOIDC      bool
 	}{
 		{
 			name: "RBAC with OIDC",
 			image: docker.New().
 				WithWeaviate().WithMockOIDC().WithRBAC().WithRbacAdmins("admin-user"),
 			nameCollision: false,
+			onlyOIDC:      true,
 		},
 		{
 			name: "RBAC with OIDC and API key",
@@ -114,13 +116,28 @@ func TestRbacWithOIDC(t *testing.T) {
 			// only OIDC user has role assigned
 			rolesOIDC := helper.GetRolesForUserOIDC(t, customUser, tokenAdmin)
 			require.Len(t, rolesOIDC, 1)
-			rolesDB := helper.GetRolesForUser(t, customUser, tokenAdmin)
-			require.Len(t, rolesDB, 0)
+
+			if test.onlyOIDC {
+				_, err := helper.Client(t).Authz.GetRolesForUser(authz.NewGetRolesForUserParams().WithID(customUser).WithUserType(string(models.UserTypeDb)), helper.CreateAuth(tokenAdmin))
+				require.Error(t, err)
+				var notFound *authz.GetRolesForUserNotFound
+				require.True(t, errors.As(err, &notFound))
+			} else {
+				rolesDB := helper.GetRolesForUser(t, customUser, tokenAdmin)
+				require.Len(t, rolesDB, 0)
+			}
 
 			usersOidc := helper.GetUserForRolesOIDC(t, createSchemaRoleName, tokenAdmin)
 			require.Len(t, usersOidc, 1)
-			usersDB := helper.GetUserForRoles(t, createSchemaRoleName, tokenAdmin)
-			require.Len(t, usersDB, 0)
+			if test.onlyOIDC {
+				_, err := helper.Client(t).Authz.GetRolesForUser(authz.NewGetRolesForUserParams().WithID(customUser).WithUserType(string(models.UserTypeDb)), helper.CreateAuth(tokenAdmin))
+				require.Error(t, err)
+				var notFound *authz.GetRolesForUserNotFound
+				require.True(t, errors.As(err, &notFound))
+			} else {
+				usersDB := helper.GetUserForRoles(t, createSchemaRoleName, tokenAdmin)
+				require.Len(t, usersDB, 0)
+			}
 
 			// assign role to non-existing user => no error (if OIDC is enabled)
 			helper.AssignRoleToUserOIDC(t, tokenAdmin, createSchemaRoleName, "i-dont-exist")
@@ -134,6 +151,36 @@ func TestRbacWithOIDC(t *testing.T) {
 
 				helper.AssignRoleToUser(t, tokenAdmin, createSchemaRoleName, "custom-user")
 				err = createClass(t, &models.Class{Class: "testingApiKey"}, helper.CreateAuth(customKey))
+				require.NoError(t, err)
+			}
+
+			if test.onlyOIDC {
+				// cannot assign/revoke to/from db users
+				resp, err := helper.Client(t).Authz.AssignRoleToUser(
+					authz.NewAssignRoleToUserParams().WithID("random-user").WithBody(authz.AssignRoleToUserBody{Roles: []string{createSchemaRoleName}, UserType: models.UserTypeDb}),
+					helper.CreateAuth(tokenAdmin),
+				)
+				require.Nil(t, resp)
+				require.Error(t, err)
+
+				resp2, err := helper.Client(t).Authz.RevokeRoleFromUser(
+					authz.NewRevokeRoleFromUserParams().WithID("random-user").WithBody(authz.RevokeRoleFromUserBody{Roles: []string{createSchemaRoleName}, UserType: models.UserTypeDb}),
+					helper.CreateAuth(tokenAdmin),
+				)
+				require.Nil(t, resp2)
+				require.Error(t, err)
+
+				// no validation for deprecated path when OIDC is enabled:
+				_, err = helper.Client(t).Authz.AssignRoleToUser(
+					authz.NewAssignRoleToUserParams().WithID("random-user").WithBody(authz.AssignRoleToUserBody{Roles: []string{createSchemaRoleName}}),
+					helper.CreateAuth(tokenAdmin),
+				)
+				require.NoError(t, err)
+
+				_, err = helper.Client(t).Authz.RevokeRoleFromUser(
+					authz.NewRevokeRoleFromUserParams().WithID("random-user").WithBody(authz.RevokeRoleFromUserBody{Roles: []string{createSchemaRoleName}}),
+					helper.CreateAuth(tokenAdmin),
+				)
 				require.NoError(t, err)
 			}
 		})

--- a/test/acceptance/authz/oidc_test.go
+++ b/test/acceptance/authz/oidc_test.go
@@ -39,7 +39,7 @@ func TestRbacWithOIDC(t *testing.T) {
 	tests := []struct {
 		name          string
 		image         *docker.Compose
-		nameCollision bool
+		nameCollision bool // same username for DB and OIDC
 		onlyOIDC      bool
 	}{
 		{
@@ -117,7 +117,8 @@ func TestRbacWithOIDC(t *testing.T) {
 			rolesOIDC := helper.GetRolesForUserOIDC(t, customUser, tokenAdmin)
 			require.Len(t, rolesOIDC, 1)
 
-			if test.onlyOIDC {
+			if test.onlyOIDC || !test.nameCollision {
+				// validation check for existence will fail
 				_, err := helper.Client(t).Authz.GetRolesForUser(authz.NewGetRolesForUserParams().WithID(customUser).WithUserType(string(models.UserTypeDb)), helper.CreateAuth(tokenAdmin))
 				require.Error(t, err)
 				var notFound *authz.GetRolesForUserNotFound
@@ -129,7 +130,7 @@ func TestRbacWithOIDC(t *testing.T) {
 
 			usersOidc := helper.GetUserForRolesOIDC(t, createSchemaRoleName, tokenAdmin)
 			require.Len(t, usersOidc, 1)
-			if test.onlyOIDC {
+			if test.onlyOIDC || !test.nameCollision {
 				_, err := helper.Client(t).Authz.GetRolesForUser(authz.NewGetRolesForUserParams().WithID(customUser).WithUserType(string(models.UserTypeDb)), helper.CreateAuth(tokenAdmin))
 				require.Error(t, err)
 				var notFound *authz.GetRolesForUserNotFound

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/weaviate/weaviate-python-client.git@5ecbd1dda50809558f2723acfd866b6f2c66da7b
+git+https://github.com/weaviate/weaviate-python-client.git@9abcbce0b9c439959b7a35d3b00dca26615e6be2
 
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1


### PR DESCRIPTION
### What's being changed:

With the newly introduced usertype, we know if an assignment is for OIDC or DB users. Now we can validate the user existence for both cases separetely:
- OIDC user: All names accepted if OIDC is activated
- DB user: Check for existence in static and/or dynamic users if any are activated

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
