### PR TITLE
Rename `opsByNode` to `opsByTarget` and add `opsBySource`

### DIFF
--- a/cluster/replication/producer.go
+++ b/cluster/replication/producer.go
@@ -120,7 +120,7 @@ func (p *FSMOpProducer) Produce(ctx context.Context, out chan<- ShardReplication
 //
 // Returns only operations that should be actively processed by this node.
 func (p *FSMOpProducer) allOpsForNode(nodeId string) []ShardReplicationOp {
-	allNodeOps := p.fsm.GetOpsForNode(nodeId)
+	allNodeOps := p.fsm.GetOpsForTarget(nodeId)
 
 	nodeOpsSubset := make([]ShardReplicationOp, 0, len(allNodeOps))
 	for _, op := range allNodeOps {

--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -98,7 +98,7 @@ func (s *ShardReplicationFSM) deleteShardReplicationOp(id uint64) error {
 
 	ops, ok = s.opsBySource[op.TargetShard.NodeId]
 	if !ok {
-		err = multierror.Append(err, fmt.Errorf("could not find op in ops by target, this should not happen"))
+		err = multierror.Append(err, fmt.Errorf("could not find op in ops by source, this should not happen"))
 	}
 	opsReplace, ok = findAndDeleteOp(op.ID, ops)
 	if ok {

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -60,8 +60,10 @@ func NewShardReplicationOp(id uint64, sourceNode, targetNode, collectionId, shar
 type ShardReplicationFSM struct {
 	opsLock sync.RWMutex
 
-	// opsByNode stores the array of ShardReplicationOp for each "target" node
-	opsByNode map[string][]ShardReplicationOp
+	// opsByTarget stores the array of ShardReplicationOp for each "target" node
+	opsByTarget map[string][]ShardReplicationOp
+	// opsBySource stores the array of ShardReplicationOp for each "source" node
+	opsBySource map[string][]ShardReplicationOp
 	// opsByCollection stores the array of ShardReplicationOp for each collection
 	opsByCollection map[string][]ShardReplicationOp
 	// opsByShard stores the array of ShardReplicationOp for each shard
@@ -78,7 +80,8 @@ type ShardReplicationFSM struct {
 
 func newShardReplicationFSM(reg prometheus.Registerer) *ShardReplicationFSM {
 	fsm := &ShardReplicationFSM{
-		opsByNode:       make(map[string][]ShardReplicationOp),
+		opsByTarget:     make(map[string][]ShardReplicationOp),
+		opsBySource:     make(map[string][]ShardReplicationOp),
 		opsByCollection: make(map[string][]ShardReplicationOp),
 		opsByShard:      make(map[string][]ShardReplicationOp),
 		opsByTargetFQDN: make(map[shardFQDN]ShardReplicationOp),
@@ -132,7 +135,8 @@ func (s *ShardReplicationFSM) Restore(bytes []byte) error {
 // The lock onto the underlying data is *not acquired* by this function the callee must ensure the lock is held
 func (s *ShardReplicationFSM) resetState() {
 	// Reset data
-	maps.Clear(s.opsByNode)
+	maps.Clear(s.opsByTarget)
+	maps.Clear(s.opsBySource)
 	maps.Clear(s.opsByCollection)
 	maps.Clear(s.opsByShard)
 	maps.Clear(s.opsByTargetFQDN)
@@ -142,10 +146,10 @@ func (s *ShardReplicationFSM) resetState() {
 	s.opsByStateGauge.Reset()
 }
 
-func (s *ShardReplicationFSM) GetOpsForNode(node string) []ShardReplicationOp {
+func (s *ShardReplicationFSM) GetOpsForTarget(node string) []ShardReplicationOp {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
-	return s.opsByNode[node]
+	return s.opsByTarget[node]
 }
 
 func (s shardReplicationOpStatus) ShouldRestartOp() bool {


### PR DESCRIPTION
### What's being changed:

This PR refactors the replication operation tracking FSM to support both target and source node operations. The change:

1. Renames the existing `opsByNode` map to `opsByTarget` to clarify its purpose
2. Adds a new `opsBySource` map to efficiently track operations by source node

This refactoring paves the way for implementing the complete move replication operation flow. While our replication engine is pull-based with each node executing operations where it is the target, replication operation ins `DEHYDRATING` state for move operations require source nodes to clean up shard files.

The new `opsBySource` map will enable efficient filtering of operations in the `DEHYDRATING` state where the current node is the source, allowing us to implement a polling mechanism for these cleanup operations.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.