### PR TITLE
chore: add test for adding multi-vector index to an existing legacy collection

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_add_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_add_vectors.go
@@ -174,5 +174,67 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 			require.Len(t, obj2.Vectors[contextionary], 300)
 			require.Len(t, obj2.Vectors[transformers], 384)
 		})
+
+		t.Run("add colbert vector to a schema with legacy vector", func(t *testing.T) {
+			require.NoError(t, client.Schema().AllDeleter().Do(ctx))
+
+			class := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{
+						Name: "text", DataType: []string{schema.DataTypeText.String()},
+					},
+				},
+				Vectorizer:      text2vecContextionary,
+				VectorIndexType: "hnsw",
+				VectorConfig:    map[string]models.VectorConfig{},
+			}
+
+			require.NoError(t, client.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+			_, err = client.Data().Creator().
+				WithID(UUID1).
+				WithClassName(className).
+				WithProperties(map[string]interface{}{
+					"text": "I love pizza",
+				}).
+				Do(ctx)
+			require.NoError(t, err)
+
+			class.VectorConfig["multi"] = models.VectorConfig{
+				VectorIndexConfig: map[string]interface{}{
+					"multivector": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				Vectorizer: map[string]interface{}{
+					"none": map[string]interface{}{},
+				},
+				VectorIndexType: "hnsw",
+			}
+			require.NoError(t, client.Schema().ClassUpdater().WithClass(class).Do(ctx))
+
+			multiVec := [][]float32{{1, 2, 3}, {4, 5, 6}}
+			_, err = client.Data().Creator().
+				WithID(UUID2).
+				WithClassName(className).
+				WithProperties(map[string]interface{}{
+					"text": "I love pizza",
+				}).
+				WithVectors(map[string]models.Vector{
+					"multi": multiVec,
+				}).
+				Do(ctx)
+			require.NoError(t, err)
+
+			obj1 := fetchObject(t, UUID1)
+			require.Len(t, obj1.Vector, 300)
+			require.Len(t, obj1.Vectors, 0)
+
+			obj2 := fetchObject(t, UUID2)
+			require.Len(t, obj2.Vector, 300)
+			require.Len(t, obj2.Vectors, 1)
+			require.Equal(t, multiVec, obj2.Vectors["multi"].([][]float32))
+		})
 	}
 }


### PR DESCRIPTION
### What's being changed:
Increasing test coverage for mixed vectors by adding a test which creates a new multi-vector (e.g., ColBERT) index on a collection with a legacy vector index. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
