### PR TITLE
add dedicated handler for each state in the state machine

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -36,7 +36,6 @@ packages:
     interfaces:
       OpProducer:
       OpConsumer:
-      TimeProvider:
       Timer:
   github.com/weaviate/weaviate/cluster/replication/types:
     interfaces:

--- a/cluster/distributedtask/mock_task_cleaner.go
+++ b/cluster/distributedtask/mock_task_cleaner.go
@@ -86,8 +86,7 @@ func (_c *MockTaskCleaner_CleanUpDistributedTask_Call) RunAndReturn(run func(con
 func NewMockTaskCleaner(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockTaskCleaner {
+}) *MockTaskCleaner {
 	mock := &MockTaskCleaner{}
 	mock.Mock.Test(t)
 

--- a/cluster/distributedtask/mock_task_completion_recorder.go
+++ b/cluster/distributedtask/mock_task_completion_recorder.go
@@ -136,8 +136,7 @@ func (_c *MockTaskCompletionRecorder_RecordDistributedTaskNodeFailure_Call) RunA
 func NewMockTaskCompletionRecorder(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockTaskCompletionRecorder {
+}) *MockTaskCompletionRecorder {
 	mock := &MockTaskCompletionRecorder{}
 	mock.Mock.Test(t)
 

--- a/cluster/replication/consumer_ops_cache.go
+++ b/cluster/replication/consumer_ops_cache.go
@@ -1,0 +1,22 @@
+package replication
+
+import "sync"
+
+type OpsCache struct {
+	ops sync.Map
+}
+
+func NewOpsCache() *OpsCache {
+	return &OpsCache{
+		ops: sync.Map{},
+	}
+}
+
+func (c *OpsCache) LoadOrStore(opId uint64) bool {
+	_, ok := c.ops.LoadOrStore(opId, struct{}{})
+	return ok
+}
+
+func (c *OpsCache) Remove(opId uint64) {
+	c.ops.Delete(opId)
+}

--- a/cluster/replication/consumer_ops_cache.go
+++ b/cluster/replication/consumer_ops_cache.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package replication
 
 import "sync"

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -168,13 +168,18 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		opId, err := randInt(t, 100, 200)
 		require.NoError(t, err, "error generating random operation id")
 
-		mockFSMUpdater.On("ReplicationUpdateReplicaOpStatus", uint64(opId), api.HYDRATING).Return(nil)
-		mockReplicaCopier.On("CopyReplica",
-			mock.Anything,
-			"node1",
-			"TestCollection",
-			"test-shard",
-		).Once().Return(errors.New("simulated copy failure"))
+		mockFSMUpdater.EXPECT().
+			ReplicationUpdateReplicaOpStatus(uint64(opId), api.HYDRATING).
+			Return(nil)
+		mockReplicaCopier.EXPECT().
+			CopyReplica(
+				mock.Anything,
+				"node1",
+				"TestCollection",
+				"test-shard",
+			).
+			Once().
+			Return(errors.New("simulated copy failure"))
 
 		var (
 			prepareProcessingCallbacksCounter int

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -97,7 +97,7 @@ func (m *Manager) GetReplicationDetailsByReplicationId(c *cmd.QueryRequest) ([]b
 		Collection:   op.SourceShard.CollectionId,
 		SourceNodeId: op.SourceShard.NodeId,
 		TargetNodeId: op.TargetShard.NodeId,
-		Status:       status.state.String(),
+		Status:       status.State.String(),
 	}
 
 	payload, err := json.Marshal(response)

--- a/cluster/replication/mock_op_consumer.go
+++ b/cluster/replication/mock_op_consumer.go
@@ -33,7 +33,7 @@ func (_m *MockOpConsumer) EXPECT() *MockOpConsumer_Expecter {
 }
 
 // Consume provides a mock function with given fields: ctx, in
-func (_m *MockOpConsumer) Consume(ctx context.Context, in <-chan ShardReplicationOp) error {
+func (_m *MockOpConsumer) Consume(ctx context.Context, in <-chan ShardReplicationOpAndStatus) error {
 	ret := _m.Called(ctx, in)
 
 	if len(ret) == 0 {
@@ -41,7 +41,7 @@ func (_m *MockOpConsumer) Consume(ctx context.Context, in <-chan ShardReplicatio
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, <-chan ShardReplicationOp) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, <-chan ShardReplicationOpAndStatus) error); ok {
 		r0 = rf(ctx, in)
 	} else {
 		r0 = ret.Error(0)
@@ -57,14 +57,14 @@ type MockOpConsumer_Consume_Call struct {
 
 // Consume is a helper method to define mock.On call
 //   - ctx context.Context
-//   - in <-chan ShardReplicationOp
+//   - in <-chan ShardReplicationOpAndStatus
 func (_e *MockOpConsumer_Expecter) Consume(ctx interface{}, in interface{}) *MockOpConsumer_Consume_Call {
 	return &MockOpConsumer_Consume_Call{Call: _e.mock.On("Consume", ctx, in)}
 }
 
-func (_c *MockOpConsumer_Consume_Call) Run(run func(ctx context.Context, in <-chan ShardReplicationOp)) *MockOpConsumer_Consume_Call {
+func (_c *MockOpConsumer_Consume_Call) Run(run func(ctx context.Context, in <-chan ShardReplicationOpAndStatus)) *MockOpConsumer_Consume_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(<-chan ShardReplicationOp))
+		run(args[0].(context.Context), args[1].(<-chan ShardReplicationOpAndStatus))
 	})
 	return _c
 }
@@ -74,7 +74,7 @@ func (_c *MockOpConsumer_Consume_Call) Return(_a0 error) *MockOpConsumer_Consume
 	return _c
 }
 
-func (_c *MockOpConsumer_Consume_Call) RunAndReturn(run func(context.Context, <-chan ShardReplicationOp) error) *MockOpConsumer_Consume_Call {
+func (_c *MockOpConsumer_Consume_Call) RunAndReturn(run func(context.Context, <-chan ShardReplicationOpAndStatus) error) *MockOpConsumer_Consume_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cluster/replication/mock_op_producer.go
+++ b/cluster/replication/mock_op_producer.go
@@ -33,7 +33,7 @@ func (_m *MockOpProducer) EXPECT() *MockOpProducer_Expecter {
 }
 
 // Produce provides a mock function with given fields: ctx, out
-func (_m *MockOpProducer) Produce(ctx context.Context, out chan<- ShardReplicationOp) error {
+func (_m *MockOpProducer) Produce(ctx context.Context, out chan<- ShardReplicationOpAndStatus) error {
 	ret := _m.Called(ctx, out)
 
 	if len(ret) == 0 {
@@ -41,7 +41,7 @@ func (_m *MockOpProducer) Produce(ctx context.Context, out chan<- ShardReplicati
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, chan<- ShardReplicationOp) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, chan<- ShardReplicationOpAndStatus) error); ok {
 		r0 = rf(ctx, out)
 	} else {
 		r0 = ret.Error(0)
@@ -57,14 +57,14 @@ type MockOpProducer_Produce_Call struct {
 
 // Produce is a helper method to define mock.On call
 //   - ctx context.Context
-//   - out chan<- ShardReplicationOp
+//   - out chan<- ShardReplicationOpAndStatus
 func (_e *MockOpProducer_Expecter) Produce(ctx interface{}, out interface{}) *MockOpProducer_Produce_Call {
 	return &MockOpProducer_Produce_Call{Call: _e.mock.On("Produce", ctx, out)}
 }
 
-func (_c *MockOpProducer_Produce_Call) Run(run func(ctx context.Context, out chan<- ShardReplicationOp)) *MockOpProducer_Produce_Call {
+func (_c *MockOpProducer_Produce_Call) Run(run func(ctx context.Context, out chan<- ShardReplicationOpAndStatus)) *MockOpProducer_Produce_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(chan<- ShardReplicationOp))
+		run(args[0].(context.Context), args[1].(chan<- ShardReplicationOpAndStatus))
 	})
 	return _c
 }
@@ -74,7 +74,7 @@ func (_c *MockOpProducer_Produce_Call) Return(_a0 error) *MockOpProducer_Produce
 	return _c
 }
 
-func (_c *MockOpProducer_Produce_Call) RunAndReturn(run func(context.Context, chan<- ShardReplicationOp) error) *MockOpProducer_Produce_Call {
+func (_c *MockOpProducer_Produce_Call) RunAndReturn(run func(context.Context, chan<- ShardReplicationOpAndStatus) error) *MockOpProducer_Produce_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cluster/replication/shard_replication_engine.go
+++ b/cluster/replication/shard_replication_engine.go
@@ -89,7 +89,7 @@ type ShardReplicationEngine struct {
 	// opsChan is the buffered channel used to pass operations from the producer to the consumer.
 	// A bounded channel ensures that backpressure is applied when the consumer is overwhelmed or when
 	// a certain number of concurrent workers are already busy processing replication operations.
-	opsChan chan ShardReplicationOp
+	opsChan chan ShardReplicationOpAndStatus
 
 	// stopChan is a signal-only channel used to trigger graceful shutdown of the engine.
 	// It is closed when Stop() is invoked, prompting shutdown of producer and consumer goroutines.
@@ -168,7 +168,7 @@ func (e *ShardReplicationEngine) Start(ctx context.Context) error {
 
 	e.engineMetricCallbacks.OnEngineStart(e.nodeId)
 	// Channels are creating while starting the replication engine to allow start/stop.
-	e.opsChan = make(chan ShardReplicationOp, e.opBufferSize)
+	e.opsChan = make(chan ShardReplicationOpAndStatus, e.opBufferSize)
 	e.stopChan = make(chan struct{})
 
 	engineCtx, engineCancel := context.WithCancel(ctx)

--- a/cluster/replication/shard_replication_engine.go
+++ b/cluster/replication/shard_replication_engine.go
@@ -29,19 +29,6 @@ const (
 	replicationEngineLogAction = "replication_engine"
 )
 
-// TimeProvider abstracts time operations to enable testing without time dependencies.
-type TimeProvider interface {
-	Now() time.Time
-}
-
-// RealTimeProvider implements the TimeProvider interface using the standard time package
-type RealTimeProvider struct{}
-
-// Now returns the current time
-func (p RealTimeProvider) Now() time.Time {
-	return time.Now()
-}
-
 // ShardReplicationEngine coordinates the replication of shard data between nodes in a distributed system.
 //
 // It uses a producer-consumer pattern where replication operations are pulled from a source (e.g., FSM)

--- a/cluster/replication/shard_replication_engine_test.go
+++ b/cluster/replication/shard_replication_engine_test.go
@@ -24,6 +24,7 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/replication"
 	"github.com/weaviate/weaviate/cluster/replication/metrics"
 )
@@ -33,12 +34,10 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producerStartedChan := make(chan struct{})
 		consumerStartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -99,11 +98,9 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producerStartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -151,11 +148,9 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		consumerStartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -202,12 +197,10 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producerStartedChan := make(chan struct{})
 		consumerStartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -265,12 +258,10 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producerStarted := make(chan struct{})
 		consumerStarted := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -334,14 +325,12 @@ func TestShardReplicationEngine(t *testing.T) {
 		mockConsumer1 := replication.NewMockOpConsumer(t)
 		mockProducer2 := replication.NewMockOpProducer(t)
 		mockConsumer2 := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producer1StartedChan := make(chan struct{})
 		consumer1StartedChan := make(chan struct{})
 		producer2StartedChan := make(chan struct{})
 		consumer2StartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer1.On("Produce", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -436,12 +425,10 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producerStarted := make(chan struct{})
 		consumerStarted := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -500,15 +487,11 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
-
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 
 		// First start/stop cycle
 		producer1StartedChan := make(chan struct{})
 		consumer1StartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -612,9 +595,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		logger, _ := logrustest.NewNullLogger()
 
 		engine := replication.NewShardReplicationEngine(
@@ -685,9 +666,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		logger, _ := logrustest.NewNullLogger()
 
 		engine := replication.NewShardReplicationEngine(
@@ -716,12 +695,10 @@ func TestShardReplicationEngine(t *testing.T) {
 		// GIVEN
 		mockProducer := replication.NewMockOpProducer(t)
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockTimer := replication.NewMockTimer(t)
 
 		producerStartedChan := make(chan struct{})
 		consumerStartedChan := make(chan struct{})
 
-		mockTimer.On("Now").Return(time.Now()).Maybe()
 		mockProducer.On("Produce", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
@@ -791,9 +768,6 @@ func TestShardReplicationEngine(t *testing.T) {
 		opIds, err := randomOpIds(t, opsCount)
 		require.NoError(t, err, "error generating operation IDs")
 
-		mockTimer := replication.NewMockTimer(t)
-		mockTimer.On("Now").Return(time.Now()).Maybe()
-
 		var producerWg sync.WaitGroup
 		producerWg.Add(1)
 
@@ -802,7 +776,7 @@ func TestShardReplicationEngine(t *testing.T) {
 			func(args mock.Arguments) {
 				defer producerWg.Done()
 				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(chan<- replication.ShardReplicationOp)
+				opsChan := args.Get(1).(chan<- replication.ShardReplicationOpAndStatus)
 
 				for _, opId := range opIds {
 					randomSleepTime, e := randInt(t, 10, 50)
@@ -811,7 +785,7 @@ func TestShardReplicationEngine(t *testing.T) {
 					op := replication.NewShardReplicationOp(opId, "node1", "node2", "TestCollection", "shard1")
 
 					select {
-					case opsChan <- op:
+					case opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
 						producedOpsChan <- op
 					case <-ctx.Done():
 						return
@@ -823,7 +797,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(<-chan replication.ShardReplicationOp)
+				opsChan := args.Get(1).(<-chan replication.ShardReplicationOpAndStatus)
 
 				processedOps := 0
 				for {
@@ -839,8 +813,8 @@ func TestShardReplicationEngine(t *testing.T) {
 						require.NoErrorf(t, e, "error generating random sleep time")
 						time.Sleep(time.Millisecond * time.Duration(randomSleepTime))
 
-						consumedOpsChan <- op.ID
-						completedOpsChan <- op.ID
+						consumedOpsChan <- op.Op.ID
+						completedOpsChan <- op.Op.ID
 
 						processedOps++
 						if processedOps == opsCount {
@@ -930,7 +904,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(chan<- replication.ShardReplicationOp)
+				opsChan := args.Get(1).(chan<- replication.ShardReplicationOpAndStatus)
 
 				producerStartedChan <- struct{}{}
 
@@ -938,7 +912,7 @@ func TestShardReplicationEngine(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					return
-				case opsChan <- op:
+				case opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
 					// Error after sending a valid op
 					producerErrorChan <- struct{}{}
 				}
@@ -1052,7 +1026,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(chan<- replication.ShardReplicationOp)
+				opsChan := args.Get(1).(chan<- replication.ShardReplicationOpAndStatus)
 
 				producerStartedChan <- struct{}{}
 
@@ -1060,7 +1034,7 @@ func TestShardReplicationEngine(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					return
-				case opsChan <- op:
+				case opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
 				}
 
 				// Wait for cancellation
@@ -1081,7 +1055,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
 			func(args mock.Arguments) {
 				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(<-chan replication.ShardReplicationOp)
+				opsChan := args.Get(1).(<-chan replication.ShardReplicationOpAndStatus)
 
 				consumerStartedChan <- struct{}{}
 

--- a/cluster/replication/shard_replication_engine_test.go
+++ b/cluster/replication/shard_replication_engine_test.go
@@ -38,19 +38,23 @@ func TestShardReplicationEngine(t *testing.T) {
 		producerStartedChan := make(chan struct{})
 		consumerStartedChan := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 
@@ -101,13 +105,17 @@ func TestShardReplicationEngine(t *testing.T) {
 
 		producerStartedChan := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Return(context.Canceled)
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Return(errors.New("unexpected consumer error"))
+			}).
+			Return(context.Canceled)
+
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Return(errors.New("unexpected consumer error"))
 
 		logger, _ := logrustest.NewNullLogger()
 
@@ -151,13 +159,17 @@ func TestShardReplicationEngine(t *testing.T) {
 
 		consumerStartedChan := make(chan struct{})
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Return(context.Canceled)
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Return(errors.New("unexpected producer error"))
+			}).
+			Return(context.Canceled)
+
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Return(errors.New("unexpected producer error"))
 
 		logger, _ := logrustest.NewNullLogger()
 
@@ -188,7 +200,7 @@ func TestShardReplicationEngine(t *testing.T) {
 		// THEN
 		require.Error(t, engineStartErr)
 		require.Contains(t, engineStartErr.Error(), "unexpected producer error")
-		require.False(t, engine.IsRunning(), "engine should report not running after consumer error")
+		require.False(t, engine.IsRunning(), "engine should not be running after consumer error")
 		mockProducer.AssertExpectations(t)
 		mockConsumer.AssertExpectations(t)
 	})
@@ -201,19 +213,23 @@ func TestShardReplicationEngine(t *testing.T) {
 		producerStartedChan := make(chan struct{})
 		consumerStartedChan := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStartedChan <- struct{}{} // producer started event
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStartedChan <- struct{}{} // consumer started event
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 		engine := replication.NewShardReplicationEngine(
@@ -262,19 +278,23 @@ func TestShardReplicationEngine(t *testing.T) {
 		producerStarted := make(chan struct{})
 		consumerStarted := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStarted <- struct{}{} // producer started event
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStarted <- struct{}{} // consumer started event
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 		engine := replication.NewShardReplicationEngine(
@@ -287,7 +307,7 @@ func TestShardReplicationEngine(t *testing.T) {
 			1*time.Minute,
 			metrics.NewReplicationEngineCallbacks(prometheus.NewPedanticRegistry()),
 		)
-		require.False(t, engine.IsRunning(), "engine should report not running before start")
+		require.False(t, engine.IsRunning(), "engine should not be running before start")
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -331,31 +351,41 @@ func TestShardReplicationEngine(t *testing.T) {
 		producer2StartedChan := make(chan struct{})
 		consumer2StartedChan := make(chan struct{})
 
-		mockProducer1.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer1.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producer1StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer1.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer1.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumer1StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
-		mockProducer2.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+			}).
+			Once().
+			Return(context.Canceled)
+
+		mockProducer2.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producer2StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
-		mockConsumer2.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+			}).
+			Once().
+			Return(context.Canceled)
+
+		mockConsumer2.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumer2StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 		engine1 := replication.NewShardReplicationEngine(logger,
@@ -429,19 +459,23 @@ func TestShardReplicationEngine(t *testing.T) {
 		producerStarted := make(chan struct{})
 		consumerStarted := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStarted <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStarted <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 		engine := replication.NewShardReplicationEngine(
@@ -492,37 +526,45 @@ func TestShardReplicationEngine(t *testing.T) {
 		producer1StartedChan := make(chan struct{})
 		consumer1StartedChan := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producer1StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumer1StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		// Second start/stop cycle
 		producer2StartedChan := make(chan struct{})
 		consumer2StartedChan := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producer2StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumer2StartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 
@@ -619,19 +661,23 @@ func TestShardReplicationEngine(t *testing.T) {
 			producerStartedChan := make(chan struct{})
 			consumerStartedChan := make(chan struct{})
 
-			mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-				func(args mock.Arguments) {
-					ctx := args.Get(0).(context.Context)
+			mockProducer.EXPECT().
+				Produce(mock.Anything, mock.Anything).
+				Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 					producerStartedChan <- struct{}{}
 					<-ctx.Done()
-				}).Once().Return(context.Canceled)
+				}).
+				Once().
+				Return(context.Canceled)
 
-			mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-				func(args mock.Arguments) {
-					ctx := args.Get(0).(context.Context)
+			mockConsumer.EXPECT().
+				Consume(mock.Anything, mock.Anything).
+				Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 					consumerStartedChan <- struct{}{}
 					<-ctx.Done()
-				}).Once().Return(context.Canceled)
+				}).
+				Once().
+				Return(context.Canceled)
 
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -699,19 +745,23 @@ func TestShardReplicationEngine(t *testing.T) {
 		producerStartedChan := make(chan struct{})
 		consumerStartedChan := make(chan struct{})
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStartedChan <- struct{}{} // producer started event
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStartedChan <- struct{}{} // consumer started event
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		logger, _ := logrustest.NewNullLogger()
 		randomOpBufferSize, err := randInt(t, 16, 128)
@@ -772,12 +822,10 @@ func TestShardReplicationEngine(t *testing.T) {
 		producerWg.Add(1)
 
 		mockProducer := replication.NewMockOpProducer(t)
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				defer producerWg.Done()
-				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(chan<- replication.ShardReplicationOpAndStatus)
-
 				for _, opId := range opIds {
 					randomSleepTime, e := randInt(t, 10, 50)
 					require.NoErrorf(t, e, "error generating random sleep time")
@@ -785,26 +833,25 @@ func TestShardReplicationEngine(t *testing.T) {
 					op := replication.NewShardReplicationOp(opId, "node1", "node2", "TestCollection", "shard1")
 
 					select {
-					case opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
+					case out <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
 						producedOpsChan <- op
 					case <-ctx.Done():
 						return
 					}
 				}
-			}).Return(nil)
+			}).
+			Return(nil)
 
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(<-chan replication.ShardReplicationOpAndStatus)
-
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				processedOps := 0
 				for {
 					select {
 					case <-ctx.Done():
 						return
-					case op, ok := <-opsChan:
+					case op, ok := <-in:
 						if !ok {
 							return
 						}
@@ -823,7 +870,8 @@ func TestShardReplicationEngine(t *testing.T) {
 						}
 					}
 				}
-			}).Return(nil)
+			}).
+			Return(nil)
 
 		engine := replication.NewShardReplicationEngine(
 			logger,
@@ -901,39 +949,43 @@ func TestShardReplicationEngine(t *testing.T) {
 
 		// First attempt - producer sends one operation then errors
 		mockProducer := replication.NewMockOpProducer(t)
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(chan<- replication.ShardReplicationOpAndStatus)
-
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStartedChan <- struct{}{}
 
 				op := replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "collection1", "shard1")
 				select {
 				case <-ctx.Done():
 					return
-				case opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
+				case out <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
 					// Error after sending a valid op
 					producerErrorChan <- struct{}{}
 				}
-			}).Once().Return(expectedErr)
+			}).
+			Once().
+			Return(expectedErr)
 
 		// Second attempt - producer runs normally until canceled
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerRestartChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		// Consumer runs normally processing operations
 		mockConsumer := replication.NewMockOpConsumer(t)
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStartedChan <- struct{}{}
 				<-ctx.Done()
-			}).Return(context.Canceled).Twice()
+			}).
+			Return(context.Canceled).
+			Twice()
 
 		randomBufferSize, err := randInt(t, 10, 20)
 		require.NoErrorf(t, err, "error generating random buffer size")
@@ -1023,59 +1075,63 @@ func TestShardReplicationEngine(t *testing.T) {
 		mockProducer := replication.NewMockOpProducer(t)
 
 		// First attempt - producer sends operation and waits for cancellation
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(chan<- replication.ShardReplicationOpAndStatus)
-
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerStartedChan <- struct{}{}
 
 				op := replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "collection1", "shard1")
 				select {
 				case <-ctx.Done():
 					return
-				case opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
+				case out <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.REGISTERED)):
 				}
 
 				// Wait for cancellation
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		// Second attempt - producer runs normally again after restarting the engine
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, out chan<- replication.ShardReplicationOpAndStatus) {
 				producerRestartChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		mockConsumer := replication.NewMockOpConsumer(t)
 
 		// First consumer attempt - fails with error
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
-				opsChan := args.Get(1).(<-chan replication.ShardReplicationOpAndStatus)
-
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerStartedChan <- struct{}{}
 
 				// Process one operation then fail
 				select {
 				case <-ctx.Done():
 					return
-				case <-opsChan:
+				case <-in:
 					consumerErrorChan <- struct{}{}
 					return
 				}
-			}).Once().Return(expectedErr)
+			}).
+			Once().
+			Return(expectedErr)
 
 		// Second consumer attempt - succeeds after restarting the engine
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Run(
-			func(args mock.Arguments) {
-				ctx := args.Get(0).(context.Context)
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Run(func(ctx context.Context, in <-chan replication.ShardReplicationOpAndStatus) {
 				consumerRestartChan <- struct{}{}
 				<-ctx.Done()
-			}).Once().Return(context.Canceled)
+			}).
+			Once().
+			Return(context.Canceled)
 
 		randomBufferSize, err := randInt(t, 10, 20)
 		require.NoErrorf(t, err, "error generating random buffer size")
@@ -1200,8 +1256,12 @@ func TestEngineWithCallbacks(t *testing.T) {
 			}).
 			Build()
 
-		mockProducer.On("Produce", mock.Anything, mock.Anything).Return(nil).Maybe()
-		mockConsumer.On("Consume", mock.Anything, mock.Anything).Return(nil).Maybe()
+		mockProducer.EXPECT().
+			Produce(mock.Anything, mock.Anything).
+			Return(nil).Maybe()
+		mockConsumer.EXPECT().
+			Consume(mock.Anything, mock.Anything).
+			Return(nil).Maybe()
 
 		engine := replication.NewShardReplicationEngine(
 			logger,

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -170,14 +170,15 @@ func (s *ShardReplicationFSM) GetOpsForTarget(node string) []ShardReplicationOp 
 	return s.opsByTarget[node]
 }
 
-func (s ShardReplicationOpStatus) ShouldRestartOp() bool {
-	return s.State == api.REGISTERED || s.State == api.HYDRATING || s.State == api.FINALIZING
+func (s ShardReplicationOpStatus) ShouldConsumeOps() bool {
+	return s.State != api.ABORTED
 }
 
-func (s *ShardReplicationFSM) GetOpState(op ShardReplicationOp) ShardReplicationOpStatus {
+func (s *ShardReplicationFSM) GetOpState(op ShardReplicationOp) (ShardReplicationOpStatus, bool) {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
-	return s.opsStatus[op]
+	v, ok := s.opsStatus[op]
+	return v, ok
 }
 
 func (s *ShardReplicationFSM) FilterOneShardReplicasReadWrite(collection string, shard string, shardReplicasLocation []string) ([]string, []string) {

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -23,9 +23,9 @@ import (
 	"github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-type shardReplicationOpStatus struct {
+type ShardReplicationOpStatus struct {
 	// state is the current state of the shard replication operation
-	state api.ShardReplicationState
+	State api.ShardReplicationState
 }
 
 type ShardReplicationOp struct {
@@ -34,6 +34,24 @@ type ShardReplicationOp struct {
 	// Targeting information of the replication operation
 	SourceShard shardFQDN
 	TargetShard shardFQDN
+}
+
+type ShardReplicationOpAndStatus struct {
+	Op     ShardReplicationOp
+	Status ShardReplicationOpStatus
+}
+
+func NewShardReplicationOpAndStatus(op ShardReplicationOp, status ShardReplicationOpStatus) ShardReplicationOpAndStatus {
+	return ShardReplicationOpAndStatus{
+		Op:     op,
+		Status: status,
+	}
+}
+
+func NewShardReplicationStatus(state api.ShardReplicationState) ShardReplicationOpStatus {
+	return ShardReplicationOpStatus{
+		State: state,
+	}
 }
 
 func (s ShardReplicationOp) MarshalText() (text []byte, err error) {
@@ -73,7 +91,7 @@ type ShardReplicationFSM struct {
 	// opsByShard stores opId -> replicationOp
 	opsById map[uint64]ShardReplicationOp
 	// opsStatus stores op -> opStatus
-	opsStatus map[ShardReplicationOp]shardReplicationOpStatus
+	opsStatus map[ShardReplicationOp]ShardReplicationOpStatus
 
 	opsByStateGauge *prometheus.GaugeVec
 }
@@ -86,7 +104,7 @@ func newShardReplicationFSM(reg prometheus.Registerer) *ShardReplicationFSM {
 		opsByShard:      make(map[string][]ShardReplicationOp),
 		opsByTargetFQDN: make(map[shardFQDN]ShardReplicationOp),
 		opsById:         make(map[uint64]ShardReplicationOp),
-		opsStatus:       make(map[ShardReplicationOp]shardReplicationOpStatus),
+		opsStatus:       make(map[ShardReplicationOp]ShardReplicationOpStatus),
 	}
 
 	fsm.opsByStateGauge = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
@@ -99,7 +117,7 @@ func newShardReplicationFSM(reg prometheus.Registerer) *ShardReplicationFSM {
 }
 
 type snapshot struct {
-	Ops map[ShardReplicationOp]shardReplicationOpStatus
+	Ops map[ShardReplicationOp]ShardReplicationOpStatus
 }
 
 func (s *ShardReplicationFSM) Snapshot() ([]byte, error) {
@@ -152,11 +170,11 @@ func (s *ShardReplicationFSM) GetOpsForTarget(node string) []ShardReplicationOp 
 	return s.opsByTarget[node]
 }
 
-func (s shardReplicationOpStatus) ShouldRestartOp() bool {
-	return s.state == api.REGISTERED || s.state == api.HYDRATING
+func (s ShardReplicationOpStatus) ShouldRestartOp() bool {
+	return s.State == api.REGISTERED || s.State == api.HYDRATING
 }
 
-func (s *ShardReplicationFSM) GetOpState(op ShardReplicationOp) shardReplicationOpStatus {
+func (s *ShardReplicationFSM) GetOpState(op ShardReplicationOp) ShardReplicationOpStatus {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
 	return s.opsStatus[op]
@@ -205,7 +223,7 @@ func (s *ShardReplicationFSM) filterOneReplicaReadWrite(node string, collection 
 	// Filter read/write based on the state of the replica
 	readOk := false
 	writeOk := false
-	switch opState.state {
+	switch opState.State {
 	case api.FINALIZING:
 		writeOk = true
 	case api.READY:
@@ -218,5 +236,5 @@ func (s *ShardReplicationFSM) filterOneReplicaReadWrite(node string, collection 
 
 // IsOpCompletedOrInProgress returns true if the given replication operation has started or completed execution.
 func (s *ShardReplicationFSM) IsOpCompletedOrInProgress(op ShardReplicationOp) bool {
-	return api.REGISTERED != s.GetOpState(op).state
+	return api.REGISTERED != s.GetOpState(op).State
 }

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -171,7 +171,7 @@ func (s *ShardReplicationFSM) GetOpsForTarget(node string) []ShardReplicationOp 
 }
 
 func (s ShardReplicationOpStatus) ShouldRestartOp() bool {
-	return s.State == api.REGISTERED || s.State == api.HYDRATING
+	return s.State == api.REGISTERED || s.State == api.HYDRATING || s.State == api.FINALIZING
 }
 
 func (s *ShardReplicationFSM) GetOpState(op ShardReplicationOp) ShardReplicationOpStatus {
@@ -232,9 +232,4 @@ func (s *ShardReplicationFSM) filterOneReplicaReadWrite(node string, collection 
 	default:
 	}
 	return readOk, writeOk
-}
-
-// IsOpCompletedOrInProgress returns true if the given replication operation has started or completed execution.
-func (s *ShardReplicationFSM) IsOpCompletedOrInProgress(op ShardReplicationOp) bool {
-	return api.REGISTERED != s.GetOpState(op).State
 }

--- a/cluster/replication/types/mock_fsm_updater.go
+++ b/cluster/replication/types/mock_fsm_updater.go
@@ -145,8 +145,7 @@ func (_c *MockFSMUpdater_ReplicationUpdateReplicaOpStatus_Call) RunAndReturn(run
 func NewMockFSMUpdater(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockFSMUpdater {
+}) *MockFSMUpdater {
 	mock := &MockFSMUpdater{}
 	mock.Mock.Test(t)
 

--- a/cluster/replication/types/mock_replica_copier.go
+++ b/cluster/replication/types/mock_replica_copier.go
@@ -86,8 +86,7 @@ func (_c *MockReplicaCopier_CopyReplica_Call) RunAndReturn(run func(context.Cont
 func NewMockReplicaCopier(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockReplicaCopier {
+}) *MockReplicaCopier {
 	mock := &MockReplicaCopier{}
 	mock.Mock.Test(t)
 

--- a/cluster/replication/utils.go
+++ b/cluster/replication/utils.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package replication
 
 import "github.com/sirupsen/logrus"

--- a/cluster/replication/utils.go
+++ b/cluster/replication/utils.go
@@ -1,0 +1,15 @@
+package replication
+
+import "github.com/sirupsen/logrus"
+
+func getLoggerForOp(logger *logrus.Logger, op ShardReplicationOp) *logrus.Entry {
+	return logger.WithFields(logrus.Fields{
+		"op":                op.ID,
+		"source_node":       op.SourceShard.NodeId,
+		"target_node":       op.TargetShard.NodeId,
+		"source_shard":      op.SourceShard.ShardId,
+		"target_shard":      op.TargetShard.ShardId,
+		"source_collection": op.SourceShard.CollectionId,
+		"target_collection": op.TargetShard.CollectionId,
+	})
+}

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -79,17 +79,13 @@ func New(cfg Config, authZController authorization.Controller, snapshotter fsm.S
 		replicationEngineMaxWorkers*time.Second,
 		cfg.NodeSelector.LocalName(),
 	)
-	realTimeProvider := replication.RealTimeProvider{}
 	replicaCopyOpConsumer := replication.NewCopyOpConsumer(
 		cfg.Logger,
-		func(op replication.ShardReplicationOp) bool {
-			return fsm.replicationManager.GetReplicationFSM().IsOpCompletedOrInProgress(op)
-		},
 		raft,
 		cfg.ReplicaCopier,
-		realTimeProvider,
 		cfg.NodeSelector.LocalName(),
 		&backoff.StopBackOff{},
+		replication.NewOpsCache(),
 		replicationOperationTimeout,
 		replicationEngineMaxWorkers,
 		metrics.NewReplicationEngineOpsCallbacks(prometheus.DefaultRegisterer),


### PR DESCRIPTION
### What's being changed:

Add dedicated handler in the consumer for each state an operation can be in to ease recovery mechanism when recovering a state in which op can be in any state.

Because an operation in different state will keep getting produced into the consumer also change the shouldOpSkip callback to instead be a sync map stored internally in the consumer. This way we can handle ops being recurring but in different states.

Remove the TimeProvider struct/interface to 
1. Simplify the code, it's only used to request time to log a query is done (it's not critical to help testing using ordered time)
2. Reduce mock usage


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
