### PR TITLE
Skip replication ops that are already running or completed

### DIFF
--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -88,6 +88,9 @@ func TestConsumerWithCallbacks(t *testing.T) {
 
 		consumer := replication.NewCopyOpConsumer(
 			logger,
+			func(op replication.ShardReplicationOp) bool {
+				return false
+			},
 			mockFSMUpdater,
 			mockReplicaCopier,
 			mockTimeProvider,
@@ -185,6 +188,9 @@ func TestConsumerWithCallbacks(t *testing.T) {
 
 		consumer := replication.NewCopyOpConsumer(
 			logger,
+			func(op replication.ShardReplicationOp) bool {
+				return false
+			},
 			mockFSMUpdater,
 			mockReplicaCopier,
 			mockTimeProvider,
@@ -282,8 +288,18 @@ func TestConsumerWithCallbacks(t *testing.T) {
 			}).Build()
 
 		consumer := replication.NewCopyOpConsumer(
-			logger, mockFSMUpdater, mockReplicaCopier, mockTimeProvider,
-			"node2", &backoff.StopBackOff{}, time.Second*10, 1, metricsCallbacks,
+			logger,
+			func(op replication.ShardReplicationOp) bool {
+				return false
+			},
+			mockFSMUpdater,
+			mockReplicaCopier,
+			mockTimeProvider,
+			"node2",
+			&backoff.StopBackOff{},
+			time.Second*10,
+			1,
+			metricsCallbacks,
 		)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -147,3 +147,16 @@ func (s *ShardReplicationFSM) filterOneReplicaReadWrite(node string, collection 
 	}
 	return readOk, writeOk
 }
+
+// ShouldSkipReplicationOp determines whether the given replication operation
+// should be skipped before starting it in the OpConsumer.
+//
+// An operation is considered eligible for skipping if it is not in the REGISTERED state,
+// which means it has already started, completed, successfully or not.
+//
+// Returns:
+//   - true if the operation should be skipped
+//   - false if the operation is in the REGISTERED state and ready to run
+func (s *ShardReplicationFSM) ShouldSkipReplicationOp(op ShardReplicationOp) bool {
+	return api.REGISTERED != s.GetOpState(op).state
+}

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -82,6 +82,9 @@ func New(cfg Config, authZController authorization.Controller, snapshotter fsm.S
 	realTimeProvider := replication.RealTimeProvider{}
 	replicaCopyOpConsumer := replication.NewCopyOpConsumer(
 		cfg.Logger,
+		func(op replication.ShardReplicationOp) bool {
+			return fsm.replicationManager.GetReplicationFSM().ShouldSkipReplicationOp(op)
+		},
 		raft,
 		cfg.ReplicaCopier,
 		realTimeProvider,


### PR DESCRIPTION
### What's being changed:

This commit updates the CopyOpConsumer to skip replication operations that are not in the REGISTERED state, meaning they are already running, completed, or otherwise not eligible to start.

This avoids:
- unnecessary retries of completed operations
- skewing success/failure metrics with already-processed ops
- wasting worker tokens and system resources

To support this, the consumer now checks op state before proceeding. The check is injected as a function to simplify testing and avoid tight coupling to the FSM.

Worker tokens are still acquired before the check to maintain strict concurrency control, ensuring that maxWorkers is always respected even when many ops are skipped. This is also required as the producer might write the same op multiple times if the replication operation statys in REGISTRED state across multiple polling intervals.

This results in cleaner logs, accurate metrics, and more efficient execution.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
