### PR TITLE
Read small segments fully into memory

### DIFF
--- a/adapters/repos/db/lsmkv/mmap_vs_read_test.go
+++ b/adapters/repos/db/lsmkv/mmap_vs_read_test.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"crypto/rand"
+	"io"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/mmap"
+)
+
+func BenchmarkMMap(b *testing.B) {
+	tests := []struct {
+		size int
+	}{
+		{size: 100},
+		{size: 1000},
+		{size: 10000},
+		{size: 100000},
+	}
+
+	dir := b.TempDir()
+	f, err := os.Create(dir + "/test.tmp")
+	require.NoError(b, err)
+
+	bytes := make([]byte, 100000)
+	read, err := rand.Read(bytes)
+	require.NoError(b, err)
+	require.Equal(b, read, len(bytes))
+
+	written, err := f.Write(bytes)
+	require.NoError(b, err)
+	require.Equal(b, written, len(bytes))
+
+	b.ResetTimer()
+
+	for _, test := range tests {
+		sum := 0
+		for i := range bytes[:test.size] {
+			sum += int(bytes[i])
+		}
+
+		b.Run(strconv.Itoa(test.size)+"mmap", func(b *testing.B) {
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				// not needed here, but we need to do it to have the same overhead in both tests
+				_, err := f.Seek(0, io.SeekStart)
+				require.NoError(b, err)
+
+				contents, err := mmap.MapRegion(f, int(test.size), mmap.RDONLY, 0, 0)
+				require.NoError(b, err)
+
+				innerSum := 0
+				for j := range contents {
+					innerSum += int(contents[j])
+				}
+				require.Equal(b, sum, innerSum)
+				require.NoError(b, contents.Unmap())
+			}
+		})
+
+		b.Run(strconv.Itoa(test.size)+"full read", func(b *testing.B) {
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, err := f.Seek(0, io.SeekStart)
+				require.NoError(b, err)
+
+				data := make([]byte, test.size)
+				n, err := f.Read(data)
+				if err != nil {
+					return
+				}
+				require.NoError(b, err)
+				require.Equal(b, n, test.size)
+
+				innerSum := 0
+				for j := range data {
+					innerSum += int(data[j])
+				}
+				require.Equal(b, sum, innerSum)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -44,6 +44,7 @@ type segment struct {
 	metrics             *Metrics
 	size                int64
 	mmapContents        bool
+	unMapContents       bool
 
 	useBloomFilter        bool // see bucket for more datails
 	bloomFilter           *bloom.BloomFilter
@@ -113,11 +114,23 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	}
 	size := fileInfo.Size()
 
-	contents, err := mmap.MapRegion(file, int(fileInfo.Size()), mmap.RDONLY, 0, 0)
-	if err != nil {
-		return nil, fmt.Errorf("mmap file: %w", err)
+	var contents []byte
+	var unMapContents bool
+	// mmap has some overhead, we can read small files directly to memory
+	if size > int64(PageSize) {
+		contents2, err := mmap.MapRegion(file, int(fileInfo.Size()), mmap.RDONLY, 0, 0)
+		if err != nil {
+			return nil, fmt.Errorf("mmap file: %w", err)
+		}
+		contents = contents2
+		unMapContents = true
+	} else {
+		contents, err = io.ReadAll(file)
+		if err != nil {
+			return nil, fmt.Errorf("read file: %w", err)
+		}
+		unMapContents = false
 	}
-
 	header, err := segmentindex.ParseHeader(contents[:segmentindex.HeaderSize])
 	if err != nil {
 		return nil, fmt.Errorf("parse header: %w", err)
@@ -128,6 +141,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	}
 
 	if header.Version >= segmentindex.SegmentV1 && cfg.enableChecksumValidation {
+		file.Seek(0, io.SeekStart)
 		segmentFile := segmentindex.NewSegmentFile(segmentindex.WithReader(file))
 		if err := segmentFile.ValidateChecksum(fileInfo); err != nil {
 			return nil, fmt.Errorf("validate segment %q: %w", path, err)
@@ -159,6 +173,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		mmapContents:          cfg.mmapContents,
 		useBloomFilter:        cfg.useBloomFilter,
 		calcCountNetAdditions: cfg.calcCountNetAdditions,
+		unMapContents:         unMapContents,
 	}
 
 	// Using pread strategy requires file to remain open for segment lifetime
@@ -195,9 +210,10 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 
 func (s *segment) close() error {
 	var munmapErr, fileCloseErr error
-
-	m := mmap.MMap(s.contents)
-	munmapErr = m.Unmap()
+	if s.unMapContents {
+		m := mmap.MMap(s.contents)
+		munmapErr = m.Unmap()
+	}
 	if s.contentFile != nil {
 		fileCloseErr = s.contentFile.Close()
 	}


### PR DESCRIPTION
### What's being changed:
```
BenchmarkMMap/100mmap-10         	  329785	      3621 ns/op	      16 B/op	       2 allocs/op
BenchmarkMMap/100full_read-10    	  668402	      1795 ns/op	     128 B/op	       3 allocs/op
BenchmarkMMap/1000mmap-10        	  304891	      3945 ns/op	      16 B/op	       2 allocs/op
BenchmarkMMap/1000full_read-10   	  497036	      2286 ns/op	    1056 B/op	       5 allocs/op
BenchmarkMMap/10000mmap-10       	  174980	      6756 ns/op	      16 B/op	       2 allocs/op
BenchmarkMMap/10000full_read-10  	  191953	      6055 ns/op	   10272 B/op	       5 allocs/op
BenchmarkMMap/100000mmap-10      	   27242	     43768 ns/op	      16 B/op	       2 allocs/op
BenchmarkMMap/100000full_read-10 	   24738	     48045 ns/op	  106528 B/op	       5 allocs/op
```

chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14724743687
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14724739524

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
