### PR TITLE
add snapshot/restore mechanism to replication fsm

### DIFF
--- a/cluster/fsm/snapshot.go
+++ b/cluster/fsm/snapshot.go
@@ -29,6 +29,8 @@ type Snapshot struct {
 	RBAC []byte `json:"rbac,omitempty"`
 	// DistributedTasks are the tasks that will be used to restore the FSM.
 	DistributedTasks []byte `json:"distributed_tasks,omitempty"`
+	// ReplicationOps are the currently ongoing operation for replica replication
+	ReplicationOps []byte `json:"replication_ops,omitempty"`
 }
 
 // Snapshotter is used to snapshot and restore any (FSM) state

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -156,12 +156,12 @@ func (c *CopyOpConsumer) Consume(ctx context.Context, in <-chan ShardReplication
 					opLogger := c.logger.WithFields(logrus.Fields{
 						"consumer":          c,
 						"op":                operation.ID,
-						"source_node":       operation.sourceShard.nodeId,
-						"target_node":       operation.targetShard.nodeId,
-						"source_shard":      operation.sourceShard.shardId,
-						"target_shard":      operation.targetShard.shardId,
-						"source_collection": operation.sourceShard.collectionId,
-						"target_collection": operation.targetShard.collectionId,
+						"source_node":       operation.SourceShard.NodeId,
+						"target_node":       operation.TargetShard.NodeId,
+						"source_shard":      operation.SourceShard.ShardId,
+						"target_shard":      operation.TargetShard.ShardId,
+						"source_collection": operation.SourceShard.CollectionId,
+						"target_collection": operation.TargetShard.CollectionId,
 					})
 
 					opLogger.Info("worker processing replication operation")
@@ -199,12 +199,12 @@ func (c *CopyOpConsumer) processReplicationOp(ctx context.Context, workerId uint
 	logger := c.logger.WithFields(logrus.Fields{
 		"consumer":          c,
 		"op":                op.ID,
-		"source_node":       op.sourceShard.nodeId,
-		"target_node":       op.targetShard.nodeId,
-		"source_shard":      op.sourceShard.shardId,
-		"target_shard":      op.targetShard.shardId,
-		"source_collection": op.sourceShard.collectionId,
-		"target_collection": op.targetShard.collectionId,
+		"source_node":       op.SourceShard.NodeId,
+		"target_node":       op.TargetShard.NodeId,
+		"source_shard":      op.SourceShard.ShardId,
+		"target_shard":      op.TargetShard.ShardId,
+		"source_collection": op.SourceShard.CollectionId,
+		"target_collection": op.TargetShard.CollectionId,
 	})
 
 	startTime := c.timeProvider.Now()
@@ -222,12 +222,12 @@ func (c *CopyOpConsumer) processReplicationOp(ctx context.Context, workerId uint
 
 		logger.WithField("consumer", c).Info("starting replication copy operation")
 
-		if err := c.replicaCopier.CopyReplica(ctx, op.sourceShard.nodeId, op.sourceShard.collectionId, op.targetShard.shardId); err != nil {
+		if err := c.replicaCopier.CopyReplica(ctx, op.SourceShard.NodeId, op.SourceShard.CollectionId, op.TargetShard.ShardId); err != nil {
 			logger.WithField("consumer", c).WithError(err).Error("failure while copying replica shard")
 			return err
 		}
 
-		if _, err := c.leaderClient.AddReplicaToShard(ctx, op.targetShard.collectionId, op.targetShard.shardId, op.targetShard.nodeId); err != nil {
+		if _, err := c.leaderClient.AddReplicaToShard(ctx, op.TargetShard.CollectionId, op.TargetShard.ShardId, op.TargetShard.NodeId); err != nil {
 			logger.WithField("consumer", c).WithError(err).Error("failure while updating sharding state")
 			return err
 		}
@@ -247,11 +247,11 @@ func (c *CopyOpConsumer) logCompletedReplicationOp(workerId uint64, startTime ti
 		"duration":          duration.String(),
 		"start_time":        startTime.Format(time.RFC1123),
 		"completed_since":   c.timeProvider.Now().Sub(endTime),
-		"source_node":       op.sourceShard.nodeId,
-		"target_node":       op.targetShard.nodeId,
-		"source_shard":      op.sourceShard.shardId,
-		"target_shard":      op.targetShard.shardId,
-		"source_collection": op.sourceShard.collectionId,
-		"target_collection": op.targetShard.collectionId,
+		"source_node":       op.SourceShard.NodeId,
+		"target_node":       op.TargetShard.NodeId,
+		"source_shard":      op.SourceShard.ShardId,
+		"target_shard":      op.TargetShard.ShardId,
+		"source_collection": op.SourceShard.CollectionId,
+		"target_collection": op.TargetShard.CollectionId,
 	}).Info("Replication operation completed successfully")
 }

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -43,6 +43,14 @@ func (m *Manager) GetReplicationFSM() *ShardReplicationFSM {
 	return m.replicationFSM
 }
 
+func (m *Manager) Snapshot() ([]byte, error) {
+	return m.replicationFSM.Snapshot()
+}
+
+func (m *Manager) Restore(bytes []byte) error {
+	return m.replicationFSM.Restore(bytes)
+}
+
 func (m *Manager) Replicate(logId uint64, c *cmd.ApplyRequest) error {
 	req := &cmd.ReplicationReplicateShardRequest{}
 	if err := json.Unmarshal(c.SubCommand, req); err != nil {
@@ -85,10 +93,10 @@ func (m *Manager) GetReplicationDetailsByReplicationId(c *cmd.QueryRequest) ([]b
 
 	response := cmd.ReplicationDetailsResponse{
 		Id:           op.ID,
-		ShardId:      op.sourceShard.shardId,
-		Collection:   op.sourceShard.collectionId,
-		SourceNodeId: op.sourceShard.nodeId,
-		TargetNodeId: op.targetShard.nodeId,
+		ShardId:      op.SourceShard.ShardId,
+		Collection:   op.SourceShard.CollectionId,
+		SourceNodeId: op.SourceShard.NodeId,
+		TargetNodeId: op.TargetShard.NodeId,
 		Status:       status.state.String(),
 	}
 

--- a/cluster/replication/producer.go
+++ b/cluster/replication/producer.go
@@ -129,15 +129,15 @@ func (p *FSMOpProducer) allOpsForNode(nodeId string) []ShardReplicationOp {
 		if opState.ShouldRestartOp() {
 			nodeOpsSubset = append(nodeOpsSubset, ShardReplicationOp{
 				ID: op.ID,
-				sourceShard: shardFQDN{
-					nodeId:       op.sourceShard.nodeId,
-					collectionId: op.sourceShard.collectionId,
-					shardId:      op.sourceShard.shardId,
+				SourceShard: shardFQDN{
+					NodeId:       op.SourceShard.NodeId,
+					CollectionId: op.SourceShard.CollectionId,
+					ShardId:      op.SourceShard.ShardId,
 				},
-				targetShard: shardFQDN{
-					nodeId:       op.targetShard.nodeId,
-					collectionId: op.targetShard.collectionId,
-					shardId:      op.targetShard.shardId,
+				TargetShard: shardFQDN{
+					NodeId:       op.TargetShard.NodeId,
+					CollectionId: op.TargetShard.CollectionId,
+					ShardId:      op.TargetShard.ShardId,
 				},
 			})
 		}

--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -29,23 +29,27 @@ func (s *ShardReplicationFSM) Replicate(id uint64, c *api.ReplicationReplicateSh
 	s.opsLock.Lock()
 	defer s.opsLock.Unlock()
 
-	srcFQDN := newShardFQDN(c.SourceNode, c.SourceCollection, c.SourceShard)
-	targetFQDN := newShardFQDN(c.TargetNode, c.SourceCollection, c.SourceShard)
-	if _, ok := s.opsByTargetFQDN[targetFQDN]; ok {
+	op := ShardReplicationOp{
+		ID:          id,
+		SourceShard: newShardFQDN(c.SourceNode, c.SourceCollection, c.SourceShard),
+		TargetShard: newShardFQDN(c.TargetNode, c.SourceCollection, c.SourceShard),
+	}
+	return s.writeOpIntoFSM(op, shardReplicationOpStatus{state: api.REGISTERED})
+}
+
+// writeOpIntoFSM writes the op with status into the FSM. It *does* not holds the lock onto the maps so the callee must make sure the lock
+// is held
+func (s *ShardReplicationFSM) writeOpIntoFSM(op ShardReplicationOp, status shardReplicationOpStatus) error {
+	if _, ok := s.opsByTargetFQDN[op.TargetShard]; ok {
 		return ErrShardAlreadyReplicating
 	}
 
-	op := ShardReplicationOp{
-		ID:          id,
-		sourceShard: srcFQDN,
-		targetShard: targetFQDN,
-	}
-	s.opsByNode[c.TargetNode] = append(s.opsByNode[c.TargetNode], op)
-	s.opsByShard[c.SourceShard] = append(s.opsByShard[c.SourceShard], op)
-	s.opsByCollection[c.SourceCollection] = append(s.opsByCollection[c.SourceCollection], op)
-	s.opsByTargetFQDN[targetFQDN] = op
+	s.opsByNode[op.TargetShard.NodeId] = append(s.opsByNode[op.TargetShard.NodeId], op)
+	s.opsByShard[op.SourceShard.CollectionId] = append(s.opsByShard[op.SourceShard.ShardId], op)
+	s.opsByCollection[op.SourceShard.CollectionId] = append(s.opsByCollection[op.SourceShard.CollectionId], op)
+	s.opsByTargetFQDN[op.TargetShard] = op
 	s.opsById[op.ID] = op
-	s.opsStatus[op] = shardReplicationOpStatus{state: api.REGISTERED}
+	s.opsStatus[op] = status
 
 	s.opsByStateGauge.WithLabelValues(s.opsStatus[op].state.String()).Inc()
 
@@ -82,36 +86,36 @@ func (s *ShardReplicationFSM) deleteShardReplicationOp(id uint64) error {
 		return ErrReplicationOpNotFound
 	}
 
-	ops, ok := s.opsByNode[op.sourceShard.nodeId]
+	ops, ok := s.opsByNode[op.SourceShard.NodeId]
 	if !ok {
 		err = multierror.Append(err, fmt.Errorf("could not find op in ops by node, this should not happen"))
 	}
 	opsReplace, ok := findAndDeleteOp(op.ID, ops)
 	if ok {
-		s.opsByNode[op.sourceShard.nodeId] = opsReplace
+		s.opsByNode[op.SourceShard.NodeId] = opsReplace
 	}
 
-	ops, ok = s.opsByCollection[op.sourceShard.collectionId]
+	ops, ok = s.opsByCollection[op.SourceShard.CollectionId]
 	if !ok {
 		err = multierror.Append(err, fmt.Errorf("could not find op in ops by collection, this should not happen"))
 	}
 	opsReplace, ok = findAndDeleteOp(op.ID, ops)
 	if ok {
-		s.opsByCollection[op.sourceShard.collectionId] = opsReplace
+		s.opsByCollection[op.SourceShard.CollectionId] = opsReplace
 	}
 
-	ops, ok = s.opsByShard[op.sourceShard.shardId]
+	ops, ok = s.opsByShard[op.SourceShard.ShardId]
 	if !ok {
 		err = multierror.Append(err, fmt.Errorf("could not find op in ops by shard, this should not happen"))
 	}
 	opsReplace, ok = findAndDeleteOp(op.ID, ops)
 	if ok {
-		s.opsByShard[op.sourceShard.shardId] = opsReplace
+		s.opsByShard[op.SourceShard.ShardId] = opsReplace
 	}
 
 	s.opsByStateGauge.WithLabelValues(s.opsStatus[op].state.String()).Dec()
 
-	delete(s.opsByTargetFQDN, op.targetShard)
+	delete(s.opsByTargetFQDN, op.TargetShard)
 	delete(s.opsById, op.ID)
 	delete(s.opsStatus, op)
 

--- a/cluster/replication/shard_replication_fqdn.go
+++ b/cluster/replication/shard_replication_fqdn.go
@@ -11,26 +11,28 @@
 
 package replication
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // shardFQDN uniquely identify a shard in a weaviate cluster
 type shardFQDN struct {
 	// nodeId is the node containing the shard
-	nodeId string
+	NodeId string
 	// collectionId is the collection containing the shard
-	collectionId string
+	CollectionId string
 	// shardId is the id of the shard
-	shardId string
+	ShardId string
 }
 
 func newShardFQDN(nodeId, collectionId, shardId string) shardFQDN {
 	return shardFQDN{
-		nodeId:       nodeId,
-		collectionId: collectionId,
-		shardId:      shardId,
+		NodeId:       nodeId,
+		CollectionId: collectionId,
+		ShardId:      shardId,
 	}
 }
 
 func (s shardFQDN) String() string {
-	return fmt.Sprintf("%s/%s/%s", s.nodeId, s.collectionId, s.shardId)
+	return fmt.Sprintf("%s/%s/%s", s.NodeId, s.CollectionId, s.ShardId)
 }

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -43,12 +43,18 @@ func (s *Store) Persist(sink raft.SnapshotSink) (err error) {
 		return fmt.Errorf("tasks snapshot: %w", err)
 	}
 
+	replicationSnapshot, err := s.replicationManager.Snapshot()
+	if err != nil {
+		return fmt.Errorf("replication snapshot: %w", err)
+	}
+
 	snap := fsm.Snapshot{
 		NodeID:           s.cfg.NodeID,
 		SnapshotID:       sink.ID(),
 		Schema:           schemaSnapshot,
 		RBAC:             rbacSnapshot,
 		DistributedTasks: tasksSnapshot,
+		ReplicationOps:   replicationSnapshot,
 	}
 	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
 		return fmt.Errorf("encode: %w", err)
@@ -127,6 +133,13 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 			if err := st.distributedTasksManager.Restore(snap.DistributedTasks); err != nil {
 				st.log.WithError(err).Error("restoring distributed tasks from snapshot")
 				return fmt.Errorf("restore distributed tasks from snapshot: %w", err)
+			}
+		}
+
+		if snap.ReplicationOps != nil {
+			if err := st.replicationManager.Restore(snap.ReplicationOps); err != nil {
+				st.log.WithError(err).Error("restoring replication ops from snapshot")
+				return fmt.Errorf("restore replication ops from snapshot: %w", err)
 			}
 		}
 


### PR DESCRIPTION
### What's being changed:

Add snapshot/restore mechanism to replication FSM to fully comply with raft.
Updating the fields in internal struct to ensure they are exported and can be json serialized/unserialized


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
