### PR TITLE
hnsw: protect node levels from accidental downgrade on restore

### DIFF
--- a/adapters/repos/db/vector/dynamic/restore_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_integration_test.go
@@ -132,3 +132,69 @@ func TestBackup_Integration(t *testing.T) {
 	recall2, _ := recallAndLatency(ctx, queries, k, idx, truths)
 	assert.Equal(t, recall1, recall2)
 }
+
+func TestBackup_IntegrationHnsw(t *testing.T) {
+	ctx := context.Background()
+	dimensions := 20
+	vectors_size := 10_000
+	queries_size := 200
+	k := 10
+
+	vectors, queries := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
+	truths := make([][]uint64, queries_size)
+	distancer := distancer.NewL2SquaredProvider()
+	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
+		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, distanceWrapper(distancer))
+	})
+	logger, _ := test.NewNullLogger()
+
+	dirName := t.TempDir()
+	indexID := "restore-integration-test"
+	noopCallback := cyclemanager.NewCallbackGroupNoop()
+	hnswuc := hnswent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 1_000_000,
+	}
+
+	config := hnsw.Config{
+		RootPath:         dirName,
+		ID:               indexID,
+		Logger:           logger,
+		DistanceProvider: distancer,
+		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
+			return hnsw.NewCommitLogger(dirName, indexID, logger, noopCallback)
+		},
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			vec := vectors[int(id)]
+			if vec == nil {
+				return nil, storobj.NewErrNotFoundf(id, "nil vec")
+			}
+			return vec, nil
+		},
+		TempVectorForIDThunk: TempVectorForIDThunk(vectors),
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+
+	idx, err := hnsw.New(config, hnswuc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+	idx.PostStartup()
+
+	compressionhelpers.Concurrently(logger, uint64(vectors_size), func(i uint64) {
+		idx.Add(ctx, i, vectors[i])
+	})
+	recall1, _ := recallAndLatency(ctx, queries, k, idx, truths)
+	assert.True(t, recall1 > 0.9)
+
+	assert.Nil(t, idx.Flush())
+	assert.Nil(t, idx.Shutdown(context.Background()))
+
+	idx, err = hnsw.New(config, hnswuc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+	idx.PostStartup()
+
+	recall2, _ := recallAndLatency(ctx, queries, k, idx, truths)
+	assert.Equal(t, recall1, recall2)
+}

--- a/adapters/repos/db/vector/hnsw/deserializer.go
+++ b/adapters/repos/db/vector/hnsw/deserializer.go
@@ -190,7 +190,7 @@ func (d *Deserializer) ReadNode(r io.Reader, res *DeserializationResult) error {
 		res.Nodes.Set(graph.NewVertexWithConnections(id, int(level), make([][]uint64, level+1)))
 	} else {
 		node.Edit(func(v *graph.VertexEditor) error {
-			v.SetLevel(int(level))
+			v.ForceSetLevel(int(level))
 			return nil
 		})
 	}

--- a/adapters/repos/db/vector/hnsw/graph/vertex.go
+++ b/adapters/repos/db/vector/hnsw/graph/vertex.go
@@ -175,9 +175,10 @@ func (v *VertexEditor) LevelLen(level int) int {
 }
 
 func (v *VertexEditor) SetLevel(level int) {
-	v.v.level = level
-
-	v.EnsureLevel(level)
+	if level > v.v.level {
+		v.v.level = level
+		v.EnsureLevel(level)
+	}
 }
 
 func (v *VertexEditor) EnsureLevel(level int) {

--- a/adapters/repos/db/vector/hnsw/graph/vertex.go
+++ b/adapters/repos/db/vector/hnsw/graph/vertex.go
@@ -181,8 +181,14 @@ func (v *VertexEditor) SetLevel(level int) {
 	}
 }
 
+func (v *VertexEditor) ForceSetLevel(level int) {
+	v.v.level = level
+
+	v.EnsureLevel(level)
+}
+
 func (v *VertexEditor) EnsureLevel(level int) {
-	if level >= len(v.v.connections) {
+	if len(v.v.connections) <= level {
 		// we need to grow the connections slice
 		newConns := make([][]uint64, level+1)
 		copy(newConns, v.v.connections)


### PR DESCRIPTION
### What's being changed:

Prevent accidental level downgrades during HNSW restore by making SetLevel only allow level increases. Introduced a ForceSetLevel method for ReadNode to explicitly apply persisted levels without affecting restore correctness.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: [E2E](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14076390521) - [Chaos](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14076417408) pipeline
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
