### PR TITLE
feat: Instrument `commitLogger`(WAL) at the storage layer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ contextionary: ## Run the contextionary embedding server
 monitoring: ## Run the prometheus and grafana for monitoring
 	./tools/dev/restart_dev_environment.sh --prometheus
 
-local: ## Run the local development setup with single node
+local: contextionary ## Run the local development setup with single node
 	./tools/dev/run_dev_server.sh local-single-node
 
 debug: ## Connect local weaviate server via delv for debugging

--- a/adapters/repos/db/index_queue_test.go
+++ b/adapters/repos/db/index_queue_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -1227,8 +1228,10 @@ func (m *mockBatchIndexer) ValidateBeforeInsert(vector []float32) error {
 
 func newDummyStore(t *testing.T) *lsmkv.Store {
 	logger, _ := test.NewNullLogger()
+	walMetrics := lsmkv.NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
+
 	storeDir := t.TempDir()
-	store, err := lsmkv.New(storeDir, storeDir, logger, nil,
+	store, err := lsmkv.New(storeDir, storeDir, logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop())

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -113,7 +113,7 @@ func (db *DB) init(ctx context.Context) error {
 				convertToVectorIndexConfig(class.VectorIndexConfig),
 				convertToVectorIndexConfigs(class.VectorConfig),
 				db.schemaGetter, db, db.logger, db.nodeResolver, db.remoteIndex,
-				db.replicaClient, db.promMetrics, class, db.jobQueueCh, db.indexCheckpoints,
+				db.replicaClient, db.promMetrics, db.walMetrics, class, db.jobQueueCh, db.indexCheckpoints,
 				db.memMonitor)
 			if err != nil {
 				return errors.Wrap(err, "create index")

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -38,7 +38,7 @@ const FlushAfterDirtyDefault = 60 * time.Second
 
 type BucketCreator interface {
 	NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
-		metrics *Metrics, walMetrics *commitLoggerMetrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
+		metrics *Metrics, walMetrics *CommitLoggerMetrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
 		opts ...BucketOption,
 	) (*Bucket, error)
 }
@@ -57,7 +57,7 @@ type Bucket struct {
 	haltedFlushTimer *interval.BackoffTimer
 
 	walThreshold      uint64
-	walMetrics        *commitLoggerMetrics
+	walMetrics        *CommitLoggerMetrics
 	flushDirtyAfter   time.Duration
 	memtableThreshold uint64
 	minMMapSize       int64
@@ -146,7 +146,7 @@ func NewBucketCreator() *Bucket { return &Bucket{} }
 // [Store]. In this case the [Store] can manage buckets for you, using methods
 // such as CreateOrLoadBucket().
 func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
-	metrics *Metrics, walMetrics *commitLoggerMetrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
+	metrics *Metrics, walMetrics *CommitLoggerMetrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
 	opts ...BucketOption,
 ) (*Bucket, error) {
 	beforeAll := time.Now()

--- a/adapters/repos/db/lsmkv/bucket_backup_test.go
+++ b/adapters/repos/db/lsmkv/bucket_backup_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,8 +48,9 @@ func Test_BucketBackup(t *testing.T) {
 func bucketBackup_FlushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 	t.Run("assert that readonly bucket fails to flush", func(t *testing.T) {
 		dirName := t.TempDir()
+		walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil,
+		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil, walMetrics,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 		b.UpdateStatus(storagestate.StatusReadOnly)
@@ -65,8 +67,9 @@ func bucketBackup_FlushMemtable(ctx context.Context, t *testing.T, opts []Bucket
 
 func bucketBackup_ListFiles(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/weaviate/weaviate/entities/diskio"
 )
@@ -83,7 +84,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 	for _, fname := range walFileNames {
 		path := filepath.Join(b.dir, strings.TrimSuffix(fname, ".wal"))
 
-		cl, err := newCommitLogger(path, b.strategy)
+		cl, err := newCommitLogger(path, b.strategy, newcommitLoggerMetrics(prometheus.NewPedanticRegistry()))
 		if err != nil {
 			return errors.Wrap(err, "init commit logger")
 		}

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -80,11 +80,13 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		})
 	}
 
+	clMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
+
 	// recover from each log
 	for _, fname := range walFileNames {
 		path := filepath.Join(b.dir, strings.TrimSuffix(fname, ".wal"))
 
-		cl, err := newCommitLogger(path, b.strategy, newcommitLoggerMetrics(prometheus.NewPedanticRegistry()))
+		cl, err := newCommitLogger(path, b.strategy, clMetrics)
 		if err != nil {
 			return errors.Wrap(err, "init commit logger")
 		}

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -122,8 +122,6 @@ func newbufWriter(size int, w io.Writer) *bufWriter {
 }
 
 func (b *bufWriter) Write(p []byte) (int, error) {
-	len := len(p)
-
 	n, err := b.buf.Write(p)
 	if err != nil {
 		return n, err
@@ -134,19 +132,18 @@ func (b *bufWriter) Write(p []byte) (int, error) {
 		}
 	}
 
-	b.writtenSize.Observe(float64(len))
+	b.writtenSize.Observe(float64(n))
 
 	return n, nil
 }
 
 func (b *bufWriter) Flush() error {
-	len := b.buf.Len()
-
-	if _, err := b.w.Write(b.buf.Bytes()); err != nil {
+	n, err := b.w.Write(b.buf.Bytes())
+	if err != nil {
 		return err
 	}
 
-	b.pageFlushedSize.Observe(float64(len))
+	b.pageFlushedSize.Observe(float64(n))
 
 	return nil
 }

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"sync/atomic"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -312,9 +313,11 @@ func (cl *commitLogger) close() error {
 			return err
 		}
 
+		start := time.Now()
 		if err := cl.file.Sync(); err != nil {
 			return err
 		}
+		cl.metrics.fsyncDuration.Observe(float64(time.Since(start)))
 	}
 
 	return cl.file.Close()

--- a/adapters/repos/db/lsmkv/commitlogger_test.go
+++ b/adapters/repos/db/lsmkv/commitlogger_test.go
@@ -16,13 +16,16 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkCommitlogWriter(b *testing.B) {
+	metrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
+
 	for _, val := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("%d", val), func(b *testing.B) {
-			cl, err := newCommitLogger(b.TempDir(), "n/a")
+			cl, err := newCommitLogger(b.TempDir(), "n/a", metrics)
 			require.NoError(b, err)
 
 			data := make([]byte, val)

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,8 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	var bucket *Bucket
 
 	dirName := t.TempDir()
+
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("create test data", func(t *testing.T) {
 		// The test data is split into 4 scenarios evenly:
@@ -133,7 +136,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	})
 
 	t.Run("init bucket", func(t *testing.T) {
-		b, err := NewBucketCreator().NewBucket(context.TODO(), dirName, "", nullLogger2(), nil,
+		b, err := NewBucketCreator().NewBucket(context.TODO(), dirName, "", nullLogger2(), nil, walMetrics,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 		require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +63,8 @@ func prepareBucket(b *testing.B) (bucket *Bucket, cleanup func()) {
 		fmt.Println(err)
 	}()
 
-	bucket, err := NewBucketCreator().NewBucket(testCtxB(), dirName, "", nullLoggerB(), nil,
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
+	bucket, err := NewBucketCreator().NewBucket(testCtxB(), dirName, "", nullLoggerB(), nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_range_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,9 +32,10 @@ func TestMemtableRoaringSetRange(t *testing.T) {
 	memPath := func() string {
 		return path.Join(t.TempDir(), "memtable")
 	}
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("concurrent writes and search", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSetRange)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSetRange, walMetrics)
 		require.NoError(t, err)
 		m, err := newMemtable(memPath(), StrategyRoaringSetRange, 0, cl, nil, logger, false)
 		require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_test.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,9 +27,10 @@ func TestMemtableRoaringSet(t *testing.T) {
 	memPath := func() string {
 		return path.Join(t.TempDir(), "fake")
 	}
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("inserting individual entries", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -60,7 +62,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("inserting lists", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -90,7 +92,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("inserting bitmaps", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -122,7 +124,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing individual entries", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -148,7 +150,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing lists", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -178,7 +180,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("removing bitmaps", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)
@@ -208,7 +210,7 @@ func TestMemtableRoaringSet(t *testing.T) {
 	})
 
 	t.Run("adding/removing slices", func(t *testing.T) {
-		cl, err := newCommitLogger(memPath(), StrategyRoaringSet)
+		cl, err := newCommitLogger(memPath(), StrategyRoaringSet, walMetrics)
 		require.NoError(t, err)
 
 		m, err := newMemtable(memPath(), StrategyRoaringSet, 0, cl, nil, logger, false)

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,9 +26,10 @@ import (
 // https://www.youtube.com/watch?v=OS8taasZl8k
 func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	dir := t.TempDir()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	logger, _ := test.NewNullLogger()
-	cl, err := newCommitLogger(dir, StrategyReplace)
+	cl, err := newCommitLogger(dir, StrategyReplace, walMetrics)
 	require.NoError(t, err)
 
 	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, cl, nil, logger, false)

--- a/adapters/repos/db/lsmkv/mock_bucket_creator.go
+++ b/adapters/repos/db/lsmkv/mock_bucket_creator.go
@@ -35,14 +35,14 @@ func (_m *MockBucketCreator) EXPECT() *MockBucketCreator_Expecter {
 	return &MockBucketCreator_Expecter{mock: &_m.Mock}
 }
 
-// NewBucket provides a mock function with given fields: ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks, opts
-func (_m *MockBucketCreator) NewBucket(ctx context.Context, dir string, rootDir string, logger logrus.FieldLogger, metrics *Metrics, compactionCallbacks cyclemanager.CycleCallbackGroup, flushCallbacks cyclemanager.CycleCallbackGroup, opts ...BucketOption) (*Bucket, error) {
+// NewBucket provides a mock function with given fields: ctx, dir, rootDir, logger, metrics, walMetrics, compactionCallbacks, flushCallbacks, opts
+func (_m *MockBucketCreator) NewBucket(ctx context.Context, dir string, rootDir string, logger logrus.FieldLogger, metrics *Metrics, walMetrics *CommitLoggerMetrics, compactionCallbacks cyclemanager.CycleCallbackGroup, flushCallbacks cyclemanager.CycleCallbackGroup, opts ...BucketOption) (*Bucket, error) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks)
+	_ca = append(_ca, ctx, dir, rootDir, logger, metrics, walMetrics, compactionCallbacks, flushCallbacks)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
@@ -52,19 +52,19 @@ func (_m *MockBucketCreator) NewBucket(ctx context.Context, dir string, rootDir 
 
 	var r0 *Bucket
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, logrus.FieldLogger, *Metrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) (*Bucket, error)); ok {
-		return rf(ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks, opts...)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, logrus.FieldLogger, *Metrics, *CommitLoggerMetrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) (*Bucket, error)); ok {
+		return rf(ctx, dir, rootDir, logger, metrics, walMetrics, compactionCallbacks, flushCallbacks, opts...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, logrus.FieldLogger, *Metrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) *Bucket); ok {
-		r0 = rf(ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks, opts...)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, logrus.FieldLogger, *Metrics, *CommitLoggerMetrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) *Bucket); ok {
+		r0 = rf(ctx, dir, rootDir, logger, metrics, walMetrics, compactionCallbacks, flushCallbacks, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Bucket)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, logrus.FieldLogger, *Metrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) error); ok {
-		r1 = rf(ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks, opts...)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, logrus.FieldLogger, *Metrics, *CommitLoggerMetrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) error); ok {
+		r1 = rf(ctx, dir, rootDir, logger, metrics, walMetrics, compactionCallbacks, flushCallbacks, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -83,23 +83,24 @@ type MockBucketCreator_NewBucket_Call struct {
 //   - rootDir string
 //   - logger logrus.FieldLogger
 //   - metrics *Metrics
+//   - walMetrics *CommitLoggerMetrics
 //   - compactionCallbacks cyclemanager.CycleCallbackGroup
 //   - flushCallbacks cyclemanager.CycleCallbackGroup
 //   - opts ...BucketOption
-func (_e *MockBucketCreator_Expecter) NewBucket(ctx interface{}, dir interface{}, rootDir interface{}, logger interface{}, metrics interface{}, compactionCallbacks interface{}, flushCallbacks interface{}, opts ...interface{}) *MockBucketCreator_NewBucket_Call {
+func (_e *MockBucketCreator_Expecter) NewBucket(ctx interface{}, dir interface{}, rootDir interface{}, logger interface{}, metrics interface{}, walMetrics interface{}, compactionCallbacks interface{}, flushCallbacks interface{}, opts ...interface{}) *MockBucketCreator_NewBucket_Call {
 	return &MockBucketCreator_NewBucket_Call{Call: _e.mock.On("NewBucket",
-		append([]interface{}{ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks}, opts...)...)}
+		append([]interface{}{ctx, dir, rootDir, logger, metrics, walMetrics, compactionCallbacks, flushCallbacks}, opts...)...)}
 }
 
-func (_c *MockBucketCreator_NewBucket_Call) Run(run func(ctx context.Context, dir string, rootDir string, logger logrus.FieldLogger, metrics *Metrics, compactionCallbacks cyclemanager.CycleCallbackGroup, flushCallbacks cyclemanager.CycleCallbackGroup, opts ...BucketOption)) *MockBucketCreator_NewBucket_Call {
+func (_c *MockBucketCreator_NewBucket_Call) Run(run func(ctx context.Context, dir string, rootDir string, logger logrus.FieldLogger, metrics *Metrics, walMetrics *CommitLoggerMetrics, compactionCallbacks cyclemanager.CycleCallbackGroup, flushCallbacks cyclemanager.CycleCallbackGroup, opts ...BucketOption)) *MockBucketCreator_NewBucket_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]BucketOption, len(args)-7)
-		for i, a := range args[7:] {
+		variadicArgs := make([]BucketOption, len(args)-8)
+		for i, a := range args[8:] {
 			if a != nil {
 				variadicArgs[i] = a.(BucketOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(logrus.FieldLogger), args[4].(*Metrics), args[5].(cyclemanager.CycleCallbackGroup), args[6].(cyclemanager.CycleCallbackGroup), variadicArgs...)
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(logrus.FieldLogger), args[4].(*Metrics), args[5].(*CommitLoggerMetrics), args[6].(cyclemanager.CycleCallbackGroup), args[7].(cyclemanager.CycleCallbackGroup), variadicArgs...)
 	})
 	return _c
 }
@@ -109,7 +110,7 @@ func (_c *MockBucketCreator_NewBucket_Call) Return(_a0 *Bucket, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockBucketCreator_NewBucket_Call) RunAndReturn(run func(context.Context, string, string, logrus.FieldLogger, *Metrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) (*Bucket, error)) *MockBucketCreator_NewBucket_Call {
+func (_c *MockBucketCreator_NewBucket_Call) RunAndReturn(run func(context.Context, string, string, logrus.FieldLogger, *Metrics, *CommitLoggerMetrics, cyclemanager.CycleCallbackGroup, cyclemanager.CycleCallbackGroup, ...BucketOption) (*Bucket, error)) *MockBucketCreator_NewBucket_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -119,8 +120,7 @@ func (_c *MockBucketCreator_NewBucket_Call) RunAndReturn(run func(context.Contex
 func NewMockBucketCreator(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockBucketCreator {
+}) *MockBucketCreator {
 	mock := &MockBucketCreator{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/lsmkv/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/quantile_keys_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,9 +28,10 @@ func TestQuantileKeysSingleSegment(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	b, err := NewBucketCreator().NewBucket(
-		ctx, dir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(),
+		ctx, dir, "", logger, nil, walMetrics, cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 
@@ -69,9 +71,10 @@ func TestQuantileKeysMultipleSegmentsUniqueEntries(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	b, err := NewBucketCreator().NewBucket(
-		ctx, dir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(),
+		ctx, dir, "", logger, nil, walMetrics, cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,8 +59,9 @@ func createCNAOnFlush(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -80,8 +82,9 @@ func createCNAInit(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -106,7 +109,7 @@ func createCNAInit(ctx context.Context, t *testing.T, opts []BucketOption) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
-	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -123,8 +126,9 @@ func repairCorruptedCNAOnInit(ctx context.Context, t *testing.T, opts []BucketOp
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -144,7 +148,7 @@ func repairCorruptedCNAOnInit(ctx context.Context, t *testing.T, opts []BucketOp
 	require.Nil(t, b.Shutdown(ctx))
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
-	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -186,8 +190,9 @@ func TestCNA_OFF(t *testing.T) {
 func dontCreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		opts...)
 	require.NoError(t, err)
@@ -214,9 +219,10 @@ func dontCreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 func dontRecreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("create, populate, shutdown", func(t *testing.T) {
-		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 			opts...)
 		require.NoError(t, err)
@@ -226,7 +232,7 @@ func dontRecreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 		require.NoError(t, b.FlushMemtable())
 	})
 
-	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		opts...)
 	require.NoError(t, err)
@@ -248,8 +254,9 @@ func dontRecreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 func dontPrecomputeCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		opts...)
 	require.NoError(t, err)

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,8 +56,9 @@ func precomputeSegmentMeta_Replace(ctx context.Context, t *testing.T, opts []Buc
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -115,8 +117,9 @@ func precomputeSegmentMeta_Set(ctx context.Context, t *testing.T, opts []BucketO
 	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
@@ -50,7 +49,7 @@ type Store struct {
 
 	logger     logrus.FieldLogger
 	metrics    *Metrics
-	walMetrics *commitLoggerMetrics
+	walMetrics *CommitLoggerMetrics
 
 	cycleCallbacks *storeCycleCallbacks
 	bcreator       BucketCreator
@@ -65,11 +64,10 @@ type Store struct {
 // New initializes a new [Store] based on the root dir. If state is present on
 // disk, it is loaded, if the folder is empty a new store is initialized in
 // there.
-func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
+func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics, walMetrics *CommitLoggerMetrics,
 	shardCompactionCallbacks, shardCompactionAuxCallbacks,
 	shardFlushCallbacks cyclemanager.CycleCallbackGroup,
 ) (*Store, error) {
-	walMetrics := newcommitLoggerMetrics(prometheus.DefaultRegisterer)
 
 	s := &Store{
 		dir:           dir,

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,7 @@ func TestStoreBackup(t *testing.T) {
 
 func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("assert that context timeout works for long compactions", func(t *testing.T) {
 		for _, buckets := range [][]string{
@@ -61,7 +63,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardCompactionAuxCallbacks := cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1)
 				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
-				store, err := New(dirName, dirName, logger, nil,
+				store, err := New(dirName, dirName, logger, nil, walMetrics,
 					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
@@ -98,7 +100,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardCompactionAuxCallbacks := cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1)
 				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
-				store, err := New(dirName, dirName, logger, nil,
+				store, err := New(dirName, dirName, logger, nil, walMetrics,
 					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
@@ -130,6 +132,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 func resumeCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("assert compaction restarts after pausing", func(t *testing.T) {
 		for _, buckets := range [][]string{
@@ -144,7 +147,7 @@ func resumeCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardCompactionAuxCallbacks := cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1)
 				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
-				store, err := New(dirName, dirName, logger, nil,
+				store, err := New(dirName, dirName, logger, nil, walMetrics,
 					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
@@ -182,6 +185,7 @@ func resumeCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
 	t.Run("assert that context timeout works for long flushes", func(t *testing.T) {
 		for _, buckets := range [][]string{
@@ -196,7 +200,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardCompactionAuxCallbacks := cyclemanager.NewCallbackGroupNoop()
 				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
-				store, err := New(dirName, dirName, logger, nil,
+				store, err := New(dirName, dirName, logger, nil, walMetrics,
 					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
@@ -233,7 +237,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardCompactionAuxCallbacks := cyclemanager.NewCallbackGroupNoop()
 				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
-				store, err := New(dirName, dirName, logger, nil,
+				store, err := New(dirName, dirName, logger, nil, walMetrics,
 					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 
@@ -287,7 +291,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardCompactionAuxCallbacks := cyclemanager.NewCallbackGroupNoop()
 				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
-				store, err := New(dirName, dirName, logger, nil,
+				store, err := New(dirName, dirName, logger, nil, walMetrics,
 					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 				require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/store_test.go
+++ b/adapters/repos/db/lsmkv/store_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -29,8 +30,9 @@ func TestCreateOrLoadBucketConcurrency(t *testing.T) {
 	dirName := t.TempDir()
 	defer os.RemoveAll(dirName)
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	store, err := New(dirName, dirName, logger, nil,
+	store, err := New(dirName, dirName, logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1),
 		cyclemanager.NewCallbackGroup("classCompactionNonObjects", logger, 1),
 		cyclemanager.NewCallbackGroupNoop())
@@ -75,8 +77,9 @@ func TestCreateBucketConcurrency(t *testing.T) {
 	dirName := t.TempDir()
 	defer os.RemoveAll(dirName)
 	logger, _ := test.NewNullLogger()
+	walMetrics := NewCommitLoggerMetrics(prometheus.NewPedanticRegistry())
 
-	store, err := New(dirName, dirName, logger, nil,
+	store, err := New(dirName, dirName, logger, nil, walMetrics,
 		cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1),
 		cyclemanager.NewCallbackGroup("classCompactionNonObjects", logger, 1),
 		cyclemanager.NewCallbackGroupNoop())

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -142,7 +142,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 		convertToVectorIndexConfig(class.VectorIndexConfig),
 		convertToVectorIndexConfigs(class.VectorConfig),
 		m.db.schemaGetter, m.db, m.logger, m.db.nodeResolver, m.db.remoteIndex,
-		m.db.replicaClient, m.db.promMetrics, class, m.db.jobQueueCh, m.db.indexCheckpoints,
+		m.db.replicaClient, m.db.promMetrics, m.db.walMetrics, class, m.db.jobQueueCh, m.db.indexCheckpoints,
 		m.db.memMonitor)
 	if err != nil {
 		return errors.Wrap(err, "create index")

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -189,6 +189,7 @@ type Shard struct {
 	vectorIndexes     map[string]VectorIndex
 	metrics           *Metrics
 	promMetrics       *monitoring.PrometheusMetrics
+	walMetrics        *lsmkv.CommitLoggerMetrics
 	slowQueryReporter helpers.SlowQueryReporter
 	propertyIndices   propertyspecific.Indices
 	propLenTracker    *inverted.JsonShardMetaData

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
@@ -31,7 +32,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
+func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics, walMetrics *lsmkv.CommitLoggerMetrics,
 	shardName string, index *Index, class *models.Class, jobQueueCh chan job,
 	indexCheckpoints *indexcheckpoint.Checkpoints,
 ) (_ *Shard, err error) {
@@ -48,6 +49,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		class:       class,
 		name:        shardName,
 		promMetrics: promMetrics,
+		walMetrics:  walMetrics,
 		metrics: NewMetrics(index.logger, promMetrics,
 			string(index.Config.ClassName), shardName),
 		slowQueryReporter:     helpers.NewSlowQueryReporterFromEnv(index.logger),

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -17,6 +17,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/entities/schema"
 
 	"github.com/sirupsen/logrus"
@@ -120,7 +121,9 @@ func (s *Shard) initLSMStore() error {
 		metrics = lsmkv.NewMetrics(s.promMetrics, string(s.index.Config.ClassName), s.name)
 	}
 
-	store, err := lsmkv.New(s.pathLSM(), s.path(), annotatedLogger, metrics,
+	walMetrics := lsmkv.NewCommitLoggerMetrics(prometheus.DefaultRegisterer)
+
+	store, err := lsmkv.New(s.pathLSM(), s.path(), annotatedLogger, metrics, walMetrics,
 		s.cycleCallbacks.compactionCallbacks,
 		s.cycleCallbacks.compactionAuxCallbacks,
 		s.cycleCallbacks.flushCallbacks)

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/entities/schema"
 
 	"github.com/sirupsen/logrus"
@@ -121,9 +120,7 @@ func (s *Shard) initLSMStore() error {
 		metrics = lsmkv.NewMetrics(s.promMetrics, string(s.index.Config.ClassName), s.name)
 	}
 
-	walMetrics := lsmkv.NewCommitLoggerMetrics(prometheus.DefaultRegisterer)
-
-	store, err := lsmkv.New(s.pathLSM(), s.path(), annotatedLogger, metrics, walMetrics,
+	store, err := lsmkv.New(s.pathLSM(), s.path(), annotatedLogger, metrics, s.walMetrics,
 		s.cycleCallbacks.compactionCallbacks,
 		s.cycleCallbacks.compactionAuxCallbacks,
 		s.cycleCallbacks.flushCallbacks)

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -49,10 +49,11 @@ case $CONFIG in
   ;;
 
   local-single-node)
+      CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       PERSISTENCE_DATA_PATH="./data-weaviate-0" \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
-      ENABLE_MODULES="backup-filesystem" \
+      ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       PROMETHEUS_MONITORING_PORT="2112" \
       PROMETHEUS_MONITORING_METRIC_NAMESPACE="weaviate" \
       CLUSTER_IN_LOCALHOST=true \
@@ -874,7 +875,7 @@ case $CONFIG in
     ;;
   local-prometheus)
     echo "Starting monitoring setup..."
-      
+
     cleanup() {
       echo "Cleaning up existing containers and volumes..."
       docker stop prometheus grafana 2>/dev/null || true
@@ -883,14 +884,14 @@ case $CONFIG in
       docker network rm monitoring 2>/dev/null || true
       echo "Cleanup complete."
     }
-    
+
     cleanup
 
     echo "Creating new setup..."
-    
+
     docker network create monitoring 2>/dev/null || true
 
-    
+
     echo "Starting Prometheus..."
     docker run -d \
       --name prometheus \
@@ -900,7 +901,7 @@ case $CONFIG in
       -v "$(pwd)/tools/dev/prometheus_config/prometheus.yml:/etc/prometheus/prometheus.yml" \
       prom/prometheus
 
-    
+
     echo "Starting Grafana..."
     docker run -d \
       --name grafana \
@@ -912,7 +913,7 @@ case $CONFIG in
       -v "$(pwd)/tools/dev/grafana/dashboards/dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml" \
       -v "$(pwd)/tools/dev/grafana/dashboards:/etc/grafana/dashboards" \
       grafana/grafana
-    
+
     echo "Waiting for services to start..."
     sleep 5
 


### PR DESCRIPTION
### What's being changed:

commitLoggerMetrics exposes metrics to understand IO happending at the WAL layer.

Store ----> WAL ----> Filesystem page cache ----> Disk

WAL does buffered IO. Meaning `Write()` fill the buffer and `Flush()` actually does the IO by writing to Filesystem page cache and eventually `Fsync()` persist to disk. Given the expensive nature of `fsync()` and the fact internally Operating System does periodic `fsync()` to transfer bytes from filesystem cache into disk, at the application layer we do `fsync()` only during closing the underlying WAL segment file.

```
type commitLoggerMetrics struct {
	// writtenEntriesSize gives visibility on size distribution of write payload coming to commitLogger via `Write()`.
	// It also gives visibility on IOPS and Througput of the WAL at the application layer.
	writtenEntriesSize prometheus.Histogram

	// flushedEntriesSize gives visibility on size distribution of actual pages being `Flush()`ed.
	// Ideally this should all be PageSize of the underlying buffered writed.
	flushedEntriesSize prometheus.Histogram

	fsyncDuration prometheus.Histogram
}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
