### PR TITLE
chore: refactor vector index and queue access to be thread-safe

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -395,9 +395,9 @@ func setupDebugHandlers(appState *state.State) {
 		}
 
 		colName, shardName := parts[0], parts[2]
-		vecIdxID := "main"
+		var targetVector string
 		if len(parts) == 4 {
-			vecIdxID = parts[3]
+			targetVector = parts[3]
 		}
 
 		idx := appState.DB.GetIndex(schema.ClassName(colName))
@@ -420,15 +420,8 @@ func setupDebugHandlers(appState *state.State) {
 		}
 		defer release()
 
-		// Get the vector index
-		var vidx db.VectorIndex
-		if vecIdxID == "main" {
-			vidx = shard.VectorIndex()
-		} else {
-			vidx = shard.VectorIndexes()[vecIdxID]
-		}
-
-		if vidx == nil {
+		vidx, ok := shard.GetVectorIndex(targetVector)
+		if !ok {
 			logger.WithField("shard", shardName).Error("vector index not found")
 			http.Error(w, "vector index not found", http.StatusNotFound)
 			return

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2785,30 +2785,13 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 	defer release()
 
 	// Get the vector index
-	var vidx VectorIndex
-	if targetVector == "" {
-		vidx = shard.VectorIndex()
-	} else {
-		vidx = shard.VectorIndexes()[targetVector]
-	}
-
-	if vidx == nil {
+	vidx, ok := shard.GetVectorIndex(targetVector)
+	if !ok {
 		return errors.New("vector index not found")
 	}
 
 	if !hnsw.IsHNSWIndex(vidx) {
 		return errors.New("vector index is not hnsw")
-	}
-
-	// Reset the queue
-	var q *VectorIndexQueue
-	if targetVector == "" {
-		q = shard.Queue()
-	} else {
-		q = shard.Queues()[targetVector]
-	}
-	if q == nil {
-		return errors.New("index queue not found")
 	}
 
 	// Reset the vector index

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -571,20 +571,22 @@ func TestIndex_DebugResetVectorIndex(t *testing.T) {
 		require.Nil(t, err)
 	}
 
+	vidx, q := getVectorIndexAndQueue(t, shard, "")
+
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.Queue().Size() == 0 {
+		if q.Size() == 0 {
 			break
 		}
 	}
 
 	// wait for the in-flight indexing to finish
-	shard.Queue().Wait()
+	q.Wait()
 
 	// make sure the new index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
+		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -595,17 +597,17 @@ func TestIndex_DebugResetVectorIndex(t *testing.T) {
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.Queue().Size() == 0 {
+		if q.Size() == 0 {
 			break
 		}
 	}
 
 	// wait for the in-flight indexing to finish
-	shard.Queue().Wait()
+	q.Wait()
 
 	// make sure the new index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
+		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -661,7 +663,8 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	q := shard.Queues()["foo"]
+	vidx, q := getVectorIndexAndQueue(t, shard, "")
+
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
@@ -674,7 +677,6 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 	q.Wait()
 
 	// make sure the new index contains all the objects
-	vidx := shard.VectorIndexes()["foo"]
 	for _, obj := range objs {
 		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
@@ -684,7 +686,6 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 	err = index.DebugResetVectorIndex(ctx, shard.Name(), "foo")
 	require.Nil(t, err)
 
-	q = shard.Queues()["foo"]
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
@@ -697,7 +698,6 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 	q.Wait()
 
 	// make sure the new index contains all the objects
-	vidx = shard.VectorIndexes()["foo"]
 	for _, obj := range objs {
 		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
@@ -752,20 +752,22 @@ func TestIndex_DebugResetVectorIndexPQ(t *testing.T) {
 		require.Nil(t, err)
 	}
 
+	vidx, q := getVectorIndexAndQueue(t, shard, "")
+
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.Queue().Size() == 0 {
+		if q.Size() == 0 {
 			break
 		}
 	}
 
-	shard.Queue().Wait()
+	q.Wait()
 
 	// wait until the index is compressed
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.VectorIndex().Compressed() {
+		if vidx.Compressed() {
 			break
 		}
 	}
@@ -776,25 +778,25 @@ func TestIndex_DebugResetVectorIndexPQ(t *testing.T) {
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.Queue().Size() == 0 {
+		if q.Size() == 0 {
 			break
 		}
 	}
 
 	// wait for the in-flight indexing to finish
-	shard.Queue().Wait()
+	q.Wait()
 
 	// wait until the index is compressed
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shard.VectorIndex().Compressed() {
+		if vidx.Compressed() {
 			break
 		}
 	}
 
 	// make sure the new index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
+		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -862,8 +864,8 @@ func TestIndex_ConvertQueue(t *testing.T) {
 	}
 
 	// reset the queue
-	q := shard.Queue()
-	q.ResetWith(shard.VectorIndex())
+	vidx, q := getVectorIndexAndQueue(t, shard, "")
+	q.ResetWith(vidx)
 	q.Resume()
 
 	err := shard.ConvertQueue("")
@@ -882,7 +884,7 @@ func TestIndex_ConvertQueue(t *testing.T) {
 
 	// make sure the index contains all the objects
 	for _, obj := range objs {
-		if !shard.VectorIndex().ContainsDoc(obj.DocID) {
+		if !vidx.ContainsDoc(obj.DocID) {
 			t.Fatalf("node %d should be in the vector index", obj.DocID)
 		}
 	}
@@ -924,8 +926,7 @@ func TestIndex_ConvertQueueTargetVector(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	q := shard.Queues()["foo"]
-	vectorIndex := shard.VectorIndexes()["foo"]
+	vectorIndex, q := getVectorIndexAndQueue(t, shard, "foo")
 
 	// reset the queue
 	q.Pause()

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -663,7 +663,7 @@ func TestIndex_DebugResetVectorIndexTargetVector(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	vidx, q := getVectorIndexAndQueue(t, shard, "")
+	vidx, q := getVectorIndexAndQueue(t, shard, "foo")
 
 	// wait until the queue is empty
 	for i := 0; i < 10; i++ {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -196,6 +196,7 @@ type Shard struct {
 	propLenTracker    *inverted.JsonShardMetaData
 	versioner         *shardVersioner
 
+	vectorIndexMu sync.RWMutex
 	vectorIndex   VectorIndex
 	queue         *VectorIndexQueue
 	vectorIndexes map[string]VectorIndex

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -196,7 +196,6 @@ type Shard struct {
 	propLenTracker    *inverted.JsonShardMetaData
 	versioner         *shardVersioner
 
-	// invariant: if vector index is present, then corresponding queue is also present and initialized
 	vectorIndex   VectorIndex
 	queue         *VectorIndexQueue
 	vectorIndexes map[string]VectorIndex

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -98,8 +98,6 @@ type ShardLike interface {
 	Aggregate(ctx context.Context, params aggregation.Params, modules *modules.Provider) (*aggregation.Result, error)
 	HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 	MergeObject(ctx context.Context, object objects.MergeDocument) error
-	Queue() *VectorIndexQueue
-	Queues() map[string]*VectorIndexQueue
 	VectorDistanceForQuery(ctx context.Context, id uint64, searchVectors []models.Vector, targets []string) ([]float32, error)
 	ConvertQueue(targetVector string) error
 	FillQueue(targetVector string, from uint64) error
@@ -110,12 +108,10 @@ type ShardLike interface {
 	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor,
 		additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) // Search and return objects
 	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) // Check if an object was deleted
-	VectorIndex() VectorIndex                                                // Get the vector index
-	VectorIndexes() map[string]VectorIndex                                   // Get the vector indexes
-	ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error
-	ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error
 	GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool)
 	GetVectorIndex(targetVector string) (VectorIndex, bool)
+	ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error
+	ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error
 	// TODO tests only
 	Versioner() *shardVersioner // Get the shard versioner
 
@@ -188,21 +184,23 @@ type onDeleteFromPropertyValueIndex func(shard *Shard, docID uint64, property *i
 type Shard struct {
 	index             *Index // a reference to the underlying index, which in turn contains schema information
 	class             *models.Class
-	queue             *VectorIndexQueue
-	queues            map[string]*VectorIndexQueue
 	scheduler         *queue.Scheduler
 	name              string
 	store             *lsmkv.Store
 	counter           *indexcounter.Counter
 	indexCheckpoints  *indexcheckpoint.Checkpoints
-	vectorIndex       VectorIndex
-	vectorIndexes     map[string]VectorIndex
 	metrics           *Metrics
 	promMetrics       *monitoring.PrometheusMetrics
 	slowQueryReporter helpers.SlowQueryReporter
 	propertyIndices   propertyspecific.Indices
 	propLenTracker    *inverted.JsonShardMetaData
 	versioner         *shardVersioner
+
+	// invariant: if vector index is present, then corresponding queue is also present and initialized
+	vectorIndex   VectorIndex
+	queue         *VectorIndexQueue
+	vectorIndexes map[string]VectorIndex
+	queues        map[string]*VectorIndexQueue
 
 	// async replication
 	asyncReplicationRWMux      sync.RWMutex
@@ -322,7 +320,12 @@ func (s *Shard) UpdateVectorIndexConfig(ctx context.Context, updated schemaConfi
 		return fmt.Errorf("attempt to mark read-only: %w", err)
 	}
 
-	return s.VectorIndex().UpdateUserConfig(updated, func() {
+	index, ok := s.GetVectorIndex("")
+	if !ok {
+		return fmt.Errorf("vector index does not exist")
+	}
+
+	return index.UpdateUserConfig(updated, func() {
 		s.UpdateStatus(storagestate.StatusReady.String())
 	})
 }
@@ -337,10 +340,13 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 
 	wg := new(sync.WaitGroup)
 	var err error
-	for targetName, targetCfg := range updated {
+	for targetVector, targetCfg := range updated {
 		wg.Add(1)
-		if err = s.VectorIndexForName(targetName).UpdateUserConfig(targetCfg, wg.Done); err != nil {
-			break
+
+		if index, ok := s.GetVectorIndex(targetVector); ok {
+			if err = index.UpdateUserConfig(targetCfg, wg.Done); err != nil {
+				break
+			}
 		}
 	}
 
@@ -372,46 +378,6 @@ func (s *Shard) ObjectCountAsync() int {
 	}
 
 	return b.CountAsync()
-}
-
-// ForEachVectorIndex iterates through each vector index initialized in the shard (named and legacy).
-// Iteration stops at the first return of non-nil error.
-func (s *Shard) ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error {
-	for targetVector, idx := range s.vectorIndexes {
-		if idx == nil {
-			continue
-		}
-
-		if err := f(targetVector, idx); err != nil {
-			return err
-		}
-	}
-	if s.vectorIndex != nil {
-		if err := f("", s.vectorIndex); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ForEachVectorQueue iterates through each vector index queue initialized in the shard (named and legacy).
-// Iteration stops at the first return of non-nil error.
-func (s *Shard) ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error {
-	for targetVector, q := range s.queues {
-		if q == nil {
-			continue
-		}
-
-		if err := f(targetVector, q); err != nil {
-			return err
-		}
-	}
-	if s.queue != nil {
-		if err := f("", s.queue); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *Shard) isFallbackToSearchable() bool {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -218,6 +218,9 @@ func (s *Shard) getOrInitDynamicVectorIndexDB() (*bbolt.DB, error) {
 }
 
 func (s *Shard) initTargetVectors(ctx context.Context) error {
+	s.vectorIndexMu.Lock()
+	defer s.vectorIndexMu.Unlock()
+
 	s.vectorIndexes = make(map[string]VectorIndex, len(s.index.vectorIndexUserConfigs))
 	s.queues = make(map[string]*VectorIndexQueue, len(s.index.vectorIndexUserConfigs))
 
@@ -238,6 +241,9 @@ func (s *Shard) initTargetVectors(ctx context.Context) error {
 }
 
 func (s *Shard) initLegacyVector(ctx context.Context) error {
+	s.vectorIndexMu.Lock()
+	defer s.vectorIndexMu.Unlock()
+
 	vectorIndex, err := s.initVectorIndex(ctx, "", s.index.vectorIndexUserConfig)
 	if err != nil {
 		return err
@@ -250,4 +256,15 @@ func (s *Shard) initLegacyVector(ctx context.Context) error {
 	s.vectorIndex = vectorIndex
 	s.queue = queue
 	return nil
+}
+
+func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {
+	s.vectorIndexMu.Lock()
+	defer s.vectorIndexMu.Unlock()
+
+	if targetVector == "" {
+		s.vectorIndex = index
+	} else {
+		s.vectorIndexes[targetVector] = index
+	}
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -439,16 +439,6 @@ func (l *LazyLoadShard) MergeObject(ctx context.Context, object objects.MergeDoc
 	return l.shard.MergeObject(ctx, object)
 }
 
-func (l *LazyLoadShard) Queue() *VectorIndexQueue {
-	l.mustLoad()
-	return l.shard.Queue()
-}
-
-func (l *LazyLoadShard) Queues() map[string]*VectorIndexQueue {
-	l.mustLoad()
-	return l.shard.Queues()
-}
-
 func (l *LazyLoadShard) GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool) {
 	l.mustLoad()
 	return l.shard.GetVectorIndexQueue(targetVector)
@@ -528,16 +518,6 @@ func (l *LazyLoadShard) WasDeleted(ctx context.Context, id strfmt.UUID) (bool, t
 		return false, time.Time{}, err
 	}
 	return l.shard.WasDeleted(ctx, id)
-}
-
-func (l *LazyLoadShard) VectorIndex() VectorIndex {
-	l.mustLoad()
-	return l.shard.VectorIndex()
-}
-
-func (l *LazyLoadShard) VectorIndexes() map[string]VectorIndex {
-	l.mustLoad()
-	return l.shard.VectorIndexes()
 }
 
 func (l *LazyLoadShard) Versioner() *shardVersioner {

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -348,9 +348,8 @@ func (s *Shard) VectorDistanceForQuery(ctx context.Context, docId uint64, search
 	}
 
 	distances := make([]float32, len(targetVectors))
-	indexes := s.VectorIndexes()
 	for j, target := range targetVectors {
-		index, ok := indexes[target]
+		index, ok := s.GetVectorIndex(target)
 		if !ok {
 			return nil, fmt.Errorf("index %s not found", target)
 		}

--- a/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
@@ -533,15 +533,17 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		}
 	}
 
-	createShard := func(t *testing.T) ShardLike {
+	createShard := func(t *testing.T) (ShardLike, *VectorIndexQueue) {
 		vectorIndexConfig := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
 		shard, _ := testShardWithSettings(t, ctx, class, vectorIndexConfig, true, true)
-		return shard
+		queue, ok := shard.GetVectorIndexQueue("")
+		require.True(t, ok)
+		return shard, queue
 	}
 
 	t.Run("single object", func(t *testing.T) {
 		t.Run("sanity check - search after add", func(t *testing.T) {
-			shard := createShard(t)
+			shard, queue := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -549,9 +551,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("wait for queue to be empty", func(t *testing.T) {
-				shard.Queue().Scheduler().Schedule(context.Background())
+				queue.Scheduler().Schedule(context.Background())
 				time.Sleep(50 * time.Millisecond)
-				shard.Queue().Wait()
+				queue.Wait()
 			})
 
 			t.Run("verify initial docID and timestamps", func(t *testing.T) {
@@ -569,7 +571,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("replace with different object, same vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, queue := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -584,9 +586,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("wait for queue to be empty", func(t *testing.T) {
-				shard.Queue().Scheduler().Schedule(context.Background())
+				queue.Scheduler().Schedule(context.Background())
 				time.Sleep(50 * time.Millisecond)
-				shard.Queue().Wait()
+				queue.Wait()
 			})
 
 			t.Run("verify same docID, changed create & update timestamps", func(t *testing.T) {
@@ -604,7 +606,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("replace with different object, different vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, queue := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -621,9 +623,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("wait for queue to be empty", func(t *testing.T) {
-				shard.Queue().Scheduler().Schedule(context.Background())
+				queue.Scheduler().Schedule(context.Background())
 				time.Sleep(50 * time.Millisecond)
-				shard.Queue().Wait()
+				queue.Wait()
 			})
 
 			t.Run("verify changed docID, changed create & update timestamps", func(t *testing.T) {
@@ -641,7 +643,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("replace with different object, different geo", func(t *testing.T) {
-			shard := createShard(t)
+			shard, queue := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -661,9 +663,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("wait for queue to be empty", func(t *testing.T) {
-				shard.Queue().Scheduler().Schedule(context.Background())
+				queue.Scheduler().Schedule(context.Background())
 				time.Sleep(50 * time.Millisecond)
-				shard.Queue().Wait()
+				queue.Wait()
 			})
 
 			t.Run("verify changed docID, changed create & update timestamps", func(t *testing.T) {
@@ -681,7 +683,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("merge with different object, same vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, queue := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -696,9 +698,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("wait for queue to be empty", func(t *testing.T) {
-				shard.Queue().Scheduler().Schedule(context.Background())
+				queue.Scheduler().Schedule(context.Background())
 				time.Sleep(50 * time.Millisecond)
-				shard.Queue().Wait()
+				queue.Wait()
 			})
 
 			t.Run("verify same docID, changed update timestamp", func(t *testing.T) {
@@ -716,7 +718,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("merge with different object, different vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, queue := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -733,9 +735,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("wait for queue to be empty", func(t *testing.T) {
-				shard.Queue().Scheduler().Schedule(context.Background())
+				queue.Scheduler().Schedule(context.Background())
 				time.Sleep(50 * time.Millisecond)
-				shard.Queue().Wait()
+				queue.Wait()
 			})
 
 			t.Run("verify changed docID, changed update timestamp", func(t *testing.T) {
@@ -753,7 +755,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("merge with different object, different geo", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -787,7 +789,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("replace with same object, same vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -819,7 +821,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("replace with same object, different vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -852,7 +854,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("replace with same object, different geo", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -888,7 +890,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("merge with same object, same vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -927,7 +929,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("merge with same object, different vector", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -966,7 +968,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 		})
 
 		t.Run("merge with same object, different geo", func(t *testing.T) {
-			shard := createShard(t)
+			shard, _ := createShard(t)
 
 			t.Run("add object", func(t *testing.T) {
 				err := shard.PutObject(ctx, createOrigObj())
@@ -1009,7 +1011,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 	t.Run("batch", func(t *testing.T) {
 		runBatch := func(t *testing.T) {
 			t.Run("sanity check - search after add", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1019,9 +1021,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("verify initial docID and timestamps", func(t *testing.T) {
@@ -1039,7 +1041,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("replace with different object, same vector", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1049,9 +1051,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("add 2nd batch", func(t *testing.T) {
@@ -1078,7 +1080,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("replace with different object, different vector", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1099,9 +1101,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("verify changed docID, changed create & update timestamps", func(t *testing.T) {
@@ -1119,7 +1121,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("replace with different object, different geo", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1143,9 +1145,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("verify changed docID, changed create & update timestamps", func(t *testing.T) {
@@ -1163,7 +1165,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("replace with same object, same vector", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1185,9 +1187,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("verify same docID, same timestamps", func(t *testing.T) {
@@ -1205,7 +1207,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("replace with same object, different vector", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1228,9 +1230,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("verify changed docID, changed create & update timestamps", func(t *testing.T) {
@@ -1248,7 +1250,7 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 			})
 
 			t.Run("replace with same object, different geo", func(t *testing.T) {
-				shard := createShard(t)
+				shard, queue := createShard(t)
 
 				t.Run("add batch", func(t *testing.T) {
 					errs := shard.PutObjectBatch(ctx, []*storobj.Object{createOrigObj()})
@@ -1274,9 +1276,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				})
 
 				t.Run("wait for queue to be empty", func(t *testing.T) {
-					shard.Queue().Scheduler().Schedule(context.Background())
+					queue.Scheduler().Schedule(context.Background())
 					time.Sleep(50 * time.Millisecond)
-					shard.Queue().Wait()
+					queue.Wait()
 				})
 
 				t.Run("verify changed docID, changed create & update timestamps", func(t *testing.T) {

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -47,7 +47,7 @@ func (s *Shard) GetStatus() storagestate.Status {
 		return s.status.Status
 	}
 
-	if len(s.queues) == 0 && !s.hasLegacyVectorIndex() {
+	if !s.hasAnyVectorIndex() {
 		return s.status.Status
 	}
 

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -258,12 +258,11 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	oldIdx := shd.VectorIndex()
-
 	// wait for the first batch to be indexed
+	oldIdx, q := getVectorIndexAndQueue(t, shd, "")
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if shd.Queue().Size() <= 500 {
+		if q.Size() <= 500 {
 			break
 		}
 	}
@@ -271,14 +270,14 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 	err := shd.DebugResetVectorIndex(ctx, "")
 	require.Nil(t, err)
 
-	newIdx := shd.VectorIndex()
+	newIdx, q := getVectorIndexAndQueue(t, shd, "")
 
 	// the new index should be different from the old one.
 	// pointer comparison is enough here
 	require.NotEqual(t, oldIdx, newIdx)
 
 	// queue should be empty after reset
-	require.EqualValues(t, 0, shd.Queue().Size())
+	require.EqualValues(t, 0, q.Size())
 
 	// make sure the new index does not contain any of the objects
 	for _, obj := range objs {
@@ -289,76 +288,6 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
-}
-
-func TestShard_ForEachVectorIndexAndQueue(t *testing.T) {
-	for _, tt := range []struct {
-		name          string
-		setConfigs    func(idx *Index)
-		expectIndexes []string
-	}{
-		{
-			name: "only legacy vector",
-			setConfigs: func(idx *Index) {
-				idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
-			},
-			expectIndexes: []string{""},
-		},
-		{
-			name: "only named vector",
-			setConfigs: func(idx *Index) {
-				idx.vectorIndexUserConfig = nil
-				idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
-					"vector1": hnsw.NewDefaultUserConfig(),
-					"vector2": flat.NewDefaultUserConfig(),
-				}
-			},
-			expectIndexes: []string{"vector1", "vector2"},
-		},
-		{
-			name: "mixed vectors",
-			setConfigs: func(idx *Index) {
-				idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
-				idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
-					"vector1": hnsw.NewDefaultUserConfig(),
-					"vector2": flat.NewDefaultUserConfig(),
-				}
-			},
-			expectIndexes: []string{"", "vector1", "vector2"},
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			shard, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "TestClass"}, hnsw.NewDefaultUserConfig(), false, true, tt.setConfigs)
-
-			capturedIndexes := make(map[string]any)
-			err := shard.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
-				require.NotNil(t, index)
-				capturedIndexes[targetVector] = index
-				return nil
-			})
-			require.NoError(t, err)
-
-			capturedQueues := make(map[string]any)
-			err = shard.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
-				require.NotNil(t, queue)
-				capturedQueues[targetVector] = queue
-				return nil
-			})
-			require.NoError(t, err)
-
-			require.Len(t, capturedIndexes, len(tt.expectIndexes))
-			for _, name := range tt.expectIndexes {
-				_, ok := capturedIndexes[name]
-				require.True(t, ok)
-			}
-
-			require.Len(t, capturedQueues, len(tt.expectIndexes))
-			for _, name := range tt.expectIndexes {
-				_, ok := capturedQueues[name]
-				require.True(t, ok)
-			}
-		})
-	}
 }
 
 func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
@@ -403,8 +332,7 @@ func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	oldIdx := shd.VectorIndexes()["foo"]
-	q := shd.Queues()["foo"]
+	oldIdx, q := getVectorIndexAndQueue(t, shd, "foo")
 
 	// wait for the first batch to be indexed
 	for i := 0; i < 10; i++ {
@@ -417,7 +345,7 @@ func TestShard_DebugResetVectorIndex_WithTargetVectors(t *testing.T) {
 	err := shd.DebugResetVectorIndex(ctx, "foo")
 	require.Nil(t, err)
 
-	newIdx := shd.VectorIndexes()["foo"]
+	newIdx, q := getVectorIndexAndQueue(t, shd, "foo")
 
 	// the new index should be different from the old one.
 	// pointer comparison is enough here
@@ -442,22 +370,18 @@ func TestShard_RepairIndex(t *testing.T) {
 	t.Setenv("ASYNC_INDEXING_STALE_TIMEOUT", "200ms")
 
 	tests := []struct {
-		name           string
-		targetVector   string
-		multiVector    bool
-		cfg            schemaConfig.VectorIndexConfig
-		idxOpt         func(*Index)
-		getQueue       func(ShardLike) *VectorIndexQueue
-		getVectorIndex func(ShardLike) VectorIndex
+		name                   string
+		targetVector           string
+		multiVector            bool
+		cfg                    schemaConfig.VectorIndexConfig
+		idxOpt                 func(*Index)
+		getVectorIndexAndQueue func(ShardLike) (VectorIndex, *VectorIndexQueue)
 	}{
 		{
 			name: "hnsw",
 			cfg:  hnsw.UserConfig{},
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queue()
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndex()
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "")
 			},
 		},
 		{
@@ -468,11 +392,8 @@ func TestShard_RepairIndex(t *testing.T) {
 				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
 				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{}
 			},
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queues()["foo"]
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndexes()["foo"]
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "foo")
 			},
 		},
 		{
@@ -488,21 +409,15 @@ func TestShard_RepairIndex(t *testing.T) {
 					},
 				}
 			},
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queues()["foo"]
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndexes()["foo"]
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "foo")
 			},
 		},
 		{
 			name: "flat",
 			cfg:  flat.NewDefaultUserConfig(),
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queue()
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndex()
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "")
 			},
 		},
 	}
@@ -550,8 +465,7 @@ func TestShard_RepairIndex(t *testing.T) {
 				require.Nil(t, err)
 			}
 
-			vidx := test.getVectorIndex(shd)
-			q := test.getQueue(shd)
+			vidx, q := test.getVectorIndexAndQueue(shd)
 
 			// wait for the queue to be empty
 			for i := 0; i < 20; i++ {
@@ -626,22 +540,18 @@ func TestShard_FillQueue(t *testing.T) {
 	t.Setenv("ASYNC_INDEXING_STALE_TIMEOUT", "200ms")
 
 	tests := []struct {
-		name           string
-		targetVector   string
-		multiVector    bool
-		cfg            schemaConfig.VectorIndexConfig
-		idxOpt         func(*Index)
-		getQueue       func(ShardLike) *VectorIndexQueue
-		getVectorIndex func(ShardLike) VectorIndex
+		name                   string
+		targetVector           string
+		multiVector            bool
+		cfg                    schemaConfig.VectorIndexConfig
+		idxOpt                 func(*Index)
+		getVectorIndexAndQueue func(ShardLike) (VectorIndex, *VectorIndexQueue)
 	}{
 		{
 			name: "hnsw",
 			cfg:  hnsw.UserConfig{},
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queue()
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndex()
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "")
 			},
 		},
 		{
@@ -652,11 +562,8 @@ func TestShard_FillQueue(t *testing.T) {
 				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
 				i.vectorIndexUserConfigs["foo"] = hnsw.UserConfig{}
 			},
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queues()["foo"]
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndexes()["foo"]
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "foo")
 			},
 		},
 		{
@@ -672,21 +579,15 @@ func TestShard_FillQueue(t *testing.T) {
 					},
 				}
 			},
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queues()["foo"]
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndexes()["foo"]
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "foo")
 			},
 		},
 		{
 			name: "flat",
 			cfg:  flat.NewDefaultUserConfig(),
-			getQueue: func(s ShardLike) *VectorIndexQueue {
-				return s.Queue()
-			},
-			getVectorIndex: func(s ShardLike) VectorIndex {
-				return s.VectorIndex()
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "")
 			},
 		},
 	}
@@ -734,8 +635,7 @@ func TestShard_FillQueue(t *testing.T) {
 				require.Nil(t, err)
 			}
 
-			vidx := test.getVectorIndex(shd)
-			q := test.getQueue(shd)
+			vidx, q := test.getVectorIndexAndQueue(shd)
 
 			// wait for the queue to be empty
 			require.EventuallyWithT(t, func(t *assert.CollectT) {
@@ -849,4 +749,11 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func getVectorIndexAndQueue(t *testing.T, shard ShardLike, targetVector string) (VectorIndex, *VectorIndexQueue) {
+	idx, vok := shard.GetVectorIndex(targetVector)
+	q, qok := shard.GetVectorIndexQueue(targetVector)
+	require.True(t, vok && qok)
+	return idx, q
 }

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -33,8 +33,8 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 
 	for targetVector, vector := range merge.Vectors {
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-		vectorIndex := s.VectorIndexForName(targetVector)
-		if vectorIndex == nil {
+		vectorIndex, ok := s.GetVectorIndex(targetVector)
+		if !ok {
 			return errors.Errorf("Validate vector index for update of %v for target vector %s: vector index not found", merge.ID, targetVector)
 		}
 		switch v := vector.(type) {
@@ -53,9 +53,14 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 		}
 	}
 
-	if len(merge.Vector) > 0 && s.hasLegacyVectorIndex() {
+	if len(merge.Vector) > 0 {
+		vectorIndex, ok := s.GetVectorIndex("")
+		if !ok {
+			return errors.Errorf("Validate vector index for update of %v for vector: vector index not found", merge.ID)
+		}
+
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-		err := s.vectorIndex.ValidateBeforeInsert(merge.Vector)
+		err := vectorIndex.ValidateBeforeInsert(merge.Vector)
 		if err != nil {
 			return errors.Wrapf(err, "Validate vector index for update of %v", merge.ID)
 		}
@@ -82,18 +87,18 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 	}
 
 	for targetVector, vector := range obj.Vectors {
-		if err = s.updateVectorIndexForName(ctx, vector, status, targetVector); err != nil {
+		if err = s.updateVectorIndex(ctx, vector, status, targetVector); err != nil {
 			return errors.Wrapf(err, "update vector index for target vector %s", targetVector)
 		}
 	}
 	for targetVector, vector := range obj.MultiVectors {
-		if err = s.updateMultiVectorIndexForName(ctx, vector, status, targetVector); err != nil {
+		if err = s.updateMultiVectorIndex(ctx, vector, status, targetVector); err != nil {
 			return errors.Wrapf(err, "update multi vector index for target vector %s", targetVector)
 		}
 	}
 
 	if s.hasLegacyVectorIndex() {
-		if err = s.updateVectorIndex(ctx, obj.Vector, status); err != nil {
+		if err = s.updateVectorIndex(ctx, obj.Vector, status, ""); err != nil {
 			return errors.Wrap(err, "update vector index")
 		}
 	}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -35,34 +35,34 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
 		vectorIndex, ok := s.GetVectorIndex(targetVector)
 		if !ok {
-			return errors.Errorf("Validate vector index for update of %v for target vector %s: vector index not found", merge.ID, targetVector)
+			return errors.Errorf("validate vector index for update of %v for target vector %s: vector index not found", merge.ID, targetVector)
 		}
 		switch v := vector.(type) {
 		case []float32:
 			err := vectorIndex.ValidateBeforeInsert(v)
 			if err != nil {
-				return errors.Wrapf(err, "Validate vector index for update of %v for target vector %s", merge.ID, targetVector)
+				return errors.Wrapf(err, "validate vector index for update of %v for target vector %s", merge.ID, targetVector)
 			}
 		case [][]float32:
 			err := vectorIndex.ValidateMultiBeforeInsert(v)
 			if err != nil {
-				return errors.Wrapf(err, "Validate multi vector index for update of %v for target vector %s", merge.ID, targetVector)
+				return errors.Wrapf(err, "validate multi vector index for update of %v for target vector %s", merge.ID, targetVector)
 			}
 		default:
-			return errors.Errorf("Validate vector index for update of %v for target vector %s: unrecongnized vector type: %T", merge.ID, targetVector, vector)
+			return errors.Errorf("validate vector index for update of %v for target vector %s: unrecongnized vector type: %T", merge.ID, targetVector, vector)
 		}
 	}
 
 	if len(merge.Vector) > 0 {
 		vectorIndex, ok := s.GetVectorIndex("")
 		if !ok {
-			return errors.Errorf("Validate vector index for update of %v for vector: vector index not found", merge.ID)
+			return errors.Errorf("validate vector index for update of %v for vector: vector index not found", merge.ID)
 		}
 
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
 		err := vectorIndex.ValidateBeforeInsert(merge.Vector)
 		if err != nil {
-			return errors.Wrapf(err, "Validate vector index for update of %v", merge.ID)
+			return errors.Wrapf(err, "validate vector index for update of %v", merge.ID)
 		}
 	}
 

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -55,18 +55,18 @@ func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object)
 	}
 
 	for targetVector, vector := range object.Vectors {
-		if err := s.updateVectorIndexForName(ctx, vector, status, targetVector); err != nil {
+		if err := s.updateVectorIndex(ctx, vector, status, targetVector); err != nil {
 			return errors.Wrapf(err, "update vector index for target vector %s", targetVector)
 		}
 	}
 	for targetVector, multiVector := range object.MultiVectors {
-		if err := s.updateMultiVectorIndexForName(ctx, multiVector, status, targetVector); err != nil {
+		if err := s.updateMultiVectorIndex(ctx, multiVector, status, targetVector); err != nil {
 			return errors.Wrapf(err, "update multi vector index for target vector %s", targetVector)
 		}
 	}
 
 	if s.hasLegacyVectorIndex() {
-		if err := s.updateVectorIndex(ctx, object.Vector, status); err != nil {
+		if err := s.updateVectorIndex(ctx, object.Vector, status, ""); err != nil {
 			return errors.Wrap(err, "update vector index")
 		}
 	}
@@ -109,8 +109,10 @@ func (s *Shard) updateVectorIndexIgnoreDelete(ctx context.Context, vector []floa
 		return nil
 	}
 
-	if err := s.queue.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector}); err != nil {
-		return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
+	if queue, ok := s.GetVectorIndexQueue(""); ok {
+		if err := queue.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector}); err != nil {
+			return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
+		}
 	}
 
 	return nil
@@ -136,7 +138,7 @@ func (s *Shard) updateVectorIndexesIgnoreDelete(ctx context.Context,
 	}
 
 	for targetVector, vector := range vectors {
-		if q := s.QueueForName(targetVector); q != nil {
+		if q, ok := s.GetVectorIndexQueue(targetVector); ok {
 			if err := q.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector}); err != nil {
 				return errors.Wrapf(err, "insert doc id %d to vector index for target vector %s", status.docID, targetVector)
 			}
@@ -165,7 +167,7 @@ func (s *Shard) updateMultiVectorIndexesIgnoreDelete(ctx context.Context,
 	}
 
 	for targetVector, vector := range multiVectors {
-		if q := s.QueueForName(targetVector); q != nil {
+		if q, ok := s.GetVectorIndexQueue(targetVector); ok {
 			if err := q.Insert(ctx, &common.Vector[[][]float32]{ID: status.docID, Vector: vector}); err != nil {
 				return errors.Wrapf(err, "insert doc id %d to multi vector index for target vector %s", status.docID, targetVector)
 			}
@@ -176,41 +178,15 @@ func (s *Shard) updateMultiVectorIndexesIgnoreDelete(ctx context.Context,
 }
 
 func (s *Shard) updateVectorIndex(ctx context.Context, vector []float32,
-	status objectInsertStatus,
-) error {
-	return updateVectorInVectorIndex(ctx, vector, status, s.queue, s.vectorIndex)
-}
-
-func (s *Shard) updateVectorIndexForName(ctx context.Context, vector []float32,
 	status objectInsertStatus, targetVector string,
 ) error {
-	queue, vectorIndex, err := s.getQueueAndVectorIndexForName(targetVector)
-	if err != nil {
-		return fmt.Errorf("update vector index: %w", err)
-	}
-	return updateVectorInVectorIndex(ctx, vector, status, queue, vectorIndex)
+	return updateVectorInVectorIndex(ctx, s, targetVector, vector, status)
 }
 
-func (s *Shard) updateMultiVectorIndexForName(ctx context.Context, vector [][]float32,
+func (s *Shard) updateMultiVectorIndex(ctx context.Context, vector [][]float32,
 	status objectInsertStatus, targetVector string,
 ) error {
-	queue, vectorIndex, err := s.getQueueAndVectorIndexForName(targetVector)
-	if err != nil {
-		return fmt.Errorf("update multi vector index: %w", err)
-	}
-	return updateVectorInVectorIndex(ctx, vector, status, queue, vectorIndex)
-}
-
-func (s *Shard) getQueueAndVectorIndexForName(targetVector string) (*VectorIndexQueue, VectorIndex, error) {
-	queue, ok := s.queues[targetVector]
-	if !ok {
-		return nil, nil, fmt.Errorf("vector queue not found for target vector %s", targetVector)
-	}
-	vectorIndex := s.VectorIndexForName(targetVector)
-	if vectorIndex == nil {
-		return nil, nil, fmt.Errorf("vector index not found for target vector %s", targetVector)
-	}
-	return queue, vectorIndex, nil
+	return updateVectorInVectorIndex(ctx, s, targetVector, vector, status)
 }
 
 func fetchObject(bucket *lsmkv.Bucket, idBytes []byte) (*storobj.Object, error) {
@@ -236,7 +212,7 @@ func (s *Shard) putObjectLSM(obj *storobj.Object, idBytes []byte,
 	defer s.metrics.PutObject(before)
 
 	for targetVector, vector := range obj.Vectors {
-		if vectorIndex := s.VectorIndexForName(targetVector); vectorIndex != nil {
+		if vectorIndex, ok := s.GetVectorIndex(targetVector); ok {
 			if err := vectorIndex.ValidateBeforeInsert(vector); err != nil {
 				return status, errors.Wrapf(err, "Validate vector index %s for target vector %s", targetVector, obj.ID())
 			}
@@ -244,7 +220,7 @@ func (s *Shard) putObjectLSM(obj *storobj.Object, idBytes []byte,
 	}
 
 	for targetVector, vector := range obj.MultiVectors {
-		if vectorIndex := s.VectorIndexForName(targetVector); vectorIndex != nil {
+		if vectorIndex, ok := s.GetVectorIndex(targetVector); ok {
 			if err := vectorIndex.ValidateMultiBeforeInsert(vector); err != nil {
 				return status, errors.Wrapf(err, "Validate vector index %s for target multi vector %s", targetVector, obj.ID())
 			}
@@ -253,9 +229,10 @@ func (s *Shard) putObjectLSM(obj *storobj.Object, idBytes []byte,
 
 	if len(obj.Vector) > 0 && s.hasLegacyVectorIndex() {
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-		err := s.vectorIndex.ValidateBeforeInsert(obj.Vector)
-		if err != nil {
-			return status, errors.Wrapf(err, "Validate vector index for %s", obj.ID())
+		if index, ok := s.GetVectorIndex(""); ok {
+			if err = index.ValidateBeforeInsert(obj.Vector); err != nil {
+				return status, errors.Wrapf(err, "Validate vector index for %s", obj.ID())
+			}
 		}
 	}
 
@@ -763,9 +740,14 @@ func propsEqual(prevProps, nextProps map[string]interface{}) bool {
 	return true
 }
 
-func updateVectorInVectorIndex[T dto.Embedding](ctx context.Context, vector T,
-	status objectInsertStatus, queue *VectorIndexQueue, vectorIndex VectorIndex,
+func updateVectorInVectorIndex[T dto.Embedding](ctx context.Context, shard *Shard, targetVector string, vector T,
+	status objectInsertStatus,
 ) error {
+	queue, ok := shard.GetVectorIndexQueue(targetVector)
+	if !ok {
+		return fmt.Errorf("vector index not found for %s", targetVector)
+	}
+
 	// even if no vector is provided in an update, we still need
 	// to delete the previous vector from the index, if it
 	// exists. otherwise, the associated doc id is left dangling,

--- a/adapters/repos/db/vector_index_queue_test.go
+++ b/adapters/repos/db/vector_index_queue_test.go
@@ -54,7 +54,9 @@ func TestVectorIndexQueueBatchSize(t *testing.T) {
 		})
 	}
 
-	q := shd.Queue()
+	q, ok := shd.GetVectorIndexQueue("")
+	require.True(t, ok)
+
 	// ensure the queue doesn't get scheduled
 	q.Pause()
 


### PR DESCRIPTION
### What's being changed:
We are planning to add an ability to add a new named vector for an already existing collection. This means we are going to modify `shard.queues` and `shard.vectorIndexes` fields during runtime which were treated as immutable up until now.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
