### PR TITLE
chore: concurrent segments markForDeletion(),  dropImmediately(), dropMarked()

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -317,7 +317,7 @@ func (s *segment) markForDeletion() error {
 	})
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("%w", err)
+		return err
 	}
 
 	// for the segment itself, we're not accepting a NotExists error. If there


### PR DESCRIPTION
### What's being changed:
this PR does convert segments markForDeletion(),  dropImmediately() dropMarked() to run concurrently to speed segments operations 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14645078727
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
