### PR TITLE
DB-18: Stabilize flaky test

### DIFF
--- a/test/acceptance_with_python/test_stats_hnsw.py
+++ b/test/acceptance_with_python/test_stats_hnsw.py
@@ -1,7 +1,9 @@
 import json
+
 import httpx
-from weaviate.classes.config import Configure, VectorDistances
+
 import weaviate
+from weaviate.classes.config import Configure, VectorDistances
 
 
 def test_stats_hnsw() -> None:
@@ -60,6 +62,8 @@ def test_stats_hnsw() -> None:
         "compressionStats",
         "compressionType",
     ] == keywords
+
+    flat_index = client.collections.delete("flatIndex")
 
     # Flat index
     flat_index = client.collections.create(


### PR DESCRIPTION
### What's being changed:
Related: https://semi-technology.atlassian.net/browse/DB-18

This PR:
- Deletes "flatIndex" collection before creating it. This has no effect on CI, but causes errors when repeatedly running the tests suit against the same Docker container locally.
- Explicitly passes collection name when adding a reference in `test_ref_with_multiple_cycle`

The reason `test_ref_with_multiple_cycle` was is because the references created there only specify object IDs, so the server has to go and find the collection to which each one belongs before inserting them.

Due to _some_ (haven't figured out which) synchronization issues, a `class not found` error prevents the server from checking one of the indices for the target ID. Notably, it always fails for indices which _definitely do not contain the ID_, but the error does break the loop and so Weaviate assumes the object is not a "reference" but an `object`.
You can find further details in the ticket description.

While it does not address the synchronization issue, this fix should make the test more stable. It's _one_ solution -- the test checks that cyclic references are resolved correctly.

`Draft` because we probably want to investigate the underlying issue.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

