### PR TITLE
fix(bm25_block): :bug: Fix concurrent access to segment and memtable tombstones

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -941,7 +941,7 @@ func (b *Bucket) loadAllTombstones(segmentsDisk []*segment) ([]*sroar.Bitmap, er
 	allTombstones := make([]*sroar.Bitmap, len(segmentsDisk)+2)
 	for i, segment := range segmentsDisk {
 		if segment.strategy == segmentindex.StrategyInverted {
-			tombstones, err := segment.GetTombstones()
+			tombstones, err := segment.ReadOnlyTombstones()
 			if err != nil {
 				return nil, err
 			}
@@ -952,14 +952,14 @@ func (b *Bucket) loadAllTombstones(segmentsDisk []*segment) ([]*sroar.Bitmap, er
 	if hasTombstones {
 
 		if b.flushing != nil {
-			tombstones, err := b.flushing.GetTombstones()
+			tombstones, err := b.flushing.ReadOnlyTombstones()
 			if err != nil {
 				return nil, err
 			}
 			allTombstones[len(segmentsDisk)] = tombstones
 		}
 
-		tombstones, err := b.active.GetTombstones()
+		tombstones, err := b.active.ReadOnlyTombstones()
 		if err != nil {
 			return nil, err
 		}
@@ -1305,6 +1305,7 @@ func (b *Bucket) isReadOnly() bool {
 // in test scenarios or when a force flush is desired.
 func (b *Bucket) FlushAndSwitch() error {
 	before := time.Now()
+	var err error
 
 	bucketPath := b.GetDir()
 
@@ -1331,11 +1332,9 @@ func (b *Bucket) FlushAndSwitch() error {
 	}
 
 	var tombstones *sroar.Bitmap
-	var err2 error
 	if b.strategy == StrategyInverted {
-		tombstones, err2 = b.flushing.GetTombstones()
-		if err2 != nil {
-			return fmt.Errorf("get tombstones: %w", err2)
+		if tombstones, err = b.flushing.ReadOnlyTombstones(); err != nil {
+			return fmt.Errorf("get tombstones: %w", err)
 		}
 	}
 
@@ -1349,21 +1348,18 @@ func (b *Bucket) FlushAndSwitch() error {
 	}
 
 	if b.strategy == StrategyInverted && !tombstones.IsEmpty() {
-		errInn := func() error {
+		if err = func() error {
 			b.disk.maintenanceLock.RLock()
 			defer b.disk.maintenanceLock.RUnlock()
 			// add flushing memtable tombstones to all segments
 			for _, seg := range b.disk.segments {
-				segTombstones, errInner := seg.GetTombstones()
-				if errInner != nil {
-					return fmt.Errorf("get tombstones: %w", errInner)
+				if _, err := seg.MergeTombstones(tombstones); err != nil {
+					return fmt.Errorf("merge tombstones: %w", err)
 				}
-				segTombstones.Or(tombstones)
 			}
 			return nil
-		}()
-		if errInn != nil {
-			return fmt.Errorf("add tombstones: %w", errInn)
+		}(); err != nil {
+			return fmt.Errorf("add tombstones: %w", err)
 		}
 	}
 
@@ -1583,7 +1579,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 	// active memtable
 	output[len(segmentsDisk)+1] = make([]*SegmentBlockMax, 0, len(query))
 
-	allTombstones := make([]*sroar.Bitmap, 2)
+	memTombstones := sroar.NewBitmap()
 
 	for i, queryTerm := range query {
 		key := []byte(queryTerm)
@@ -1592,6 +1588,7 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 		active := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
 		flushing := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
 
+		var activeTombstones *sroar.Bitmap
 		if b.active != nil {
 			memtable := b.active
 			n2, _ := fillTerm(memtable, key, active, filterDocIds)
@@ -1599,14 +1596,16 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 				output[len(segmentsDisk)+1] = append(output[len(segmentsDisk)+1], active)
 			}
 			n += n2
-			tombstones, err := b.active.GetTombstones()
+
+			var err error
+			activeTombstones, err = b.active.ReadOnlyTombstones()
 			if err != nil {
 				release()
 				return nil, nil, func() {}, err
 			}
-			allTombstones[1] = tombstones
+			memTombstones.Or(activeTombstones)
 
-			if !active.Exhausted() {
+			if n2 > 0 {
 				active.advanceOnTombstoneOrFilter()
 			}
 		}
@@ -1619,16 +1618,15 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 			}
 			n += n2
 
-			tombstones, err := b.flushing.GetTombstones()
+			tombstones, err := b.flushing.ReadOnlyTombstones()
 			if err != nil {
 				release()
 				return nil, nil, func() {}, err
 			}
+			memTombstones.Or(tombstones)
 
-			allTombstones[0] = tombstones
-			if !flushing.Exhausted() {
-				tombstones, _ = b.active.GetTombstones()
-				flushing.tombstones = tombstones
+			if n2 > 0 {
+				flushing.tombstones = activeTombstones
 				flushing.advanceOnTombstoneOrFilter()
 			}
 
@@ -1656,37 +1654,22 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 		segment := segmentsDisk[j]
 		output[j] = make([]*SegmentBlockMax, 0, len(query))
 
-		var tombstones *sroar.Bitmap
-		var err error
-		if j == len(segmentsDisk)-1 {
-			tombstones = sroar.NewBitmap()
-		} else {
-			tombstones, err = segmentsDisk[j+1].GetTombstones()
+		allTombstones := memTombstones.Clone()
+		if j != len(segmentsDisk)-1 {
+			segTombstones, err := segmentsDisk[j+1].ReadOnlyTombstones()
 			if err != nil {
 				release()
 				return nil, nil, func() {}, err
 			}
+			allTombstones.Or(segTombstones)
 		}
 
-		if err != nil {
-			release()
-			return nil, nil, func() {}, err
-		}
-
-		if allTombstones[0] != nil {
-			tombstones.Or(allTombstones[0])
-		}
-		if allTombstones[1] != nil {
-			tombstones.Or(allTombstones[1])
-		}
 		for i, key := range query {
-
-			term := NewSegmentBlockMax(segment, []byte(key), i, idfs[i], propertyBoost, tombstones, filterDocIds, averagePropLength, config)
+			term := NewSegmentBlockMax(segment, []byte(key), i, idfs[i], propertyBoost, allTombstones, filterDocIds, averagePropLength, config)
 			if term != nil {
 				output[j] = append(output[j], term)
 			}
 		}
-
 	}
 	return output, idfCounts, release, nil
 }
@@ -1738,7 +1721,7 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 	if len(term.blockDataDecoded.DocIds) == 0 {
 		return n, nil
 	}
-	term.exhausted = false
+
 	term.blockEntries = make([]*terms.BlockEntry, 1)
 	term.blockEntries[0] = &terms.BlockEntry{
 		MaxId:  term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],

--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -84,12 +84,12 @@ func (c *compactorInverted) do() error {
 		return errors.Wrap(err, "init")
 	}
 
-	c.tombstonesToWrite, err = c.c1.segment.GetTombstones()
+	c.tombstonesToWrite, err = c.c1.segment.ReadOnlyTombstones()
 	if err != nil {
 		return errors.Wrap(err, "get tombstones")
 	}
 
-	c.tombstonesToClean, err = c.c2.segment.GetTombstones()
+	c.tombstonesToClean, err = c.c2.segment.ReadOnlyTombstones()
 	if err != nil {
 		return errors.Wrap(err, "get tombstones")
 	}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -431,7 +431,7 @@ func (m *Memtable) writeWAL() error {
 	return m.commitlog.flushBuffers()
 }
 
-func (m *Memtable) GetTombstones() (*sroar.Bitmap, error) {
+func (m *Memtable) ReadOnlyTombstones() (*sroar.Bitmap, error) {
 	if m.strategy != StrategyInverted {
 		return nil, errors.Errorf("tombstones only supported for strategy %q", StrategyInverted)
 	}
@@ -440,7 +440,7 @@ func (m *Memtable) GetTombstones() (*sroar.Bitmap, error) {
 	defer m.RUnlock()
 
 	if m.tombstones != nil {
-		return m.tombstones, nil
+		return m.tombstones.Clone(), nil
 	}
 
 	return nil, lsmkv.NotFound
@@ -451,8 +451,8 @@ func (m *Memtable) SetTombstone(docId uint64) error {
 		return errors.Errorf("tombstones only supported for strategy %q", StrategyInverted)
 	}
 
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	m.tombstones.Set(docId)
 


### PR DESCRIPTION
### What's being changed:

Backport the changes in concurrent memtable tombstone access from 1.30 to 1.28

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
