### PR TITLE
Metrics for every write

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -922,7 +922,7 @@ func (b *Bucket) DeleteWith(key []byte, deletionTime time.Time, opts ...Secondar
 func (b *Bucket) setNewActiveMemtable() error {
 	path := filepath.Join(b.dir, fmt.Sprintf("segment-%d", time.Now().UnixNano()))
 
-	cl, err := newCommitLogger(path)
+	cl, err := newCommitLogger(path, b.strategy)
 	if err != nil {
 		return errors.Wrap(err, "init commit logger")
 	}

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -83,7 +83,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 	for _, fname := range walFileNames {
 		path := filepath.Join(b.dir, strings.TrimSuffix(fname, ".wal"))
 
-		cl, err := newCommitLogger(path)
+		cl, err := newCommitLogger(path, b.strategy)
 		if err != nil {
 			return errors.Wrap(err, "init commit logger")
 		}

--- a/adapters/repos/db/lsmkv/commitlogger_test.go
+++ b/adapters/repos/db/lsmkv/commitlogger_test.go
@@ -22,7 +22,7 @@ import (
 func BenchmarkCommitlogWriter(b *testing.B) {
 	for _, val := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("%d", val), func(b *testing.B) {
-			cl, err := newCommitLogger(b.TempDir())
+			cl, err := newCommitLogger(b.TempDir(), "n/a")
 			require.NoError(b, err)
 
 			data := make([]byte, val)

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -269,6 +269,10 @@ func (c *compactorMap) writeIndexes(f *segmentindex.SegmentFile,
 		Keys:                keys,
 		SecondaryIndexCount: c.secondaryIndexCount,
 		ScratchSpacePath:    c.scratchSpacePath,
+		ObserveWrite: monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+			"strategy":  StrategyMapCollection,
+			"operation": "writeIndices",
+		}),
 	}
 	_, err := f.WriteIndexes(indexes)
 	return err

--- a/adapters/repos/db/lsmkv/compactor_replace.go
+++ b/adapters/repos/db/lsmkv/compactor_replace.go
@@ -216,6 +216,10 @@ func (c *compactorReplace) writeIndexes(f *segmentindex.SegmentFile,
 		Keys:                keys,
 		SecondaryIndexCount: c.secondaryIndexCount,
 		ScratchSpacePath:    c.scratchSpacePath,
+		ObserveWrite: monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+			"strategy":  StrategyReplace,
+			"operation": "writeIndices",
+		}),
 	}
 	_, err := f.WriteIndexes(indexes)
 	return err

--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -211,6 +211,10 @@ func (c *compactorSet) writeIndexes(f *segmentindex.SegmentFile,
 		Keys:                keys,
 		SecondaryIndexCount: c.secondaryIndexCount,
 		ScratchSpacePath:    c.scratchSpacePath,
+		ObserveWrite: monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+			"strategy":  StrategySetCollection,
+			"operation": "writeIndices",
+		}),
 	}
 	_, err := f.WriteIndexes(indexes)
 	return err

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -18,6 +18,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/entities/diskio"
@@ -107,6 +110,10 @@ func (m *Memtable) flush() (rerr error) {
 			Keys:                keys,
 			SecondaryIndexCount: m.secondaryIndices,
 			ScratchSpacePath:    m.path + ".scratch.d",
+			ObserveWrite: monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+				"strategy":  m.strategy,
+				"operation": "writeIndices",
+			}),
 		}
 
 		if _, err := segmentFile.WriteIndexes(indexes); err != nil {

--- a/adapters/repos/db/lsmkv/memtable_metrics.go
+++ b/adapters/repos/db/lsmkv/memtable_metrics.go
@@ -21,6 +21,7 @@ type memtableMetrics struct {
 	getMap          NsObserver
 	getCollection   NsObserver
 	size            Setter
+	writeMemtable   BytesObserver
 }
 
 // newMemtableMetrics curries the prometheus-functions just once to make sure
@@ -37,5 +38,6 @@ func newMemtableMetrics(metrics *Metrics, path, strategy string) *memtableMetric
 		getMap:          metrics.MemtableOpObserver(path, strategy, "getMap"),
 		getCollection:   metrics.MemtableOpObserver(path, strategy, "getCollection"),
 		size:            metrics.MemtableSizeSetter(path, strategy),
+		writeMemtable:   metrics.MemtableWriteObserver(strategy, "flushMemtable"),
 	}
 }

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_range_test.go
@@ -33,7 +33,7 @@ func TestMemtableRoaringSetRange(t *testing.T) {
 	}
 
 	t.Run("concurrent writes and search", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSetRange)
 		require.NoError(t, err)
 		m, err := newMemtable(memPath(), StrategyRoaringSetRange, 0, cl, nil, logger, false)
 		require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
