### PR TITLE
feat(bm25_block): Trigger reindexing using REST call by triggering shard reinit

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -682,6 +682,7 @@ func configureReindexer(appState *state.State, reindexCtx context.Context) db.Sh
 			cfg.ReindexMapToBlockmaxConfig.UnswapBuckets,
 			cfg.ReindexMapToBlockmaxConfig.TidyBuckets,
 			cfg.ReindexMapToBlockmaxConfig.Rollback,
+			cfg.ReindexMapToBlockmaxConfig.ConditionalStart,
 			time.Second*time.Duration(cfg.ReindexMapToBlockmaxConfig.ProcessingDurationSeconds),
 			time.Second*time.Duration(cfg.ReindexMapToBlockmaxConfig.PauseDurationSeconds),
 			concurrency, cfg.ReindexMapToBlockmaxConfig.CollectionsPropsTenants, appState.SchemaManager,

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -180,9 +180,11 @@ func (t *ShardReindexTask_MapToBlockmax) OnBeforeLsmInit(ctx context.Context, sh
 			err = fmt.Errorf("rollback: searchable map buckets are deleted, can not restore")
 			return
 		}
-		if err = t.unswapIngestAndMapBuckets(ctx, logger, shard, rt, props); err != nil {
-			err = fmt.Errorf("rollback: unswapping buckets: %w", err)
-			return
+		if rt.isSwapped() {
+			if err = t.unswapIngestAndMapBuckets(ctx, logger, shard, rt, props); err != nil {
+				err = fmt.Errorf("rollback: unswapping buckets: %w", err)
+				return
+			}
 		}
 		if err = t.removeReindexBucketsDirs(ctx, logger, shard, props); err != nil {
 			err = fmt.Errorf("rollback: removing reindex buckets: %w", err)

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -308,6 +308,11 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInit(ctx context.Context, sha
 		return
 	}
 
+	if !rt.shouldStart() {
+		err = fmt.Errorf("reindex task should not start")
+		return
+	}
+
 	props, err := t.getPropsToReindex(shard, rt)
 	if err != nil {
 		err = fmt.Errorf("getting reindexable props: %w", err)
@@ -395,6 +400,11 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 	if err != nil {
 		err = fmt.Errorf("creating reindex tracker: %w", err)
 		return zerotime, err
+	}
+
+	if !rt.shouldStart() {
+		err = fmt.Errorf("reindex task should not start")
+		return
 	}
 
 	props, err := t.readPropsToReindex(rt)

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -167,6 +167,7 @@ type MapToBlockamaxConfig struct {
 	UnswapBuckets             bool                     `json:"unswap_buckets" yaml:"unswap_buckets"`
 	TidyBuckets               bool                     `json:"tidy_buckets" yaml:"tidy_buckets"`
 	Rollback                  bool                     `json:"rollback" yaml:"rollback"`
+	ConditionalStart          bool                     `json:"conditional_start" yaml:"conditional_start"`
 	ProcessingDurationSeconds int                      `json:"processing_duration_seconds" yaml:"processing_duration_seconds"`
 	PauseDurationSeconds      int                      `json:"pause_duration_seconds" yaml:"pause_duration_seconds"`
 	CollectionsPropsTenants   []CollectionPropsTenants `json:"collections_props_tenants" yaml:"collections_props_tenants"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -351,6 +351,9 @@ func FromEnv(config *Config) error {
 		if enabledForHost("REINDEX_MAP_TO_BLOCKMAX_ROLLBACK", clusterCfg.Hostname) {
 			config.ReindexMapToBlockmaxConfig.Rollback = true
 		}
+		if enabledForHost("REINDEX_MAP_TO_BLOCKMAX_CONDITIONAL_START", clusterCfg.Hostname) {
+			config.ReindexMapToBlockmaxConfig.ConditionalStart = true
+		}
 		parsePositiveInt("REINDEX_MAP_TO_BLOCKMAX_PROCESSING_DURATION_SECONDS",
 			func(val int) { config.ReindexMapToBlockmaxConfig.ProcessingDurationSeconds = val },
 			DefaultMapToBlockmaxProcessingDurationSeconds)


### PR DESCRIPTION
### What's being changed:

Trigger reindexing using REST call by triggering shard reinit

- if `REINDEX_MAP_TO_BLOCKMAX_CHECK_START` is enabled, migration only starts if a `start.mig `file exists in the folder
  - using new check `rt.shouldStart()`
  - if REINDEX_MAP_TO_BLOCKMAX_CHECK_START isn't set, old behavior prevails
-  calling `/debug/index/rebuild/inverted/start?collection=<collection_name>` will create `start.mig` files and do `IncomingReinitShard`
- migration starts when shard is loaded, which, right now, needs any request to the collection (e.g. query, index request...)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
