### PR TITLE
chore: remove index shutdown dependency on queue on DB shutdown

### DIFF
--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -103,7 +103,7 @@ func (s *Shard) drop() (err error) {
 			})
 		}
 
-		// we have to close queue before index for versions before 1.28
+		// we have to close queue before index because the index is using the queue in case of drop
 		if err = eg.Wait(); err != nil {
 			return err
 		}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -86,22 +86,15 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		for targetVector, queue := range s.queues {
 			targetVector, queue := targetVector, queue // capture loop variables
 			eg.Go(func() error {
-				err = queue.Flush()
-				if err != nil {
+				if err := queue.Flush(); err != nil {
 					ec.Add(fmt.Errorf("flush vector index queue commitlog of vector %q: %w", targetVector, err))
 				}
 
-				err := queue.Close()
-				if err != nil {
+				if err := queue.Close(); err != nil {
 					ec.Add(fmt.Errorf("shut down vector index queue of vector %q: %w", targetVector, err))
 				}
 				return nil
 			})
-		}
-
-		// we have to close queue before index for versions before 1.28
-		if err = eg.Wait(); err != nil {
-			ec.Add(err)
 		}
 
 		for targetVector, vectorIndex := range s.vectorIndexes {

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -25,8 +25,8 @@ type ShardStatus struct {
 }
 
 func (s *Shard) GetStatus() storagestate.Status {
-	s.statusLock.RLock()
-	defer s.statusLock.RUnlock()
+	s.statusLock.Lock()
+	defer s.statusLock.Unlock()
 
 	if s.status.Status != storagestate.StatusReady && s.status.Status != storagestate.StatusIndexing {
 		return s.status.Status


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14731555092
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
