### PR TITLE
feat(bm25_block): :sparkles: Use inverted format and blockmax by default

### DIFF
--- a/adapters/repos/db/bm25f_block_test.go
+++ b/adapters/repos/db/bm25f_block_test.go
@@ -31,9 +31,6 @@ import (
 )
 
 func TestBM25FJourneyBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -296,10 +293,6 @@ func TestBM25FJourneyBlock(t *testing.T) {
 }
 
 func TestBM25FSinglePropBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -354,10 +347,6 @@ func TestBM25FSinglePropBlock(t *testing.T) {
 }
 
 func TestBM25FWithFiltersBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -433,10 +422,6 @@ func TestBM25FWithFiltersBlock(t *testing.T) {
 }
 
 func TestBM25FWithFilters_ScoreIsIdenticalWithOrWithoutFilterBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -508,10 +493,6 @@ func TestBM25FWithFilters_ScoreIsIdenticalWithOrWithoutFilterBlock(t *testing.T)
 }
 
 func TestBM25FDifferentParamsJourneyBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -577,10 +558,6 @@ func TestBM25FDifferentParamsJourneyBlock(t *testing.T) {
 
 // Compare with previous BM25 version to ensure the algorithm functions correctly
 func TestBM25FCompareBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -666,10 +643,6 @@ func TestBM25FCompareBlock(t *testing.T) {
 }
 
 func TestBM25F_ComplexDocumentsBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -767,10 +740,6 @@ func TestBM25F_ComplexDocumentsBlock(t *testing.T) {
 }
 
 func TestBM25F_SortMultiPropBlock(t *testing.T) {
-	t.Setenv("USE_INVERTED_SEARCHABLE", "true")
-	t.Setenv("USE_BLOCKMAX_WAND", "true")
-	t.Setenv("COMPUTE_PROPLENGTH_WITH_DUPS", "true")
-
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -222,6 +222,7 @@ func SetupClassForFilterScoringTest(t require.TestingT, repo *DB, schemaGetter *
 }
 
 func TestBM25FJourney(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -471,6 +472,7 @@ func TestBM25FJourney(t *testing.T) {
 }
 
 func TestBM25FSingleProp(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -513,6 +515,7 @@ func TestBM25FSingleProp(t *testing.T) {
 }
 
 func TestBM25FWithFilters(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -576,6 +579,7 @@ func TestBM25FWithFilters(t *testing.T) {
 }
 
 func TestBM25FWithFilters_ScoreIsIdenticalWithOrWithoutFilter(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -635,6 +639,7 @@ func TestBM25FWithFilters_ScoreIsIdenticalWithOrWithoutFilter(t *testing.T) {
 }
 
 func TestBM25FDifferentParamsJourney(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -703,6 +708,7 @@ func EqualFloats(t *testing.T, expected, actual float32, significantFigures int)
 
 // Compare with previous BM25 version to ensure the algorithm functions correctly
 func TestBM25FCompare(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -776,6 +782,7 @@ func TestBM25FCompare(t *testing.T) {
 }
 
 func Test_propertyHasSearchableIndex(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	vFalse := false
 	vTrue := true
 
@@ -882,6 +889,7 @@ func SetupClassDocuments(t require.TestingT, repo *DB, schemaGetter *fakeSchemaG
 }
 
 func TestBM25F_ComplexDocuments(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()
@@ -1023,6 +1031,7 @@ func MultiPropClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGetter
 }
 
 func TestBM25F_SortMultiProp(t *testing.T) {
+	t.Setenv("USE_INVERTED_SEARCHABLE", "false")
 	dirName := t.TempDir()
 
 	logger := logrus.New()

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -99,11 +98,7 @@ func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList
 	var scores []float32
 	var err error
 
-	if os.Getenv("USE_BLOCKMAX_WAND") == "true" {
-		objs, scores, err = b.wandBlock(ctx, filterDocIds, class, keywordRanking, limit, additional)
-	} else {
-		objs, scores, err = b.wand(ctx, filterDocIds, class, keywordRanking, limit, additional)
-	}
+	objs, scores, err = b.wandBlock(ctx, filterDocIds, class, keywordRanking, limit, additional)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "wand")
 	}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1600,7 +1600,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			memTombstones.Or(activeTombstones)
 
-			if n2 > 0 {
+			if active.Count() > 0 {
 				active.advanceOnTombstoneOrFilter()
 			}
 		}
@@ -1620,7 +1620,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			memTombstones.Or(tombstones)
 
-			if n2 > 0 {
+			if flushing.Count() > 0 {
 				flushing.tombstones = activeTombstones
 				flushing.advanceOnTombstoneOrFilter()
 			}
@@ -1696,7 +1696,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if v.Tombstone {
 			continue
 		}
-
+		n++
 		if len(v.Value) < 8 {
 			// b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(v.Value))
 			continue
@@ -1708,14 +1708,14 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if filterDocIds != nil && !filterDocIds.Contains(d.Id) {
 			continue
 		}
-		n++
+
 		term.blockDataDecoded.DocIds = append(term.blockDataDecoded.DocIds, d.Id)
 		term.blockDataDecoded.Tfs = append(term.blockDataDecoded.Tfs, uint64(d.Frequency))
 		term.propLengths[d.Id] = uint32(d.PropLength)
 
 	}
 	if len(term.blockDataDecoded.DocIds) == 0 {
-		return 0, nil
+		return n, nil
 	}
 
 	term.blockEntries = make([]*terms.BlockEntry, 1)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1696,7 +1696,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if v.Tombstone {
 			continue
 		}
-		n++
+
 		if len(v.Value) < 8 {
 			// b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(v.Value))
 			continue
@@ -1708,13 +1708,14 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if filterDocIds != nil && !filterDocIds.Contains(d.Id) {
 			continue
 		}
+		n++
 		term.blockDataDecoded.DocIds = append(term.blockDataDecoded.DocIds, d.Id)
 		term.blockDataDecoded.Tfs = append(term.blockDataDecoded.Tfs, uint64(d.Frequency))
 		term.propLengths[d.Id] = uint32(d.PropLength)
 
 	}
 	if len(term.blockDataDecoded.DocIds) == 0 {
-		return n, nil
+		return 0, nil
 	}
 
 	term.blockEntries = make([]*terms.BlockEntry, 1)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1600,7 +1600,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			memTombstones.Or(activeTombstones)
 
-			if active.Count() > 0 {
+			if !active.Exhausted() {
 				active.advanceOnTombstoneOrFilter()
 			}
 		}
@@ -1620,7 +1620,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			memTombstones.Or(tombstones)
 
-			if flushing.Count() > 0 {
+			if !flushing.Exhausted() {
 				flushing.tombstones = activeTombstones
 				flushing.advanceOnTombstoneOrFilter()
 			}
@@ -1718,6 +1718,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		return n, nil
 	}
 
+	term.exhausted = false
 	term.blockEntries = make([]*terms.BlockEntry, 1)
 	term.blockEntries[0] = &terms.BlockEntry{
 		MaxId:  term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -283,6 +283,7 @@ func NewSegmentBlockMaxDecoded(key []byte, queryTermIndex int, propertyBoost flo
 		blockDataIdx:      0,
 		decoded:           true,
 		freqDecoded:       true,
+		exhausted:         true,
 	}
 
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -93,7 +93,8 @@ func CheckStrategyRoaringSetRange(strategy string) error {
 }
 
 func DefaultSearchableStrategy() string {
-	if config.Disabled(os.Getenv("USE_INVERTED_SEARCHABLE")) {
+	val := os.Getenv("USE_INVERTED_SEARCHABLE")
+	if val != "" && !config.Enabled(val) {
 		return StrategyMapCollection
 	}
 	return StrategyInverted

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -93,8 +93,8 @@ func CheckStrategyRoaringSetRange(strategy string) error {
 }
 
 func DefaultSearchableStrategy() string {
-	if config.Enabled(os.Getenv("USE_INVERTED_SEARCHABLE")) {
-		return StrategyInverted
+	if config.Disabled(os.Getenv("USE_INVERTED_SEARCHABLE")) {
+		return StrategyMapCollection
 	}
-	return StrategyMapCollection
+	return StrategyInverted
 }

--- a/entities/config/helpers.go
+++ b/entities/config/helpers.go
@@ -21,3 +21,12 @@ func Enabled(value string) bool {
 		return false
 	}
 }
+
+func Disabled(value string) bool {
+	switch strings.ToLower(value) {
+	case "off", "disabled", "0", "false":
+		return true
+	default:
+		return false
+	}
+}

--- a/entities/config/helpers.go
+++ b/entities/config/helpers.go
@@ -21,12 +21,3 @@ func Enabled(value string) bool {
 		return false
 	}
 }
-
-func Disabled(value string) bool {
-	switch strings.ToLower(value) {
-	case "off", "disabled", "0", "false":
-		return true
-	default:
-		return false
-	}
-}


### PR DESCRIPTION
### What's being changed:

Use inverted format and blockmax by default on searchable properties
Falls back to mapcollection and wand when it detects "non-migrated" data.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
