### PR TITLE
Recreate mt out of .wal file instead of flushing

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -13,7 +13,9 @@ package lsmkv
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -305,4 +307,80 @@ func TestBucketGetBySecondary(t *testing.T) {
 
 	_, err = b.GetBySecondary(1, []byte("bonjour"))
 	require.Error(t, err)
+}
+
+func TestBucketWalReload(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	// initial bucket, always create segment, even if it is just a single entry
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello"), []byte("world"), WithSecondaryKey(0, []byte("bonjour"))))
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err := os.ReadDir(dirName)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "single segment file should be created")
+
+	// start fresh with a new memtable, new entries will stay in way until size is reached
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err = os.ReadDir(dirName)
+	require.NoError(t, err)
+	fileTypes := map[string]int{}
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	require.Equal(t, fileTypes[".db"], 1, "single segment file")
+	require.Equal(t, fileTypes[".wal"], 1, "single wal file")
+
+	// will load wal and reuse memtable
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello3"), []byte("world3"), WithSecondaryKey(0, []byte("bonjour3"))))
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err = os.ReadDir(dirName)
+	require.NoError(t, err)
+	clear(fileTypes)
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	require.Equal(t, fileTypes[".db"], 1, "single segment file")
+	require.Equal(t, fileTypes[".wal"], 1, "single wal file")
+
+	// now add a lot of entries to hit .wal file limit
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	for i := 4; i < 120; i++ { // larger than pagesize
+		require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i)), WithSecondaryKey(0, []byte(fmt.Sprintf("bonjour%d", i)))))
+	}
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err = os.ReadDir(dirName)
+	require.NoError(t, err)
+	clear(fileTypes)
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	require.Equal(t, fileTypes[".db"], 2, "single segment file")
+	require.Equal(t, fileTypes[".wal"], 0, "single wal file")
 }

--- a/test/acceptance_lsmkv/data_integrity_test.go
+++ b/test/acceptance_lsmkv/data_integrity_test.go
@@ -69,6 +69,7 @@ func TestLSMKV_ChecksumsCatchCorruptedFiles(t *testing.T) {
 
 	// create a bucket with checksums enabled and flush some data to disk
 	bucket, err := newTestBucket(dataDir, true)
+
 	require.NoError(t, err)
 	require.NoError(t, bucket.Put(key, val))
 	require.NoError(t, bucket.Shutdown(context.Background()))
@@ -77,12 +78,12 @@ func TestLSMKV_ChecksumsCatchCorruptedFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1, "single segment file should be created")
 
-	segmentPath := path.Join(dataDir, entries[0].Name())
+	segmentPath := path.Join(dataDir, entries[0].Name()) // db file
 	fileContent, err := os.ReadFile(segmentPath)
 	require.NoError(t, err)
 
 	valueOffset := bytes.Index(fileContent, val)
-	require.NotEqual(t, -1, valueOffset, "value was not find in the segment file")
+	require.NotEqual(t, -1, valueOffset, "value was not found in the segment file")
 
 	// corrupt the file contents
 	fileContent[valueOffset] = 0xFF


### PR DESCRIPTION
### What's being changed:

When recovering from a .wal file we will reuse it as the next memtable instead of flushing it (==creating a new segment). When shutdown is called, we will only flush the mt if the size limit is reached and otherwise leave the .wal file behind to reuse on the next load.

This should dramatically reduce the amount of segments when we have many tiny writes per tenant with activation/deactivation each

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
