### PR TITLE
chore: Some cleanup related to runtime overrides.

### DIFF
--- a/tools/dev/config.runtime-overrides.yaml
+++ b/tools/dev/config.runtime-overrides.yaml
@@ -1,0 +1,3 @@
+maximum_allowed_collections_count: 8
+auto_schema_enabled: true
+async_replication_disabled: false

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -59,6 +59,9 @@ case $CONFIG in
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       RAFT_BOOTSTRAP_EXPECT=1 \
+      RUNTIME_OVERRIDES_ENABLED=true \
+      RUNTIME_OVERRIDES_PATH="${PWD}/tools/dev/config.runtime-overrides.yaml" \
+      RUNTIME_OVERRIDES_LOAD_INTERVAL=30s \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -981,7 +984,7 @@ case $CONFIG in
     ;;
   local-prometheus)
     echo "Starting monitoring setup..."
-      
+
     cleanup() {
       echo "Cleaning up existing containers and volumes..."
       docker stop prometheus grafana 2>/dev/null || true
@@ -990,14 +993,14 @@ case $CONFIG in
       docker network rm monitoring 2>/dev/null || true
       echo "Cleanup complete."
     }
-    
+
     cleanup
 
     echo "Creating new setup..."
-    
+
     docker network create monitoring 2>/dev/null || true
 
-    
+
     echo "Starting Prometheus..."
     docker run -d \
       --name prometheus \
@@ -1007,7 +1010,7 @@ case $CONFIG in
       -v "$(pwd)/tools/dev/prometheus_config/prometheus.yml:/etc/prometheus/prometheus.yml" \
       prom/prometheus
 
-    
+
     echo "Starting Grafana..."
     docker run -d \
       --name grafana \
@@ -1019,7 +1022,7 @@ case $CONFIG in
       -v "$(pwd)/tools/dev/grafana/dashboards/dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml" \
       -v "$(pwd)/tools/dev/grafana/dashboards:/etc/grafana/dashboards" \
       grafana/grafana
-    
+
     echo "Waiting for services to start..."
     sleep 5
 

--- a/usecases/config/runtime/manager.go
+++ b/usecases/config/runtime/manager.go
@@ -177,7 +177,7 @@ func (cm *ConfigManager[T]) loop(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			if err := cm.loadConfig(); err != nil {
-				cm.log.Error("loading runtime config every %s failed, using old config: %w", cm.interval, err)
+				cm.log.Errorf("loading runtime config every %s failed, using old config: %w", cm.interval, err)
 			}
 		case <-sighup:
 			if err := cm.loadConfig(); err != nil {

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -27,7 +27,7 @@ type WeaviateRuntimeConfig struct {
 	// AutoSchemaEnabled marking it as pointer type to differentiate default values.
 	AutoSchemaEnabled *bool `json:"auto_schema_enabled" yaml:"auto_schema_enabled"`
 
-	AsyncReplicationDisabled bool `json:"async_replication_disabled" yaml:"async_replication_disabled"`
+	AsyncReplicationDisabled *bool `json:"async_replication_disabled" yaml:"async_replication_disabled"`
 
 	// config manager that keep the runtime config up to date
 	cm ConfigManager
@@ -55,7 +55,7 @@ func (rc *WeaviateRuntimeConfig) GetAutoSchemaEnabled() *bool {
 
 func (rc *WeaviateRuntimeConfig) GetAsyncReplicationDisabled() *bool {
 	if cfg, err := rc.cm.Config(); err == nil {
-		return &cfg.AsyncReplicationDisabled
+		return cfg.AsyncReplicationDisabled
 	}
 	return nil
 }

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -13,6 +13,8 @@ package config
 
 import (
 	"bytes"
+	"errors"
+	"io"
 
 	"gopkg.in/yaml.v2"
 )
@@ -65,7 +67,10 @@ func ParseYaml(buf []byte) (*WeaviateRuntimeConfig, error) {
 
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
 	dec.SetStrict(true)
-	if err := dec.Decode(&conf); err != nil {
+
+	// Am empty runtime yaml file is still a valid file. So treating io.EOF as
+	// non-error case returning default values of conf.
+	if err := dec.Decode(&conf); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	return &conf, nil

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -82,7 +82,7 @@ maximum_allowed_collections_count: 5
 non_exist_filed: 78
 `
 		b = []byte(val)
-		v, err = ParseYaml(b)
+		_, err = ParseYaml(b)
 		require.Error(t, err)
 	})
 }

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -53,6 +53,12 @@ func TestRuntimeConfig(t *testing.T) {
 		val := rm.GetMaximumAllowedCollectionsCount()
 		require.Nil(t, val)
 	})
+
+	t.Run("async replicsation disabled not being set should return nil", func(t *testing.T) {
+		cm.c.AsyncReplicationDisabled = nil
+		val := rm.GetAsyncReplicationDisabled()
+		require.Nil(t, val)
+	})
 }
 
 type mockManager struct {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -61,6 +61,32 @@ func TestRuntimeConfig(t *testing.T) {
 	})
 }
 
+func TestParseYaml(t *testing.T) {
+	t.Run("empty bytes shouldn't return error", func(t *testing.T) {
+		b := []byte("")
+		v, err := ParseYaml(b)
+		require.NoError(t, err)
+		require.NotNil(t, v)
+	})
+	t.Run("strict parsing should fail for non-existing field", func(t *testing.T) {
+		val := `
+maximum_allowed_collections_count: 5
+`
+		b := []byte(val)
+		v, err := ParseYaml(b)
+		require.NoError(t, err)
+		require.NotNil(t, v)
+
+		val = `
+maximum_allowed_collections_count: 5
+non_exist_filed: 78
+`
+		b = []byte(val)
+		v, err = ParseYaml(b)
+		require.Error(t, err)
+	})
+}
+
 type mockManager struct {
 	c *WeaviateRuntimeConfig
 }


### PR DESCRIPTION

### What's being changed:

Changes:
    1. Add dev runtime overrides file
    2. Handle empty runtime overrides file correctly
    3. Fix the order of initialization with runtime overrides and passing replication config in `configure_api.go`
    4. Handle default value for async_replication_disabled config properly
    5. Some more tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
