### PR TITLE
Add changes from other branch targetting 1.29 instead

### DIFF
--- a/test/acceptance/authz/tenants_test.go
+++ b/test/acceptance/authz/tenants_test.go
@@ -13,9 +13,11 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/test/docker"
@@ -38,7 +40,7 @@ func TestAuthZTenants(t *testing.T) {
 	updateTenantAction := authorization.UpdateTenants
 
 	ctx := context.Background()
-	compose, err := docker.New().WithWeaviate().
+	compose, err := docker.New().WithWeaviateWithGRPC().
 		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(customUser, customKey).
 		WithRBAC().WithRbacAdmins(adminUser).
 		WithBackendFilesystem().
@@ -49,6 +51,7 @@ func TestAuthZTenants(t *testing.T) {
 	}()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
+	helper.SetupGRPCClient(t, compose.GetWeaviate().GrpcURI())
 	defer helper.ResetClient()
 
 	className := "AuthzTenantTestClass"
@@ -68,93 +71,220 @@ func TestAuthZTenants(t *testing.T) {
 
 	// user needs to be able to create objects and read the configs
 	all := "*"
+	tenant1 := "Tenant1"
+	tenant2 := "Tenant2"
+	tenants := []*models.Tenant{{Name: tenant1}, {Name: tenant2}}
+	tenantNames := []string{tenant1, tenant2}
 
-	createTenantRoleName := "readSchemaAndCreateTenant"
-	createTenantRole := &models.Role{
-		Name: &createTenantRoleName,
+	createAllTenantsRoleName := "readSchemaAndCreateAllTenants"
+	createAllTenantsRole := &models.Role{
+		Name: &createAllTenantsRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
 			{Action: &createTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
 		},
 	}
 
-	readTenantRoleName := "readSchemaAndReadTenant"
-	readTenantRole := &models.Role{
-		Name: &readTenantRoleName,
+	createSpecificTenantsRoleName := "readSchemaAndCreateSpecificTenant"
+	createSpecificTenantsRole := &models.Role{
+		Name: &createSpecificTenantsRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &createTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
+		},
+	}
+
+	readAllTenantsRoleName := "readSchemaAndReadAllTenants"
+	readAllTenantsRole := &models.Role{
+		Name: &readAllTenantsRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
 			{Action: &readTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
 		},
 	}
 
-	deleteTenantRoleName := "readSchemaAndDeleteTenant"
-	deleteTenantRole := &models.Role{
-		Name: &deleteTenantRoleName,
+	readSpecificTenantRoleName := "readSchemaAndReadSpecificTenant"
+	readSpecificTenantRole := &models.Role{
+		Name: &readSpecificTenantRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
-			{Action: &deleteTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+			{Action: &readTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
 		},
 	}
 
-	updateTenantRoleName := "readSchemaAndUpdateTenant"
-	updateTenantRole := &models.Role{
-		Name: &updateTenantRoleName,
+	deleteSpecificTenantRoleName := "readSchemaAndDeleteSpecificTenant"
+	deleteSpecificTenantRole := &models.Role{
+		Name: &deleteSpecificTenantRoleName,
 		Permissions: []*models.Permission{
 			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
-			{Action: &updateTenantAction, Tenants: &models.PermissionTenants{Collection: &all}},
+			{Action: &deleteTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
 		},
 	}
 
-	helper.DeleteRole(t, adminKey, *createTenantRole.Name)
-	helper.DeleteRole(t, adminKey, *readTenantRole.Name)
-	helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
-	helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
-	helper.CreateRole(t, adminKey, createTenantRole)
-	helper.CreateRole(t, adminKey, readTenantRole)
-	helper.CreateRole(t, adminKey, deleteTenantRole)
-	helper.CreateRole(t, adminKey, updateTenantRole)
-	defer helper.DeleteRole(t, adminKey, *createTenantRole.Name)
-	defer helper.DeleteRole(t, adminKey, *readTenantRole.Name)
-	defer helper.DeleteRole(t, adminKey, *deleteTenantRole.Name)
-	defer helper.DeleteRole(t, adminKey, *updateTenantRole.Name)
+	updateSpecificTenantRoleName := "readSchemaAndUpdateTenant"
+	updateSpecificTenantRole := &models.Role{
+		Name: &updateSpecificTenantRoleName,
+		Permissions: []*models.Permission{
+			{Action: &readSchemaAction, Collections: &models.PermissionCollections{Collection: &all}},
+			{Action: &updateTenantAction, Tenants: &models.PermissionTenants{Collection: &all, Tenant: &tenants[0].Name}},
+		},
+	}
 
-	tenants := []*models.Tenant{{Name: "Tenant1"}}
+	roles := []*models.Role{
+		createAllTenantsRole,
+		createSpecificTenantsRole,
+		readAllTenantsRole,
+		readSpecificTenantRole,
+		deleteSpecificTenantRole,
+		updateSpecificTenantRole,
+	}
 
-	t.Run("Create tenant", func(t *testing.T) {
-		helper.AssignRoleToUser(t, adminKey, *createTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *createTenantRole.Name, customUser)
+	for _, role := range roles {
+		helper.DeleteRole(t, adminKey, *role.Name)
+		helper.CreateRole(t, adminKey, role)
+	}
+	defer func() {
+		for _, role := range roles {
+			helper.DeleteRole(t, adminKey, *role.Name)
+		}
+	}()
+
+	t.Run("Create all tenants", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createAllTenantsRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createAllTenantsRole.Name, customUser)
 		require.NoError(t, createTenant(t, className, tenants, customKey))
-		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, adminKey))
+		require.NoError(t, deleteTenant(t, className, tenantNames, adminKey))
 	})
 
-	t.Run("Tenant read and exist", func(t *testing.T) {
-		require.NoError(t, createTenant(t, className, tenants, adminKey))
-		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+	t.Run("Create specific tenant with needed permission", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		require.NoError(t, createTenant(t, className, []*models.Tenant{{Name: tenant1}}, customKey))
+		require.NoError(t, deleteTenant(t, className, []string{tenant1}, adminKey))
+	})
 
-		helper.AssignRoleToUser(t, adminKey, *readTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *readTenantRole.Name, customUser)
+	t.Run("Fail to create specific tenant without needed permission", func(t *testing.T) {
+		helper.AssignRoleToUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, *createSpecificTenantsRole.Name, customUser)
+		err := createTenant(t, className, []*models.Tenant{{Name: tenant2}}, customKey)
+		require.NotNil(t, err)
+		var forbidden *clschema.TenantsCreateForbidden
+		require.True(t, errors.As(err, &forbidden))
+	})
+
+	setupRUDTests := func(role string) func() {
+		require.NoError(t, createTenant(t, className, tenants, adminKey))
+		helper.AssignRoleToUser(t, adminKey, role, customUser)
+		return func() {
+			defer deleteTenant(t, className, tenantNames, adminKey)
+			defer helper.RevokeRoleFromUser(t, adminKey, role, customUser)
+		}
+	}
+
+	t.Run("Tenant read and exist", func(t *testing.T) {
+		cleanup := setupRUDTests(readAllTenantsRoleName)
+		defer cleanup()
 
 		require.NoError(t, readTenant(t, className, tenants[0].Name, customKey))
-		require.NoError(t, readTenants(t, className, customKey))
 		require.NoError(t, existsTenant(t, className, tenants[0].Name, customKey))
 	})
 
-	t.Run("delete tenant", func(t *testing.T) {
-		require.NoError(t, createTenant(t, className, tenants, adminKey))
+	t.Run("Read a specific tenant with needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
 
-		helper.AssignRoleToUser(t, adminKey, *deleteTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *deleteTenantRole.Name, customUser)
+		require.NoError(t, readTenant(t, className, tenants[0].Name, customKey))
+		require.NoError(t, existsTenant(t, className, tenants[0].Name, customKey))
+	})
+
+	t.Run("Fail to read a specific tenant and all tenants without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		err := readTenant(t, className, tenants[1].Name, customKey)
+		require.NotNil(t, err)
+		var forbiddenGetOne *clschema.TenantsGetOneForbidden
+		require.True(t, errors.As(err, &forbiddenGetOne))
+
+		err = existsTenant(t, className, tenants[1].Name, customKey)
+		var forbiddenExists *clschema.TenantExistsForbidden
+		require.True(t, errors.As(err, &forbiddenExists))
+
+		// tests for tenant filtering
+		res, err := readTenants(t, className, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Payload, 1)
+		require.Equal(t, tenants[0].Name, res.Payload[0].Name)
+	})
+
+	t.Run("Get specific tenant using grpc", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		_, err := readTenantGRPC(t, ctx, className, tenants[0].Name, customKey)
+		require.Nil(t, err)
+	})
+
+	t.Run("Return no tenants via grpc when one is forbidden", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		res, err := readTenantGRPC(t, ctx, className, tenants[1].Name, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Tenants, 0)
+	})
+
+	t.Run("Get filtered tenants using rest", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		res, err := readTenants(t, className, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Payload, 1)
+		require.Equal(t, tenants[0].Name, res.Payload[0].Name)
+	})
+
+	t.Run("Get filtered tenants using grpc", func(t *testing.T) {
+		cleanup := setupRUDTests(readSpecificTenantRoleName)
+		defer cleanup()
+
+		res, err := readTenantsGRPC(t, ctx, className, customKey)
+		require.Nil(t, err)
+		require.Len(t, res.Tenants, 1)
+		require.Equal(t, tenants[0].Name, res.Tenants[0].Name)
+	})
+
+	t.Run("Delete specific tenant with needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(deleteSpecificTenantRoleName)
+		defer cleanup()
 
 		require.NoError(t, deleteTenant(t, className, []string{tenants[0].Name}, customKey))
 	})
 
-	t.Run("update tenant status", func(t *testing.T) {
-		require.NoError(t, createTenant(t, className, tenants, adminKey))
-		defer deleteTenant(t, className, []string{tenants[0].Name}, adminKey)
+	t.Run("Fail to delete specific tenant without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(deleteSpecificTenantRoleName)
+		defer cleanup()
 
-		helper.AssignRoleToUser(t, adminKey, *updateTenantRole.Name, customUser)
-		defer helper.RevokeRoleFromUser(t, adminKey, *updateTenantRole.Name, customUser)
+		err := deleteTenant(t, className, []string{tenants[1].Name}, customKey)
+		require.NotNil(t, err)
+		var forbidden *clschema.TenantsDeleteForbidden
+		require.True(t, errors.As(err, &forbidden))
+	})
 
-		require.NoError(t, updateTenantStatus(t, className, []*models.Tenant{{Name: "Tenant1", ActivityStatus: "INACTIVE"}}, customKey))
+	t.Run("Update specific tenant status with needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(updateSpecificTenantRoleName)
+		defer cleanup()
+
+		require.NoError(t, updateTenantStatus(t, className, []*models.Tenant{{Name: tenants[0].Name, ActivityStatus: "INACTIVE"}}, customKey))
+	})
+
+	t.Run("Fail to update specific tenant status without needed permission", func(t *testing.T) {
+		cleanup := setupRUDTests(updateSpecificTenantRoleName)
+		defer cleanup()
+
+		err := updateTenantStatus(t, className, []*models.Tenant{{Name: tenants[1].Name, ActivityStatus: "INACTIVE"}}, customKey)
+		require.NotNil(t, err)
+		var forbidden *clschema.TenantsUpdateForbidden
+		require.True(t, errors.As(err, &forbidden))
 	})
 }

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -145,7 +145,7 @@ func Test_Schema_Authorization(t *testing.T) {
 				// Cluster/nodes related endpoint
 				"JoinNode", "RemoveNode", "Nodes", "NodeName", "ClusterHealthScore", "ClusterStatus", "ResolveParentNodes",
 				// revert to schema v0 (non raft),
-				"GetConsistentSchema", "GetConsistentTenants",
+				"GetConsistentSchema", "GetConsistentTenants", "GetConsistentTenant",
 				// ignored because it will check if schema has collections otherwise returns nothing
 				"StoreSchemaV1":
 				// don't require auth on methods which are exported because other

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -32,7 +32,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-var ErrNotFound = errors.New("not found")
+var (
+	ErrNotFound           = errors.New("not found")
+	ErrUnexpectedMultiple = errors.New("unexpected multiple results")
+)
 
 // SchemaManager is responsible for consistent schema operations.
 // It allows reading and writing the schema while directly talking to the leader, no matter which node it is.

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -241,6 +241,33 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	return filteredTenants, nil
 }
 
+func (h *Handler) GetConsistentTenant(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) (*models.TenantResponse, error) {
+	if err := h.Authorizer.Authorize(principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
+		return nil, err
+	}
+
+	var allTenants []*models.TenantResponse
+	var err error
+
+	tenants := []string{tenant}
+	if consistency {
+		allTenants, _, err = h.schemaManager.QueryTenants(class, tenants)
+	} else {
+		// If non consistent, fallback to the default implementation
+		allTenants, err = h.getTenantsByNames(class, tenants)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(allTenants) == 0 {
+		return nil, ErrNotFound
+	}
+	if len(allTenants) > 1 {
+		return nil, ErrUnexpectedMultiple
+	}
+	return allTenants[0], nil
+}
+
 func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 	info := h.schemaReader.ClassInfo(class)
 	if !info.Exists {


### PR DESCRIPTION
### What's being changed:

Add tests for all schema/{className}/tenants/{tenantName} ops and rpc.TenantsGet. In the process, identify the need for GetConsistentTenant to avoid filtering when performing GetOne tenant requests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
