### PR TITLE
Fix race between delete and deactive/activate

### DIFF
--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -200,3 +200,24 @@ func TestSnapShotAndRestore(t *testing.T) {
 	_, err = dynUsers2.ValidateAndExtract(login3, identifier3)
 	require.Error(t, err)
 }
+
+func TestSuspendAfterDelete(t *testing.T) {
+	dynUsers, err := NewDBUser(t.TempDir())
+	require.NoError(t, err)
+	userId := "id"
+
+	_, hash, identifier, err := keys.CreateApiKeyAndHash("")
+	require.NoError(t, err)
+
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier))
+
+	users, err := dynUsers.GetUsers(userId)
+	require.NoError(t, err)
+	require.Contains(t, users, userId)
+	require.Len(t, users, 1)
+
+	require.NoError(t, dynUsers.DeleteUser(userId))
+
+	require.Error(t, dynUsers.DeactivateUser(userId, false))
+	require.Error(t, dynUsers.ActivateUser(userId))
+}

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -114,6 +114,7 @@ func NewDBUser(path string) (*DBUser, error) {
 func (c *DBUser) CreateUser(userId, secureHash, userIdentifier string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	c.data.SecureKeyStorageById[userId] = secureHash
 	c.data.IdentifierToId[userIdentifier] = userId
 	c.data.IdToIdentifier[userId] = userIdentifier
@@ -148,6 +149,10 @@ func (c *DBUser) ActivateUser(userId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	if _, ok := c.data.Users[userId]; !ok {
+		return fmt.Errorf("user %s does not exist", userId)
+	}
+
 	c.data.Users[userId].Active = true
 	return c.storeToFile()
 }
@@ -155,6 +160,9 @@ func (c *DBUser) ActivateUser(userId string) error {
 func (c *DBUser) DeactivateUser(userId string, revokeKey bool) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	if _, ok := c.data.Users[userId]; !ok {
+		return fmt.Errorf("user %s does not exist", userId)
+	}
 	if revokeKey {
 		c.data.UserKeyRevoked[userId] = struct{}{}
 	}

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -114,7 +114,6 @@ func NewDBUser(path string) (*DBUser, error) {
 func (c *DBUser) CreateUser(userId, secureHash, userIdentifier string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
 	c.data.SecureKeyStorageById[userId] = secureHash
 	c.data.IdentifierToId[userIdentifier] = userId
 	c.data.IdToIdentifier[userId] = userIdentifier
@@ -137,8 +136,8 @@ func (c *DBUser) DeleteUser(userId string) error {
 	defer c.lock.Unlock()
 
 	delete(c.data.SecureKeyStorageById, userId)
-	delete(c.data.IdToIdentifier, userId)
 	delete(c.data.IdentifierToId, c.data.IdToIdentifier[userId])
+	delete(c.data.IdToIdentifier, userId)
 	delete(c.data.Users, userId)
 	delete(c.memoryOnyData.WeakKeyStorageById, userId)
 	delete(c.data.UserKeyRevoked, userId)


### PR DESCRIPTION
### What's being changed:

There is a small gap in the endpoint between checking for user existence and (de)-activating which could result in a (harmless) panic. Check for existence

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
