### PR TITLE
test: add Snapshot test to verify FSM snapshots e.g. the RBAC was restored correctly from a snapshot

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -478,7 +478,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		EnableFQDNResolver:     appState.ServerConfig.Config.Raft.EnableFQDNResolver,
 		FQDNResolverTLD:        appState.ServerConfig.Config.Raft.FQDNResolverTLD,
 		SentryEnabled:          appState.ServerConfig.Config.Sentry.Enabled,
-		AuthzController:        appState.AuthzController,
 	}
 	for _, name := range appState.ServerConfig.Config.Raft.Join[:rConfig.BootstrapExpect] {
 		if strings.Contains(name, rConfig.NodeID) {
@@ -487,7 +486,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		}
 	}
 
-	appState.ClusterService = rCluster.New(rConfig, appState.GRPCServerMetrics)
+	appState.ClusterService = rCluster.New(rConfig, appState.AuthzController, appState.AuthzSnapshotter, appState.GRPCServerMetrics)
 	migrator.SetCluster(appState.ClusterService.Raft)
 
 	executor := schema.NewExecutor(migrator,

--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -125,6 +125,7 @@ func configureAuthorizer(appState *state.State) error {
 		}
 
 		appState.AuthzController = rbacController
+		appState.AuthzSnapshotter = rbacController
 		appState.Authorizer = rbacController
 	} else if appState.ServerConfig.Config.Authorization.AdminList.Enabled {
 		appState.Authorizer = adminlist.New(appState.ServerConfig.Config.Authorization.AdminList)

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -17,11 +17,13 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/handlers/graphql"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/tenantactivity"
 	"github.com/weaviate/weaviate/adapters/repos/classifications"
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	rCluster "github.com/weaviate/weaviate/cluster"
+	"github.com/weaviate/weaviate/cluster/fsm"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/anonymous"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/oidc"
@@ -46,11 +48,12 @@ import (
 // NOTE: This is not true yet, see gh-723
 // TODO: remove dependencies to anything that's not an ent or uc
 type State struct {
-	OIDC            *oidc.Client
-	AnonymousAccess *anonymous.Client
-	APIKey          *apikey.Client
-	Authorizer      authorization.Authorizer
-	AuthzController authorization.Controller
+	OIDC             *oidc.Client
+	AnonymousAccess  *anonymous.Client
+	APIKey           *apikey.Client
+	Authorizer       authorization.Authorizer
+	AuthzController  authorization.Controller
+	AuthzSnapshotter fsm.Snapshotter
 
 	ServerConfig          *config.WeaviateConfig
 	LDIntegration         *configRuntime.LDIntegration

--- a/cluster/fsm/snapshot.go
+++ b/cluster/fsm/snapshot.go
@@ -1,0 +1,36 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package fsm
+
+// Snapshot is the snapshot of the cluster FSMs (schema, rbac, etc)
+// it is used to restore the Snapshot to a previous state,
+// or to bring out-of-date followers up to a recent log index.
+type Snapshot struct {
+	// NodeID is the id of the node that created the snapshot
+	NodeID string `json:"node_id"`
+	// SnapshotID is the id of the snapshot comes from the provided Sink
+	SnapshotID string `json:"snapshot_id"`
+	// LegacySchema is the old schema that was used to create the snapshot
+	// it is used to restore the schema if the snapshot is not compatible with the current schema
+	// note: this is not used anymore, but we keep it for backwards compatibility
+	LegacySchema map[string]any `json:"classes,omitempty"`
+	// Schema is the new schema that will be used to restore the FSM
+	Schema []byte `json:"schema,omitempty"`
+	// RBAC is the rbac that will be used to restore the FSM
+	RBAC []byte `json:"rbac,omitempty"`
+}
+
+// Snapshotter is used to snapshot and restore any (FSM) state
+type Snapshotter interface {
+	Snapshot() ([]byte, error)
+	Restore([]byte) error
+}

--- a/cluster/mocks/sink.go
+++ b/cluster/mocks/sink.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package mocks
+
+import "bytes"
+
+// Snapshot sink implementation for testing
+type SnapshotSink struct {
+	Buffer     *bytes.Buffer
+	WriteError error
+}
+
+func (t *SnapshotSink) Write(p []byte) (n int, err error) {
+	if t.WriteError != nil {
+		return 0, t.WriteError
+	}
+	return t.Buffer.Write(p)
+}
+
+func (t *SnapshotSink) Close() error {
+	return nil
+}
+
+func (t *SnapshotSink) ID() string {
+	return "test-snapshot-id"
+}
+
+func (t *SnapshotSink) Cancel() error {
+	return nil
+}

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -94,7 +94,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	m.indexer.AssertExpectations(t)
 
 	// Create a new FSM that will restore from it's state from the disk (using snapshot and logs)
-	s := NewFSM(m.cfg, prometheus.NewPedanticRegistry())
+	s := NewFSM(m.cfg, nil, nil, prometheus.NewPedanticRegistry())
 	m.store = &s
 	// We refresh the mock schema to ensure that we can assert no calls except Open are sent to the database
 	m.indexer = fakes.NewMockSchemaExecutor()
@@ -112,7 +112,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 
 	// Ensure that the class has been restored and that the tenant is present with the right state
 	schemaReader = srv.SchemaReader()
-	assert.Equal(t, schemaReader.ClassEqual(cls.Class), cls.Class)
+	assert.Equal(t, cls.Class, schemaReader.ClassEqual(cls.Class))
 	assert.Equal(t, "S1", schemaReader.CopyShardingState(cls.Class).Physical["T0"].Status)
 
 	// Ensure there was no supplementary call to the underlying DB as we were just recovering the schema

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/cluster/types"
@@ -297,7 +298,7 @@ func TestRaftEndpoints(t *testing.T) {
 	// restore from snapshot
 	assert.Nil(t, srv.Close(ctx))
 
-	s := NewFSM(m.cfg, prometheus.NewPedanticRegistry())
+	s := NewFSM(m.cfg, nil, nil, prometheus.NewPedanticRegistry())
 	m.store = &s
 	srv = NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	assert.Nil(t, srv.Open(ctx, m.indexer))
@@ -339,7 +340,7 @@ func TestRaftClose(t *testing.T) {
 	ctx := context.Background()
 	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
 	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
-	s := NewFSM(m.cfg, prometheus.NewPedanticRegistry())
+	s := NewFSM(m.cfg, nil, nil, prometheus.NewPedanticRegistry())
 	m.store = &s
 	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	m.indexer.On("Open", mock.Anything).Return(nil)

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/cluster/fsm"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
@@ -25,12 +26,13 @@ import (
 var ErrBadRequest = errors.New("bad request")
 
 type Manager struct {
-	authZ  authorization.Controller
-	logger logrus.FieldLogger
+	authZ       authorization.Controller
+	snapshotter fsm.Snapshotter
+	logger      logrus.FieldLogger
 }
 
-func NewManager(authZ authorization.Controller, logger logrus.FieldLogger) *Manager {
-	return &Manager{authZ: authZ, logger: logger}
+func NewManager(authZ authorization.Controller, snapshotter fsm.Snapshotter, logger logrus.FieldLogger) *Manager {
+	return &Manager{authZ: authZ, snapshotter: snapshotter, logger: logger}
 }
 
 func (m *Manager) GetRoles(req *cmd.QueryRequest) ([]byte, error) {
@@ -227,4 +229,22 @@ func (m *Manager) RevokeRolesForUser(c *cmd.ApplyRequest) error {
 	}
 
 	return m.authZ.RevokeRolesForUser(req.User, req.Roles...)
+}
+
+func (m *Manager) Snapshot() ([]byte, error) {
+	if m.snapshotter == nil {
+		return nil, nil
+	}
+	return m.snapshotter.Snapshot()
+}
+
+func (m *Manager) Restore(b []byte) error {
+	if m.snapshotter == nil {
+		return nil
+	}
+	if err := m.snapshotter.Restore(b); err != nil {
+		return err
+	}
+	m.logger.Info("successfully restored rbac from snapshot")
+	return nil
 }

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -12,25 +12,17 @@
 package schema
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
-
-var errAny = errors.New("any error")
 
 func TestVersionedSchemaReaderShardReplicas(t *testing.T) {
 	var (
@@ -262,51 +254,6 @@ func TestSchemaReaderClass(t *testing.T) {
 	assert.Empty(t, shards)
 }
 
-func TestSchemaSnapshot(t *testing.T) {
-	var (
-		node   = "N1"
-		sc     = NewSchema(node, fakes.NewMockSchemaExecutor(), prometheus.NewPedanticRegistry())
-		parser = fakes.NewMockParser()
-
-		cls = &models.Class{Class: "C"}
-		ss  = &sharding.State{
-			Physical: map[string]sharding.Physical{
-				"S1": {Status: "A"},
-				"S2": {Status: "A", BelongsToNodes: []string{"A", "B"}},
-			},
-		}
-	)
-	ss.SetLocalName(node)
-	assert.Nil(t, sc.addClass(cls, ss, 1))
-	parser.On("ParseClass", mock.Anything).Return(nil)
-
-	// Create Snapshot
-	sink := &MockSnapshotSink{}
-	assert.Nil(t, sc.Persist(sink))
-
-	// restore snapshot. Restore should also set the metrics correctly.
-	sc2 := NewSchema("N1", fakes.NewMockSchemaExecutor(), prometheus.NewPedanticRegistry())
-	assert.Nil(t, sc2.Restore(sink, parser))
-	assert.Equal(t, sc.classes, sc2.classes)
-	assert.Equal(t, float64(1), testutil.ToFloat64(sc2.collectionsCount))
-	assert.Equal(t, float64(2), testutil.ToFloat64(sc2.shardsCount.WithLabelValues("A")))
-
-	// Encoding error
-	sink2 := &MockSnapshotSink{wErr: errAny, rErr: errAny}
-	assert.ErrorContains(t, sc.Persist(sink2), "encode")
-
-	// Decoding Error
-	assert.ErrorContains(t, sc.Restore(sink2, parser), "decode")
-
-	// Parsing Error
-	parser2 := fakes.NewMockParser()
-	parser2.On("ParseClass", mock.Anything).Return(errAny)
-
-	sink3 := &MockSnapshotSink{}
-	assert.Nil(t, sc.Persist(sink3))
-	assert.ErrorContains(t, sc.Restore(sink3, parser2), "pars")
-}
-
 // TestPropertiesMigration ensures that our migration function sets proper default values
 // The test verifies that we migrate top level properties and then at least one layer deep nested properties
 func TestPropertiesMigration(t *testing.T) {
@@ -347,30 +294,4 @@ type MockShardReader struct {
 
 func (m *MockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
 	return m.lst, m.err
-}
-
-type MockSnapshotSink struct {
-	buf bytes.Buffer
-	io.WriteCloser
-	wErr error
-	rErr error
-}
-
-func (MockSnapshotSink) ID() string    { return "ID" }
-func (MockSnapshotSink) Cancel() error { return nil }
-
-func (m *MockSnapshotSink) Write(p []byte) (n int, err error) {
-	if m.wErr != nil {
-		return 0, m.wErr
-	}
-	return m.buf.Write(p)
-}
-
-func (m *MockSnapshotSink) Close() error { return nil }
-
-func (m *MockSnapshotSink) Read(p []byte) (n int, err error) {
-	if m.rErr != nil {
-		return 0, m.rErr
-	}
-	return m.buf.Read(p)
 }

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -15,11 +15,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -539,40 +537,32 @@ func (s *schema) MetaClasses() map[string]*metaClass {
 	return classesCopy
 }
 
-func (s *schema) Restore(r io.Reader, parser Parser) error {
-	snap := snapshot{}
-	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+func (s *schema) Restore(data []byte, parser Parser) error {
+	var classes map[string]*metaClass
+	if err := json.Unmarshal(data, &classes); err != nil {
 		return fmt.Errorf("restore snapshot: decode json: %w", err)
 	}
-	for _, cls := range snap.Classes {
+
+	return s.restore(classes, parser)
+}
+
+func (s *schema) RestoreLegacy(data []byte, parser Parser) error {
+	snap := snapshot{}
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return fmt.Errorf("restore snapshot: decode json: %w", err)
+	}
+	return s.restore(snap.Classes, parser)
+}
+
+func (s *schema) restore(classes map[string]*metaClass, parser Parser) error {
+	for _, cls := range classes {
 		if err := parser.ParseClass(&cls.Class); err != nil { // should not fail
 			return fmt.Errorf("parsing class %q: %w", cls.Class.Class, err) // schema might be corrupted
 		}
 		cls.Sharding.SetLocalName(s.nodeID)
 	}
-
-	s.replaceClasses(snap.Classes)
+	s.replaceClasses(classes)
 	return nil
-}
-
-// Persist should dump all necessary state to the WriteCloser 'sink',
-// and call sink.Close() when finished or call sink.Cancel() on error.
-func (s *schema) Persist(sink raft.SnapshotSink) (err error) {
-	// we don't need to lock here because, we call MetaClasses() which is thread-safe
-	defer sink.Close()
-	snap := snapshot{
-		NodeID:     s.nodeID,
-		SnapshotID: sink.ID(),
-		Classes:    s.MetaClasses(),
-	}
-	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
-		return fmt.Errorf("encode: %w", err)
-	}
-
-	return nil
-}
-
-func (s *schema) Release() {
 }
 
 // makeTenant creates a tenant with the given name and status

--- a/cluster/schema/snapshot.go
+++ b/cluster/schema/snapshot.go
@@ -17,13 +17,15 @@ import (
 	"io"
 
 	"github.com/hashicorp/raft"
+
 	"github.com/weaviate/weaviate/cluster/types"
 )
 
+// snapshot is the old format, we keep it for backwards compatibility
 type snapshot struct {
 	NodeID     string                `json:"node_id"`
 	SnapshotID string                `json:"snapshot_id"`
-	Classes    map[string]*metaClass `json:"classes"`
+	Classes    map[string]*metaClass `json:"classes,omitempty"`
 }
 
 // LegacySnapshot returns a ready-to-use in-memory Raft snapshot based on the provided legacy schema

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/cluster/fsm"
 	"github.com/weaviate/weaviate/cluster/log"
 	rbacRaft "github.com/weaviate/weaviate/cluster/rbac"
 	"github.com/weaviate/weaviate/cluster/resolver"
@@ -148,9 +149,6 @@ type Config struct {
 
 	EnableFQDNResolver bool
 	FQDNResolverTLD    string
-
-	// 	AuthzController to manage RBAC commands and apply it to casbin
-	AuthzController authorization.Controller
 }
 
 // Store is the implementation of RAFT on this local node. It will handle the local schema and RAFT operations (startup,
@@ -203,7 +201,7 @@ type Store struct {
 	lastAppliedIndex atomic.Uint64
 }
 
-func NewFSM(cfg Config, reg prometheus.Registerer) Store {
+func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fsm.Snapshotter, reg prometheus.Registerer) Store {
 	// We have different resolver in raft so that depending on the environment we can resolve a node-id to an IP using
 	// different methods.
 	var raftResolver types.RaftResolver
@@ -231,7 +229,7 @@ func NewFSM(cfg Config, reg prometheus.Registerer) Store {
 		applyTimeout:  time.Second * 20,
 		raftResolver:  raftResolver,
 		schemaManager: schemaManager,
-		authZManager:  rbacRaft.NewManager(cfg.AuthzController, cfg.Logger),
+		authZManager:  rbacRaft.NewManager(authZController, snapshotter, cfg.Logger),
 	}
 }
 
@@ -763,6 +761,7 @@ func (st *Store) recoverSingleNode(force bool) error {
 		applyTimeout:  st.applyTimeout,
 		snapshotStore: st.snapshotStore,
 		schemaManager: st.schemaManager,
+		authZManager:  st.authZManager,
 		logStore:      st.logStore,
 		logCache:      st.logCache,
 	}, st.logCache,

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -12,14 +12,48 @@
 package cluster
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
 
 	"github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/cluster/fsm"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
+
+// Persist should dump all necessary state to the WriteCloser 'sink',
+// and call sink.Close() when finished or call sink.Cancel() on error.
+func (s *Store) Persist(sink raft.SnapshotSink) (err error) {
+	defer sink.Close()
+	schemaSnapshot, err := s.schemaManager.Snapshot()
+	if err != nil {
+		return fmt.Errorf("schema snapshot: %w", err)
+	}
+
+	rbacSnapshot, err := s.authZManager.Snapshot()
+	if err != nil {
+		return fmt.Errorf("rbac snapshot: %w", err)
+	}
+	snap := fsm.Snapshot{
+		NodeID:     s.cfg.NodeID,
+		SnapshotID: sink.ID(),
+		Schema:     schemaSnapshot,
+		RBAC:       rbacSnapshot,
+	}
+	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+
+	return nil
+}
+
+// Release is invoked when we are finished with the snapshot.
+// Satisfy the interface for raft.FSMSnapshot
+func (s *Store) Release() {
+}
 
 // Snapshot returns an FSMSnapshot used to: support log compaction, to
 // restore the FSM to a previous state, or to bring out-of-date followers up
@@ -35,7 +69,7 @@ import (
 // be implemented to allow for concurrent updates while a snapshot is happening.
 func (st *Store) Snapshot() (raft.FSMSnapshot, error) {
 	st.log.Info("persisting snapshot")
-	return st.schemaManager.Snapshot(), nil
+	return st, nil
 }
 
 // Restore is used to restore an FSM from a snapshot. It is not called
@@ -50,11 +84,35 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 			}
 		}()
 
-		if err := st.schemaManager.Restore(rc, st.cfg.Parser); err != nil {
-			st.log.WithError(err).Error("restoring schema from snapshot")
-			return fmt.Errorf("restore schema from snapshot: %w", err)
+		snap := fsm.Snapshot{}
+		if err := json.NewDecoder(rc).Decode(&snap); err != nil {
+			return fmt.Errorf("restore snapshot: decode json: %w", err)
 		}
+
+		if snap.Schema != nil {
+			if err := st.schemaManager.Restore(snap.Schema, st.cfg.Parser); err != nil {
+				st.log.WithError(err).Error("restoring schema from snapshot")
+				return fmt.Errorf("restore schema from snapshot: %w", err)
+			}
+		} else {
+			// old snapshot format
+			jsonBytes, err := json.Marshal(snap)
+			if err != nil {
+				return fmt.Errorf("restore snapshot: marshal json: %w", err)
+			}
+
+			if err := st.schemaManager.RestoreLegacy(jsonBytes, st.cfg.Parser); err != nil {
+				st.log.WithError(err).Error("restoring schema from snapshot")
+				return fmt.Errorf("restore schema from snapshot: %w", err)
+			}
+		}
+
 		st.log.Info("successfully restored schema from snapshot")
+
+		if err := st.authZManager.Restore(snap.RBAC); err != nil {
+			st.log.WithError(err).Error("restoring rbac from snapshot")
+			return fmt.Errorf("restore rbac from snapshot: %w", err)
+		}
 
 		if st.cfg.MetadataOnlyVoters {
 			return nil

--- a/cluster/store_snapshot_test.go
+++ b/cluster/store_snapshot_test.go
@@ -1,0 +1,355 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/weaviate/weaviate/cluster/mocks"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/utils"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestSchemaSnapshotPersistAndRestore tests snapshot persistence and restoration
+func TestSchemaSnapshotPersistAndRestore(t *testing.T) {
+	// Setup test schema data directly using the Store's Apply method
+	source := NewMockStore(t, "source-node", utils.MustGetFreeTCPPort())
+	setupTestSchema(t, source)
+	snapshotSink := &mocks.SnapshotSink{
+		Buffer: bytes.NewBuffer(nil),
+	}
+
+	snapshot, err := source.store.Snapshot()
+	assert.NoError(t, err)
+
+	err = snapshot.Persist(snapshotSink)
+	assert.NoError(t, err)
+
+	target := NewMockStore(t, "target-node", utils.MustGetFreeTCPPort())
+	target.store.init()
+	target.parser.On("ParseClass", mock.Anything).Return(nil)
+	target.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+	target.indexer.On("RestoreClassDir", mock.Anything).Return(nil)
+	target.indexer.On("UpdateShardStatus", mock.Anything).Return(nil)
+	target.indexer.On("AddClass", mock.Anything).Return(nil)
+
+	snapshotReader := io.NopCloser(bytes.NewReader(snapshotSink.Buffer.Bytes()))
+
+	err = target.store.Restore(snapshotReader)
+	assert.NoError(t, err)
+
+	verifySchemaRestoration(t, source, target)
+}
+
+// TestSchemaSnapshotEmptyStore tests snapshot persistence and restoration with an empty store
+func TestSchemaSnapshotEmptyStore(t *testing.T) {
+	source := NewMockStore(t, "empty-source-node", utils.MustGetFreeTCPPort())
+
+	snapshotSink := &mocks.SnapshotSink{
+		Buffer: bytes.NewBuffer(nil),
+	}
+
+	snapshot, err := source.store.Snapshot()
+	assert.NoError(t, err)
+
+	err = snapshot.Persist(snapshotSink)
+	assert.NoError(t, err)
+
+	target := NewMockStore(t, "empty-target-node", utils.MustGetFreeTCPPort())
+	target.store.init()
+
+	target.parser.On("ParseClass", mock.Anything).Return(nil)
+	target.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+	snapshotReader := io.NopCloser(bytes.NewReader(snapshotSink.Buffer.Bytes()))
+
+	err = target.store.Restore(snapshotReader)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, source.store.SchemaReader().Len(), "Source schema should be empty")
+	assert.Equal(t, 0, target.store.SchemaReader().Len(), "Target schema should be empty")
+}
+
+// TestSchemaSnapshotPersistError tests handling errors during snapshot persistence
+func TestSchemaSnapshotPersistError(t *testing.T) {
+	// Create source store with schema data
+	source := NewMockStore(t, "error-source-node", utils.MustGetFreeTCPPort())
+
+	errorSink := &mocks.SnapshotSink{
+		Buffer:     bytes.NewBuffer(nil),
+		WriteError: errors.New("simulated write error"),
+	}
+
+	snapshot, err := source.store.Snapshot()
+	assert.NoError(t, err)
+
+	// Persist the snapshot - should return an error
+	err = snapshot.Persist(errorSink)
+	assert.Error(t, err, "Expected an error during snapshot persistence")
+	assert.Contains(t, err.Error(), "simulated write error", "Error should contain the specific write error")
+}
+
+// TestSchemaSnapshotRestoreError tests handling errors during snapshot restoration
+func TestSchemaSnapshotRestoreError(t *testing.T) {
+	// Create source store with schema data
+	source := NewMockStore(t, "restore-error-source-node", utils.MustGetFreeTCPPort())
+	setupTestSchema(t, source)
+
+	snapshotSink := &mocks.SnapshotSink{
+		Buffer: bytes.NewBuffer(nil),
+	}
+
+	snapshot, err := source.store.Snapshot()
+	assert.NoError(t, err)
+
+	err = snapshot.Persist(snapshotSink)
+	assert.NoError(t, err)
+
+	target := NewMockStore(t, "restore-error-target-node", utils.MustGetFreeTCPPort())
+	target.store.init()
+
+	snapshotReader := io.NopCloser(bytes.NewReader(snapshotSink.Buffer.Bytes()))
+
+	// Restore from snapshot - should return an error
+	target.parser.On("ParseClass", mock.Anything).Return(errors.New("simulated parse error"))
+	err = target.store.Restore(snapshotReader)
+	assert.Error(t, err, "Expected an error during snapshot restoration")
+	assert.Contains(t, err.Error(), "simulated parse error", "Error should contain the specific parse error")
+}
+
+// TestSchemaSnapshotCorruptedData tests restoration from corrupted snapshot data
+func TestSchemaSnapshotCorruptedData(t *testing.T) {
+	target := NewMockStore(t, "corrupt-target-node", utils.MustGetFreeTCPPort())
+
+	target.parser.On("ParseClass", mock.Anything).Return(nil)
+	target.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+	corruptedData := bytes.NewBufferString(`{invalid`)
+	snapshotReader := io.NopCloser(corruptedData)
+
+	// Restore from snapshot - should return an error
+	err := target.store.Restore(snapshotReader)
+	assert.Error(t, err, "Expected an error when restoring from corrupted data")
+}
+
+// TestConcurrentSnapshotOperations tests the thread safety of snapshot operations
+// when performed concurrently
+func TestConcurrentSnapshotOperations(t *testing.T) {
+	source := NewMockStore(t, "concurrent-snapshot-node", utils.MustGetFreeTCPPort())
+	setupTestSchema(t, source)
+	source.store.init()
+	const numGoroutines = 10
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 3)
+
+	// Test concurrent Persist operations
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				sink := &mocks.SnapshotSink{
+					Buffer: &bytes.Buffer{},
+				}
+				err := source.store.Persist(sink)
+				assert.NoError(t, err)
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+	target := NewMockStore(t, "concurrent-snapshot-node", utils.MustGetFreeTCPPort())
+	target.store.init()
+	// Test concurrent Restore operations
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				sink := &mocks.SnapshotSink{
+					Buffer: &bytes.Buffer{},
+				}
+				err := source.store.Persist(sink)
+				assert.NoError(t, err)
+
+				target.parser.On("ParseClass", mock.Anything).Return(nil)
+				target.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+				// Restore from the snapshot
+				err = target.store.Restore(io.NopCloser(bytes.NewBuffer(sink.Buffer.Bytes())))
+				assert.NoError(t, err)
+				time.Sleep(time.Microsecond)
+				verifySchemaRestoration(t, source, target)
+				sourceSchema := source.store.SchemaReader().ReadOnlySchema()
+				targetSchema := target.store.SchemaReader().ReadOnlySchema()
+				assert.Greater(t, len(sourceSchema.Classes), 0)
+				assert.Equal(t, len(sourceSchema.Classes), len(targetSchema.Classes))
+			}
+		}()
+	}
+
+	// Test concurrent reads while snapshot operations are happening
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				schema := source.store.SchemaReader().ReadOnlySchema()
+				assert.NotNil(t, schema)
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func setupTestSchema(t *testing.T, ms MockStore) {
+	// Set up mock behaviors
+	ms.parser.On("ParseClass", mock.Anything).Return(nil)
+	ms.indexer.On("AddClass", mock.Anything).Return(nil)
+	ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+	productClass := &models.Class{
+		Class: "Product",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"tenant1": {
+				Name:           "tenant1",
+				BelongsToNodes: []string{ms.cfg.NodeID},
+				Status:         models.TenantActivityStatusHOT,
+			},
+			"tenant2": {
+				Name:           "tenant2",
+				BelongsToNodes: []string{ms.cfg.NodeID},
+				Status:         models.TenantActivityStatusCOLD,
+			},
+		},
+	}
+
+	categoryClass := &models.Class{
+		Class: "Category",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	categoryShardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"tenant3": {
+				Name:           "tenant3",
+				BelongsToNodes: []string{ms.cfg.NodeID},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+	}
+
+	// Create mock raft logs to use with the Store's Apply method
+	productLog := raft.Log{
+		Data: cmdAsBytes("Product",
+			cmd.ApplyRequest_TYPE_ADD_CLASS,
+			cmd.AddClassRequest{
+				Class: productClass,
+				State: shardingState,
+			}, nil),
+	}
+
+	categoryLog := raft.Log{
+		Data: cmdAsBytes("Category",
+			cmd.ApplyRequest_TYPE_ADD_CLASS,
+			cmd.AddClassRequest{
+				Class: categoryClass,
+				State: categoryShardingState,
+			}, nil),
+	}
+
+	// Apply the logs to add the classes
+	ms.store.Apply(&productLog)
+	ms.store.Apply(&categoryLog)
+
+	// Verify classes were added
+	assert.NotNil(t, ms.store.SchemaReader().ReadOnlyClass("Product"), "Product class should be added")
+	assert.NotNil(t, ms.store.SchemaReader().ReadOnlyClass("Category"), "Category class should be added")
+}
+
+func verifySchemaRestoration(t *testing.T, source, target MockStore) {
+	// Get source and target schema readers
+	sourceSchema := source.store.SchemaReader()
+	targetSchema := target.store.SchemaReader()
+
+	// Verify classes count
+	assert.Equal(t, sourceSchema.Len(), targetSchema.Len(), "Schema class count should match")
+
+	// Get all classes via ReadOnlySchema
+	sourceClasses := sourceSchema.ReadOnlySchema().Classes
+	targetClasses := targetSchema.ReadOnlySchema().Classes
+
+	// Verify class count
+	assert.Equal(t, len(sourceClasses), len(targetClasses), "Number of classes should match")
+
+	// Create a map for easier lookup of target classes
+	targetClassMap := make(map[string]*models.Class)
+	for _, class := range targetClasses {
+		targetClassMap[class.Class] = class
+	}
+
+	// Verify class properties and configuration
+	for _, sourceClass := range sourceClasses {
+		targetClass, exists := targetClassMap[sourceClass.Class]
+		assert.True(t, exists, "Class %s should exist in target", sourceClass.Class)
+
+		if exists {
+			// Compare properties
+			assert.Equal(t, len(sourceClass.Properties), len(targetClass.Properties),
+				"Number of properties should match for class %s", sourceClass.Class)
+
+			// Compare vector configs
+			assert.Equal(t, len(sourceClass.VectorConfig), len(targetClass.VectorConfig),
+				"Vector config count should match for class %s", sourceClass.Class)
+
+			// Compare sharding state
+			sourceShardingState := sourceSchema.CopyShardingState(sourceClass.Class)
+			targetShardingState := targetSchema.CopyShardingState(sourceClass.Class)
+
+			if sourceShardingState != nil && targetShardingState != nil {
+				assert.Equal(t, len(sourceShardingState.Physical), len(targetShardingState.Physical),
+					"Number of tenants should match for class %s", sourceClass.Class)
+
+				// Compare each tenant's configuration
+				for tenantName, sourceTenant := range sourceShardingState.Physical {
+					targetTenant, exists := targetShardingState.Physical[tenantName]
+					assert.True(t, exists, "Tenant %s should exist in target for class %s", tenantName, sourceClass.Class)
+
+					if exists {
+						assert.Equal(t, sourceTenant.Status, targetTenant.Status,
+							"Tenant status should match for %s in class %s", tenantName, sourceClass.Class)
+						assert.Equal(t, len(sourceTenant.BelongsToNodes), len(targetTenant.BelongsToNodes),
+							"Node count should match for tenant %s in class %s", tenantName, sourceClass.Class)
+					}
+				}
+			}
+		}
+	}
+}

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -586,7 +586,7 @@ func NewMockStore(t *testing.T, nodeID string, raftPort int) MockStore {
 			ConsistencyWaitTimeout: time.Millisecond * 50,
 		},
 	}
-	s := NewFSM(ms.cfg, prometheus.NewPedanticRegistry())
+	s := NewFSM(ms.cfg, nil, nil, prometheus.NewPedanticRegistry())
 	ms.store = &s
 	return ms
 }

--- a/test/acceptance/snapshots/raft_snapshot_test.go
+++ b/test/acceptance/snapshots/raft_snapshot_test.go
@@ -1,0 +1,128 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package recovery
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+)
+
+func TestRBACSnapshotRecovery(t *testing.T) {
+	// Set up test users and roles
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	testRole := "test_role"
+
+	ctx := context.Background()
+	// Start a 3-node cluster with RBAC enabled and a low snapshot threshold
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithApiKey().
+		WithUserApiKey(adminUser, adminKey).
+		WithRBAC().
+		WithRbacAdmins(adminUser).
+		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", "1"). // Force snapshot after every change
+		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").  // Force snapshot every second
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").      // Keep one trailing logs
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %v", err)
+		}
+	}()
+
+	// Stop node 3 directly to make sure it doesn't get any added roles
+	t.Run("stop node 3", func(t *testing.T) {
+		require.NoError(t, compose.StopAt(ctx, 2, nil))
+	})
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	// Create all roles while node 3 is down
+	t.Run("create roles while node 3 is down", func(t *testing.T) {
+		// Create roles
+		for idx := 0; idx < 100; idx++ {
+			roleName := fmt.Sprintf("%s_while_down_%d", testRole, idx)
+			helper.CreateRole(t, adminKey, &models.Role{
+				Name: &roleName,
+				Permissions: []*models.Permission{{
+					Action: String(authorization.CreateCollections),
+					Collections: &models.PermissionCollections{
+						Collection: String("*"),
+					},
+				}},
+			})
+		}
+
+		for idx := 0; idx < 100; idx++ {
+			roleName := fmt.Sprintf("%s_while_down_%d", testRole, idx)
+			role := helper.GetRoleByName(t, adminKey, roleName)
+			require.NotNil(t, role)
+			require.Equal(t, roleName, *role.Name)
+		}
+	})
+
+	// Start node 3 back up
+	t.Run("start node 3", func(t *testing.T) {
+		require.NoError(t, compose.StartAt(ctx, 2))
+		helper.SetupClient(compose.GetWeaviateNode3().URI())
+	})
+
+	// Verify all roles exist on recovered node
+	t.Run("verify roles on recovered node", func(t *testing.T) {
+		// Wait for node 3 to be ready and verify checksums match
+		assert.Eventually(t, func() bool {
+			checksum1 := getPolicyChecksum(t, compose.GetWeaviate().Container())
+			checksum2 := getPolicyChecksum(t, compose.GetWeaviateNode2().Container())
+			checksum3 := getPolicyChecksum(t, compose.GetWeaviateNode3().Container())
+
+			// All checksums should match
+			return checksum1 != "" && checksum2 != "" && checksum3 != "" &&
+				checksum1 == checksum2 && checksum1 == checksum3
+		}, 60*time.Second, 1*time.Second, "Policy checksums should match across all nodes")
+	})
+}
+
+func getPolicyChecksum(t *testing.T, container testcontainers.Container) string {
+	// Run md5sum command on the policy.csv file
+	cmd := exec.Command("docker", "exec", container.GetContainerID(), "md5sum", "data/raft/rbac/policy.csv")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+
+	// Extract the checksum from the output
+	parts := strings.Fields(string(output))
+	if len(parts) < 1 {
+		return ""
+	}
+	return parts[0]
+}
+
+func String(s string) *string {
+	return &s
+}

--- a/test/acceptance/snapshots/raft_snapshot_test.go
+++ b/test/acceptance/snapshots/raft_snapshot_test.go
@@ -101,7 +101,7 @@ func TestSchemaSnapshotRecovery(t *testing.T) {
 			return len(schema1.Payload.Classes) == len(schema2.Payload.Classes) &&
 				len(schema1.Payload.Classes) == len(schema3.Payload.Classes) &&
 				len(schema1.Payload.Classes) == 100
-		}, 60*time.Second, 1*time.Second, "Schema should match across all nodes")
+		}, 90*time.Second, 1*time.Second, "Schema should match across all nodes")
 	})
 }
 
