### PR TITLE
Save first letters of the api key

### DIFF
--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -87,7 +87,7 @@ func TestCreateInternalServerError(t *testing.T) {
 				dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(tt.CheckUserIdentifierExistsValueReturn, tt.CheckUserIdentifierExistsErrorReturn)
 			}
 			if tt.CheckUserIdentifierExistsErrorReturn == nil && !tt.CheckUserIdentifierExistsValueReturn && tt.GetUserReturn == nil {
-				dynUser.On("CreateUser", "user", mock.Anything, mock.Anything, mock.Anything).Return(tt.CreateUserReturn)
+				dynUser.On("CreateUser", "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.CreateUserReturn)
 			}
 
 			h := dynUserHandler{
@@ -147,7 +147,7 @@ func TestCreateSuccess(t *testing.T) {
 	dynUser := mocks.NewDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers", user).Return(map[string]*apikey.User{}, nil)
 	dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
-	dynUser.On("CreateUser", user, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	dynUser.On("CreateUser", user, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -254,7 +254,7 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 		count++
 	}
 
-	if err := h.dbUsers.CreateUser(params.UserID, hash, userIdentifier, time.Now()); err != nil {
+	if err := h.dbUsers.CreateUser(params.UserID, hash, userIdentifier, apiKey[:3], time.Now()); err != nil {
 		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
 	}
 

--- a/adapters/handlers/rest/db_users/mocks/DbUserAndRolesGetter.go
+++ b/adapters/handlers/rest/db_users/mocks/DbUserAndRolesGetter.go
@@ -75,17 +75,17 @@ func (_m *DbUserAndRolesGetter) CheckUserIdentifierExists(userIdentifier string)
 	return r0, r1
 }
 
-// CreateUser provides a mock function with given fields: userId, secureHash, userIdentifier, createdAt
-func (_m *DbUserAndRolesGetter) CreateUser(userId string, secureHash string, userIdentifier string, createdAt time.Time) error {
-	ret := _m.Called(userId, secureHash, userIdentifier, createdAt)
+// CreateUser provides a mock function with given fields: userId, secureHash, userIdentifier, apiKeyFirstLetters, createdAt
+func (_m *DbUserAndRolesGetter) CreateUser(userId string, secureHash string, userIdentifier string, apiKeyFirstLetters string, createdAt time.Time) error {
+	ret := _m.Called(userId, secureHash, userIdentifier, apiKeyFirstLetters, createdAt)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, time.Time) error); ok {
-		r0 = rf(userId, secureHash, userIdentifier, createdAt)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, time.Time) error); ok {
+		r0 = rf(userId, secureHash, userIdentifier, apiKeyFirstLetters, createdAt)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -41,7 +41,7 @@ func (m *Manager) CreateUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.CreateUser(req.UserId, req.SecureHash, req.UserIdentifier, req.CreatedAt)
+	return m.dynUser.CreateUser(req.UserId, req.SecureHash, req.UserIdentifier, req.ApiKeyFirstLetters, req.CreatedAt)
 }
 
 func (m *Manager) DeleteUser(c *cmd.ApplyRequest) error {

--- a/cluster/proto/api/dyn_user_requests.go
+++ b/cluster/proto/api/dyn_user_requests.go
@@ -23,11 +23,12 @@ const (
 )
 
 type CreateUsersRequest struct {
-	UserId         string
-	SecureHash     string
-	UserIdentifier string
-	CreatedAt      time.Time
-	Version        int
+	UserId             string
+	SecureHash         string
+	UserIdentifier     string
+	ApiKeyFirstLetters string
+	CreatedAt          time.Time
+	Version            int
 }
 
 type RotateUserApiKeyRequest struct {

--- a/cluster/raft_dynuser_apply_endpoints.go
+++ b/cluster/raft_dynuser_apply_endpoints.go
@@ -20,13 +20,14 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-func (s *Raft) CreateUser(userId, secureHash, userIdentifier string, createdAt time.Time) error {
+func (s *Raft) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters string, createdAt time.Time) error {
 	req := cmd.CreateUsersRequest{
-		UserId:         userId,
-		SecureHash:     secureHash,
-		UserIdentifier: userIdentifier,
-		CreatedAt:      createdAt,
-		Version:        cmd.DynUserLatestCommandPolicyVersion,
+		UserId:             userId,
+		SecureHash:         secureHash,
+		UserIdentifier:     userIdentifier,
+		CreatedAt:          createdAt,
+		ApiKeyFirstLetters: apiKeyFirstLetters,
+		Version:            cmd.DynUserLatestCommandPolicyVersion,
 	}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -36,7 +36,7 @@ func TestDynUserConcurrency(t *testing.T) {
 	for i := 0; i < numUsers; i++ {
 		userName := fmt.Sprintf("user%v", i)
 		go func() {
-			err := dynUsers.CreateUser(userName, "something", userName, time.Now())
+			err := dynUsers.CreateUser(userName, "something", userName, "", time.Now())
 			require.NoError(t, err)
 			wg.Done()
 		}()
@@ -57,7 +57,7 @@ func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash("")
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", time.Now()))
 
 	randomKey, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestUpdateUser(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash("")
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", time.Now()))
 
 	// login works
 	randomKeyOld, _, err := keys.DecodeApiKey(apiKey)
@@ -134,13 +134,13 @@ func TestSnapShotAndRestore(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash("")
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId1, hash, identifier, time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId1, hash, identifier, "", time.Now()))
 	login1, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
 
 	apiKey2, hash2, identifier2, err := keys.CreateApiKeyAndHash("")
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.CreateUser(userId2, hash2, identifier2, time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId2, hash2, identifier2, "", time.Now()))
 	login2, _, err := keys.DecodeApiKey(apiKey2)
 	require.NoError(t, err)
 
@@ -209,7 +209,7 @@ func TestSuspendAfterDelete(t *testing.T) {
 	_, hash, identifier, err := keys.CreateApiKeyAndHash("")
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", time.Now()))
 
 	users, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)


### PR DESCRIPTION
### What's being changed:

Saves the first 3 letters of the API key so we can display it to our users in WCD

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
