### PR TITLE
chore: create new fsm inside recoverSingleNode to avoid panics with new fields 

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -446,7 +446,7 @@ func (s *SchemaManager) apply(op applyOp) error {
 		return fmt.Errorf("%w: %s: %w", ErrSchema, op.op, err)
 	}
 
-	if op.enableSchemaCallback {
+	if op.enableSchemaCallback && s.db != nil {
 		// TriggerSchemaUpdateCallbacks is concurrent and at
 		// this point of time schema shall be up to date.
 		s.db.TriggerSchemaUpdateCallbacks()

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -784,7 +784,9 @@ func (st *Store) recoverSingleNode(force bool) error {
 	// we don't use actual registry here, because we don't want to register metrics, it's already registered
 	// in actually FSM and this is FSM is temporary for recovery.
 	tempFSM := NewFSM(recoveryConfig, st.authZController, st.snapshotter, prometheus.NewPedanticRegistry())
-	if err := raft.RecoverCluster(st.raftConfig(), &tempFSM, st.logCache,
+	if err := raft.RecoverCluster(st.raftConfig(),
+		&tempFSM,
+		st.logCache,
 		st.logStore,
 		st.snapshotStore,
 		st.raftTransport,

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -782,7 +782,7 @@ func (st *Store) recoverSingleNode(force bool) error {
 	recoveryConfig.MetadataOnlyVoters = true
 	recoveryConfig.DB = nil
 	// we don't use actual registry here, because we don't want to register metrics, it's already registered
-	// in actualy FSM and this is FSM is temporary for recovery.
+	// in actually FSM and this is FSM is temporary for recovery.
 	tempFSM := NewFSM(recoveryConfig, st.authZController, st.snapshotter, prometheus.NewPedanticRegistry())
 	if err := raft.RecoverCluster(st.raftConfig(), &tempFSM, st.logCache,
 		st.logStore,

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -781,7 +781,9 @@ func (st *Store) recoverSingleNode(force bool) error {
 	// the restore to avoid any data change.
 	recoveryConfig.MetadataOnlyVoters = true
 	recoveryConfig.DB = nil
-	tempFSM := NewFSM(recoveryConfig, st.authZController, st.snapshotter, prometheus.DefaultRegisterer)
+	// we don't use actual registry here, because we don't want to register metrics, it's already registered
+	// in actualy FSM and this is FSM is temporary for recovery.
+	tempFSM := NewFSM(recoveryConfig, st.authZController, st.snapshotter, prometheus.NewPedanticRegistry())
 	if err := raft.RecoverCluster(st.raftConfig(), &tempFSM, st.logCache,
 		st.logStore,
 		st.snapshotStore,


### PR DESCRIPTION
### What's being changed:
recoverSingleNode() create new store and perform a snapshot directly, to avoid panics in case of newly fields introduced in the FSM, this change make sure when FSM is created it has all the newly introduced fields 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14702826352
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
