### PR TITLE
Fix: change default full read mmap and add mem watcher

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -130,10 +130,10 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	var contents []byte
 	var unMapContents bool
 
-	if size <= cfg.MinMMapSize { // check if it is a candidate for mmap
+	if size <= cfg.MinMMapSize { // check if it is a candidate for full reading
 		err = cfg.allocChecker.CheckAlloc(size) // check if we have enough memory
 		if err != nil {
-			logger.WithError(err).Errorf("memory pressure: cannot mmap segment")
+			logger.Debugf("memory pressure: cannot fully read segment")
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -574,7 +574,7 @@ func (sg *SegmentGroup) replaceSegment(segmentIdx int, tmpSegmentPath string,
 	countNetAdditions := oldSegment.countNetAdditions
 
 	precomputedFiles, err := preComputeSegmentMeta(tmpSegmentPath, countNetAdditions,
-		sg.logger, sg.useBloomFilter, sg.calcCountNetAdditions, sg.enableChecksumValidation, sg.MinMMapSize)
+		sg.logger, sg.useBloomFilter, sg.calcCountNetAdditions, sg.enableChecksumValidation, sg.MinMMapSize, sg.allocChecker)
 	if err != nil {
 		return nil, fmt.Errorf("precompute segment meta: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -348,7 +348,7 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	// WIP: we could add a random suffix to the tmp file to avoid conflicts
 	precomputedFiles, err := preComputeSegmentMeta(newPathTmp,
 		updatedCountNetAdditions, sg.logger, sg.useBloomFilter,
-		sg.calcCountNetAdditions, sg.enableChecksumValidation, sg.MinMMapSize)
+		sg.calcCountNetAdditions, sg.enableChecksumValidation, sg.MinMMapSize, sg.allocChecker)
 	if err != nil {
 		return fmt.Errorf("precompute segment meta: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -62,10 +62,10 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 
 	// mmap has some overhead, we can read small files directly to memory
 
-	if size <= minMMapSize { // check if it is a candidate for mmap
+	if size <= minMMapSize { // check if it is a candidate for full reading
 		err = allocChecker.CheckAlloc(size) // check if we have enough memory
 		if err != nil {
-			logger.WithError(err).Errorf("memory pressure: cannot mmap segment")
+			logger.Debugf("memory pressure: cannot fully read segment")
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -59,17 +59,18 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 	size := fileInfo.Size()
 
 	var contents []byte
+	var allocCheckerErr error
 
 	// mmap has some overhead, we can read small files directly to memory
 
 	if size <= minMMapSize { // check if it is a candidate for full reading
-		err = allocChecker.CheckAlloc(size) // check if we have enough memory
-		if err != nil {
+		allocCheckerErr = allocChecker.CheckAlloc(size) // check if we have enough memory
+		if allocCheckerErr != nil {
 			logger.Debugf("memory pressure: cannot fully read segment")
 		}
 	}
 
-	if size > minMMapSize || err != nil { // mmap the file if it's too large or if we have memory pressure
+	if size > minMMapSize || allocCheckerErr != nil { // mmap the file if it's too large or if we have memory pressure
 		contents2, err := mmap.MapRegion(file, int(fileInfo.Size()), mmap.RDONLY, 0, 0)
 		if err != nil {
 			return nil, fmt.Errorf("mmap file: %w", err)

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 func TestPrecomputeForCompaction(t *testing.T) {
@@ -91,7 +92,7 @@ func precomputeSegmentMeta_Replace(ctx context.Context, t *testing.T, opts []Buc
 	err = os.Rename(path.Join(dirName, fname), segmentTmp)
 	require.Nil(t, err)
 
-	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger, true, true, false, 100)
+	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger, true, true, false, 100, memwatch.NewDummyMonitor())
 	require.Nil(t, err)
 
 	// there should be 4 files and they should all have a .tmp suffix:
@@ -148,7 +149,7 @@ func precomputeSegmentMeta_Set(ctx context.Context, t *testing.T, opts []BucketO
 	err = os.Rename(path.Join(dirName, fname), segmentTmp)
 	require.Nil(t, err)
 
-	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger, true, true, false, 100)
+	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger, true, true, false, 100, memwatch.NewDummyMonitor())
 	require.Nil(t, err)
 
 	// there should be 2 files and they should all have a .tmp suffix:
@@ -163,14 +164,14 @@ func precomputeSegmentMeta_Set(ctx context.Context, t *testing.T, opts []BucketO
 func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 	t.Run("file without .tmp suffix", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
-		_, err := preComputeSegmentMeta("a-path-without-the-required-suffix", 7, logger, true, true, false, 100)
+		_, err := preComputeSegmentMeta("a-path-without-the-required-suffix", 7, logger, true, true, false, 100, memwatch.NewDummyMonitor())
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "expects a .tmp segment")
 	})
 
 	t.Run("file does not exist", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
-		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger, true, true, false, 100)
+		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger, true, true, false, 100, memwatch.NewDummyMonitor())
 		require.NotNil(t, err)
 		unixErr := "no such file or directory"
 		windowsErr := "The system cannot find the file specified."
@@ -195,7 +196,7 @@ func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 		err = f.Close()
 		require.Nil(t, err)
 
-		_, err = preComputeSegmentMeta(segmentName, 7, logger, true, true, false, 100)
+		_, err = preComputeSegmentMeta(segmentName, 7, logger, true, true, false, 100, memwatch.NewDummyMonitor())
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parse header")
 	})
@@ -219,7 +220,7 @@ func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
 		err = f.Close()
 		require.Nil(t, err)
 
-		_, err = preComputeSegmentMeta(segmentName, 7, logger, true, true, false, 100)
+		_, err = preComputeSegmentMeta(segmentName, 7, logger, true, true, false, 100, memwatch.NewDummyMonitor())
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "unsupported strategy")
 	})

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -258,7 +258,7 @@ const DefaultHNSWVisitedListPoolSize = -1 // unlimited for backward compatibilit
 
 const DefaultHNSWFlatSearchConcurrency = 1 // 1 for backward compatibility
 
-const DefaultMinMMapSize = 0 // setting it to 0 means that no segments are read by default
+const DefaultMinMMapSize = 0 // setting it to 0 means that no segments are always mmaped (and not fully read) by default
 
 func (p Persistence) Validate() error {
 	if p.DataPath == "" {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -258,7 +258,7 @@ const DefaultHNSWVisitedListPoolSize = -1 // unlimited for backward compatibilit
 
 const DefaultHNSWFlatSearchConcurrency = 1 // 1 for backward compatibility
 
-const DefaultMinMMapSize = 4096
+const DefaultMinMMapSize = 0 // setting it to 0 means that no segments are read by default
 
 func (p Persistence) Validate() error {
 	if p.DataPath == "" {


### PR DESCRIPTION
### What's being changed:

- change default full read mmap to 0 (disabled by default)
- add mem watcher to stop allocations if under memory pressure

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
