### PR TITLE
feature (blockmax migrator): reload shards after reindex phase

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -684,8 +684,7 @@ func configureReindexer(appState *state.State, reindexCtx context.Context) db.Sh
 			cfg.ReindexMapToBlockmaxConfig.Rollback,
 			time.Second*time.Duration(cfg.ReindexMapToBlockmaxConfig.ProcessingDurationSeconds),
 			time.Second*time.Duration(cfg.ReindexMapToBlockmaxConfig.PauseDurationSeconds),
-			concurrency,
-			appState.SchemaManager,
+			concurrency, cfg.ReindexMapToBlockmaxConfig.CollectionsPropsTenants, appState.SchemaManager,
 		))
 	}
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -681,6 +681,7 @@ func configureReindexer(appState *state.State, reindexCtx context.Context) db.Sh
 			cfg.ReindexMapToBlockmaxConfig.SwapBuckets,
 			cfg.ReindexMapToBlockmaxConfig.UnswapBuckets,
 			cfg.ReindexMapToBlockmaxConfig.TidyBuckets,
+			cfg.ReindexMapToBlockmaxConfig.ReloadShards,
 			cfg.ReindexMapToBlockmaxConfig.Rollback,
 			time.Second*time.Duration(cfg.ReindexMapToBlockmaxConfig.ProcessingDurationSeconds),
 			time.Second*time.Duration(cfg.ReindexMapToBlockmaxConfig.PauseDurationSeconds),

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -312,6 +312,13 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInit(ctx context.Context, sha
 		return nil
 	}
 
