### PR TITLE
Add named `Vectors` to `GroupHitAdditional` struct

### DIFF
--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -217,7 +217,7 @@ func TestGRPCReply(t *testing.T) {
 			name: "named vector only",
 			res: []interface{}{
 				map[string]interface{}{
-					"_additional": map[string]interface{}{"vectors": map[string][]float32{"custom": {1}, "first": {2}}},
+					"_additional": map[string]interface{}{"vectors": map[string]models.Vector{"custom": {1}, "first": {2}}},
 				},
 			},
 			searchParams: dto.GetParams{AdditionalProperties: additional.Properties{Vectors: []string{"custom", "first"}}},

--- a/adapters/repos/db/refcache/resolver.go
+++ b/adapters/repos/db/refcache/resolver.go
@@ -233,7 +233,7 @@ func (r *Resolver) resolveRef(item *models.SingleRef, desiredClass string,
 		nested["vector"] = res.Vector
 	}
 	if len(additionalProperties.Vectors) > 0 {
-		vectors := make(map[string][]float32)
+		vectors := make(map[string]models.Vector)
 		for _, targetVector := range additionalProperties.Vectors {
 			vectors[targetVector] = res.Vectors[targetVector]
 		}

--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -170,7 +170,9 @@ DOCS_LOOP:
 				ID:       docIDObject[docID].ID(),
 				Distance: docIDDistance[docID],
 				Vector:   docIDObject[docID].Vector,
+				Vectors:  docIDObject[docID].GetVectors(),
 			}
+
 			hits[j] = props
 		}
 		group := &additional.Group{

--- a/entities/additional/group.go
+++ b/entities/additional/group.go
@@ -11,7 +11,10 @@
 
 package additional
 
-import "github.com/go-openapi/strfmt"
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/weaviate/weaviate/entities/models"
+)
 
 type Group struct {
 	ID          int                      `json:"id"`
@@ -28,7 +31,8 @@ type GroupedBy struct {
 }
 
 type GroupHitAdditional struct {
-	ID       strfmt.UUID `json:"id"`
-	Vector   []float32   `json:"vector"`
-	Distance float32     `json:"distance"`
+	ID       strfmt.UUID    `json:"id"`
+	Vector   []float32      `json:"vector"`
+	Vectors  models.Vectors `json:"vectors"`
+	Distance float32        `json:"distance"`
 }

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -527,6 +527,10 @@ func (ko *Object) asVectors(in map[string][]float32) models.Vectors {
 	return nil
 }
 
+func (ko *Object) GetVectors() models.Vectors {
+	return ko.asVectors(ko.Vectors)
+}
+
 func (ko *Object) SearchResultWithDist(addl additional.Properties, dist float32) search.Result {
 	res := ko.SearchResult(addl, "")
 	res.Dist = dist

--- a/test/acceptance/grpc/grpc_named_vectors_test.go
+++ b/test/acceptance/grpc/grpc_named_vectors_test.go
@@ -13,6 +13,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,99 +49,142 @@ func TestGRPC_NamedVectors(t *testing.T) {
 		require.NotNil(t, resp)
 	})
 
-	t.Run("Search with hybrid", func(t *testing.T) {
-		resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
-			Collection: booksClass.Class,
-			HybridSearch: &pb.Hybrid{
-				Query:         "Dune",
-				TargetVectors: []string{"all"},
-			},
-			Uses_123Api: true,
-			Uses_125Api: true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.Results)
-		require.Equal(t, "Dune", resp.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
-	})
-
-	t.Run("Search with hybrid and group by", func(t *testing.T) {
-		resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
-			Collection: booksClass.Class,
-			GroupBy: &pb.GroupBy{
-				Path:            []string{"title"},
-				NumberOfGroups:  1,
-				ObjectsPerGroup: 1,
-			},
-			HybridSearch: &pb.Hybrid{
-				Query:         "Dune",
-				TargetVectors: []string{"all"},
-			},
-			Uses_123Api: true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.GroupByResults)
-		require.Len(t, resp.GroupByResults, 1)
-	})
-
-	t.Run("Search with hybrid near text and group by", func(t *testing.T) {
-		resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
-			Collection: booksClass.Class,
-			GroupBy: &pb.GroupBy{
-				Path:            []string{"title"},
-				NumberOfGroups:  1,
-				ObjectsPerGroup: 1,
-			},
-			HybridSearch: &pb.Hybrid{
-				Alpha: 0.5,
-				NearText: &pb.NearTextSearch{
-					Query: []string{"Dune"},
+	tests := []struct {
+		name         string
+		req          *pb.MetadataRequest
+		expectedVecs int
+	}{
+		{
+			name:         "all vectors",
+			req:          &pb.MetadataRequest{Vector: true},
+			expectedVecs: 3,
+		},
+		{
+			name:         "one vector",
+			req:          &pb.MetadataRequest{Vectors: []string{"all"}},
+			expectedVecs: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Search with hybrid return returning %s", tt.name), func(t *testing.T) {
+			resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
+				Collection: booksClass.Class,
+				Metadata:   tt.req,
+				HybridSearch: &pb.Hybrid{
+					Query:         "Dune",
+					TargetVectors: []string{"all"},
 				},
-				TargetVectors: []string{"all"},
-			},
-			Uses_123Api: true,
-			Uses_125Api: true,
+				Uses_123Api: true,
+				Uses_125Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.Results)
+			require.Equal(t, "Dune", resp.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
+			require.Len(t, resp.Results[0].Metadata.Vectors, tt.expectedVecs)
+			if tt.expectedVecs == 1 {
+				require.Equal(t, "all", resp.Results[0].Metadata.Vectors[0].Name)
+			}
 		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.GroupByResults)
-		require.Len(t, resp.GroupByResults, 1)
-	})
 
-	t.Run("Search with near text", func(t *testing.T) {
-		resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
-			Collection: booksClass.Class,
-			NearText: &pb.NearTextSearch{
-				Query:         []string{"Dune"},
-				TargetVectors: []string{"all"},
-			},
-			Uses_123Api: true,
-			Uses_125Api: true,
+		t.Run(fmt.Sprintf("Search with hybrid and group by returning %s", tt.name), func(t *testing.T) {
+			resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
+				Collection: booksClass.Class,
+				Metadata:   tt.req,
+				GroupBy: &pb.GroupBy{
+					Path:            []string{"title"},
+					NumberOfGroups:  1,
+					ObjectsPerGroup: 1,
+				},
+				HybridSearch: &pb.Hybrid{
+					Query:         "Dune",
+					TargetVectors: []string{"all"},
+				},
+				Uses_123Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.GroupByResults)
+			require.Len(t, resp.GroupByResults, 1)
+			require.Len(t, resp.GroupByResults[0].Objects[0].Metadata.Vectors, tt.expectedVecs)
+			if tt.expectedVecs == 1 {
+				require.Equal(t, "all", resp.GroupByResults[0].Objects[0].Metadata.Vectors[0].Name)
+			}
 		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.Results)
-		require.Equal(t, "Dune", resp.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
-	})
 
-	t.Run("Search with near text and group by", func(t *testing.T) {
-		resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
-			Collection: booksClass.Class,
-			GroupBy: &pb.GroupBy{
-				Path:            []string{"title"},
-				NumberOfGroups:  1,
-				ObjectsPerGroup: 1,
-			},
-			NearText: &pb.NearTextSearch{
-				Query:         []string{"Dune"},
-				TargetVectors: []string{"all"},
-			},
-			Uses_123Api: true,
+		t.Run(fmt.Sprintf("Search with hybrid near text and group by returning %s", tt.name), func(t *testing.T) {
+			resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
+				Collection: booksClass.Class,
+				GroupBy: &pb.GroupBy{
+					Path:            []string{"title"},
+					NumberOfGroups:  1,
+					ObjectsPerGroup: 1,
+				},
+				Metadata: tt.req,
+				HybridSearch: &pb.Hybrid{
+					Alpha: 0.5,
+					NearText: &pb.NearTextSearch{
+						Query: []string{"Dune"},
+					},
+					TargetVectors: []string{"all"},
+				},
+				Uses_123Api: true,
+				Uses_125Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.GroupByResults)
+			require.Len(t, resp.GroupByResults, 1)
+			require.Len(t, resp.GroupByResults[0].Objects[0].Metadata.Vectors, tt.expectedVecs)
+			if tt.expectedVecs == 1 {
+				require.Equal(t, "all", resp.GroupByResults[0].Objects[0].Metadata.Vectors[0].Name)
+			}
 		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.GroupByResults)
-		require.Len(t, resp.GroupByResults, 1)
-	})
+
+		t.Run(fmt.Sprintf("Search with near text returning %s", tt.name), func(t *testing.T) {
+			resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
+				Collection: booksClass.Class,
+				Metadata:   tt.req,
+				NearText: &pb.NearTextSearch{
+					Query:         []string{"Dune"},
+					TargetVectors: []string{"all"},
+				},
+				Uses_123Api: true,
+				Uses_125Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.Results)
+			require.Equal(t, "Dune", resp.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
+			require.Len(t, resp.Results[0].Metadata.Vectors, tt.expectedVecs)
+			if tt.expectedVecs == 1 {
+				require.Equal(t, "all", resp.Results[0].Metadata.Vectors[0].Name)
+			}
+		})
+
+		t.Run(fmt.Sprintf("Search with near text and group by returning %s", tt.name), func(t *testing.T) {
+			resp, err := grpcClient.Search(context.TODO(), &pb.SearchRequest{
+				Collection: booksClass.Class,
+				GroupBy: &pb.GroupBy{
+					Path:            []string{"title"},
+					NumberOfGroups:  1,
+					ObjectsPerGroup: 1,
+				},
+				Metadata: tt.req,
+				NearText: &pb.NearTextSearch{
+					Query:         []string{"Dune"},
+					TargetVectors: []string{"all"},
+				},
+				Uses_123Api: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.GroupByResults)
+			require.Len(t, resp.GroupByResults, 1)
+			require.Len(t, resp.GroupByResults[0].Objects[0].Metadata.Vectors, tt.expectedVecs)
+			if tt.expectedVecs == 1 {
+				require.Equal(t, "all", resp.GroupByResults[0].Objects[0].Metadata.Vectors[0].Name)
+			}
+		})
+	}
 }

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -493,7 +493,7 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 		}
 
 		if len(params.AdditionalProperties.Vectors) > 0 {
-			vectors := make(map[string][]float32)
+			vectors := make(map[string]models.Vector)
 			for _, targetVector := range params.AdditionalProperties.Vectors {
 				vectors[targetVector] = res.Vectors[targetVector]
 			}

--- a/usecases/traverser/hybrid_group_by.go
+++ b/usecases/traverser/hybrid_group_by.go
@@ -66,6 +66,7 @@ func (e *Explorer) groupSearchResults(ctx context.Context, sr search.Results, gr
 				ID:       groupMember.ID,
 				Distance: groupMember.Dist,
 				Vector:   groupMember.Vector,
+				Vectors:  groupMember.Vectors,
 			}
 			hits[j] = props
 		}


### PR DESCRIPTION
This PR introduces the `Vectors` to the `GroupHitAdditional` struct so that there is BC when clients switch from legacy vectors to named vectors with groupBy searches containing the vectors of the group hits themselves.

In the process, it improves the gRPC parsing of the `interface{}` result for vectors and attempts to align the codebase to use `models.Vector` for this very reason.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
