### PR TITLE
queue: recover corrupt chunks

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -895,7 +895,7 @@ func (w *chunkWriter) Open() error {
 			if err != nil {
 				return errors.Wrap(err, "failed to sync chunk file")
 			}
-			w.size -= 4
+			w.size -= uint64(n)
 			break
 		}
 		if err != nil {

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -886,6 +886,10 @@ func (w *chunkWriter) Open() error {
 		}
 		if errors.Is(err, io.ErrUnexpectedEOF) {
 			// a record was not fully written, probably because of a crash.
+			w.logger.WithField("action", "queue_log_corruption").
+				WithField("path", filepath.Join(w.dir, lastChunk)).
+				Error(errors.Wrap(err, "queue ended abruptly, some elements may not have been recovered"))
+
 			// truncate the file to the last complete record
 			err = w.f.Truncate(int64(w.size) - int64(n))
 			if err != nil {
@@ -911,6 +915,10 @@ func (w *chunkWriter) Open() error {
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				// a record was not fully written, probably because of a crash.
+				w.logger.WithField("action", "queue_log_corruption").
+					WithField("path", filepath.Join(w.dir, lastChunk)).
+					Error(errors.Wrap(err, "queue ended abruptly, some elements may not have been recovered"))
+
 				// truncate the file to the last complete record
 				err = w.f.Truncate(int64(w.size) - 4 - int64(n))
 				if err != nil {

--- a/adapters/repos/db/queue/scheduler_test.go
+++ b/adapters/repos/db/queue/scheduler_test.go
@@ -233,13 +233,12 @@ func makeScheduler(t testing.TB, workers ...int) *Scheduler {
 	})
 }
 
-func makeQueueSize(t *testing.T, s *Scheduler, decoder TaskDecoder, chunkSize uint64) *DiskQueue {
+func makeQueueWith(t *testing.T, s *Scheduler, decoder TaskDecoder, chunkSize uint64, dir string) *DiskQueue {
 	t.Helper()
 
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
 
-	dir := t.TempDir()
 	q, err := NewDiskQueue(DiskQueueOptions{
 		ID:           "test_queue",
 		Scheduler:    s,
@@ -257,6 +256,10 @@ func makeQueueSize(t *testing.T, s *Scheduler, decoder TaskDecoder, chunkSize ui
 	s.RegisterQueue(q)
 
 	return q
+}
+
+func makeQueueSize(t *testing.T, s *Scheduler, decoder TaskDecoder, chunkSize uint64) *DiskQueue {
+	return makeQueueWith(t, s, decoder, chunkSize, t.TempDir())
 }
 
 func makeQueue(t *testing.T, s *Scheduler, decoder TaskDecoder) *DiskQueue {


### PR DESCRIPTION
### What's being changed:

The queue now recovers from corrupt or incomplete chunks by truncating the files to the last valid record.
This minimizes data loss and prevents the queue from being stuck.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
