### PR TITLE
chore(tests): add possibility to pass a prebuilt MockOIDC image to tests

### DIFF
--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -78,6 +78,8 @@ const (
 	envTestImg2VecNeuralImage = "TEST_IMG2VEC_NEURAL_IMAGE"
 	// envTestRerankerTransformersImage adds ability to pass a custom image to module tests
 	envTestRerankerTransformersImage = "TEST_RERANKER_TRANSFORMERS_IMAGE"
+	// envTestMockOIDCImage adds ability to pass a custom image to module tests
+	envTestMockOIDCImage = "TEST_MOCKOIDC_IMAGE"
 )
 
 const (
@@ -721,7 +723,8 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 		containers = append(containers, container)
 	}
 	if d.withMockOIDC {
-		container, err := startMockOIDC(ctx, networkName)
+		image := os.Getenv(envTestMockOIDCImage)
+		container, err := startMockOIDC(ctx, networkName, image)
 		if err != nil {
 			return nil, errors.Wrapf(err, "start %s", MockOIDC)
 		}

--- a/test/run.sh
+++ b/test/run.sh
@@ -123,6 +123,7 @@ function main() {
     if $run_acceptance_only_authz || $run_acceptance_only_python
     then
       tools/test/run_ci_server.sh --with-auth
+      build_mockoidc_docker_image_for_tests
     else
       tools/test/run_ci_server.sh
     fi
@@ -196,6 +197,14 @@ function build_docker_image_for_tests() {
 
   docker build --build-arg GIT_REVISION="$GIT_REVISION" --build-arg GIT_BRANCH="$GIT_BRANCH" --target weaviate -t $module_test_image .
   export "TEST_WEAVIATE_IMAGE"=$module_test_image
+}
+
+function build_mockoidc_docker_image_for_tests() {
+  local mockoidc_test_image=mockoidc:module-tests
+  echo_green "Building MockOIDC image for module acceptance tests..."
+  docker build  -t $mockoidc_test_image test/docker/mockoidc
+  export "TEST_MOCKOIDC_IMAGE"=$mockoidc_test_image
+  echo_green "MockOIDC image successfully built"
 }
 
 function run_unit_tests() {


### PR DESCRIPTION
### What's being changed:

This change avoids building MockOIDC docker image each time an e2e test is being run.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
