### PR TITLE
refact: correct return msg and optimize logic of AddMultiBatch()

### DIFF
--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -47,7 +47,7 @@ func (h *hnsw) ValidateMultiBeforeInsert(vector [][]float32) error {
 	// no vectors exist
 	if dims == 0 {
 		vecDimensions := make(map[int]struct{})
-		for i := range vector {
+		for i := 0; i < len(vector) && len(vecDimensions) <= 1; i++{
 			vecDimensions[len(vector[i])] = struct{}{}
 		}
 		if len(vecDimensions) > 1 {
@@ -75,10 +75,10 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 		return errors.Errorf("AddBatch called on multivector index")
 	}
 	if len(ids) != len(vectors) {
-		return errors.Errorf("ids and vectors sizes does not match")
+		return errors.Errorf("ids and vectors sizes do not match")
 	}
 	if len(ids) == 0 {
-		return errors.Errorf("insertBatch called with empty lists")
+		return errors.Errorf("AddBatch called with empty lists")
 	}
 
 	var err error
@@ -159,7 +159,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 		return errors.Errorf("addMultiBatch called on non-multivector index")
 	}
 	if len(docIDs) != len(vectors) {
-		return errors.Errorf("ids and vectors sizes does not match")
+		return errors.Errorf("ids and vectors sizes do not match")
 	}
 	if len(docIDs) == 0 {
 		return errors.Errorf("addMultiBatch called with empty lists")
@@ -240,8 +240,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 
 			vector = h.normalizeVec(vector)
 
-			nodeId := counter
-			counter++
+			nodeId := ids[j]
 
 			node := &vertex{
 				id:    uint64(nodeId),
@@ -249,7 +248,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			}
 
 			h.Lock()
-			h.docIDVectors[docID] = append(h.docIDVectors[docIDs[i]], nodeId)
+			h.docIDVectors[docID] = append(h.docIDVectors[docID], nodeId)
 			h.Unlock()
 
 			nodeIDBytes := make([]byte, 8)


### PR DESCRIPTION
### What's being changed:
1. correct return msg in func  `AddBatch()`:
    1.1  "**insertBatch** called with empty lists" ----> "**AddBatch** called with empty lists"
    1.2  "ids and vectors sizes **does** not match ----> "ids and vectors sizes **do** not match"
2.  refactor the `for` loop in func `ValidateMultiBeforeInsert`, which acts as a **fast-path** and lets us immediately terminate the loop once we find that the vectors in `vector` are of different dimensions
<img width="576" alt="fastpath" src="https://github.com/user-attachments/assets/1c101624-ddfd-40fb-812f-9a9a87ff198c" />

3.  optimize code in func `AddMultiBatch()` to **avoid repeated calculation of  `nodeId`**:  note that all  `nodeId` for current `doc` has been calculated in  slice `ids`, so we could directly fetch the `Id` for current node which is to be inserted into HNSW index. **Necessary Proof**:
<img width="682" alt="nodeId" src="https://github.com/user-attachments/assets/52652e19-824c-4e84-a6c1-6cfca5b58436" />

4.  optimize code `h.docIDVectors[docID] = append(h.docIDVectors[<==docIDs[i]==>], nodeId)`  -----> `h.docIDVectors[docID] = append(h.docIDVectors[<==docID==>], nodeId)`, which may avoid one time of slice access and improve code readability.  **Necessary Proof**:  from the outer `for` loop(line188, `for i,docID := range docIDs`), we could conclude that `docID == docIDs[i]`
