### PR TITLE
Fix(bm25_block): Memtable filtered count

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1596,7 +1596,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			allTombstones[1] = tombstones
 
-			if n2 > 0 {
+			if active.Count() > 0 {
 				active.advanceOnTombstoneOrFilter()
 			}
 		}
@@ -1616,7 +1616,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 
 			allTombstones[0] = tombstones
-			if n2 > 0 {
+			if flushing.Count() > 0 {
 				tombstones, _ = b.active.GetTombstones()
 				flushing.tombstones = tombstones
 				flushing.advanceOnTombstoneOrFilter()
@@ -1708,6 +1708,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if v.Tombstone {
 			continue
 		}
+		n++
 		if len(v.Value) < 8 {
 			// b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(v.Value))
 			continue
@@ -1719,7 +1720,6 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if filterDocIds != nil && !filterDocIds.Contains(d.Id) {
 			continue
 		}
-		n++
 		term.blockDataDecoded.DocIds = append(term.blockDataDecoded.DocIds, d.Id)
 		term.blockDataDecoded.Tfs = append(term.blockDataDecoded.Tfs, uint64(d.Frequency))
 		term.propLengths[d.Id] = uint32(d.PropLength)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1596,7 +1596,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			allTombstones[1] = tombstones
 
-			if active.Count() > 0 {
+			if !active.Exhausted() {
 				active.advanceOnTombstoneOrFilter()
 			}
 		}
@@ -1616,7 +1616,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 
 			allTombstones[0] = tombstones
-			if flushing.Count() > 0 {
+			if !flushing.Exhausted() {
 				tombstones, _ = b.active.GetTombstones()
 				flushing.tombstones = tombstones
 				flushing.advanceOnTombstoneOrFilter()
@@ -1728,7 +1728,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 	if len(term.blockDataDecoded.DocIds) == 0 {
 		return n, nil
 	}
-
+	term.exhausted = false
 	term.blockEntries = make([]*terms.BlockEntry, 1)
 	term.blockEntries[0] = &terms.BlockEntry{
 		MaxId:  term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1708,7 +1708,6 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if v.Tombstone {
 			continue
 		}
-		n++
 		if len(v.Value) < 8 {
 			// b.logger.Warnf("Skipping pair in BM25: MapPair.Value should be 8 bytes long, but is %d.", len(v.Value))
 			continue
@@ -1720,6 +1719,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		if filterDocIds != nil && !filterDocIds.Contains(d.Id) {
 			continue
 		}
+		n++
 		term.blockDataDecoded.DocIds = append(term.blockDataDecoded.DocIds, d.Id)
 		term.blockDataDecoded.Tfs = append(term.blockDataDecoded.Tfs, uint64(d.Frequency))
 		term.propLengths[d.Id] = uint32(d.PropLength)

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -283,6 +283,7 @@ func NewSegmentBlockMaxDecoded(key []byte, queryTermIndex int, propertyBoost flo
 		blockDataIdx:      0,
 		decoded:           true,
 		freqDecoded:       true,
+		exhausted:         true,
 	}
 
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))


### PR DESCRIPTION
### What's being changed:

Properly fill SegmentBlockMax from Memtables on filter and deal with exhausted terms if no doc matches filter.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
