### PR TITLE
Add tenant filtering tests for all tenant ops

### DIFF
--- a/adapters/handlers/grpc/v1/tenants.go
+++ b/adapters/handlers/grpc/v1/tenants.go
@@ -39,17 +39,9 @@ func (s *Service) tenantsGet(ctx context.Context, principal *models.Principal, r
 			if len(requestedNames) == 0 {
 				return nil, fmt.Errorf("must specify at least one tenant name")
 			}
-			if len(requestedNames) == 1 {
-				tenantResponse, err := s.schemaManager.GetConsistentTenant(ctx, principal, req.Collection, true, requestedNames[0])
-				if err != nil {
-					return nil, err
-				}
-				tenantResponses = []*models.TenantResponse{tenantResponse}
-			} else {
-				tenantResponses, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, requestedNames)
-				if err != nil {
-					return nil, err
-				}
+			tenantResponses, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, requestedNames)
+			if err != nil {
+				return nil, err
 			}
 		default:
 			return nil, fmt.Errorf("unknown tenant parameter %v", req.Params)

--- a/adapters/handlers/grpc/v1/tenants.go
+++ b/adapters/handlers/grpc/v1/tenants.go
@@ -39,9 +39,17 @@ func (s *Service) tenantsGet(ctx context.Context, principal *models.Principal, r
 			if len(requestedNames) == 0 {
 				return nil, fmt.Errorf("must specify at least one tenant name")
 			}
-			tenantResponses, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, requestedNames)
-			if err != nil {
-				return nil, err
+			if len(requestedNames) == 1 {
+				tenantResponse, err := s.schemaManager.GetConsistentTenant(ctx, principal, req.Collection, true, requestedNames[0])
+				if err != nil {
+					return nil, err
+				}
+				tenantResponses = []*models.TenantResponse{tenantResponse}
+			} else {
+				tenantResponses, err = s.schemaManager.GetConsistentTenants(ctx, principal, req.Collection, true, requestedNames)
+				if err != nil {
+					return nil, err
+				}
 			}
 		default:
 			return nil, fmt.Errorf("unknown tenant parameter %v", req.Params)

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -13,7 +13,6 @@ package rest
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
@@ -309,9 +308,16 @@ func (s *schemaHandlers) getTenant(
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
-	tenants, err := s.manager.GetConsistentTenants(ctx, principal, params.ClassName, *params.Consistency, []string{params.TenantName})
+	tenant, err := s.manager.GetConsistentTenant(ctx, principal, params.ClassName, *params.Consistency, params.TenantName)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
+		if errors.Is(err, schemaUC.ErrNotFound) {
+			return schema.NewTenantsGetOneNotFound()
+		}
+		if errors.Is(err, schemaUC.ErrUnexpectedMultiple) {
+			return schema.NewTenantsGetOneInternalServerError().
+				WithPayload(errPayloadFromSingleErr(err))
+		}
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsGetOneForbidden().
@@ -321,19 +327,8 @@ func (s *schemaHandlers) getTenant(
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
-	if len(tenants) == 0 {
-		s.metricRequestsTotal.logUserError(params.ClassName)
-		return schema.NewTenantsGetOneNotFound()
-	}
-	// we shouldn't ever get more than 1 tenant here, just adding handling to be safe
-	if len(tenants) > 1 {
-		return schema.NewTenantsGetOneInternalServerError().
-			WithPayload(errPayloadFromSingleErr(
-				fmt.Errorf("internal error: multiple tenants found: %v", tenants)))
-	}
-	// at this point we know we have exactly 1 tenant
 	s.metricRequestsTotal.logOk(params.ClassName)
-	return schema.NewTenantsGetOneOK().WithPayload(tenants[0])
+	return schema.NewTenantsGetOneOK().WithPayload(tenant)
 }
 
 func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principal *models.Principal) middleware.Responder {

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -13,6 +13,7 @@ package rest
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
@@ -326,6 +327,11 @@ func (s *schemaHandlers) getTenant(
 			return schema.NewTenantsGetOneUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
+	}
+	if tenant == nil {
+		s.metricRequestsTotal.logUserError(params.ClassName)
+		return schema.NewTenantsGetOneUnprocessableEntity().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("tenant '%s' not found when it should have been", params.TenantName)))
 	}
 	s.metricRequestsTotal.logOk(params.ClassName)
 	return schema.NewTenantsGetOneOK().WithPayload(tenant)

