### PR TITLE
Optimize writing bloom filters + net additions

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
@@ -27,7 +28,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/mmap"
 	"github.com/weaviate/weaviate/usecases/monitoring"
-	"github.com/willf/bloom"
 )
 
 type segment struct {

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/diskio"
-	"github.com/willf/bloom"
 )
 
 func (s *segment) bloomFilterPath() string {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/weaviate/contextionary v1.2.1
-	github.com/willf/bloom v2.0.3+incompatible
 	go.etcd.io/bbolt v1.3.11
 	go.opentelemetry.io/otel v1.32.0 // indirect
 	golang.org/x/net v0.33.0
@@ -51,6 +50,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.36
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.34
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.17.0
+	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/edsrzf/mmap-go v1.1.0
@@ -109,6 +109,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.31.0 // indirect
 	github.com/aws/smithy-go v1.21.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cheggaaa/pb/v3 v3.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
+github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bloom/v3 v3.7.0 h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56jeWUzvzdls=
+github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/bmatcuk/doublestar v1.1.3 h1:S4Ka/fLvUtm+5TqKuByWyuGenBjTP8w+Z/GpQIWB9Yg=
 github.com/bmatcuk/doublestar v1.1.3/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
@@ -633,6 +637,8 @@ github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYN
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
+github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
 github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
 github.com/vcaesar/cedar v0.20.1 h1:cDOmYWdprO7ZW8cngJrDi8Zivnscj9dA/y8Y+2SB1P0=
@@ -655,8 +661,6 @@ github.com/weaviate/tiktoken-go v0.0.2 h1:lkwTMEoXSFSXxYvw1c44/xz3OOAh27L3+3vvNN
 github.com/weaviate/tiktoken-go v0.0.2/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
-github.com/willf/bloom v2.0.3+incompatible h1:QDacWdqcAUI1MPOwIQZRy9kOR7yxfyEmxX8Wdm2/JPA=
-github.com/willf/bloom v2.0.3+incompatible/go.mod h1:MmAltL9pDMNTrvUkxdg0k0q5I0suxmuwp3KbyrZLOZ8=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -15,6 +15,7 @@ package byteops
 import (
 	"encoding/binary"
 	"errors"
+	"io"
 	"math"
 )
 
@@ -150,6 +151,17 @@ func (bo *ReadWriter) CopyBytesToBuffer(copyBytes []byte) error {
 		return errors.New("could not copy data into buffer")
 	}
 	return nil
+}
+
+// for io.Writer interface
+func (bo *ReadWriter) Write(p []byte) (int, error) {
+	lenCopyBytes := uint64(len(p))
+	bo.Position += lenCopyBytes
+	if bo.Position > uint64(len(bo.Buffer)) {
+		return 0, io.EOF
+	}
+	numCopiedBytes := copy(bo.Buffer[bo.Position-lenCopyBytes:bo.Position], p)
+	return numCopiedBytes, nil
 }
 
 // Writes a uint64 length indicator about the buffer that's about to follow,


### PR DESCRIPTION
### What's being changed:

Do a single write for bloom filters and net additions instead of two

chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14900805159
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14900803058

chaos_2: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/14905943013
e2e_2: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14905956735

compatibility between v2 and v3 of the bloomfilter library
```
func TestBloomFilterUpgrade(t *testing.T) {
	// create a v2 bloom filter and write to file
	bf2 := bloomv2.NewWithEstimates(100, 0.01)
	for i := 0; i < 100; i++ {
		bf2.Add([]byte(fmt.Sprintf("hello-%v", i)))
	}

	dirName := t.TempDir()
	f, err := os.Create(dirName + "/test.bloom")
	require.NoError(t, err)

	to, err := bf2.WriteTo(f)
	require.NoError(t, err)

	require.NoError(t, f.Sync())
	require.NoError(t, f.Close())

	f2, err := os.Open(dirName + "/test.bloom")
	require.NoError(t, err)

	// load with v3 and write to a different file
	bf3 := bloom.NewWithEstimates(100, 0.01)
	from, err := bf3.ReadFrom(f2)
	require.NoError(t, err)
	require.Equal(t, to, from)
	require.NoError(t, f2.Sync())
	require.NoError(t, f2.Close())

	f3, err := os.Create(dirName + "/test2.bloom")
	require.NoError(t, err)
	to2, err := bf3.WriteTo(f3)
	require.NoError(t, err)
	require.Equal(t, to2, from)
	require.NoError(t, f3.Sync())
	require.NoError(t, f3.Close())

	// load with v2 again and check that the reloaded bloom filters is identical to the initial one
	f4, err := os.Open(dirName + "/test2.bloom")
	require.NoError(t, err)
	bf2New := bloomv2.NewWithEstimates(100, 0.01)
	from2, err := bf2New.ReadFrom(f4)
	require.NoError(t, err)
	require.Equal(t, to, from2)
	require.True(t, bf2.Equal(bf2New))
}
```