### PR TITLE
possible optimization: persistent memtable

### DIFF
--- a/adapters/repos/db/lsmkv/binary_search_tree_map_serialization.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map_serialization.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// ------------------ Serialization ------------------
+
+func serializeSearchTreeMap(tree *binarySearchTreeMap, w io.Writer) error {
+	return serializeSearchNodeMap(w, tree.root)
+}
+
+func serializeSearchNodeMap(w io.Writer, node *binarySearchNodeMap) error {
+	if node == nil {
+		return binary.Write(w, binary.LittleEndian, byte(0))
+	}
+	binary.Write(w, binary.LittleEndian, byte(1)) // presence
+
+	binary.Write(w, binary.LittleEndian, boolToByte(node.colourIsRed))
+	writeBytes(w, node.key)
+
+	binary.Write(w, binary.LittleEndian, uint32(len(node.values)))
+	for _, pair := range node.values {
+		writeBytes(w, pair.Key)
+		writeBytes(w, pair.Value)
+		binary.Write(w, binary.LittleEndian, boolToByte(pair.Tombstone))
+	}
+
+	serializeSearchNodeMap(w, node.left)
+	serializeSearchNodeMap(w, node.right)
+
+	return nil
+}
+
+// ------------------ Deserialization ------------------
+
+func deserializeSearchTreeMap(r io.Reader) (*binarySearchTreeMap, error) {
+	root, err := deserializeSearchNodeMap(r, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &binarySearchTreeMap{root: root}, nil
+}
+
+func deserializeSearchNodeMap(r io.Reader, parent *binarySearchNodeMap) (*binarySearchNodeMap, error) {
+	var marker byte
+	binary.Read(r, binary.LittleEndian, &marker)
+	if marker == 0 {
+		return nil, nil
+	}
+
+	node := &binarySearchNodeMap{}
+	var b byte
+
+	binary.Read(r, binary.LittleEndian, &b)
+	node.colourIsRed = b == 1
+
+	node.key, _ = readBytes(r)
+
+	var numPairs uint32
+	binary.Read(r, binary.LittleEndian, &numPairs)
+	node.values = make([]MapPair, numPairs)
+	for i := uint32(0); i < numPairs; i++ {
+		k, _ := readBytes(r)
+		v, _ := readBytes(r)
+		binary.Read(r, binary.LittleEndian, &b)
+		node.values[i] = MapPair{
+			Key:       k,
+			Value:     v,
+			Tombstone: b == 1,
+		}
+	}
+
+	node.left, _ = deserializeSearchNodeMap(r, node)
+	node.right, _ = deserializeSearchNodeMap(r, node)
+	node.parent = parent
+	return node, nil
+}

--- a/adapters/repos/db/lsmkv/binary_search_tree_map_serialization_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map_serialization_test.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeDeserializeTreeMap(t *testing.T) {
+	tree := &binarySearchTreeMap{
+		root: &binarySearchNodeMap{
+			key:         []byte("root"),
+			colourIsRed: false,
+			values: []MapPair{
+				{Key: []byte("k1"), Value: []byte("v1"), Tombstone: false},
+				{Key: []byte("k2"), Value: []byte("v2"), Tombstone: true},
+			},
+			left: &binarySearchNodeMap{
+				key:         []byte("left"),
+				colourIsRed: true,
+				values: []MapPair{
+					{Key: []byte("lk"), Value: []byte("lv"), Tombstone: false},
+				},
+			},
+			right: &binarySearchNodeMap{
+				key:         []byte("right"),
+				colourIsRed: false,
+				values: []MapPair{
+					{Key: []byte("rk"), Value: []byte("rv"), Tombstone: true},
+				},
+			},
+		},
+	}
+	tree.root.left.parent = tree.root
+	tree.root.right.parent = tree.root
+
+	// Create temporary file
+	tmpFile, err := os.CreateTemp("", "tree-map-*.bin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	// Serialize
+	fw, err := os.OpenFile(tmpFile.Name(), os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := serializeSearchTreeMap(tree, fw); err != nil {
+		t.Fatalf("Serialization failed: %v", err)
+	}
+	fw.Close()
+
+	// Deserialize
+	fr, err := os.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	deserializedTree, err := deserializeSearchTreeMap(fr)
+	if err != nil {
+		t.Fatalf("Deserialization failed: %v", err)
+	}
+	fr.Close()
+
+	require.Equal(t, tree, deserializedTree)
+}

--- a/adapters/repos/db/lsmkv/binary_search_tree_multi_serialization.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_multi_serialization.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// ------------------ Serialization ------------------
+
+func serializeSearchTreeMulti(tree *binarySearchTreeMulti, w io.Writer) error {
+	return serializeSearchNodeMulti(w, tree.root)
+}
+
+func serializeSearchNodeMulti(w io.Writer, node *binarySearchNodeMulti) error {
+	if node == nil {
+		return binary.Write(w, binary.LittleEndian, byte(0))
+	}
+	binary.Write(w, binary.LittleEndian, byte(1)) // presence
+
+	binary.Write(w, binary.LittleEndian, boolToByte(node.colourIsRed))
+	writeBytes(w, node.key)
+
+	binary.Write(w, binary.LittleEndian, uint32(len(node.values)))
+	for _, v := range node.values {
+		writeBytes(w, v.value)
+		binary.Write(w, binary.LittleEndian, boolToByte(v.tombstone))
+	}
+
+	serializeSearchNodeMulti(w, node.left)
+	serializeSearchNodeMulti(w, node.right)
+
+	return nil
+}
+
+// ------------------ Deserialization ------------------
+
+func deserializeSearchTreeMulti(r io.Reader) (*binarySearchTreeMulti, error) {
+	root, err := deserializeSearchNodeMulti(r, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &binarySearchTreeMulti{root: root}, nil
+}
+
+func deserializeSearchNodeMulti(r io.Reader, parent *binarySearchNodeMulti) (*binarySearchNodeMulti, error) {
+	var marker byte
+	binary.Read(r, binary.LittleEndian, &marker)
+	if marker == 0 {
+		return nil, nil
+	}
+
+	node := &binarySearchNodeMulti{}
+	var b byte
+
+	binary.Read(r, binary.LittleEndian, &b)
+	node.colourIsRed = b == 1
+
+	node.key, _ = readBytes(r)
+
+	var numValues uint32
+	binary.Read(r, binary.LittleEndian, &numValues)
+	node.values = make([]value, numValues)
+	for i := uint32(0); i < numValues; i++ {
+		val, _ := readBytes(r)
+		binary.Read(r, binary.LittleEndian, &b)
+		node.values[i] = value{value: val, tombstone: b == 1}
+	}
+
+	node.left, _ = deserializeSearchNodeMulti(r, node)
+	node.right, _ = deserializeSearchNodeMulti(r, node)
+	node.parent = parent
+	return node, nil
+}

--- a/adapters/repos/db/lsmkv/binary_search_tree_multi_serialization_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_multi_serialization_test.go
@@ -1,0 +1,76 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinarySearchTreeMultiSerialization(t *testing.T) {
+	tree := &binarySearchTreeMulti{
+		root: &binarySearchNodeMulti{
+			key:         []byte("root"),
+			colourIsRed: false,
+			values: []value{
+				{value: []byte("v1"), tombstone: false},
+				{value: []byte("v2"), tombstone: true},
+			},
+			left: &binarySearchNodeMulti{
+				key:         []byte("left"),
+				colourIsRed: true,
+				values:      []value{{value: []byte("vL"), tombstone: false}},
+			},
+			right: &binarySearchNodeMulti{
+				key:         []byte("right"),
+				colourIsRed: false,
+				values:      []value{{value: []byte("vR"), tombstone: true}},
+			},
+		},
+	}
+	tree.root.left.parent = tree.root
+	tree.root.right.parent = tree.root
+
+	// Create temporary file
+	tmpFile, err := os.CreateTemp("", "tree-multi-*.bin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	// Serialize
+	fw, err := os.OpenFile(tmpFile.Name(), os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := serializeSearchTreeMulti(tree, fw); err != nil {
+		t.Fatalf("Serialize failed: %v", err)
+	}
+	fw.Close()
+
+	// Deserialize
+	fr, err := os.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deserializedTree, err := deserializeSearchTreeMulti(fr)
+	if err != nil {
+		t.Fatalf("Deserialize failed: %v", err)
+	}
+	fr.Close()
+
+	require.Equal(t, tree, deserializedTree)
+}

--- a/adapters/repos/db/lsmkv/binary_search_tree_serialization.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_serialization.go
@@ -1,0 +1,159 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// ------------------ Serialization ------------------
+
+func serializeBinarySearchTree(tree *binarySearchTree, w io.Writer) error {
+	return serializeBinarySearchNode(w, tree.root)
+}
+
+func serializeBinarySearchNode(w io.Writer, node *binarySearchNode) error {
+	if node == nil {
+		return binary.Write(w, binary.LittleEndian, byte(0)) // null marker
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, byte(1)); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, boolToByte(node.tombstone)); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, boolToByte(node.colourIsRed)); err != nil {
+		return err
+	}
+	if err := writeBytes(w, node.key); err != nil {
+		return err
+	}
+	if err := writeBytes(w, node.value); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(node.secondaryKeys))); err != nil {
+		return err
+	}
+	for _, sec := range node.secondaryKeys {
+		if err := writeBytes(w, sec); err != nil {
+			return err
+		}
+	}
+
+	if err := serializeBinarySearchNode(w, node.left); err != nil {
+		return err
+	}
+	if err := serializeBinarySearchNode(w, node.right); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeBytes(w io.Writer, data []byte) error {
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(data))); err != nil {
+		return err
+	}
+	_, err := w.Write(data)
+	return err
+}
+
+func boolToByte(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// ------------------ Deserialization ------------------
+
+func deserializeBinarySearchTree(r io.Reader) (*binarySearchTree, error) {
+	root, err := deserializeBinarySearchNode(r, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &binarySearchTree{root: root}, nil
+}
+
+func deserializeBinarySearchNode(r io.Reader, parent *binarySearchNode) (*binarySearchNode, error) {
+	var marker byte
+	if err := binary.Read(r, binary.LittleEndian, &marker); err != nil {
+		return nil, err
+	}
+	if marker == 0 {
+		return nil, nil
+	}
+
+	node := &binarySearchNode{}
+	var b byte
+
+	if err := binary.Read(r, binary.LittleEndian, &b); err != nil {
+		return nil, err
+	}
+	node.tombstone = b == 1
+
+	if err := binary.Read(r, binary.LittleEndian, &b); err != nil {
+		return nil, err
+	}
+	node.colourIsRed = b == 1
+
+	if key, err := readBytes(r); err != nil {
+		return nil, err
+	} else {
+		node.key = key
+	}
+	if val, err := readBytes(r); err != nil {
+		return nil, err
+	} else {
+		node.value = val
+	}
+
+	var numSec uint32
+	if err := binary.Read(r, binary.LittleEndian, &numSec); err != nil {
+		return nil, err
+	}
+
+	if numSec > 0 {
+		node.secondaryKeys = make([][]byte, numSec)
+		for i := uint32(0); i < numSec; i++ {
+			if sec, err := readBytes(r); err != nil {
+				return nil, err
+			} else {
+				node.secondaryKeys[i] = sec
+			}
+		}
+	}
+
+	var err error
+	node.left, err = deserializeBinarySearchNode(r, node)
+	if err != nil {
+		return nil, err
+	}
+	node.right, err = deserializeBinarySearchNode(r, node)
+	if err != nil {
+		return nil, err
+	}
+	node.parent = parent
+
+	return node, nil
+}
+
+func readBytes(r io.Reader) ([]byte, error) {
+	var length uint32
+	if err := binary.Read(r, binary.LittleEndian, &length); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, length)
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}

--- a/adapters/repos/db/lsmkv/binary_search_tree_serialization_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_serialization_test.go
@@ -1,0 +1,68 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinarySearchTreeSerialization(t *testing.T) {
+	tree := &binarySearchTree{
+		root: &binarySearchNode{
+			key:         []byte("root"),
+			value:       []byte("root-val"),
+			tombstone:   false,
+			colourIsRed: true,
+			secondaryKeys: [][]byte{
+				[]byte("sec1"),
+				[]byte("sec2"),
+			},
+			left: &binarySearchNode{
+				key:         []byte("left"),
+				value:       []byte("left-val"),
+				tombstone:   false,
+				colourIsRed: false,
+			},
+			right: &binarySearchNode{
+				key:         []byte("right"),
+				value:       []byte("right-val"),
+				tombstone:   true,
+				colourIsRed: true,
+			},
+		},
+	}
+	tree.root.left.parent = tree.root
+	tree.root.right.parent = tree.root
+
+	// Serialize to file
+	tmpFile, err := os.CreateTemp("", "tree-binary-*.bin")
+	require.NoError(t, err)
+
+	err = serializeBinarySearchTree(tree, tmpFile)
+	require.NoError(t, err)
+
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	// Deserialize from file
+	tmpFile, err = os.Open(tmpFile.Name())
+	require.NoError(t, err)
+	defer tmpFile.Close()
+
+	deserializedTree, err := deserializeBinarySearchTree(tmpFile)
+	require.NoError(t, err)
+
+	require.Equal(t, tree, deserializedTree)
+}

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -173,6 +173,13 @@ func WithSegmentsChecksumValidationEnabled(enable bool) BucketOption {
 	}
 }
 
+func WithActiveMemtableReuseDisabled(disableActiveMemtableReuse bool) BucketOption {
+	return func(b *Bucket) error {
+		b.disableActiveMemtableReuse = disableActiveMemtableReuse
+		return nil
+	}
+}
+
 /*
 Background for this option:
 

--- a/adapters/repos/db/lsmkv/memtable_raw_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_raw_flush.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func (m *Memtable) rawFlush() (rerr error) {
+	// close the commit log first, this also forces it to be fsynced. If
+	// something fails there, don't proceed with flushing. The commit log will
+	// only be deleted at the very end, if the flush was successful
+	// (indicated by a successful close of the flush file - which indicates a
+	// successful fsync)
+
+	if err := m.commitlog.close(); err != nil {
+		return errors.Wrap(err, "close commit log file")
+	}
+
+	if m.Size() == 0 {
+		// this is an empty memtable, nothing to do
+		// however, we still have to cleanup the commit log, otherwise we will
+		// attempt to recover from it on the next cycle
+		if err := m.commitlog.delete(); err != nil {
+			return errors.Wrap(err, "delete commit log file")
+		}
+		return nil
+	}
+
+	tmpMemtablePath := m.path + ".mem.tmp"
+
+	f, err := os.OpenFile(tmpMemtablePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o666)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rerr != nil {
+			f.Close()
+			os.Remove(tmpMemtablePath)
+		}
+	}()
+
+	w := bufio.NewWriter(f)
+
+	err = SerializeMemtable(m, w)
+	if err != nil {
+		return err
+	}
+
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	err = os.Rename(tmpMemtablePath, strings.TrimSuffix(tmpMemtablePath, ".tmp"))
+	if err != nil {
+		return err
+	}
+
+	// fsync parent directory
+	err = fsync(filepath.Dir(m.path))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/adapters/repos/db/lsmkv/memtable_serialization.go
+++ b/adapters/repos/db/lsmkv/memtable_serialization.go
@@ -1,0 +1,189 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+)
+
+const currentVersion uint16 = 1
+
+func SerializeMemtable(m *Memtable, w io.Writer) error {
+	if err := binary.Write(w, binary.LittleEndian, currentVersion); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, m.size); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, m.createdAt.UnixNano()); err != nil {
+		return err
+	}
+
+	// Serialize secondaryToPrimary
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(m.secondaryToPrimary))); err != nil {
+		return err
+	}
+	for _, mp := range m.secondaryToPrimary {
+		if err := binary.Write(w, binary.LittleEndian, uint32(len(mp))); err != nil {
+			return err
+		}
+		for k, v := range mp {
+			if err := writeBytes(w, []byte(k)); err != nil {
+				return err
+			}
+			if err := writeBytes(w, v); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := serializeBinarySearchTree(m.key, w); err != nil {
+		return err
+	}
+
+	if err := serializeSearchTreeMulti(m.keyMulti, w); err != nil {
+		return err
+	}
+
+	if err := serializeSearchTreeMap(m.keyMap, w); err != nil {
+		return err
+	}
+
+	if err := serializeBinarySearchTree(m.primaryIndex, w); err != nil {
+		return err
+	}
+
+	if err := roaringset.SerializeBinarySearchTree(m.roaringSet, w); err != nil {
+		return err
+	}
+
+	if err := roaringsetrange.SerializeMemtable(m.roaringSetRange, w); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DeserializeMemtable(r io.Reader, path string, strategy string, secondaryIndices uint16,
+	enableChecksumValidation bool, cl *commitLogger, metrics *Metrics, logger logrus.FieldLogger,
+) (*Memtable, error) {
+	m := &Memtable{
+		path:                     path,
+		strategy:                 strategy,
+		secondaryIndices:         secondaryIndices,
+		enableChecksumValidation: enableChecksumValidation,
+		commitlog:                cl,
+		dirtyAt:                  time.Now(),
+		metrics:                  newMemtableMetrics(metrics, filepath.Dir(path), strategy),
+	}
+
+	var version uint16
+
+	err := binary.Read(r, binary.LittleEndian, &version)
+	if err != nil {
+		return nil, err
+	}
+
+	if version != currentVersion {
+		return nil, fmt.Errorf("memtable deserialization: unsupported version %d expected %d", version, currentVersion)
+	}
+
+	err = binary.Read(r, binary.LittleEndian, &m.size)
+	if err != nil {
+		return nil, err
+	}
+
+	var createdNano int64
+	err = binary.Read(r, binary.LittleEndian, &createdNano)
+	if err != nil {
+		return nil, err
+	}
+	m.createdAt = time.Unix(0, createdNano)
+
+	// SecondaryToPrimary
+	var outerLen uint32
+	err = binary.Read(r, binary.LittleEndian, &outerLen)
+	if err != nil {
+		return nil, err
+	}
+
+	m.secondaryToPrimary = make([]map[string][]byte, outerLen)
+
+	for i := uint32(0); i < outerLen; i++ {
+		var innerLen uint32
+
+		if err := binary.Read(r, binary.LittleEndian, &innerLen); err != nil {
+			return nil, err
+		}
+
+		mp := make(map[string][]byte)
+
+		for j := uint32(0); j < innerLen; j++ {
+			k, err := readBytes(r)
+			if err != nil {
+				return nil, err
+			}
+
+			v, err := readBytes(r)
+			if err != nil {
+				return nil, err
+			}
+
+			mp[string(k)] = v
+		}
+
+		m.secondaryToPrimary[i] = mp
+	}
+
+	m.key, err = deserializeBinarySearchTree(r)
+	if err != nil {
+		return nil, err
+	}
+
+	m.keyMulti, err = deserializeSearchTreeMulti(r)
+	if err != nil {
+		return nil, err
+	}
+
+	m.keyMap, err = deserializeSearchTreeMap(r)
+	if err != nil {
+		return nil, err
+	}
+
+	m.primaryIndex, err = deserializeBinarySearchTree(r)
+	if err != nil {
+		return nil, err
+	}
+
+	m.roaringSet, err = roaringset.DeserializeBinarySearchTree(r)
+	if err != nil {
+		return nil, err
+	}
+
+	m.roaringSetRange, err = roaringsetrange.DeserializeMemtable(r, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	m.metrics.size(m.size)
+
+	return m, nil
+}

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -66,10 +66,12 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 		})
 
 		t.Run("shutdown (orderly) bucket to create first segment", func(t *testing.T) {
+			err := b.FlushAndSwitch()
+			require.NoError(t, err)
+
 			b.Shutdown(context.Background())
 
 			// then recreate bucket
-			var err error
 			b, err = NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithStrategy(StrategyReplace))

--- a/adapters/repos/db/roaringset/binary_search_tree_serialization.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_serialization.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringset
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/weaviate/sroar"
+)
+
+// ------------------ Serialization ------------------
+
+func SerializeBinarySearchTree(tree *BinarySearchTree, w io.Writer) error {
+	return serializeBinarySearchNode(w, tree.root)
+}
+
+func serializeBinarySearchNode(w io.Writer, node *BinarySearchNode) error {
+	if node == nil {
+		return binary.Write(w, binary.LittleEndian, byte(0))
+	}
+	binary.Write(w, binary.LittleEndian, byte(1)) // presence
+
+	binary.Write(w, binary.LittleEndian, boolToByte(node.colourIsRed))
+	writeBytes(w, node.Key)
+
+	// Serialize BitmapLayer
+	serializeBitmapLayer(w, node.Value)
+
+	serializeBinarySearchNode(w, node.left)
+	serializeBinarySearchNode(w, node.right)
+
+	return nil
+}
+
+func serializeBitmapLayer(w io.Writer, layer BitmapLayer) {
+	if layer.Additions != nil {
+		writeBytes(w, layer.Additions.ToBuffer())
+	} else {
+		writeBytes(w, []byte{})
+	}
+
+	if layer.Deletions != nil {
+		writeBytes(w, layer.Deletions.ToBuffer())
+	} else {
+		writeBytes(w, []byte{})
+	}
+}
+
+// ------------------ Deserialization ------------------
+
+func DeserializeBinarySearchTree(r io.Reader) (*BinarySearchTree, error) {
+	root, err := deserializeBinarySearchNode(r, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BinarySearchTree{root: root}, nil
+}
+
+func deserializeBinarySearchNode(r io.Reader, parent *BinarySearchNode) (*BinarySearchNode, error) {
+	var marker byte
+	binary.Read(r, binary.LittleEndian, &marker)
+	if marker == 0 {
+		return nil, nil
+	}
+
+	node := &BinarySearchNode{}
+	var b byte
+
+	binary.Read(r, binary.LittleEndian, &b)
+	node.colourIsRed = b == 1
+
+	node.Key, _ = readBytes(r)
+
+	// Deserialize BitmapLayer
+	node.Value = deserializeBitmapLayer(r)
+
+	node.left, _ = deserializeBinarySearchNode(r, node)
+	node.right, _ = deserializeBinarySearchNode(r, node)
+	node.parent = parent
+	return node, nil
+}
+
+func deserializeBitmapLayer(r io.Reader) BitmapLayer {
+	var layer BitmapLayer
+
+	additionsData, _ := readBytes(r)
+	layer.Additions = sroar.FromBuffer(additionsData)
+
+	deletionsData, _ := readBytes(r)
+	layer.Deletions = sroar.FromBuffer(deletionsData)
+
+	return layer
+}
+
+// ------------------ Helpers ------------------
+
+func writeBytes(w io.Writer, data []byte) error {
+	binary.Write(w, binary.LittleEndian, uint32(len(data)))
+	_, err := w.Write(data)
+	return err
+}
+
+func readBytes(r io.Reader) ([]byte, error) {
+	var length uint32
+	binary.Read(r, binary.LittleEndian, &length)
+	buf := make([]byte, length)
+	_, err := io.ReadFull(r, buf)
+	return buf, err
+}
+
+func boolToByte(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/adapters/repos/db/roaringset/binary_search_tree_serialization_test.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_serialization_test.go
@@ -1,0 +1,83 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringset
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+)
+
+func TestSerializeDeserializeBinarySearchTree(t *testing.T) {
+	tree := &BinarySearchTree{
+		root: &BinarySearchNode{
+			Key:         []byte("root"),
+			colourIsRed: false,
+			Value: BitmapLayer{
+				Additions: sroar.NewBitmap(),
+				Deletions: sroar.NewBitmap(),
+			},
+			left: &BinarySearchNode{
+				Key:         []byte("left"),
+				colourIsRed: true,
+				Value: BitmapLayer{
+					Additions: sroar.NewBitmap(),
+					Deletions: sroar.NewBitmap(),
+				},
+			},
+			right: &BinarySearchNode{
+				Key:         []byte("right"),
+				colourIsRed: false,
+				Value: BitmapLayer{
+					Additions: sroar.NewBitmap(),
+					Deletions: sroar.NewBitmap(),
+				},
+			},
+		},
+	}
+	tree.root.left.parent = tree.root
+	tree.root.right.parent = tree.root
+
+	// Create temporary file
+	tmpFile, err := os.CreateTemp("", "tree-bitmap-*.bin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	// Serialize
+	fw, err := os.OpenFile(tmpFile.Name(), os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SerializeBinarySearchTree(tree, fw); err != nil {
+		t.Fatalf("Serialization failed: %v", err)
+	}
+	fw.Close()
+
+	// Deserialize
+	fr, err := os.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deserializedTree, err := DeserializeBinarySearchTree(fr)
+	if err != nil {
+		t.Fatalf("Deserialization failed: %v", err)
+	}
+	fr.Close()
+
+	require.Equal(t, tree, deserializedTree)
+}

--- a/adapters/repos/db/roaringsetrange/memtable_serialization.go
+++ b/adapters/repos/db/roaringsetrange/memtable_serialization.go
@@ -1,0 +1,86 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+func SerializeMemtable(m *Memtable, w io.Writer) error {
+	// Write additions
+	if err := binary.Write(w, binary.LittleEndian, uint64(len(m.additions))); err != nil {
+		return err
+	}
+	for k, v := range m.additions {
+		if err := binary.Write(w, binary.LittleEndian, k); err != nil {
+			return err
+		}
+		if err := binary.Write(w, binary.LittleEndian, v); err != nil {
+			return err
+		}
+	}
+
+	// Write deletions
+	if err := binary.Write(w, binary.LittleEndian, uint64(len(m.deletions))); err != nil {
+		return err
+	}
+	for k := range m.deletions {
+		if err := binary.Write(w, binary.LittleEndian, k); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func DeserializeMemtable(r io.Reader, logger logrus.FieldLogger) (*Memtable, error) {
+	m := &Memtable{
+		additions: make(map[uint64]uint64),
+		deletions: make(map[uint64]struct{}),
+	}
+
+	var addCount uint64
+	if err := binary.Read(r, binary.LittleEndian, &addCount); err != nil {
+		return nil, fmt.Errorf("reading additions count: %w", err)
+	}
+
+	for i := uint64(0); i < addCount; i++ {
+		var k, v uint64
+		if err := binary.Read(r, binary.LittleEndian, &k); err != nil {
+			return nil, fmt.Errorf("reading addition key: %w", err)
+		}
+		if err := binary.Read(r, binary.LittleEndian, &v); err != nil {
+			return nil, fmt.Errorf("reading addition value: %w", err)
+		}
+		logger.WithFields(logrus.Fields{"key": k, "value": v}).Debug("Deserialized addition")
+		m.additions[k] = v
+	}
+
+	var delCount uint64
+	if err := binary.Read(r, binary.LittleEndian, &delCount); err != nil {
+		return nil, fmt.Errorf("reading deletions count: %w", err)
+	}
+	for i := uint64(0); i < delCount; i++ {
+		var k uint64
+		if err := binary.Read(r, binary.LittleEndian, &k); err != nil {
+			return nil, fmt.Errorf("reading deletion key: %w", err)
+		}
+		logger.WithField("key", k).Debug("Deserialized deletion")
+		m.deletions[k] = struct{}{}
+	}
+
+	return m, nil
+}

--- a/adapters/repos/db/roaringsetrange/memtable_serialization_test.go
+++ b/adapters/repos/db/roaringsetrange/memtable_serialization_test.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringsetrange
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestSerializeDeserializeMemtable_WithTempFile(t *testing.T) {
+	original := &Memtable{
+		additions: map[uint64]uint64{
+			1: 100,
+			2: 200,
+		},
+		deletions: map[uint64]struct{}{
+			42: {},
+		},
+	}
+
+	// Create temp file
+	tmpFile, err := os.CreateTemp("", "memtable-*.bin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name()) // Clean up
+
+	// Serialize to file
+	if err := SerializeMemtable(original, tmpFile); err != nil {
+		t.Fatalf("Serialization to file failed: %v", err)
+	}
+	tmpFile.Close()
+
+	// Reopen for reading
+	tmpFile, err = os.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open temp file: %v", err)
+	}
+	defer tmpFile.Close()
+
+	// Setup logger to test logs
+	logger := logrus.New()
+	logger.SetOutput(testWriter{t})
+	logger.SetLevel(logrus.DebugLevel)
+
+	// Deserialize
+	restored, err := DeserializeMemtable(tmpFile, logger)
+	if err != nil {
+		t.Fatalf("Deserialization from file failed: %v", err)
+	}
+
+	// Check data matches
+	for k, v := range original.additions {
+		if restored.additions[k] != v {
+			t.Errorf("Addition mismatch: key %d got %d, want %d", k, restored.additions[k], v)
+		}
+	}
+	for k := range original.deletions {
+		if _, ok := restored.deletions[k]; !ok {
+			t.Errorf("Missing deletion: key %d", k)
+		}
+	}
+}
+
+// Redirect logrus logs to test logs
+type testWriter struct {
+	t *testing.T
+}
+
+func (tw testWriter) Write(p []byte) (n int, err error) {
+	tw.t.Logf("%s", p)
+	return len(p), nil
+}

--- a/test/acceptance_lsmkv/data_integrity_test.go
+++ b/test/acceptance_lsmkv/data_integrity_test.go
@@ -99,5 +99,6 @@ func newTestBucket(dataPath string, checkSumEnabled bool) (*lsmkv.Bucket, error)
 			cyclemanager.NewCallbackGroupNoop(),
 			cyclemanager.NewCallbackGroupNoop(),
 			lsmkv.WithSegmentsChecksumValidationEnabled(checkSumEnabled),
+			lsmkv.WithActiveMemtableReuseDisabled(true),
 		)
 }


### PR DESCRIPTION
### What's being changed:

TODO: it may be beneficial to introduce a separate setting to control whether to reuse or perform standard memtable flushing. Currently, this decision is tied to the memtable flushing options.


e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/1478
7097868
chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14786886387

pre-existing issue with wal recovery 1.24: https://github.com/weaviate/weaviate/pull/8011

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
