### PR TITLE
RBAC: Add downgrade path 1.30=>1.29 to RAFT snapshots

### DIFF
--- a/usecases/auth/authorization/rbac/model_downgrade_test.go
+++ b/usecases/auth/authorization/rbac/model_downgrade_test.go
@@ -86,7 +86,7 @@ func TestDowngradeRoles(t *testing.T) {
 			enforcer.SetAdapter(fileadapter.NewAdapter(tmpFile.Name()))
 			require.NoError(t, enforcer.LoadPolicy())
 
-			require.NoError(t, downgradeRolesFrom130(enforcer))
+			require.NoError(t, downgradeRolesFrom130(enforcer, false))
 			policies, _ := enforcer.GetPolicy()
 			require.Len(t, policies, len(tt.expectedPolicies))
 			for i, policy := range tt.expectedPolicies {
@@ -97,16 +97,6 @@ func TestDowngradeRoles(t *testing.T) {
 }
 
 func TestDowngradeGroupings(t *testing.T) {
-	path := t.TempDir()
-	tmpFile, err := os.Create(path + "/version")
-	require.NoError(t, err)
-	writer := bufio.NewWriter(tmpFile)
-	_, err = fmt.Fprint(writer, "1.30.0")
-	require.NoError(t, err)
-	require.NoError(t, writer.Flush())
-	require.NoError(t, tmpFile.Sync())
-	require.NoError(t, tmpFile.Close())
-
 	tests := []struct {
 		name               string
 		rolesToAdd         []string
@@ -158,7 +148,7 @@ func TestDowngradeGroupings(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.NoError(t, downgradesAssignmentsFrom130(enforcer, path))
+			require.NoError(t, downgradesAssignmentsFrom130(enforcer, false))
 			roles, _ := enforcer.GetAllSubjects()
 			require.Len(t, roles, len(tt.rolesToAdd))
 			for user, role := range tt.expectedAfterWards {


### PR DESCRIPTION
### What's being changed:

This should be reverted when merging to 1.30

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
