### PR TITLE
Handle upgrades from stable/v1.29 that need role info

### DIFF
--- a/usecases/auth/authorization/rbac/model_upgrade_test.go
+++ b/usecases/auth/authorization/rbac/model_upgrade_test.go
@@ -12,8 +12,13 @@
 package rbac
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"slices"
 	"testing"
+
+	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
 
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
@@ -93,6 +98,91 @@ func TestUpdateGroupings(t *testing.T) {
 				users, err := enforcer.GetUsersForRole(role)
 				require.NoError(t, err)
 				require.True(t, slices.Contains(users, user))
+			}
+		})
+	}
+}
+
+func TestUpgradeRoles(t *testing.T) {
+	tests := []struct {
+		name             string
+		lines            []string
+		expectedPolicies [][]string
+		version          string
+	}{
+		{
+			name: "skip build in roles",
+			lines: []string{
+				"p, role:other_role, data/collections/.*/shards/.*/objects/.*, R, data",
+				"p, role:viewer, *, R, *",
+			},
+			expectedPolicies: [][]string{
+				{"role:other_role", "data/collections/.*/shards/.*/objects/.*", " R", "data"},
+			},
+			version: DEFAULT_POLICY_VERSION,
+		},
+		{
+			name: "upgrade update user if coming from old version",
+			lines: []string{
+				"p, role:some_role, users/.*, U, users",
+			},
+			expectedPolicies: [][]string{
+				{"p, role:some_role, users/.*, A, users"},
+			},
+			version: DEFAULT_POLICY_VERSION,
+		},
+		{
+			name: "dont upgrade if coming from 1.30+",
+			lines: []string{
+				"p, role:some_role, users/.*, U, users",
+			},
+			expectedPolicies: [][]string{
+				{"p, role:some_role, users/.*, A, users"},
+			},
+			version: "1.30.1",
+		},
+		{
+			name: "mixed upgrade and not upgrade and skip",
+			lines: []string{
+				"p, role:some_role, users/.*, U, users",
+				"p, role:other_role, data/collections/.*/shards/.*/objects/.*, R, data",
+				"p, role:viewer, *, R, *",
+			},
+			expectedPolicies: [][]string{
+				{"p, role:some_role, users/.*, A, users, "},
+				{"role:other_role", "data/collections/.*/shards/.*/objects/.*", " R", "data"},
+			},
+			version: DEFAULT_POLICY_VERSION,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			tmpFile, err := os.CreateTemp(path, "upgrade-temp-*.tmp")
+			require.NoError(t, err)
+
+			writer := bufio.NewWriter(tmpFile)
+			for _, line := range tt.lines {
+				_, err := fmt.Fprintln(writer, line)
+				require.NoError(t, err)
+			}
+			require.NoError(t, writer.Flush())
+			require.NoError(t, tmpFile.Sync())
+			require.NoError(t, tmpFile.Close())
+
+			m, err := model.NewModelFromString(MODEL)
+			require.NoError(t, err)
+
+			enforcer, err := casbin.NewSyncedCachedEnforcer(m)
+			require.NoError(t, err)
+			enforcer.SetAdapter(fileadapter.NewAdapter(tmpFile.Name()))
+			require.NoError(t, enforcer.LoadPolicy())
+
+			require.NoError(t, upgradeRolesFrom129(enforcer, tt.version))
+			policies, _ := enforcer.GetPolicy()
+			require.Len(t, policies, len(tt.expectedPolicies))
+			for i, policy := range tt.expectedPolicies {
+				require.Equal(t, tt.expectedPolicies[i], policy)
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:

Add an extra version file that contains the version of weaviate that created the policy. This can be used to distinguish between upgrading and not upgrading

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
