### PR TITLE
RBAC: Handle policy (roles) upgrades from 1.29 in casbin

### DIFF
--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -179,6 +179,7 @@ func TestAuthzRolesJourney(t *testing.T) {
 	_, down := composeUp(t, map[string]string{adminUser: adminKey}, nil, nil)
 	defer down()
 
+	helper.DeleteRole(t, adminKey, *testRole1.Name)
 	t.Run("get all roles before create", func(t *testing.T) {
 		roles := helper.GetRoles(t, adminKey)
 		require.Equal(t, NumBuildInRoles, len(roles))

--- a/test/acceptance/authz/roles_test.go
+++ b/test/acceptance/authz/roles_test.go
@@ -453,16 +453,15 @@ func TestAuthzRolesHasPermission(t *testing.T) {
 	_, down := composeUp(t, map[string]string{adminUser: adminKey}, map[string]string{customUser: customKey}, nil)
 	defer down()
 
-	t.Run("create role", func(t *testing.T) {
-		helper.CreateRole(t, adminKey, &models.Role{
-			Name: &testRole,
-			Permissions: []*models.Permission{{
-				Action: &authorization.CreateCollections,
-				Collections: &models.PermissionCollections{
-					Collection: authorization.All,
-				},
-			}},
-		})
+	helper.DeleteRole(t, adminKey, testRole)
+	helper.CreateRole(t, adminKey, &models.Role{
+		Name: &testRole,
+		Permissions: []*models.Permission{{
+			Action: &authorization.CreateCollections,
+			Collections: &models.PermissionCollections{
+				Collection: authorization.All,
+			},
+		}},
 	})
 
 	t.Run("true", func(t *testing.T) {

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -17,6 +17,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/weaviate/weaviate/usecases/build"
+
 	"github.com/weaviate/weaviate/usecases/config"
 
 	"github.com/sirupsen/logrus"
@@ -70,7 +72,7 @@ func TestAuthorize(t *testing.T) {
 			verb:      authorization.READ,
 			resources: authorization.CollectionsMetadata("Test1", "Test2"),
 			setupPolicies: func(m *manager) error {
-				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", authorization.SchemaDomain, authorization.READ)
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", authorization.SchemaDomain, authorization.READ, build.Version)
 				if err != nil {
 					return err
 				}
@@ -106,7 +108,7 @@ func TestAuthorize(t *testing.T) {
 			verb:      authorization.READ,
 			resources: authorization.CollectionsMetadata("Test1", "Test2"),
 			setupPolicies: func(m *manager) error {
-				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("partial"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("partial"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain, build.Version)
 				if err != nil {
 					return err
 				}
@@ -132,7 +134,7 @@ func TestAuthorize(t *testing.T) {
 			verb:      authorization.READ,
 			resources: authorization.CollectionsMetadata("Test1"),
 			setupPolicies: func(m *manager) error {
-				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("group-role"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("group-role"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain, build.Version)
 				if err != nil {
 					return err
 				}
@@ -158,7 +160,7 @@ func TestAuthorize(t *testing.T) {
 			resources: authorization.CollectionsMetadata("Test1"),
 			skipAudit: true,
 			setupPolicies: func(m *manager) error {
-				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("audit-role"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("audit-role"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain, build.Version)
 				if err != nil {
 					return err
 				}
@@ -257,7 +259,7 @@ func TestFilterAuthorizedResources(t *testing.T) {
 			resources: authorization.CollectionsMetadata("Test1", "Test2"),
 			setupPolicies: func(m *manager) error {
 				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"),
-					"*", authorization.READ, authorization.SchemaDomain)
+					"*", authorization.READ, authorization.SchemaDomain, build.Version)
 				if err != nil {
 					return err
 				}
@@ -283,7 +285,7 @@ func TestFilterAuthorizedResources(t *testing.T) {
 			resources: authorization.CollectionsMetadata("Test1", "Test2"),
 			setupPolicies: func(m *manager) error {
 				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("limited"),
-					authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain)
+					authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain, build.Version)
 				if err != nil {
 					return err
 				}
@@ -318,7 +320,7 @@ func TestFilterAuthorizedResources(t *testing.T) {
 			resources: authorization.CollectionsMetadata("Test1", "Test2"),
 			setupPolicies: func(m *manager) error {
 				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("collections-admin"),
-					authorization.CollectionsMetadata()[0], authorization.READ, authorization.SchemaDomain)
+					authorization.CollectionsMetadata()[0], authorization.READ, authorization.SchemaDomain, build.Version)
 				if err != nil {
 					return err
 				}
@@ -354,10 +356,10 @@ func TestFilterAuthorizedResources(t *testing.T) {
 			verb:      authorization.READ,
 			resources: authorization.CollectionsMetadata("Test1", "Test2", "Test3"),
 			setupPolicies: func(m *manager) error {
-				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("role1"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("role1"), authorization.CollectionsMetadata("Test1")[0], authorization.READ, authorization.SchemaDomain, build.Version); err != nil {
 					return err
 				}
-				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("role2"), authorization.CollectionsMetadata("Test2")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("role2"), authorization.CollectionsMetadata("Test2")[0], authorization.READ, authorization.SchemaDomain, build.Version); err != nil {
 					return err
 				}
 				if ok, err := m.casbin.AddRoleForUser(conv.UserNameWithTypeFromId("multi-role-user", models.UserTypeInputDb), conv.PrefixRoleName("role1")); err != nil {
@@ -421,7 +423,7 @@ func TestFilterAuthorizedResourcesLogging(t *testing.T) {
 	testResources := authorization.CollectionsMetadata("Test1", "Test2")
 
 	// Setup a policy
-	_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", "*", authorization.RolesDomain)
+	_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", "*", authorization.RolesDomain, build.Version)
 	require.NoError(t, err)
 	_, err = m.casbin.AddRoleForUser(conv.UserNameWithTypeFromId("test-user", models.UserTypeInputDb), conv.PrefixRoleName("admin"))
 	require.NoError(t, err)

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -17,6 +17,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/weaviate/weaviate/usecases/build"
+
 	"github.com/weaviate/weaviate/usecases/config"
 
 	"github.com/casbin/casbin/v2"
@@ -59,7 +61,7 @@ func (m *manager) upsertRolesPermissions(roles map[string][]authorization.Policy
 			return fmt.Errorf("AddRoleForUser: %w", err)
 		}
 		for _, policy := range policies {
-			if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName(roleName), policy.Resource, policy.Verb, policy.Domain); err != nil {
+			if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName(roleName), policy.Resource, policy.Verb, policy.Domain, build.Version); err != nil {
 				return fmt.Errorf("AddNamedPolicy: %w", err)
 			}
 		}

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -146,7 +146,7 @@ func (m *manager) RemovePermissions(roleName string, permissions []*authorizatio
 }
 
 func (m *manager) HasPermission(roleName string, permission *authorization.Policy) (bool, error) {
-	policy, err := m.casbin.HasNamedPolicy("p", conv.PrefixRoleName(roleName), permission.Resource, permission.Verb, permission.Domain)
+	policy, err := m.casbin.HasNamedPolicy("p", conv.PrefixRoleName(roleName), permission.Resource, permission.Verb, permission.Domain, build.Version)
 	if err != nil {
 		return false, fmt.Errorf("HasNamedPolicy: %w", err)
 	}

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -128,7 +128,7 @@ func (m *manager) GetRoles(names ...string) (map[string][]authorization.Policy, 
 
 func (m *manager) RemovePermissions(roleName string, permissions []*authorization.Policy) error {
 	for _, permission := range permissions {
-		ok, err := m.casbin.RemoveNamedPolicy("p", conv.PrefixRoleName(roleName), permission.Resource, permission.Verb, permission.Domain)
+		ok, err := m.casbin.RemoveNamedPolicy("p", conv.PrefixRoleName(roleName), permission.Resource, permission.Verb, permission.Domain, build.Version)
 		if err != nil {
 			return fmt.Errorf("RemoveNamedPolicy: %w", err)
 		}

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -41,7 +41,7 @@ const (
 	r = sub, obj, act
 
 	[policy_definition]
-	p = sub, obj, act, dom
+	p = sub, obj, act, dom, version
 
 	[role_definition]
 	g = _, _


### PR DESCRIPTION
### What's being changed:

To handle upgrades of the casbin roles between 1.29 and 1.30 we need to add a version number to the policies. This way we can decide if we need to upgrade a role definition or not.

This adds:
- upgrading the policy file and adding a version number


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
