### PR TITLE
chore(ci): move less relevant module tests to be run only during release

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -143,15 +143,9 @@ jobs:
           "--only-module-backup-gcs",
           "--only-module-backup-s3",
           "--only-module-offload-s3",
-          "--only-module-img2vec-neural",
-          "--only-module-many-modules",
-          "--only-module-many-generative",
-          "--only-module-ref2vec-centroid",
-          "--only-module-text2vec-contextionary",
           "--only-module-text2vec-transformers",
           "--only-module-text2vec-ollama",
           "--only-module-generative-ollama",
-          "--only-module-many-generative",
           "--only-module-text2vec-model2vec"
         ]
     steps:
@@ -211,6 +205,42 @@ jobs:
           "--only-module-sum-transformers",
           "--only-module-multi2vec-clip",
           "--only-module-reranker-transformers"
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' }}
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Acceptance tests Large (modules)
+        uses: nick-fields/retry@v3
+        with:
+          # 15 Minute is a large enough timeout for most of our tests
+          timeout_minutes: 15
+          max_attempts: 3
+          command: ./test/run.sh ${{ matrix.test }}
+          on_retry_command: ./test/run.sh --cleanup
+  Modules-Acceptance-Tests-light:
+    name: modules-acceptance-tests-light
+    runs-on: ubuntu-latest
+    needs: [Modules-On-Demand-Tests-Check]
+    if: ${{ needs.Modules-On-Demand-Tests-Check.outputs.run_pipeline == 'true' }}  # no PRs from fork
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [
+          "--only-module-text2vec-contextionary",
+          "--only-module-img2vec-neural",
+          "--only-module-ref2vec-centroid",
+          "--only-module-many-modules",
+          "--only-module-many-generative"
         ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### What's being changed:

In order to save up on some github runners (`ubuntu-latest` runners) this PR moves less relevant module tests to be run only during release or on demand (by adding `[test]` to commit title message).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
