### PR TITLE
Disable default dimensions in Azure

### DIFF
--- a/modules/text2vec-openai/ent/class_settings.go
+++ b/modules/text2vec-openai/ent/class_settings.go
@@ -156,6 +156,9 @@ func (cs *classSettings) IsAzure() bool {
 
 func (cs *classSettings) Dimensions() *int64 {
 	defaultValue := PickDefaultDimensions(cs.Model())
+	if cs.IsAzure() {
+		defaultValue = nil
+	}
 	return cs.BaseClassSettings.GetPropertyAsInt64("dimensions", defaultValue)
 }
 


### PR DESCRIPTION
### What's being changed:

- In the Azure OpenAI embeddings api the `deploymentId` is used vs the `model`
- We changed the default OpenAI model from `ada` to `text-embedding-3-small` in https://github.com/weaviate/weaviate/commit/ae2c5862052c25c3ad71bfa34a5517614ff65bb0.
- As a side effect of this, people using the OpenAI Azure module who were not provided the model and creating new classes would have the `model` change from `ada` to `text-embedding-3-small`
- Normally this is harmless but a dimensions parameter is conditionally provided to `text-embedding-3-small` for truncation, this parameter however leads to the following error when using the older ada models:

```
{'errors': {'error': [{'message': 'connection to: Azure OpenAI API failed with status: 400 request-id: xxx-xxx-xx error: This model does not support specifying dimensions.'}]}, 'status': 'FAILED'}}
```

To fix this we are no longer setting the default dimensions parameter in Azure. The dimensions is an optional parameter and not needed unless wanting to truncate.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
