### PR TITLE
Add first 3 letters of api key to return values

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5516,6 +5516,14 @@ func init() {
           "description": "activity status of the returned user",
           "type": "boolean"
         },
+        "apiKeyFirstLetters": {
+          "description": "First 3 letters of the associated API-key",
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 3
+        },
         "createdAt": {
           "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)",
           "type": [
@@ -13050,6 +13058,14 @@ func init() {
         "active": {
           "description": "activity status of the returned user",
           "type": "boolean"
+        },
+        "apiKeyFirstLetters": {
+          "description": "First 3 letters of the associated API-key",
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 3
         },
         "createdAt": {
           "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)",

--- a/entities/models/d_b_user_info.go
+++ b/entities/models/d_b_user_info.go
@@ -35,6 +35,10 @@ type DBUserInfo struct {
 	// Required: true
 	Active *bool `json:"active"`
 
+	// First 3 letters of the associated API-key
+	// Max Length: 3
+	APIKeyFirstLetters string `json:"apiKeyFirstLetters,omitempty"`
+
 	// Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"createdAt,omitempty"`
@@ -58,6 +62,10 @@ func (m *DBUserInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateActive(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateAPIKeyFirstLetters(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -86,6 +94,18 @@ func (m *DBUserInfo) Validate(formats strfmt.Registry) error {
 func (m *DBUserInfo) validateActive(formats strfmt.Registry) error {
 
 	if err := validate.Required("active", "body", m.Active); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *DBUserInfo) validateAPIKeyFirstLetters(formats strfmt.Registry) error {
+	if swag.IsZero(m.APIKeyFirstLetters) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("apiKeyFirstLetters", "body", m.APIKeyFirstLetters, 3); err != nil {
 		return err
 	}
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -70,6 +70,11 @@
           "type": ["string", "null"],
           "format": "date-time",
           "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)"
+        },
+        "apiKeyFirstLetters": {
+          "type": ["string", "null"],
+          "maxLength": 3,
+          "description": "First 3 letters of the associated API-key"
         }
       },
       "required": [

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -542,9 +542,11 @@ func TestListAllUsers(t *testing.T) {
 			userNames = append(userNames, fmt.Sprintf("user-%d", i))
 		}
 
+		apiKeys := make([]string, 0, len(userNames))
 		for i, userName := range userNames {
 			helper.DeleteUser(t, userName, adminKey)
-			helper.CreateUser(t, userName, adminKey)
+			apiKey := helper.CreateUser(t, userName, adminKey)
+			apiKeys = append(apiKeys, apiKey)
 			defer helper.DeleteUser(t, userName, adminKey) // runs at end of test function to clear everything
 			if i%2 == 0 {
 				helper.AssignRoleToUser(t, adminKey, "viewer", userName)
@@ -575,6 +577,8 @@ func TestListAllUsers(t *testing.T) {
 			require.Equal(t, number%5 != 0, *user.Active)
 			require.Less(t, strfmt.DateTime(start), user.CreatedAt)
 			require.Less(t, user.CreatedAt, strfmt.DateTime(time.Now()))
+			require.Len(t, user.APIKeyFirstLetters, 3)
+			require.Equal(t, user.APIKeyFirstLetters, apiKeys[number][:3])
 		}
 
 		allUsersViewer := helper.ListAllUsers(t, viewerKey)


### PR DESCRIPTION
### What's being changed:

Adds the first 3 letters of an api key to the response, IF the request is done by the root user. This will allow WCD to display them and improve their UX. Cleared with Spiros

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
