### PR TITLE
Revert "refact: (shutdown) improve db and shard dropping shutdown performance  (#7571)"

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -24,6 +24,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -40,13 +44,10 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/autocut"
-	entcfg "github.com/weaviate/weaviate/entities/config"
-	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -2231,53 +2232,26 @@ func (i *Index) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// stopCycleManagers stops all cycle managers concurrently
 func (i *Index) stopCycleManagers(ctx context.Context, usecase string) error {
-	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
-
-	eg.Go(func() error {
-		if err := i.cycleCallbacks.compactionCycle.StopAndWait(ctx); err != nil {
-			return fmt.Errorf("%s: stop compaction cycle: %w", usecase, err)
-		}
-		return nil
-	})
-
-	eg.Go(func() error {
-		if err := i.cycleCallbacks.flushCycle.StopAndWait(ctx); err != nil {
-			return fmt.Errorf("%s: stop flush cycle: %w", usecase, err)
-		}
-		return nil
-	})
-
-	eg.Go(func() error {
-		if err := i.cycleCallbacks.vectorCommitLoggerCycle.StopAndWait(ctx); err != nil {
-			return fmt.Errorf("%s: stop vector commit logger cycle: %w", usecase, err)
-		}
-		return nil
-	})
-
-	eg.Go(func() error {
-		if err := i.cycleCallbacks.vectorTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-			return fmt.Errorf("%s: stop vector tombstone cleanup cycle: %w", usecase, err)
-		}
-		return nil
-	})
-
-	eg.Go(func() error {
-		if err := i.cycleCallbacks.geoPropsCommitLoggerCycle.StopAndWait(ctx); err != nil {
-			return fmt.Errorf("%s: stop geo props commit logger cycle: %w", usecase, err)
-		}
-		return nil
-	})
-
-	eg.Go(func() error {
-		if err := i.cycleCallbacks.geoPropsTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-			return fmt.Errorf("%s: stop geo props tombstone cleanup cycle: %w", usecase, err)
-		}
-		return nil
-	})
-
-	return eg.Wait()
+	if err := i.cycleCallbacks.compactionCycle.StopAndWait(ctx); err != nil {
+		return fmt.Errorf("%s: stop compaction cycle: %w", usecase, err)
+	}
+	if err := i.cycleCallbacks.flushCycle.StopAndWait(ctx); err != nil {
+		return fmt.Errorf("%s: stop flush cycle: %w", usecase, err)
+	}
+	if err := i.cycleCallbacks.vectorCommitLoggerCycle.StopAndWait(ctx); err != nil {
+		return fmt.Errorf("%s: stop vector commit logger cycle: %w", usecase, err)
+	}
+	if err := i.cycleCallbacks.vectorTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
+		return fmt.Errorf("%s: stop vector tombstone cleanup cycle: %w", usecase, err)
+	}
+	if err := i.cycleCallbacks.geoPropsCommitLoggerCycle.StopAndWait(ctx); err != nil {
+		return fmt.Errorf("%s: stop geo props commit logger cycle: %w", usecase, err)
+	}
+	if err := i.cycleCallbacks.geoPropsTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
+		return fmt.Errorf("%s: stop geo props tombstone cleanup cycle: %w", usecase, err)
+	}
+	return nil
 }
 
 func (i *Index) shardState() *sharding.State {

--- a/adapters/repos/db/index_queue.go
+++ b/adapters/repos/db/index_queue.go
@@ -22,18 +22,18 @@ import (
 	"sync/atomic"
 	"time"
 
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
-	entcfg "github.com/weaviate/weaviate/entities/config"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storagestate"
-	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // IndexQueue is an in-memory queue of vectors to index.
@@ -379,9 +379,6 @@ func (q *IndexQueue) Delete(ids ...uint64) error {
 // It does not remove the index.
 // It should be called only when the index is dropped.
 func (q *IndexQueue) Drop() error {
-	q.indexLock.Lock()
-	defer q.indexLock.Unlock()
-
 	_ = q.Close()
 
 	if q.Checkpoints != nil {

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/cluster/utils"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -309,21 +308,10 @@ func (db *DB) Shutdown(ctx context.Context) error {
 
 	db.indexLock.Lock()
 	defer db.indexLock.Unlock()
-
-	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(db.logger, ctx)
-	eg.SetLimit(_NUMCPU)
 	for id, index := range db.indices {
-		id, index := id, index // capture loop variables
-		eg.Go(func() error {
-			if err := index.Shutdown(ctx); err != nil {
-				return errors.Wrapf(err, "shutdown index %q", id)
-			}
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return err
+		if err := index.Shutdown(ctx); err != nil {
+			return errors.Wrapf(err, "shutdown index %q", id)
+		}
 	}
 
 	if asyncEnabled() {

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -19,9 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/entities/cyclemanager"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
 // IMPORTANT:
@@ -87,38 +85,16 @@ func (s *Shard) drop() (err error) {
 	}
 
 	if s.hasTargetVectors() {
-		eg, ctx := enterrors.NewErrorGroupWithContextWrapper(s.index.logger, ctx)
-		eg.SetLimit(_NUMCPU)
-
+		// TODO run in parallel?
 		for targetVector, queue := range s.queues {
-			targetVector, queue := targetVector, queue // capture loop variables
-			eg.Go(func() error {
-				// Remove err from closure scope, use local error
-				if dropErr := queue.Drop(); dropErr != nil {
-					return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), dropErr)
-				}
-				return nil
-			})
+			if err = queue.Drop(); err != nil {
+				return fmt.Errorf("close queue of vector %q at %s: %w", targetVector, s.path(), err)
+			}
 		}
-
-		// we have to close queue before index for versions before 1.28
-		if err = eg.Wait(); err != nil {
-			return err
-		}
-
 		for targetVector, vectorIndex := range s.vectorIndexes {
-			targetVector, vectorIndex := targetVector, vectorIndex // capture loop variables
-			eg.Go(func() error {
-				// Remove err from closure scope, use local error
-				if dropErr := vectorIndex.Drop(ctx); dropErr != nil {
-					return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), dropErr)
-				}
-				return nil
-			})
-		}
-
-		if err = eg.Wait(); err != nil {
-			return err
+			if err = vectorIndex.Drop(ctx); err != nil {
+				return fmt.Errorf("remove vector index of vector %q at %s: %w", targetVector, s.path(), err)
+			}
 		}
 	} else {
 		// delete queue cursor

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -16,11 +16,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
 /*
@@ -51,10 +48,10 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		return
 	}
 
-	ec := errorcompounder.NewSafe()
+	ec := errorcompounder.New()
 
 	err = s.GetPropertyLengthTracker().Close()
-	ec.Add(errors.Wrap(err, "close prop length tracker"))
+	ec.AddWrap(err, "close prop length tracker")
 
 	// unregister all callbacks at once, in parallel
 	err = cyclemanager.NewCombinedCallbackCtrl(0, s.index.logger,
@@ -69,21 +66,12 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.mayCloseAndStoreHashTree()
 
 	if s.hasTargetVectors() {
-		eg := enterrors.NewErrorGroupWrapper(s.Index().logger)
-		eg.SetLimit(_NUMCPU)
+		// TODO run in parallel?
 		for targetVector, queue := range s.queues {
-			targetVector, queue := targetVector, queue // capture loop variables
-			eg.Go(func() error {
-				if err := queue.Close(); err != nil {
-					ec.Add(fmt.Errorf("shut down vector index queue of vector %q: %w", targetVector, err))
-				}
-				return nil
-			})
-		}
-
-		// we have to close queue before index for versions before 1.28
-		if err = eg.Wait(); err != nil {
-			ec.Add(err)
+			err := queue.Close()
+			if err != nil {
+				ec.Add(fmt.Errorf("shut down vector index queue of vector %q: %w", targetVector, err))
+			}
 		}
 
 		for targetVector, vectorIndex := range s.vectorIndexes {
@@ -93,25 +81,19 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 				continue
 			}
 
-			targetVector, vectorIndex := targetVector, vectorIndex // capture loop variables
-			eg.Go(func() error {
-				if err := vectorIndex.Flush(); err != nil {
-					ec.Add(fmt.Errorf("flush vector index commitlog of vector %q: %w", targetVector, err))
-				}
+			err := vectorIndex.Flush()
+			if err != nil {
+				ec.Add(fmt.Errorf("flush vector index commitlog of vector %q: %w", targetVector, err))
+			}
 
-				if err := vectorIndex.Shutdown(ctx); err != nil {
-					ec.Add(fmt.Errorf("shut down vector index of vector %q: %w", targetVector, err))
-				}
-				return nil
-			})
-		}
-
-		if err = eg.Wait(); err != nil {
-			ec.Add(err)
+			err = vectorIndex.Shutdown(ctx)
+			if err != nil {
+				ec.Add(fmt.Errorf("shut down vector index of vector %q: %w", targetVector, err))
+			}
 		}
 	} else {
 		err = s.queue.Close()
-		ec.Add(errors.Wrap(err, "shut down vector index queue"))
+		ec.AddWrap(err, "shut down vector index queue")
 
 		if s.vectorIndex != nil {
 			// a nil-vector index during shutdown would indicate that the shard was not
@@ -123,10 +105,10 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 			// resulting in perpetually attempting to remove a tombstone
 			// which doesn't actually exist anymore
 			err = s.vectorIndex.Flush()
-			ec.Add(errors.Wrap(err, "flush vector index commitlog"))
+			ec.AddWrap(err, "flush vector index commitlog")
 
 			err = s.vectorIndex.Shutdown(ctx)
-			ec.Add(errors.Wrap(err, "shut down vector index"))
+			ec.AddWrap(err, "shut down vector index")
 		}
 	}
 
@@ -134,7 +116,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		// store would be nil if loading the objects bucket failed, as we would
 		// only return the store on success from s.initLSMStore()
 		err = s.store.Shutdown(ctx)
-		ec.Add(errors.Wrap(err, "stop lsmkv store"))
+		ec.AddWrap(err, "stop lsmkv store")
 	}
 
 	if s.dimensionTrackingInitialized.Load() {

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -566,9 +565,6 @@ func (l *hnswCommitLogger) combineLogs() (bool, error) {
 }
 
 func (l *hnswCommitLogger) Drop(ctx context.Context) error {
-	l.Lock()
-	defer l.Unlock()
-
 	if err := l.commitLogger.Close(); err != nil {
 		return errors.Wrap(err, "close hnsw commit logger prior to delete")
 	}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
@@ -595,9 +594,6 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 }
 
 func (h *hnsw) Drop(ctx context.Context) error {
-	h.Lock()
-	defer h.Unlock()
-
 	// cancel tombstone cleanup goroutine
 	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
@@ -624,9 +620,6 @@ func (h *hnsw) Drop(ctx context.Context) error {
 }
 
 func (h *hnsw) Shutdown(ctx context.Context) error {
-	h.Lock()
-	defer h.Unlock()
-
 	h.shutdownCtxCancel()
 
 	if err := h.commitLog.Shutdown(ctx); err != nil {


### PR DESCRIPTION


This reverts commit 1a6133cbecac6a5d05adcee9ed2f2aee50dc21fd.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
