### PR TITLE
Replace -arm64/-amd64 by .arm64/.amd64 in docker tags

### DIFF
--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -55,7 +55,7 @@ function release() {
         tag_exact="${DOCKER_REPO}:${weaviate_version}"
   else
     if [ -n "$arch" ]; then
-      tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}-${arch}"
+      tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}.${arch}"
     else
       tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}"
     fi
@@ -66,7 +66,7 @@ function release() {
       weaviate_version="${prefix}-${git_hash}"
     else
       if [ -n "$arch" ]; then
-        tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}-${arch}"
+        tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}.${arch}"
       else
         tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}"
       fi

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -32,7 +32,7 @@ function release() {
   tag_preview=
   tag_preview_semver=
 
-  git_hash=$(echo "$GITHUB_SHA" | cut -c1-7)
+  git_revision=$(echo "$GITHUB_SHA" | cut -c1-7)
 
   # Determine architecture and platform
   arch=""
@@ -62,8 +62,8 @@ function release() {
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
       prefix="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g')"
-      tag_preview="${DOCKER_REPO}:${prefix}-${git_hash}"
-      weaviate_version="${prefix}-${git_hash}"
+      tag_preview="${DOCKER_REPO}:${prefix}-${git_revision}"
+      weaviate_version="${prefix}-${git_revision}"
     else
       if [ -n "$arch" ]; then
         tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}.${arch}"
@@ -74,10 +74,8 @@ function release() {
     fi
   fi
 
-  args=("--build-arg=GIT_REVISION=$git_revision"
-        "--build-arg=GIT_BRANCH=$git_branch"
-        "--build-arg=BUILD_USER=$build_user"
-        "--build-arg=BUILD_DATE=$build_date"
+  args=("--build-arg=GITHASH=$git_revision"
+        "--build-arg=DOCKER_IMAGE_TAG=$weaviate_version"
         "--build-arg=CGO_ENABLED=0" # Force-disable CGO for cross-compilation - Fixes segmentation faults on arm64 (https://docs.docker.com/docker-hub/image-library/trusted-content/#alpine-images)
         "--platform=$build_platform"
         "--target=weaviate"


### PR DESCRIPTION
### What's being changed:

The existing approach for the semver tag does not match the semver rules, being not accepted by the semver checks in WCD.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
