### PR TITLE
Revert "Do not back up subdirecties"

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_backup_test.go
+++ b/adapters/repos/db/lsmkv/bucket_backup_test.go
@@ -14,8 +14,6 @@ package lsmkv
 import (
 	"context"
 	"fmt"
-	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -68,39 +66,30 @@ func bucketBackup_ListFiles(ctx context.Context, t *testing.T, opts []BucketOpti
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
-	require.NoError(t, err)
+	require.Nil(t, err)
 
-	for i := 0; i < 10; i++ {
-		err := b.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
-		require.NoError(t, err)
-	}
+	t.Run("insert contents into bucket", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			err := b.Put([]byte(fmt.Sprint(i)), []byte(fmt.Sprint(i)))
+			require.Nil(t, err)
+		}
+		b.FlushMemtable() // flush memtable to generate .db files
+	})
 
-	// flush memtable to generate .db files
-	err = b.FlushMemtable()
-	require.NoError(t, err)
+	t.Run("assert expected bucket contents", func(t *testing.T) {
+		files, err := b.ListFiles(ctx, dirName)
+		assert.Nil(t, err)
+		assert.Len(t, files, 3)
 
-	// create an arbitrary directory and file that is a leftover of some old process
-	leftoverDir := path.Join(dirName, "scratch_leftover")
-	require.NoError(t, os.MkdirAll(leftoverDir, 0o755))
-	require.NoError(t, os.WriteFile(path.Join(leftoverDir, "partial_segment.db"), []byte("some data"), 0o644))
+		exts := make([]string, 3)
+		for i, file := range files {
+			exts[i] = filepath.Ext(file)
+		}
+		assert.Contains(t, exts, ".db")    // the segment itself
+		assert.Contains(t, exts, ".bloom") // the segment's bloom filter
+		assert.Contains(t, exts, ".cna")   // the segment's count net additions
+	})
 
-	files, err := b.ListFiles(ctx, dirName)
-	assert.NoError(t, err)
-	assert.Len(t, files, 3)
-
-	// make sure all these files are accessible to prove that the paths are correct
-	for _, file := range files {
-		_, err = os.Stat(file)
-		require.NoError(t, err)
-	}
-
-	exts := make([]string, 3)
-	for i, file := range files {
-		exts[i] = filepath.Ext(file)
-	}
-	assert.Contains(t, exts, ".db")    // the segment itself
-	assert.Contains(t, exts, ".bloom") // the segment's bloom filter
-	assert.Contains(t, exts, ".cna")   // the segment's count net additions
-
-	require.NoError(t, b.Shutdown(context.Background()))
+	err = b.Shutdown(context.Background())
+	require.Nil(t, err)
 }


### PR DESCRIPTION
This reverts commit 00ab68d2c0b76744397d214980f445a5e51ab226.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
