### PR TITLE
chore: add metric fo db internal shard status

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
@@ -261,6 +262,7 @@ func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Clas
 			QueryMaximumResults: maxResults,
 			ReplicationFactor:   NewAtomicInt64(1),
 		},
+		metrics:               NewMetrics(logger, nil, class.Class, ""),
 		partitioningEnabled:   shardState.PartitioningEnabled,
 		invertedIndexConfig:   iic,
 		vectorIndexUserConfig: vic,

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -151,12 +151,10 @@ func (m *Metrics) UpdateShardStatus(old, new string) {
 		return
 	}
 
-	if old == "" {
-		m.shardsCount.WithLabelValues(new).Inc()
-		return
+	if old != "" {
+		m.shardsCount.WithLabelValues(old).Dec()
 	}
 
-	m.shardsCount.WithLabelValues(old).Dec()
 	m.shardsCount.WithLabelValues(new).Inc()
 }
 

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -146,7 +146,25 @@ func NewMetrics(
 	return m
 }
 
+func (m *Metrics) UpdateShardStatus(old, new string) {
+	if m.shardsCount == nil {
+		return
+	}
+
+	if old == "" {
+		m.shardsCount.WithLabelValues(new).Inc()
+		return
+	}
+
+	m.shardsCount.WithLabelValues(old).Dec()
+	m.shardsCount.WithLabelValues(new).Inc()
+}
+
 func (m *Metrics) ObserveUpdateShardStatus(status string, duration time.Duration) {
+	if m.shardStatusUpdateDurationsSeconds == nil {
+		return
+	}
+
 	m.shardStatusUpdateDurationsSeconds.With(prometheus.Labels{"status": status}).Observe(float64(duration.Seconds()))
 }
 

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -34,6 +35,9 @@ type Metrics struct {
 	filteredVectorSort    prometheus.Observer
 	grouped               bool
 	baseMetrics           *monitoring.PrometheusMetrics
+
+	shardsCount                       *prometheus.GaugeVec
+	shardStatusUpdateDurationsSeconds *prometheus.HistogramVec
 }
 
 func NewMetrics(
@@ -106,7 +110,44 @@ func NewMetrics(
 		"operation":  "sort",
 	})
 
+	if prom.Registerer == nil {
+		prom.Registerer = prometheus.DefaultRegisterer
+	}
+
+	// TODO: This is a temporary solution to avoid duplicating metrics registered
+	// in the index package. it shall be removed once the index package metric is refactored
+	// and to bring the metrics to the db package.
+	shardsCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "weaviate_index_shards_total",
+		Help: "Total number of shards per index status",
+	}, []string{"status"}) // status: READONLY, INDEXING, LOADING, READY, SHUTDOWN
+
+	shardStatusUpdateDurationsSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "weaviate_index_shard_status_update_duration_seconds",
+		Help: "Time taken to update shard status in seconds",
+	}, []string{"status"}) // status: READONLY, INDEXING, LOADING, READY, SHUTDOWN
+
+	// Try to register metrics, reuse existing ones if already registered
+	if err := prom.Registerer.Register(shardsCount); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			shardsCount = are.ExistingCollector.(*prometheus.GaugeVec)
+		}
+	}
+
+	if err := prom.Registerer.Register(shardStatusUpdateDurationsSeconds); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			shardStatusUpdateDurationsSeconds = are.ExistingCollector.(*prometheus.HistogramVec)
+		}
+	}
+
+	m.shardsCount = shardsCount
+	m.shardStatusUpdateDurationsSeconds = shardStatusUpdateDurationsSeconds
+
 	return m
+}
+
+func (m *Metrics) ObserveUpdateShardStatus(status string, duration time.Duration) {
+	m.shardStatusUpdateDurationsSeconds.With(prometheus.Labels{"status": status}).Observe(float64(duration.Seconds()))
 }
 
 func (m *Metrics) DeleteShardLabels(class, shard string) {

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -62,7 +62,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		status: ShardStatus{Status: storagestate.StatusLoading},
 	}
 
-	index.metrics.shardsCount.WithLabelValues(storagestate.StatusLoading.String()).Inc()
+	index.metrics.UpdateShardStatus("", storagestate.StatusLoading.String())
 
 	defer func() {
 		p := recover()

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
 /*
@@ -44,6 +45,17 @@ import (
 // component was initialized. If not, it turns it into a noop to prevent
 // blocking.
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
+	start := time.Now()
+	defer func() {
+		s.index.metrics.ObserveUpdateShardStatus(storagestate.StatusShutdown.String(), time.Since(start))
+
+		if err != nil {
+			return
+		}
+
+		s.UpdateStatus(storagestate.StatusShutdown.String())
+	}()
+
 	if err = s.waitForShutdown(ctx); err != nil {
 		return
 	}

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -95,8 +95,7 @@ func (s *Shard) updateStatusUnlocked(in, reason string) error {
 		return err
 	}
 
-	s.index.metrics.shardsCount.WithLabelValues(oldStatus.String()).Dec()
-	s.index.metrics.shardsCount.WithLabelValues(targetStatus.String()).Inc()
+	s.index.metrics.UpdateShardStatus(oldStatus.String(), targetStatus.String())
 
 	s.index.logger.
 		WithField("action", "update shard status").

--- a/entities/storagestate/status.go
+++ b/entities/storagestate/status.go
@@ -21,6 +21,7 @@ const (
 	StatusIndexing Status = "INDEXING"
 	StatusLoading  Status = "LOADING"
 	StatusReady    Status = "READY"
+	StatusShutdown Status = "SHUTDOWN"
 )
 
 var ErrStatusReadOnlyWithReason = func(reason string) error {

--- a/tools/dev/grafana/dashboards/db_shards.json
+++ b/tools/dev/grafana/dashboards/db_shards.json
@@ -1,0 +1,332 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 15,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(weaviate_schema_shards) by (status, class_name)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Schema shards per collection",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "weaviate_index_shards_total",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Database shards per collection",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(weaviate_index_shard_status_update_duration_seconds_sum[$__rate_interval])/rate(weaviate_index_shard_status_update_duration_seconds_count[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Shard load time",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "DB Shards Status",
+  "uid": "dej35ju98g6bke",
+  "version": 5,
+  "weekStart": ""
+}


### PR DESCRIPTION
### What's being changed:
this PR 
- simplifies the DB internal shards status by removing not needed functions 
- introduce new shard status `SHUTDOWN`
- adds metric to measure time needed for shard to be `loaded` and `shutdown`
- adds metric to measure shards count by status 
- adds dashboard to be used to show the created metrics 
e.g. 
<img width="1610" alt="Screenshot 2025-04-16 at 17 53 45" src="https://github.com/user-attachments/assets/f5951257-b441-48e3-a2c0-9646d12a14d4" />

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14511671089
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
