### PR TITLE
refact: correct Error msg of vectorFromParams()&validateNearParams()

### DIFF
--- a/usecases/traverser/near_params_vector.go
+++ b/usecases/traverser/near_params_vector.go
@@ -114,7 +114,7 @@ func (v *nearParamsVector) vectorFromParams(ctx context.Context,
 
 	// either nearObject or nearVector or module search param has to be set,
 	// so if we land here, something has gone very wrong
-	return []float32{}, errors.Errorf("targetFromParams was called without any known params present")
+	return []float32{}, errors.Errorf("vectorFromParams was called without any known params present")
 }
 
 func (v *nearParamsVector) validateNearParams(nearVector *searchparams.NearVector,
@@ -143,11 +143,11 @@ func (v *nearParamsVector) validateNearParams(nearVector *searchparams.NearVecto
 
 	if v.modulesProvider != nil {
 		if len(moduleParams) > 1 {
-			params := []string{}
+			params := make([]string, 0, len(moduleParams))
 			for p := range moduleParams {
 				params = append(params, fmt.Sprintf("'%s'", p))
 			}
-			return errors.Errorf("found more then one module param: %s which are conflicting "+
+			return errors.Errorf("found more than one module params: %s which are conflicting "+
 				"choose one instead", strings.Join(params, ", "))
 		}
 


### PR DESCRIPTION
### What's being changed:
1. correct spelling mistakes in func `validateNearParams()`:  "more **then** one"   ------>  "more **than** one". 
Besides, I guess it could be more memory-efficient if we could pre-allocate memory for a `slice` whose final capacity is known at the beginning
2. correct Error msg in func `vectorFromParams()`:  "**targetFromParams** was called ......"   ------>   "**vectorFromParams** was called ......"

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.


