### PR TITLE
fix: snapshot restore hanlde cases where rbac is nil

### DIFF
--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -109,9 +109,11 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 
 		st.log.Info("successfully restored schema from snapshot")
 
-		if err := st.authZManager.Restore(snap.RBAC); err != nil {
-			st.log.WithError(err).Error("restoring rbac from snapshot")
-			return fmt.Errorf("restore rbac from snapshot: %w", err)
+		if snap.RBAC != nil {
+			if err := st.authZManager.Restore(snap.RBAC); err != nil {
+				st.log.WithError(err).Error("restoring rbac from snapshot")
+				return fmt.Errorf("restore rbac from snapshot: %w", err)
+			}
 		}
 
 		if st.cfg.MetadataOnlyVoters {


### PR DESCRIPTION
### What's being changed:
handle rbac restore if restore is enabled but snapshot has empty rbac 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