@@ -179,7 +179,7 @@ func TestRBACSnapshotRecovery(t *testing.T) {
 			// All checksums should match
 			return checksum1 != "" && checksum2 != "" && checksum3 != "" &&
 				checksum1 == checksum2 && checksum1 == checksum3
-		}, 60*time.Second, 1*time.Second, "Policy checksums should match across all nodes")
+		}, 90*time.Second, 1*time.Second, "Policy checksums should match across all nodes")
 	})
 }
 

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -12,6 +12,8 @@
 package rbac
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -216,6 +218,72 @@ func (m *manager) RevokeRolesForUser(userName string, roles ...string) error {
 		return err
 	}
 	return m.casbin.InvalidateCache()
+}
+
+// Snapshot is the RBAC state to be used for RAFT snapshots
+type snapshot struct {
+	Policy         [][]string `json:"roles_policies"`
+	GroupingPolicy [][]string `json:"grouping_policies"`
+}
+
+func (m *manager) Snapshot() ([]byte, error) {
+	if m.casbin == nil {
+		return nil, nil
+	}
+
+	policy, err := m.casbin.GetPolicy()
+	if err != nil {
+		return nil, err
+	}
+	groupingPolicy, err := m.casbin.GetGroupingPolicy()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a buffer to stream the JSON encoding
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(snapshot{Policy: policy, GroupingPolicy: groupingPolicy}); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (m *manager) Restore(b []byte) error {
+	if m.casbin == nil {
+		return nil
+	}
+
+	snapshot := snapshot{}
+	if err := json.Unmarshal(b, &snapshot); err != nil {
+		return fmt.Errorf("restore snapshot: decode json: %w", err)
+	}
+
+	// we need to clear the policies before adding the new ones
+	m.casbin.ClearPolicy()
+
+	// TODO : migration has to be done here if needed
+	_, err := m.casbin.AddPolicies(snapshot.Policy)
+	if err != nil {
+		return fmt.Errorf("add policies: %w", err)
+	}
+
+	// TODO : migration has to be done here if needed
+	_, err = m.casbin.AddGroupingPolicies(snapshot.GroupingPolicy)
+	if err != nil {
+		return fmt.Errorf("add grouping policies: %w", err)
+	}
+
+	// Save the policies to ensure they are persisted
+	if err := m.casbin.SavePolicy(); err != nil {
+		return fmt.Errorf("save policies: %w", err)
+	}
+
+	// Load the policies to ensure they are in memory
+	if err := m.casbin.LoadPolicy(); err != nil {
+		return fmt.Errorf("load policies: %w", err)
+	}
+
+	return nil
 }
 
 // BatchEnforcers is not needed after some digging they just loop over requests,

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -1,0 +1,199 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rbac
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+)
+
+func TestSnapshotAndRestore(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupPolicies func(*manager) error
+		wantErr       bool
+	}{
+		{
+			name: "empty policies",
+			setupPolicies: func(m *manager) error {
+				return nil
+			},
+		},
+		{
+			name: "with role and policy",
+			setupPolicies: func(m *manager) error {
+				// Add a role and policy
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				_, err = m.casbin.AddRoleForUser(conv.PrefixUserName("test-user"), conv.PrefixRoleName("admin"))
+				return err
+			},
+		},
+		{
+			name: "multiple roles and policies",
+			setupPolicies: func(m *manager) error {
+				// Add multiple roles and policies
+				_, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", authorization.READ, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("editor"), "collections/*", authorization.UPDATE, authorization.SchemaDomain)
+				if err != nil {
+					return err
+				}
+				_, err = m.casbin.AddRoleForUser(conv.PrefixUserName("test-user"), conv.PrefixRoleName("admin"))
+				if err != nil {
+					return err
+				}
+				_, err = m.casbin.AddRoleForUser(conv.PrefixUserName("test-user"), conv.PrefixRoleName("editor"))
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup logger with hook for testing
+			logger, _ := test.NewNullLogger()
+			m, err := setupTestManager(t, logger)
+			require.NoError(t, err)
+
+			// Get initial policies before our test setup
+			initialPolicies, err := m.casbin.GetPolicy()
+			require.NoError(t, err)
+			initialGroupingPolicies, err := m.casbin.GetGroupingPolicy()
+			require.NoError(t, err)
+
+			// Setup policies if needed
+			if tt.setupPolicies != nil {
+				err := tt.setupPolicies(m)
+				require.NoError(t, err)
+			}
+
+			// Take snapshot
+			snapshotData, err := m.Snapshot()
+			require.NoError(t, err)
+			require.NotNil(t, snapshotData)
+
+			// Create a new manager for restore
+			m2, err := setupTestManager(t, logger)
+			require.NoError(t, err)
+
+			// Restore from snapshot
+			err = m2.Restore(snapshotData)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Get final policies after our test setup
+			finalPolicies, err := m.casbin.GetPolicy()
+			require.NoError(t, err)
+			finalGroupingPolicies, err := m.casbin.GetGroupingPolicy()
+			require.NoError(t, err)
+
+			// Get restored policies
+			restoredPolicies, err := m2.casbin.GetPolicy()
+			require.NoError(t, err)
+			restoredGroupingPolicies, err := m2.casbin.GetGroupingPolicy()
+			require.NoError(t, err)
+
+			// Compare only the delta of policies we added
+			addedPolicies := getPolicyDelta(initialPolicies, finalPolicies)
+			restoredAddedPolicies := getPolicyDelta(initialPolicies, restoredPolicies)
+			assert.ElementsMatch(t, addedPolicies, restoredAddedPolicies)
+
+			// Compare only the delta of grouping policies we added
+			addedGroupingPolicies := getPolicyDelta(initialGroupingPolicies, finalGroupingPolicies)
+			restoredAddedGroupingPolicies := getPolicyDelta(initialGroupingPolicies, restoredGroupingPolicies)
+			assert.ElementsMatch(t, addedGroupingPolicies, restoredAddedGroupingPolicies)
+		})
+	}
+}
+
+// getPolicyDelta returns the policies that are in b but not in a
+func getPolicyDelta(a, b [][]string) [][]string {
+	delta := make([][]string, 0)
+	for _, policyB := range b {
+		found := false
+		for _, policyA := range a {
+			if equalPolicies(policyA, policyB) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			delta = append(delta, policyB)
+		}
+	}
+	return delta
+}
+
+// equalPolicies compares two policies for equality
+func equalPolicies(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSnapshotNilCasbin(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	m := &manager{
+		casbin: nil,
+		logger: logger,
+	}
+
+	snapshotData, err := m.Snapshot()
+	require.NoError(t, err)
+	assert.Nil(t, snapshotData)
+}
+
+func TestRestoreNilCasbin(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	m := &manager{
+		casbin: nil,
+		logger: logger,
+	}
+
+	err := m.Restore([]byte("{}"))
+	require.NoError(t, err)
+}
+
+func TestRestoreInvalidData(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	m, err := setupTestManager(t, logger)
+	require.NoError(t, err)
+
+	// Test with invalid JSON
+	err = m.Restore([]byte("invalid json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode json")
+
+	// Test with empty data
+	err = m.Restore([]byte("{}"))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### What's being changed:
this PR adds snapshot acceptance tests to schema & RBAC, in order to force node to restore from snapshot and check if the snapshot includes all the FSM data

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
