### PR TITLE
chore: flush active memtable only if threshold is reached

### DIFF
--- a/test/acceptance_lsmkv/data_integrity_test.go
+++ b/test/acceptance_lsmkv/data_integrity_test.go
@@ -71,11 +71,12 @@ func TestLSMKV_ChecksumsCatchCorruptedFiles(t *testing.T) {
 	bucket, err := newTestBucket(dataDir, true)
 	require.NoError(t, err)
 	require.NoError(t, bucket.Put(key, val))
+	require.NoError(t, bucket.FlushMemtable())
 	require.NoError(t, bucket.Shutdown(context.Background()))
 
 	entries, err := os.ReadDir(dataDir)
 	require.NoError(t, err)
-	require.Len(t, entries, 1, "single segment file should be created")
+	require.Len(t, entries, 2, "one segment and one wal file should be created")
 
 	segmentPath := path.Join(dataDir, entries[0].Name())
 	fileContent, err := os.ReadFile(segmentPath)


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
