### PR TITLE
fix(raft): part 2 reload db from schema incase of rollbacks

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -410,7 +410,10 @@ func (s *SchemaManager) apply(op applyOp) error {
 	}
 
 	// Create a deep copy of the current schema state for potential rollback
-	schemaSnapshot := s.schema.deepCopy()
+	var schemaSnapshot map[string]metaClass
+	if !op.schemaOnly {
+		schemaSnapshot = s.schema.deepCopy()
+	}
 
 	// schema applied 1st to make sure any validation happen before applying it to db
 	if err := op.updateSchema(); err != nil {

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -426,6 +426,7 @@ func (s *SchemaManager) apply(op applyOp) error {
 		if err := op.updateStore(); err != nil {
 			// If store update fails, rollback schema changes and return the error
 			s.schema.rollback(schemaSnapshot)
+			s.ReloadDBFromSchema()
 			if op.enableSchemaCallback {
 				// TriggerSchemaUpdateCallbacks is concurrent and at
 				// this point of time schema shall be up to date.

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -339,6 +339,8 @@ func TestSchemaManagerAtomicApply(t *testing.T) {
 			name: "failed tenant update with rollback",
 			setupMocks: func() {
 				mockIndexer.EXPECT().UpdateTenants("TestClass", mock.Anything).Return(fmt.Errorf("db failed for tenant1 update"))
+				mockIndexer.EXPECT().TriggerSchemaUpdateCallbacks().Return()
+				mockIndexer.EXPECT().ReloadLocalDB(mock.Anything, mock.Anything).Return(nil)
 			},
 			cmd: &api.ApplyRequest{
 				Type:    api.ApplyRequest_TYPE_UPDATE_TENANT,


### PR DESCRIPTION
### What's being changed:
to make sure the db matches schema in case of rollbacks we force it by reload 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14834797861
- [x] E2E pipeline run : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14834789186
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