--- a/test/acceptance/authz/helper.go
+++ b/test/acceptance/authz/helper.go
@@ -142,12 +142,6 @@ func readTenant(t *testing.T, class string, tenant string, key string) error {
 	return err
 }
 
-func readTenants(t *testing.T, class string, key string) error {
-	params := clschema.NewTenantsGetParams().WithClassName(class)
-	_, err := helper.Client(t).Schema.TenantsGet(params, helper.CreateAuth(key))
-	return err
-}
-
 func readTenantGRPC(t *testing.T, ctx context.Context, class, tenant, key string) error {
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", fmt.Sprintf("Bearer %s", key))
 	_, err := helper.ClientGRPC(t).TenantsGet(ctx, &protocol.TenantsGetRequest{
@@ -159,12 +153,12 @@ func readTenantGRPC(t *testing.T, ctx context.Context, class, tenant, key string
 	return err
 }
 
-func readTenantsReturn(t *testing.T, class string, key string) (*clschema.TenantsGetOK, error) {
+func readTenants(t *testing.T, class string, key string) (*clschema.TenantsGetOK, error) {
 	params := clschema.NewTenantsGetParams().WithClassName(class)
 	return helper.Client(t).Schema.TenantsGet(params, helper.CreateAuth(key))
 }
 
-func readTenantsGRPCReturn(t *testing.T, ctx context.Context, class string, key string) (*protocol.TenantsGetReply, error) {
+func readTenantsGRPC(t *testing.T, ctx context.Context, class string, key string) (*protocol.TenantsGetReply, error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", fmt.Sprintf("Bearer %s", key))
 	return helper.ClientGRPC(t).TenantsGet(ctx, &protocol.TenantsGetRequest{
 		Collection: class,

--- a/test/acceptance/authz/helper.go
+++ b/test/acceptance/authz/helper.go
@@ -142,15 +142,14 @@ func readTenant(t *testing.T, class string, tenant string, key string) error {
 	return err
 }
 
-func readTenantGRPC(t *testing.T, ctx context.Context, class, tenant, key string) error {
+func readTenantGRPC(t *testing.T, ctx context.Context, class, tenant, key string) (*protocol.TenantsGetReply, error) {
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", fmt.Sprintf("Bearer %s", key))
-	_, err := helper.ClientGRPC(t).TenantsGet(ctx, &protocol.TenantsGetRequest{
+	return helper.ClientGRPC(t).TenantsGet(ctx, &protocol.TenantsGetRequest{
 		Collection: class,
 		Params: &protocol.TenantsGetRequest_Names{
 			Names: &protocol.TenantNames{Values: []string{tenant}},
 		},
 	})
-	return err
 }
 
 func readTenants(t *testing.T, class string, key string) (*clschema.TenantsGetOK, error) {

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -20,6 +20,7 @@ import (
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"google.golang.org/grpc/codes"
@@ -27,7 +28,7 @@ import (
 )
 
 func TestAuthZTenants(t *testing.T) {
-	// adminUser := "admin-user"
+	adminUser := "admin-user"
 	adminKey := "admin-key"
 	adminAuth := helper.CreateAuth(adminKey)
 
@@ -41,20 +42,19 @@ func TestAuthZTenants(t *testing.T) {
 	updateTenantAction := authorization.UpdateTenants
 
 	ctx := context.Background()
-	// compose, err := docker.New().WithWeaviate().
-	// 	WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
-	// 	WithRBAC().WithRbacAdmins(adminUser).
-	// 	WithBackendFilesystem().
-	// 	Start(ctx)
-	// require.NoError(t, err)
-	// defer func() {
-	// 	require.NoError(t, compose.Terminate(ctx))
-	// }()
+	compose, err := docker.New().WithWeaviateWithGRPC().
+		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
+		WithRBAC().WithRbacAdmins(adminUser).
+		WithBackendFilesystem().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
 
-	// helper.SetupClient(compose.GetWeaviate().URI())
-	// defer helper.ResetClient()
-	helper.SetupClient("localhost:8081")
-	helper.SetupGRPCClient(t, "localhost:50052")
+	helper.SetupClient(compose.GetWeaviate().URI())
+	helper.SetupGRPCClient(t, compose.GetWeaviate().GrpcURI())
+	defer helper.ResetClient()
 
 	className := "AuthzTenantTestClass"
 	deleteObjectClass(t, className, adminAuth)

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -13,18 +13,21 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAuthZTenants(t *testing.T) {
-	adminUser := "admin-user"
+	// adminUser := "admin-user"
 	adminKey := "admin-key"
 	adminAuth := helper.CreateAuth(adminKey)
 
@@ -38,18 +41,20 @@ func TestAuthZTenants(t *testing.T) {
 	updateTenantAction := authorization.UpdateTenants
 
 	ctx := context.Background()
-	compose, err := docker.New().WithWeaviate().
-		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
-		WithRBAC().WithRbacAdmins(adminUser).
-		WithBackendFilesystem().
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
+	// compose, err := docker.New().WithWeaviate().
+	// 	WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
+	// 	WithRBAC().WithRbacAdmins(adminUser).
+	// 	WithBackendFilesystem().
+	// 	Start(ctx)
+	// require.NoError(t, err)
+	// defer func() {
+	// 	require.NoError(t, compose.Terminate(ctx))
+	// }()
 
-	helper.SetupClient(compose.GetWeaviate().URI())
-	defer helper.ResetClient()
+	// helper.SetupClient(compose.GetWeaviate().URI())
+	// defer helper.ResetClient()
+	helper.SetupClient("localhost:8081")
+	helper.SetupGRPCClient(t, "localhost:50052")
 
 	className := "AuthzTenantTestClass"
 	deleteObjectClass(t, className, adminAuth)
@@ -68,93 +73,220 @@ func TestAuthZTenants(t *testing.T) {
 
 	// user needs to be able to create objects and read the configs
 	all := "*"
+	tenant1 := "Tenant1"
+	tenant2 := "Tenant2"
+	tenants := []*models.Tenant{{Name: tenant1}, {Name: tenant2}}
+	tenantNames := []string{tenant1, tenant2}
 
-	createTenantRoleName := "readSchemaAndCreateTenant"
-	createTenantRole := &models.Role{
-		Name: &createTenantRoleName,
+	createAllTenantsRoleName := "readSchemaAndCreateAllTenants"
+	createAllTenantsRole := &models.Role{
+		Name: &createAllTenantsRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
 			{Action: &createTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
 		},
 	}
 
-	readTenantRoleName := "readSchemaAndReadTenant"
-	readTenantRole := &models.Role{
-		Name: &readTenantRoleName,
+	createSpecificTenantsRoleName := "readSchemaAndCreateSpecificTenant"
+	createSpecificTenantsRole := &models.Role{
+		Name: &createSpecificTenantsRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &createTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
+		},
+	}
+
+	readAllTenantsRoleName := "readSchemaAndReadAllTenants"
+	readAllTenantsRole := &models.Role{
+		Name: &readAllTenantsRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
 			{Action: &readTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
 		},
 	}
 
-	deleteTenantRoleName := "readSchemaAndDeleteTenant"
-	deleteTenantRole := &models.Role{
-		Name: &deleteTenantRoleName,
+	readSpecificTenantRoleName := "readSchemaAndReadSpecificTenant"
+	readSpecificTenantRole := &models.Role{
+		Name: &readSpecificTenantRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
-			{Action: &deleteTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+			{Action: &readTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
 		},
 	}
 
-	updateTenantRoleName := "readSchemaAndUpdateTenant"
-	updateTenantRole := &models.Role{
-		Name: &updateTenantRoleName,
+	deleteSpecificTenantRoleName := "readSchemaAndDeleteSpecificTenant"
+	deleteSpecificTenantRole := &models.Role{
+		Name: &deleteSpecificTenantRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
-			{Action: &updateTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+			{Action: &deleteTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
 		},
 	}
 
-	helper.DeleteRole(t, adminKey, *createTenantRole.Name)
-	helper.DeleteRole(t, adminKey, *readTenantRole.Name)
-	helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
-	helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
-	helper.CreateRole(t, adminKey, createTenantRole)
-	helper.CreateRole(t, adminKey, readTenantRole)
-	helper.CreateRole(t, adminKey, deleteTenantRole)
-	helper.CreateRole(t, adminKey, updateTenantRole)
-	defer helper.DeleteRole(t, adminKey, *createTenantRole.Name)
-	defer helper.DeleteRole(t, adminKey, *readTenantRole.Name)
-	defer helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
-	defer helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
+	updateSpecificTenantRoleName := "readSchemaAndUpdateTenant"
+	updateSpecificTenantRole := &models.Role{
+		Name: &updateSpecificTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &updateTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
+		},
+	}
 
-	tenants := []*models.Tenant{{Name: "Tenant1"}}
+	roles := []*models.Role{
+		createAllTenantsRole,
+		createSpecificTenantsRole,
+		readAllTenantsRole,
+		readSpecificTenantRole,
+		deleteSpecificTenantRole,
+		updateSpecificTenantRole,
+	}
 
-	t.Run("Create tenant", func(t *testing.T) {
-		helper.AssignRoleToUser(t, adminKey, *createTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *createTenantRole.Name, customUser)
+	for _, role := range roles {
+		helper.DeleteRole(t, adminKey, *role.Name)
+		helper.CreateRole(t, adminKey, role)
+	}
+	defer func() {
+		for _, role := range roles {
+			helper.DeleteRole(t, adminKey, *role.Name)
+		}
+	}()
+
+	t.Run("Create all tenants", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createAllTenantsRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createAllTenantsRole.Name, customUser)
 		require.NoError(t, createTenant(t, className, tenants, customKey))
-		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, adminKey))
+		require.NoError(t, deleteTenant(t, className, tenantNames, adminKey))
 	})
 
-	t.Run("Tenant read and exist", func(t *testing.T) {
-		require.NoError(t, createTenant(t, className, tenants, adminKey))
-		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+	t.Run("Create specific tenant with needed permission", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		require.NoError(t, createTenant(t, className, []*models.Tenant{{Name: tenant1}}, customKey))
+		require.NoError(t, deleteTenant(t, className, []string{tenant1}, adminKey))
+	})
 
-		helper.AssignRoleToUser(t, adminKey, *readTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *readTenantRole.Name, customUser)
+	t.Run("Fail to create specific tenant without needed permission", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		err := createTenant(t, className, []*models.Tenant{{Name: tenant2}}, customKey)
+		require.NotNil(t, err)
+		var forbidden *clschema.TenantsCreateForbidden
+		require.True(t, errors.As(err, &forbidden))
+	})
+
+	setupRUDTests := func(role string) func() {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+		helper.AssignRoleToUser(t, adminKey, role, customUser)
+		return func() {
+			defer deleteTenant(t, className, tenantNames, adminKey)
+			defer helper.RevokeRoleFromUser(t, adminKey, role, customUser)
+		}
+	}
+
+	t.Run("Tenant read and exist", func(t *testing.T) {
+		cleanup := setupRUDTests(readAllTenantsRoleName)
+		defer cleanup()
 
 		require.NoError(t, readTenant(t, className, tenants[0].Name, customKey))
-		require.NoError(t, readTenants(t, className, customKey))
 		require.NoError(t, existsTenant(t, className, tenants[0].Name, customKey))
 	})
 
-	t.Run("delete tenant", func(t *testing.T) {
-		require.NoError(t, createTenant(t, className, tenants, adminKey))
+	t.Run("Read a specific tenant with needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
 
-		helper.AssignRoleToUser(t, adminKey, *deleteTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *deleteTenantRole.Name, customUser)
+		require.NoError(t, readTenant(t, className, tenants[0].Name, customKey))
+		require.NoError(t, existsTenant(t, className, tenants[0].Name, customKey))
+	})
+
+	t.Run("Fail to read a specific tenant and all tenants without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		err := readTenant(t, className, tenants[1].Name, customKey)
+		require.NotNil(t, err)
+		var forbiddenGetOne *clschema.TenantsGetOneForbidden
+		require.True(t, errors.As(err, &forbiddenGetOne))
+
+		err = existsTenant(t, className, tenants[1].Name, customKey)
+		var forbiddenExists *clschema.TenantExistsForbidden
+		require.True(t, errors.As(err, &forbiddenExists))
+
+		// tests for tenant filtering
+		readTenants, err := readTenantsReturn(t, className, customKey)
+		require.Nil(t, err)
+		require.Len(t, readTenants.Payload, 1)
+		require.Equal(t, tenants[0].Name, readTenants.Payload[0].Name)
+	})
+
+	t.Run("Get specific tenant using grpc", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		err := readTenantGRPC(t, ctx, className, tenants[0].Name, customKey)
+		require.Nil(t, err)
+	})
+
+	t.Run("Fail to get specific tenant using grpc without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		err := readTenantGRPC(t, ctx, className, tenants[1].Name, customKey)
+		require.NotNil(t, err)
+		require.Equal(t, status.Code(err), codes.PermissionDenied)
+	})
+
+	t.Run("Get filtered tenants using rest", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		res, err := readTenantsReturn(t, className, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Payload, 1)
+		require.Equal(t, tenants[0].Name, res.Payload[0].Name)
+	})
+
+	t.Run("Get filtered tenants using grpc", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		res, err := readTenantsGRPCReturn(t, ctx, className, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Tenants, 1)
+		require.Equal(t, tenants[0].Name, res.Tenants[0].Name)
+	})
+
+	t.Run("Delete specific tenant with needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(deleteSpecificTenantRoleName)
+		defer cleanup()
 
 		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, customKey))
 	})
 
-	t.Run("update tenant status", func(t *testing.T) {
-		require.NoError(t, createTenant(t, className, tenants, adminKey))
-		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+	t.Run("Fail to delete specific tenant without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(deleteSpecificTenantRoleName)
+		defer cleanup()
 
-		helper.AssignRoleToUser(t, adminKey, *updateTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *updateTenantRole.Name, customUser)
+		err := deleteTenant(t, className, []string{tenants[1].Name}, customKey)
+		require.NotNil(t, err)
+		var forbidden *clschema.TenantsDeleteForbidden
+		require.True(t, errors.As(err, &forbidden))
+	})
 
-		require.NoError(t, updateTenantStatus(t, className, []*models.Tenant{{Name: "Tenant1", ActivityStatus: "INACTIVE"}}, customKey))
+	t.Run("Update specific tenant status with needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(updateSpecificTenantRoleName)
+		defer cleanup()
+
+		require.NoError(t, updateTenantStatus(t, className, []*models.Tenant{{Name: tenants[0].Name, ActivityStatus: "INACTIVE"}}, customKey))
+	})
+
+	t.Run("Fail to update specific tenant status without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(updateSpecificTenantRoleName)
+		defer cleanup()
+
+		err := updateTenantStatus(t, className, []*models.Tenant{{Name: tenants[1].Name, ActivityStatus: "INACTIVE"}}, customKey)
+		require.NotNil(t, err)
+		var forbidden *clschema.TenantsUpdateForbidden
+		require.True(t, errors.As(err, &forbidden))
 	})
 }

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestAuthZTenants(t *testing.T) {
@@ -223,17 +221,17 @@ func TestAuthZTenants(t *testing.T) {
 		cleanup := setupRUDTests(readSpecificTenantRoleName)
 		defer cleanup()
 
-		err := readTenantGRPC(t, ctx, className, tenants[0].Name, customKey)
+		_, err := readTenantGRPC(t, ctx, className, tenants[0].Name, customKey)
 		require.Nil(t, err)
 	})
 
-	t.Run("Fail to get specific tenant using grpc without needed permission", func(t *testing.T) {
+	t.Run("Return no tenants via grpc when one is forbidden", func(t *testing.T) {
 		cleanup := setupRUDTests(readSpecificTenantRoleName)
 		defer cleanup()
 
-		err := readTenantGRPC(t, ctx, className, tenants[1].Name, customKey)
-		require.NotNil(t, err)
-		require.Equal(t, status.Code(err), codes.PermissionDenied)
+		res, err := readTenantGRPC(t, ctx, className, tenants[1].Name, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Tenants, 0)
 	})
 
 	t.Run("Get filtered tenants using rest", func(t *testing.T) {

--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -213,10 +213,10 @@ func TestAuthZTenants(t *testing.T) {
 		require.True(t, errors.As(err, &forbiddenExists))
 
 		// tests for tenant filtering
-		readTenants, err := readTenantsReturn(t, className, customKey)
+		res, err := readTenants(t, className, customKey)
 		require.Nil(t, err)
-		require.Len(t, readTenants.Payload, 1)
-		require.Equal(t, tenants[0].Name, readTenants.Payload[0].Name)
+		require.Len(t, res.Payload, 1)
+		require.Equal(t, tenants[0].Name, res.Payload[0].Name)
 	})
 
 	t.Run("Get specific tenant using grpc", func(t *testing.T) {
@@ -240,7 +240,7 @@ func TestAuthZTenants(t *testing.T) {
 		cleanup := setupRUDTests(readSpecificTenantRoleName)
 		defer cleanup()
 
-		res, err := readTenantsReturn(t, className, customKey)
+		res, err := readTenants(t, className, customKey)
 		require.Nil(t, err)
 		require.Len(t, res.Payload, 1)
 		require.Equal(t, tenants[0].Name, res.Payload[0].Name)
@@ -250,7 +250,7 @@ func TestAuthZTenants(t *testing.T) {
 		cleanup := setupRUDTests(readSpecificTenantRoleName)
 		defer cleanup()
 
-		res, err := readTenantsGRPCReturn(t, ctx, className, customKey)
+		res, err := readTenantsGRPC(t, ctx, className, customKey)
 		require.Nil(t, err)
 		require.Len(t, res.Tenants, 1)
 		require.Equal(t, tenants[0].Name, res.Tenants[0].Name)

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -145,7 +145,7 @@ func Test_Schema_Authorization(t *testing.T) {
 				// Cluster/nodes related endpoint
 				"JoinNode", "RemoveNode", "Nodes", "NodeName", "ClusterHealthScore", "ClusterStatus", "ResolveParentNodes",
 				// revert to schema v0 (non raft),
-				"GetConsistentSchema", "GetConsistentTenants",
+				"GetConsistentSchema", "GetConsistentTenants", "GetConsistentTenant",
 				// ignored because it will check if schema has collections otherwise returns nothing
 				"StoreSchemaV1":
 				// don't require auth on methods which are exported because other

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -31,7 +31,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-var ErrNotFound = errors.New("not found")
+var (
+	ErrNotFound           = errors.New("not found")
+	ErrUnexpectedMultiple = errors.New("unexpected multiple results")
+)
 
 // SchemaManager is responsible for consistent schema operations.
 // It allows reading and writing the schema while directly talking to the leader, no matter which node it is.

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -241,6 +241,33 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	return filteredTenants, nil
 }
 
+func (h *Handler) GetConsistentTenant(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) (*models.TenantResponse, error) {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
+		return nil, err
+	}
+
+	var allTenants []*models.TenantResponse
+	var err error
+
+	tenants := []string{tenant}
+	if consistency {
+		allTenants, _, err = h.schemaManager.QueryTenants(class, tenants)
+	} else {
+		// If non consistent, fallback to the default implementation
+		allTenants, err = h.getTenantsByNames(class, tenants)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(allTenants) == 0 {
+		return nil, ErrNotFound
+	}
+	if len(allTenants) > 1 {
+		return nil, ErrUnexpectedMultiple
+	}
+	return allTenants[0], nil
+}
+
 func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 	info := h.schemaReader.ClassInfo(class)
 	if !info.Exists {


### PR DESCRIPTION
### What's being changed:

Add tests for all `schema/{className}/tenants/{tenantName}` ops and `rpc.TenantsGet`. In the process, identify the need for `GetConsistentTenant` to avoid filtering when performing `GetOne` tenant requests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
