### PR TITLE
fix potential risk of out-of-range in func WithSecondaryKey()

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -103,7 +103,7 @@ type SecondaryKeyOption func(s secondaryIndexKeys) error
 
 func WithSecondaryKey(pos int, key []byte) SecondaryKeyOption {
 	return func(s secondaryIndexKeys) error {
-		if pos > len(s) {
+		if pos >= len(s) {
 			return errors.Errorf("set secondary index %d on an index of length %d",
 				pos, len(s))
 		}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -282,6 +282,8 @@ func TestBucketGetBySecondary(t *testing.T) {
 
 	err = b.Put([]byte("hello"), []byte("world"), WithSecondaryKey(0, []byte("bonjour")))
 	require.Nil(t, err)
+	err = b.Put([]byte("hello"), []byte("world"), WithSecondaryKey(1, []byte("bonjour")))
+	require.Error(t, err)
 
 	value, err := b.Get([]byte("hello"))
 	require.Nil(t, err)


### PR DESCRIPTION
### What's being changed:
Fix  potential risk of `index out of range` in function `WithSecondaryKey()`. Currently, the `if` statement only reports `Error` when its first argument `pos` is greater than `len(s)`(equivalent to `len([][]byte)`), which may miss the boundary case of `pos==len(s)`  and thus incur the risk mentioned before.
**func WithSecondaryKey()**
<img width="347" alt="func1" src="https://github.com/user-attachments/assets/f84067d2-ce20-4de8-89f1-3c2fce448d26" />
**Experiment1**
<img width="724" alt="func2" src="https://github.com/user-attachments/assets/d3368251-1991-4754-acbb-c2557ac07835" />
**Experiment2**
<img width="745" alt="func3" src="https://github.com/user-attachments/assets/8169a690-58ce-4e02-8f14-51d762f17197" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
