### PR TITLE
Context lock

### DIFF
--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -15,7 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"path/filepath"
-	"sync"
+
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,10 +24,12 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/lsmkv"
+	"github.com/weaviate/weaviate/entities/ctxlock"
+
 )
 
 type Memtable struct {
-	sync.RWMutex
+	ctxlock.CtxRWMutex
 	key                *binarySearchTree
 	keyMulti           *binarySearchTreeMulti
 	keyMap             *binarySearchTreeMap

--- a/entities/ctxlock/ctx_lock.go
+++ b/entities/ctxlock/ctx_lock.go
@@ -1,0 +1,63 @@
+package ctxlock
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type CtxLock struct {
+	ch           chan struct{}
+	timeoutMu    sync.RWMutex
+	timeout      time.Duration
+}
+
+func NewCtxLock(timeoutMillis int) *CtxLock {
+	return &CtxLock{
+		ch:      make(chan struct{}, 1),
+		timeout: time.Duration(timeoutMillis) * time.Millisecond,
+	}
+}
+
+// Lock attempts to acquire the lock with both context and internal timeout
+func (l *CtxLock) Lock(ctx context.Context) error {
+	l.timeoutMu.RLock()
+	timeout := l.timeout
+	l.timeoutMu.RUnlock()
+
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	select {
+	case l.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Unlock releases the lock
+func (l *CtxLock) Unlock() {
+	select {
+	case <-l.ch:
+	default:
+		panic("unlock of unlocked CtxLock")
+	}
+}
+
+// SetTimeout updates the default timeout (in milliseconds) for the lock
+func (l *CtxLock) SetTimeout(timeoutMillis int) {
+	l.timeoutMu.Lock()
+	defer l.timeoutMu.Unlock()
+	l.timeout = time.Duration(timeoutMillis) * time.Millisecond
+}
+
+// Timeout returns the current default timeout
+func (l *CtxLock) Timeout() time.Duration {
+	l.timeoutMu.RLock()
+	defer l.timeoutMu.RUnlock()
+	return l.timeout
+}

--- a/entities/ctxlock/ctx_lock.go
+++ b/entities/ctxlock/ctx_lock.go
@@ -2,62 +2,110 @@ package ctxlock
 
 import (
 	"context"
-	"sync"
+	"errors"
 	"time"
 )
 
-type CtxLock struct {
-	ch           chan struct{}
-	timeoutMu    sync.RWMutex
-	timeout      time.Duration
+var ErrCtxTimeout = errors.New("ctxsync: lock acquisition timed out")
+
+type CtxRWMutex struct {
+	writeCh   chan struct{}
+	readersCh chan struct{}
+	readers   int
+	writer    bool
 }
 
-func NewCtxLock(timeoutMillis int) *CtxLock {
-	return &CtxLock{
-		ch:      make(chan struct{}, 1),
-		timeout: time.Duration(timeoutMillis) * time.Millisecond,
+// NewCtxRWMutex creates a new context-aware read/write mutex
+func NewCtxRWMutex() *CtxRWMutex {
+	return &CtxRWMutex{
+		writeCh:   make(chan struct{}, 1),
+		readersCh: make(chan struct{}, 1),
 	}
 }
 
-// Lock attempts to acquire the lock with both context and internal timeout
-func (l *CtxLock) Lock(ctx context.Context) error {
-	l.timeoutMu.RLock()
-	timeout := l.timeout
-	l.timeoutMu.RUnlock()
-
-	var cancel context.CancelFunc
-	if timeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
-
+// LockContext acquires the write lock or returns an error on timeout/cancel
+func (m *CtxRWMutex) LockContext(ctx context.Context) error {
 	select {
-	case l.ch <- struct{}{}:
-		return nil
+	case m.writeCh <- struct{}{}:
+		// Wait for all readers to exit
+		for {
+			select {
+			case <-m.readersCh:
+				m.readers--
+				if m.readers == 0 {
+					m.writer = true
+					return nil
+				}
+			default:
+				if m.readers == 0 {
+					m.writer = true
+					return nil
+				}
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 }
 
-// Unlock releases the lock
-func (l *CtxLock) Unlock() {
+func (m *CtxRWMutex) Lock() {
+	_ = m.LockContext(context.Background())
+}
+
+func (m *CtxRWMutex) TryLock() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	return m.LockContext(ctx) == nil
+}
+
+func (m *CtxRWMutex) Unlock() {
+	if !m.writer {
+		panic("ctxsync: unlock called without writer lock")
+	}
+	m.writer = false
 	select {
-	case <-l.ch:
+	case <-m.writeCh:
 	default:
-		panic("unlock of unlocked CtxLock")
+		panic("ctxsync: inconsistent writeCh")
 	}
 }
 
-// SetTimeout updates the default timeout (in milliseconds) for the lock
-func (l *CtxLock) SetTimeout(timeoutMillis int) {
-	l.timeoutMu.Lock()
-	defer l.timeoutMu.Unlock()
-	l.timeout = time.Duration(timeoutMillis) * time.Millisecond
+// RLockContext acquires the read lock or returns on context cancel/timeout
+func (m *CtxRWMutex) RLockContext(ctx context.Context) error {
+	for {
+		if m.writer || len(m.writeCh) > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				time.Sleep(1 * time.Millisecond)
+			}
+		} else {
+			m.readers++
+			m.readersCh <- struct{}{}
+			return nil
+		}
+	}
 }
 
-// Timeout returns the current default timeout
-func (l *CtxLock) Timeout() time.Duration {
-	l.timeoutMu.RLock()
-	defer l.timeoutMu.RUnlock()
-	return l.timeout
+func (m *CtxRWMutex) RLock() {
+	_ = m.RLockContext(context.Background())
+}
+
+func (m *CtxRWMutex) TryRLock() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	return m.RLockContext(ctx) == nil
+}
+
+func (m *CtxRWMutex) RUnlock() {
+	if m.readers <= 0 {
+		panic("ctxsync: RUnlock without RLock")
+	}
+	m.readers--
+	select {
+	case <-m.readersCh:
+	default:
+	}
 }

--- a/entities/ctxlock/ctx_lock_test.go
+++ b/entities/ctxlock/ctx_lock_test.go
@@ -1,0 +1,121 @@
+package ctxlock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCtxLock_LockUnlock(t *testing.T) {
+	lock := NewCtxLock(0)
+
+	if err := lock.Lock(context.Background()); err != nil {
+		t.Fatalf("unexpected error acquiring lock: %v", err)
+	}
+	lock.Unlock()
+
+	// Try again after unlock
+	if err := lock.Lock(context.Background()); err != nil {
+		t.Fatalf("unexpected error on re-acquire: %v", err)
+	}
+	lock.Unlock()
+}
+
+func TestCtxLock_ContextTimeout(t *testing.T) {
+	lock := NewCtxLock(0)
+
+	// Acquire lock to block the next goroutine
+	if err := lock.Lock(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := lock.Lock(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got: %v", err)
+	}
+
+	lock.Unlock()
+}
+
+func TestCtxLock_DefaultTimeout(t *testing.T) {
+	lock := NewCtxLock(100) // 100ms default timeout
+
+	// First goroutine locks and holds
+	if err := lock.Lock(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	err := lock.Lock(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error due to timeout, got none")
+	}
+	if elapsed < 90*time.Millisecond || elapsed > 200*time.Millisecond {
+		t.Fatalf("expected ~100ms wait, got %v", elapsed)
+	}
+
+	lock.Unlock()
+}
+
+func TestCtxLock_UpdateTimeoutThreadSafe(t *testing.T) {
+	lock := NewCtxLock(50)
+
+	// Acquire lock so next goroutine has to wait
+	if err := lock.Lock(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		<-ready // wait until main signals to proceed
+		err := lock.Lock(context.Background())
+		if err == nil {
+			t.Error("expected timeout error but got none")
+		}
+		close(done)
+	}()
+
+	// Increase timeout *before* the goroutine starts waiting
+	lock.SetTimeout(500)
+	if newTimeout := lock.Timeout(); newTimeout != 500*time.Millisecond {
+		t.Errorf("expected timeout to be 500ms, got %v", newTimeout)
+	}
+
+	close(ready) // allow goroutine to try locking (after timeout is updated)
+
+	// Sleep past original timeout but not past new one
+	time.Sleep(100 * time.Millisecond)
+	lock.Unlock() // allow other goroutine to try
+
+	<-done
+}
+
+func TestCtxLock_ContextOverridesDefaultTimeout(t *testing.T) {
+	lock := NewCtxLock(500) // Should be overridden by context
+
+	lock.Lock(context.Background()) // Block lock
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := lock.Lock(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got: %v", err)
+	}
+	if elapsed < 90*time.Millisecond || elapsed > 200*time.Millisecond {
+		t.Fatalf("context deadline not respected, waited: %v", elapsed)
+	}
+
+	lock.Unlock()
+}


### PR DESCRIPTION
### What's being changed:

Add a new type of lock, context lock, to allow cancelling threads waiting on a lock

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
