### PR TITLE
fix call errors.As with a nil value error err

### DIFF
--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -113,11 +113,11 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 		}
 	}
 
-	if input.validateSchema(class) != nil {
+	if inputErr := input.validateSchema(class); inputErr != nil {
 		if deprecatedEndpoint { // for backward comp reasons
 			return &Error{"bad inputs deprecated", StatusNotFound, err}
 		}
-		if errors.As(err, &ErrMultiTenancy{}) {
+		if errors.As(inputErr, &ErrMultiTenancy{}) {
 			return &Error{"bad inputs", StatusUnprocessableEntity, err}
 		}
 		return &Error{"bad inputs", StatusBadRequest, err}

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -113,11 +113,11 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 		}
 	}
 
-	if inputErr := input.validateSchema(class); inputErr != nil {
+	if err := input.validateSchema(class); err != nil {
 		if deprecatedEndpoint { // for backward comp reasons
 			return &Error{"bad inputs deprecated", StatusNotFound, err}
 		}
-		if errors.As(inputErr, &ErrMultiTenancy{}) {
+		if errors.As(err, &ErrMultiTenancy{}) {
 			return &Error{"bad inputs", StatusUnprocessableEntity, err}
 		}
 		return &Error{"bad inputs", StatusBadRequest, err}


### PR DESCRIPTION
### What's being changed:

bug fix

the err has been checked, it is a nil value, `errors.As(err, &ErrMultiTenancy{})` is always false

I think it should be `errors.As(inputErr, &ErrMultiTenancy{}) `


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
