### PR TITLE
feat: allow to refer to legacy vector as default named vector in mixed  collections

### DIFF
--- a/adapters/repos/db/shard_accessors_test.go
+++ b/adapters/repos/db/shard_accessors_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -82,9 +83,17 @@ func TestShared_GetVectorIndexAndQueue(t *testing.T) {
 			legacyIndex, ok := s.GetVectorIndex("")
 			require.Equal(t, tt.wantLegacyExists, ok)
 
+			defaultQueue, ok := s.GetVectorIndex(modelsext.DefaultNamedVectorName)
+			require.Equal(t, tt.wantLegacyExists, ok)
+
+			defaultIndex, ok := s.GetVectorIndex(modelsext.DefaultNamedVectorName)
+			require.Equal(t, tt.wantLegacyExists, ok)
+
 			if tt.wantLegacyExists {
 				require.NotNil(t, legacyQueue)
 				require.NotNil(t, legacyIndex)
+				require.NotNil(t, defaultQueue)
+				require.NotNil(t, defaultIndex)
 			}
 		})
 	}

--- a/entities/modelsext/class.go
+++ b/entities/modelsext/class.go
@@ -21,3 +21,21 @@ const DefaultNamedVectorName = "default"
 func ClassHasLegacyVectorIndex(class *models.Class) bool {
 	return class.Vectorizer != "" || class.VectorIndexConfig != nil || class.VectorIndexType != ""
 }
+
+// ClassGetVectorConfig returns the vector config for a given class and target vector.
+// There is a special case for the default vector name, which is used to access the legacy vector.
+func ClassGetVectorConfig(class *models.Class, targetVector string) (models.VectorConfig, bool) {
+	if cfg, ok := class.VectorConfig[targetVector]; ok {
+		return cfg, ok
+	}
+
+	if (ClassHasLegacyVectorIndex(class) && targetVector == DefaultNamedVectorName) || targetVector == "" {
+		return models.VectorConfig{
+			VectorIndexConfig: class.VectorIndexConfig,
+			VectorIndexType:   class.VectorIndexType,
+			Vectorizer:        class.Vectorizer,
+		}, true
+	}
+
+	return models.VectorConfig{}, false
+}

