### PR TITLE
chore: optimize reading headers to precompute compaction

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -118,7 +118,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		return nil, fmt.Errorf("mmap file: %w", err)
 	}
 
-	header, err := segmentindex.ParseHeader(bytes.NewReader(contents[:segmentindex.HeaderSize]))
+	header, err := segmentindex.ParseHeader(contents[:segmentindex.HeaderSize])
 	if err != nil {
 		return nil, fmt.Errorf("parse header: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -12,7 +12,6 @@
 package lsmkv
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -64,7 +63,7 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 
 	defer contents.Unmap()
 
-	header, err := segmentindex.ParseHeader(bytes.NewReader(contents[:segmentindex.HeaderSize]))
+	header, err := segmentindex.ParseHeader(contents[:segmentindex.HeaderSize])
 	if err != nil {
 		return nil, fmt.Errorf("parse header: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segmentindex/header.go
+++ b/adapters/repos/db/lsmkv/segmentindex/header.go
@@ -114,15 +114,9 @@ func (h *Header) SecondaryIndex(source []byte, indexID uint16) ([]byte, error) {
 	return source[start:end], nil
 }
 
-func ParseHeader(r io.Reader) (*Header, error) {
-	data := make([]byte, HeaderSize)
-
-	full, err := io.ReadFull(r, data)
-	if err != nil {
-		return nil, err
-	}
-	if full != HeaderSize {
-		return nil, fmt.Errorf("expected %d bytes, got %d", HeaderSize, full)
+func ParseHeader(data []byte) (*Header, error) {
+	if len(data) != HeaderSize {
+		return nil, fmt.Errorf("expected %d bytes, got %d", HeaderSize, len(data))
 	}
 	rw := byteops.NewReadWriter(data)
 	out := &Header{}

--- a/adapters/repos/db/lsmkv/segmentindex/header_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/header_test.go
@@ -12,7 +12,6 @@
 package segmentindex
 
 import (
-	"bytes"
 	"os"
 	"testing"
 
@@ -24,7 +23,7 @@ func BenchmarkParseHeader(b *testing.B) {
 	require.Len(b, data, HeaderSize)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseHeader(bytes.NewReader(data))
+		_, err := ParseHeader(data)
 		require.NoError(b, err)
 	}
 }

--- a/adapters/repos/db/roaringset/compactor_test.go
+++ b/adapters/repos/db/roaringset/compactor_test.go
@@ -421,18 +421,15 @@ func Test_Compactor(t *testing.T) {
 			f, err = os.Open(segmentFile)
 			require.NoError(t, err)
 
-			data, err := io.ReadAll(f)
-			require.NoError(t, err)
-
-			header, err := segmentindex.ParseHeader(data)
-			require.NoError(t, err)
-
 			segmentBytes, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			header, err := segmentindex.ParseHeader(segmentBytes[:segmentindex.HeaderSize])
 			require.NoError(t, err)
 
 			require.NoError(t, f.Close())
 
-			cu := NewSegmentCursor(segmentBytes[:header.IndexStart-segmentindex.HeaderSize], nil)
+			cu := NewSegmentCursor(segmentBytes[segmentindex.HeaderSize:header.IndexStart], nil)
 
 			i := 0
 			for k, v, _ := cu.First(); k != nil; k, v, _ = cu.Next() {
@@ -465,18 +462,15 @@ func Test_Compactor(t *testing.T) {
 			f, err = os.Open(segmentFile)
 			require.NoError(t, err)
 
-			data, err := io.ReadAll(f)
-			require.NoError(t, err)
-
-			header, err := segmentindex.ParseHeader(data)
-			require.NoError(t, err)
-
 			segmentBytes, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			header, err := segmentindex.ParseHeader(segmentBytes[:segmentindex.HeaderSize])
 			require.NoError(t, err)
 
 			require.NoError(t, f.Close())
 
-			cu := NewSegmentCursor(segmentBytes[:header.IndexStart-segmentindex.HeaderSize], nil)
+			cu := NewSegmentCursor(segmentBytes[segmentindex.HeaderSize:header.IndexStart], nil)
 
 			i := 0
 			for k, v, _ := cu.First(); k != nil; k, v, _ = cu.Next() {

--- a/adapters/repos/db/roaringset/compactor_test.go
+++ b/adapters/repos/db/roaringset/compactor_test.go
@@ -421,7 +421,10 @@ func Test_Compactor(t *testing.T) {
 			f, err = os.Open(segmentFile)
 			require.NoError(t, err)
 
-			header, err := segmentindex.ParseHeader(f)
+			data, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			header, err := segmentindex.ParseHeader(data)
 			require.NoError(t, err)
 
 			segmentBytes, err := io.ReadAll(f)
@@ -462,7 +465,10 @@ func Test_Compactor(t *testing.T) {
 			f, err = os.Open(segmentFile)
 			require.NoError(t, err)
 
-			header, err := segmentindex.ParseHeader(f)
+			data, err := io.ReadAll(f)
+			require.NoError(t, err)
+
+			header, err := segmentindex.ParseHeader(data)
 			require.NoError(t, err)
 
 			segmentBytes, err := io.ReadAll(f)

--- a/adapters/repos/db/roaringsetrange/compactor_test.go
+++ b/adapters/repos/db/roaringsetrange/compactor_test.go
@@ -457,7 +457,10 @@ func Test_Compactor(t *testing.T) {
 				f, err = os.Open(segmentFile)
 				require.NoError(t, err)
 
-				header, err := segmentindex.ParseHeader(f)
+				data, err := io.ReadAll(f)
+				require.NoError(t, err)
+
+				header, err := segmentindex.ParseHeader(data)
 				require.NoError(t, err)
 
 				segmentBytes, err := io.ReadAll(f)
@@ -503,7 +506,10 @@ func Test_Compactor(t *testing.T) {
 				f, err = os.Open(segmentFile)
 				require.NoError(t, err)
 
-				header, err := segmentindex.ParseHeader(f)
+				data, err := io.ReadAll(f)
+				require.NoError(t, err)
+
+				header, err := segmentindex.ParseHeader(data)
 				require.NoError(t, err)
 
 				segmentBytes, err := io.ReadAll(f)

--- a/adapters/repos/db/roaringsetrange/compactor_test.go
+++ b/adapters/repos/db/roaringsetrange/compactor_test.go
@@ -457,18 +457,15 @@ func Test_Compactor(t *testing.T) {
 				f, err = os.Open(segmentFile)
 				require.NoError(t, err)
 
-				data, err := io.ReadAll(f)
-				require.NoError(t, err)
-
-				header, err := segmentindex.ParseHeader(data)
-				require.NoError(t, err)
-
 				segmentBytes, err := io.ReadAll(f)
+				require.NoError(t, err)
+
+				header, err := segmentindex.ParseHeader(segmentBytes[:segmentindex.HeaderSize])
 				require.NoError(t, err)
 
 				require.NoError(t, f.Close())
 
-				cu := NewSegmentCursorMmap(segmentBytes[:header.IndexStart-segmentindex.HeaderSize])
+				cu := NewSegmentCursorMmap(segmentBytes[segmentindex.HeaderSize:header.IndexStart])
 
 				i := 0
 				for k, l, ok := cu.First(); ok; k, l, ok = cu.Next() {
@@ -506,18 +503,15 @@ func Test_Compactor(t *testing.T) {
 				f, err = os.Open(segmentFile)
 				require.NoError(t, err)
 
-				data, err := io.ReadAll(f)
-				require.NoError(t, err)
-
-				header, err := segmentindex.ParseHeader(data)
-				require.NoError(t, err)
-
 				segmentBytes, err := io.ReadAll(f)
+				require.NoError(t, err)
+
+				header, err := segmentindex.ParseHeader(segmentBytes[:segmentindex.HeaderSize])
 				require.NoError(t, err)
 
 				require.NoError(t, f.Close())
 
-				cu := NewSegmentCursorMmap(segmentBytes[:header.IndexStart-segmentindex.HeaderSize])
+				cu := NewSegmentCursorMmap(segmentBytes[segmentindex.HeaderSize:header.IndexStart])
 
 				i := 0
 				for k, l, ok := cu.First(); ok; k, l, ok = cu.Next() {


### PR DESCRIPTION
### What's being changed:

remove unneeded alloc when parsing headers

Before: BenchmarkParseHeader-10    	 7289858	       165.1 ns/op
After: BenchmarkParseHeader-10    	 9454771	       126.8 ns/op


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
