### PR TITLE
chore: TestRBACSnapshotRecovery sort files content before md5sum checks

### DIFF
--- a/test/acceptance/snapshots/raft_snapshot_test.go
+++ b/test/acceptance/snapshots/raft_snapshot_test.go
@@ -175,7 +175,6 @@ func TestRBACSnapshotRecovery(t *testing.T) {
 			checksum1 := getPolicyChecksum(t, compose.GetWeaviate().Container())
 			checksum2 := getPolicyChecksum(t, compose.GetWeaviateNode2().Container())
 			checksum3 := getPolicyChecksum(t, compose.GetWeaviateNode3().Container())
-
 			// All checksums should match
 			return checksum1 != "" && checksum2 != "" && checksum3 != "" &&
 				checksum1 == checksum2 && checksum1 == checksum3
@@ -184,10 +183,11 @@ func TestRBACSnapshotRecovery(t *testing.T) {
 }
 
 func getPolicyChecksum(t *testing.T, container testcontainers.Container) string {
-	// Run md5sum command on the policy.csv file
-	cmd := exec.Command("docker", "exec", container.GetContainerID(), "md5sum", "data/raft/rbac/policy.csv")
+	// Run sort | md5sum on the policy file directly in the container
+	cmd := exec.Command("docker", "exec", container.GetContainerID(), "sh", "-c", "sort data/raft/rbac/policy.csv | md5sum")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		t.Logf("Failed to get policy checksum: %v", err)
 		return ""
 	}
 


### PR DESCRIPTION
### What's being changed:
because produced policy files maybe not sorted and that would produce different md5sum, this PR makes sure that the file content is sorted before collecting the md5sum 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
