### PR TITLE
Fix potential vectorization batch deadlock

### DIFF
--- a/modules/text2vec-openai/clients/openai_test.go
+++ b/modules/text2vec-openai/clients/openai_test.go
@@ -166,6 +166,33 @@ func TestClient(t *testing.T) {
 		assert.Equal(t, -1, rl.LimitRequests)
 	})
 
+	t.Run("when rate limit values are returned but are bad values", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t, noRlHeader: false, RlValues: "0"})
+		defer server.Close()
+
+		c := New("apiKey", "", "", 0, nullLogger())
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+			return server.URL, nil
+		}
+
+		expected := &modulecomponents.VectorizationResult{
+			Text:       []string{"This is my text"},
+			Vector:     [][]float32{{0.1, 0.2, 0.3}},
+			Dimensions: 3,
+			Errors:     []error{nil},
+		}
+		res, rl, _, err := c.Vectorize(context.Background(), []string{"This is my text"}, fakeClassConfig{classConfig: map[string]interface{}{"Type": "text", "Model": "ada"}})
+
+		assert.Nil(t, err)
+		assert.Equal(t, expected, res)
+
+		assert.Equal(t, true, rl.UpdateWithMissingValues)
+		assert.Equal(t, 0, rl.RemainingTokens)
+		assert.Equal(t, 0, rl.RemainingRequests)
+		assert.Equal(t, 0, rl.LimitTokens)
+		assert.Equal(t, 0, rl.LimitRequests)
+	})
+
 	t.Run("when the context is expired", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
@@ -331,6 +358,7 @@ type fakeHandler struct {
 	serverError     error
 	headerRequestID string
 	noRlHeader      bool
+	RlValues        string
 }
 
 func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -380,10 +408,14 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	require.Nil(f.t, err)
 
 	if !f.noRlHeader {
-		w.Header().Add("x-ratelimit-limit-requests", "100")
-		w.Header().Add("x-ratelimit-limit-tokens", "100")
-		w.Header().Add("x-ratelimit-remaining-requests", "100")
-		w.Header().Add("x-ratelimit-remaining-tokens", "100")
+		rlValues := f.RlValues
+		if f.RlValues == "" {
+			rlValues = "100"
+		}
+		w.Header().Add("x-ratelimit-limit-requests", rlValues)
+		w.Header().Add("x-ratelimit-limit-tokens", rlValues)
+		w.Header().Add("x-ratelimit-remaining-requests", rlValues)
+		w.Header().Add("x-ratelimit-remaining-tokens", rlValues)
 	}
 
 	w.Write(outBytes)

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -55,6 +55,7 @@ func GetRateLimitsFromHeader(l *logrusext.Sampler, header http.Header, isAzure b
 				Warn("rate limit headers are missing or invalid, going to keep using the old values")
 		})
 	}
+
 	return &modulecomponents.RateLimits{
 		LimitRequests:           limitRequests,
 		LimitTokens:             limitTokens,

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -45,6 +45,8 @@ func GetRateLimitsFromHeader(l *logrusext.Sampler, header http.Header, isAzure b
 	}
 
 	updateWithMissingValues := false
+	// the absolute limits should never be 0, while it is possible to use up all tokens/requests which results in the
+	// remaining tokens/requests to be 0
 	if limitRequests <= 0 || limitTokens <= 0 || remainingRequests < 0 || remainingTokens < 0 {
 		updateWithMissingValues = true
 

--- a/modules/text2vec-openai/ent/vectorization_result.go
+++ b/modules/text2vec-openai/ent/vectorization_result.go
@@ -45,7 +45,7 @@ func GetRateLimitsFromHeader(l *logrusext.Sampler, header http.Header, isAzure b
 	}
 
 	updateWithMissingValues := false
-	if limitRequests < 0 || limitTokens < 0 || remainingRequests < 0 || remainingTokens < 0 {
+	if limitRequests <= 0 || limitTokens <= 0 || remainingRequests < 0 || remainingTokens < 0 {
 		updateWithMissingValues = true
 
 		// logging all headers as there should not be anything sensitive according to the documentation:

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -358,14 +358,19 @@ func (b *Batch) sendBatch(job BatchJob, objCounter int, rateLimit *modulecompone
 		batchesPerMinute := 61.0 / batchTookInS
 		if batchesPerMinute > float64(rateLimit.LimitRequests) {
 			sleepFor := time.Duration((60.0-batchTookInS*float64(rateLimit.LimitRequests))/float64(rateLimit.LimitRequests)) * time.Second
-			time.Sleep(sleepFor)
+			// limit for how long we sleep to avoid deadlocks. This can happen if we get values from the vectorizer that
+			// should not happen such as the LimitRequests being 0
+			time.Sleep(min(b.maxBatchTime/2, sleepFor))
 
 			// adapt the batches per limit
 			batchesPerMinute = float64(rateLimit.LimitRequests)
 		}
 		if batchesPerMinute*float64(estimatedTokensInCurrentBatch) > float64(rateLimit.LimitTokens) {
 			sleepFor := batchTookInS * (batchesPerMinute*float64(estimatedTokensInCurrentBatch) - float64(rateLimit.LimitTokens)) / float64(rateLimit.LimitTokens)
-			time.Sleep(time.Duration(sleepFor * float64(time.Second)))
+			// limit for how long we sleep to avoid deadlocks. This can happen if we get values from the vectorizer that
+			// should not happen such as the LimitTokens being 0
+			sleepTime := min(b.maxBatchTime/2, time.Duration(sleepFor*float64(time.Second)))
+			time.Sleep(sleepTime)
 		}
 
 		// not all request limits are included in "RemainingRequests" and "ResetRequests". For example, in the OpenAI

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -281,7 +281,8 @@ func TestBatchTokenLimitZero(t *testing.T) {
 	client := &fakeBatchClientWithRL{
 		defaultResetRate: 1,
 		defaultRPM:       500,
-		rateLimit:        &modulecomponents.RateLimits{RemainingRequests: 100, LimitRequests: 100},
+		// token limits are all 0
+		rateLimit: &modulecomponents.RateLimits{RemainingRequests: 100, LimitRequests: 100},
 	}
 	cfg := &fakeClassConfig{vectorizePropertyName: false, classConfig: map[string]interface{}{"vectorizeClassName": false}}
 	longString := "ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab ab"


### PR DESCRIPTION
### What's being changed:

When the absolute token limit is 0 (which could be caused by a wrong value in the header returned by openai) the batch algo could sleep forever due to a float-division by 0.

This PR adds two things:
- limit sleep time to reasonable value
- handle explicit 0s returned by openai, missing values were already handled here: https://github.com/weaviate/weaviate/pull/7562

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
