### PR TITLE
chore: initBloomFilters concurrently and upgrade bloom filter dependency

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -24,10 +24,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	entcfg "github.com/weaviate/weaviate/entities/config"
-	"github.com/weaviate/weaviate/entities/dto"
-	"github.com/weaviate/weaviate/entities/modulecapabilities"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -44,10 +40,13 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/autocut"
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -2297,29 +2296,60 @@ func (i *Index) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// stopCycleManagers stops all cycle managers concurrently
 func (i *Index) stopCycleManagers(ctx context.Context, usecase string) error {
-	if err := i.cycleCallbacks.compactionCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop objects compaction cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.compactionAuxCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop non objects compaction cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.flushCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop flush cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.vectorCommitLoggerCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop vector commit logger cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.vectorTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop vector tombstone cleanup cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.geoPropsCommitLoggerCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop geo props commit logger cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.geoPropsTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop geo props tombstone cleanup cycle: %w", usecase, err)
-	}
-	return nil
+	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.compactionCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop objects compaction cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.compactionAuxCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop non objects compaction cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.flushCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop flush cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.vectorCommitLoggerCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop vector commit logger cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.vectorTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop vector tombstone cleanup cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.geoPropsCommitLoggerCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop geo props commit logger cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		if err := i.cycleCallbacks.geoPropsTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
+			return fmt.Errorf("%s: stop geo props tombstone cleanup cycle: %w", usecase, err)
+		}
+		return nil
+	})
+
+	return eg.Wait()
 }
 
 func (i *Index) shardState() *sharding.State {

--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -22,18 +22,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	entcfg "github.com/weaviate/weaviate/entities/config"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-	"github.com/weaviate/weaviate/usecases/monitoring"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // IndexQueue is an in-memory queue of vectors to index.
@@ -379,6 +379,9 @@ func (q *IndexQueue) Delete(ids ...uint64) error {
 // It does not remove the index.
 // It should be called only when the index is dropped.
 func (q *IndexQueue) Drop() error {
+	q.indexLock.Lock()
+	defer q.indexLock.Unlock()
+
 	_ = q.Close()
 
 	if q.Checkpoints != nil {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/edsrzf/mmap-go"
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -18,13 +18,15 @@ import (
 	"io"
 	"os"
 
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/edsrzf/mmap-go"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/mmap"
-	"github.com/willf/bloom"
 )
 
 type segment struct {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -254,18 +254,34 @@ func (s *segment) dropImmediately() error {
 	// therefore the files may not be present on segments created with previous
 	// versions. By using RemoveAll, which does not error on NotExists, these
 	// drop calls are backward-compatible:
-	if err := os.RemoveAll(s.bloomFilterPath()); err != nil {
-		return fmt.Errorf("drop bloom filter: %w", err)
-	}
-
-	for i := 0; i < int(s.secondaryIndexCount); i++ {
-		if err := os.RemoveAll(s.bloomFilterSecondaryPath(i)); err != nil {
+	g := enterrors.NewErrorGroupWrapper(s.logger)
+	g.SetLimit(_NUMCPU)
+	g.Go(func() error {
+		if err := os.RemoveAll(s.bloomFilterPath()); err != nil {
 			return fmt.Errorf("drop bloom filter: %w", err)
 		}
+		return nil
+	})
+
+	for i := 0; i < int(s.secondaryIndexCount); i++ {
+		i := i // capture loop var
+		g.Go(func() error {
+			if err := os.RemoveAll(s.bloomFilterSecondaryPath(i)); err != nil {
+				return fmt.Errorf("drop bloom filter: %w", err)
+			}
+			return nil
+		})
 	}
 
-	if err := os.RemoveAll(s.countNetPath()); err != nil {
-		return fmt.Errorf("drop count net additions file: %w", err)
+	g.Go(func() error {
+		if err := os.RemoveAll(s.countNetPath()); err != nil {
+			return fmt.Errorf("drop count net additions file: %w", err)
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	// for the segment itself, we're not using RemoveAll, but Remove. If there
@@ -283,18 +299,34 @@ func (s *segment) dropMarked() error {
 	// therefore the files may not be present on segments created with previous
 	// versions. By using RemoveAll, which does not error on NotExists, these
 	// drop calls are backward-compatible:
-	if err := os.RemoveAll(s.bloomFilterPath() + DeleteMarkerSuffix); err != nil {
-		return fmt.Errorf("drop previously marked bloom filter: %w", err)
-	}
+	g := enterrors.NewErrorGroupWrapper(s.logger)
+	g.SetLimit(_NUMCPU)
+	g.Go(func() error {
+		if err := os.RemoveAll(s.bloomFilterPath() + DeleteMarkerSuffix); err != nil {
+			return fmt.Errorf("drop previously marked bloom filter: %w", err)
+		}
+		return nil
+	})
 
 	for i := 0; i < int(s.secondaryIndexCount); i++ {
-		if err := os.RemoveAll(s.bloomFilterSecondaryPath(i) + DeleteMarkerSuffix); err != nil {
-			return fmt.Errorf("drop previously marked secondary bloom filter: %w", err)
-		}
+		i := i // capture loop var
+		g.Go(func() error {
+			if err := os.RemoveAll(s.bloomFilterSecondaryPath(i) + DeleteMarkerSuffix); err != nil {
+				return fmt.Errorf("drop previously marked secondary bloom filter: %w", err)
+			}
+			return nil
+		})
 	}
 
-	if err := os.RemoveAll(s.countNetPath() + DeleteMarkerSuffix); err != nil {
-		return fmt.Errorf("drop previously marked count net additions file: %w", err)
+	g.Go(func() error {
+		if err := os.RemoveAll(s.countNetPath() + DeleteMarkerSuffix); err != nil {
+			return fmt.Errorf("drop previously marked count net additions file: %w", err)
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	// for the segment itself, we're not using RemoveAll, but Remove. If there
@@ -318,7 +350,6 @@ func (s *segment) markForDeletion() error {
 	// therefore the files may not be present on segments created with previous
 	// versions. If we get a not exist error, we ignore it.
 	g := enterrors.NewErrorGroupWrapper(s.logger)
-
 	g.SetLimit(_NUMCPU)
 
 	// Mark bloom filter
@@ -344,7 +375,6 @@ func (s *segment) markForDeletion() error {
 		})
 	}
 
-	// Mark count net file
 	g.Go(func() error {
 		if err := markDeleted(s.countNetPath()); err != nil {
 			if !os.IsNotExist(err) {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -355,7 +355,7 @@ func (s *segment) markForDeletion() error {
 	})
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("%w", err)
+		return err
 	}
 
 	// for the segment itself, we're not accepting a NotExists error. If there

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -316,24 +317,45 @@ func (s *segment) markForDeletion() error {
 	// support for persisting bloom filters and cnas was added in v1.17,
 	// therefore the files may not be present on segments created with previous
 	// versions. If we get a not exist error, we ignore it.
-	if err := markDeleted(s.bloomFilterPath()); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("mark bloom filter deleted: %w", err)
-		}
-	}
+	g := enterrors.NewErrorGroupWrapper(s.logger)
 
-	for i := 0; i < int(s.secondaryIndexCount); i++ {
-		if err := markDeleted(s.bloomFilterSecondaryPath(i)); err != nil {
+	g.SetLimit(_NUMCPU)
+
+	// Mark bloom filter
+	g.Go(func() error {
+		if err := markDeleted(s.bloomFilterPath()); err != nil {
 			if !os.IsNotExist(err) {
-				return fmt.Errorf("mark secondary bloom filter deleted: %w", err)
+				return fmt.Errorf("mark bloom filter deleted: %w", err)
 			}
 		}
+		return nil
+	})
+
+	// Mark secondary bloom filters concurrently
+	for i := 0; i < int(s.secondaryIndexCount); i++ {
+		i := i // capture loop var
+		g.Go(func() error {
+			if err := markDeleted(s.bloomFilterSecondaryPath(i)); err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("mark secondary bloom filter deleted: %w", err)
+				}
+			}
+			return nil
+		})
 	}
 
-	if err := markDeleted(s.countNetPath()); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("mark count net additions file deleted: %w", err)
+	// Mark count net file
+	g.Go(func() error {
+		if err := markDeleted(s.countNetPath()); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("mark count net additions file deleted: %w", err)
+			}
 		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("%w", err)
 	}
 
 	// for the segment itself, we're not accepting a NotExists error. If there

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -18,6 +18,7 @@ import (
 	"hash/crc32"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -26,6 +27,8 @@ import (
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
+
+var _NUMCPU = runtime.GOMAXPROCS(0)
 
 func (s *segment) bloomFilterPath() string {
 	extless := strings.TrimSuffix(s.path, filepath.Ext(s.path))
@@ -39,7 +42,7 @@ func (s *segment) bloomFilterSecondaryPath(pos int) string {
 
 func (s *segment) initBloomFilters(metrics *Metrics, overwrite bool) error {
 	g := enterrors.NewErrorGroupWrapper(s.logger)
-
+	g.SetLimit(_NUMCPU)
 	g.Go(func() error {
 		if err := s.initBloomFilter(overwrite); err != nil {
 			return fmt.Errorf("primary index: %w", err)

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
+	bloom "github.com/bits-and-blooms/bloom/v3"
 	"github.com/pkg/errors"
-	"github.com/willf/bloom"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 )

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/cluster/utils"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -311,10 +312,21 @@ func (db *DB) Shutdown(ctx context.Context) error {
 
 	db.indexLock.Lock()
 	defer db.indexLock.Unlock()
+
+	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(db.logger, ctx)
+	eg.SetLimit(_NUMCPU)
 	for id, index := range db.indices {
-		if err := index.Shutdown(ctx); err != nil {
-			return errors.Wrapf(err, "shutdown index %q", id)
-		}
+		id, index := id, index // capture loop variables
+		eg.Go(func() error {
+			if err := index.Shutdown(ctx); err != nil {
+				return errors.Wrapf(err, "shutdown index %q", id)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
 	}
 
 	if asyncEnabled() {

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
 // IMPORTANT:
@@ -86,16 +88,38 @@ func (s *Shard) drop() (err error) {
 	}
 
 	if s.hasTargetVectors() {
-		// TODO run in parallel?
+		eg, ctx := enterrors.NewErrorGroupWithContextWrapper(s.index.logger, ctx)
+		eg.SetLimit(_NUMCPU)
+
 		for targetVector, queue := range s.queues {
-			if err = queue.Drop(); err != nil {
-				return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), err)
-			}
+			targetVector, queue := targetVector, queue // capture loop variables
+			eg.Go(func() error {
+				// Remove err from closure scope, use local error
+				if dropErr := queue.Drop(); dropErr != nil {
+					return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), dropErr)
+				}
+				return nil
+			})
 		}
+
+		// we have to close queue before index for versions before 1.28
+		if err = eg.Wait(); err != nil {
+			return err
+		}
+
 		for targetVector, vectorIndex := range s.vectorIndexes {
-			if err = vectorIndex.Drop(ctx); err != nil {
-				return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), err)
-			}
+			targetVector, vectorIndex := targetVector, vectorIndex // capture loop variables
+			eg.Go(func() error {
+				// Remove err from closure scope, use local error
+				if dropErr := vectorIndex.Drop(ctx); dropErr != nil {
+					return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), dropErr)
+				}
+				return nil
+			})
+		}
+
+		if err = eg.Wait(); err != nil {
+			return err
 		}
 	} else {
 		// delete queue cursor

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -16,8 +16,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
@@ -60,10 +63,10 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		return
 	}
 
-	ec := errorcompounder.New()
+	ec := errorcompounder.NewSafe()
 
 	err = s.GetPropertyLengthTracker().Close()
-	ec.AddWrap(err, "close prop length tracker")
+	ec.Add(errors.Wrap(err, "close prop length tracker"))
 
 	// unregister all callbacks at once, in parallel
 	err = cyclemanager.NewCombinedCallbackCtrl(0, s.index.logger,
@@ -79,12 +82,21 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.mayCloseAndStoreHashTree()
 
 	if s.hasTargetVectors() {
-		// TODO run in parallel?
+		eg := enterrors.NewErrorGroupWrapper(s.Index().logger)
+		eg.SetLimit(_NUMCPU)
 		for targetVector, queue := range s.queues {
-			err := queue.Close()
-			if err != nil {
-				ec.Add(fmt.Errorf("shut down vector index queue of vector %q: %w", targetVector, err))
-			}
+			targetVector, queue := targetVector, queue // capture loop variables
+			eg.Go(func() error {
+				if err := queue.Close(); err != nil {
+					ec.Add(fmt.Errorf("shut down vector index queue of vector %q: %w", targetVector, err))
+				}
+				return nil
+			})
+		}
+
+		// we have to close queue before index for versions before 1.28
+		if err = eg.Wait(); err != nil {
+			ec.Add(err)
 		}
 
 		for targetVector, vectorIndex := range s.vectorIndexes {
@@ -94,19 +106,25 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 				continue
 			}
 
-			err := vectorIndex.Flush()
-			if err != nil {
-				ec.Add(fmt.Errorf("flush vector index commitlog of vector %q: %w", targetVector, err))
-			}
+			targetVector, vectorIndex := targetVector, vectorIndex // capture loop variables
+			eg.Go(func() error {
+				if err := vectorIndex.Flush(); err != nil {
+					ec.Add(fmt.Errorf("flush vector index commitlog of vector %q: %w", targetVector, err))
+				}
 
-			err = vectorIndex.Shutdown(ctx)
-			if err != nil {
-				ec.Add(fmt.Errorf("shut down vector index of vector %q: %w", targetVector, err))
-			}
+				if err := vectorIndex.Shutdown(ctx); err != nil {
+					ec.Add(fmt.Errorf("shut down vector index of vector %q: %w", targetVector, err))
+				}
+				return nil
+			})
+		}
+
+		if err = eg.Wait(); err != nil {
+			ec.Add(err)
 		}
 	} else {
 		err = s.queue.Close()
-		ec.AddWrap(err, "shut down vector index queue")
+		ec.Add(errors.Wrap(err, "shut down vector index queue"))
 
 		if s.vectorIndex != nil {
 			// a nil-vector index during shutdown would indicate that the shard was not
@@ -118,10 +136,10 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 			// resulting in perpetually attempting to remove a tombstone
 			// which doesn't actually exist anymore
 			err = s.vectorIndex.Flush()
-			ec.AddWrap(err, "flush vector index commitlog")
+			ec.Add(errors.Wrap(err, "flush vector index commitlog"))
 
 			err = s.vectorIndex.Shutdown(ctx)
-			ec.AddWrap(err, "shut down vector index")
+			ec.Add(errors.Wrap(err, "shut down vector index"))
 		}
 	}
 
@@ -129,7 +147,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		// store would be nil if loading the objects bucket failed, as we would
 		// only return the store on success from s.initLSMStore()
 		err = s.store.Shutdown(ctx)
-		ec.AddWrap(err, "stop lsmkv store")
+		ec.Add(errors.Wrap(err, "stop lsmkv store"))
 	}
 
 	if s.dimensionTrackingInitialized.Load() {

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -565,6 +566,9 @@ func (l *hnswCommitLogger) combineLogs() (bool, error) {
 }
 
 func (l *hnswCommitLogger) Drop(ctx context.Context) error {
+	l.Lock()
+	defer l.Unlock()
+
 	if err := l.commitLogger.Close(); err != nil {
 		return errors.Wrap(err, "close hnsw commit logger prior to delete")
 	}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
@@ -586,6 +587,9 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 }
 
 func (h *hnsw) Drop(ctx context.Context) error {
+	h.Lock()
+	defer h.Unlock()
+
 	// cancel tombstone cleanup goroutine
 	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
@@ -612,6 +616,9 @@ func (h *hnsw) Drop(ctx context.Context) error {
 }
 
 func (h *hnsw) Shutdown(ctx context.Context) error {
+	h.Lock()
+	defer h.Unlock()
+
 	h.shutdownCtxCancel()
 
 	if err := h.commitLog.Shutdown(ctx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/weaviate/contextionary v1.2.1
-	github.com/willf/bloom v2.0.3+incompatible
 	go.etcd.io/bbolt v1.3.11
 	go.opentelemetry.io/otel v1.32.0 // indirect
 	golang.org/x/net v0.33.0
@@ -51,6 +50,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.36
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.34
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.17.0
+	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/edsrzf/mmap-go v1.1.0
@@ -109,6 +109,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.31.0 // indirect
 	github.com/aws/smithy-go v1.21.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cheggaaa/pb/v3 v3.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
+github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bloom/v3 v3.7.0 h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56jeWUzvzdls=
+github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/bmatcuk/doublestar v1.1.3 h1:S4Ka/fLvUtm+5TqKuByWyuGenBjTP8w+Z/GpQIWB9Yg=
 github.com/bmatcuk/doublestar v1.1.3/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
@@ -633,6 +637,8 @@ github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYN
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
+github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
 github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
 github.com/vcaesar/cedar v0.20.1 h1:cDOmYWdprO7ZW8cngJrDi8Zivnscj9dA/y8Y+2SB1P0=
@@ -655,8 +661,6 @@ github.com/weaviate/tiktoken-go v0.0.2 h1:lkwTMEoXSFSXxYvw1c44/xz3OOAh27L3+3vvNN
 github.com/weaviate/tiktoken-go v0.0.2/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
-github.com/willf/bloom v2.0.3+incompatible h1:QDacWdqcAUI1MPOwIQZRy9kOR7yxfyEmxX8Wdm2/JPA=
-github.com/willf/bloom v2.0.3+incompatible/go.mod h1:MmAltL9pDMNTrvUkxdg0k0q5I0suxmuwp3KbyrZLOZ8=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=


### PR DESCRIPTION
### What's being changed:
- `github.com/willf/bloom` is stale now and has been renamed to `github.com/bits-and-blooms/bloom`
- `initBloomFilters()` takes long time to execute we have seen from profiles, so this PR makes sure we init filters concurrently 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14627011541
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
