### PR TITLE
fix: cherry-pick a commit to fix multi-vector validation test

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/cluster/cluster_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/cluster/cluster_test.go
@@ -29,7 +29,7 @@ func TestNamedVectors_Cluster(t *testing.T) {
 		require.NoError(t, compose.Terminate(ctx))
 	}()
 	endpoint := compose.GetWeaviate().URI()
-	t.Run("tests", test_suits.AllTests(endpoint))
+	t.Run("tests", test_suits.AllTests(endpoint, false))
 	t.Run("legacy tests", test_suits.AllLegacyTests(endpoint))
 }
 
@@ -41,7 +41,7 @@ func TestNamedVectors_Cluster_AsyncIndexing(t *testing.T) {
 		require.NoError(t, compose.Terminate(ctx))
 	}()
 	endpoint := compose.GetWeaviate().URI()
-	t.Run("tests", test_suits.AllTests(endpoint))
+	t.Run("tests", test_suits.AllTests(endpoint, true))
 	t.Run("legacy tests", test_suits.AllLegacyTests(endpoint))
 }
 

--- a/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
@@ -29,7 +29,7 @@ func TestNamedVectors_SingleNode(t *testing.T) {
 		require.NoError(t, compose.Terminate(ctx))
 	}()
 	endpoint := compose.GetWeaviate().URI()
-	t.Run("tests", test_suits.AllTests(endpoint))
+	t.Run("tests", test_suits.AllTests(endpoint, false))
 	t.Run("legacy tests", test_suits.AllLegacyTests(endpoint))
 }
 
@@ -41,7 +41,7 @@ func TestNamedVectors_SingleNode_AsyncIndexing(t *testing.T) {
 		require.NoError(t, compose.Terminate(ctx))
 	}()
 	endpoint := compose.GetWeaviate().URI()
-	t.Run("tests", test_suits.AllTests(endpoint))
+	t.Run("tests", test_suits.AllTests(endpoint, true))
 	t.Run("legacy tests", test_suits.AllLegacyTests(endpoint))
 }
 

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors.go
@@ -18,7 +18,7 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 )
 
-func AllTests(endpoint string) func(t *testing.T) {
+func AllTests(endpoint string, asyncIndexingEnabled bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("hybrid", testHybrid(endpoint))
 		t.Run("schema", testCreateSchema(endpoint))
@@ -34,7 +34,7 @@ func AllTests(endpoint string) func(t *testing.T) {
 		t.Run("generative modules", testNamedVectorsWithGenerativeModules(endpoint))
 		t.Run("aggregate", testAggregate(endpoint))
 		t.Run("vector index types", testVectorIndexTypesConfigurations(endpoint))
-		t.Run("colbert", testColBERT(endpoint))
+		t.Run("colbert", testColBERT(endpoint, asyncIndexingEnabled))
 	}
 }
 

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
@@ -28,7 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-func testColBERT(host string) func(t *testing.T) {
+func testColBERT(host string, asyncIndexingEnabled bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
@@ -658,7 +658,12 @@ func testColBERT(host string) func(t *testing.T) {
 				// Weaviate overrides the multivector setting if it finds that someone has enabled
 				// multi vector vectorizer
 				require.Error(t, err)
-				assert.ErrorContains(t, err, `parse vector index config: multi vector index is not supported for vector index type: \"dynamic\", only supported type is hnsw`)
+
+				if asyncIndexingEnabled {
+					assert.ErrorContains(t, err, `parse vector index config: multi vector index is not supported for vector index type: \"dynamic\", only supported type is hnsw`)
+				} else {
+					assert.ErrorContains(t, err, `the dynamic index can only be created under async indexing environment`)
+				}
 			})
 		})
 


### PR DESCRIPTION
### What's being changed:
Cherry picking a commit (https://github.com/weaviate/weaviate/pull/7705/commits/0fc9b7fc6dbc6ae8ab0ef5404dfad7e20b7b5300), which was included in the merge PR instead of directly into a branch.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
