### PR TITLE
async indexing: fix deadlock during upgrade of dynamic index

### DIFF
--- a/adapters/repos/db/queue/scheduler.go
+++ b/adapters/repos/db/queue/scheduler.go
@@ -441,8 +441,9 @@ func (s *Scheduler) dispatchQueue(q *queueState) (int64, error) {
 
 				q.m.Lock()
 				counter--
-				if counter == 0 {
-					q.m.Unlock()
+				c := counter
+				q.m.Unlock()
+				if c == 0 {
 					// It is important to unlock the queue here
 					// to avoid a deadlock when the last worker calls Done.
 					batch.Done()
@@ -451,8 +452,6 @@ func (s *Scheduler) dispatchQueue(q *queueState) (int64, error) {
 						WithField("queue_size", q.q.Size()).
 						WithField("count", taskCount).
 						Debug("tasks processed")
-				} else {
-					q.m.Unlock()
 				}
 			},
 			onCanceled: func() {

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -778,11 +778,10 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 
 func TestShard_UpgradeIndex(t *testing.T) {
 	t.Setenv("ASYNC_INDEXING", "true")
-	t.Setenv("ASYNC_INDEXING_STALE_TIMEOUT", "10ms")
 	t.Setenv("QUEUE_SCHEDULER_INTERVAL", "10ms")
 
 	cfg := dynamic.NewDefaultUserConfig()
-	cfg.Threshold = 1000
+	cfg.Threshold = 500
 
 	ctx := context.Background()
 	className := "SomeClass"
@@ -800,9 +799,9 @@ func TestShard_UpgradeIndex(t *testing.T) {
 		}
 	}(shd.Index().Config.RootPath)
 
-	amount := 10_000
-	for i := 0; i < 10; i++ {
-		var objs []*storobj.Object
+	amount := 5000
+	for i := 0; i < 5; i++ {
+		objs := make([]*storobj.Object, 0, amount)
 		for j := 0; j < amount; j++ {
 			objs = append(objs, testObject(className))
 		}
@@ -818,5 +817,5 @@ func TestShard_UpgradeIndex(t *testing.T) {
 	// wait for the queue to be empty
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.Zero(t, q.Size())
-	}, 10*time.Second, 100*time.Millisecond)
+	}, 60*time.Second, 500*time.Millisecond)
 }

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -825,5 +825,5 @@ func TestShard_UpgradeIndex(t *testing.T) {
 	// wait for the queue to be empty
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.Zero(t, q.Size())
-	}, 60*time.Second, 500*time.Millisecond)
+	}, 300*time.Second, 1*time.Second)
 }

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -36,6 +36,7 @@ import (
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
@@ -773,4 +774,49 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_UpgradeIndex(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+	t.Setenv("ASYNC_INDEXING_STALE_TIMEOUT", "10ms")
+	t.Setenv("QUEUE_SCHEDULER_INTERVAL", "10ms")
+
+	cfg := dynamic.NewDefaultUserConfig()
+	cfg.Threshold = 1000
+
+	ctx := context.Background()
+	className := "SomeClass"
+	var opts []func(*Index)
+	opts = append(opts, func(i *Index) {
+		i.vectorIndexUserConfig = cfg
+	})
+
+	shd, _ := testShardWithSettings(t, ctx, &models.Class{Class: className}, cfg, false, true /* withCheckpoints */, opts...)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	amount := 10_000
+	for i := 0; i < 10; i++ {
+		var objs []*storobj.Object
+		for j := 0; j < amount; j++ {
+			objs = append(objs, testObject(className))
+		}
+
+		errs := shd.PutObjectBatch(ctx, objs)
+		for _, err := range errs {
+			require.Nil(t, err)
+		}
+	}
+
+	q := shd.Queue()
+
+	// wait for the queue to be empty
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Zero(t, q.Size())
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -225,7 +225,7 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 
 	if iq.vectorIndex.AlreadyIndexed() > uint64(shouldUpgradeAt) {
 		iq.scheduler.PauseQueue(iq.DiskQueue.ID())
-		iq.scheduler.Wait(iq.DiskQueue.ID())
+		// iq.scheduler.Wait(iq.DiskQueue.ID())
 
 		err := ci.Upgrade(func() {
 			iq.scheduler.ResumeQueue(iq.DiskQueue.ID())

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -225,7 +225,6 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 
 	if iq.vectorIndex.AlreadyIndexed() > uint64(shouldUpgradeAt) {
 		iq.scheduler.PauseQueue(iq.DiskQueue.ID())
-		// iq.scheduler.Wait(iq.DiskQueue.ID())
 
 		err := ci.Upgrade(func() {
 			iq.scheduler.ResumeQueue(iq.DiskQueue.ID())

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -225,6 +225,7 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 
 	if iq.vectorIndex.AlreadyIndexed() > uint64(shouldUpgradeAt) {
 		iq.scheduler.PauseQueue(iq.DiskQueue.ID())
+		iq.scheduler.Wait(iq.DiskQueue.ID())
 
 		err := ci.Upgrade(func() {
 			iq.scheduler.ResumeQueue(iq.DiskQueue.ID())


### PR DESCRIPTION
### What's being changed:

This fixes a deadlock that happens during the upgrade of a dynamic index while vectors are being indexed asynchronously.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] E2E pipeline run or not necessary. Link to pipeline:  https://github.com/weaviate/weaviate-e2e-tests/actions/runs/13991293992
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
