### PR TITLE
bug(raft): fix lastAppliedIndex to be updated if there was no error

### DIFF
--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -111,7 +111,6 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		}
 
 		st.lastAppliedIndex.Store(l.Index)
-		st.lastAppliedIndexToDB.Store(l.Index)
 	}()
 
 	cmd.Version = l.Index

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -17,10 +17,11 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/cluster/proto/api"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"google.golang.org/protobuf/proto"
 	gproto "google.golang.org/protobuf/proto"
+
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
 func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
@@ -97,8 +98,6 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 			st.reloadDBFromSchema()
 		}
 
-		st.lastAppliedIndex.Store(l.Index)
-
 		if ret.Error != nil {
 			st.log.WithFields(logrus.Fields{
 				"log_type":      l.Type,
@@ -108,7 +107,10 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 				"cmd_type_name": cmd.Type.String(),
 				"cmd_class":     cmd.Class,
 			}).WithError(ret.Error).Error("apply command")
+			return
 		}
+
+		st.lastAppliedIndex.Store(l.Index)
 	}()
 
 	cmd.Version = l.Index

--- a/cluster/store_apply_index_test.go
+++ b/cluster/store_apply_index_test.go
@@ -1,0 +1,115 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestLastAppliedIndexOnSuccess(t *testing.T) {
+	mockStore := NewMockStore(t, "Node-1", 0)
+
+	initialIndex := uint64(100)
+	mockStore.store.lastAppliedIndex.Store(initialIndex)
+
+	cls := &models.Class{
+		Class: "TestClass",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	ss := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"T1": {
+				Name:           "T1",
+				BelongsToNodes: []string{"Node-1"},
+				Status:         "HOT",
+			},
+		},
+	}
+
+	log := &raft.Log{
+		Index: 101,
+		Type:  raft.LogCommand,
+		Data:  cmdAsBytes("TestClass", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{Class: cls, State: ss}, nil),
+	}
+
+	mockStore.parser.On("ParseClass", mock.Anything).Return(nil)
+	mockStore.indexer.On("AddClass", mock.Anything).Return(nil)
+	mockStore.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+	result := mockStore.store.Apply(log)
+
+	// Verify that the result contains no error
+	resp, ok := result.(Response)
+	assert.True(t, ok)
+	assert.NoError(t, resp.Error)
+
+	// Verify that lastAppliedIndex was updated
+	currentIndex := mockStore.store.lastAppliedIndex.Load()
+	assert.Equal(t, log.Index, initialIndex+1)
+	assert.Equal(t, log.Index, currentIndex, "lastAppliedIndex should be updated on success")
+}
+
+func TestLastAppliedIndexOnFailure(t *testing.T) {
+	mockStore := NewMockStore(t, "Node-1", 0)
+
+	initialIndex := uint64(100)
+	mockStore.store.lastAppliedIndex.Store(initialIndex)
+
+	cls := &models.Class{
+		Class: "TestClass",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	ss := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"T1": {
+				Name:           "T1",
+				BelongsToNodes: []string{"Node-1"},
+				Status:         "HOT",
+			},
+		},
+	}
+
+	log := &raft.Log{
+		Index: 101,
+		Type:  raft.LogCommand,
+		Data:  cmdAsBytes("TestClass", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{Class: cls, State: ss}, nil),
+	}
+
+	mockStore.parser.On("ParseClass", mock.Anything).Return(errors.New("parse error"))
+
+	// Apply the log entry
+	result := mockStore.store.Apply(log)
+
+	// Verify that the result contains an error
+	resp, ok := result.(Response)
+	assert.True(t, ok)
+	assert.Error(t, resp.Error)
+
+	// Verify that lastAppliedIndex was not updated
+	currentIndex := mockStore.store.lastAppliedIndex.Load()
+	assert.Equal(t, initialIndex, currentIndex, "lastAppliedIndex should not be updated when there's an error")
+}


### PR DESCRIPTION
### What's being changed:
we were updating `lastAppliedIndex()` and may reload the database even thought the apply was failing. with this PR we return early in case of failure to avoid any reload when it's not needed and avoid updating for lastAppliedIndex  with non applied index 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14798465728
- [x] E2E pipeline run : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14798665500
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
