### PR TITLE
fix: force k strictly greater than zero in `knnSearchByVector()`

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -611,7 +611,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		return nil, nil, nil
 	}
 
-	if k < 0 {
+	if k <= 0 {
 		return nil, nil, fmt.Errorf("k must be greater than zero")
 	}
 


### PR DESCRIPTION
### What's being changed:
According to the `Error` message returned("k **must be greater than** zero"), the `if` statement currently may miss the boundary case when parameter `k` is equal to zero. Besides, when `k` is equal to zero, func `knnSearchByVector` may be meaningless?

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
