### PR TITLE
feat(bm25_block): Allow setting an higher segment inspection limit by env var

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"sort"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -148,10 +149,22 @@ func (b *BM25Searcher) wandBlock(
 		}
 		internalLimit = limit
 
-	} else if len(allResults) > 1 { // we only need to increase the limit if there are multiple properties
+	} else if len(allResults) > 1 {
+		// we only need to increase the limit if there are multiple properties
 		// TODO: the limit is increased by 10 to make sure candidates that are on the edge of the limit are not missed for multi-property search
 		// the proper fix is to either make sure that the limit is always high enough, or force a rerank of the top results from all properties
-		internalLimit = limit + 10
+		defaultLimit := int(math.Max(float64(limit)*1.1, float64(limit+10)))
+		// allow overriding the defaultLimit with an env var
+		internalLimitString := os.Getenv("BLOCKMAX_WAND_PER_SEGMENT_LIMIT")
+		if internalLimitString != "" {
+			// if the env var is set, use it as the limit
+			internalLimit, _ = strconv.Atoi(internalLimitString)
+		}
+
+		if internalLimit < defaultLimit {
+			// if the limit is smaller than the defaultLimit, use the defaultLimit
+			internalLimit = defaultLimit
+		}
 	}
 
 	eg := enterrors.NewErrorGroupWrapper(b.logger)


### PR DESCRIPTION
### What's being changed:

Allow setting an higher segment inspection limit by env var

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
