### PR TITLE
DB Users: add last used time

### DIFF
--- a/adapters/clients/db_users.go
+++ b/adapters/clients/db_users.go
@@ -39,7 +39,7 @@ func NewRemoteUser(httpClient *http.Client, nodeResolver nodeResolver) *RemoteUs
 }
 
 func (c *RemoteUser) GetUserStatus(ctx context.Context, nodeName string, users map[string]time.Time, returnStatus bool) (*apikey.UserStatusResponse, error) {
-	p := "/cluster/users/db"
+	p := "/cluster/users/db/lastUsedTime"
 	method := http.MethodPost
 	hostName, found := c.nodeResolver.NodeHostname(nodeName)
 	if !found {

--- a/adapters/clients/db_users.go
+++ b/adapters/clients/db_users.go
@@ -53,7 +53,6 @@ func (c *RemoteUser) GetUserStatus(ctx context.Context, nodeName string, users m
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewBuffer(jsonBody))
-	req.Header.Set("TEST", "TEST")
 	if err != nil {
 		return nil, enterrors.NewErrOpenHttpRequest(err)
 	}

--- a/adapters/clients/db_users.go
+++ b/adapters/clients/db_users.go
@@ -38,7 +38,7 @@ func NewRemoteUser(httpClient *http.Client, nodeResolver nodeResolver) *RemoteUs
 	return &RemoteUser{client: httpClient, nodeResolver: nodeResolver}
 }
 
-func (c *RemoteUser) GetUserStatus(ctx context.Context, nodeName string, users map[string]time.Time, returnStatus bool) (*apikey.UserStatusResponse, error) {
+func (c *RemoteUser) GetAndUpdateLastUsedTime(ctx context.Context, nodeName string, users map[string]time.Time, returnStatus bool) (*apikey.UserStatusResponse, error) {
 	p := "/cluster/users/db/lastUsedTime"
 	method := http.MethodPost
 	hostName, found := c.nodeResolver.NodeHostname(nodeName)

--- a/adapters/clients/db_users.go
+++ b/adapters/clients/db_users.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
+)
+
+type RemoteUser struct {
+	client       *http.Client
+	nodeResolver nodeResolver
+}
+
+type nodeResolver interface {
+	NodeHostname(nodeName string) (string, bool)
+}
+
+func NewRemoteUser(httpClient *http.Client, nodeResolver nodeResolver) *RemoteUser {
+	return &RemoteUser{client: httpClient, nodeResolver: nodeResolver}
+}
+
+func (c *RemoteUser) GetUserStatus(ctx context.Context, nodeName string, users map[string]time.Time, returnStatus bool) (*apikey.UserStatusResponse, error) {
+	p := "/cluster/users/db"
+	method := http.MethodPost
+	hostName, found := c.nodeResolver.NodeHostname(nodeName)
+	if !found {
+		return nil, fmt.Errorf("unable to resolve hostname for %s", nodeName)
+	}
+	url := url.URL{Scheme: "http", Host: hostName, Path: p}
+
+	jsonBody, err := json.Marshal(apikey.UserStatusRequest{Users: users, ReturnStatus: returnStatus})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewBuffer(jsonBody))
+	req.Header.Set("TEST", "TEST")
+	if err != nil {
+		return nil, enterrors.NewErrOpenHttpRequest(err)
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, enterrors.NewErrSendHttpRequest(err)
+	}
+
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusOK {
+		return nil, enterrors.NewErrUnexpectedStatusCode(res.StatusCode, body)
+	}
+
+	var userStatus apikey.UserStatusResponse
+	err = json.Unmarshal(body, &userStatus)
+	if err != nil {
+		return nil, enterrors.NewErrUnmarshalBody(err)
+	}
+
+	return &userStatus, nil
+}

--- a/adapters/handlers/rest/clusterapi/db_users.go
+++ b/adapters/handlers/rest/clusterapi/db_users.go
@@ -57,15 +57,8 @@ func (d *DbUsers) incomingUserStatus() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "Error reading request body", http.StatusBadRequest)
-			return
-		}
-		defer r.Body.Close()
-
 		var body apikey.UserStatusRequest
-		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "Error parsing JSON body", http.StatusBadRequest)
 			return
 		}

--- a/adapters/handlers/rest/clusterapi/db_users.go
+++ b/adapters/handlers/rest/clusterapi/db_users.go
@@ -37,7 +37,7 @@ func (d *DbUsers) userHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		switch path {
-		case "/cluster/users/db/":
+		case "/cluster/users/db/lastUsedTime":
 			if r.Method != http.MethodPost {
 				msg := fmt.Sprintf("/user api path %q with method %v not found", path, r.Method)
 				http.Error(w, msg, http.StatusMethodNotAllowed)

--- a/adapters/handlers/rest/clusterapi/db_users.go
+++ b/adapters/handlers/rest/clusterapi/db_users.go
@@ -1,0 +1,91 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clusterapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
+)
+
+type DbUsers struct {
+	userManager *apikey.RemoteApiKey
+	auth        auth
+}
+
+func NewDbUsers(manager *apikey.RemoteApiKey, auth auth) *DbUsers {
+	return &DbUsers{userManager: manager, auth: auth}
+}
+
+func (d *DbUsers) Users() http.Handler {
+	return d.auth.handleFunc(d.userHandler())
+}
+
+func (d *DbUsers) userHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch path {
+		case "/cluster/users/db/":
+			if r.Method != http.MethodPost {
+				msg := fmt.Sprintf("/user api path %q with method %v not found", path, r.Method)
+				http.Error(w, msg, http.StatusMethodNotAllowed)
+				return
+			}
+
+			d.incomingUserStatus().ServeHTTP(w, r)
+			return
+		default:
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+	}
+}
+
+func (d *DbUsers) incomingUserStatus() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Error reading request body", http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+
+		var body apikey.UserStatusRequest
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			http.Error(w, "Error parsing JSON body", http.StatusBadRequest)
+			return
+		}
+		userStatus, err := d.userManager.GetUserStatus(r.Context(), body)
+		if err != nil {
+			http.Error(w, "/user fulfill request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if userStatus == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		userStatusBytes, err := json.Marshal(userStatus)
+		if err != nil {
+			http.Error(w, "/user marshal response: "+err.Error(),
+				http.StatusInternalServerError)
+		}
+
+		w.Write(userStatusBytes)
+	})
+}

--- a/adapters/handlers/rest/clusterapi/db_users.go
+++ b/adapters/handlers/rest/clusterapi/db_users.go
@@ -72,12 +72,9 @@ func (d *DbUsers) incomingUserStatus() http.Handler {
 			return
 		}
 
-		userStatusBytes, err := json.Marshal(userStatus)
-		if err != nil {
+		if err := json.NewEncoder(w).Encode(userStatus); err != nil {
 			http.Error(w, "/user marshal response: "+err.Error(),
 				http.StatusInternalServerError)
 		}
-
-		w.Write(userStatusBytes)
 	})
 }

--- a/adapters/handlers/rest/clusterapi/db_users.go
+++ b/adapters/handlers/rest/clusterapi/db_users.go
@@ -14,7 +14,6 @@ package clusterapi
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -34,12 +34,14 @@ func Serve(appState *state.State) {
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager(), auth)
 	nodes := NewNodes(appState.RemoteNodeIncoming, auth)
 	backups := NewBackups(appState.BackupManager, auth)
+	dbUsers := NewDbUsers(appState.APIKeyRemote, auth)
 
 	mux := http.NewServeMux()
 	mux.Handle("/classifications/transactions/",
 		http.StripPrefix("/classifications/transactions/",
 			classifications.Transactions()))
 
+	mux.Handle("/cluster/users/db/", dbUsers.Users())
 	mux.Handle("/nodes/", nodes.Nodes())
 	mux.Handle("/indices/", indices.Indices())
 	mux.Handle("/replicas/indices/", replicatedIndices.Indices())

