### PR TITLE
Feat: set inverted index at index level

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5728,6 +5728,10 @@ func init() {
         },
         "stopwords": {
           "$ref": "#/definitions/StopwordConfig"
+        },
+        "useInvertedSearchable": {
+          "description": "Use inverted format for searchable properties (default: 'true' for new collections).",
+          "type": "boolean"
         }
       }
     },
@@ -13266,6 +13270,10 @@ func init() {
         },
         "stopwords": {
           "$ref": "#/definitions/StopwordConfig"
+        },
+        "useInvertedSearchable": {
+          "description": "Use inverted format for searchable properties (default: 'true' for new collections).",
+          "type": "boolean"
         }
       }
     },

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -44,8 +45,9 @@ func BM25FinvertedConfig(k1, b float32, stopWordPreset string) *models.InvertedI
 		Stopwords: &models.StopwordConfig{
 			Preset: stopWordPreset,
 		},
-		IndexNullState:      true,
-		IndexPropertyLength: true,
+		IndexNullState:        true,
+		IndexPropertyLength:   true,
+		UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 	}
 }
 

--- a/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/cluster/mocks"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	shardingConfig "github.com/weaviate/weaviate/usecases/sharding/config"
@@ -206,6 +207,7 @@ func secondClassWithRef() *models.Class {
 func invertedConfig() *models.InvertedIndexConfig {
 	return &models.InvertedIndexConfig{
 		CleanupIntervalSeconds: 60,
+		UseInvertedSearchable:  config.DefaultUseInvertedSearchable,
 	}
 }
 

--- a/adapters/repos/db/crud_null_objects_integration_test.go
+++ b/adapters/repos/db/crud_null_objects_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
@@ -167,8 +168,9 @@ func createClassWithEverything(IndexNullState bool, IndexPropertyLength bool) *m
 			Stopwords: &models.StopwordConfig{
 				Preset: "none",
 			},
-			IndexNullState:      IndexNullState,
-			IndexPropertyLength: IndexPropertyLength,
+			IndexNullState:        IndexNullState,
+			IndexPropertyLength:   IndexPropertyLength,
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 		},
 		Class: "EverythingClass",
 		Properties: []*models.Property{

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -29,6 +29,7 @@ import (
 	libschema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -309,6 +310,7 @@ func updateTestClass() *models.Class {
 		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 		InvertedIndexConfig: &models.InvertedIndexConfig{
 			CleanupIntervalSeconds: 3,
+			UseInvertedSearchable:  config.DefaultUseInvertedSearchable,
 		},
 		Properties: []*models.Property{
 			{

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -839,8 +840,9 @@ var carClassNoLengthIndex = &models.Class{
 		Stopwords: &models.StopwordConfig{
 			Preset: "none",
 		},
-		IndexNullState:      true,
-		IndexPropertyLength: false,
+		IndexNullState:        true,
+		IndexPropertyLength:   false,
+		UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 	},
 	Properties: []*models.Property{
 		{

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	esync "github.com/weaviate/weaviate/entities/sync"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
@@ -325,7 +326,8 @@ func invertedConfig() *models.InvertedIndexConfig {
 		Stopwords: &models.StopwordConfig{
 			Preset: "none",
 		},
-		IndexNullState:      true,
-		IndexPropertyLength: true,
+		IndexNullState:        true,
+		IndexPropertyLength:   true,
+		UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 	}
 }

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -73,6 +73,7 @@ func (db *DB) init(ctx context.Context) error {
 						K1: config.DefaultBM25k1,
 						B:  config.DefaultBM25b,
 					},
+					UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 				}
 			}
 			if err := replica.ValidateConfig(class, db.config.Replication); err != nil {

--- a/adapters/repos/db/inverted/config.go
+++ b/adapters/repos/db/inverted/config.go
@@ -67,6 +67,8 @@ func ConfigFromModel(iicm *models.InvertedIndexConfig) schema.InvertedIndexConfi
 		conf.Stopwords.Removals = iicm.Stopwords.Removals
 	}
 
+	conf.UseInvertedSearchable = iicm.UseInvertedSearchable
+
 	return conf
 }
 

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 
 	"github.com/go-openapi/strfmt"
@@ -47,9 +48,10 @@ func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
 			Stopwords: &models.StopwordConfig{
 				Preset: "none",
 			},
-			IndexTimestamps:     true,
-			IndexNullState:      true,
-			IndexPropertyLength: true,
+			IndexTimestamps:       true,
+			IndexNullState:        true,
+			IndexPropertyLength:   true,
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 		},
 		Properties: []*models.Property{
 			{
@@ -219,9 +221,10 @@ func TestIndexNullState_GetClass(t *testing.T) {
 			Class:             "TestClass",
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				IndexNullState:      true,
-				IndexTimestamps:     true,
-				IndexPropertyLength: true,
+				IndexNullState:        true,
+				IndexTimestamps:       true,
+				IndexPropertyLength:   true,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{
@@ -236,8 +239,9 @@ func TestIndexNullState_GetClass(t *testing.T) {
 			Class:             "RefClass",
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				IndexTimestamps:     true,
-				IndexPropertyLength: true,
+				IndexTimestamps:       true,
+				IndexPropertyLength:   true,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{
@@ -485,8 +489,9 @@ func TestIndexPropLength_GetClass(t *testing.T) {
 			Class:             "TestClass",
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				IndexPropertyLength: true,
-				IndexTimestamps:     true,
+				IndexPropertyLength:   true,
+				IndexTimestamps:       true,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{
@@ -505,7 +510,8 @@ func TestIndexPropLength_GetClass(t *testing.T) {
 			Class:             "RefClass",
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				IndexTimestamps: true,
+				IndexTimestamps:       true,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{
@@ -838,8 +844,9 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 			Class:             "TestClass",
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				IndexTimestamps:     true,
-				IndexPropertyLength: true,
+				IndexTimestamps:       true,
+				IndexPropertyLength:   true,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{
@@ -854,8 +861,9 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 			Class:             "RefClass",
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				IndexTimestamps:     true,
-				IndexPropertyLength: true,
+				IndexTimestamps:       true,
+				IndexPropertyLength:   true,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -108,6 +108,12 @@ func (t *ShardInvertedReindexTask_MapToBlockmax) OnBefore(ctx context.Context) (
 	return nil
 }
 
+func (t *ShardInvertedReindexTask_MapToBlockmax) OnBeforeByIndex(ctx context.Context, index *Index) (err error) {
+	conf := index.invertedIndexConfig
+	conf.UseInvertedSearchable = true
+	return index.updateInvertedIndexConfig(ctx, conf)
+}
+
 func (t *ShardInvertedReindexTask_MapToBlockmax) OnBeforeByShard(ctx context.Context, shard ShardLike) (err error) {
 	collectionName := shard.Index().Config.ClassName.String()
 	logger := t.logger.WithFields(map[string]any{

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -13,10 +13,8 @@ package lsmkv
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
-	"github.com/weaviate/weaviate/entities/config"
 )
 
 const (
@@ -92,10 +90,9 @@ func CheckStrategyRoaringSetRange(strategy string) error {
 	return CheckExpectedStrategy(strategy, StrategyRoaringSetRange)
 }
 
-func DefaultSearchableStrategy() string {
-	val := os.Getenv("USE_INVERTED_SEARCHABLE")
-	if val != "" && !config.Enabled(val) {
-		return StrategyMapCollection
+func DefaultSearchableStrategy(useInvertedSearchable bool) string {
+	if useInvertedSearchable {
+		return StrategyInverted
 	}
-	return StrategyInverted
+	return StrategyMapCollection
 }

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/weaviate/weaviate/entities/searchparams"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -167,6 +168,7 @@ func Test_MultiShardJourneys_BM25_Search(t *testing.T) {
 			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
 			InvertedIndexConfig: &models.InvertedIndexConfig{
 				CleanupIntervalSeconds: 60,
+				UseInvertedSearchable:  config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -123,7 +123,7 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 	}
 
 	if inverted.HasSearchableIndex(prop) {
-		strategy := lsmkv.DefaultSearchableStrategy()
+		strategy := lsmkv.DefaultSearchableStrategy(s.index.invertedIndexConfig.UseInvertedSearchable)
 		searchableBucketOpts := append(bucketOpts, lsmkv.WithStrategy(strategy))
 		if strategy == lsmkv.StrategyMapCollection && s.versioner.Version() < 2 {
 			searchableBucketOpts = append(searchableBucketOpts, lsmkv.WithLegacyMapSorting())

--- a/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
@@ -47,9 +48,10 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 	class := &models.Class{
 		Class: "TestClass",
 		InvertedIndexConfig: &models.InvertedIndexConfig{
-			IndexTimestamps:     true,
-			IndexNullState:      true,
-			IndexPropertyLength: true,
+			IndexTimestamps:       true,
+			IndexNullState:        true,
+			IndexPropertyLength:   true,
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 		},
 		Properties: []*models.Property{
 			{

--- a/entities/deepcopy/models_deepcopy.go
+++ b/entities/deepcopy/models_deepcopy.go
@@ -99,5 +99,6 @@ func InvertedIndexConfig(i *models.InvertedIndexConfig) *models.InvertedIndexCon
 		IndexPropertyLength:    i.IndexPropertyLength,
 		IndexTimestamps:        i.IndexTimestamps,
 		Stopwords:              stopwords,
+		UseInvertedSearchable:  i.UseInvertedSearchable,
 	}
 }

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model InvertedIndexConfig
 type InvertedIndexConfig struct {
-
 	// bm25
 	Bm25 *BM25Config `json:"bm25,omitempty"`
 
@@ -46,6 +45,9 @@ type InvertedIndexConfig struct {
 
 	// stopwords
 	Stopwords *StopwordConfig `json:"stopwords,omitempty"`
+
+	// Use inverted format for searchable properties (default: 'true' for new collections).
+	UseInvertedSearchable bool `json:"useInvertedSearchable,omitempty"`
 }
 
 // Validate validates this inverted index config
@@ -123,7 +125,6 @@ func (m *InvertedIndexConfig) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *InvertedIndexConfig) contextValidateBm25(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Bm25 != nil {
 		if err := m.Bm25.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -139,7 +140,6 @@ func (m *InvertedIndexConfig) contextValidateBm25(ctx context.Context, formats s
 }
 
 func (m *InvertedIndexConfig) contextValidateStopwords(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Stopwords != nil {
 		if err := m.Stopwords.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {

--- a/entities/schema/inverted_index_config.go
+++ b/entities/schema/inverted_index_config.go
@@ -22,6 +22,7 @@ type InvertedIndexConfig struct {
 	IndexTimestamps        bool
 	IndexNullState         bool
 	IndexPropertyLength    bool
+	UseInvertedSearchable  bool
 }
 
 type BM25Config struct {
@@ -43,6 +44,7 @@ func InvertedIndexConfigFromModel(m models.InvertedIndexConfig) InvertedIndexCon
 	i.IndexTimestamps = m.IndexTimestamps
 	i.IndexNullState = m.IndexNullState
 	i.IndexPropertyLength = m.IndexPropertyLength
+	i.UseInvertedSearchable = m.UseInvertedSearchable
 
 	return i
 }
@@ -62,6 +64,7 @@ func InvertedIndexConfigToModel(i InvertedIndexConfig) models.InvertedIndexConfi
 	m.IndexTimestamps = i.IndexTimestamps
 	m.IndexNullState = i.IndexNullState
 	m.IndexPropertyLength = i.IndexPropertyLength
+	m.UseInvertedSearchable = i.UseInvertedSearchable
 
 	return m
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -625,6 +625,10 @@
         "indexPropertyLength": {
           "description": "Index length of properties (default: 'false').",
           "type": "boolean"
+        },
+        "useInvertedSearchable": {
+          "description": "Use inverted format for searchable properties (default: 'true' for new collections).",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/test/acceptance/graphql_resolvers/local_aggregate_matrix_setup_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_matrix_setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 const notExistingObjectId = "cfa3b21e-ca5f-4db7-a412-ffffffffffff"
@@ -61,7 +62,7 @@ func arrayClassSchema() *models.Class {
 				"vectorizeClassName": true,
 			},
 		},
-		InvertedIndexConfig: &models.InvertedIndexConfig{IndexPropertyLength: true, IndexNullState: true},
+		InvertedIndexConfig: &models.InvertedIndexConfig{IndexPropertyLength: true, IndexNullState: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 		Properties: []*models.Property{
 			{
 				Name:         "texts",

--- a/test/acceptance/grpc/filtered_search_test.go
+++ b/test/acceptance/grpc/filtered_search_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/config"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -48,6 +49,7 @@ func TestGRPC_FilteredSearch(t *testing.T) {
 			Stopwords: &models.StopwordConfig{
 				Preset: "none",
 			},
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 		},
 	})
 	defer helper.DeleteClass(t, collectionName)

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // this test prevents a regression on
@@ -268,6 +269,7 @@ func TestUpdateClassWithoutVectorIndex(t *testing.T) {
 				Stopwords: &models.StopwordConfig{
 					Preset: "en",
 				},
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Properties: []*models.Property{
 				{

--- a/test/acceptance_with_go_client/endpoint_test.go
+++ b/test/acceptance_with_go_client/endpoint_test.go
@@ -22,6 +22,7 @@ import (
 	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func TestUpdatingPropertiesWithNil(t *testing.T) {
@@ -55,7 +56,7 @@ func TestUpdatingPropertiesWithNil(t *testing.T) {
 					// TODO change to constant
 					Tokenization: "whitespace",
 				}},
-				InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true},
+				InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 			}
 			require.Nil(t, classCreator.WithClass(&class).Do(ctx))
 

--- a/test/acceptance_with_go_client/fixtures/food.go
+++ b/test/acceptance_with_go_client/fixtures/food.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 const (
@@ -148,7 +149,7 @@ func classPizza() *models.Class {
 	return &models.Class{
 		Class:               "Pizza",
 		Description:         "A delicious religion like food and arguably the best export of Italy.",
-		InvertedIndexConfig: &models.InvertedIndexConfig{IndexTimestamps: true},
+		InvertedIndexConfig: &models.InvertedIndexConfig{IndexTimestamps: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 		Properties:          classPropertiesFood(),
 	}
 }
@@ -165,7 +166,7 @@ func classRisotto() *models.Class {
 	return &models.Class{
 		Class:               "Risotto",
 		Description:         "Risotto is a northern Italian rice dish cooked with broth.",
-		InvertedIndexConfig: &models.InvertedIndexConfig{IndexTimestamps: true},
+		InvertedIndexConfig: &models.InvertedIndexConfig{IndexTimestamps: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 		Properties:          classPropertiesFood(),
 	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_ref_props.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_ref_props.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func testReferenceProperties(host string) func(t *testing.T) {
@@ -67,7 +68,7 @@ func testReferenceProperties(host string) func(t *testing.T) {
 						DataType: []string{"text"},
 					},
 				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{IndexTimestamps: true},
+				InvertedIndexConfig: &models.InvertedIndexConfig{IndexTimestamps: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 				VectorConfig: map[string]models.VectorConfig{
 					c11y_bookshelf_name: {
 						Vectorizer: map[string]interface{}{

--- a/test/acceptance_with_go_client/search_test.go
+++ b/test/acceptance_with_go_client/search_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 var paragraphs = []string{
@@ -43,7 +44,7 @@ func AddClassAndObjects(t *testing.T, className string, datatype string, c *clie
 			{Name: "contents", DataType: []string{datatype}, Tokenization: "word", IndexFilterable: &TRUE, IndexSearchable: &TRUE},
 			{Name: "num", DataType: []string{"int"}},
 		},
-		InvertedIndexConfig: &models.InvertedIndexConfig{Bm25: &models.BM25Config{K1: 1.2, B: 0.75}},
+		InvertedIndexConfig: &models.InvertedIndexConfig{Bm25: &models.BM25Config{K1: 1.2, B: 0.75}, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 		Vectorizer:          vectorizer,
 	}
 	require.Nil(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
@@ -108,7 +109,7 @@ func TestSearchOnArrays(t *testing.T) {
 						IndexFilterable: &vTrue,
 					},
 				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{Bm25: &models.BM25Config{K1: 1.2, B: 0.75}},
+				InvertedIndexConfig: &models.InvertedIndexConfig{Bm25: &models.BM25Config{K1: 1.2, B: 0.75}, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 				Vectorizer:          "none",
 			}
 			require.Nil(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
@@ -180,7 +181,7 @@ func TestSearchOnSomeProperties(t *testing.T) {
 						IndexSearchable: &vTrue,
 					},
 				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{Bm25: &models.BM25Config{K1: 1.2, B: 0.75}},
+				InvertedIndexConfig: &models.InvertedIndexConfig{Bm25: &models.BM25Config{K1: 1.2, B: 0.75}, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 				Vectorizer:          "none",
 			}
 			require.Nil(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))

--- a/test/acceptance_with_go_client/where_filters_test.go
+++ b/test/acceptance_with_go_client/where_filters_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/filters"
@@ -36,7 +37,7 @@ func TestCorrectErrorForIsNullFilter(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: propName, DataType: []string{string(schema.DataTypeText)}, IndexInverted: &vTrue},
 		},
-		InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true},
+		InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 		Vectorizer:          "none",
 	}
 

--- a/test/helper/sample-schema/books/books.go
+++ b/test/helper/sample-schema/books/books.go
@@ -16,6 +16,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/usecases/config"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -180,9 +181,10 @@ func classBase(className, vectorizer string, vectorConfig map[string]models.Vect
 		Vectorizer:   vectorizer,
 		ModuleConfig: moduleConfig,
 		InvertedIndexConfig: &models.InvertedIndexConfig{
-			IndexNullState:      true,
-			IndexTimestamps:     true,
-			IndexPropertyLength: true,
+			IndexNullState:        true,
+			IndexTimestamps:       true,
+			IndexPropertyLength:   true,
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 		},
 		VectorConfig: vectorConfig,
 		Properties: []*models.Property{

--- a/test/helper/sample-schema/cities/cities.go
+++ b/test/helper/sample-schema/cities/cities.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 const (
@@ -83,7 +84,7 @@ func CreateCountryCityAirportSchema(t *testing.T, host string) {
 				"vectorizeClassName": true,
 			},
 		},
-		InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true, IndexPropertyLength: true, IndexTimestamps: true},
+		InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true, IndexPropertyLength: true, IndexTimestamps: true, UseInvertedSearchable: config.DefaultUseInvertedSearchable},
 		Properties: []*models.Property{
 			{
 				Name:         "name",
@@ -202,7 +203,8 @@ func CreateCountryCityAirportSchema(t *testing.T, host string) {
 			Stopwords: &models.StopwordConfig{
 				Preset: "en",
 			},
-			IndexTimestamps: true,
+			IndexTimestamps:       true,
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 		},
 		Properties: []*models.Property{
 			{

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -54,6 +54,8 @@ const (
 	DefaultBM25b  = float32(0.75)
 )
 
+var DefaultUseInvertedSearchable = os.Getenv("USE_INVERTED_SEARCHABLE") == "" || os.Getenv("USE_INVERTED_SEARCHABLE") == "true"
+
 const (
 	DefaultMaxImportGoroutinesFactor = float64(1.5)
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -611,7 +611,9 @@ func (h *Handler) validateProperty(
 
 func setInvertedConfigDefaults(class *models.Class) {
 	if class.InvertedIndexConfig == nil {
-		class.InvertedIndexConfig = &models.InvertedIndexConfig{}
+		class.InvertedIndexConfig = &models.InvertedIndexConfig{
+			UseInvertedSearchable: config.DefaultUseInvertedSearchable,
+		}
 	}
 
 	if class.InvertedIndexConfig.CleanupIntervalSeconds == 0 {

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -163,6 +163,7 @@ func Test_AddClass(t *testing.T) {
 			Bm25:                   expectedBM25Config,
 			CleanupIntervalSeconds: 60,
 			Stopwords:              expectedStopwordConfig,
+			UseInvertedSearchable:  config.DefaultUseInvertedSearchable,
 		}
 		fakeSchemaManager.On("AddClass", expectedClass, mock.Anything).Return(nil)
 		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
@@ -180,7 +181,8 @@ func Test_AddClass(t *testing.T) {
 		class := models.Class{
 			Class: "NewClass",
 			InvertedIndexConfig: &models.InvertedIndexConfig{
-				Bm25: expectedBM25Config,
+				Bm25:                  expectedBM25Config,
+				UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 			},
 			Vectorizer: "none",
 		}
@@ -195,6 +197,7 @@ func Test_AddClass(t *testing.T) {
 			Bm25:                   expectedBM25Config,
 			CleanupIntervalSeconds: 60,
 			Stopwords:              expectedStopwordConfig,
+			UseInvertedSearchable:  config.DefaultUseInvertedSearchable,
 		}
 		fakeSchemaManager.On("AddClass", expectedClass, mock.Anything).Return(nil)
 		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
@@ -1324,6 +1327,7 @@ func Test_UpdateClass(t *testing.T) {
 					Vectorizer: "none",
 					InvertedIndexConfig: &models.InvertedIndexConfig{
 						CleanupIntervalSeconds: 17,
+						UseInvertedSearchable:  config.DefaultUseInvertedSearchable,
 					},
 				},
 				update: &models.Class{
@@ -1335,6 +1339,7 @@ func Test_UpdateClass(t *testing.T) {
 							K1: config.DefaultBM25k1,
 							B:  config.DefaultBM25b,
 						},
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 				},
 			},
@@ -1349,6 +1354,7 @@ func Test_UpdateClass(t *testing.T) {
 							K1: 1.012,
 							B:  0.125,
 						},
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 				},
 				update: &models.Class{
@@ -1360,6 +1366,7 @@ func Test_UpdateClass(t *testing.T) {
 							K1: 1.012,
 							B:  0.125,
 						},
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 				},
 			},
@@ -1373,6 +1380,7 @@ func Test_UpdateClass(t *testing.T) {
 						Stopwords: &models.StopwordConfig{
 							Preset: "en",
 						},
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 				},
 				update: &models.Class{
@@ -1385,6 +1393,7 @@ func Test_UpdateClass(t *testing.T) {
 							Additions: []string{"banana", "passionfruit", "kiwi"},
 							Removals:  []string{"a", "the"},
 						},
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 				},
 			},

--- a/usecases/schema/schema_comparison_test.go
+++ b/usecases/schema/schema_comparison_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -149,7 +150,8 @@ func Test_SchemaComparison_VariousMismatches(t *testing.T) {
 					},
 					Description: "foo",
 					InvertedIndexConfig: &models.InvertedIndexConfig{
-						IndexPropertyLength: true,
+						IndexPropertyLength:   true,
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 					ModuleConfig: "bar",
 					ReplicationConfig: &models.ReplicationConfig{
@@ -208,7 +210,8 @@ func Test_SchemaComparison_VariousMismatches(t *testing.T) {
 						},
 					},
 					InvertedIndexConfig: &models.InvertedIndexConfig{
-						IndexTimestamps: true,
+						IndexTimestamps:       true,
+						UseInvertedSearchable: config.DefaultUseInvertedSearchable,
 					},
 					ReplicationConfig: &models.ReplicationConfig{
 						Factor: 8,


### PR DESCRIPTION
### What's being changed:

Set BlockMax Inverted index as part of Inverted index config, on by default for new indices.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
