### PR TITLE
chore: Handle file descriptors cleanup in few places

### DIFF
--- a/adapters/repos/db/indexcounter/counter.go
+++ b/adapters/repos/db/indexcounter/counter.go
@@ -43,6 +43,7 @@ func New(shardPath string) (*Counter, error) {
 		// the file has existed before, we need to initialize with its content
 		err := binary.Read(f, binary.LittleEndian, &initialCount)
 		if err != nil {
+			f.Close()
 			return nil, errors.Wrap(err, "read initial count from file")
 		}
 

--- a/adapters/repos/db/indexcounter/counter.go
+++ b/adapters/repos/db/indexcounter/counter.go
@@ -52,7 +52,6 @@ func New(shardPath string) (cr *Counter, rerr error) {
 		// the file has existed before, we need to initialize with its content
 		err := binary.Read(f, binary.LittleEndian, &initialCount)
 		if err != nil {
-			f.Close()
 			return nil, errors.Wrap(err, "read initial count from file")
 		}
 

--- a/adapters/repos/db/inverted/prop_length_tracker.go
+++ b/adapters/repos/db/inverted/prop_length_tracker.go
@@ -75,10 +75,12 @@ func NewPropertyLengthTracker(path string) (*PropertyLengthTracker, error) {
 		// can read the entire contents into memory
 		existingPages, err := io.ReadAll(f)
 		if err != nil {
+			f.Close()
 			return nil, errors.Wrap(err, "read initial count from file")
 		}
 
 		if len(existingPages)%4096 != 0 {
+			f.Close()
 			return nil, errors.Errorf(
 				"failed sanity check, prop len tracker file %s has length %d", path,
 				len(existingPages))


### PR DESCRIPTION
### What's being changed:
These code path previously never cleaned up the opened file descriptors if the code path fails for other reasons


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
