### PR TITLE
Dynamic users: Return code for conflicts when (de)activating users

### DIFF
--- a/adapters/handlers/rest/dynamic_user/deactivate_user_test.go
+++ b/adapters/handlers/rest/dynamic_user/deactivate_user_test.go
@@ -80,7 +80,6 @@ func TestDeactivateBadParameters(t *testing.T) {
 	}{
 		{name: "static user", user: "static-user", principal: "admin"},
 		{name: "root user", user: "root-user", principal: "admin"},
-		{name: "Deactivateed user", user: "Deactivateed-user", getUserReturn: map[string]*apikey.User{"Deactivateed-user": {Id: "Deactivateed-user", Active: false}}, principal: "admin"},
 		{name: "own user", user: "myself", principal: "myself"},
 	}
 
@@ -106,6 +105,26 @@ func TestDeactivateBadParameters(t *testing.T) {
 			assert.True(t, ok)
 		})
 	}
+}
+
+func TestDoubleDeactivate(t *testing.T) {
+	user := "deactivated-user"
+	principal := &models.Principal{}
+	authorizer := authzMocks.NewAuthorizer(t)
+	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Users(user)[0]).Return(nil)
+	dynUser := mocks.NewDynamicUserAndRolesGetter(t)
+	dynUser.On("GetUsers", user).Return(map[string]*apikey.User{user: {Id: user, Active: false}}, nil)
+
+	h := dynUserHandler{
+		dynamicUser:          dynUser,
+		authorizer:           authorizer,
+		staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static-user"}},
+		rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root-user"}}, dynUserEnabled: true,
+	}
+
+	res := h.deactivateUser(users.DeactivateUserParams{UserID: user}, principal)
+	_, ok := res.(*users.DeactivateUserConflict)
+	assert.True(t, ok)
 }
 
 func TestSuspendNoDynamic(t *testing.T) {

--- a/adapters/handlers/rest/dynamic_user/handlers_dynamic_users.go
+++ b/adapters/handlers/rest/dynamic_user/handlers_dynamic_users.go
@@ -354,7 +354,7 @@ func (h *dynUserHandler) deactivateUser(params users.DeactivateUserParams, princ
 	}
 
 	if !existingUser[params.UserID].Active {
-		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user already deactivated")))
+		return users.NewDeactivateUserConflict()
 	}
 
 	revokeKey := false
@@ -396,7 +396,7 @@ func (h *dynUserHandler) activateUser(params users.ActivateUserParams, principal
 	}
 
 	if existingUser[params.UserID].Active {
-		return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user already activated")))
+		return users.NewActivateUserConflict()
 	}
 
 	if err := h.dynamicUser.ActivateUser(params.UserID); err != nil {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4464,6 +4464,9 @@ func init() {
           "404": {
             "description": "user not found"
           },
+          "409": {
+            "description": "user already activated"
+          },
           "422": {
             "description": "Request body is well-formed (i.e., syntactically correct), but semantically erroneous.",
             "schema": {
@@ -4533,6 +4536,9 @@ func init() {
           },
           "404": {
             "description": "user not found"
+          },
+          "409": {
+            "description": "user already deactivated"
           },
           "422": {
             "description": "Request body is well-formed (i.e., syntactically correct), but semantically erroneous. Are you sure the class is defined in the configuration file?",
@@ -11816,6 +11822,9 @@ func init() {
           "404": {
             "description": "user not found"
           },
+          "409": {
+            "description": "user already activated"
+          },
           "422": {
             "description": "Request body is well-formed (i.e., syntactically correct), but semantically erroneous.",
             "schema": {
@@ -11885,6 +11894,9 @@ func init() {
           },
           "404": {
             "description": "user not found"
+          },
+          "409": {
+            "description": "user already deactivated"
           },
           "422": {
             "description": "Request body is well-formed (i.e., syntactically correct), but semantically erroneous. Are you sure the class is defined in the configuration file?",

--- a/adapters/handlers/rest/operations/users/activate_user_responses.go
+++ b/adapters/handlers/rest/operations/users/activate_user_responses.go
@@ -189,6 +189,31 @@ func (o *ActivateUserNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 	rw.WriteHeader(404)
 }
 
+// ActivateUserConflictCode is the HTTP code returned for type ActivateUserConflict
+const ActivateUserConflictCode int = 409
+
+/*
+ActivateUserConflict user already activated
+
+swagger:response activateUserConflict
+*/
+type ActivateUserConflict struct {
+}
+
+// NewActivateUserConflict creates ActivateUserConflict with default headers values
+func NewActivateUserConflict() *ActivateUserConflict {
+
+	return &ActivateUserConflict{}
+}
+
+// WriteResponse to the client
+func (o *ActivateUserConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(409)
+}
+
 // ActivateUserUnprocessableEntityCode is the HTTP code returned for type ActivateUserUnprocessableEntity
 const ActivateUserUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/users/deactivate_user_responses.go
+++ b/adapters/handlers/rest/operations/users/deactivate_user_responses.go
@@ -189,6 +189,31 @@ func (o *DeactivateUserNotFound) WriteResponse(rw http.ResponseWriter, producer 
 	rw.WriteHeader(404)
 }
 
+// DeactivateUserConflictCode is the HTTP code returned for type DeactivateUserConflict
+const DeactivateUserConflictCode int = 409
+
+/*
+DeactivateUserConflict user already deactivated
+
+swagger:response deactivateUserConflict
+*/
+type DeactivateUserConflict struct {
+}
+
+// NewDeactivateUserConflict creates DeactivateUserConflict with default headers values
+func NewDeactivateUserConflict() *DeactivateUserConflict {
+
+	return &DeactivateUserConflict{}
+}
+
+// WriteResponse to the client
+func (o *DeactivateUserConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(409)
+}
+
 // DeactivateUserUnprocessableEntityCode is the HTTP code returned for type DeactivateUserUnprocessableEntity
 const DeactivateUserUnprocessableEntityCode int = 422
 

--- a/client/users/activate_user_responses.go
+++ b/client/users/activate_user_responses.go
@@ -64,6 +64,12 @@ func (o *ActivateUserReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 409:
+		result := NewActivateUserConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewActivateUserUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -381,6 +387,62 @@ func (o *ActivateUserNotFound) String() string {
 }
 
 func (o *ActivateUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewActivateUserConflict creates a ActivateUserConflict with default headers values
+func NewActivateUserConflict() *ActivateUserConflict {
+	return &ActivateUserConflict{}
+}
+
+/*
+ActivateUserConflict describes a response with status code 409, with default header values.
+
+user already activated
+*/
+type ActivateUserConflict struct {
+}
+
+// IsSuccess returns true when this activate user conflict response has a 2xx status code
+func (o *ActivateUserConflict) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this activate user conflict response has a 3xx status code
+func (o *ActivateUserConflict) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this activate user conflict response has a 4xx status code
+func (o *ActivateUserConflict) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this activate user conflict response has a 5xx status code
+func (o *ActivateUserConflict) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this activate user conflict response a status code equal to that given
+func (o *ActivateUserConflict) IsCode(code int) bool {
+	return code == 409
+}
+
+// Code gets the status code for the activate user conflict response
+func (o *ActivateUserConflict) Code() int {
+	return 409
+}
+
+func (o *ActivateUserConflict) Error() string {
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserConflict ", 409)
+}
+
+func (o *ActivateUserConflict) String() string {
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserConflict ", 409)
+}
+
+func (o *ActivateUserConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/users/deactivate_user_responses.go
+++ b/client/users/deactivate_user_responses.go
@@ -66,6 +66,12 @@ func (o *DeactivateUserReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return nil, result
+	case 409:
+		result := NewDeactivateUserConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewDeactivateUserUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -383,6 +389,62 @@ func (o *DeactivateUserNotFound) String() string {
 }
 
 func (o *DeactivateUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeactivateUserConflict creates a DeactivateUserConflict with default headers values
+func NewDeactivateUserConflict() *DeactivateUserConflict {
+	return &DeactivateUserConflict{}
+}
+
+/*
+DeactivateUserConflict describes a response with status code 409, with default header values.
+
+user already deactivated
+*/
+type DeactivateUserConflict struct {
+}
+
+// IsSuccess returns true when this deactivate user conflict response has a 2xx status code
+func (o *DeactivateUserConflict) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this deactivate user conflict response has a 3xx status code
+func (o *DeactivateUserConflict) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this deactivate user conflict response has a 4xx status code
+func (o *DeactivateUserConflict) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this deactivate user conflict response has a 5xx status code
+func (o *DeactivateUserConflict) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this deactivate user conflict response a status code equal to that given
+func (o *DeactivateUserConflict) IsCode(code int) bool {
+	return code == 409
+}
+
+// Code gets the status code for the deactivate user conflict response
+func (o *DeactivateUserConflict) Code() int {
+	return 409
+}
+
+func (o *DeactivateUserConflict) Error() string {
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserConflict ", 409)
+}
+
+func (o *DeactivateUserConflict) String() string {
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserConflict ", 409)
+}
+
+func (o *DeactivateUserConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3019,6 +3019,9 @@
           "404": {
             "description": "user not found"
           },
+          "409": {
+            "description": "user already activated"
+          },
           "422": {
             "description": "Request body is well-formed (i.e., syntactically correct), but semantically erroneous.",
             "schema": {
@@ -3089,6 +3092,9 @@
           },
           "404": {
             "description": "user not found"
+          },
+          "409": {
+            "description": "user already deactivated"
           },
           "422": {
             "description": "Request body is well-formed (i.e., syntactically correct), but semantically erroneous. Are you sure the class is defined in the configuration file?",

--- a/test/acceptance/authn/dynamic_users_test.go
+++ b/test/acceptance/authn/dynamic_users_test.go
@@ -226,6 +226,8 @@ func TestSuspendAndActivate(t *testing.T) {
 		// suspend again
 		_, err := helper.Client(t).Users.DeactivateUser(users.NewDeactivateUserParams().WithUserID(dynamicUser), helper.CreateAuth(adminKey))
 		require.Error(t, err)
+		var conflict *users.DeactivateUserConflict
+		require.True(t, errors.As(err, &conflict))
 	})
 
 	t.Run("activate active user", func(t *testing.T) {
@@ -233,5 +235,7 @@ func TestSuspendAndActivate(t *testing.T) {
 		helper.CreateUser(t, dynamicUser, adminKey)
 		_, err := helper.Client(t).Users.ActivateUser(users.NewActivateUserParams().WithUserID(dynamicUser), helper.CreateAuth(adminKey))
 		require.Error(t, err)
+		var conflict *users.ActivateUserConflict
+		require.True(t, errors.As(err, &conflict))
 	})
 }


### PR DESCRIPTION
### What's being changed:

return 409 when a user is already (de)activated. The clients can return True/False to indicate this, but repeated will not fail.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
