### PR TITLE
Add global shutdown manager

### DIFF
--- a/adapters/handlers/grpc/v1/batch_parse_request.go
+++ b/adapters/handlers/grpc/v1/batch_parse_request.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/usecases/byteops"
+	"github.com/weaviate/weaviate/usecases/global"
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -34,6 +35,11 @@ func sliceToInterface[T any](values []T) []interface{} {
 }
 
 func BatchFromProto(req *pb.BatchObjectsRequest, authorizedGetClass func(string, string) (*models.Class, error)) ([]*models.Object, map[int]int, map[int]error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, nil, map[int]error{
+			0: fmt.Errorf("server is shutting down"),
+		}
+	}
 	objectsBatch := req.Objects
 	objs := make([]*models.Object, 0, len(objectsBatch))
 	objOriginalIndex := make(map[int]int)

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/global"
 
 	"github.com/sirupsen/logrus"
 	restCtx "github.com/weaviate/weaviate/adapters/handlers/rest/context"
@@ -69,6 +70,9 @@ func NewService(traverser *traverser.Traverser, authComposer composer.TokenFunc,
 }
 
 func (s *Service) Aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.AggregateReply, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("server is shutting down")
+	}
 	var result *pb.AggregateReply
 	var errInner error
 
@@ -118,6 +122,9 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 }
 
 func (s *Service) TenantsGet(ctx context.Context, req *pb.TenantsGetRequest) (*pb.TenantsGetReply, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("server is shutting down")
+	}
 	before := time.Now()
 
 	principal, err := s.principalFromContext(ctx)
@@ -139,6 +146,9 @@ func (s *Service) TenantsGet(ctx context.Context, req *pb.TenantsGetRequest) (*p
 }
 
 func (s *Service) BatchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (*pb.BatchDeleteReply, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("server is shutting down")
+	}
 	var result *pb.BatchDeleteReply
 	var errInner error
 
@@ -190,6 +200,9 @@ func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 }
 
 func (s *Service) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest) (*pb.BatchObjectsReply, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("server is shutting down")
+	}
 	var result *pb.BatchObjectsReply
 	var errInner error
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -133,6 +133,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/global"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/modules"
 	"github.com/weaviate/weaviate/usecases/monitoring"
