### PR TITLE
RBAC: Fix upgrading from version without rbac snapshots to rbac snapshots

### DIFF
--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -253,6 +253,12 @@ func (m *manager) Restore(b []byte) error {
 		return nil
 	}
 
+	// don't overwrite with empty snapshot to avoid overwriting recovery from file
+	// with a non-existent RBAC snapshot when coming from old versions
+	if len(b) == 0 {
+		return nil
+	}
+
 	snapshot := snapshot{}
 	if err := json.Unmarshal(b, &snapshot); err != nil {
 		return fmt.Errorf("restore snapshot: decode json: %w", err)

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -197,3 +197,24 @@ func TestRestoreInvalidData(t *testing.T) {
 	err = m.Restore([]byte("{}"))
 	require.NoError(t, err)
 }
+
+func TestRestoreEmptyData(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	m, err := setupTestManager(t, logger)
+	require.NoError(t, err)
+
+	_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("admin"), "*", authorization.READ, authorization.SchemaDomain)
+	require.NoError(t, err)
+
+	policies, err := m.casbin.GetPolicy()
+	require.NoError(t, err)
+	require.Len(t, policies, 4)
+
+	err = m.Restore([]byte{})
+	require.NoError(t, err)
+
+	// nothing overwritten
+	policies, err = m.casbin.GetPolicy()
+	require.NoError(t, err)
+	require.Len(t, policies, 4)
+}


### PR DESCRIPTION
### What's being changed:

Snapshots from old versions don't contain any data for RBAC => `[]byte{}` which results in a crash


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