@@ -28,7 +28,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	}
 
 	t.Run("inserting individual entries", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -60,7 +60,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("inserting lists", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -90,7 +90,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("inserting bitmaps", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -122,7 +122,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing individual entries", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -148,7 +148,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing lists", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -178,7 +178,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing bitmaps", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -208,7 +208,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("adding/removing slices", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath())
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -27,7 +27,7 @@ func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	dir := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
-	cl, err := newCommitLogger(dir)
+	cl, err := newCommitLogger(dir, StrategyReplace)
 	require.NoError(t, err)
 
 	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, cl, nil, logger, false)

--- a/adapters/repos/db/lsmkv/segment_cleaner_replace.go
+++ b/adapters/repos/db/lsmkv/segment_cleaner_replace.go
@@ -17,9 +17,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/lsmkv"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 type segmentCleanerReplace struct {
@@ -151,6 +153,10 @@ func (p *segmentCleanerReplace) writeIndexes(f *segmentindex.SegmentFile,
 		Keys:                keys,
 		SecondaryIndexCount: p.secondaryIndexCount,
 		ScratchSpacePath:    p.scratchSpacePath,
+		ObserveWrite: monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+			"strategy":  StrategyReplace,
+			"operation": "cleanupWriteIndices",
+		}),
 	}
 	_, err := f.WriteIndexes(indexes)
 	return err

--- a/adapters/repos/db/lsmkv/segment_group_cleanup_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup_test.go
@@ -308,12 +308,14 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		t.Run("new segments created", func(t *testing.T) {
 			sg.segments = append(sg.segments,
 				&segment{
-					path: filepath.Join(dir, "segment-0005.db"),
-					size: 10005,
+					path:             filepath.Join(dir, "segment-0005.db"),
+					size:             10005,
+					observeMetaWrite: func(n int64) {},
 				},
 				&segment{
-					path: filepath.Join(dir, "segment-0006.db"),
-					size: 10006,
+					path:             filepath.Join(dir, "segment-0006.db"),
+					size:             10006,
+					observeMetaWrite: func(n int64) {},
 				},
 			)
 		})
@@ -456,12 +458,14 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		t.Run("new segments created", func(t *testing.T) {
 			sg.segments = append(sg.segments,
 				&segment{
-					path: filepath.Join(dir, "segment-0005.db"),
-					size: 405,
+					path:             filepath.Join(dir, "segment-0005.db"),
+					size:             405,
+					observeMetaWrite: func(n int64) {},
 				},
 				&segment{
-					path: filepath.Join(dir, "segment-0006.db"),
-					size: 406,
+					path:             filepath.Join(dir, "segment-0006.db"),
+					size:             406,
+					observeMetaWrite: func(n int64) {},
 				},
 			)
 		})
@@ -508,12 +512,14 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		t.Run("new segments created", func(t *testing.T) {
 			sg.segments = append(sg.segments,
 				&segment{
-					path: filepath.Join(dir, "segment-0007.db"),
-					size: 407,
+					path:             filepath.Join(dir, "segment-0007.db"),
+					size:             407,
+					observeMetaWrite: func(n int64) {},
 				},
 				&segment{
-					path: filepath.Join(dir, "segment-0008.db"),
-					size: 408,
+					path:             filepath.Join(dir, "segment-0008.db"),
+					size:             408,
+					observeMetaWrite: func(n int64) {},
 				},
 			)
 		})
@@ -695,8 +701,9 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		t.Run("new segments created", func(t *testing.T) {
 			sg.segments = append(sg.segments,
 				&segment{
-					path: filepath.Join(dir, "segment-0006.db"),
-					size: 10006,
+					path:             filepath.Join(dir, "segment-0006.db"),
+					size:             10006,
+					observeMetaWrite: func(n int64) {},
 				},
 			)
 		})
@@ -729,8 +736,9 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		t.Run("new segments created while 3rd round", func(t *testing.T) {
 			sg.segments = append(sg.segments,
 				&segment{
-					path: filepath.Join(dir, "segment-0007.db"),
-					size: 10007,
+					path:             filepath.Join(dir, "segment-0007.db"),
+					size:             10007,
+					observeMetaWrite: func(n int64) {},
 				},
 			)
 		})
