### PR TITLE
fix (blockmax migrator): move started marking to sync phase

### DIFF
--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -312,6 +312,13 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInit(ctx context.Context, sha
 		return nil
 	}
 
+	if !rt.isStarted() {
+		if err = rt.markStarted(time.Now()); err != nil {
+			err = fmt.Errorf("marking reindex started: %w", err)
+			return
+		}
+	}
+
 	if rt.isSwapped() {
 		if !rt.isTidied() {
 			logger.Debug("swapped, not tidied. starting map buckets")
@@ -414,14 +421,12 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 		return zerotime, nil
 	}
 
-	reindexStarted := time.Now()
-	if rt.isStarted() {
-		if reindexStarted, err = rt.getStarted(); err != nil {
-			err = fmt.Errorf("getting reindex started: %w", err)
-			return zerotime, err
-		}
-	} else if err = rt.markStarted(reindexStarted); err != nil {
-		err = fmt.Errorf("marking reindex started: %w", err)
+	var reindexStarted time.Time
+	if !rt.isStarted() {
+		err = fmt.Errorf("missing reindex started")
+		return zerotime, err
+	} else if reindexStarted, err = rt.getStarted(); err != nil {
+		err = fmt.Errorf("getting reindex started: %w", err)
 		return zerotime, err
 	}
 


### PR DESCRIPTION
### What's being changed:
moves creating `started` marker to sync phase, to keep consistency with double writes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
