### PR TITLE
improve error verbosity when not finding replication op

### DIFF
--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -43,7 +43,7 @@ func (s *ShardReplicationFSM) RegisterError(id uint64, c *api.ReplicationRegiste
 
 	op, ok := s.opsById[id]
 	if !ok {
-		return ErrReplicationOpNotFound
+		return fmt.Errorf("could not find op %d: %w", id, ErrReplicationOpNotFound)
 	}
 	status, ok := s.opsStatus[op]
 	if !ok {
@@ -83,7 +83,7 @@ func (s *ShardReplicationFSM) UpdateReplicationOpStatus(c *api.ReplicationUpdate
 
 	op, ok := s.opsById[c.Id]
 	if !ok {
-		return ErrReplicationOpNotFound
+		return fmt.Errorf("could not find op %d: %w", c.Id, ErrReplicationOpNotFound)
 	}
 	status, ok := s.opsStatus[op]
 	if !ok {


### PR DESCRIPTION
### What's being changed:

Make the error tell which op it couldn't locate

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
