### PR TITLE
Fix OpenAPI schema to account for changed Scalar URL display

### DIFF
--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1,7 +1,7 @@
 {
   "servers": [
     {
-      "url": "http://localhost:8080/v1"
+      "url": "http(s):{WEAVIATE_HOSTNAME}:{PORT}/v1"
     }
   ],
   "consumes": [

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3,8 +3,7 @@
     {
       "url": "http://localhost:8080/v1"
     }
-  ],  
-  "basePath": "/v1",
+  ],
   "consumes": [
     "application/json"
   ],


### PR DESCRIPTION
### What's being changed:

- Fixes the display to correctly show the base URL (to account for changes with Scalar)
- Update base URL to look like a template

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
