### PR TITLE
fix(bm25_block): :bug: Fix condition for filter matching no docs

### DIFF
--- a/adapters/repos/db/bm25f_block_test.go
+++ b/adapters/repos/db/bm25f_block_test.go
@@ -411,6 +411,25 @@ func TestBM25FWithFiltersBlock(t *testing.T) {
 		},
 	}
 
+	filterEmpty := &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{
+				{
+					Operator: filters.OperatorEqual,
+					On: &filters.Path{
+						Class:    schema.ClassName("MyClass"),
+						Property: schema.PropertyName("title"),
+					},
+					Value: &filters.Value{
+						Value: "asdasdas",
+						Type:  schema.DataType("text"),
+					},
+				},
+			},
+		},
+	}
+
 	for _, location := range []string{"memory", "disk"} {
 		t.Run("bm25f with filter "+location, func(t *testing.T) {
 			kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"description"}, Query: "journey"}
@@ -420,6 +439,15 @@ func TestBM25FWithFiltersBlock(t *testing.T) {
 			require.Nil(t, err)
 			require.True(t, len(res) == 1)
 			require.Equal(t, uint64(2), res[0].DocID)
+		})
+
+		t.Run("bm25f with filter matching no docs "+location, func(t *testing.T) {
+			kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"description"}, Query: "journey"}
+			addit := additional.Properties{}
+			res, _, err := idx.objectSearch(context.TODO(), 1000, filterEmpty, kwr, nil, nil, addit, nil, "", 0, props)
+
+			require.Nil(t, err)
+			require.True(t, len(res) == 0)
 		})
 
 		for _, index := range repo.indices {

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -163,7 +163,7 @@ func generateSingleFilter(tombstones *sroar.Bitmap, filterDocIds helpers.AllowLi
 
 	var filterSroar *sroar.Bitmap
 	// if we don't have an allow list filter, tombstones are the only needed filter
-	if filterDocIds != nil && filterDocIds.Len() > 0 {
+	if filterDocIds != nil {
 		// the ok check should always succeed, but we keep it for safety
 		bm, ok := filterDocIds.(*helpers.BitmapAllowList)
 		// if we have a (allow list) filter and a (block list) tombstones filter, we can combine them into a single allowlist filter filter


### PR DESCRIPTION
### What's being changed:

Fix bug where BlockMax search would ignore the an empty filter (i.e. a filter that matches no documents)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
