### PR TITLE
feat: add additional mixed vector schema validation

### DIFF
--- a/entities/schema/constants.go
+++ b/entities/schema/constants.go
@@ -1,0 +1,16 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+// DefaultNamedVectorName is a default vector named used to create a named vector or to allow access
+// to legacy vector through named vector API.
+const DefaultNamedVectorName = "default"

--- a/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
@@ -59,35 +59,6 @@ func TestNamedVectors_SingleNode_Restart(t *testing.T) {
 	t.Run("restart", test_suits.TestRestart(compose))
 }
 
-func TestNamedVectors_VerifyMixedSchemaIsRejectedWithoutEnvFlag(t *testing.T) {
-	ctx := context.Background()
-	compose, err := test_suits.ComposeModules().
-		WithWeaviate().
-		Start(context.Background())
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
-
-	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
-	require.Nil(t, err)
-
-	err = client.Schema().ClassCreator().
-		WithClass(&models.Class{
-			Class: "MixedVectors",
-			VectorConfig: map[string]models.VectorConfig{
-				"contextionary": {
-					Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
-					VectorIndexType: "hnsw",
-				},
-			},
-			VectorIndexType: "hnsw",
-			Vectorizer:      "text2vec-contextionary",
-		}).
-		Do(ctx)
-	require.ErrorContains(t, err, "class MixedVectors has configuration for both class level and named vectors which is currently not supported.")
-}
-
 func TestNamedVectors_VectorCanNotBeAddedWithoutEnvFlag(t *testing.T) {
 	ctx := context.Background()
 	compose, err := test_suits.ComposeModules().

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_add_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_add_vectors.go
@@ -40,6 +40,8 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 		}
 
 		t.Run("add vector to schema with legacy vector", func(t *testing.T) {
+			require.NoError(t, client.Schema().AllDeleter().Do(ctx))
+
 			class := &models.Class{
 				Class: className,
 				Properties: []*models.Property{
@@ -51,9 +53,6 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 				VectorIndexType: "hnsw",
 				VectorConfig:    map[string]models.VectorConfig{},
 			}
-
-			err = client.Schema().AllDeleter().Do(ctx)
-			require.NoError(t, err)
 
 			// start with a collection that has only a legacy vector
 			require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
@@ -119,6 +118,8 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 		})
 
 		t.Run("add vector to schema with named vector", func(t *testing.T) {
+			require.NoError(t, client.Schema().AllDeleter().Do(ctx))
+
 			class := &models.Class{
 				Class: className,
 				Properties: []*models.Property{
@@ -133,10 +134,6 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 					},
 				},
 			}
-
-			err = client.Schema().AllDeleter().Do(ctx)
-			require.NoError(t, err)
-
 			require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
 
 			_, err = client.Data().Creator().

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -251,7 +251,7 @@ func createMixedVectorsSchema(t *testing.T, client *wvt.Client) *models.Class {
 		},
 	}
 
-	class := &models.Class{
+	return createMixedVectorsSchemaHelper(t, client, &models.Class{
 		Class: className,
 		Properties: []*models.Property{
 			{
@@ -285,11 +285,5 @@ func createMixedVectorsSchema(t *testing.T, client *wvt.Client) *models.Class {
 				VectorIndexType: "flat",
 			},
 		},
-	}
-	require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(context.Background()))
-
-	fetchedSchema, err := client.Schema().ClassGetter().WithClassName(class.Class).Do(context.Background())
-	require.NoError(t, err)
-
-	return fetchedSchema
+	})
 }

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -134,8 +134,6 @@ type Handler struct {
 	scaleOut                scaleOut
 	parser                  Parser
 	classGetter             *ClassGetter
-
-	experimentBackwardsCompatibleNamedVectorsEnabled bool
 }
 
 // NewHandler creates a new handler
@@ -169,8 +167,6 @@ func NewHandler(
 		scaleOut:                scaleoutManager,
 		cloud:                   cloud,
 		classGetter:             classGetter,
-
-		experimentBackwardsCompatibleNamedVectorsEnabled: experimentBackwardsCompatibleNamedVectorsEnabled(),
 	}
 
 	handler.scaleOut.SetSchemaReader(schemaReader)

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -55,7 +55,6 @@ func newTestHandler(t *testing.T, db clusterSchema.Indexer) (*Handler, *fakeSche
 		&fakeModuleConfig{}, fakeClusterState, &fakeScaleOutManager{}, nil, *schemaParser, nil)
 	require.NoError(t, err)
 	handler.schemaConfig.MaximumAllowedCollectionsCount = -1
-	handler.experimentBackwardsCompatibleNamedVectorsEnabled = true
 	handler.parser.experimentBackwardsCompatibleNamedVectorsEnabled = true
 	return &handler, schemaManager
 }

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemachecks "github.com/weaviate/weaviate/entities/schema/checks"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -501,6 +502,14 @@ func (p *Parser) validateNamedVectorConfigsParityAndImmutables(initial, updated 
 		for vecName := range updated.VectorConfig {
 			if _, ok := initial.VectorConfig[vecName]; !ok {
 				return fmt.Errorf("additional config for vector %q", vecName)
+			}
+		}
+	}
+
+	if schemachecks.HasLegacyVectorIndex(initial) {
+		for targetVector := range updated.VectorConfig {
+			if targetVector == schema.DefaultNamedVectorName {
+				return fmt.Errorf("vector named %s cannot be created when collection level vector index is configured", schema.DefaultNamedVectorName)
 			}
 		}
 	}


### PR DESCRIPTION
### What's being changed:

Adding additional validation regarding mixed schema classes:
1. Removing the ability to create a class with mixed vector indexes as we never want a user to do so, and we already can add new named vectors via update.
2. If a schema has a legacy vector index, we are prohibiting adding a named vector called `default` as this would break the contract with clients. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
