### PR TITLE
hnsw: check nodes slice as part of tombstone cleanup

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -436,7 +436,7 @@ func (h *hnsw) reassignNeighborsOf(ctx context.Context, deleteList helpers.Allow
 						return nil
 					}
 					h.shardedNodeLocks.RLock(deletedID)
-					if uint64(size) < deletedID || h.nodes[deletedID] == nil {
+					if deletedID >= uint64(size) || deletedID >= uint64(len(h.nodes)) || h.nodes[deletedID] == nil {
 						h.shardedNodeLocks.RUnlock(deletedID)
 						continue
 					}
@@ -511,6 +511,11 @@ func (h *hnsw) reassignNeighbor(
 
 	h.RLock()
 	h.shardedNodeLocks.RLock(neighbor)
+	if neighbor >= uint64(len(h.nodes)) {
+		h.shardedNodeLocks.RUnlock(neighbor)
+		h.RUnlock()
+		return true, nil
+	}
 	neighborNode := h.nodes[neighbor]
 	h.shardedNodeLocks.RUnlock(neighbor)
 	currentMaximumLayer := h.currentMaximumLayer

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -1897,3 +1897,72 @@ func TestDelete_WithCleaningUpTombstonesWithHighConcurrency(t *testing.T) {
 		require.Nil(t, vectorIndex.Drop(context.Background()))
 	})
 }
+
+func Test_ResetNodesDuringTombstoneCleanup(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForDeleteTest() // Use your existing test vectors
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(context.Background())
+
+	// Initialize the HNSW index
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "concurrent-growth-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[int(id)%len(vectors)], nil // Wrap around to reuse vectors
+		},
+		TempVectorForIDThunk: TempVectorForIDThunk(vectors),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+	index.logger = logrus.New() // Ensure logging is set up for debugging
+
+	// Step 1: Import initial vectors
+	initialSize := 50
+	offset := 20000
+	for i := 0; i < initialSize; i++ {
+		err := index.Add(ctx, uint64(offset+i), vectors[i%len(vectors)])
+		require.Nil(t, err)
+	}
+
+	// Step 2: Delete some nodes to create tombstones
+	for i := 0; i < initialSize; i += 2 { // Delete even-numbered nodes
+		err := index.Delete(uint64(offset + i))
+		require.Nil(t, err)
+	}
+
+	// Step 3: Run concurrent cleanup and growth
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: Run tombstone cleanup
+	go func() {
+		defer wg.Done()
+		err := index.CleanUpTombstonedNodes(neverStop)
+		if err != nil {
+			t.Logf("Cleanup error: %v", err)
+		}
+	}()
+
+	// Goroutine 2: Insert new nodes to trigger growth
+	go func() {
+		defer wg.Done()
+		index.Lock()
+		index.shardedNodeLocks.LockAll()
+		index.nodes = make([]*vertex, 10)
+		index.shardedNodeLocks.UnlockAll()
+		index.Unlock()
+		if err != nil {
+			t.Logf("Drop error: %v", err)
+		}
+	}()
+
+	// Wait for both operations to complete
+	wg.Wait()
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -573,7 +573,7 @@ func (h *hnsw) isEmpty() bool {
 }
 
 func (h *hnsw) isEmptyUnlocked() bool {
-	return h.nodes[h.entryPointID] == nil
+	return h.entryPointID > uint64(len(h.nodes)) || h.nodes[h.entryPointID] == nil
 }
 
 func (h *hnsw) nodeByID(id uint64) *vertex {


### PR DESCRIPTION
### What's being changed:
- In some situations the `h.nodes` can be reset (i.e. when all elements are deleted).
- If a tombstone cleanup cycle is running and cleanups an older tombstone, this could result in an out of range runtime error.
- This PR adds more bounds checking including in `h.isEmpty`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
