### PR TITLE
Update pull_requests.yaml to reconfigure Orca SAST scanning

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -94,6 +94,9 @@ jobs:
           project_key: ${{ env.PROJECT_KEY }}
           # diff scans against the entire git history, so should only scan changes in this PR
           fetch-depth: 0
+          path:
+            # scanning the entire repository
+            "."
   Unit-Tests:
     name: unit-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -92,9 +92,8 @@ jobs:
         with:
           api_token: ${{ secrets.ORCA_SECURITY_API_TOKEN }}
           project_key: ${{ env.PROJECT_KEY }}
-          path:
-            # scanning the entire repository
-            "."
+          # diff scans against the entire git history, so should only scan changes in this PR
+          fetch-depth: 0
   Unit-Tests:
     name: unit-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What's being changed:

In line with the recommendations from Orca, I'm changing how the Orca SAST scanner calculates a diff before it scans files in a PR. 

This _should_ result in less noise in PRs and in the CICD, as Orca won't flag files that aren't in the PR but have vulnerabilities. 

However I need help testing it and won't merge it until it's fully validated - I don't want to risk breaking the CICD or having vulnerabilities get into production that we should have caught and fixed. 

