### PR TITLE
If nested object is `nil`, return `NilValue` in grpc

### DIFF
--- a/adapters/handlers/grpc/v1/mapping.go
+++ b/adapters/handlers/grpc/v1/mapping.go
@@ -113,6 +113,9 @@ func (m *Mapper) NewPrimitiveValue(v interface{}, dt schema.DataType) (*pb.Value
 }
 
 func (m *Mapper) NewNestedValue(v interface{}, dt schema.DataType, parent schema.PropertyInterface, prop search.SelectProperty) (*pb.Value, error) {
+	if v == nil {
+		return m.NewNilValue(), nil
+	}
 	switch dt {
 	case schema.DataTypeObject:
 		if _, ok := v.(map[string]interface{}); !ok {

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -408,8 +408,12 @@ func TestGRPCReply(t *testing.T) {
 				},
 			},
 			searchParams: dto.GetParams{
-				ClassName:  className,
-				Properties: search.SelectProperties{{Name: "word", IsPrimitive: true}, {Name: "age", IsPrimitive: true}},
+				ClassName: className,
+				Properties: search.SelectProperties{
+					{Name: "word", IsPrimitive: true},
+					{Name: "age", IsPrimitive: true},
+					{Name: "nested", IsPrimitive: false, IsObject: true, Props: []search.SelectProperty{{Name: "text", IsPrimitive: true}}},
+				},
 			},
 			outSearch: []*pb.SearchResult{
 				{
@@ -418,8 +422,9 @@ func TestGRPCReply(t *testing.T) {
 						TargetCollection: className,
 						NonRefProps: &pb.Properties{
 							Fields: map[string]*pb.Value{
-								"word": {Kind: &pb.Value_StringValue{StringValue: "word"}},
-								"age":  {Kind: &pb.Value_NullValue{}},
+								"word":   {Kind: &pb.Value_StringValue{StringValue: "word"}},
+								"age":    {Kind: &pb.Value_NullValue{}},
+								"nested": {Kind: &pb.Value_NullValue{}},
 							},
 						},
 						RefProps:          []*pb.RefPropertiesResult{},


### PR DESCRIPTION
### What's being changed:

Fix parsing of nested objects if they're `nil`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
