### PR TITLE
avoid nil logger in pv-pair

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -45,14 +44,13 @@ type propValuePair struct {
 	hasSearchableIndex bool
 	hasRangeableIndex  bool
 	Class              *models.Class // The schema
-	logger             logrus.FieldLogger
 }
 
-func newPropValuePair(class *models.Class, logger logrus.FieldLogger) (*propValuePair, error) {
+func newPropValuePair(class *models.Class) (*propValuePair, error) {
 	if class == nil {
 		return nil, errors.Errorf("class must not be nil")
 	}
-	return &propValuePair{logger: logger, docIDs: newDocBitmap(), Class: class}, nil
+	return &propValuePair{docIDs: newDocBitmap(), Class: class}, nil
 }
 
 func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) error {
@@ -94,7 +92,7 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 		}
 		pv.docIDs = dbm
 	} else {
-		eg := enterrors.NewErrorGroupWrapper(pv.logger)
+		eg := enterrors.NewErrorGroupWrapper(s.logger)
 		// prevent unbounded concurrency, see
 		// https://github.com/weaviate/weaviate/issues/3179 for details
 		eg.SetLimit(2 * _NUMCPU)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -227,7 +227,7 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 	if class == nil {
 		return nil, fmt.Errorf("class %q not found", className)
 	}
-	out, err := newPropValuePair(class, s.logger)
+	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)
 	}
@@ -706,7 +706,7 @@ func (s *Searcher) extractContains(path *filters.Path, propType schema.DataType,
 	if err != nil {
 		return nil, err
 	}
-	out, err := newPropValuePair(class, s.logger)
+	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)
 	}


### PR DESCRIPTION
The current logic was far to complex and tried to pass a logger to pv. That failed when a new, nested pv was created that could have a nil logger.

This new solution is much simpler because it removes the logger from pv entirely. Instead it takes the logger out of the Searcher struct which is a singleton and always has a logger

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
