### PR TITLE
refactor async replication retry

### DIFF
--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -688,6 +688,81 @@ func TestConsumerWithCallbacks(t *testing.T) {
 	})
 }
 
+func TestConsumerRetryAsyncReplication(t *testing.T) {
+	opId := uint64(1)
+	op := replication.NewShardReplicationOp(opId, "node1", "node2", "TestCollection", "test-shard")
+	logger, _ := logrustest.NewNullLogger()
+	mockFSMUpdater := types.NewMockFSMUpdater(t)
+	mockReplicaCopier := types.NewMockReplicaCopier(t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	mockReplicaCopier.EXPECT().
+		SetAsyncReplicationTargetNode(mock.Anything, mock.Anything).Return(nil)
+	mockReplicaCopier.EXPECT().
+		InitAsyncReplicationLocally(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+	// Trigger one failure to ensure we retry
+	mockReplicaCopier.EXPECT().AsyncReplicationStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(models.AsyncReplicationStatus{}, fmt.Errorf("simulated async replication error")).Times(1)
+	mockReplicaCopier.EXPECT().AsyncReplicationStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(models.AsyncReplicationStatus{
+		ObjectsPropagated:       0,
+		StartDiffTimeUnixMillis: time.Now().Add(200 * time.Second).UnixMilli(),
+	}, nil).Times(1)
+	// Succeed the rest of the op
+	mockFSMUpdater.EXPECT().AddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil)
+	mockFSMUpdater.EXPECT().
+		ReplicationUpdateReplicaOpStatus(uint64(opId), api.READY).
+		Return(nil).
+		Run(func(id uint64, state api.ShardReplicationState) {
+			wg.Done()
+		})
+
+	consumer := replication.NewCopyOpConsumer(
+		logger,
+		mockFSMUpdater,
+		mockReplicaCopier,
+		op.TargetShard.NodeId,
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*1), 4),
+		replication.NewOpsCache(),
+		time.Second*10,
+		1,
+		metrics.NewReplicationEngineOpsCallbacksBuilder().Build(),
+	)
+
+	ctx := t.Context()
+
+	opsChan := make(chan replication.ShardReplicationOpAndStatus, 1)
+	doneChan := make(chan error, 1)
+
+	// WHEN
+	go func() {
+		doneChan <- consumer.Consume(ctx, opsChan)
+	}()
+
+	// Start in finalizing state directly
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, replication.NewShardReplicationStatus(api.FINALIZING))
+	waitChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		waitChan <- struct{}{}
+	}()
+
+	select {
+	case <-waitChan:
+		// This is here just to make sure the test does not run indefinitely
+	case <-time.After(10 * time.Second):
+		t.Fatal("Test timed out waiting for operation completion")
+	}
+
+	close(opsChan)
+	err := <-doneChan
+	require.NoError(t, err, "expected consumer to stop without error")
+
+	mockFSMUpdater.AssertExpectations(t)
+	mockReplicaCopier.AssertExpectations(t)
+}
+
 func TestConsumerBackoffPolicyRetriesOnStateChangeFailure(t *testing.T) {
 	opId := uint64(1)
 	op := replication.NewShardReplicationOp(opId, "node1", "node2", "TestCollection", "test-shard")


### PR DESCRIPTION
### What's being changed:

Change the retry logic to actually work, as the `break` would break out of the switch but not the loop.
add a test to ensure behaviour


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
