### PR TITLE
RBAC: Improve root role assignments

### DIFF
--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -118,7 +118,7 @@ func configureAuthorizer(appState *state.State) error {
 		// if rbac enforcer enabled, start forcing all requests using the casbin enforcer
 		rbacController, err := rbac.New(
 			filepath.Join(appState.ServerConfig.Config.Persistence.DataPath, config.DefaultRaftDir),
-			appState.ServerConfig.Config.Authorization.Rbac,
+			appState.ServerConfig.Config.Authorization.Rbac, appState.ServerConfig.Config.Authentication,
 			appState.Logger)
 		if err != nil {
 			return fmt.Errorf("can't init casbin %w", err)

--- a/test/acceptance/authz/oidc_test.go
+++ b/test/acceptance/authz/oidc_test.go
@@ -143,6 +143,12 @@ func TestRbacWithOIDC(t *testing.T) {
 			// assign role to non-existing user => no error (if OIDC is enabled)
 			helper.AssignRoleToUserOIDC(t, tokenAdmin, createSchemaRoleName, "i-dont-exist")
 
+			// only oidc root user, as api-keys are either not enabled or do not have a root user
+			users := helper.GetUserForRolesBoth(t, "root", tokenAdmin)
+			for _, user := range users {
+				require.Equal(t, *user.UserType, models.UserTypeOutputOidc)
+			}
+
 			if test.nameCollision {
 				// api key user does NOT have the rights, even though it has the same name
 				err = createClass(t, &models.Class{Class: "testingApiKey"}, helper.CreateAuth(customKey))

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -1121,6 +1121,13 @@ func TestRolesUserExistence(t *testing.T) {
 		require.Nil(t, resp2)
 		require.Error(t, err)
 	})
+
+	t.Run("No assignment of root user to oidc when disabled", func(t *testing.T) {
+		users := helper.GetUserForRolesBoth(t, "root", adminKey)
+		for _, user := range users {
+			require.NotEqual(t, *user.UserType, models.UserTypeOutputOidc)
+		}
+	})
 }
 
 func TestGetRolesForUserPermission(t *testing.T) {

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -17,6 +17,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/weaviate/weaviate/usecases/config"
+
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -484,9 +486,9 @@ func setupTestManager(t *testing.T, logger *logrus.Logger) (*manager, error) {
 
 	policyPath := filepath.Join(rbacDir, "policy.csv")
 
-	config := rbacconf.Config{
+	conf := rbacconf.Config{
 		Enabled: true,
 	}
 
-	return New(policyPath, config, logger)
+	return New(policyPath, conf, config.Authentication{OIDC: config.OIDC{Enabled: true}}, logger)
 }

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -17,6 +17,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/weaviate/weaviate/usecases/config"
+
 	"github.com/casbin/casbin/v2"
 	"github.com/sirupsen/logrus"
 
@@ -31,8 +33,8 @@ type manager struct {
 	logger logrus.FieldLogger
 }
 
-func New(rbacStoragePath string, rbac rbacconf.Config, logger logrus.FieldLogger) (*manager, error) {
-	csbin, err := Init(rbac, rbacStoragePath)
+func New(rbacStoragePath string, rbac rbacconf.Config, authNconf config.Authentication, logger logrus.FieldLogger) (*manager, error) {
+	csbin, err := Init(rbac, rbacStoragePath, authNconf)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -17,6 +17,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/weaviate/weaviate/usecases/config"
+
 	"github.com/weaviate/weaviate/entities/models"
 
 	"github.com/casbin/casbin/v2"
@@ -73,7 +75,7 @@ func createStorage(filePath string) error {
 	return err
 }
 
-func Init(conf rbacconf.Config, policyPath string) (*casbin.SyncedCachedEnforcer, error) {
+func Init(conf rbacconf.Config, policyPath string, authNconf config.Authentication) (*casbin.SyncedCachedEnforcer, error) {
 	if !conf.Enabled {
 		return nil, nil
 	}
@@ -129,13 +131,14 @@ func Init(conf rbacconf.Config, policyPath string) (*casbin.SyncedCachedEnforcer
 			continue
 		}
 
-		// add root role to db as well as OIDC users - we block db users from being created with the same name
 		if _, err := enforcer.AddRoleForUser(conv.UserNameWithTypeFromId(conf.RootUsers[i], models.UserTypeInputDb), conv.PrefixRoleName(authorization.Root)); err != nil {
 			return nil, fmt.Errorf("add role for user: %w", err)
 		}
 
-		if _, err := enforcer.AddRoleForUser(conv.UserNameWithTypeFromId(conf.RootUsers[i], models.UserTypeInputOidc), conv.PrefixRoleName(authorization.Root)); err != nil {
-			return nil, fmt.Errorf("add role for user: %w", err)
+		if authNconf.OIDC.Enabled {
+			if _, err := enforcer.AddRoleForUser(conv.UserNameWithTypeFromId(conf.RootUsers[i], models.UserTypeInputOidc), conv.PrefixRoleName(authorization.Root)); err != nil {
+				return nil, fmt.Errorf("add role for user: %w", err)
+			}
 		}
 	}
 

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/weaviate/weaviate/usecases/config"
@@ -131,8 +132,10 @@ func Init(conf rbacconf.Config, policyPath string, authNconf config.Authenticati
 			continue
 		}
 
-		if _, err := enforcer.AddRoleForUser(conv.UserNameWithTypeFromId(conf.RootUsers[i], models.UserTypeInputDb), conv.PrefixRoleName(authorization.Root)); err != nil {
-			return nil, fmt.Errorf("add role for user: %w", err)
+		if authNconf.APIKey.Enabled && slices.Contains(authNconf.APIKey.Users, conf.RootUsers[i]) {
+			if _, err := enforcer.AddRoleForUser(conv.UserNameWithTypeFromId(conf.RootUsers[i], models.UserTypeInputDb), conv.PrefixRoleName(authorization.Root)); err != nil {
+				return nil, fmt.Errorf("add role for user: %w", err)
+			}
 		}
 
 		if authNconf.OIDC.Enabled {


### PR DESCRIPTION
### What's being changed:

- Only assign the root role to OIDC namespace if OIDC is enabled
- Only assign the root role to DB namespace if static apikeys are enabled and root user exists

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
