### PR TITLE
Add tests for batching with auto-tenancy

### DIFF
--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -88,6 +88,7 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	parser := NewAggregateParser(
 		s.classGetterWithAuthzFunc(principal),
@@ -123,6 +124,7 @@ func (s *Service) TenantsGet(ctx context.Context, req *pb.TenantsGetRequest) (*p
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	retTenants, err := s.tenantsGet(ctx, principal, req)
 	if err != nil {
@@ -155,6 +157,8 @@ func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	ctx = restCtx.AddPrincipalToContext(ctx, principal)
+
 	replicationProperties := extractReplicationProperties(req.ConsistencyLevel)
 
 	tenant := ""
@@ -204,6 +208,8 @@ func (s *Service) batchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	ctx = restCtx.AddPrincipalToContext(ctx, principal)
+
 	ctx = classcache.ContextWithClassCache(ctx)
 
 	// we need to save the class two times:
@@ -294,6 +300,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	parser := NewParser(
 		req.Uses_127Api,

--- a/test/acceptance/authz/auto_tenancy_test.go
+++ b/test/acceptance/authz/auto_tenancy_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	grpchelper "github.com/weaviate/weaviate/test/helper/grpc"
+
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
@@ -154,8 +156,8 @@ func TestAuthzAutoTenantActivationRBAC(t *testing.T) {
 func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 	adminKey := "admin-key"
 	adminUser := "admin-user"
-	readonlyKey := "readonly-key"
-	readonlyUser := "readonly-user"
+	readonlyKey := "viewer-key"
+	readonlyUser := "viewer-user"
 	adminAuth := helper.CreateAuth(adminKey)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -179,16 +181,20 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 
 	cls := articles.ParagraphsClass()
 	tenant := "tenant"
-	obj := articles.NewParagraph().WithID(UUID1).WithTenant(tenant).Object()
+	obj1 := articles.NewParagraph().WithID(UUID1).WithTenant(tenant).Object()
 	obj2 := articles.NewParagraph().WithID(UUID2).WithTenant(tenant).Object()
+	obj3 := articles.NewParagraph().WithID(UUID3).WithTenant("tenant2").Object()
+	obj4 := articles.NewParagraph().WithID(UUID4).WithTenant("tenant3").Object()
 
 	defer func() {
 		helper.DeleteClassWithAuthz(t, cls.Class, adminAuth)
 		teardown()
 	}()
 
-	deactivateTenant := func(t *testing.T) {
-		helper.UpdateTenantsWithAuthz(t, cls.Class, []*models.Tenant{{Name: obj.Tenant, ActivityStatus: models.TenantActivityStatusCOLD}}, adminAuth)
+	deactivateTenants := func(t *testing.T) {
+		for _, obj := range []*models.Object{obj1, obj2, obj3, obj4} {
+			helper.UpdateTenantsWithAuthz(t, cls.Class, []*models.Tenant{{Name: obj.Tenant, ActivityStatus: models.TenantActivityStatusCOLD}}, adminAuth)
+		}
 	}
 
 	cls.MultiTenancyConfig = &models.MultiTenancyConfig{
@@ -196,34 +202,49 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 		AutoTenantActivation: true,
 		AutoTenantCreation:   false,
 	}
+	helper.DeleteClassWithAuthz(t, cls.Class, adminAuth)
 	helper.CreateClassAuth(t, cls, adminKey)
-	helper.CreateTenantsAuth(t, cls.Class, []*models.Tenant{{Name: obj.Tenant, ActivityStatus: models.TenantActivityStatusHOT}}, adminKey)
+	helper.CreateTenantsAuth(t, cls.Class, []*models.Tenant{{Name: obj1.Tenant, ActivityStatus: models.TenantActivityStatusHOT}}, adminKey)
+	helper.CreateTenantsAuth(t, cls.Class, []*models.Tenant{{Name: obj3.Tenant, ActivityStatus: models.TenantActivityStatusHOT}}, adminKey)
+	helper.CreateTenantsAuth(t, cls.Class, []*models.Tenant{{Name: obj4.Tenant, ActivityStatus: models.TenantActivityStatusHOT}}, adminKey)
 	helper.CreateObjectAuth(t, obj2, adminKey)
-	deactivateTenant(t)
+	deactivateTenants(t)
 
 	t.Run("successfully create object in tenant as admin", func(t *testing.T) {
-		defer deactivateTenant(t)
-		err := helper.CreateObjectAuth(t, obj, adminKey)
+		defer deactivateTenants(t)
+		err := helper.CreateObjectAuth(t, obj1, adminKey)
 		helper.AssertRequestOk(t, nil, err, nil)
 	})
 
 	t.Run("successfully update object in tenant as admin", func(t *testing.T) {
-		defer deactivateTenant(t)
-		obj.Properties = map[string]string{"contents": "updated"}
-		_, err := updateObject(t, obj, adminKey)
+		defer deactivateTenants(t)
+		obj1.Properties = map[string]string{"contents": "updated"}
+		_, err := updateObject(t, obj1, adminKey)
 		helper.AssertRequestOk(t, nil, err, nil)
 	})
 
+	t.Run("successfully batch-create object in tenant as admin", func(t *testing.T) {
+		defer deactivateTenants(t)
+		helper.CreateObjectsBatchAuth(t, []*models.Object{obj3}, adminKey)
+	})
+
+	t.Run("successfully GRPC batch-create object in tenant as admin", func(t *testing.T) {
+		defer deactivateTenants(t)
+		batchReply, err := grpchelper.BatchGRPCWithTenantAuth(t, []*models.Object{obj4}, adminKey)
+		require.NoError(t, err)
+		require.Len(t, batchReply.Errors, 0)
+	})
+
 	t.Run("fail to update object in tenant as read-only", func(t *testing.T) {
-		defer deactivateTenant(t)
-		obj.Properties = map[string]string{"contents": "updated"}
-		_, err := updateObject(t, obj, readonlyKey)
+		defer deactivateTenants(t)
+		obj1.Properties = map[string]string{"contents": "updated"}
+		_, err := updateObject(t, obj1, readonlyKey)
 		helper.AssertRequestFail(t, nil, err, nil)
 	})
 
 	t.Run("fail to delete object in tenant as read-only", func(t *testing.T) {
-		defer deactivateTenant(t)
-		_, err := deleteObject(t, obj.Class, obj.ID, &obj.Tenant, readonlyKey)
+		defer deactivateTenants(t)
+		_, err := deleteObject(t, obj1.Class, obj1.ID, &obj1.Tenant, readonlyKey)
 		helper.AssertRequestFail(t, nil, err, nil)
 	})
 
@@ -237,14 +258,14 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("successfully get object in tenant as %s", tt.name), func(t *testing.T) {
-			defer deactivateTenant(t)
-			_, err := getObject(t, obj.Class, obj.ID, &obj.Tenant, tt.key)
+			defer deactivateTenants(t)
+			_, err := getObject(t, obj1.Class, obj1.ID, &obj1.Tenant, tt.key)
 			helper.AssertRequestOk(t, nil, err, nil)
 		})
 
 		t.Run(fmt.Sprintf("successfully search (Get) with gql in tenant as %s", tt.name), func(t *testing.T) {
-			defer deactivateTenant(t)
-			res, err := queryGQL(t, fmt.Sprintf(`{Get{%s(tenant:%q){_additional{id}}}}`, cls.Class, obj.Tenant), tt.key)
+			defer deactivateTenants(t)
+			res, err := queryGQL(t, fmt.Sprintf(`{Get{%s(tenant:%q){_additional{id}}}}`, cls.Class, obj1.Tenant), tt.key)
 			require.Nil(t, err)
 			require.NotNil(t, res)
 			require.NotEmpty(t, res.GetPayload().Data)
@@ -252,8 +273,8 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("successfully search (Aggregate) with gql in tenant as %s", tt.name), func(t *testing.T) {
-			defer deactivateTenant(t)
-			res, err := queryGQL(t, fmt.Sprintf(`{Aggregate{%s(tenant:%q){meta{count}}}}`, cls.Class, obj.Tenant), tt.key)
+			defer deactivateTenants(t)
+			res, err := queryGQL(t, fmt.Sprintf(`{Aggregate{%s(tenant:%q){meta{count}}}}`, cls.Class, obj1.Tenant), tt.key)
 			require.Nil(t, err)
 			require.NotNil(t, res)
 			require.NotEmpty(t, res.GetPayload().Data)
@@ -261,7 +282,7 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("successfully search (Get) with grpc in tenant as %s", tt.name), func(t *testing.T) {
-			defer deactivateTenant(t)
+			defer deactivateTenants(t)
 			ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", fmt.Sprintf("Bearer %s", tt.key))
 			resp, err := helper.ClientGRPC(t).Search(ctx, &protocol.SearchRequest{
 				Collection: cls.Class,
@@ -272,7 +293,7 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("successfully search (Aggregate) with grpc in tenant as %s", tt.name), func(t *testing.T) {
-			defer deactivateTenant(t)
+			defer deactivateTenants(t)
 			ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", fmt.Sprintf("Bearer %s", tt.key))
 			resp, err := helper.ClientGRPC(t).Aggregate(ctx, &protocol.AggregateRequest{
 				Collection:   cls.Class,
@@ -285,14 +306,14 @@ func TestAuthzAutoTenantActivationAdminList(t *testing.T) {
 	}
 
 	t.Run("successfully delete object in tenant as admin", func(t *testing.T) {
-		defer deactivateTenant(t)
-		_, err := deleteObject(t, obj.Class, obj.ID, &obj.Tenant, adminKey)
+		defer deactivateTenants(t)
+		_, err := deleteObject(t, obj1.Class, obj1.ID, &obj1.Tenant, adminKey)
 		helper.AssertRequestOk(t, nil, err, nil)
 	})
 
 	t.Run("fail to create object in tenant as read-only", func(t *testing.T) {
-		defer deactivateTenant(t)
-		err := helper.CreateObjectAuth(t, obj, readonlyKey)
+		defer deactivateTenants(t)
+		err := helper.CreateObjectAuth(t, obj1, readonlyKey)
 		helper.AssertRequestFail(t, nil, err, nil)
 	})
 }

--- a/test/helper/grpc/grpc_helper.go
+++ b/test/helper/grpc/grpc_helper.go
@@ -13,8 +13,13 @@ package grpchelper
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/stretchr/testify/require"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
@@ -46,6 +51,31 @@ func AssertSearchWithTimeout(t *testing.T, req *pb.SearchRequest, timeout time.D
 		t.Errorf("SearchWithTimeout failed: %v", err)
 	}
 	return resp
+}
+
+func BatchGRPCWithTenantAuth(t *testing.T, objects []*models.Object, key string) (*pb.BatchObjectsReply, error) {
+	var objectsGRPC []*pb.BatchObject
+
+	for _, obj := range objects {
+		props := &structpb.Struct{Fields: map[string]*structpb.Value{}}
+		for name, val := range obj.Properties.(map[string]interface{}) {
+			valTyped := val.(*structpb.Value)
+			props.Fields[name] = valTyped
+		}
+
+		objectsGRPC = append(objectsGRPC, &pb.BatchObject{
+			Tenant:     obj.Tenant,
+			Collection: obj.Class,
+			Uuid:       obj.ID.String(),
+			Properties: &pb.BatchObject_Properties{NonRefProperties: props},
+			// Vector is missing
+		},
+		)
+	}
+	req := &pb.BatchObjectsRequest{Objects: objectsGRPC}
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", fmt.Sprintf("Bearer %s", key))
+
+	return helper.ClientGRPC(t).BatchObjects(ctx, req)
 }
 
 func ToPtr[T any](val T) *T {


### PR DESCRIPTION
### What's being changed:

We had an incident with v1.28.10 where we didn’t add the principal to the context. When the auto_tenancy permission check happens:
- the principal is nil 
- user anonymous 
- permission check fails even though an admin-key was used

We removed the required permissions for auto_tenancy as part of [the original bug fix](https://github.com/weaviate/weaviate/pull/7537), so the problem does exist on stable/v1.28 anymore.

This PR adds:
- tests that trigger the problem on v1.28.10 and pass now
- added the principal to the context just-in-case and verified that this would have fixed the problem on v1.28.10
  - This would not have fixed the problem with ro keys

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
