### PR TITLE
chore(ci): split integration tests into two pipelines

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -117,6 +117,13 @@ jobs:
   Integration-Tests:
     name: integration-tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [
+          "--integration-vector-package-only",
+          "--integration-without-vector-package"
+        ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -125,11 +132,11 @@ jobs:
           go-version: '1.24'
           cache: true
       - name: Integration test
-        run: ./test/run.sh --integration-only
+        run: ./test/run.sh ${{ matrix.test }}
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report-integration
+          name: coverage-report-integration${{ matrix.test }}
           path: coverage-integration.txt
   Modules-Acceptance-Tests:
     name: modules-acceptance-tests
@@ -425,15 +432,21 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report-unit
-      - name: Download coverage unit
+      - name: Download coverage integration without vector package
         uses: actions/download-artifact@v4
         with:
-          name: coverage-report-integration
+          name: coverage-report-integration--integration-without-vector-package
+          path: coverage-integration-without-vector-package.txt
+      - name: Download coverage integration vector package only
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report-integration--integration-vector-package-only
+          path: coverage-integration-vector-package-only.txt
       - name: Codecov
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
-          files: ./coverage-integration.txt, ./coverage-unit.txt
+          files: ./coverage-integration-without-vector-package.txt, ./coverage-integration-vector-package-only.txt, ./coverage-unit.txt
           verbose: true
   Compile-and-upload-binaries:
     name: compile-and-upload-binaries

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ weaviate-server
 
 # weaviate querier
 exp/query/testdata/lsmroot/lsm/meta.db
+
+# weaviate backup-filesystem tests
+test/modules/backup-filesystem/bucketPath

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -11,25 +11,45 @@ function echo_yellow() {
 export DISABLE_RECOVERY_ON_PANIC=true 
 
 includeslow=false
+onlyvectorpkg=false
+withoutvectorpkg=false
 
 for arg in "$@"; do
   if [[ $arg == --include-slow ]]; then
     includeslow=true
     shift
   fi
+  if [[ $arg == --only-vector-pkg ]]; then
+    onlyvectorpkg=true
+    shift
+  fi
+  if [[ $arg == --without-vector-pkg ]]; then
+    withoutvectorpkg=true
+    shift
+  fi
 done
 
 tags=integrationTest
 if [ $includeslow = true ]; then
-  echo "Found --include-slow flag, running all tests, including the slow ones"
+  echo_yellow "Found --include-slow flag, running all tests, including the slow ones"
   tags="$tags,integrationTestSlow"
 else 
-  echo "Found no --include-slow flag, skipping the slow ones"
+  echo_yellow "Found no --include-slow flag, skipping the slow ones"
 fi
 
+pkgs=""
+if [ $withoutvectorpkg = true ]; then
+  echo_yellow "Running integration tests without adapters/repos/db/vector package"
+  pkgs=$(go list ./adapters/repos/... | grep -v "adapters/repos/db/vector")
+elif [ $onlyvectorpkg = true ]; then
+  echo_yellow "Running only adapters/repos/db/vector package integration tests"
+  pkgs="./adapters/repos/db/vector/..."
+fi
+
+
 echo_yellow "Run the regular integration tests with race detector ON"
-go test -count 1 -timeout 3000s -coverpkg=./adapters/repos/... -coverprofile=coverage-integration.txt -race -tags=$tags "$@" ./adapters/repos/...
+go test $pkgs -count 1 -timeout 3000s -coverpkg=./adapters/repos/... -coverprofile=coverage-integration.txt -race -tags=$tags "$@" ./adapters/repos/...
 echo_yellow "Run the !race integration tests with race detector OFF"
-go test -count 1 -coverpkg=./adapters/repos/... -tags=$tags "$@" -run Test_NoRace ./adapters/repos/...
+go test $pkgs -count 1 -coverpkg=./adapters/repos/... -tags=$tags "$@" -run Test_NoRace ./adapters/repos/...
 echo_yellow "Run the classification integration tests with race detector ON"
 go test -count 1 -race -tags=$tags "$@" ./usecases/classification/...

--- a/test/run.sh
+++ b/test/run.sh
@@ -21,6 +21,8 @@ function main() {
   run_unit_and_integration_tests=false
   run_unit_tests=false
   run_integration_tests=false
+  run_integration_tests_only_vector_package=false
+  run_integration_tests_without_vector_package=false
   run_benchmark=false
   run_module_only_backup_tests=false
   run_module_only_offload_tests=false
@@ -37,6 +39,8 @@ function main() {
           --unit-only|-u) run_all_tests=false; run_unit_tests=true;;
           --unit-and-integration-only|-ui) run_all_tests=false; run_unit_and_integration_tests=true;;
           --integration-only|-i) run_all_tests=false; run_integration_tests=true;;
+          --integration-vector-package-only|-ivpo) run_all_tests=false; run_integration_tests=true; run_integration_tests_only_vector_package=true;;
+          --integration-without-vector-package|-iwvp) run_all_tests=false; run_integration_tests=true; run_integration_tests_without_vector_package=true;;
           --acceptance-only|--e2e-only|-a) run_all_tests=false; run_acceptance_tests=true ;;
           --acceptance-only-fast|-aof) run_all_tests=false; run_acceptance_only_fast=true;;
           --acceptance-only-python|-aop) run_all_tests=false; run_acceptance_only_python=true;;
@@ -223,7 +227,13 @@ function run_integration_tests() {
     return
   fi
 
-  ./test/integration/run.sh --include-slow
+  if $run_integration_tests_only_vector_package; then
+    ./test/integration/run.sh --include-slow --only-vector-pkg
+  elif $run_integration_tests_without_vector_package; then
+    ./test/integration/run.sh --include-slow --without-vector-pkg
+  else
+    ./test/integration/run.sh --include-slow
+  fi
 }
 
 function run_acceptance_lsmkv() {


### PR DESCRIPTION
### What's being changed:

split integration tests into two pipelines

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
