### PR TITLE
Add test for recall restore with hnsw

### DIFF
--- a/adapters/repos/db/vector/dynamic/restore_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_integration_test.go
@@ -47,7 +47,7 @@ func TestBackup_Integration(t *testing.T) {
 	truths := make([][]uint64, queries_size)
 	distancer := distancer.NewL2SquaredProvider()
 	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
-		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, distanceWrapper(distancer))
+		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, testinghelpers.DistanceWrapper(distancer))
 	})
 	logger, _ := test.NewNullLogger()
 
@@ -114,7 +114,7 @@ func TestBackup_Integration(t *testing.T) {
 		wg.Done()
 	})
 	wg.Wait()
-	recall1, _ := recallAndLatency(ctx, queries, k, idx, truths)
+	recall1, _ := testinghelpers.RecallAndLatency(ctx, queries, k, idx, truths)
 	assert.True(t, recall1 > 0.9)
 
 	assert.Nil(t, idx.Flush())
@@ -128,7 +128,6 @@ func TestBackup_Integration(t *testing.T) {
 	idx, err = New(config, uc, store)
 	require.Nil(t, err)
 	idx.PostStartup()
-
-	recall2, _ := recallAndLatency(ctx, queries, k, idx, truths)
+	recall2, _ := testinghelpers.RecallAndLatency(ctx, queries, k, idx, truths)
 	assert.Equal(t, recall1, recall2)
 }

--- a/adapters/repos/db/vector/hnsw/flat_search_test.go
+++ b/adapters/repos/db/vector/hnsw/flat_search_test.go
@@ -110,7 +110,7 @@ func Test_NoRaceCompressionRecall(t *testing.T) {
 				}
 				truths := make([][]uint64, queries_size)
 				compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
-					truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, distanceWrapper(distancer))
+					truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, testinghelpers.DistanceWrapper(distancer))
 				})
 				index.UpdateUserConfig(uc, func() {
 					fmt.Printf("Time to compress: %s\n", time.Since(before))
@@ -149,13 +149,6 @@ func Test_NoRaceCompressionRecall(t *testing.T) {
 				wg.Wait()
 			})
 		}
-	}
-}
-
-func distanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
-	return func(x, y []float32) float32 {
-		dist, _ := provider.SingleDist(x, y)
-		return dist
 	}
 }
 

--- a/adapters/repos/db/vector/testinghelpers/helpers.go
+++ b/adapters/repos/db/vector/testinghelpers/helpers.go
@@ -12,6 +12,7 @@
 package testinghelpers
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
@@ -299,4 +302,38 @@ func NewDummyStore(t testing.TB) *lsmkv.Store {
 		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 	return store
+}
+
+type VectorIndex interface {
+	SearchByVector(ctx context.Context, vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error)
+}
+
+func RecallAndLatency(ctx context.Context, queries [][]float32, k int, index VectorIndex, truths [][]uint64) (float32, float32) {
+	var relevant uint64
+	retrieved := k * len(queries)
+
+	var querying time.Duration = 0
+	mutex := &sync.Mutex{}
+	logger, _ := test.NewNullLogger()
+	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
+		before := time.Now()
+		results, _, _ := index.SearchByVector(ctx, queries[i], k, nil)
+		ellapsed := time.Since(before)
+		hits := MatchesInLists(truths[i], results)
+		mutex.Lock()
+		querying += ellapsed
+		relevant += hits
+		mutex.Unlock()
+	})
+
+	recall := float32(relevant) / float32(retrieved)
+	latency := float32(querying.Microseconds()) / float32(len(queries))
+	return recall, latency
+}
+
+func DistanceWrapper(provider distancer.Provider) func(x, y []float32) float32 {
+	return func(x, y []float32) float32 {
+		dist, _ := provider.SingleDist(x, y)
+		return dist
+	}
 }


### PR DESCRIPTION
### What's being changed:

This PR adds coverage to verify the recall of Weaviate after performing a restore of Weaviate when using HNSW.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
