### PR TITLE
dynamic index: unblock index during upgrade

### DIFF
--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -782,7 +782,7 @@ func TestShard_UpgradeIndex(t *testing.T) {
 	t.Setenv("QUEUE_SCHEDULER_INTERVAL", "1ms")
 
 	cfg := dynamic.NewDefaultUserConfig()
-	cfg.Threshold = 1000
+	cfg.Threshold = 400
 
 	ctx := context.Background()
 	className := "SomeClass"
@@ -800,7 +800,7 @@ func TestShard_UpgradeIndex(t *testing.T) {
 		}
 	}(shd.Index().Config.RootPath)
 
-	amount := 1000
+	amount := 400
 	for i := 0; i < 3; i++ {
 		objs := make([]*storobj.Object, 0, amount)
 		for j := 0; j < amount; j++ {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -477,6 +477,11 @@ func float32SliceFromByteSlice(vector []byte, slice []float32) []float32 {
 }
 
 func (dynamic *dynamic) Upgrade(callback func()) error {
+	if dynamic.ctx.Err() != nil {
+		// already closed
+		return dynamic.ctx.Err()
+	}
+
 	if dynamic.upgraded.Load() {
 		return dynamic.index.(upgradableIndexer).Upgrade(callback)
 	}


### PR DESCRIPTION
### What's being changed:

Currently, when the dynamic index is upgraded, it blocks the whole index. Since upgrades are expensive, this prevents read requests from being executed.
This allows the dynamic index to upgrade without blocking search and other read-only operations.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14789465379
- [x] E2E pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14789459009
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
