### PR TITLE
simple tenant movement test

### DIFF
--- a/test/acceptance/replication/replica_replication/replica_replication_test.go
+++ b/test/acceptance/replication/replica_replication/replica_replication_test.go
@@ -220,6 +220,175 @@ func (suite *ReplicaReplicationTestSuite) TestReplicaMovementHappyPath() {
 	})
 }
 
+func (suite *ReplicaReplicationTestSuite) TestReplicaMovementTenantHappyPath() {
+	t := suite.T()
+	mainCtx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		Start(mainCtx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(mainCtx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
+	defer cancel()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	paragraphClass := articles.ParagraphsClass()
+	articleClass := articles.ArticlesClass()
+
+	t.Run("create schema", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
+			Factor:       1,
+			AsyncEnabled: false,
+		}
+		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
+			Enabled:              true,
+			AutoTenantActivation: true,
+			AutoTenantCreation:   true,
+		}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		helper.CreateClass(t, paragraphClass)
+		articleClass.ReplicationConfig = &models.ReplicationConfig{
+			Factor:       1,
+			AsyncEnabled: false,
+		}
+		articleClass.MultiTenancyConfig = &models.MultiTenancyConfig{
+			Enabled:              true,
+			AutoTenantActivation: true,
+			AutoTenantCreation:   true,
+		}
+		helper.CreateClass(t, articleClass)
+	})
+
+	// Setup client again after restart to avoid HTTP error if client setup to container that now has a changed port
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	t.Run("insert paragraphs", func(t *testing.T) {
+		batch := make([]*models.Object, len(paragraphIDs))
+		for i, id := range paragraphIDs {
+			batch[i] = articles.NewParagraph().
+				WithID(id).
+				WithContents(fmt.Sprintf("paragraph#%d", i)).
+				WithTenant("tenant0").
+				Object()
+		}
+		common.CreateObjects(t, compose.GetWeaviate().URI(), batch)
+	})
+
+	// any node can be chosen as the tenant source node (even if that node is down at the time of creation)
+	// so we dynamically find the source and target nodes
+	sourceNode := -1
+	var targetNode string
+	var targetNodeURI string
+
+	t.Run("start replica replication to a different node for paragraph", func(t *testing.T) {
+		verbose := verbosity.OutputVerbose
+		params := nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class)
+		body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+		require.NoError(t, clientErr)
+		require.NotNil(t, body.Payload)
+
+		hasFoundNode := false
+		hasFoundShard := false
+
+		for i, node := range body.Payload.Nodes {
+			if len(node.Shards) >= 1 {
+				hasFoundNode = true
+			} else {
+				continue
+			}
+
+			for _, shard := range node.Shards {
+				if shard.Class != paragraphClass.Class {
+					continue
+				}
+				hasFoundShard = true
+
+				t.Logf("Starting replica replication from %s to another node for shard %s", node.Name, shard.Name)
+				// i + 1 because stop/start routine are 1 based not 0
+				sourceNode = i + 1
+				break
+			}
+
+			if hasFoundShard {
+				break
+			}
+		}
+
+		require.True(t, hasFoundShard, "could not find shard for class %s", paragraphClass.Class)
+		require.True(t, hasFoundNode, "could not find node with shards for paragraph")
+
+		// Choose a target node that is not the source node
+		for i, node := range body.Payload.Nodes {
+			if i+1 == sourceNode {
+				continue
+			}
+			targetNode = node.Name
+			targetNodeURI = compose.ContainerURI(i + 1)
+			break
+		}
+
+		require.NotEmpty(t, targetNode, "could not find a target node different from the source node")
+
+		for _, node := range body.Payload.Nodes {
+			if node.Name == targetNode {
+				continue
+			}
+
+			for _, shard := range node.Shards {
+				if shard.Class != paragraphClass.Class {
+					continue
+				}
+
+				t.Logf("Starting replica replication from %s to %s for shard %s", node.Name, targetNode, shard.Name)
+				resp, err := helper.Client(t).Replication.Replicate(
+					replication.NewReplicateParams().WithBody(
+						&models.ReplicationReplicateReplicaRequest{
+							CollectionID:        &paragraphClass.Class,
+							SourceNodeName:      &node.Name,
+							DestinationNodeName: &targetNode,
+							ShardID:             &shard.Name,
+						},
+					),
+					nil,
+				)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, resp.Code(), "replication replicate operation didn't return 200 OK")
+			}
+		}
+	})
+
+	// If no node was found fail now
+	if sourceNode == -1 {
+		t.FailNow()
+	}
+
+	// TODO: Start watch status until completion
+	// For now we sleep, remove the sleep and instead poll status once API is up
+	time.Sleep(20 * time.Second)
+
+	// Kills the original node with the data to ensure we have only one replica available (the new one)
+	t.Run(fmt.Sprintf("stop node %d", sourceNode), func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, sourceNode)
+	})
+
+	t.Run("assert data is available for paragraph on node3 with consistency level one", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, objId := range paragraphIDs {
+				obj, err := common.GetTenantObjectFromNode(t, targetNodeURI, paragraphClass.Class, objId, targetNode, "tenant0")
+				assert.Nil(ct, err)
+				assert.NotNil(ct, obj)
+			}
+		}, 10*time.Second, 1*time.Second, "node3 doesn't have paragraph data")
+	})
+}
+
 func (suite *ReplicaReplicationTestSuite) TestReplicaMovementOneWriteExtraSlowFileCopy() {
 	t := suite.T()
 	mainCtx := context.Background()


### PR DESCRIPTION
### What's being changed:

Adds a simple shard replica movement acceptance test which uses a tenant instead of just a "normal" shard.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
