### PR TITLE
Make improvements to attempt flake fixes

### DIFF
--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -167,7 +167,7 @@ func (c *CopyOpConsumer) Consume(ctx context.Context, in <-chan ShardReplication
 					// Continue to ensure we don't accidentally re-spawn the operation in a new worker
 					continue
 				}
-				// Otherwise, the operation is not in-flight and should therefore be processed in a worker where cancellation happens
+				// Otherwise, the operation is not in-flight and should therefore be processed in a worker where clean-up happens
 			}
 
 			c.engineOpCallbacks.OnOpPending(c.nodeId)

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -44,6 +44,9 @@ type OpConsumer interface {
 // DELETED is a constant representing a temporary deleted state of a replication operation that should not be stored in the FSM.
 const DELETED = "deleted"
 
+// errOpCancelled is an error indicating that the operation was cancelled.
+var errOpCancelled = errors.New("operation cancelled")
+
 // CopyOpConsumer is an implementation of the OpConsumer interface that processes replication operations
 // by executing copy operations from a source shard to a target shard. It uses a ReplicaCopier to actually
 // carry out the copy operation. Moreover, it supports configurable backoff, timeout and concurrency limits.
@@ -153,15 +156,18 @@ func (c *CopyOpConsumer) Consume(ctx context.Context, in <-chan ShardReplication
 			// This is done outside of the worker goroutine, and therefore without acquiring a token, so that
 			// we can cancel operations that have frozen or become unresponsive. If we were to acquire a token
 			// we would block the worker pool and not be able to cancel the operation leading to resource starvation.
-			if op.Status.ShouldCancel && c.ongoingOps.Load(op.Op.ID) && !c.ongoingOps.HasBeenCancelled(op.Op.ID) {
+			if op.Status.ShouldCancel && !c.ongoingOps.HasBeenCancelled(op.Op.ID) {
 				// Update the cache to mark the operation as cancelled
 				c.ongoingOps.StoreHasBeenCancelled(op.Op.ID)
 				c.logger.WithFields(logrus.Fields{"op": op}).Debug("cancelled the replication op")
-				// Cancel the in-flight operation
-				// Is a noop, returns false if the op doesn't exist
-				c.ongoingOps.Cancel(op.Op.ID)
-				// Continue to ensure we don't accidentally re-spawn the operation in a new worker
-				continue
+				if c.ongoingOps.InFlight(op.Op.ID) {
+					// Cancel the in-flight operation
+					// Is a noop, returns false if the op doesn't exist
+					c.ongoingOps.Cancel(op.Op.ID)
+					// Continue to ensure we don't accidentally re-spawn the operation in a new worker
+					continue
+				}
+				// Otherwise, the operation is not in-flight and should therefore be processed in a worker where cancellation happens
 			}
 
 			c.engineOpCallbacks.OnOpPending(c.nodeId)
@@ -195,7 +201,7 @@ func (c *CopyOpConsumer) Consume(ctx context.Context, in <-chan ShardReplication
 					defer func() {
 						<-c.tokens // Release token when completed
 						// Delete the operation from the ongoingOps map when the operation processing is complete
-						c.ongoingOps.Remove(op.Op.ID)
+						c.ongoingOps.DeleteInFlight(op.Op.ID)
 						wg.Done()
 					}()
 
@@ -217,18 +223,27 @@ func (c *CopyOpConsumer) Consume(ctx context.Context, in <-chan ShardReplication
 					c.ongoingOps.StoreCancel(op.Op.ID, opCancel)
 
 					err := c.dispatchReplicationOp(opCtx, operation)
-					if err != nil && errors.Is(err, context.DeadlineExceeded) {
+					if err == nil {
+						c.engineOpCallbacks.OnOpComplete(c.nodeId)
+						return
+					}
+					if errors.Is(err, context.DeadlineExceeded) {
 						c.engineOpCallbacks.OnOpFailed(c.nodeId)
 						opLogger.WithError(err).Error("replication operation timed out")
-					} else if err != nil && errors.Is(err, context.Canceled) && c.ongoingOps.HasBeenCancelled(op.Op.ID) {
+						return
+					}
+					if errors.Is(err, context.Canceled) && c.ongoingOps.HasBeenCancelled(op.Op.ID) {
 						opLogger.WithError(err).Debug("replication operation cancelled")
 						c.cancelOp(workerCtx, operation, opLogger)
-					} else if err != nil {
-						c.engineOpCallbacks.OnOpFailed(c.nodeId)
-						opLogger.WithError(err).Error("replication operation failed")
-					} else {
-						c.engineOpCallbacks.OnOpComplete(c.nodeId)
+						return
 					}
+					if errors.Is(err, errOpCancelled) {
+						opLogger.WithError(err).Debug("replication operation cancelled")
+						c.cancelOp(workerCtx, operation, opLogger)
+						return
+					}
+					c.engineOpCallbacks.OnOpFailed(c.nodeId)
+					opLogger.WithError(err).Error("replication operation failed")
 				}, c.logger)
 
 			case <-ctx.Done():
@@ -265,6 +280,14 @@ func (c *CopyOpConsumer) dispatchReplicationOp(ctx context.Context, op ShardRepl
 // stateFuncHandler is a function that processes a replication operation and returns the next state and an error.
 type stateFuncHandler func(ctx context.Context, op ShardReplicationOpAndStatus) (api.ShardReplicationState, error)
 
+func (c *CopyOpConsumer) checkCancelled(logger *logrus.Entry, op ShardReplicationOpAndStatus) error {
+	if c.ongoingOps.HasBeenCancelled(op.Op.ID) {
+		logger.WithFields(logrus.Fields{"op": op}).Debug("replication op cancelled, stopping replication operation")
+		return errOpCancelled
+	}
+	return nil
+}
+
 // processStateAndTransition processes a replication operation and transitions it to the next state.
 // It retries the operation using a backoff policy if it returns an error.
 // If the operation is successful, the operation is transitioned to the next state.
@@ -276,13 +299,19 @@ func (c *CopyOpConsumer) processStateAndTransition(ctx context.Context, op Shard
 			logger.WithError(ctx.Err()).Error("error while processing replication operation, shutting down")
 			return api.ShardReplicationState(""), backoff.Permanent(ctx.Err())
 		}
+		if err := c.checkCancelled(logger, op); err != nil {
+			return api.ShardReplicationState(""), backoff.Permanent(err)
+		}
 
 		nextState, err := stateFuncHandler(ctx, op)
 		// If we receive an error from the state handler make sure we store it and then stop processing
 		if err != nil {
-			// If the op was cancelled, pass the error up the stack to be handled higher up
+			// If the op was cancelled for any reason, pass the error up the stack to be handled higher up
 			if errors.Is(err, context.Canceled) {
 				logger.Debug("context cancelled, stopping replication operation")
+				return api.ShardReplicationState(""), backoff.Permanent(err)
+			}
+			if err := c.checkCancelled(logger, op); err != nil {
 				return api.ShardReplicationState(""), backoff.Permanent(err)
 			}
 			// Otherwise, register the error with the FSM
@@ -293,9 +322,8 @@ func (c *CopyOpConsumer) processStateAndTransition(ctx context.Context, op Shard
 			return api.ShardReplicationState(""), err
 		}
 
-		if c.ongoingOps.HasBeenCancelled(op.Op.ID) {
-			logger.WithFields(logrus.Fields{"op": op}).Debug("replication op cancelled, stopping replication operation")
-			return api.ShardReplicationState(""), backoff.Permanent(ctx.Err())
+		if err := c.checkCancelled(logger, op); err != nil {
+			return api.ShardReplicationState(""), backoff.Permanent(err)
 		}
 		// No error from the state handler, update the state to the next, if this errors we will stop processing
 		if err := c.leaderClient.ReplicationUpdateReplicaOpStatus(op.Op.ID, nextState); err != nil {
@@ -319,9 +347,8 @@ func (c *CopyOpConsumer) processStateAndTransition(ctx context.Context, op Shard
 		return nil
 	}
 
-	if c.ongoingOps.HasBeenCancelled(op.Op.ID) {
-		logger.WithFields(logrus.Fields{"op": op}).Debug("replication op cancelled, stopping replication operation")
-		return ctx.Err()
+	if err := c.checkCancelled(logger, op); err != nil {
+		return err
 	}
 	return c.dispatchReplicationOp(ctx, op)
 }
@@ -335,33 +362,29 @@ func (c *CopyOpConsumer) processStateAndTransition(ctx context.Context, op Shard
 //
 // It exists outside of the formal state machine to allow for cancellation of operations that are in progress
 // or have been cancelled but not yet processed without introducing new intermediate states to the FSM.
-func (c *CopyOpConsumer) cancelOp(ctx context.Context, op ShardReplicationOpAndStatus, logger *logrus.Entry) error {
-	defer c.engineOpCallbacks.OnOpCancelled(c.nodeId)
+func (c *CopyOpConsumer) cancelOp(ctx context.Context, op ShardReplicationOpAndStatus, logger *logrus.Entry) {
+	defer func() {
+		c.ongoingOps.DeleteHasBeenCancelled(op.Op.ID)
+		c.engineOpCallbacks.OnOpCancelled(c.nodeId)
+	}()
 
-	if err := c.replicaCopier.RemoveLocalReplica(ctx, op.Op.SourceShard.CollectionId, op.Op.TargetShard.ShardId); err != nil {
-		logger.WithError(err).Error("failure while removing replica shard")
-		return err
-	}
+	c.replicaCopier.RemoveLocalReplica(ctx, op.Op.SourceShard.CollectionId, op.Op.TargetShard.ShardId)
 
 	// If the operation is only being cancelled then notify the FSM so it can update its state
 	if op.Status.OnlyCancellation() {
 		if err := c.leaderClient.ReplicationCancellationComplete(op.Op.ID); err != nil {
 			logger.WithError(err).Error("failure while completing cancellation of replica operation")
-			return err
 		}
-		return nil
+		return
 	}
 
 	// If the operation is being deleted then remove it from the FSM
 	if op.Status.ShouldDelete {
 		if err := c.leaderClient.ReplicationRemoveReplicaOp(op.Op.ID); err != nil {
 			logger.WithError(err).Error("failure while deleting replica operation")
-			return err
 		}
-		return nil
+		return
 	}
-
-	return nil
 }
 
 // processRegisteredOp is the state handler for the REGISTERED state.
@@ -438,6 +461,10 @@ func (c *CopyOpConsumer) processFinalizingOp(ctx context.Context, op ShardReplic
 	// we only check the status of the async replication every 5 seconds to avoid
 	// spamming with too many requests too quickly
 	err := backoff.Retry(func() error {
+		if ctx.Err() != nil {
+			logger.WithError(ctx.Err()).Debug("error while processing replication operation, shutting down")
+			return backoff.Permanent(ctx.Err())
+		}
 		if do() {
 			return nil
 		}

--- a/cluster/replication/consumer_ops_cache.go
+++ b/cluster/replication/consumer_ops_cache.go
@@ -29,14 +29,14 @@ type OpsCache struct {
 	// ops is a map of opId to an empty struct
 	// It is used to track whether an operation is currently being handled by
 	// a worker goroutine
-	ops sync.Map
+	inFlight sync.Map
 }
 
 func NewOpsCache() *OpsCache {
 	return &OpsCache{
 		hasBeenCancelled: sync.Map{},
 		cancels:          sync.Map{},
-		ops:              sync.Map{},
+		inFlight:         sync.Map{},
 	}
 }
 
@@ -49,13 +49,17 @@ func (c *OpsCache) StoreHasBeenCancelled(opId uint64) {
 	c.hasBeenCancelled.Store(opId, struct{}{})
 }
 
+func (c *OpsCache) DeleteHasBeenCancelled(opId uint64) {
+	c.hasBeenCancelled.Delete(opId)
+}
+
 func (c *OpsCache) LoadOrStore(opId uint64) bool {
-	_, ok := c.ops.LoadOrStore(opId, struct{}{})
+	_, ok := c.inFlight.LoadOrStore(opId, struct{}{})
 	return ok
 }
 
-func (c *OpsCache) Load(opId uint64) bool {
-	_, ok := c.ops.Load(opId)
+func (c *OpsCache) InFlight(opId uint64) bool {
+	_, ok := c.inFlight.Load(opId)
 	return ok
 }
 
@@ -84,8 +88,7 @@ func (c *OpsCache) Cancel(opId uint64) bool {
 	return true
 }
 
-func (c *OpsCache) Remove(opId uint64) {
-	c.hasBeenCancelled.Delete(opId)
+func (c *OpsCache) DeleteInFlight(opId uint64) {
 	c.cancels.Delete(opId)
-	c.ops.Delete(opId)
+	c.inFlight.Delete(opId)
 }

--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -58,12 +58,12 @@ func New(t types.RemoteIndex, nodeSelector cluster.NodeSelector, rootPath string
 func (c *Copier) RemoveLocalReplica(ctx context.Context, collectionName, shardName string) error {
 	index := c.dbWrapper.GetIndex(schema.ClassName(collectionName))
 	if index == nil {
-		return fmt.Errorf("index for collection %s not found", collectionName)
+		return nil // no index found, nothing to do
 	}
 
 	err := index.DropShard(shardName)
 	if err != nil {
-		return fmt.Errorf("remove local replica: %w", err)
+		return nil // no shard found, nothing to do
 	}
 
 	return nil

--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -65,8 +65,6 @@ func (c *Copier) RemoveLocalReplica(ctx context.Context, collectionName, shardNa
 	if err != nil {
 		return // no shard found, nothing to do
 	}
-
-	return
 }
 
 // CopyReplica copies a shard replica from the source node to this node.

--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -55,18 +55,18 @@ func New(t types.RemoteIndex, nodeSelector cluster.NodeSelector, rootPath string
 }
 
 // RemoveLocalReplica removes the local replica of a shard on this node.
-func (c *Copier) RemoveLocalReplica(ctx context.Context, collectionName, shardName string) error {
+func (c *Copier) RemoveLocalReplica(ctx context.Context, collectionName, shardName string) {
 	index := c.dbWrapper.GetIndex(schema.ClassName(collectionName))
 	if index == nil {
-		return nil // no index found, nothing to do
+		return // no index found, nothing to do
 	}
 
 	err := index.DropShard(shardName)
 	if err != nil {
-		return nil // no shard found, nothing to do
+		return // no shard found, nothing to do
 	}
 
-	return nil
+	return
 }
 
 // CopyReplica copies a shard replica from the source node to this node.

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -64,14 +64,14 @@ func (m *Manager) Replicate(logId uint64, c *cmd.ApplyRequest) error {
 	return m.replicationFSM.Replicate(logId, req)
 }
 
-func (m *Manager) RegisterError(logId uint64, c *cmd.ApplyRequest) error {
+func (m *Manager) RegisterError(c *cmd.ApplyRequest) error {
 	req := &cmd.ReplicationRegisterErrorRequest{}
 	if err := json.Unmarshal(c.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
 	// Store an op's error emitted by the consumer in the FSM
-	return m.replicationFSM.RegisterError(logId, req)
+	return m.replicationFSM.RegisterError(req)
 }
 
 func (m *Manager) UpdateReplicateOpState(c *cmd.ApplyRequest) error {

--- a/cluster/replication/manager_test.go
+++ b/cluster/replication/manager_test.go
@@ -387,7 +387,7 @@ func TestManager_UpdateReplicaOpStatusAndRegisterErrors(t *testing.T) {
 					applyRequest = &api.ApplyRequest{
 						SubCommand: subCommand,
 					}
-					err = manager.RegisterError(errReq.Id, applyRequest)
+					err = manager.RegisterError(applyRequest)
 					if expectedErr != nil {
 						assert.ErrorAs(t, err, &expectedErr)
 					} else {
@@ -543,7 +543,7 @@ func TestManager_SnapshotRestore(t *testing.T) {
 					var originalReq api.ReplicationRegisterErrorRequest
 					err := json.Unmarshal(req.SubCommand, &originalReq)
 					require.NoError(t, err)
-					err = manager.RegisterError(originalReq.Id, req)
+					err = manager.RegisterError(req)
 					assert.NoError(t, err)
 				default:
 					t.Fatalf("unknown apply request type: %v", req.Type)
@@ -566,7 +566,7 @@ func TestManager_SnapshotRestore(t *testing.T) {
 					var originalReq api.ReplicationRegisterErrorRequest
 					err := json.Unmarshal(req.SubCommand, &originalReq)
 					require.NoError(t, err)
-					err = manager.RegisterError(originalReq.Id, req)
+					err = manager.RegisterError(req)
 					assert.NoError(t, err)
 				default:
 					t.Fatalf("unknown apply request type: %v", req.Type)

--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -37,17 +37,17 @@ func (s *ShardReplicationFSM) Replicate(id uint64, c *api.ReplicationReplicateSh
 	return s.writeOpIntoFSM(op, NewShardReplicationStatus(api.REGISTERED))
 }
 
-func (s *ShardReplicationFSM) RegisterError(id uint64, c *api.ReplicationRegisterErrorRequest) error {
+func (s *ShardReplicationFSM) RegisterError(c *api.ReplicationRegisterErrorRequest) error {
 	s.opsLock.Lock()
 	defer s.opsLock.Unlock()
 
-	op, ok := s.opsById[id]
+	op, ok := s.opsById[c.Id]
 	if !ok {
-		return fmt.Errorf("could not find op %d: %w", id, types.ErrReplicationOperationNotFound)
+		return fmt.Errorf("could not find op %d: %w", c.Id, types.ErrReplicationOperationNotFound)
 	}
 	status, ok := s.opsStatus[op]
 	if !ok {
-		return fmt.Errorf("could not find op status for op %d", id)
+		return fmt.Errorf("could not find op status for op %d", c.Id)
 	}
 	if err := status.AddError(c.Error); err != nil {
 		return err

--- a/cluster/replication/types/mock_replica_copier.go
+++ b/cluster/replication/types/mock_replica_copier.go
@@ -194,21 +194,8 @@ func (_c *MockReplicaCopier_InitAsyncReplicationLocally_Call) RunAndReturn(run f
 }
 
 // RemoveLocalReplica provides a mock function with given fields: ctx, sourceCollection, sourceShard
-func (_m *MockReplicaCopier) RemoveLocalReplica(ctx context.Context, sourceCollection string, sourceShard string) error {
-	ret := _m.Called(ctx, sourceCollection, sourceShard)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RemoveLocalReplica")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, sourceCollection, sourceShard)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *MockReplicaCopier) RemoveLocalReplica(ctx context.Context, sourceCollection string, sourceShard string) {
+	_m.Called(ctx, sourceCollection, sourceShard)
 }
 
 // MockReplicaCopier_RemoveLocalReplica_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveLocalReplica'
@@ -231,13 +218,13 @@ func (_c *MockReplicaCopier_RemoveLocalReplica_Call) Run(run func(ctx context.Co
 	return _c
 }
 
-func (_c *MockReplicaCopier_RemoveLocalReplica_Call) Return(_a0 error) *MockReplicaCopier_RemoveLocalReplica_Call {
-	_c.Call.Return(_a0)
+func (_c *MockReplicaCopier_RemoveLocalReplica_Call) Return() *MockReplicaCopier_RemoveLocalReplica_Call {
+	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockReplicaCopier_RemoveLocalReplica_Call) RunAndReturn(run func(context.Context, string, string) error) *MockReplicaCopier_RemoveLocalReplica_Call {
-	_c.Call.Return(run)
+func (_c *MockReplicaCopier_RemoveLocalReplica_Call) RunAndReturn(run func(context.Context, string, string)) *MockReplicaCopier_RemoveLocalReplica_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/cluster/replication/types/replica_copier.go
+++ b/cluster/replication/types/replica_copier.go
@@ -24,7 +24,7 @@ type ReplicaCopier interface {
 	CopyReplica(ctx context.Context, sourceNode string, sourceCollection string, sourceShard string) error
 
 	// CopyReplica see cluster/replication/copier.Copier.RemoveLocalReplica
-	RemoveLocalReplica(ctx context.Context, sourceCollection string, sourceShard string) error
+	RemoveLocalReplica(ctx context.Context, sourceCollection string, sourceShard string)
 
 	// InitAsyncReplicationLocally see cluster/replication/copier.Copier.InitAsyncReplicationLocally
 	InitAsyncReplicationLocally(ctx context.Context, collectionName, shardName string) error

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -246,7 +246,7 @@ func (st *Store) Apply(l *raft.Log) interface{} {
 		}
 	case api.ApplyRequest_TYPE_REPLICATION_REPLICATE_REGISTER_ERROR:
 		f = func() {
-			ret.Error = st.replicationManager.RegisterError(l.Index, &cmd)
+			ret.Error = st.replicationManager.RegisterError(&cmd)
 		}
 	case api.ApplyRequest_TYPE_REPLICATION_REPLICATE_UPDATE_STATE:
 		f = func() {


### PR DESCRIPTION
### What's being changed:

- store HasBeenCancelled even if op is not in flight
- make cancelOp a full no-op
- return specific error up through stack on cancellation detection in worker dispatch
- removes dependence on `logId` from `RegisterError` preferring the ID of the `req` itself

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
