### PR TITLE
feat(bm25_block): :sparkles: use per prop length from segments

### DIFF
--- a/adapters/repos/db/bm25f_block_test.go
+++ b/adapters/repos/db/bm25f_block_test.go
@@ -170,8 +170,8 @@ func TestBM25FJourneyBlock(t *testing.T) {
 			require.Equal(t, len(scores), len(res))
 			// Check results in correct order
 			require.Equal(t, uint64(4), res[0].DocID)
-			require.Equal(t, uint64(5), res[1].DocID)
-			require.Equal(t, uint64(1), res[2].DocID)
+			require.Equal(t, uint64(1), res[1].DocID)
+			require.Equal(t, uint64(5), res[2].DocID)
 			require.Equal(t, uint64(6), res[3].DocID)
 			require.Equal(t, uint64(2), res[4].DocID)
 		})
@@ -184,8 +184,8 @@ func TestBM25FJourneyBlock(t *testing.T) {
 
 			// Check results in correct order
 			require.Equal(t, uint64(4), res[0].DocID)
-			require.Equal(t, uint64(5), res[1].DocID)
-			require.Equal(t, uint64(1), res[2].DocID)
+			require.Equal(t, uint64(1), res[1].DocID)
+			require.Equal(t, uint64(5), res[2].DocID)
 			require.Equal(t, uint64(6), res[3].DocID)
 		})
 
@@ -270,15 +270,15 @@ func TestBM25FJourneyBlock(t *testing.T) {
 
 			require.Less(t, len(resAutoCut), len(resNoAutoCut))
 
-			EqualFloats(t, float32(0.51602507), noautocutscores[0], 5)
-			EqualFloats(t, float32(0.4975062), noautocutscores[1], 5) // <= autocut last element
-			EqualFloats(t, float32(0.34149727), noautocutscores[2], 5)
-			EqualFloats(t, float32(0.3049518), noautocutscores[3], 5)
-			EqualFloats(t, float32(0.27547202), noautocutscores[4], 5)
+			EqualFloats(t, float32(0.5253056), noautocutscores[0], 5)
+			EqualFloats(t, float32(0.50612706), noautocutscores[1], 5) // <= autocut last element
+			EqualFloats(t, float32(0.35391074), noautocutscores[2], 5)
+			EqualFloats(t, float32(0.31824225), noautocutscores[3], 5)
+			EqualFloats(t, float32(0.28910512), noautocutscores[4], 5)
 
 			require.Len(t, resAutoCut, 2)
-			EqualFloats(t, float32(0.51602507), autocutscores[0], 5)
-			EqualFloats(t, float32(0.4975062), autocutscores[1], 5)
+			EqualFloats(t, float32(0.5253056), autocutscores[0], 5)
+			EqualFloats(t, float32(0.50612706), autocutscores[1], 5)
 		})
 
 		for _, index := range repo.indices {
@@ -311,7 +311,7 @@ func TestBM25FSinglePropBlock(t *testing.T) {
 	require.Nil(t, repo.WaitForStartup(context.TODO()))
 	defer repo.Shutdown(context.Background())
 
-	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 100)
+	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 1)
 
 	idx := repo.GetIndex("MyClass")
 	require.NotNil(t, idx)
@@ -328,12 +328,12 @@ func TestBM25FSinglePropBlock(t *testing.T) {
 			}
 			require.Nil(t, err)
 			// Check results in correct order
-			require.Equal(t, uint64(3), res[0].DocID)
-			require.Equal(t, uint64(6), res[3].DocID)
+			require.Equal(t, uint64(5), res[0].DocID)
+			require.Equal(t, uint64(3), res[3].DocID)
 
 			// Check scores
-			EqualFloats(t, float32(0.1248), scores[0], 5)
-			EqualFloats(t, float32(0.0363), scores[1], 5)
+			EqualFloats(t, float32(0.6178051), scores[0], 5)
+			EqualFloats(t, float32(0.6178051), scores[1], 5)
 		})
 
 		for _, index := range repo.indices {
@@ -365,7 +365,7 @@ func TestBM25FWithFiltersBlock(t *testing.T) {
 	require.Nil(t, repo.WaitForStartup(context.TODO()))
 	defer repo.Shutdown(context.Background())
 
-	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 100)
+	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 1)
 
 	idx := repo.GetIndex("MyClass")
 	require.NotNil(t, idx)
@@ -539,7 +539,7 @@ func TestBM25FDifferentParamsJourneyBlock(t *testing.T) {
 	require.Nil(t, repo.WaitForStartup(context.TODO()))
 	defer repo.Shutdown(context.Background())
 
-	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 100)
+	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 1)
 
 	idx := repo.GetIndex("MyClass")
 	require.NotNil(t, idx)
