### PR TITLE
Fix: pass missing memwatch from segment group -> segment

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -205,6 +205,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 					overwriteDerived:         false,
 					enableChecksumValidation: sg.enableChecksumValidation,
 					MinMMapSize:              sg.MinMMapSize,
+					allocChecker:             sg.allocChecker,
 				})
 			if err != nil {
 				return nil, fmt.Errorf("init already compacted right segment %s: %w", rightSegmentFilename, err)
@@ -254,6 +255,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 				overwriteDerived:         true,
 				enableChecksumValidation: sg.enableChecksumValidation,
 				MinMMapSize:              sg.MinMMapSize,
+				allocChecker:             sg.allocChecker,
 			},
 		)
 		if err != nil {
@@ -326,6 +328,7 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 				overwriteDerived:         false,
 				enableChecksumValidation: sg.enableChecksumValidation,
 				MinMMapSize:              sg.MinMMapSize,
+				allocChecker:             sg.allocChecker,
 			})
 		if err != nil {
 			return nil, fmt.Errorf("init segment %s: %w", entry.Name(), err)
@@ -386,6 +389,7 @@ func (sg *SegmentGroup) add(path string) error {
 			overwriteDerived:         true,
 			enableChecksumValidation: sg.enableChecksumValidation,
 			MinMMapSize:              sg.MinMMapSize,
+			allocChecker:             sg.allocChecker,
 		})
 	if err != nil {
 		return fmt.Errorf("init segment %s: %w", path, err)

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -639,6 +639,7 @@ func (sg *SegmentGroup) replaceSegmentBlocking(
 			overwriteDerived:         false,
 			enableChecksumValidation: sg.enableChecksumValidation,
 			MinMMapSize:              sg.MinMMapSize,
+			allocChecker:             sg.allocChecker,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("create new segment %q: %w", segmentPath, err)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -453,6 +453,7 @@ func (sg *SegmentGroup) replaceCompactedSegmentsBlocking(
 			overwriteDerived:         false,
 			enableChecksumValidation: sg.enableChecksumValidation,
 			MinMMapSize:              sg.MinMMapSize,
+			allocChecker:             sg.allocChecker,
 		})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "create new segment")

--- a/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
@@ -46,6 +46,7 @@ func (sg *SegmentGroup) initAndPrecomputeNewSegment(path string) (*segment, erro
 			overwriteDerived:         true,
 			enableChecksumValidation: sg.enableChecksumValidation,
 			MinMMapSize:              sg.MinMMapSize,
+			allocChecker:             sg.allocChecker,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("init and pre-compute new segment %s: %w", path, err)


### PR DESCRIPTION
### What's being changed:
Fix potential nil pointer panic when `PERSISTENCE_MIN_MMAP_SIZE` is used

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
