### PR TITLE
chore: change the order of generative images passed with prompt

### DIFF
--- a/usecases/modulecomponents/generative/generative.go
+++ b/usecases/modulecomponents/generative/generative.go
@@ -55,7 +55,6 @@ func Blobs(properties []*modulecapabilities.GenerateProperties) []map[string]*st
 // It returns a slice of pointers to base64 strings in order to optimise for memory usage when dealing with large images.
 func ParseImageProperties(inputBase64Images []*string, inputImagePropertyNames []string, storedBase64ImagesArray []map[string]*string) []*string {
 	images := []*string{}
-	images = append(images, inputBase64Images...)
 	if len(storedBase64ImagesArray) > 0 {
 		for _, storedBase64Images := range storedBase64ImagesArray {
 			for _, inputImagePropertyName := range inputImagePropertyNames {
@@ -63,6 +62,7 @@ func ParseImageProperties(inputBase64Images []*string, inputImagePropertyNames [
 			}
 		}
 	}
+	images = append(images, inputBase64Images...)
 	return images
 }
 


### PR DESCRIPTION
### What's being changed:

This PR changes the order of images passed to generative modules so that now first images added are collection's image properties then the custom images.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