@@ -560,8 +560,8 @@ func TestBM25FDifferentParamsJourneyBlock(t *testing.T) {
 			require.Nil(t, err)
 
 			// Check results in correct order
-			require.Equal(t, uint64(6), res[0].DocID)
-			require.Equal(t, uint64(2), res[2].DocID)
+			require.Equal(t, uint64(5), res[0].DocID)
+			require.Equal(t, uint64(6), res[2].DocID)
 
 			// Print results
 			t.Log("--- Start results for boosted search ---")
@@ -570,8 +570,8 @@ func TestBM25FDifferentParamsJourneyBlock(t *testing.T) {
 			}
 
 			// Check scores
-			EqualFloats(t, float32(0.98), scores[0], 2)
-			EqualFloats(t, float32(0.59), scores[1], 2)
+			EqualFloats(t, float32(1.7730504), scores[0], 2)
+			EqualFloats(t, float32(1.7730504), scores[1], 2)
 		})
 
 		for _, index := range repo.indices {
@@ -604,7 +604,7 @@ func TestBM25FCompareBlock(t *testing.T) {
 	require.Nil(t, repo.WaitForStartup(context.TODO()))
 	defer repo.Shutdown(context.Background())
 
-	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 100)
+	props := SetupClass(t, repo, schemaGetter, logger, 0.5, 1)
 
 	idx := repo.GetIndex("MyClass")
 	require.NotNil(t, idx)
@@ -643,19 +643,19 @@ func TestBM25FCompareBlock(t *testing.T) {
 				}
 
 				// Not all the scores are unique and the search is not stable, so pick ones that don't move
-				require.Equal(t, uint64(4), objs[0].DocID)
-				require.Equal(t, uint64(6), objs[1].DocID)
-				require.Equal(t, uint64(5), objs[2].DocID)
-				require.Equal(t, uint64(1), objs[3].DocID)
-				require.Equal(t, uint64(2), objs[4].DocID)
-				require.Equal(t, uint64(0), objs[5].DocID)
+				require.Equal(t, uint64(1), objs[0].DocID)
+				require.Equal(t, uint64(2), objs[1].DocID)
+				require.Equal(t, uint64(0), objs[2].DocID)
+				require.Equal(t, uint64(6), objs[3].DocID)
+				require.Equal(t, uint64(5), objs[4].DocID)
+				require.Equal(t, uint64(4), objs[5].DocID)
 
-				require.Equal(t, uint64(4), withBM25Fobjs[0].DocID)
-				require.Equal(t, uint64(6), withBM25Fobjs[1].DocID)
-				require.Equal(t, uint64(5), withBM25Fobjs[2].DocID)
-				require.Equal(t, uint64(1), withBM25Fobjs[3].DocID)
-				require.Equal(t, uint64(2), withBM25Fobjs[4].DocID)
-				require.Equal(t, uint64(0), withBM25Fobjs[5].DocID)
+				require.Equal(t, uint64(1), withBM25Fobjs[0].DocID)
+				require.Equal(t, uint64(2), withBM25Fobjs[1].DocID)
+				require.Equal(t, uint64(0), withBM25Fobjs[2].DocID)
+				require.Equal(t, uint64(6), withBM25Fobjs[3].DocID)
+				require.Equal(t, uint64(5), withBM25Fobjs[4].DocID)
+				require.Equal(t, uint64(4), withBM25Fobjs[5].DocID)
 
 			}
 		})
