### PR TITLE
DB Users: Fix concurrency issues

### DIFF
--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -268,6 +268,8 @@ func TestSuspendAfterDelete(t *testing.T) {
 
 	require.Error(t, dynUsers.DeactivateUser(userId, false))
 	require.Error(t, dynUsers.ActivateUser(userId))
+	require.Error(t, dynUsers.RotateKey(userId, "", "", ""))
+	require.Error(t, dynUsers.ActivateUser(userId))
 }
 
 func TestLastUsedTime(t *testing.T) {

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -67,7 +67,7 @@ func TestConcurrentValidate(t *testing.T) {
 	require.NoError(t, err)
 	start := time.Now()
 	wg := sync.WaitGroup{}
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			_, err := dynUsers.ValidateAndExtract(randomKey, identifier)

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -168,6 +168,10 @@ func (c *DBUser) RotateKey(userId, secureHash, oldIdentifier, newIdentifier stri
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	if _, ok := c.data.Users[userId]; !ok {
+		return fmt.Errorf("user %s does not exist", userId)
+	}
+
 	// replay of old raft commands can have these be ""
 	if oldIdentifier != "" && newIdentifier != "" {
 		c.data.IdToIdentifier[userId] = newIdentifier


### PR DESCRIPTION
### What's being changed:

- Fixes a panic with concurrent _first_ logins when writing the weakHash to a shared map
- Makes updating the last used time threadsafe. I wasn't able to provoke a data race but this _should_ race. Note: I think I found a valid usecase for TryLock!
- Fixes rotation after deletion. The handler already checks this, but there is a small time-window between that check and the rotation

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