--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -97,7 +97,7 @@ func configureOIDC(appState *state.State) *oidc.Client {
 }
 
 func configureAPIKey(appState *state.State) *apikey.ApiKey {
-	c, err := apikey.New(appState.ServerConfig.Config)
+	c, err := apikey.New(appState.ServerConfig.Config, appState.Logger)
 	if err != nil {
 		appState.Logger.WithField("action", "api_keys_init").WithError(err).Fatal("apikey client could not start up")
 		os.Exit(1)

--- a/adapters/handlers/rest/db_users/get_user_test.go
+++ b/adapters/handlers/rest/db_users/get_user_test.go
@@ -12,12 +12,9 @@
 package db_users
 
 import (
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -98,47 +95,6 @@ func TestSuccessGetUser(t *testing.T) {
 			}
 		})
 	}
-}
-
-type FakeNodeResolver struct {
-	path string
-}
-
-func (f FakeNodeResolver) NodeHostname(nodeName string) (string, bool) {
-	return strings.TrimPrefix(f.path, "http://"), true
-}
-
-type fakeHandler struct {
-	t             *testing.T
-	nodeResponses []map[string]time.Time
-	counter       atomic.Int32
-}
-
-func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	assert.Equal(f.t, http.MethodPost, r.Method)
-
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "Error reading request body", http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	var body apikey.UserStatusRequest
-	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		http.Error(w, "Error parsing JSON body", http.StatusBadRequest)
-		return
-	}
-	if !body.ReturnStatus {
-		return
-	}
-	counter := f.counter.Add(1) - 1
-
-	ret := apikey.UserStatusResponse{Users: f.nodeResponses[counter]}
-	outBytes, err := json.Marshal(ret)
-	require.Nil(f.t, err)
-
-	w.Write(outBytes)
 }
 
 func TestSuccessGetUserMultiNode(t *testing.T) {

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -266,11 +266,12 @@ func (h *dynUserHandler) getLastUsed(users []*apikey.User) map[string]time.Time 
 	wg.Wait()
 
 	for _, status := range userStatuses {
-		if status != nil {
-			for userId, lastUsedTime := range status.Users {
-				if lastUsedTime.After(usersWithTime[userId]) {
-					usersWithTime[userId] = lastUsedTime
-				}
+		if status == nil {
+			continue
+		}
+		for userId, lastUsedTime := range status.Users {
+			if lastUsedTime.After(usersWithTime[userId]) {
+				usersWithTime[userId] = lastUsedTime
 			}
 		}
 	}

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -256,7 +256,7 @@ func (h *dynUserHandler) getLastUsed(users []*apikey.User) map[string]time.Time 
 	for i, nodeName := range nodes {
 		i, nodeName := i, nodeName
 		enterrors.GoWrapper(func() {
-			status, err := h.remoteUser.GetUserStatus(ctx, nodeName, usersWithTime, true)
+			status, err := h.remoteUser.GetAndUpdateLastUsedTime(ctx, nodeName, usersWithTime, true)
 			if err == nil {
 				userStatuses[i] = status
 			}
@@ -288,7 +288,7 @@ func (h *dynUserHandler) getLastUsed(users []*apikey.User) map[string]time.Time 
 			nodeName := nodeName
 			enterrors.GoWrapper(func() {
 				// dont care about returns or errors
-				_, _ = h.remoteUser.GetUserStatus(ctx2, nodeName, usersWithTime, false)
+				_, _ = h.remoteUser.GetAndUpdateLastUsedTime(ctx2, nodeName, usersWithTime, false)
 				wg.Done()
 			}, h.logger)
 		}

--- a/adapters/handlers/rest/db_users/list_all_users_test.go
+++ b/adapters/handlers/rest/db_users/list_all_users_test.go
@@ -98,7 +98,7 @@ func TestSuccessListAllUserMultiNode(t *testing.T) {
 
 	usersIds := []string{"user1", "user2", "user3", "user4", "user5", "user6"}
 
-	truep := true
+	trueptr := true
 	tests := []struct {
 		name          string
 		nodeResponses []map[string]time.Time

--- a/adapters/handlers/rest/db_users/list_all_users_test.go
+++ b/adapters/handlers/rest/db_users/list_all_users_test.go
@@ -13,7 +13,15 @@ package db_users
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/weaviate/weaviate/adapters/clients"
+	schemaMocks "github.com/weaviate/weaviate/usecases/schema/mocks"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
@@ -50,15 +58,15 @@ func TestSuccessListAll(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			authorizer := authzMocks.NewAuthorizer(t)
-			authorizer.On("Authorize", test.principal, authorization.READ, authorization.Users()[0]).Return(nil)
+			authorizer.On("Authorize", tt.principal, authorization.READ, authorization.Users()[0]).Return(nil)
 			dynUser := mocks.NewDbUserAndRolesGetter(t)
 			dynUser.On("GetUsers").Return(map[string]*apikey.User{dbUser: {Id: dbUser}}, nil)
 			dynUser.On("GetRolesForUser", dbUser, models.UserTypeInputDb).Return(
 				map[string][]authorization.Policy{"role": {}}, nil)
-			if test.includeStatic {
+			if tt.includeStatic {
 				dynUser.On("GetRolesForUser", staticUser, models.UserTypeInputDb).Return(
 					map[string][]authorization.Policy{"role": {}}, nil)
 			}
@@ -71,15 +79,113 @@ func TestSuccessListAll(t *testing.T) {
 				dbUserEnabled:        true,
 			}
 
-			res := h.listUsers(users.ListAllUsersParams{}, test.principal)
+			res := h.listUsers(users.ListAllUsersParams{}, tt.principal)
 			parsed, ok := res.(*users.ListAllUsersOK)
 			assert.True(t, ok)
 			assert.NotNil(t, parsed)
 
-			if test.includeStatic {
+			if tt.includeStatic {
 				require.Equal(t, len(parsed.Payload), 2)
 			} else {
 				require.Len(t, parsed.Payload, 1)
+			}
+		})
+	}
+}
+
+func TestSuccessListAllUserMultiNode(t *testing.T) {
+	baseTime := time.Now()
+
+	userId := "user"
+	userId2 := "user2"
+
+	truep := true
+	tests := []struct {
+		name          string
+		nodeResponses []map[string]time.Time
+		expectedTime  map[string]time.Time
+		userIds       []string
+	}{
+		{name: "single node, single user", nodeResponses: []map[string]time.Time{{}}, expectedTime: map[string]time.Time{userId: baseTime}, userIds: []string{userId}},
+		{name: "single node, multi user", nodeResponses: []map[string]time.Time{{}}, expectedTime: map[string]time.Time{userId: baseTime, userId2: baseTime}, userIds: []string{userId, userId2}},
+		{
+			name:          "multi node, latest time local node, single user",
+			userIds:       []string{userId},
+			expectedTime:  map[string]time.Time{userId: baseTime},
+			nodeResponses: []map[string]time.Time{{userId: baseTime.Add(-time.Second)}, {userId: baseTime.Add(-time.Second)}},
+		},
+		{
+			name:         "multi node, latest time local node, multi user",
+			userIds:      []string{userId, userId2},
+			expectedTime: map[string]time.Time{userId: baseTime, userId2: baseTime},
+			nodeResponses: []map[string]time.Time{
+				{userId: baseTime.Add(-time.Second), userId2: baseTime.Add(-2 * time.Second)},
+				{userId: baseTime.Add(-time.Second), userId2: baseTime.Add(-2 * time.Second)},
+			},
+		},
+		{
+			name:          "multi node, latest time other node, single user",
+			userIds:       []string{userId},
+			expectedTime:  map[string]time.Time{userId: baseTime.Add(time.Hour)},
+			nodeResponses: []map[string]time.Time{{userId: baseTime.Add(time.Hour)}, {userId: baseTime.Add(time.Minute)}},
+		},
+		{
+			name:         "multi node, latest time other node, multi user",
+			userIds:      []string{userId, userId2},
+			expectedTime: map[string]time.Time{userId: baseTime.Add(time.Hour), userId2: baseTime.Add(2 * time.Hour)},
+			nodeResponses: []map[string]time.Time{
+				{userId: baseTime.Add(time.Hour), userId2: baseTime.Add(time.Minute)},
+				{userId: baseTime.Add(time.Minute), userId2: baseTime.Add(2 * time.Hour)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			principal := &models.Principal{Username: "non-root"}
+			authorizer := authzMocks.NewAuthorizer(t)
+			authorizer.On("Authorize", principal, authorization.READ, authorization.Users()[0]).Return(nil)
+			dynUser := mocks.NewDbUserAndRolesGetter(t)
+			schemaGetter := schemaMocks.NewSchemaGetter(t)
+
+			usersRet := make(map[string]*apikey.User)
+			for _, user := range tt.userIds {
+				usersRet[user] = &apikey.User{Id: user, LastUsedAt: baseTime}
+			}
+
+			dynUser.On("GetUsers").Return(usersRet, nil)
+			for _, user := range tt.userIds {
+				dynUser.On("GetRolesForUser", user, models.UserTypeInputDb).Return(map[string][]authorization.Policy{"role": {}}, nil)
+			}
+
+			var nodes []string
+			for i := range tt.nodeResponses {
+				nodes = append(nodes, string(rune(i)))
+			}
+			schemaGetter.On("Nodes").Return(nodes)
+
+			server := httptest.NewServer(&fakeHandler{t: t, counter: atomic.Int32{}, nodeResponses: tt.nodeResponses})
+			defer server.Close()
+
+			remote := clients.NewRemoteUser(&http.Client{}, FakeNodeResolver{path: server.URL})
+
+			h := dynUserHandler{
+				dbUsers:              dynUser,
+				authorizer:           authorizer,
+				staticApiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"static"}, AllowedKeys: []string{"static"}},
+				rbacConfig:           rbacconf.Config{Enabled: true, RootUsers: []string{"root"}}, dbUserEnabled: true,
+				nodesGetter: schemaGetter,
+				remoteUser:  remote,
+			}
+
+			res := h.listUsers(users.ListAllUsersParams{IncludeLastUsedTime: &truep}, principal)
+			parsed, ok := res.(*users.ListAllUsersOK)
+			assert.True(t, ok)
+			assert.NotNil(t, parsed)
+
+			for i := range tt.userIds {
+				uid := *parsed.Payload[i].UserID
+				require.Equal(t, parsed.Payload[i].LastUsedAt.String(), strfmt.DateTime(tt.expectedTime[uid]).String())
 			}
 		})
 	}

--- a/adapters/handlers/rest/db_users/list_all_users_test.go
+++ b/adapters/handlers/rest/db_users/list_all_users_test.go
@@ -96,8 +96,7 @@ func TestSuccessListAll(t *testing.T) {
 func TestSuccessListAllUserMultiNode(t *testing.T) {
 	baseTime := time.Now()
 
-	userId := "user"
-	userId2 := "user2"
+	usersIds := []string{"user1", "user2", "user3", "user4", "user5", "user6"}
 
 	truep := true
 	tests := []struct {
@@ -106,36 +105,56 @@ func TestSuccessListAllUserMultiNode(t *testing.T) {
 		expectedTime  map[string]time.Time
 		userIds       []string
 	}{
-		{name: "single node, single user", nodeResponses: []map[string]time.Time{{}}, expectedTime: map[string]time.Time{userId: baseTime}, userIds: []string{userId}},
-		{name: "single node, multi user", nodeResponses: []map[string]time.Time{{}}, expectedTime: map[string]time.Time{userId: baseTime, userId2: baseTime}, userIds: []string{userId, userId2}},
+		{name: "single node, single user", nodeResponses: []map[string]time.Time{{}}, expectedTime: map[string]time.Time{usersIds[0]: baseTime}, userIds: usersIds[:1]},
+		{name: "single node, multi user", nodeResponses: []map[string]time.Time{{}}, expectedTime: map[string]time.Time{usersIds[0]: baseTime, usersIds[1]: baseTime}, userIds: usersIds[:2]},
 		{
 			name:          "multi node, latest time local node, single user",
-			userIds:       []string{userId},
-			expectedTime:  map[string]time.Time{userId: baseTime},
-			nodeResponses: []map[string]time.Time{{userId: baseTime.Add(-time.Second)}, {userId: baseTime.Add(-time.Second)}},
+			userIds:       usersIds[:1],
+			expectedTime:  map[string]time.Time{usersIds[0]: baseTime},
+			nodeResponses: []map[string]time.Time{{usersIds[0]: baseTime.Add(-time.Second)}, {usersIds[0]: baseTime.Add(-time.Second)}},
 		},
 		{
 			name:         "multi node, latest time local node, multi user",
-			userIds:      []string{userId, userId2},
-			expectedTime: map[string]time.Time{userId: baseTime, userId2: baseTime},
+			userIds:      usersIds[:2],
+			expectedTime: map[string]time.Time{usersIds[0]: baseTime, usersIds[1]: baseTime},
 			nodeResponses: []map[string]time.Time{
-				{userId: baseTime.Add(-time.Second), userId2: baseTime.Add(-2 * time.Second)},
-				{userId: baseTime.Add(-time.Second), userId2: baseTime.Add(-2 * time.Second)},
+				{usersIds[0]: baseTime.Add(-time.Second), usersIds[1]: baseTime.Add(-2 * time.Second)},
+				{usersIds[0]: baseTime.Add(-time.Second), usersIds[1]: baseTime.Add(-2 * time.Second)},
 			},
 		},
 		{
 			name:          "multi node, latest time other node, single user",
-			userIds:       []string{userId},
-			expectedTime:  map[string]time.Time{userId: baseTime.Add(time.Hour)},
-			nodeResponses: []map[string]time.Time{{userId: baseTime.Add(time.Hour)}, {userId: baseTime.Add(time.Minute)}},
+			userIds:       usersIds[:1],
+			expectedTime:  map[string]time.Time{usersIds[0]: baseTime.Add(time.Hour)},
+			nodeResponses: []map[string]time.Time{{usersIds[0]: baseTime.Add(time.Hour)}, {usersIds[0]: baseTime.Add(time.Minute)}},
 		},
 		{
 			name:         "multi node, latest time other node, multi user",
-			userIds:      []string{userId, userId2},
-			expectedTime: map[string]time.Time{userId: baseTime.Add(time.Hour), userId2: baseTime.Add(2 * time.Hour)},
+			userIds:      usersIds[:2],
+			expectedTime: map[string]time.Time{usersIds[0]: baseTime.Add(time.Hour), usersIds[1]: baseTime.Add(2 * time.Hour)},
 			nodeResponses: []map[string]time.Time{
-				{userId: baseTime.Add(time.Hour), userId2: baseTime.Add(time.Minute)},
-				{userId: baseTime.Add(time.Minute), userId2: baseTime.Add(2 * time.Hour)},
+				{usersIds[0]: baseTime.Add(time.Hour), usersIds[1]: baseTime.Add(time.Minute)},
+				{usersIds[0]: baseTime.Add(time.Minute), usersIds[1]: baseTime.Add(2 * time.Hour)},
+			},
+		},
+		{
+			name:    "six node, six user",
+			userIds: usersIds,
+			expectedTime: map[string]time.Time{
+				usersIds[0]: baseTime.Add(time.Hour),
+				usersIds[1]: baseTime.Add(2 * time.Hour),
+				usersIds[2]: baseTime.Add(3 * time.Hour),
+				usersIds[3]: baseTime.Add(4 * time.Hour),
+				usersIds[4]: baseTime.Add(5 * time.Hour),
+				usersIds[5]: baseTime.Add(6 * time.Hour),
+			},
+			nodeResponses: []map[string]time.Time{
+				{usersIds[0]: baseTime.Add(time.Hour), usersIds[1]: baseTime.Add(time.Minute)},
+				{usersIds[0]: baseTime.Add(time.Minute), usersIds[1]: baseTime.Add(2 * time.Hour)},
+				{usersIds[2]: baseTime.Add(3 * time.Hour), usersIds[3]: baseTime.Add(time.Minute), usersIds[1]: baseTime.Add(time.Minute)},
+				{usersIds[2]: baseTime.Add(-time.Minute), usersIds[3]: baseTime.Add(4 * time.Hour)},
+				{usersIds[4]: baseTime.Add(5 * time.Hour), usersIds[5]: baseTime.Add(time.Minute), usersIds[1]: baseTime.Add(time.Minute)},
+				{usersIds[4]: baseTime.Add(-time.Minute), usersIds[5]: baseTime.Add(6 * time.Hour)},
 			},
 		},
 	}

--- a/adapters/handlers/rest/db_users/list_all_users_test.go
+++ b/adapters/handlers/rest/db_users/list_all_users_test.go
@@ -197,7 +197,7 @@ func TestSuccessListAllUserMultiNode(t *testing.T) {
 				remoteUser:  remote,
 			}
 
-			res := h.listUsers(users.ListAllUsersParams{IncludeLastUsedTime: &truep}, principal)
+			res := h.listUsers(users.ListAllUsersParams{IncludeLastUsedTime: &trueptr}, principal)
 			parsed, ok := res.(*users.ListAllUsersOK)
 			assert.True(t, ok)
 			assert.NotNil(t, parsed)

--- a/adapters/handlers/rest/db_users/multi_node_helper.go
+++ b/adapters/handlers/rest/db_users/multi_node_helper.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db_users
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
+)
+
+type FakeNodeResolver struct {
+	path string
+}
+
+func (f FakeNodeResolver) NodeHostname(nodeName string) (string, bool) {
+	return strings.TrimPrefix(f.path, "http://"), true
+}
+
+type fakeHandler struct {
+	t             *testing.T
+	nodeResponses []map[string]time.Time
+	counter       atomic.Int32
+}
+
+func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	require.Equal(f.t, http.MethodPost, r.Method)
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error reading request body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var body apikey.UserStatusRequest
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		http.Error(w, "Error parsing JSON body", http.StatusBadRequest)
+		return
+	}
+	if !body.ReturnStatus {
+		return
+	}
+	counter := f.counter.Add(1) - 1
+
+	ret := apikey.UserStatusResponse{Users: f.nodeResponses[counter]}
+	outBytes, err := json.Marshal(ret)
+	require.Nil(f.t, err)
+
+	w.Write(outBytes)
+}

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4241,9 +4241,18 @@ func init() {
         ],
         "summary": "list all db users",
         "operationId": "listAllUsers",
+        "parameters": [
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to include the last used time of the users",
+            "name": "includeLastUsedTime",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Info about the user",
+            "description": "Info about the users",
             "schema": {
               "type": "array",
               "items": {
@@ -11644,9 +11653,18 @@ func init() {
         ],
         "summary": "list all db users",
         "operationId": "listAllUsers",
+        "parameters": [
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to include the last used time of the users",
+            "name": "includeLastUsedTime",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Info about the user",
+            "description": "Info about the users",
             "schema": {
               "type": "array",
               "items": {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4286,6 +4286,13 @@ func init() {
             "name": "user_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to include the last used time of the given user",
+            "name": "includeLastUsedTime",
+            "in": "query"
           }
         ],
         "responses": {
@@ -5539,6 +5546,14 @@ func init() {
             "db_user",
             "db_env_user"
           ]
+        },
+        "lastUsedAt": {
+          "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
         },
         "roles": {
           "description": "The role names associated to the user",
@@ -11674,6 +11689,13 @@ func init() {
             "name": "user_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to include the last used time of the given user",
+            "name": "includeLastUsedTime",
+            "in": "query"
           }
         ],
         "responses": {
@@ -13082,6 +13104,14 @@ func init() {
             "db_user",
             "db_env_user"
           ]
+        },
+        "lastUsedAt": {
+          "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
         },
         "roles": {
           "description": "The role names associated to the user",

--- a/adapters/handlers/rest/operations/users/get_user_info_parameters.go
+++ b/adapters/handlers/rest/operations/users/get_user_info_parameters.go
@@ -20,16 +20,25 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewGetUserInfoParams creates a new GetUserInfoParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewGetUserInfoParams() GetUserInfoParams {
 
-	return GetUserInfoParams{}
+	var (
+		// initialize parameters with default values
+
+		includeLastUsedTimeDefault = bool(false)
+	)
+
+	return GetUserInfoParams{
+		IncludeLastUsedTime: &includeLastUsedTimeDefault,
+	}
 }
 
 // GetUserInfoParams contains all the bound params for the get user info operation
@@ -41,6 +50,11 @@ type GetUserInfoParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Whether to include the last used time of the given user
+	  In: query
+	  Default: false
+	*/
+	IncludeLastUsedTime *bool
 	/*user id
 	  Required: true
 	  In: path
@@ -57,6 +71,13 @@ func (o *GetUserInfoParams) BindRequest(r *http.Request, route *middleware.Match
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qIncludeLastUsedTime, qhkIncludeLastUsedTime, _ := qs.GetOK("includeLastUsedTime")
+	if err := o.bindIncludeLastUsedTime(qIncludeLastUsedTime, qhkIncludeLastUsedTime, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	rUserID, rhkUserID, _ := route.Params.GetOK("user_id")
 	if err := o.bindUserID(rUserID, rhkUserID, route.Formats); err != nil {
 		res = append(res, err)
@@ -64,6 +85,30 @@ func (o *GetUserInfoParams) BindRequest(r *http.Request, route *middleware.Match
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindIncludeLastUsedTime binds and validates parameter IncludeLastUsedTime from query.
+func (o *GetUserInfoParams) bindIncludeLastUsedTime(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetUserInfoParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("includeLastUsedTime", "query", "bool", raw)
+	}
+	o.IncludeLastUsedTime = &value
+
 	return nil
 }
 

--- a/adapters/handlers/rest/operations/users/get_user_info_urlbuilder.go
+++ b/adapters/handlers/rest/operations/users/get_user_info_urlbuilder.go
@@ -21,11 +21,15 @@ import (
 	"net/url"
 	golangswaggerpaths "path"
 	"strings"
+
+	"github.com/go-openapi/swag"
 )
 
 // GetUserInfoURL generates an URL for the get user info operation
 type GetUserInfoURL struct {
 	UserID string
+
+	IncludeLastUsedTime *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -65,6 +69,18 @@ func (o *GetUserInfoURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var includeLastUsedTimeQ string
+	if o.IncludeLastUsedTime != nil {
+		includeLastUsedTimeQ = swag.FormatBool(*o.IncludeLastUsedTime)
+	}
+	if includeLastUsedTimeQ != "" {
+		qs.Set("includeLastUsedTime", includeLastUsedTimeQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/handlers/rest/operations/users/list_all_users_parameters.go
+++ b/adapters/handlers/rest/operations/users/list_all_users_parameters.go
@@ -20,15 +20,25 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewListAllUsersParams creates a new ListAllUsersParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewListAllUsersParams() ListAllUsersParams {
 
-	return ListAllUsersParams{}
+	var (
+		// initialize parameters with default values
+
+		includeLastUsedTimeDefault = bool(false)
+	)
+
+	return ListAllUsersParams{
+		IncludeLastUsedTime: &includeLastUsedTimeDefault,
+	}
 }
 
 // ListAllUsersParams contains all the bound params for the list all users operation
@@ -39,6 +49,12 @@ type ListAllUsersParams struct {
 
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
+
+	/*Whether to include the last used time of the users
+	  In: query
+	  Default: false
+	*/
+	IncludeLastUsedTime *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -50,8 +66,38 @@ func (o *ListAllUsersParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qIncludeLastUsedTime, qhkIncludeLastUsedTime, _ := qs.GetOK("includeLastUsedTime")
+	if err := o.bindIncludeLastUsedTime(qIncludeLastUsedTime, qhkIncludeLastUsedTime, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindIncludeLastUsedTime binds and validates parameter IncludeLastUsedTime from query.
+func (o *ListAllUsersParams) bindIncludeLastUsedTime(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewListAllUsersParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("includeLastUsedTime", "query", "bool", raw)
+	}
+	o.IncludeLastUsedTime = &value
+
 	return nil
 }

--- a/adapters/handlers/rest/operations/users/list_all_users_responses.go
+++ b/adapters/handlers/rest/operations/users/list_all_users_responses.go
@@ -28,7 +28,7 @@ import (
 const ListAllUsersOKCode int = 200
 
 /*
-ListAllUsersOK Info about the user
+ListAllUsersOK Info about the users
 
 swagger:response listAllUsersOK
 */

--- a/adapters/handlers/rest/operations/users/list_all_users_urlbuilder.go
+++ b/adapters/handlers/rest/operations/users/list_all_users_urlbuilder.go
@@ -20,11 +20,17 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+
+	"github.com/go-openapi/swag"
 )
 
 // ListAllUsersURL generates an URL for the list all users operation
 type ListAllUsersURL struct {
+	IncludeLastUsedTime *bool
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -53,6 +59,18 @@ func (o *ListAllUsersURL) Build() (*url.URL, error) {
 		_basePath = "/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var includeLastUsedTimeQ string
+	if o.IncludeLastUsedTime != nil {
+		includeLastUsedTimeQ = swag.FormatBool(*o.IncludeLastUsedTime)
+	}
+	if includeLastUsedTimeQ != "" {
+		qs.Set("includeLastUsedTime", includeLastUsedTimeQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -48,6 +48,7 @@ type State struct {
 	OIDC            *oidc.Client
 	AnonymousAccess *anonymous.Client
 	APIKey          *apikey.ApiKey
+	APIKeyRemote    *apikey.RemoteApiKey
 	Authorizer      authorization.Authorizer
 	AuthzController authorization.Controller
 

--- a/client/users/get_user_info_parameters.go
+++ b/client/users/get_user_info_parameters.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewGetUserInfoParams creates a new GetUserInfoParams object,
@@ -72,6 +73,12 @@ GetUserInfoParams contains all the parameters to send to the API endpoint
 */
 type GetUserInfoParams struct {
 
+	/* IncludeLastUsedTime.
+
+	   Whether to include the last used time of the given user
+	*/
+	IncludeLastUsedTime *bool
+
 	/* UserID.
 
 	   user id
@@ -95,7 +102,18 @@ func (o *GetUserInfoParams) WithDefaults() *GetUserInfoParams {
 //
 // All values with no default are reset to their zero value.
 func (o *GetUserInfoParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		includeLastUsedTimeDefault = bool(false)
+	)
+
+	val := GetUserInfoParams{
+		IncludeLastUsedTime: &includeLastUsedTimeDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the get user info params
@@ -131,6 +149,17 @@ func (o *GetUserInfoParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithIncludeLastUsedTime adds the includeLastUsedTime to the get user info params
+func (o *GetUserInfoParams) WithIncludeLastUsedTime(includeLastUsedTime *bool) *GetUserInfoParams {
+	o.SetIncludeLastUsedTime(includeLastUsedTime)
+	return o
+}
+
+// SetIncludeLastUsedTime adds the includeLastUsedTime to the get user info params
+func (o *GetUserInfoParams) SetIncludeLastUsedTime(includeLastUsedTime *bool) {
+	o.IncludeLastUsedTime = includeLastUsedTime
+}
+
 // WithUserID adds the userID to the get user info params
 func (o *GetUserInfoParams) WithUserID(userID string) *GetUserInfoParams {
 	o.SetUserID(userID)
@@ -149,6 +178,23 @@ func (o *GetUserInfoParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
+
+	if o.IncludeLastUsedTime != nil {
+
+		// query param includeLastUsedTime
+		var qrIncludeLastUsedTime bool
+
+		if o.IncludeLastUsedTime != nil {
+			qrIncludeLastUsedTime = *o.IncludeLastUsedTime
+		}
+		qIncludeLastUsedTime := swag.FormatBool(qrIncludeLastUsedTime)
+		if qIncludeLastUsedTime != "" {
+
+			if err := r.SetQueryParam("includeLastUsedTime", qIncludeLastUsedTime); err != nil {
+				return err
+			}
+		}
+	}
 
 	// path param user_id
 	if err := r.SetPathParam("user_id", o.UserID); err != nil {

--- a/client/users/list_all_users_parameters.go
+++ b/client/users/list_all_users_parameters.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewListAllUsersParams creates a new ListAllUsersParams object,
@@ -71,6 +72,13 @@ ListAllUsersParams contains all the parameters to send to the API endpoint
 	Typically these are written to a http.Request.
 */
 type ListAllUsersParams struct {
+
+	/* IncludeLastUsedTime.
+
+	   Whether to include the last used time of the users
+	*/
+	IncludeLastUsedTime *bool
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -88,7 +96,18 @@ func (o *ListAllUsersParams) WithDefaults() *ListAllUsersParams {
 //
 // All values with no default are reset to their zero value.
 func (o *ListAllUsersParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		includeLastUsedTimeDefault = bool(false)
+	)
+
+	val := ListAllUsersParams{
+		IncludeLastUsedTime: &includeLastUsedTimeDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the list all users params
@@ -124,6 +143,17 @@ func (o *ListAllUsersParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithIncludeLastUsedTime adds the includeLastUsedTime to the list all users params
+func (o *ListAllUsersParams) WithIncludeLastUsedTime(includeLastUsedTime *bool) *ListAllUsersParams {
+	o.SetIncludeLastUsedTime(includeLastUsedTime)
+	return o
+}
+
+// SetIncludeLastUsedTime adds the includeLastUsedTime to the list all users params
+func (o *ListAllUsersParams) SetIncludeLastUsedTime(includeLastUsedTime *bool) {
+	o.IncludeLastUsedTime = includeLastUsedTime
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListAllUsersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -131,6 +161,23 @@ func (o *ListAllUsersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 	var res []error
+
+	if o.IncludeLastUsedTime != nil {
+
+		// query param includeLastUsedTime
+		var qrIncludeLastUsedTime bool
+
+		if o.IncludeLastUsedTime != nil {
+			qrIncludeLastUsedTime = *o.IncludeLastUsedTime
+		}
+		qIncludeLastUsedTime := swag.FormatBool(qrIncludeLastUsedTime)
+		if qIncludeLastUsedTime != "" {
+
+			if err := r.SetQueryParam("includeLastUsedTime", qIncludeLastUsedTime); err != nil {
+				return err
+			}
+		}
+	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/client/users/list_all_users_responses.go
+++ b/client/users/list_all_users_responses.go
@@ -71,7 +71,7 @@ func NewListAllUsersOK() *ListAllUsersOK {
 /*
 ListAllUsersOK describes a response with status code 200, with default header values.
 
-Info about the user
+Info about the users
 */
 type ListAllUsersOK struct {
 	Payload []*models.DBUserInfo

--- a/entities/models/d_b_user_info.go
+++ b/entities/models/d_b_user_info.go
@@ -48,6 +48,10 @@ type DBUserInfo struct {
 	// Enum: [db_user db_env_user]
 	DbUserType *string `json:"dbUserType"`
 
+	// Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)
+	// Format: date-time
+	LastUsedAt strfmt.DateTime `json:"lastUsedAt,omitempty"`
+
 	// The role names associated to the user
 	// Required: true
 	Roles []string `json:"roles"`
@@ -74,6 +78,10 @@ func (m *DBUserInfo) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateDbUserType(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateLastUsedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -161,6 +169,18 @@ func (m *DBUserInfo) validateDbUserType(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateDbUserTypeEnum("dbUserType", "body", *m.DbUserType); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *DBUserInfo) validateLastUsedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.LastUsedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("lastUsedAt", "body", "date-time", m.LastUsedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -2757,9 +2757,19 @@
         "tags": [
           "users"
         ],
+        "parameters": [
+          {
+            "description": "Whether to include the last used time of the users",
+            "in": "query",
+            "name": "includeLastUsedTime",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Info about the user",
+            "description": "Info about the users",
             "schema": {
               "type": "array",
               "items": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -72,9 +72,17 @@
           "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)"
         },
         "apiKeyFirstLetters": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "maxLength": 3,
           "description": "First 3 letters of the associated API-key"
+        },
+        "lastUsedAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)"
         }
       },
       "required": [
@@ -2794,6 +2802,14 @@
             "name": "user_id",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "Whether to include the last used time of the given user",
+            "in": "query",
+            "name": "includeLastUsedTime",
+            "required": false,
+            "type": "boolean",
+            "default": false
           }
         ],
         "responses": {

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -748,6 +748,15 @@ func TestGetLastUsageMultinode(t *testing.T) {
 		require.Equal(t, *user.UserID, dynUser)
 		require.Less(t, lastLoginTime, user.LastUsedAt)
 		require.Less(t, user.LastUsedAt, time.Now())
+
+		allUsers := helper.ListAllUsersWithIncludeTime(t, adminKey, true)
+		for _, user := range allUsers {
+			if *user.UserID != dynUser {
+				continue
+			}
+			require.Less(t, lastLoginTime, user.LastUsedAt)
+			require.Less(t, user.LastUsedAt, time.Now())
+		}
 	})
 
 	t.Run("last usage with shutdowns", func(t *testing.T) {
@@ -784,5 +793,14 @@ func TestGetLastUsageMultinode(t *testing.T) {
 		require.Less(t, before, userNode2.LastUsedAt)
 		require.Less(t, userNode2.LastUsedAt, time.Now())
 		require.Equal(t, userNode2.LastUsedAt, user.LastUsedAt)
+
+		allUsers := helper.ListAllUsersWithIncludeTime(t, adminKey, true)
+		for _, user := range allUsers {
+			if *user.UserID != dynUser {
+				continue
+			}
+			require.Less(t, user.LastUsedAt, time.Now())
+			require.Equal(t, user.LastUsedAt, userNode2.LastUsedAt)
+		}
 	})
 }

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -920,7 +920,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		config2["CLUSTER_DATA_BIND_PORT"] = "7103"
 		config2["CLUSTER_JOIN"] = fmt.Sprintf("%s:7100", Weaviate1)
 		eg.Go(func() (err error) {
-			time.Sleep(time.Second * 3)
+			time.Sleep(time.Second * 10) // node1 needs to be up before we can start this node
 			cs[1], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
 				config2, networkName, image, Weaviate2, d.withWeaviateExposeGRPCPort, wellKnownEndpointFunc("node2"))
 			if err != nil {
@@ -937,7 +937,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		config3["CLUSTER_DATA_BIND_PORT"] = "7105"
 		config3["CLUSTER_JOIN"] = fmt.Sprintf("%s:7100", Weaviate1)
 		eg.Go(func() (err error) {
-			time.Sleep(time.Second * 3)
+			time.Sleep(time.Second * 10) // node1 needs to be up before we can start this node
 			cs[2], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
 				config3, networkName, image, Weaviate3, d.withWeaviateExposeGRPCPort, wellKnownEndpointFunc("node3"))
 			if err != nil {

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -160,6 +160,14 @@ func ListAllUsers(t *testing.T, key string) []*models.DBUserInfo {
 	return resp.Payload
 }
 
+func ListAllUsersWithIncludeTime(t *testing.T, key string, includeLastUsedTime bool) []*models.DBUserInfo {
+	t.Helper()
+	resp, err := Client(t).Users.ListAllUsers(users.NewListAllUsersParams().WithIncludeLastUsedTime(&includeLastUsedTime), CreateAuth(key))
+	AssertRequestOk(t, resp, err, nil)
+	require.Nil(t, err)
+	return resp.Payload
+}
+
 func DeleteRole(t *testing.T, key, role string) {
 	t.Helper()
 	resp, err := Client(t).Authz.DeleteRole(authz.NewDeleteRoleParams().WithID(role), CreateAuth(key))

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -107,6 +107,15 @@ func GetUser(t *testing.T, userId, key string) *models.DBUserInfo {
 	return resp.Payload
 }
 
+func GetUserWithLastUsedTime(t *testing.T, userId, key string, lastUsedTime bool) *models.DBUserInfo {
+	t.Helper()
+	resp, err := Client(t).Users.GetUserInfo(users.NewGetUserInfoParams().WithUserID(userId).WithIncludeLastUsedTime(&lastUsedTime), CreateAuth(key))
+	AssertRequestOk(t, resp, err, nil)
+	require.Nil(t, err)
+	require.NotNil(t, resp.Payload)
+	return resp.Payload
+}
+
 func CreateUser(t *testing.T, userId, key string) string {
 	t.Helper()
 	resp, err := Client(t).Users.CreateUser(users.NewCreateUserParams().WithUserID(userId), CreateAuth(key))

--- a/test/run.sh
+++ b/test/run.sh
@@ -341,7 +341,7 @@ function run_acceptance_graphql_tests() {
 function run_acceptance_only_authz() {
   export TEST_WEAVIATE_IMAGE=weaviate/test-server
   for pkg in $(go list ./.../ | grep 'test/acceptance/authz'); do
-    if ! go test -count 1 -race "$pkg"; then
+    if ! go test -timeout=15m -count 1 -race "$pkg"; then
       echo "Test for $pkg failed" >&2
       return 1
     fi

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -6,7 +6,7 @@ CONFIG=${1:-local-development}
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit 1
 
 export GO111MODULE=on
-export LOG_LEVEL=${LOG_LEVEL:-"debug"}
+export LOG_LEVEL=${LOG_LEVEL:-"error"}
 export LOG_FORMAT=${LOG_FORMAT:-"text"}
 export PROMETHEUS_MONITORING_ENABLED=${PROMETHEUS_MONITORING_ENABLED:-"true"}
 export PROMETHEUS_MONITORING_PORT=${PROMETHEUS_MONITORING_PORT:-"2112"}
@@ -179,11 +179,12 @@ case $CONFIG in
   local-development)
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
+      AUTHENTICATION_DB_USERS_ENABLED="true" \
+      AUTHENTICATION_APIKEY_ENABLED="true" \
+      AUTHENTICATION_APIKEY_USERS='admin-user' \
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS='admin-key' \
       PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-0" \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
-      DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
-      PROMETHEUS_MONITORING_PORT="2112" \
       PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       CLUSTER_IN_LOCALHOST=true \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
@@ -203,6 +204,10 @@ case $CONFIG in
       GRPC_PORT=50052 \
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
+      AUTHENTICATION_DB_USERS_ENABLED="true" \
+      AUTHENTICATION_APIKEY_ENABLED="true" \
+      AUTHENTICATION_APIKEY_USERS='admin-user' \
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS='admin-key' \
       PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-1" \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-1" \
       CLUSTER_HOSTNAME="weaviate-1" \
@@ -217,8 +222,6 @@ case $CONFIG in
       RAFT_INTERNAL_RPC_PORT="8303" \
       RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
       RAFT_BOOTSTRAP_EXPECT=3 \
-      DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -238,6 +241,10 @@ case $CONFIG in
         CLUSTER_GOSSIP_BIND_PORT="7104" \
         CLUSTER_DATA_BIND_PORT="7105" \
         CLUSTER_JOIN="localhost:7100" \
+        AUTHENTICATION_DB_USERS_ENABLED="true" \
+        AUTHENTICATION_APIKEY_ENABLED="true" \
+        AUTHENTICATION_APIKEY_USERS='admin-user' \
+        AUTHENTICATION_APIKEY_ALLOWED_KEYS='admin-key' \
         PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
         PROMETHEUS_MONITORING_PORT="$((PROMETHEUS_MONITORING_PORT + 2))" \
         PROMETHEUS_MONITORING_ENABLED=true \
@@ -245,8 +252,6 @@ case $CONFIG in
         RAFT_INTERNAL_RPC_PORT="8305" \
         RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
         RAFT_BOOTSTRAP_EXPECT=3 \
-        DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-        ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
         go_run ./cmd/weaviate-server \
           --scheme http \
           --host "127.0.0.1" \

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -6,7 +6,7 @@ CONFIG=${1:-local-development}
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit 1
 
 export GO111MODULE=on
-export LOG_LEVEL=${LOG_LEVEL:-"error"}
+export LOG_LEVEL=${LOG_LEVEL:-"debug"}
 export LOG_FORMAT=${LOG_FORMAT:-"text"}
 export PROMETHEUS_MONITORING_ENABLED=${PROMETHEUS_MONITORING_ENABLED:-"true"}
 export PROMETHEUS_MONITORING_PORT=${PROMETHEUS_MONITORING_PORT:-"2112"}
@@ -179,12 +179,10 @@ case $CONFIG in
   local-development)
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
-      AUTHENTICATION_DB_USERS_ENABLED="true" \
-      AUTHENTICATION_APIKEY_ENABLED="true" \
-      AUTHENTICATION_APIKEY_USERS='admin-user' \
-      AUTHENTICATION_APIKEY_ALLOWED_KEYS='admin-key' \
       PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-0" \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
+      DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
+      ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       CLUSTER_IN_LOCALHOST=true \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
@@ -204,10 +202,6 @@ case $CONFIG in
       GRPC_PORT=50052 \
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
-      AUTHENTICATION_DB_USERS_ENABLED="true" \
-      AUTHENTICATION_APIKEY_ENABLED="true" \
-      AUTHENTICATION_APIKEY_USERS='admin-user' \
-      AUTHENTICATION_APIKEY_ALLOWED_KEYS='admin-key' \
       PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-weaviate-1" \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-1" \
       CLUSTER_HOSTNAME="weaviate-1" \
@@ -222,6 +216,8 @@ case $CONFIG in
       RAFT_INTERNAL_RPC_PORT="8303" \
       RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
       RAFT_BOOTSTRAP_EXPECT=3 \
+      DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
+      ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -241,10 +237,6 @@ case $CONFIG in
         CLUSTER_GOSSIP_BIND_PORT="7104" \
         CLUSTER_DATA_BIND_PORT="7105" \
         CLUSTER_JOIN="localhost:7100" \
-        AUTHENTICATION_DB_USERS_ENABLED="true" \
-        AUTHENTICATION_APIKEY_ENABLED="true" \
-        AUTHENTICATION_APIKEY_USERS='admin-user' \
-        AUTHENTICATION_APIKEY_ALLOWED_KEYS='admin-key' \
         PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
         PROMETHEUS_MONITORING_PORT="$((PROMETHEUS_MONITORING_PORT + 2))" \
         PROMETHEUS_MONITORING_ENABLED=true \
@@ -252,6 +244,8 @@ case $CONFIG in
         RAFT_INTERNAL_RPC_PORT="8305" \
         RAFT_JOIN="weaviate-0:8300,weaviate-1:8302,weaviate-2:8304" \
         RAFT_BOOTSTRAP_EXPECT=3 \
+        DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
+        ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
         go_run ./cmd/weaviate-server \
           --scheme http \
           --host "127.0.0.1" \

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -28,7 +28,7 @@ import (
 var log, _ = test.NewNullLogger()
 
 func TestDynUserConcurrency(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 
 	numUsers := 10
@@ -54,7 +54,7 @@ func TestDynUserConcurrency(t *testing.T) {
 }
 
 func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 	userId := "id"
 
@@ -85,7 +85,7 @@ func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 	userId := "id"
 
@@ -129,7 +129,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestSnapShotAndRestore(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 
 	userId1 := "id-1"
@@ -176,7 +176,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 	snapshotRestore := DBUserSnapshot{}
 	require.NoError(t, json.Unmarshal(marshal, &snapshotRestore))
 
-	dynUsers2, err := NewDBUser(t.TempDir(), log)
+	dynUsers2, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 	require.NoError(t, dynUsers2.Restore(snapshotRestore))
 
@@ -206,7 +206,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 }
 
 func TestSuspendAfterDelete(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 	userId := "id"
 
@@ -227,7 +227,7 @@ func TestSuspendAfterDelete(t *testing.T) {
 }
 
 func TestLastUsedTime(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)
 	userId := "user"
 

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -18,13 +18,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus/hooks/test"
+
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
 
 	"github.com/stretchr/testify/require"
 )
 
+var log, _ = test.NewNullLogger()
+
 func TestDynUserConcurrency(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir())
+	dynUsers, err := NewDBUser(t.TempDir(), log)
 	require.NoError(t, err)
 
 	numUsers := 10
@@ -50,7 +54,7 @@ func TestDynUserConcurrency(t *testing.T) {
 }
 
 func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir())
+	dynUsers, err := NewDBUser(t.TempDir(), log)
 	require.NoError(t, err)
 	userId := "id"
 
@@ -81,7 +85,7 @@ func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir())
+	dynUsers, err := NewDBUser(t.TempDir(), log)
 	require.NoError(t, err)
 	userId := "id"
 
@@ -125,7 +129,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestSnapShotAndRestore(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir())
+	dynUsers, err := NewDBUser(t.TempDir(), log)
 	require.NoError(t, err)
 
 	userId1 := "id-1"
@@ -172,7 +176,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 	snapshotRestore := DBUserSnapshot{}
 	require.NoError(t, json.Unmarshal(marshal, &snapshotRestore))
 
-	dynUsers2, err := NewDBUser(t.TempDir())
+	dynUsers2, err := NewDBUser(t.TempDir(), log)
 	require.NoError(t, err)
 	require.NoError(t, dynUsers2.Restore(snapshotRestore))
 
@@ -202,7 +206,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 }
 
 func TestSuspendAfterDelete(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir())
+	dynUsers, err := NewDBUser(t.TempDir(), log)
 	require.NoError(t, err)
 	userId := "id"
 

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -254,7 +254,7 @@ func TestLastUsedTime(t *testing.T) {
 	lastUsedTime := user[userId].LastUsedAt
 
 	// try to update with older timestamp => no effect
-	dynUsers.UpdateLastUsedTimeStamp(map[string]time.Time{userId: start})
+	dynUsers.UpdateLastUsedTimestamp(map[string]time.Time{userId: start})
 	user, err = dynUsers.GetUsers(userId)
 	require.NoError(t, err)
 
@@ -262,7 +262,7 @@ func TestLastUsedTime(t *testing.T) {
 
 	// update with newer timestamp (that another node has seen)
 	updateTime := time.Now()
-	dynUsers.UpdateLastUsedTimeStamp(map[string]time.Time{userId: updateTime})
+	dynUsers.UpdateLastUsedTimestamp(map[string]time.Time{userId: updateTime})
 	user, err = dynUsers.GetUsers(userId)
 	require.NoError(t, err)
 

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -135,7 +135,7 @@ func NewDBUser(path string, enabled bool, logger logrus.FieldLogger) (*DBUser, e
 					if err != nil {
 						logger.WithField("action", "db_users_write_to_file").
 							WithField("error", err).
-							Warn("Db users file not written")
+							Warn("db users file not written")
 					}
 				}()
 			}

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -243,7 +243,7 @@ func (c *DBUser) CheckUserIdentifierExists(userIdentifier string) (bool, error) 
 	return ok, nil
 }
 
-func (c *DBUser) UpdateLastUsedTimeStamp(users map[string]time.Time) {
+func (c *DBUser) UpdateLastUsedTimestamp(users map[string]time.Time) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -22,14 +22,19 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+
 	"github.com/alexedwards/argon2id"
 
 	"github.com/weaviate/weaviate/entities/models"
 )
 
 const (
-	SnapshotVersion = 0
-	FileName        = "users.json"
+	SnapshotVersion   = 0
+	FileName          = "users.json"
+	UserNameMaxLength = 128
+	UserNameRegexCore = `[A-Za-z][-_0-9A-Za-z@.]{0,128}`
 )
 
 type DBUsers interface {
@@ -48,6 +53,7 @@ type User struct {
 	InternalIdentifier string
 	ApiKeyFirstLetters string
 	CreatedAt          time.Time
+	LastUsedAt         time.Time
 }
 
 type DBUser struct {
@@ -74,7 +80,7 @@ type memoryOnlyData struct {
 	WeakKeyStorageById map[string][sha256.Size]byte
 }
 
-func NewDBUser(path string) (*DBUser, error) {
+func NewDBUser(path string, logger logrus.FieldLogger) (*DBUser, error) {
 	fullpath := fmt.Sprintf("%s/raft/db_users/", path)
 	err := createStorage(fullpath + FileName)
 	if err != nil {
@@ -106,13 +112,30 @@ func NewDBUser(path string) (*DBUser, error) {
 	if snapshot.Data.UserKeyRevoked == nil {
 		snapshot.Data.UserKeyRevoked = make(map[string]struct{})
 	}
-
-	return &DBUser{
+	dbUsers := &DBUser{
 		path:          fullpath,
 		lock:          &sync.RWMutex{},
 		data:          snapshot.Data,
 		memoryOnyData: memoryOnlyData{WeakKeyStorageById: make(map[string][sha256.Size]byte)},
-	}, nil
+	}
+
+	// we save every change to file after a request is done, EXCEPT the lastUsedAt time as we do not want to write to a
+	// file with every request.
+	// This information is not terribly important (besides WCD UX), so it does not matter much if we very rarely loose
+	// some information here. This info will also be written on shutdown so the only loss of information occurs with
+	// OOM or similar.
+	enterrors.GoWrapper(func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		for range ticker.C {
+			func() {
+				dbUsers.lock.RLock()
+				defer dbUsers.lock.RUnlock()
+				_ = dbUsers.storeToFile()
+			}()
+		}
+	}, logger)
+
+	return dbUsers, nil
 }
 
 func (c *DBUser) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters string, createdAt time.Time) error {
@@ -213,6 +236,17 @@ func (c *DBUser) CheckUserIdentifierExists(userIdentifier string) (bool, error) 
 	return ok, nil
 }
 
+func (c *DBUser) UpdateLastUsedTimeStamp(users map[string]time.Time) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	for userID, lastUsed := range users {
+		if c.data.Users[userID].LastUsedAt.Before(lastUsed) {
+			c.data.Users[userID].LastUsedAt = lastUsed
+		}
+	}
+}
+
 func (c *DBUser) ValidateAndExtract(key, userIdentifier string) (*models.Principal, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -244,6 +278,8 @@ func (c *DBUser) ValidateAndExtract(key, userIdentifier string) (*models.Princip
 	if _, ok := c.data.UserKeyRevoked[userId]; ok {
 		return nil, fmt.Errorf("key is revoked")
 	}
+
+	c.data.Users[userId].LastUsedAt = time.Now()
 
 	return &models.Principal{Username: userId, UserType: models.UserTypeInputDb}, nil
 }
@@ -320,6 +356,12 @@ func (c *DBUser) storeToFile() error {
 
 	// Atomically rename the temp file to the target filename to not leave garbage when it crashes
 	return os.Rename(tempFilename, c.path+"/"+FileName)
+}
+
+func (c *DBUser) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.storeToFile()
 }
 
 func createStorage(filePath string) error {

--- a/usecases/auth/authentication/apikey/remote.go
+++ b/usecases/auth/authentication/apikey/remote.go
@@ -40,18 +40,15 @@ func (r *RemoteApiKey) GetUserStatus(ctx context.Context, users UserStatusReques
 		return nil, err
 	}
 
-	userIdsReturned := make([]string, 0, len(userReturns))
-	timesReturned := make([]time.Time, 0, len(userReturns))
+	ret := make(map[string]time.Time, len(userReturns))
 	for _, userReturn := range userReturns {
-		userIdsReturned = append(userIdsReturned, userReturn.Id)
-		timesReturned = append(timesReturned, userReturn.LastUsedAt)
+		ret[userReturn.Id] = userReturn.LastUsedAt
 	}
-	return &UserStatusResponse{UserIds: userIdsReturned, LastUsedAt: timesReturned}, nil
+	return &UserStatusResponse{Users: ret}, nil
 }
 
 type UserStatusResponse struct {
-	UserIds    []string
-	LastUsedAt []time.Time
+	Users map[string]time.Time
 }
 
 type UserStatusRequest struct {

--- a/usecases/auth/authentication/apikey/remote.go
+++ b/usecases/auth/authentication/apikey/remote.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package apikey
+
+import (
+	"context"
+	"time"
+)
+
+type RemoteApiKey struct {
+	apikey *DBUser
+}
+
+func NewRemoteApiKey(apikey *ApiKey) *RemoteApiKey {
+	return &RemoteApiKey{apikey: apikey.Dynamic}
+}
+
+func (r *RemoteApiKey) GetUserStatus(ctx context.Context, users UserStatusRequest) (*UserStatusResponse, error) {
+	r.apikey.UpdateLastUsedTimeStamp(users.Users)
+
+	if !users.ReturnStatus {
+		return nil, nil
+	}
+
+	userIds := make([]string, 0, len(users.Users))
+	for userId := range users.Users {
+		userIds = append(userIds, userId)
+	}
+	userReturns, err := r.apikey.GetUsers(userIds...)
+	if err != nil {
+		return nil, err
+	}
+
+	userIdsReturned := make([]string, 0, len(userReturns))
+	timesReturned := make([]time.Time, 0, len(userReturns))
+	for _, userReturn := range userReturns {
+		userIdsReturned = append(userIdsReturned, userReturn.Id)
+		timesReturned = append(timesReturned, userReturn.LastUsedAt)
+	}
+	return &UserStatusResponse{UserIds: userIdsReturned, LastUsedAt: timesReturned}, nil
+}
+
+type UserStatusResponse struct {
+	UserIds    []string
+	LastUsedAt []time.Time
+}
+
+type UserStatusRequest struct {
+	Users        map[string]time.Time
+	ReturnStatus bool
+}

--- a/usecases/auth/authentication/apikey/remote.go
+++ b/usecases/auth/authentication/apikey/remote.go
@@ -25,7 +25,7 @@ func NewRemoteApiKey(apikey *ApiKey) *RemoteApiKey {
 }
 
 func (r *RemoteApiKey) GetUserStatus(ctx context.Context, users UserStatusRequest) (*UserStatusResponse, error) {
-	r.apikey.UpdateLastUsedTimeStamp(users.Users)
+	r.apikey.UpdateLastUsedTimestamp(users.Users)
 
 	if !users.ReturnStatus {
 		return nil, nil

--- a/usecases/auth/authentication/apikey/wrapper.go
+++ b/usecases/auth/authentication/apikey/wrapper.go
@@ -29,7 +29,7 @@ func New(cfg config.Config, logger logrus.FieldLogger) (*ApiKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	dynamic, err := NewDBUser(cfg.Persistence.DataPath, logger)
+	dynamic, err := NewDBUser(cfg.Persistence.DataPath, cfg.Authentication.DBUsers.Enabled, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/auth/authentication/apikey/wrapper.go
+++ b/usecases/auth/authentication/apikey/wrapper.go
@@ -13,6 +13,7 @@ package apikey
 
 import (
 	"github.com/go-openapi/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -23,12 +24,12 @@ type ApiKey struct {
 	Dynamic *DBUser
 }
 
-func New(cfg config.Config) (*ApiKey, error) {
+func New(cfg config.Config, logger logrus.FieldLogger) (*ApiKey, error) {
 	static, err := NewStatic(cfg)
 	if err != nil {
 		return nil, err
 	}
-	dynamic, err := NewDBUser(cfg.Persistence.DataPath)
+	dynamic, err := NewDBUser(cfg.Persistence.DataPath, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

Adds lastUsedTime to returned db users. The return is optional (off by default) because it is expensive to fetch and should only be done when necessary.

The architecture is the following:
- each nodes records its own last used time. This is not replicated via RAFT due to the high volume as each login changes the time
- when a user is fetched all nodes are asked for their latest time. The latest of all times is used.
  - opportunistic behaviour, low timeout of 1s and errors are ignored => time could jump
- All other nodes are updated with the latest time to minimize "jumping" behaviour when a node is temporary down or unreachable. The request does not wait for this.
- The last used time is not updated in the users.json file, because we don't want to write the full file for each incoming request. There are two mechanisms to ensure that we don't lose any values:
  - background go-routine that updates the file every minute
  - on shutdown the file is written again
  - only failure mode is that we loose all times since the last write (59s max) on an OOM or similar

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
