### PR TITLE
chore(tests): stabilize flaky ColBERT e2e test

### DIFF
--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -157,6 +157,7 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae // indirect
 	github.com/testcontainers/testcontainers-go v0.35.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
@@ -183,7 +184,7 @@ require (
 	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
-	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -663,8 +663,8 @@ golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
-	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -330,8 +330,8 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
 golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=


### PR DESCRIPTION
### What's being changed:

Stabilize flaky ColBERT e2e test:
```
# acceptance_tests_with_client/named_vectors_tests/cluster.test
ld: warning: '/private/var/folders/tq/t0gf39js20n6kyzsp6mypzfm0000gn/T/go-link-4010856326/000018.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
--- FAIL: TestNamedVectors_Cluster_AsyncIndexing (164.85s)
    --- FAIL: TestNamedVectors_Cluster_AsyncIndexing/tests (120.17s)
        --- FAIL: TestNamedVectors_Cluster_AsyncIndexing/tests/colbert (67.89s)
            --- FAIL: TestNamedVectors_Cluster_AsyncIndexing/tests/colbert/bring_your_own_multivector (6.93s)
                --- FAIL: TestNamedVectors_Cluster_AsyncIndexing/tests/colbert/bring_your_own_multivector/vector_search_after_update_of_all_objects (0.06s)
                    named_vectors_colbert.go:88: 
                        	Error Trace:	/Users/rodrigo/workspace/github/weaviate/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go:88
                        	            				/Users/rodrigo/workspace/github/weaviate/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go:283
                        	Error:      	"[00000000-0000-0000-0000-000000000009 00000000-0000-0000-0000-000000000003 00000000-0000-0000-0000-000000000006 00000000-0000-0000-0000-000000000007 00000000-0000-0000-0000-000000000001 00000000-0000-0000-0000-000000000004 00000000-0000-0000-0000-000000000005 00000000-0000-0000-0000-000000000002]" should have 9 item(s), but has 8
                        	Test:       	TestNamedVectors_Cluster_AsyncIndexing/tests/colbert/bring_your_own_multivector/vector_search_after_update_of_all_objects
                    named_vectors_colbert.go:103: 
                        	Error Trace:	/Users/rodrigo/workspace/github/weaviate/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go:103
                        	            				/Users/rodrigo/workspace/github/weaviate/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go:284
                        	Error:      	"[00000000-0000-0000-0000-000000000001 00000000-0000-0000-0000-000000000004 00000000-0000-0000-0000-000000000006 00000000-0000-0000-0000-000000000003 00000000-0000-0000-0000-000000000009 00000000-0000-0000-0000-000000000002 00000000-0000-0000-0000-000000000007 00000000-0000-0000-0000-000000000005]" should have 9 item(s), but has 8
                        	Test:       	TestNamedVectors_Cluster_AsyncIndexing/tests/colbert/bring_your_own_multivector/vector_search_after_update_of_all_objects
FAIL
FAIL	acceptance_tests_with_client/named_vectors_tests/cluster	269.039s
FAIL
Test for acceptance_tests_with_client/named_vectors_tests/cluster failed
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