@@ -721,9 +721,9 @@ func TestBM25F_ComplexDocumentsBlock(t *testing.T) {
 			require.Len(t, res, 3)
 
 			// Check scores
-			EqualFloats(t, float32(0.8550), scores[0], 5)
-			EqualFloats(t, float32(0.5116), scores[1], 5)
-			EqualFloats(t, float32(0.3325), scores[2], 5)
+			EqualFloats(t, float32(0.93171), scores[0], 5)
+			EqualFloats(t, float32(0.54312956), scores[1], 5)
+			EqualFloats(t, float32(0.3794713), scores[2], 5)
 		})
 
 		t.Run("Results without stopwords "+location, func(t *testing.T) {

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -35,9 +35,9 @@ import (
 
 // var metrics = lsmkv.BlockMetrics{}
 
-func (b *BM25Searcher) createBlockTerm(N float64, filterDocIds helpers.AllowList, query []string, propName string, propertyBoost float32, duplicateTextBoosts []int, averagePropLength float64, config schema.BM25Config, ctx context.Context) ([][]*lsmkv.SegmentBlockMax, map[string]uint64, func(), error) {
+func (b *BM25Searcher) createBlockTerm(N float64, filterDocIds helpers.AllowList, query []string, propName string, propertyBoost float32, duplicateTextBoosts []int, config schema.BM25Config, ctx context.Context) ([][]*lsmkv.SegmentBlockMax, map[string]uint64, func(), error) {
 	bucket := b.store.Bucket(helpers.BucketSearchableFromPropNameLSM(propName))
-	return bucket.CreateDiskTerm(N, filterDocIds, query, propName, propertyBoost, duplicateTextBoosts, averagePropLength, config, ctx)
+	return bucket.CreateDiskTerm(N, filterDocIds, query, propName, propertyBoost, duplicateTextBoosts, config, ctx)
 }
 
 func (b *BM25Searcher) wandBlock(
@@ -96,7 +96,7 @@ func (b *BM25Searcher) wandBlock(
 			globalIdfCounts := make(map[string]uint64, len(queryTerms))
 			nonZeroTerms := make(map[string]uint64, len(queryTerms))
 			for _, propName := range propNames {
-				results, idfCounts, release, err := b.createBlockTerm(N, filterDocIds, queryTerms, propName, propertyBoosts[propName], duplicateBoosts, averagePropLength, b.config, ctx)
+				results, idfCounts, release, err := b.createBlockTerm(N, filterDocIds, queryTerms, propName, propertyBoosts[propName], duplicateBoosts, b.config, ctx)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1600,7 +1600,7 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 	return terms.NewSortedDocPointerWithScoreMerger().Do(ctx, segments)
 }
 
-func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query []string, propName string, propertyBoost float32, duplicateTextBoosts []int, averagePropLength float64, config schema.BM25Config, ctx context.Context) ([][]*SegmentBlockMax, map[string]uint64, func(), error) {
+func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query []string, propName string, propertyBoost float32, duplicateTextBoosts []int, config schema.BM25Config, ctx context.Context) ([][]*SegmentBlockMax, map[string]uint64, func(), error) {
 	release := func() {}
 
 	defer func() {
@@ -1615,6 +1615,12 @@ func (b *Bucket) CreateDiskTerm(N float64, filterDocIds helpers.AllowList, query
 
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
+
+	averagePropLength, err := b.GetAveragePropertyLength()
+	if err != nil {
+		release()
+		return nil, nil, func() {}, err
+	}
 
 	// The lock is necessary, as data is being read from the disk during blockmax wand search.
 	// BlockMax is ran outside this function, so, the lock is returned to the caller.

--- a/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
@@ -73,7 +73,7 @@ func validateMapPairListVsBlockMaxSearch(ctx context.Context, bucket *Bucket, ex
 		avgPropLen := 1.0
 		queries := []string{string(mapKey)}
 		duplicateTextBoosts := make([]int, 1)
-		diskTerms, _, release, err := bucket.CreateDiskTerm(float64(N), nil, queries, "", 1, duplicateTextBoosts, avgPropLen, bm25config, ctx)
+		diskTerms, _, release, err := bucket.CreateDiskTerm(float64(N), nil, queries, "", 1, duplicateTextBoosts, bm25config, ctx)
 
 		defer func() {
 			release()

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
 var blockMaxBufferSize = 4096
 
 func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
@@ -522,7 +523,7 @@ func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation
 
 	freq := float64(s.blockDataDecoded.Tfs[s.blockDataIdx])
 	propLength := s.propLengths[s.idPointer]
-	tf := freq / (freq + s.k1*(1-s.b+s.b*(float64(propLength)/s.averagePropLength)))
+	tf := freq / (freq + s.k1*((1-s.b)+s.b*(float64(propLength)/s.averagePropLength)))
 	s.Metrics.DocCountScored++
 	if s.blockEntryIdx != s.Metrics.LastAddedBlock {
 		s.Metrics.BlockCountDecodedFreqs++

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -95,7 +95,8 @@ func (s *segment) loadBlockDataReusable(sectionReader *io.SectionReader, blockDa
 		if offsetStart < blockDataBufferOffset || offsetEnd > blockDataBufferOffset+uint64(len(buf)) {
 			sectionReader.Seek(int64(offsetStart-offset), io.SeekStart)
 			_, err := sectionReader.Read(buf)
-			if err != nil {
+			// EOF is expected when the last block + tree are smaller than the buffer
+			if err != nil && err.Error() != "EOF" {
 				return 0, err
 			}
 			// readBytes += int64(n)

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -516,7 +516,7 @@ func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation
 
 	freq := float64(s.blockDataDecoded.Tfs[s.blockDataIdx])
 	propLength := s.propLengths[s.idPointer]
-	tf := freq / (freq + s.k1*(1-s.b+s.b*(float64(propLength)/averagePropLength)))
+	tf := freq / (freq + s.k1*(1-s.b+s.b*(float64(propLength)/s.averagePropLength)))
 	s.Metrics.DocCountScored++
 	if s.blockEntryIdx != s.Metrics.LastAddedBlock {
 		s.Metrics.BlockCountDecodedFreqs++


### PR DESCRIPTION
### What's being changed:

**Breaking change:** will cause scores to change slightly, but more relevant results are retrieved.
BMW prop length adjustments:
- Use property length from segments to compute average (instead of prop length tracker)
- Normalize property lengths using property average to better match BM25F folder 

BMW buffer read size: 
- increase from 2048 to 4096 bytes (page size), reducing sys calls in ~half and increasing performance

Validated on beir datasets, **avg@ndcg10** increased from 0.36 -> 0.43:
- nfcorpus/test: 0.29 -> 0.31
- scifact/test: 0.57 -> 0.63
- scidocs: 0.14 -> 0.15
- trec-covid: 0.53 -> 0.61
- fever/test: 0.53 -> 0.68
- climate-fever: 0.09 -> 0.19
- msmarco/test: 0.38 -> 0.45


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
