### PR TITLE
Optimize creating bytes out of Mappair

### DIFF
--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -343,15 +343,12 @@ func (m *Memtable) appendMapSorted(key []byte, pair MapPair) error {
 			StrategyMapCollection)
 	}
 
-	m.Lock()
-	defer m.Unlock()
-
 	valuesForCommitLog, err := pair.Bytes()
 	if err != nil {
 		return err
 	}
 
-	if err := m.commitlog.append(segmentCollectionNode{
+	newNode := segmentCollectionNode{
 		primaryKey: key,
 		values: []value{
 			{
@@ -359,7 +356,12 @@ func (m *Memtable) appendMapSorted(key []byte, pair MapPair) error {
 				tombstone: pair.Tombstone,
 			},
 		},
-	}); err != nil {
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.commitlog.append(newNode); err != nil {
 		return errors.Wrap(err, "write into commit log")
 	}
 

--- a/adapters/repos/db/lsmkv/strategies_map_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_benchmark_test.go
@@ -13,11 +13,34 @@ package lsmkv
 
 import (
 	"crypto/rand"
+	"fmt"
+	randInsecure "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func BenchmarkBytes(b *testing.B) {
+	for _, val := range []int{10, 100, 1000, 10000, 24 * 1024} {
+		b.Run(fmt.Sprintf("%d", val), func(b *testing.B) {
+			kv := MapPair{
+				Key:   []byte("my-key-1"),
+				Value: make([]byte, val),
+			}
+			for i := 0; i < len(kv.Value); i++ {
+				kv.Value[i] = byte(randInsecure.Intn(100))
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := kv.Bytes()
+				require.NoError(b, err)
+			}
+		})
+	}
+}
 
 func BenchmarkMapDecoderDoPartial_SingleKey(b *testing.B) {
 	before := []MapPair{{

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -841,7 +841,7 @@ func UnmarshalPropertiesFromObject(data []byte, properties *map[string]interface
 	}
 
 	startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
-	rw := byteops.NewReadWriter(data, byteops.WithPosition(startPos))
+	rw := byteops.NewReadWriterWithOps(data, byteops.WithPosition(startPos))
 	// get the length of the vector, each element is a float32 (4 bytes)
 	vectorLength := uint64(rw.ReadUint16())
 	rw.MoveBufferPositionForward(vectorLength * 4)
@@ -964,7 +964,7 @@ func (ko *Object) UnmarshalBinary(data []byte) error {
 	}
 	ko.MarshallerVersion = version
 
-	rw := byteops.NewReadWriter(data, byteops.WithPosition(1))
+	rw := byteops.NewReadWriterWithOps(data, byteops.WithPosition(1))
 	ko.DocID = rw.ReadUint64()
 	rw.MoveBufferPositionForward(1) // kind-byte
 
@@ -1070,7 +1070,7 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 
 	if targetVector != "" {
 		startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
-		rw := byteops.NewReadWriter(in, byteops.WithPosition(startPos))
+		rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(startPos))
 
 		vectorLength := uint64(rw.ReadUint16())
 		rw.MoveBufferPositionForward(vectorLength * 4)

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -36,7 +36,13 @@ func WithPosition(pos uint64) func(*ReadWriter) {
 	}
 }
 
-func NewReadWriter(buf []byte, opts ...func(writer *ReadWriter)) ReadWriter {
+func NewReadWriter(buf []byte) ReadWriter {
+	rw := ReadWriter{Buffer: buf}
+	return rw
+}
+
+// NewReadWriterWithOps escapes to heap even if no ops are given
+func NewReadWriterWithOps(buf []byte, opts ...func(writer *ReadWriter)) ReadWriter {
 	rw := ReadWriter{Buffer: buf}
 	for _, opt := range opts {
 		opt(&rw)


### PR DESCRIPTION
### What's being changed:

Two commits:
1. optimizes the .Bytes function of MapPair (stats are for this optimization) reducing runtime and allocs
  a. The optimization should reduce allocations for every use of `NewReadWriter`
2. Moves some code before the lock to reduce the amount of time the lock needs to be held (no stats, but I don't think this is bad in any case)

Before
```
BenchmarkBytes/10	         7966041	       138.5 ns/op	      64 B/op	       1 allocs/op
BenchmarkBytes/100        	 6687142	       176.6 ns/op	     192 B/op	       2 allocs/op
BenchmarkBytes/1000       	 4867688	       243.4 ns/op	    1088 B/op	       2 allocs/op
BenchmarkBytes/10000      	 1432347	       815.8 ns/op	   10304 B/op	       2 allocs/op
BenchmarkBytes/24576      	  725058	      1431 ns/op	   27328 B/op	       2 allocs/op
```

After
```
BenchmarkBytes/10	         8877076	       129.9 ns/op	      24 B/op	       1 allocs/op
BenchmarkBytes/100        	 8969838	       129.4 ns/op	     112 B/op	       1 allocs/op
BenchmarkBytes/1000       	 5925535	       198.7 ns/op	    1024 B/op	       1 allocs/op
BenchmarkBytes/10000      	 1665730	       714.3 ns/op	   10240 B/op	       1 allocs/op
BenchmarkBytes/24576      	  788707	      1312 ns/op	   27264 B/op	       1 allocs/op
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