--- a/entities/schema/config/vector_index_config.go
+++ b/entities/schema/config/vector_index_config.go
@@ -55,7 +55,7 @@ func TypeAssertVectorIndex(class *models.Class, targetVectors []string) ([]Vecto
 
 	configs := make([]VectorIndexConfig, 0, len(targetVectors))
 	for _, targetVector := range targetVectors {
-		vectorConfig, ok := class.VectorConfig[targetVector]
+		vectorConfig, ok := modelsext.ClassGetVectorConfig(class, targetVector)
 		if !ok {
 			return nil, errors.Errorf("vector config not found for target vector: %s", targetVector)
 		}

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors.go
@@ -23,6 +23,6 @@ func AllMixedVectorsTests(endpoint string) func(t *testing.T) {
 		t.Run("batch byov", testMixedVectorsBatchBYOV(endpoint))
 		t.Run("hybrid", testMixedVectorsHybrid(endpoint))
 		t.Run("aggregate", testMixedVectorsAggregate(endpoint))
-		t.Run("name forwarding", testMixedVectorsNamedForwarding(endpoint))
+		t.Run("name forwarding", testMixedVectorsDefaultNameForwarding(endpoint))
 	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_aggregate.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_aggregate.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+
 	"github.com/weaviate/weaviate/entities/modelsext"
 
 	"github.com/stretchr/testify/assert"

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_aggregate.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_aggregate.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+	"github.com/weaviate/weaviate/entities/modelsext"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,7 @@ func testMixedVectorsAggregate(host string) func(t *testing.T) {
 		require.NoError(t, err)
 
 		testAllObjectsIndexed(t, client, class.Class)
-		for _, targetVector := range []string{"", contextionary} {
+		for _, targetVector := range []string{"", modelsext.DefaultNamedVectorName, contextionary} {
 			t.Run(fmt.Sprintf("vector=%q", targetVector), func(t *testing.T) {
 				no := &graphql.NearObjectArgumentBuilder{}
 				no = no.WithID(id1).WithCertainty(0.9)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+
 	"github.com/weaviate/weaviate/entities/modelsext"
 
 	"github.com/stretchr/testify/require"

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_hybrid.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+	"github.com/weaviate/weaviate/entities/modelsext"
 
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
@@ -77,6 +78,18 @@ func testMixedVectorsHybrid(host string) func(t *testing.T) {
 			Do(ctx)
 		require.NoError(t, err)
 
+		legacyRespUsingNamedVector, err := client.GraphQL().Get().
+			WithClassName(class.Class).
+			WithHybrid(client.GraphQL().
+				HybridArgumentBuilder().
+				WithQuery("Some text goes here").
+				WithAlpha(0.5).
+				WithTargetVectors(modelsext.DefaultNamedVectorName)).
+			WithFields(field).
+			Do(ctx)
+		require.NoError(t, err)
+
 		require.Equal(t, namedResp, legacyResp)
+		require.Equal(t, legacyRespUsingNamedVector, legacyResp)
 	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_name_forwarding.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_name_forwarding.go
@@ -22,7 +22,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modelsext"
 )
 
-func testMixedVectorsNamedForwarding(endpoint string) func(t *testing.T) {
+func testMixedVectorsDefaultNameForwarding(endpoint string) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+	"github.com/weaviate/weaviate/entities/modelsext"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-openapi/strfmt"
@@ -92,7 +93,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 			require.Len(t, resultVectors[transformers], 384)
 		})
 
-		for _, targetVector := range []string{"", contextionary} {
+		for _, targetVector := range []string{"", modelsext.DefaultNamedVectorName, contextionary} {
 			t.Run(fmt.Sprintf("targetVector=%q", targetVector), func(t *testing.T) {
 				t.Run("nearText search", func(t *testing.T) {
 					nearText := client.GraphQL().NearTextArgBuilder().

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	acceptance_with_go_client "acceptance_tests_with_client"
+
 	"github.com/weaviate/weaviate/entities/modelsext"
 
 	"github.com/davecgh/go-spew/spew"

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -152,6 +152,20 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 			})
 		}
 
+		t.Run("multi target search", func(t *testing.T) {
+			res, err := client.GraphQL().Get().WithClassName(class.Class).
+				WithNearText(client.GraphQL().
+					NearTextArgBuilder().
+					WithConcepts([]string{"reading", "book"}).
+					WithTargetVectors("contextionary", modelsext.DefaultNamedVectorName)).
+				WithLimit(1).
+				WithFields(idField).
+				Do(ctx)
+			require.NoError(t, err)
+
+			require.Equal(t, []string{id1}, acceptance_with_go_client.GetIds(t, res, class.Class))
+		})
+
 		t.Run("update object", func(t *testing.T) {
 			vectorsToCheck := []string{"", contextionary}
 

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -154,7 +154,7 @@ func (c *coordinator) Nodes(ctx context.Context, req *Request) (map[string]strin
 }
 
 // Backup coordinates a distributed backup among participants
-func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Request) error {
+func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Request) error { // TODO: start
 	req.Method = OpCreate
 	leader := c.nodeResolver.LeaderID()
 	if leader == "" {

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -154,7 +154,7 @@ func (c *coordinator) Nodes(ctx context.Context, req *Request) (map[string]strin
 }
 
 // Backup coordinates a distributed backup among participants
-func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Request) error { // TODO: start
+func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Request) error {
 	req.Method = OpCreate
 	leader := c.nodeResolver.LeaderID()
 	if leader == "" {

--- a/usecases/traverser/near_params_vector.go
+++ b/usecases/traverser/near_params_vector.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
@@ -265,7 +266,11 @@ func (v *nearParamsVector) classFindVector(ctx context.Context, className string
 		return nil, "", errors.New("vector not found")
 	}
 	if targetVector != "" {
-		if len(res.Vectors) == 0 || res.Vectors[targetVector] == nil {
+		if targetVector == modelsext.DefaultNamedVectorName && len(res.Vector) > 0 {
+			return res.Vector, "", nil
+		}
+
+		if res.Vectors[targetVector] == nil {
 			return nil, "", fmt.Errorf("vector not found for target: %v", targetVector)
 		}
 		vec, ok := res.Vectors[targetVector].([]float32)

--- a/usecases/traverser/near_params_vector_test.go
+++ b/usecases/traverser/near_params_vector_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
@@ -258,7 +259,7 @@ func Test_nearParamsVector_vectorFromParams(t *testing.T) {
 			name: "Should get vector from nearObject across classes",
 			args: args{
 				nearObject: &searchparams.NearObject{
-					Beacon: crossref.NewLocalhost("SpecifiedClass", "e5dc4a4c-ef0f-3aed-89a3-a73435c6bbcf").String(),
+					Beacon: crossref.NewLocalhost("LegacyClass", "e5dc4a4c-ef0f-3aed-89a3-a73435c6bbcf").String(),
 				},
 			},
 			want:    []float32{0.0, 0.0, 0.0},
@@ -300,12 +301,12 @@ func Test_nearParamsVector_multiVectorFromParams(t *testing.T) {
 		wantTargetVector string
 	}{
 		{
-			name: "Should get vector from nearObject with single multi vector no target vector",
+			name: "should get vector from nearObject with single multi vector no target vector",
 			args: args{
 				nearObject: &searchparams.NearObject{
 					ID: "uuid",
 				},
-				className: "SingleMultiVector",
+				className: "SingleNamedVector",
 			},
 			want:             []float32{2.0, 2.0, 2.0},
 			returnVec:        true,
@@ -313,13 +314,13 @@ func Test_nearParamsVector_multiVectorFromParams(t *testing.T) {
 			wantTargetVector: "",
 		},
 		{
-			name: "Should get vector from nearObject with single multi vector and target vector",
+			name: "should get vector from nearObject with single named vector and target vector",
 			args: args{
 				nearObject: &searchparams.NearObject{
 					ID:            "uuid",
 					TargetVectors: []string{"Vector"},
 				},
-				className: "SingleMultiVector",
+				className: "SingleNamedVector",
 			},
 			want:             []float32{2.0, 2.0, 2.0},
 			returnVec:        true,
@@ -327,13 +328,13 @@ func Test_nearParamsVector_multiVectorFromParams(t *testing.T) {
 			wantTargetVector: "Vector",
 		},
 		{
-			name: "Should get vector from nearObject with multi vector no target vector",
+			name: "should get vector from nearObject with multi named vector and target vector",
 			args: args{
 				nearObject: &searchparams.NearObject{
 					ID:            "uuid",
 					TargetVectors: []string{"B"},
 				},
-				className: "MultiMultiVector",
+				className: "MultiNamedVector",
 			},
 			want:             []float32{4.0, 4.0, 4.0},
 			returnVec:        true,
@@ -341,12 +342,38 @@ func Test_nearParamsVector_multiVectorFromParams(t *testing.T) {
 			wantTargetVector: "B",
 		},
 		{
-			name: "Error if no vector is present",
+			name: "should get legacy vector from nearObject with default named vector name from legacy collection",
+			args: args{
+				nearObject: &searchparams.NearObject{
+					ID:            "uuid",
+					TargetVectors: []string{modelsext.DefaultNamedVectorName},
+				},
+				className: "LegacyCollection",
+			},
+			want:             []float32{1, 1, 1},
+			returnVec:        true,
+			wantErr:          false,
+			wantTargetVector: modelsext.DefaultNamedVectorName,
+		},
+		{
+			name: "should get legacy vector from nearObject from legacy collection",
 			args: args{
 				nearObject: &searchparams.NearObject{
 					ID: "uuid",
 				},
-				className: "SpecifiedClass",
+				className: "LegacyCollection",
+			},
+			want:      []float32{1, 1, 1},
+			returnVec: true,
+			wantErr:   false,
+		},
+		{
+			name: "error if no vector is present",
+			args: args{
+				nearObject: &searchparams.NearObject{
+					ID: "uuid",
+				},
+				className: "LegacyClass",
 			},
 			returnVec: false,
 			wantErr:   true,
@@ -529,7 +556,7 @@ func (f *fakeNearParamsSearcher) Object(ctx context.Context, className string, i
 	props search.SelectProperties, additional additional.Properties,
 	repl *additional.ReplicationProperties, tenant string,
 ) (*search.Result, error) {
-	if className == "SpecifiedClass" {
+	if className == "LegacyClass" {
 		vec := []float32{0.0, 0.0, 0.0}
 		if !f.returnVec {
 			vec = nil
@@ -538,13 +565,13 @@ func (f *fakeNearParamsSearcher) Object(ctx context.Context, className string, i
 		return &search.Result{
 			Vector: vec,
 		}, nil
-	} else if className == "SingleMultiVector" {
+	} else if className == "SingleNamedVector" {
 		return &search.Result{
 			Vectors: models.Vectors{
 				"Vector": []float32{2.0, 2.0, 2.0},
 			},
 		}, nil
-	} else if className == "MultiMultiVector" {
+	} else if className == "MultiNamedVector" {
 		return &search.Result{
 			Vectors: models.Vectors{
 				"A": []float32{3.0, 3.0, 3.0},


### PR DESCRIPTION
### What's being changed:
Allow to refer to legacy vector by `default` name when the collection has mixed vectors.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