@@ -860,6 +861,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 			}, appState.Logger)
 	}
 	api.ServerShutdown = func() {
+		global.Manager().StartShutdown()
 		if telemetryEnabled(appState) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()

--- a/adapters/repos/classifications/repo.go
+++ b/adapters/repos/classifications/repo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/classification"
+	"github.com/weaviate/weaviate/usecases/global"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -79,6 +80,9 @@ func (r *Repo) init() error {
 }
 
 func (r *Repo) Put(ctx context.Context, classification models.Classification) error {
+	if global.Manager().IsShutdownInProgress() {
+		return errors.New("server is shutting down")
+	}
 	classificationJSON, err := json.Marshal(classification)
 	if err != nil {
 		return errors.Wrap(err, "marshal classification to JSON")
@@ -91,6 +95,9 @@ func (r *Repo) Put(ctx context.Context, classification models.Classification) er
 }
 
 func (r *Repo) Get(ctx context.Context, id strfmt.UUID) (*models.Classification, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, errors.New("server is shutting down")
+	}
 	var classificationJSON []byte
 	r.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(classificationsBucket)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -41,6 +41,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/global"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -693,6 +694,9 @@ func (b *Bucket) SetList(key []byte) ([][]byte, error) {
 func (b *Bucket) Put(key, value []byte, opts ...SecondaryKeyOption) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
+	if global.Manager().IsShutdownInProgress() {
+		return fmt.Errorf("server is shutting down")
+	}
 
 	return b.active.put(key, value, opts...)
 }

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/lsmkv"
+	"github.com/weaviate/weaviate/usecases/global"
 )
 
 type Memtable struct {
@@ -325,6 +326,9 @@ func (m *Memtable) append(key []byte, values []value) error {
 
 	m.Lock()
 	defer m.Unlock()
+	if global.Manager().IsShutdownInProgress() {
+		return errors.New("server is shutting down")
+	}
 	if err := m.commitlog.append(segmentCollectionNode{
 		primaryKey: key,
 		values:     values,

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/global"
 	"github.com/weaviate/weaviate/usecases/modules"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/traverser"
@@ -40,6 +41,9 @@ import (
 func (db *DB) Aggregate(ctx context.Context,
 	params aggregation.Params, modules *modules.Provider,
 ) (*aggregation.Result, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("shutdown in progress")
+	}
 	idx := db.GetIndex(params.ClassName)
 	if idx == nil {
 		return nil, fmt.Errorf("tried to browse non-existing index for %s", params.ClassName)
@@ -59,6 +63,9 @@ func (db *DB) GetQueryMaximumResults() int {
 // for the raw storage objects, such as hybrid search.
 func (db *DB) SparseObjectSearch(ctx context.Context, params dto.GetParams) ([]*storobj.Object, []float32, error) {
 	idx := db.GetIndex(schema.ClassName(params.ClassName))
+	if global.Manager().IsShutdownInProgress() {
+		return nil, nil, fmt.Errorf("shutdown in progress")
+	}
 	if idx == nil {
 		return nil, nil, fmt.Errorf("tried to browse non-existing index for %s", params.ClassName)
 	}
@@ -90,6 +97,9 @@ func (db *DB) SparseObjectSearch(ctx context.Context, params dto.GetParams) ([]*
 }
 
 func (db *DB) Search(ctx context.Context, params dto.GetParams) ([]search.Result, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("shutdown in progress")
+	}
 	if params.Pagination == nil {
 		return nil, fmt.Errorf("invalid params, pagination object is nil")
 	}
@@ -108,6 +118,9 @@ func (db *DB) Search(ctx context.Context, params dto.GetParams) ([]search.Result
 func (db *DB) VectorSearch(ctx context.Context,
 	params dto.GetParams, targetVectors []string, searchVectors []models.Vector,
 ) ([]search.Result, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("shutdown in progress")
+	}
 	if len(searchVectors) == 0 || len(searchVectors) == 1 && isEmptyVector(searchVectors[0]) {
 		results, err := db.Search(ctx, params)
 		return results, err
@@ -161,6 +174,9 @@ func extractDistanceFromParams(params dto.GetParams) float32 {
 func (db *DB) CrossClassVectorSearch(ctx context.Context, vector models.Vector, targetVector string, offset, limit int,
 	filters *filters.LocalFilter,
 ) ([]search.Result, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("shutdown in progress")
+	}
 	var found search.Results
 
 	wg := &sync.WaitGroup{}
@@ -217,6 +233,9 @@ func (db *DB) CrossClassVectorSearch(ctx context.Context, vector models.Vector, 
 
 // Query a specific class
 func (db *DB) Query(ctx context.Context, q *objects.QueryInput) (search.Results, *objects.Error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, &objects.Error{Msg: "shutdown in progress", Code: objects.StatusInternalServerError}
+	}
 	totalLimit := q.Offset + q.Limit
 	if totalLimit == 0 {
 		return nil, nil
@@ -254,6 +273,9 @@ func (db *DB) ObjectSearch(ctx context.Context, offset, limit int,
 	filters *filters.LocalFilter, sort []filters.Sort,
 	additional additional.Properties, tenant string,
 ) (search.Results, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("shutdown in progress")
+	}
 	return db.objectSearch(ctx, offset, limit, filters, sort, additional, tenant)
 }
 
@@ -326,6 +348,9 @@ func (db *DB) ResolveReferences(ctx context.Context, objs search.Results,
 	props search.SelectProperties, groupBy *searchparams.GroupBy,
 	addl additional.Properties, tenant string,
 ) (search.Results, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("shutdown in progress")
+	}
 	if addl.NoProps {
 		// If we have no props, there also can't be refs among them, so we can skip
 		// the refcache resolver

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -23,6 +23,7 @@ import (
 	entcfg "github.com/weaviate/weaviate/entities/config"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
+	"github.com/weaviate/weaviate/usecases/global"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -34,6 +35,9 @@ import (
 func (s *Shard) PutObjectBatch(ctx context.Context,
 	objects []*storobj.Object,
 ) []error {
+	if global.Manager().IsShutdownInProgress() {
+		return []error{fmt.Errorf("server is shutting down")}
+	}
 	s.activityTracker.Add(1)
 	if err := s.isReadOnly(); err != nil {
 		return []error{err}
@@ -107,6 +111,9 @@ func newObjectsBatcher(s ShardLike) *objectsBatcher {
 func (ob *objectsBatcher) Objects(ctx context.Context,
 	objects []*storobj.Object,
 ) []error {
+	if global.Manager().IsShutdownInProgress() {
+		return []error{fmt.Errorf("server is shutting down")}
+	}
 	beforeBatch := time.Now()
 	defer ob.shard.Metrics().BatchObject(beforeBatch, len(objects))
 

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -28,9 +28,13 @@ import (
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/global"
 )
 
 func (s *Shard) PutObject(ctx context.Context, object *storobj.Object) error {
+	if global.Manager().IsShutdownInProgress() {
+		return fmt.Errorf("server is shutting down")
+	}
 	s.activityTracker.Add(1)
 	if err := s.isReadOnly(); err != nil {
 		return err

--- a/usecases/global/state.go
+++ b/usecases/global/state.go
@@ -1,0 +1,38 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package global
+
+import (
+	"sync/atomic"
+	"sync"
+)
+
+var State *StateType
+var StateOnce sync.Once
+
+func Manager() *StateType {
+	StateOnce.Do(func() {
+		State = &StateType{}
+	})
+	return State
+}
+
+type StateType struct {
+	ShutdownInProgress atomic.Bool
+}
+
+func (s *StateType) StartShutdown() {
+	s.ShutdownInProgress.Store(true)
+}
+func (s *StateType)  IsShutdownInProgress() bool {
+	return s.ShutdownInProgress.Load()
+}

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/global"
 )
 
 var _NUMCPU = runtime.NumCPU()
@@ -91,6 +92,9 @@ func (p *Provider) BatchUpdateVector(ctx context.Context, class *models.Class, o
 	findObjectFn modulecapabilities.FindObjectFn,
 	logger logrus.FieldLogger,
 ) (map[int]error, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, fmt.Errorf("cannot update vector, shutdown in progress")
+	}
 	modConfigs, err := p.getModuleConfigs(class)
 	if err != nil {
 		return nil, err
@@ -280,6 +284,9 @@ func (p *Provider) UpdateVector(ctx context.Context, object *models.Object, clas
 	findObjectFn modulecapabilities.FindObjectFn,
 	logger logrus.FieldLogger,
 ) error {
+	if global.Manager().IsShutdownInProgress() {
+		return fmt.Errorf("cannot update vector, shutdown in progress")
+	}
 	eg := enterrors.NewErrorGroupWrapper(logger)
 	eg.SetLimit(_NUMCPU)
 
@@ -354,6 +361,9 @@ func (p *Provider) vectorize(ctx context.Context, object *models.Object, class *
 	findObjectFn modulecapabilities.FindObjectFn,
 	targetVector string, modConfig map[string]interface{},
 ) error {
+	if global.Manager().IsShutdownInProgress() {
+		return fmt.Errorf("cannot vectorize, shutdown in progress")
+	}
 	found := p.getModule(modConfig)
 	if found == nil {
 		return fmt.Errorf(

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/global"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
 
@@ -34,6 +35,9 @@ var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be
 func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, fields []*string, repl *additional.ReplicationProperties,
 ) (BatchObjects, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, NewErrInternal("server is shutting down")
+	}
 	ctx = classcache.ContextWithClassCache(ctx)
 
 	classesShards := make(map[string][]string)
@@ -68,12 +72,18 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 func (b *BatchManager) AddObjectsGRPCAfterAuth(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, repl *additional.ReplicationProperties, fetchedClasses map[string]versioned.Class,
 ) (BatchObjects, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, NewErrInternal("server is shutting down")
+	}
 	return b.addObjects(ctx, principal, objects, repl, fetchedClasses)
 }
 
 func (b *BatchManager) addObjects(ctx context.Context, principal *models.Principal,
 	objects []*models.Object, repl *additional.ReplicationProperties, fetchedClasses map[string]versioned.Class,
 ) (BatchObjects, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, NewErrInternal("server is shutting down")
+	}
 	ctx = classcache.ContextWithClassCache(ctx)
 
 	before := time.Now()

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
+	"github.com/weaviate/weaviate/usecases/global"
 )
 
 // GetObject Class from the connected DB
@@ -33,6 +34,9 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, additional additional.Properties,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, NewErrInternal("server is shutting down")
+	}
 	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects(class, tenant, id))
 	if err != nil {
 		return nil, err
@@ -58,6 +62,9 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	offset *int64, limit *int64, sort *string, order *string, after *string,
 	addl additional.Properties, tenant string,
 ) ([]*models.Object, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, NewErrInternal("server is shutting down")
+	}
 	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects("", tenant, ""))
 	if err != nil {
 		return nil, err
@@ -89,6 +96,9 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Principal,
 	id strfmt.UUID,
 ) (*models.Class, error) {
+	if global.Manager().IsShutdownInProgress() {
+		return nil, NewErrInternal("server is shutting down")
+	}
 	err := m.authorizer.Authorize(principal, authorization.READ, authorization.Objects("", "", id))
 	if err != nil {
 		return nil, err
@@ -117,6 +127,9 @@ func (m *Manager) getObjectFromRepo(ctx context.Context, class string, id strfmt
 	adds additional.Properties, repl *additional.ReplicationProperties, tenant string,
 ) (res *search.Result, err error) {
 	if class != "" {
+		if global.Manager().IsShutdownInProgress() {
+			return nil, NewErrInternal("server is shutting down")
+		}
 		res, err = m.vectorRepo.Object(ctx, class, id, search.SelectProperties{}, adds, repl, tenant)
 	} else {
 		res, err = m.vectorRepo.ObjectByID(ctx, id, search.SelectProperties{}, adds, tenant)


### PR DESCRIPTION
### What's being changed:

Add a global shutdown service for weaviate.

A large amount of the weaviate code ignores shutdown, and some parts are capable of preventing weaviate from completing shutdown.  Under io pressure, they could potentially keep weaviate running for minutes, leading to a node being forcefully shutdown, and data corruption.

Notably:
* Large parts of weaviate have no shutdown awareness at all
* Some parts do take a context, but never check it
* Even the parts that take a context and check the context won't shutdown, because we don't send a shutdown signal to the active contexts anywhere.

This patch adds a simple, reliable way to check if weaviate is shutting down, and adds some checks at key points to improve shutdown speed.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
