### PR TITLE
Simplify writing indices if no secondary indices are present

### DIFF
--- a/adapters/repos/db/lsmkv/segmentindex/indexes.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes.go
@@ -35,6 +35,10 @@ type Indexes struct {
 }
 
 func (s *Indexes) WriteTo(w io.Writer) (int64, error) {
+	if s.SecondaryIndexCount == 0 {
+		return s.buildAndMarshalPrimary(w, s.Keys)
+	}
+
 	var currentOffset uint64 = HeaderSize
 	if len(s.Keys) > 0 {
 		currentOffset = uint64(s.Keys[len(s.Keys)-1].ValueEnd)


### PR DESCRIPTION
### What's being changed:

When no secondary indices are present skip all the extra work for secondary indices

chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14881128250
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14881126093

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
