### PR TITLE
fix: prevent creating dynamic index with async indexing disabled

### DIFF
--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -760,7 +760,12 @@ func (h *Handler) validateVectorizer(vectorizer string) error {
 
 func (h *Handler) validateVectorIndexType(vectorIndexType string) error {
 	switch vectorIndexType {
-	case vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT, vectorindex.VectorIndexTypeDYNAMIC:
+	case vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT:
+		return nil
+	case vectorindex.VectorIndexTypeDYNAMIC:
+		if !h.asyncIndexingEnabled {
+			return fmt.Errorf("the dynamic index can only be created under async indexing environment (ASYNC_INDEXING=true)")
+		}
 		return nil
 	default:
 		return errors.Errorf("unrecognized or unsupported vectorIndexType %q",

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -390,6 +390,61 @@ func Test_AddClass(t *testing.T) {
 		})
 		assert.EqualError(t, err, "target vector \"custom\": vectorizer: invalid vectorizer \"invalid\"")
 	})
+
+	t.Run("adding dynamic index", func(t *testing.T) { //  with async indexing disabled
+		for _, tt := range []struct {
+			name                 string
+			asyncIndexingEnabled bool
+
+			expectError string
+		}{
+			{
+				name:                 "async indexing disabled",
+				asyncIndexingEnabled: false,
+
+				expectError: "the dynamic index can only be created under async indexing environment (ASYNC_INDEXING=true)",
+			},
+			{
+				name:                 "async indexing enabled",
+				asyncIndexingEnabled: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				handler, schemaManager := newTestHandler(t, &fakeDB{})
+				handler.asyncIndexingEnabled = tt.asyncIndexingEnabled
+
+				if tt.expectError == "" {
+					schemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
+					defer schemaManager.AssertExpectations(t)
+				}
+
+				assertError := func(err error) {
+					if tt.expectError != "" {
+						require.ErrorContains(t, err, tt.expectError)
+					} else {
+						require.NoError(t, err)
+					}
+				}
+
+				_, _, err := handler.AddClass(ctx, nil, &models.Class{
+					Class:           "NewClass",
+					VectorIndexType: "dynamic",
+				})
+				assertError(err)
+
+				_, _, err = handler.AddClass(ctx, nil, &models.Class{
+					Class: "NewClass",
+					VectorConfig: map[string]models.VectorConfig{
+						"vec1": {
+							VectorIndexType: "dynamic",
+							Vectorizer:      map[string]any{"text2vec-contextionary": map[string]any{}},
+						},
+					},
+				})
+				assertError(err)
+			})
+		}
+	})
 }
 
 func Test_AddClass_DefaultsAndMigration(t *testing.T) {

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -391,7 +391,7 @@ func Test_AddClass(t *testing.T) {
 		assert.EqualError(t, err, "target vector \"custom\": vectorizer: invalid vectorizer \"invalid\"")
 	})
 
-	t.Run("adding dynamic index", func(t *testing.T) { //  with async indexing disabled
+	t.Run("adding dynamic index", func(t *testing.T) {
 		for _, tt := range []struct {
 			name                 string
 			asyncIndexingEnabled bool

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -14,12 +14,14 @@ package schema
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -131,6 +133,8 @@ type Handler struct {
 	scaleOut                scaleOut
 	parser                  Parser
 	classGetter             *ClassGetter
+
+	asyncIndexingEnabled bool
 }
 
 // NewHandler creates a new handler
@@ -162,6 +166,8 @@ func NewHandler(
 		scaleOut:                scaleoutManager,
 		cloud:                   cloud,
 		classGetter:             classGetter,
+
+		asyncIndexingEnabled: entcfg.Enabled(os.Getenv("ASYNC_INDEXING")),
 	}
 
 	handler.scaleOut.SetSchemaReader(schemaReader)


### PR DESCRIPTION
### What's being changed:

We have been allowing to create a collection with `dynamic` index even if async indexing is disabled, even though it is a hard requirement for the feature.

There was a check present already, however, it was done too low in the stack, so it was not protecting anything:
https://github.com/weaviate/weaviate/blob/bca94d3077c6cebef5aab970cf2c86a5b6003665/adapters/repos/db/vector/dynamic/index.go#L122-L124

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
