### PR TITLE
fix: sort string in /tasks to make it more deterministic

### DIFF
--- a/usecases/distributedtask/handler.go
+++ b/usecases/distributedtask/handler.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
@@ -52,6 +53,8 @@ func (h *Handler) ListTasks(ctx context.Context, principal *models.Principal) (m
 			for node := range task.FinishedNodes {
 				finishedNodes = append(finishedNodes, node)
 			}
+			// sort so it would be more deterministic and easier to test
+			sort.Strings(finishedNodes)
 
 			// Try to unmarshal the raw payload into a generic JSON object.
 			// If we introduce sensitive information to the payload, we can


### PR DESCRIPTION
### What's being changed:
Tests were flaky because we were constructing a slice by iterating a map. Sort it to make it more deterministic.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
