### PR TITLE
DO NOT MERGE: hardcode no bloom filters on all props

### DIFF
--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -98,6 +98,7 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	}
 
@@ -179,6 +180,7 @@ func (s *Shard) createPropertyLengthIndex(ctx context.Context, prop *models.Prop
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	)
 }
@@ -196,6 +198,7 @@ func (s *Shard) createPropertyNullIndex(ctx context.Context, prop *models.Proper
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	)
 }
@@ -214,6 +217,7 @@ func (s *Shard) addIDProperty(ctx context.Context) error {
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	)
 	if err != nil {
@@ -236,6 +240,7 @@ func (s *Shard) createDimensionsBucket(ctx context.Context, name string) error {
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	)
 	if err != nil {
@@ -285,6 +290,7 @@ func (s *Shard) addCreationTimeUnixProperty(ctx context.Context) error {
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	)
 }
@@ -299,6 +305,7 @@ func (s *Shard) addLastUpdateTimeUnixProperty(ctx context.Context) error {
 		lsmkv.WithMaxSegmentSize(s.index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(s.index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithMinMMapSize(s.index.Config.MinMMapSize),
+		lsmkv.WithUseBloomFilter(false),
 		s.segmentCleanupConfig(),
 	)
 }


### PR DESCRIPTION
still kept for objects buckets

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
