### PR TITLE
chore(ci): reduce retries on e2e tests from 3 to 2

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -166,7 +166,7 @@ jobs:
         with:
           # 15 Minute is a large enough timeout for most of our tests
           timeout_minutes: 15
-          max_attempts: 3
+          max_attempts: 2
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup
   Modules-On-Demand-Tests-Check:
@@ -224,7 +224,7 @@ jobs:
         with:
           # 15 Minute is a large enough timeout for most of our tests
           timeout_minutes: 15
-          max_attempts: 3
+          max_attempts: 2
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup
   Modules-Acceptance-Tests-light:
@@ -260,7 +260,7 @@ jobs:
         with:
           # 15 Minute is a large enough timeout for most of our tests
           timeout_minutes: 15
-          max_attempts: 3
+          max_attempts: 2
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup
   Modules-Acceptance-Tests-api:


### PR DESCRIPTION
### What's being changed:

This PR reduces the number of max CI pipeline retries from 3 to 2.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
