### PR TITLE
adapters/handlers/rest: Fix nil pointer dereference in `/authz/roles` and `/users/db` endpoints

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -342,11 +342,16 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 
 	sortByName(filteredRoles)
 
-	h.logger.WithFields(logrus.Fields{
+	logFields := logrus.Fields{
 		"action":    "read_all_roles",
 		"component": authorization.ComponentName,
-		"user":      principal.Username,
-	}).Info("roles requested")
+	}
+
+	if principal != nil {
+		logFields["user"] = principal.Username
+	}
+
+	h.logger.WithFields(logFields).Info("roles requested")
 
 	return authz.NewGetRolesOK().WithPayload(filteredRoles)
 }

--- a/adapters/handlers/rest/authz/handlers_authz_get_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_get_roles_test.go
@@ -51,6 +51,14 @@ func TestGetRolesSuccess(t *testing.T) {
 				"testRole": {}, "root": {},
 			},
 		},
+		{
+			name:            "success without principal",
+			principal:       nil,
+			authorizedRoles: []string{"testRole"},
+			expectedRoles: map[string][]authorization.Policy{
+				"testRole": {},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -479,6 +479,10 @@ func (h *dynUserHandler) isAdminlistUser(name string) bool {
 }
 
 func (h *dynUserHandler) isRequestFromRootUser(principal *models.Principal) bool {
+	if principal == nil {
+		return false
+	}
+
 	for _, groupName := range principal.Groups {
 		if slices.Contains(h.rbacConfig.RootGroups, groupName) {
 			return true


### PR DESCRIPTION
### What's being changed

This PR handles the null pointer reference that occurs for `models.Principal` when the `/authz/roles` and `/users/db` endpoints are invoked. This issue was identified when a fresh Weaviate instance was created from source using `make weaviate` or `make weaviate-debug`, and those endpoints were accessed immediately.

### Tasks

- [x] Fix null pointer dereference in  `/authz/roles ` and `/users/db` endpoints
- [x] Unit test `/authz/roles` endpoint given a nil `models.Principal`
- [x] Unit test `/users/db` endpoint given a nil `models.Principal`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
