### PR TITLE
fix: guard raft snapshot distributedTasks restore

### DIFF
--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -123,9 +123,11 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 			}
 		}
 
-		if err := st.distributedTasksManager.Restore(snap.DistributedTasks); err != nil {
-			st.log.WithError(err).Error("restoring distributed tasks from snapshot")
-			return fmt.Errorf("restore distributed tasks from snapshot: %w", err)
+		if snap.DistributedTasks != nil {
+			if err := st.distributedTasksManager.Restore(snap.DistributedTasks); err != nil {
+				st.log.WithError(err).Error("restoring distributed tasks from snapshot")
+				return fmt.Errorf("restore distributed tasks from snapshot: %w", err)
+			}
 		}
 
 		if st.cfg.MetadataOnlyVoters {


### PR DESCRIPTION
### What's being changed:
if there `DistributedTasks` in the snapshot that would lead to restore would fail and would affect the whole snapshot 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