+	if !rt.isStarted() {
+		if err = rt.markStarted(time.Now()); err != nil {
+			err = fmt.Errorf("marking reindex started: %w", err)
+			return
+		}
+	}
+
 	if rt.isSwapped() {
 		if !rt.isTidied() {
 			logger.Debug("swapped, not tidied. starting map buckets")
@@ -414,14 +421,12 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 		return zerotime, nil
 	}
 
-	reindexStarted := time.Now()
-	if rt.isStarted() {
-		if reindexStarted, err = rt.getStarted(); err != nil {
-			err = fmt.Errorf("getting reindex started: %w", err)
-			return zerotime, err
-		}
-	} else if err = rt.markStarted(reindexStarted); err != nil {
-		err = fmt.Errorf("marking reindex started: %w", err)
+	var reindexStarted time.Time
+	if !rt.isStarted() {
+		err = fmt.Errorf("missing reindex started")
+		return zerotime, err
+	} else if reindexStarted, err = rt.getStarted(); err != nil {
+		err = fmt.Errorf("getting reindex started: %w", err)
 		return zerotime, err
 	}
 

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -31,13 +31,14 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/config"
 	schema "github.com/weaviate/weaviate/usecases/schema"
 )
 
 func NewShardInvertedReindexTaskMapToBlockmax(logger logrus.FieldLogger,
 	swapBuckets, unswapBuckets, tidyBuckets, rollback bool,
 	processingDuration, pauseDuration time.Duration, concurrency int,
-	schemaManager *schema.Manager,
+	cpts []config.CollectionPropsTenants, schemaManager *schema.Manager,
 ) *ShardReindexTask_MapToBlockmax {
 	name := "MapToBlockmax"
 	keyParser := &uuidKeyParser{}
@@ -52,6 +53,32 @@ func NewShardInvertedReindexTaskMapToBlockmax(logger logrus.FieldLogger,
 		return rt, nil
 	}
 
+	selectionEnabled := false
+	var selectedPropsByCollection, selectedShardsByCollection map[string]map[string]struct{}
+	if count := len(cpts); count > 0 {
+		selectionEnabled = true
+		selectedPropsByCollection = make(map[string]map[string]struct{}, count)
+		selectedShardsByCollection = make(map[string]map[string]struct{}, count)
+
+		for _, cpt := range cpts {
+			var props, shards map[string]struct{}
+			if countp := len(cpt.Props); countp > 0 {
+				props = make(map[string]struct{}, countp)
+				for _, prop := range cpt.Props {
+					props[prop] = struct{}{}
+				}
+			}
+			if counts := len(cpt.Tenants); counts > 0 {
+				shards = make(map[string]struct{}, counts)
+				for _, shard := range cpt.Tenants {
+					shards[shard] = struct{}{}
+				}
+			}
+			selectedPropsByCollection[cpt.Collection] = props
+			selectedShardsByCollection[cpt.Collection] = shards
+		}
+	}
+
 	config := mapToBlockmaxConfig{
 		swapBuckets:                   swapBuckets,
 		unswapBuckets:                 unswapBuckets,
@@ -62,6 +89,9 @@ func NewShardInvertedReindexTaskMapToBlockmax(logger logrus.FieldLogger,
 		processingDuration:            processingDuration,
 		pauseDuration:                 pauseDuration,
 		checkProcessingEveryNoObjects: 1000,
+		selectionEnabled:              selectionEnabled,
+		selectedPropsByCollection:     selectedPropsByCollection,
+		selectedShardsByCollection:    selectedShardsByCollection,
 	}
 
 	logger.WithField("config", fmt.Sprintf("%+v", config)).Debug("task created")
@@ -97,6 +127,9 @@ type mapToBlockmaxConfig struct {
 	processingDuration            time.Duration
 	pauseDuration                 time.Duration
 	checkProcessingEveryNoObjects int
+	selectionEnabled              bool
+	selectedPropsByCollection     map[string]map[string]struct{}
+	selectedShardsByCollection    map[string]map[string]struct{}
 }
 
 func (t *ShardReindexTask_MapToBlockmax) Name() string {
@@ -957,21 +990,48 @@ func (t *ShardReindexTask_MapToBlockmax) mapBucketName(propName string) string {
 	return helpers.BucketSearchableFromPropNameLSM(propName) + "__blockmax_map"
 }
 
-func (t *ShardReindexTask_MapToBlockmax) findPropsToReindex(shard ShardLike) []string {
+func (t *ShardReindexTask_MapToBlockmax) findPropsToReindex(shard ShardLike) (props []string, save bool) {
 	propNames := []string{}
+	checkPropSelected := func(propName string) bool {
+		return true
+	}
+
+	if t.config.selectionEnabled {
+		collectionName := shard.Index().Config.ClassName.String()
+		selectedProps, isCollectionSelected1 := t.config.selectedPropsByCollection[collectionName]
+		selectedShards, isCollectionSelected2 := t.config.selectedShardsByCollection[collectionName]
+
+		if !(isCollectionSelected1 || isCollectionSelected2) {
+			return propNames, false
+		}
+
+		isShardSelected := true
+		if len(selectedShards) > 0 {
+			_, isShardSelected = selectedShards[shard.Name()]
+		}
+
+		if !isShardSelected {
+			return propNames, false
+		}
+
+		if len(selectedProps) > 0 {
+			checkPropSelected = func(propName string) bool {
+				_, ok := selectedProps[propName]
+				return ok
+			}
+		}
+	}
+
 	for name, bucket := range shard.Store().GetBucketsByName() {
 		if bucket.Strategy() == lsmkv.StrategyMapCollection {
 			propName, indexType := GetPropNameAndIndexTypeFromBucketName(name)
 
-			switch indexType {
-			case IndexTypePropSearchableValue:
+			if indexType == IndexTypePropSearchableValue && checkPropSelected(propName) {
 				propNames = append(propNames, propName)
-			default:
-				// skip remaining types
 			}
 		}
 	}
-	return propNames
+	return propNames, true
 }
 
 func (t *ShardReindexTask_MapToBlockmax) getPropsToReindex(shard ShardLike, rt mapToBlockmaxReindexTracker) ([]string, error) {
@@ -982,9 +1042,11 @@ func (t *ShardReindexTask_MapToBlockmax) getPropsToReindex(shard ShardLike, rt m
 		}
 		return props, nil
 	}
-	props := t.findPropsToReindex(shard)
-	if err := rt.saveProps(props); err != nil {
-		return nil, err
+	props, save := t.findPropsToReindex(shard)
+	if save {
+		if err := rt.saveProps(props); err != nil {
+			return nil, err
+		}
 	}
 	return props, nil
 }

--- a/adapters/repos/db/inverted_reindexer_v3.go
+++ b/adapters/repos/db/inverted_reindexer_v3.go
@@ -38,7 +38,7 @@ type ShardReindexTaskV3 interface {
 	OnBeforeLsmInit(ctx context.Context, shard *Shard) error
 	OnAfterLsmInit(ctx context.Context, shard *Shard) error
 	// TODO alisza:blockmax change to *Shard?
-	OnAfterLsmInitAsync(ctx context.Context, shard ShardLike) (rerunAt time.Time, err error)
+	OnAfterLsmInitAsync(ctx context.Context, shard ShardLike) (rerunAt time.Time, reloadShard bool, err error)
 }
 
 // -----------------------------------------------------------------------------
@@ -325,43 +325,61 @@ func (r *shardReindexerV3) runScheduledTask(ctx context.Context, key string, tas
 		err = fmt.Errorf("not loaded '%s' of collection '%s': %w", shardName, collectionName, err)
 		return
 	}
-	defer release()
-	if shard == nil {
-		err = fmt.Errorf("shard '%s' of collection '%s' not found", shardName, collectionName)
-		return
-	}
 
-	if err = ctx.Err(); err != nil {
-		err = fmt.Errorf("context check (2): %w / %w", ctx.Err(), context.Cause(ctx))
-		return
-	}
-
-	// at this point lazy shard should be loaded (there is no unloading), otherwise [RunAfterLsmInitAsync]
-	// would not be called and tasks scheduled for shard
-	rerunAt, err := tasks[0].OnAfterLsmInitAsync(ctx, shard)
-	r.locked(func() {
-		if err != nil {
-			// schedule tasks only if context not cancelled
-			if ctx.Err() == nil {
-				r.scheduleTasks(key, tasks[1:], time.Now())
-			}
-			err = fmt.Errorf("executing task '%s' on shard '%s' of collection '%s': %w",
-				tasks[0].Name(), shardName, collectionName, err)
-			return
+	rerunAt, reloadShard, err := func() (time.Time, bool, error) {
+		defer release()
+		if shard == nil {
+			return time.Time{}, false, fmt.Errorf("shard '%s' of collection '%s' not found", shardName, collectionName)
 		}
+
 		if err = ctx.Err(); err != nil {
-			err = fmt.Errorf("executing task '%s' on shard '%s' of collection '%s': %w",
-				tasks[0].Name(), shardName, collectionName, err)
-			return
+			return time.Time{}, false, fmt.Errorf("context check (2): %w / %w", ctx.Err(), context.Cause(ctx))
 		}
-		if rerunAt.IsZero() {
-			r.scheduleTasks(key, tasks[1:], time.Now())
-			logger.WithField("task", tasks[0].Name()).Debug("task executed completely")
-			return
-		}
-		r.scheduleTasks(key, tasks, rerunAt)
-		logger.WithField("task", tasks[0].Name()).Debug("task executed partially, rerun scheduled")
-	})
+
+		// at this point lazy shard should be loaded (there is no unloading), otherwise [RunAfterLsmInitAsync]
+		// would not be called and tasks scheduled for shard
+		return tasks[0].OnAfterLsmInitAsync(ctx, shard)
+	}()
+
+	scheduleNextTasks := func(ctx context.Context, lastErr error) (err error) {
+		r.locked(func() {
+			if lastErr != nil {
+				// schedule tasks only if context not cancelled
+				if ctx.Err() == nil {
+					r.scheduleTasks(key, tasks[1:], time.Now())
+				}
+				err = fmt.Errorf("executing task '%s' on shard '%s' of collection '%s': %w",
+					tasks[0].Name(), shardName, collectionName, lastErr)
+				return
+			}
+			if err = ctx.Err(); err != nil {
+				err = fmt.Errorf("executing task '%s' on shard '%s' of collection '%s': %w / %w",
+					tasks[0].Name(), shardName, collectionName, err, context.Cause(ctx))
+				return
+			}
+			if rerunAt.IsZero() {
+				r.scheduleTasks(key, tasks[1:], time.Now())
+				logger.WithField("task", tasks[0].Name()).Debug("task executed completely")
+				return
+			}
+			r.scheduleTasks(key, tasks, rerunAt)
+			logger.WithField("task", tasks[0].Name()).Debug("task executed partially, rerun scheduled")
+		})
+		return
+	}
+
+	// do not reload if error occurred. schedule tasks using shard's individual context
+	if !reloadShard || err != nil || ctx.Err() != nil {
+		err = scheduleNextTasks(ctx, err)
+		return
+	}
+
+	// reload uninterrupted by context. shard's context will be cancelled by shutdown anyway
+	if err = r.reloadShard(context.Background(), index, shardName); err != nil {
+		err = fmt.Errorf("reloading shard '%s' of collection '%s': %w", shardName, collectionName, err)
+	}
+	// schedule tasks using global context
+	err = scheduleNextTasks(r.ctx, err)
 	return
 }
 
@@ -378,6 +396,21 @@ func (r *shardReindexerV3) locked(callback func()) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	callback()
+}
+
+func (r *shardReindexerV3) reloadShard(ctx context.Context, index *Index, shardName string) error {
+	if err := index.IncomingReinitShard(ctx, shardName); err != nil {
+		return err
+	}
+	// force loading shard (if lazy) by getting store
+	shard, release, err := index.GetShard(ctx, shardName)
+	if err != nil {
+		return err
+	}
+	defer release()
+	shard.Store()
+
+	return nil
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/inverted_reindexer_v3_test.go
+++ b/adapters/repos/db/inverted_reindexer_v3_test.go
@@ -184,6 +184,7 @@ func (t *dummyShardReindexTaskV3) OnAfterLsmInit(ctx context.Context, shard *Sha
 	return nil
 }
 
-func (t *dummyShardReindexTaskV3) OnAfterLsmInitAsync(ctx context.Context, shard ShardLike) (rerunAt time.Time, err error) {
-	return time.Time{}, nil
+func (t *dummyShardReindexTaskV3) OnAfterLsmInitAsync(ctx context.Context, shard ShardLike,
+) (rerunAt time.Time, reloadShard bool, err error) {
+	return time.Time{}, false, nil
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -166,6 +166,7 @@ type MapToBlockamaxConfig struct {
 	SwapBuckets               bool                     `json:"swap_buckets" yaml:"swap_buckets"`
 	UnswapBuckets             bool                     `json:"unswap_buckets" yaml:"unswap_buckets"`
 	TidyBuckets               bool                     `json:"tidy_buckets" yaml:"tidy_buckets"`
+	ReloadShards              bool                     `json:"reload_shards" yaml:"reload_shards"`
 	Rollback                  bool                     `json:"rollback" yaml:"rollback"`
 	ProcessingDurationSeconds int                      `json:"processing_duration_seconds" yaml:"processing_duration_seconds"`
 	PauseDurationSeconds      int                      `json:"pause_duration_seconds" yaml:"pause_duration_seconds"`

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -163,12 +163,19 @@ type Config struct {
 }
 
 type MapToBlockamaxConfig struct {
-	SwapBuckets               bool `json:"swap_buckets" yaml:"swap_buckets"`
-	UnswapBuckets             bool `json:"unswap_buckets" yaml:"unswap_buckets"`
-	TidyBuckets               bool `json:"tidy_buckets" yaml:"tidy_buckets"`
-	Rollback                  bool `json:"rollback" yaml:"rollback"`
-	ProcessingDurationSeconds int  `json:"processing_duration_seconds" yaml:"processing_duration_seconds"`
-	PauseDurationSeconds      int  `json:"pause_duration_seconds" yaml:"pause_duration_seconds"`
+	SwapBuckets               bool                     `json:"swap_buckets" yaml:"swap_buckets"`
+	UnswapBuckets             bool                     `json:"unswap_buckets" yaml:"unswap_buckets"`
+	TidyBuckets               bool                     `json:"tidy_buckets" yaml:"tidy_buckets"`
+	Rollback                  bool                     `json:"rollback" yaml:"rollback"`
+	ProcessingDurationSeconds int                      `json:"processing_duration_seconds" yaml:"processing_duration_seconds"`
+	PauseDurationSeconds      int                      `json:"pause_duration_seconds" yaml:"pause_duration_seconds"`
+	CollectionsPropsTenants   []CollectionPropsTenants `json:"collections_props_tenants" yaml:"collections_props_tenants"`
+}
+
+type CollectionPropsTenants struct {
+	Collection string   `json:"collection" yaml:"collection"`
+	Props      []string `json:"props" yaml:"props"`
+	Tenants    []string `json:"tenants" yaml:"tenants"`
 }
 
 // Validate the configuration

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -105,12 +105,19 @@ func FromEnv(config *Config) error {
 		config.IndexMissingTextFilterableAtStartup = true
 	}
 
+	cptParser := newCollectionPropsTenantsParser()
+
 	// variable expects string in format:
 	// "Class1:property11,property12;Class2:property21,property22"
 	if v := os.Getenv("REINDEX_INDEXES_AT_STARTUP"); v != "" {
-		asClassesWithProps, err := parseClassNamesWithPropsNames(v)
+		cpts, err := cptParser.parse(v)
 		if err != nil {
 			return fmt.Errorf("parse REINDEX_INDEXES_AT_STARTUP as class with props: %w", err)
+		}
+
+		asClassesWithProps := make(map[string][]string, len(cpts))
+		for _, cpt := range cpts {
+			asClassesWithProps[cpt.Collection] = cpt.Props
 		}
 		config.ReindexIndexesAtStartup = asClassesWithProps
 	}
@@ -350,6 +357,11 @@ func FromEnv(config *Config) error {
 		parsePositiveInt("REINDEX_MAP_TO_BLOCKMAX_PAUSE_DURATION_SECONDS",
 			func(val int) { config.ReindexMapToBlockmaxConfig.PauseDurationSeconds = val },
 			DefaultMapToBlockmaxPauseDurationSeconds)
+		cpts, err := cptParser.parse(os.Getenv("REINDEX_MAP_TO_BLOCKMAX_SELECT"))
+		if err != nil {
+			return err
+		}
+		config.ReindexMapToBlockmaxConfig.CollectionsPropsTenants = cpts
 	}
 
 	if err := config.parseMemtableConfig(); err != nil {
@@ -897,61 +909,6 @@ func parseFloatVerify(envName string, defaultValue float64, cb func(val float64)
 	return nil
 }
 
-// expects "Class1:property11,property12;Class2:property21,property22"
-// returns map[Class][]property
-func parseClassNamesWithPropsNames(v string) (map[string][]string, error) {
-	classNamesWithPropsNames := map[string][]string{}
-
-	regexClass := regexp.MustCompile(`^` + schema.ClassNameRegexCore + `$`)
-	regexProp := regexp.MustCompile(`^` + schema.PropertyNameRegex + `$`)
-	uniqueClasses := map[string]struct{}{}
-	var uniqueProps map[string]struct{}
-
-	ec := &errorcompounder.ErrorCompounder{}
-	parts := strings.Split(v, ";")
-	for _, part := range parts {
-		err := func() error {
-			parts2 := strings.Split(part, ":")
-			if len(parts2) != 2 {
-				return fmt.Errorf("invalid class+property setting %q", part)
-			}
-
-			class := parts2[0]
-			if _, ok := uniqueClasses[class]; ok {
-				return fmt.Errorf("class name %q duplicated", class)
-			}
-			if !regexClass.MatchString(class) {
-				return fmt.Errorf("invalid class name %q", class)
-			}
-			uniqueClasses[class] = struct{}{}
-
-			uniqueProps = map[string]struct{}{}
-			props := strings.Split(parts2[1], ",")
-			for _, prop := range props {
-				if _, ok := uniqueProps[prop]; ok {
-					return fmt.Errorf("prop name %q duplicated in class %q", prop, class)
-				}
-				if !regexProp.MatchString(prop) {
-					return fmt.Errorf("invalid prop name %q in class %q", prop, class)
-				}
-				uniqueProps[prop] = struct{}{}
-			}
-
-			classNamesWithPropsNames[class] = props
-			return nil
-		}()
-		ec.Add(err)
-	}
-
-	if err := ec.ToError(); err != nil {
-		return nil, err
-	}
-	if len(classNamesWithPropsNames) > 0 {
-		return classNamesWithPropsNames, nil
-	}
-	return nil, nil
-}
-
 const (
 	DefaultQueryMaximumResults = int64(10000)
 	// DefaultQueryNestedCrossReferenceLimit describes the max number of nested crossrefs returned for a query
@@ -1143,4 +1100,184 @@ func enabledForHost(envName string, localHostname string) bool {
 		return slices.Contains(strings.Split(v, ","), localHostname)
 	}
 	return false
+}
+
+/*
+parses variable of format "colName1:propNames1:tenantNames1;colName2:propNames2:tenantNames2"
+propNames = prop1,prop2,...
+tenantNames = tenant1,tenant2,...
+
+examples:
+  - collection:
+    "ColName1"
+    "ColName1;ColName2"
+  - collection + properties:
+    "ColName1:propName1"
+    "ColName1:propName1,propName2;ColName2:propName3"
+  - collection + properties + tenants/shards:
+    "ColName1:propName1:tenantName1,tenantName2"
+    "ColName1:propName1:tenantName1,tenantName2;ColName2:propName2,propName3:tenantName3"
+  - collection + tenants/shards:
+    "ColName1::tenantName1"
+    "ColName1::tenantName1,tenantName2;ColName2::tenantName3"
+*/
+type collectionPropsTenantsParser struct {
+	regexpCollection *regexp.Regexp
+	regexpProp       *regexp.Regexp
+	regexpTenant     *regexp.Regexp
+}
+
+func newCollectionPropsTenantsParser() *collectionPropsTenantsParser {
+	return &collectionPropsTenantsParser{
+		regexpCollection: regexp.MustCompile(`^` + schema.ClassNameRegexCore + `$`),
+		regexpProp:       regexp.MustCompile(`^` + schema.PropertyNameRegex + `$`),
+		regexpTenant:     regexp.MustCompile(`^` + schema.ShardNameRegexCore + `$`),
+	}
+}
+
+func (p *collectionPropsTenantsParser) parse(v string) ([]CollectionPropsTenants, error) {
+	if v = strings.TrimSpace(v); v == "" {
+		return []CollectionPropsTenants{}, nil
+	}
+
+	split := strings.Split(v, ";")
+	count := len(split)
+	cpts := make([]CollectionPropsTenants, 0, count)
+	uniqMapIdx := make(map[string]int, count)
+
+	ec := errorcompounder.New()
+	for _, single := range split {
+		if single = strings.TrimSpace(single); single != "" {
+			if cpt, err := p.parseSingle(single); err != nil {
+				ec.Add(fmt.Errorf("parse '%s': %w", single, err))
+			} else {
+				if prevIdx, ok := uniqMapIdx[cpt.Collection]; ok {
+					cpts[prevIdx] = p.mergeCpt(cpts[prevIdx], cpt)
+				} else {
+					uniqMapIdx[cpt.Collection] = len(cpts)
+					cpts = append(cpts, cpt)
+				}
+			}
+		}
+	}
+
+	return cpts, ec.ToError()
+}
+
+func (p *collectionPropsTenantsParser) parseSingle(single string) (CollectionPropsTenants, error) {
+	split := strings.Split(single, ":")
+	empty := CollectionPropsTenants{}
+
+	switch count := len(split); count {
+	case 1:
+		collection, err := p.parseCollection(split[0])
+		if err != nil {
+			return empty, err
+		}
+		return CollectionPropsTenants{Collection: collection}, nil
+
+	case 2:
+		collection, err := p.parseCollection(split[0])
+		if err != nil {
+			return empty, err
+		}
+		props, err := p.parseProps(split[1])
+		if err != nil {
+			return empty, err
+		}
+		return CollectionPropsTenants{Collection: collection, Props: props}, nil
+
+	case 3:
+		collection, err := p.parseCollection(split[0])
+		if err != nil {
+			return empty, err
+		}
+		props, err := p.parseProps(split[1])
+		if err != nil {
+			return empty, err
+		}
+		tenants, err := p.parseTenants(split[2])
+		if err != nil {
+			return empty, err
+		}
+		return CollectionPropsTenants{Collection: collection, Props: props, Tenants: tenants}, nil
+
+	default:
+		return empty, fmt.Errorf("too many parts in '%s'. Expected 1-3, got %d", single, count)
+	}
+}
+
+func (p *collectionPropsTenantsParser) parseCollection(collection string) (string, error) {
+	collection = strings.TrimSpace(collection)
+	if collection == "" {
+		return "", fmt.Errorf("missing collection name")
+	}
+	if !p.regexpCollection.MatchString(collection) {
+		return "", fmt.Errorf("invalid collection name '%s'. Does not match regexp", collection)
+	}
+	return collection, nil
+}
+
+func (p *collectionPropsTenantsParser) parseProps(propsStr string) ([]string, error) {
+	return p.parseElems(propsStr, p.regexpProp, "invalid property name '%s'. Does not match regexp")
+}
+
+func (p *collectionPropsTenantsParser) parseTenants(tenantsStr string) ([]string, error) {
+	return p.parseElems(tenantsStr, p.regexpTenant, "invalid tenant/shard name '%s'. Does not match regexp")
+}
+
+func (p *collectionPropsTenantsParser) parseElems(str string, reg *regexp.Regexp, errMsg string) ([]string, error) {
+	split := strings.Split(str, ",")
+	count := len(split)
+	elems := make([]string, 0, count)
+	uniqMap := make(map[string]struct{}, count)
+
+	ec := errorcompounder.New()
+	for _, elem := range split {
+		if elem = strings.TrimSpace(elem); elem != "" {
+			if reg.MatchString(elem) {
+				if _, ok := uniqMap[elem]; !ok {
+					elems = append(elems, elem)
+					uniqMap[elem] = struct{}{}
+				}
+			} else {
+				ec.Add(fmt.Errorf(errMsg, elem))
+			}
+		}
+	}
+
+	if len(elems) == 0 {
+		return nil, ec.ToError()
+	}
+	return elems, ec.ToError()
+}
+
+func (p *collectionPropsTenantsParser) mergeCpt(cptDst, cptSrc CollectionPropsTenants) CollectionPropsTenants {
+	if cptDst.Collection != cptSrc.Collection {
+		return cptDst
+	}
+	cptDst.Props = p.mergeUniqueElems(cptDst.Props, cptSrc.Props)
+	cptDst.Tenants = p.mergeUniqueElems(cptDst.Tenants, cptSrc.Tenants)
+	return cptDst
+}
+
+func (p *collectionPropsTenantsParser) mergeUniqueElems(uniqueA, uniqueB []string) []string {
+	lA, lB := len(uniqueA), len(uniqueB)
+	if lB == 0 {
+		return uniqueA
+	}
+	if lA == 0 {
+		return uniqueB
+	}
+
+	uniqMapA := make(map[string]struct{}, lA)
+	for _, a := range uniqueA {
+		uniqMapA[a] = struct{}{}
+	}
+	for _, b := range uniqueB {
+		if _, ok := uniqMapA[b]; !ok {
+			uniqueA = append(uniqueA, b)
+		}
+	}
+	return uniqueA
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -348,6 +348,9 @@ func FromEnv(config *Config) error {
 		if enabledForHost("REINDEX_MAP_TO_BLOCKMAX_TIDY_BUCKETS", clusterCfg.Hostname) {
 			config.ReindexMapToBlockmaxConfig.TidyBuckets = true
 		}
+		if enabledForHost("REINDEX_MAP_TO_BLOCKMAX_RELOAD_SHARDS", clusterCfg.Hostname) {
+			config.ReindexMapToBlockmaxConfig.ReloadShards = true
+		}
 		if enabledForHost("REINDEX_MAP_TO_BLOCKMAX_ROLLBACK", clusterCfg.Hostname) {
 			config.ReindexMapToBlockmaxConfig.Rollback = true
 		}


### PR DESCRIPTION
### What's being changed:
introduces `REINDEX_MAP_TO_BLOCKMAX_RELOAD_SHARDS` env variable allowing for shard reload (using `Index::IncomingReinitShard`) after reindexing phase is finished.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