@@ -786,8 +794,9 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		t.Run("new segments created", func(t *testing.T) {
 			sg.segments = append(sg.segments,
 				&segment{
-					path: filepath.Join(dir, "segment-0008.db"),
-					size: 10008,
+					path:             filepath.Join(dir, "segment-0008.db"),
+					size:             10008,
+					observeMetaWrite: func(n int64) {},
 				},
 			)
 		})

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -2370,9 +2370,10 @@ func compactSegments(sg *SegmentGroup, pair []int, newLevel uint16, resizeFactor
 	left, right := sg.segments[leftId], sg.segments[rightId]
 
 	seg := &segment{
-		path:  left.path + "+" + right.path,
-		size:  int64(float32(left.size+right.size) * resizeFactor),
-		level: newLevel,
+		path:             left.path + "+" + right.path,
+		size:             int64(float32(left.size+right.size) * resizeFactor),
+		level:            newLevel,
+		observeMetaWrite: func(n int64) {},
 	}
 
 	sg.segments[leftId] = seg

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -18,10 +18,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/mmap"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // preComputeSegmentMeta has no side-effects for an already running store. As a
@@ -109,6 +111,12 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 
 	primaryDiskIndex := segmentindex.NewDiskTree(primaryIndex)
 
+	stratLabel := header.Strategy.String()
+	observeWrite := monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+		"strategy":  stratLabel,
+		"operation": "compactionMetadata",
+	})
+
 	seg := &segment{
 		level: header.Level,
 		// trim the .tmp suffix to make sure the naming rules for the files we
@@ -131,6 +139,7 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 		logger:                logger,
 		useBloomFilter:        useBloomFilter,
 		calcCountNetAdditions: calcCountNetAdditions,
+		observeMetaWrite:      func(n int64) { observeWrite.Observe(float64(n)) },
 	}
 
 	if seg.secondaryIndexCount > 0 {

--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -23,6 +23,24 @@ const (
 	StrategyRoaringSetRange
 )
 
+// consistent labels with adapters/repos/db/lsmkv/strategies.go
+func (s Strategy) String() string {
+	switch s {
+	case StrategyReplace:
+		return "replace"
+	case StrategySetCollection:
+		return "setcollection"
+	case StrategyMapCollection:
+		return "mapcollection"
+	case StrategyRoaringSet:
+		return "roaringset"
+	case StrategyRoaringSetRange:
+		return "roaringsetrange"
+	default:
+		return "n/a"
+	}
+}
+
 func IsExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) bool {
 	if len(expectedStrategies) == 0 {
 		expectedStrategies = []Strategy{

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -19,8 +19,11 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/compactor"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // Compactor takes in a left and a right segment and merges them into a single
@@ -116,12 +119,20 @@ func NewCompactor(w io.WriteSeeker,
 	scratchSpacePath string, cleanupDeletions bool,
 	enableChecksumValidation bool, maxNewFileSize int64,
 ) *Compactor {
-	writer, mw := compactor.NewWriter(w, maxNewFileSize)
+	observeWrite := monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+		"operation": "compaction",
+		"strategy":  "roaringset",
+	})
+	writeCB := func(written int64) {
+		observeWrite.Observe(float64(written))
+	}
+	meteredW := diskio.NewMeteredWriter(w, writeCB)
+	writer, mw := compactor.NewWriter(meteredW, maxNewFileSize)
 
 	return &Compactor{
 		left:                     left,
 		right:                    right,
-		w:                        w,
+		w:                        meteredW,
 		bufw:                     writer,
 		mw:                       mw,
 		currentLevel:             level,

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -358,6 +358,10 @@ func (c *Compactor) writeIndexes(f *segmentindex.SegmentFile,
 		Keys:                keys,
 		SecondaryIndexCount: 0,
 		ScratchSpacePath:    c.scratchSpacePath,
+		ObserveWrite: monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
+			"strategy":  "roaringset",
+			"operation": "writeIndices",
+		}),
 	}
 	_, err := f.WriteIndexes(indexes)
 	return err

--- a/entities/diskio/metered_writer_block_size.go
+++ b/entities/diskio/metered_writer_block_size.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package diskio
 
 import (

--- a/entities/diskio/metered_writer_block_size.go
+++ b/entities/diskio/metered_writer_block_size.go
@@ -49,10 +49,6 @@ func (m *MeteredWriter) Seek(offset int64, whence int) (int64, error) {
 	return n, err
 }
 
-// func (m *MeteredWriter) Close() error {
-// 	return m.w.Close()
-// }
-
 var _ = WriterSeekerCloser(&MeteredWriter{})
 
 func NewMeteredWriter(w WriterSeekerCloser, cb MeteredWriterCallback) *MeteredWriter {

--- a/entities/diskio/metered_writer_block_size.go
+++ b/entities/diskio/metered_writer_block_size.go
@@ -9,7 +9,6 @@ type MeteredWriterCallback func(written int64)
 type WriterSeekerCloser interface {
 	io.Writer
 	io.Seeker
-	io.Closer
 }
 
 type MeteredWriter struct {
@@ -39,9 +38,9 @@ func (m *MeteredWriter) Seek(offset int64, whence int) (int64, error) {
 	return n, err
 }
 
-func (m *MeteredWriter) Close() error {
-	return m.w.Close()
-}
+// func (m *MeteredWriter) Close() error {
+// 	return m.w.Close()
+// }
 
 var _ = WriterSeekerCloser(&MeteredWriter{})
 

--- a/entities/diskio/metered_writer_block_size.go
+++ b/entities/diskio/metered_writer_block_size.go
@@ -1,0 +1,53 @@
+package diskio
+
+import (
+	"io"
+)
+
+type MeteredWriterCallback func(written int64)
+
+type WriterSeekerCloser interface {
+	io.Writer
+	io.Seeker
+	io.Closer
+}
+
+type MeteredWriter struct {
+	w  WriterSeekerCloser
+	cb MeteredWriterCallback
+}
+
+func (m *MeteredWriter) Write(p []byte) (n int, err error) {
+	n, err = m.w.Write(p)
+	if err != nil {
+		return
+	}
+
+	if m.cb != nil {
+		m.cb(int64(n))
+	}
+
+	return
+}
+
+func (m *MeteredWriter) Seek(offset int64, whence int) (int64, error) {
+	n, err := m.w.Seek(offset, whence)
+	if m.cb != nil {
+		m.cb(0)
+	}
+
+	return n, err
+}
+
+func (m *MeteredWriter) Close() error {
+	return m.w.Close()
+}
+
+var _ = WriterSeekerCloser(&MeteredWriter{})
+
+func NewMeteredWriter(w WriterSeekerCloser, cb MeteredWriterCallback) *MeteredWriter {
+	return &MeteredWriter{
+		w:  w,
+		cb: cb,
+	}
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -72,6 +72,7 @@ type PrometheusMetrics struct {
 	BackupRestoreFromStorageDurations   *prometheus.SummaryVec
 	BackupRestoreDataTransferred        *prometheus.CounterVec
 	BackupStoreDataTransferred          *prometheus.CounterVec
+	FileIOWrites                        *prometheus.SummaryVec
 
 	// offload metric
 	TenantCloudOffloadDurations       *prometheus.SummaryVec
@@ -478,6 +479,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "lsm_memtable_durations_ms",
 			Help: "Time in ms for a bucket operation to complete",
 		}, []string{"strategy", "class_name", "shard_name", "path", "operation"}),
+		FileIOWrites: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "file_io_writes_total_bytes",
+			Help: "Total number of bytes written to disk",
+		}, []string{"operation", "strategy"}),
 
 		// Async indexing metrics
 		IndexQueuePushDuration: promauto.NewSummaryVec(prometheus.SummaryOpts{


### PR DESCRIPTION
### What's being changed:

Any writer that writes to disk is metered. This allows us to see both IOPS and write throughput per operation (wal vs flush vs compaction, etc.) as well as per bucket type (replace vs roaringset vs ...)

Some example metrics:
```
file_io_writes_total_bytes_sum{operation="appendWAL",strategy="mapcollection"} 47000
file_io_writes_total_bytes_count{operation="appendWAL",strategy="mapcollection"} 1000
file_io_writes_total_bytes_sum{operation="appendWAL",strategy="replace"} 1.2881877e+07
file_io_writes_total_bytes_count{operation="appendWAL",strategy="replace"} 5000
file_io_writes_total_bytes_sum{operation="appendWAL",strategy="roaringset"} 540000
file_io_writes_total_bytes_count{operation="appendWAL",strategy="roaringset"} 10000
file_io_writes_total_bytes_sum{operation="appendWAL",strategy="setcollection"} 75000
file_io_writes_total_bytes_count{operation="appendWAL",strategy="setcollection"} 1000
file_io_writes_total_bytes_sum{operation="compaction",strategy="mapcollection"} 57000
file_io_writes_total_bytes_count{operation="compaction",strategy="mapcollection"} 500
file_io_writes_total_bytes_sum{operation="compaction",strategy="replace"} 1.3127877e+07
file_io_writes_total_bytes_count{operation="compaction",strategy="replace"} 1500
file_io_writes_total_bytes_sum{operation="compaction",strategy="roaringset"} 2.64e+06
file_io_writes_total_bytes_count{operation="compaction",strategy="roaringset"} 5000
file_io_writes_total_bytes_sum{operation="compaction",strategy="setcollection"} 145000
file_io_writes_total_bytes_count{operation="compaction",strategy="setcollection"} 500
file_io_writes_total_bytes_sum{operation="compactionMetadata",strategy="mapcollection"} 18000
file_io_writes_total_bytes_count{operation="compactionMetadata",strategy="mapcollection"} 1000
file_io_writes_total_bytes_sum{operation="compactionMetadata",strategy="replace"} 60000
file_io_writes_total_bytes_count{operation="compactionMetadata",strategy="replace"} 4000
file_io_writes_total_bytes_sum{operation="compactionMetadata",strategy="roaringset"} 180000
file_io_writes_total_bytes_count{operation="compactionMetadata",strategy="roaringset"} 10000
file_io_writes_total_bytes_sum{operation="compactionMetadata",strategy="setcollection"} 18000
file_io_writes_total_bytes_count{operation="compactionMetadata",strategy="setcollection"} 1000
file_io_writes_total_bytes_sum{operation="flushMemtable",strategy="mapcollection"} 93000
file_io_writes_total_bytes_count{operation="flushMemtable",strategy="mapcollection"} 1000
file_io_writes_total_bytes_sum{operation="flushMemtable",strategy="replace"} 1.3159877e+07
file_io_writes_total_bytes_count{operation="flushMemtable",strategy="replace"} 5000
file_io_writes_total_bytes_sum{operation="flushMemtable",strategy="roaringset"} 2.72e+06
file_io_writes_total_bytes_count{operation="flushMemtable",strategy="roaringset"} 10000
file_io_writes_total_bytes_sum{operation="flushMemtable",strategy="setcollection"} 153000
file_io_writes_total_bytes_count{operation="flushMemtable",strategy="setcollection"} 1000
file_io_writes_total_bytes_sum{operation="segmentMetadata",strategy="mapcollection"} 36000
file_io_writes_total_bytes_count{operation="segmentMetadata",strategy="mapcollection"} 2000
file_io_writes_total_bytes_sum{operation="segmentMetadata",strategy="replace"} 120000
file_io_writes_total_bytes_count{operation="segmentMetadata",strategy="replace"} 8000
file_io_writes_total_bytes_sum{operation="segmentMetadata",strategy="roaringset"} 360000
file_io_writes_total_bytes_count{operation="segmentMetadata",strategy="roaringset"} 20000
file_io_writes_total_bytes_sum{operation="segmentMetadata",strategy="setcollection"} 36000
file_io_writes_total_bytes_count{operation="segmentMetadata",strategy="setcollection"} 2000
file_io_writes_total_bytes_sum{operation="writeIndices",strategy="mapcollection"} 60000
file_io_writes_total_bytes_count{operation="writeIndices",strategy="mapcollection"} 1500
file_io_writes_total_bytes_sum{operation="writeIndices",strategy="replace"} 488000
file_io_writes_total_bytes_count{operation="writeIndices",strategy="replace"} 6000
file_io_writes_total_bytes_sum{operation="writeIndices",strategy="roaringset"} 880000
file_io_writes_total_bytes_count{operation="writeIndices",strategy="roaringset"} 15000
file_io_writes_total_bytes_sum{operation="writeIndices",strategy="setcollection"} 144000
file_io_writes_total_bytes_count{operation="writeIndices",strategy="setcollection"} 1500
```

## Performance Considerations

tl;dr: not an issue

This observes as many events per second as there are IOPS. So if you use a 20k IOPS disk and max it out, this will observe 20,000 data points per second. I wanted to make sure that metrics are never the bottleneck. I started with a simple ChatGPT research (but have manually validated thereafter). The ChatGPT summary summarizes it better than I could:

<img width="819" alt="image" src="https://github.com/user-attachments/assets/8b5357a1-2a9a-43c6-abac-c19b16fefc76" />

I have also validated the claim that one `Observe()` call is only two atomic writes and a bounds-check. That is correct, here is a screenshot of the relevant code in the Prom library:

<img width="807" alt="Screenshot 2025-05-06 at 11 55 55 AM" src="https://github.com/user-attachments/assets/7a9668fb-c839-4249-8e10-6601863f34d2" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
