### PR TITLE
Change user id when rotating key

### DIFF
--- a/adapters/handlers/rest/db_users/mocks/DbUserAndRolesGetter.go
+++ b/adapters/handlers/rest/db_users/mocks/DbUserAndRolesGetter.go
@@ -220,17 +220,17 @@ func (_m *DbUserAndRolesGetter) RevokeRolesForUser(userName string, roles ...str
 	return r0
 }
 
-// RotateKey provides a mock function with given fields: userId, secureHash
-func (_m *DbUserAndRolesGetter) RotateKey(userId string, secureHash string) error {
-	ret := _m.Called(userId, secureHash)
+// RotateKey provides a mock function with given fields: userId, secureHash, oldIdentifier, newIdentifier
+func (_m *DbUserAndRolesGetter) RotateKey(userId string, secureHash string, oldIdentifier string, newIdentifier string) error {
+	ret := _m.Called(userId, secureHash, oldIdentifier, newIdentifier)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RotateKey")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = rf(userId, secureHash)
+	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
+		r0 = rf(userId, secureHash, oldIdentifier, newIdentifier)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/adapters/handlers/rest/db_users/rotate_key_test.go
+++ b/adapters/handlers/rest/db_users/rotate_key_test.go
@@ -35,7 +35,8 @@ func TestSuccessRotate(t *testing.T) {
 	authorizer.On("Authorize", principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := mocks.NewDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user"}}, nil)
-	dynUser.On("RotateKey", "user", mock.Anything).Return(nil)
+	dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
+	dynUser.On("RotateKey", "user", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	h := dynUserHandler{
 		dbUsers:       dynUser,
@@ -70,7 +71,8 @@ func TestRotateInternalServerError(t *testing.T) {
 			dynUser := mocks.NewDbUserAndRolesGetter(t)
 			dynUser.On("GetUsers", "user").Return(tt.GetUserReturnValue, tt.GetUserReturnErr)
 			if tt.GetUserReturnErr == nil {
-				dynUser.On("RotateKey", "user", mock.Anything).Return(tt.RotateKeyError)
+				dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
+				dynUser.On("RotateKey", "user", mock.Anything, mock.Anything, mock.Anything).Return(tt.RotateKeyError)
 			}
 
 			h := dynUserHandler{

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -89,7 +89,7 @@ func (m *Manager) RotateKey(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.RotateKey(req.UserId, req.SecureHash)
+	return m.dynUser.RotateKey(req.UserId, req.SecureHash, req.OldIdentifier, req.NewIdentifier)
 }
 
 func (m *Manager) GetUsers(req *cmd.QueryRequest) ([]byte, error) {

--- a/cluster/proto/api/dyn_user_requests.go
+++ b/cluster/proto/api/dyn_user_requests.go
@@ -32,9 +32,11 @@ type CreateUsersRequest struct {
 }
 
 type RotateUserApiKeyRequest struct {
-	UserId     string
-	SecureHash string
-	Version    int
+	UserId        string
+	SecureHash    string
+	OldIdentifier string
+	NewIdentifier string
+	Version       int
 }
 
 type DeleteUsersRequest struct {

--- a/cluster/raft_dynuser_apply_endpoints.go
+++ b/cluster/raft_dynuser_apply_endpoints.go
@@ -43,11 +43,13 @@ func (s *Raft) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters
 	return nil
 }
 
-func (s *Raft) RotateKey(userId, secureHash string) error {
+func (s *Raft) RotateKey(userId, secureHash, oldIdentifier, newIdentifier string) error {
 	req := cmd.RotateUserApiKeyRequest{
-		UserId:     userId,
-		SecureHash: secureHash,
-		Version:    cmd.DynUserLatestCommandPolicyVersion,
+		UserId:        userId,
+		SecureHash:    secureHash,
+		OldIdentifier: oldIdentifier,
+		NewIdentifier: newIdentifier,
+		Version:       cmd.DynUserLatestCommandPolicyVersion,
 	}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {

--- a/test/acceptance/authn/dynamic_users_test.go
+++ b/test/acceptance/authn/dynamic_users_test.go
@@ -84,6 +84,9 @@ func TestCreateUser(t *testing.T) {
 		infoNew := helper.GetInfoForOwnUser(t, newKey)
 		require.Equal(t, userName, *infoNew.Username)
 
+		require.NotEqual(t, newKey, oldKey)
+		require.NotEqual(t, newKey[:10], oldKey[:10])
+
 		helper.DeleteUser(t, userName, adminKey)
 	})
 }

--- a/usecases/auth/authentication/apikey/keys/key_generation.go
+++ b/usecases/auth/authentication/apikey/keys/key_generation.go
@@ -52,26 +52,24 @@ var argonParameters = &argon2id.Params{
 //   - decode the key into the 3 parts mentioned above using DecodeApiKey
 //   - fetch the saved hash based on the returned user identifier
 //   - compare the returned randomKey with the fetched hash using argon2id.ComparePasswordAndHash
-func CreateApiKeyAndHash(existingIdentifier string) (string, string, string, error) {
+func CreateApiKeyAndHash() (string, string, string, error) {
 	randomBytesKey, err := generateRandomBytes(RandomBytesLength)
 	if err != nil {
 		return "", "", "", err
 	}
 	randomKey := base64.StdEncoding.EncodeToString(randomBytesKey)
 
-	if existingIdentifier == "" {
-		randomBytesIdentifier, err := generateRandomBytes(UserIdentifierBytesLength)
-		if err != nil {
-			return "", "", "", err
-		}
-		existingIdentifier = base64.StdEncoding.EncodeToString(randomBytesIdentifier)
+	randomBytesIdentifier, err := generateRandomBytes(UserIdentifierBytesLength)
+	if err != nil {
+		return "", "", "", err
 	}
+	identifier := base64.StdEncoding.EncodeToString(randomBytesIdentifier)
 
-	fullApiKey := generateApiKey(randomKey, existingIdentifier)
+	fullApiKey := generateApiKey(randomKey, identifier)
 
 	hash, err := argon2id.CreateHash(randomKey, argonParameters)
 
-	return fullApiKey, hash, existingIdentifier, err
+	return fullApiKey, hash, identifier, err
 }
 
 func generateApiKey(randomKey, userIdentifier string) string {

--- a/usecases/auth/authentication/apikey/keys/key_generation_test.go
+++ b/usecases/auth/authentication/apikey/keys/key_generation_test.go
@@ -21,24 +21,8 @@ import (
 )
 
 func TestKeyGeneration(t *testing.T) {
-	fullApiKey, hash, userIdentifier, err := CreateApiKeyAndHash("")
+	fullApiKey, hash, userIdentifier, err := CreateApiKeyAndHash()
 	require.NoError(t, err)
-
-	randomKey, userIdentifierDecoded, err := DecodeApiKey(fullApiKey)
-	require.NoError(t, err)
-	require.Equal(t, userIdentifier, userIdentifierDecoded)
-
-	match, err := argon2id.ComparePasswordAndHash(randomKey, hash)
-	require.NoError(t, err)
-	require.True(t, match)
-}
-
-func TestKeyGenerationWithExistingIdentifier(t *testing.T) {
-	randomIdentifierDummy := strings.Repeat("A", UserIdentifierBytesBase64Length)
-
-	fullApiKey, hash, userIdentifier, err := CreateApiKeyAndHash(randomIdentifierDummy)
-	require.NoError(t, err)
-	require.Equal(t, userIdentifier, randomIdentifierDummy)
 
 	randomKey, userIdentifierDecoded, err := DecodeApiKey(fullApiKey)
 	require.NoError(t, err)


### PR DESCRIPTION
### What's being changed:

The apikeys are `base64($identifier _ $key _ $version)`, if the identifier does not change the first characters of the key will stay the same even after rotating.  This PR changes the user identifier when rotating api. Note that this is purely a UX change and has no security implications.


Before
```
first  NHRmd3V6b1hKM3ZyOUVzY19LblhQcEJRZjBnNm1PdWYxZE9pVnYvNEZEWUhwaEk1aUtvOHpBamFXWU9nPV92MjAw
second NHRmd3V6b1hKM3ZyOUVzY192d0d3L0JEdG96c2c2bTFEQjlOd2VVcjZVZnVsVWZXUmVwSEV2Q0lXTmw0PV92MjAw
third  NHRmd3V6b1hKM3ZyOUVzY18rU2E2eE4yT2JPVGxmanhsODZFRnhuMURnTVkwYXRBWURBRUVlZkJNUUJRPV92MjAw
```

After
```
first  dmlRT1lNUFB5ZksrZ2luS19HYzhtMWRZK3dsVUVWT0w0V2FKaTRUM3Z5RGxBeWVsVlhobjk4bVVXOHhzPV92MjAw
second L01UVThiODA2NUQ0c1h3YV84Y2d4VTJyUHFFMnJucy92RG0zS1BZRGhyVU40K1JFem84ZGpJdjdGOTFZPV92MjAw
third  bWNkQjQzdEhJZnB1YTV2Yl8wZzBnMFBLdkR4djgwS1FHQUxTNmIyYkFiUWVVSHZWdnRNaUU4TlByRzdnPV92MjAw
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

for
```
with weaviate.connect_to_local(port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key("admin-key")) as client:
    client.users.db.delete(user_id="testing-test")
    print("first", client.users.db.create(user_id="testing-test"))
    print("second", client.users.db.rotate_key(user_id="testing-test"))
    print("third", client.users.db.rotate_key(user_id="testing-test"))
```

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
