### PR TITLE
Lower max tokens per request limit for openai text2vec

### DIFF
--- a/modules/text2vec-openai/module.go
+++ b/modules/text2vec-openai/module.go
@@ -41,9 +41,11 @@ var batchSettings = batch.Settings{
 	TokenMultiplier:    1,
 	MaxTimePerBatch:    float64(10),
 	MaxObjectsPerBatch: 2000, // https://platform.openai.com/docs/api-reference/embeddings/create
-	MaxTokensPerBatch:  func(cfg moduletools.ClassConfig) int { return 500000 },
-	HasTokenLimit:      true,
-	ReturnsRateLimit:   true,
+	// cant find any info about this on the website besides this forum thread:https://community.openai.com/t/max-total-embeddings-tokens-per-request/1254699
+	// we had customers run into this error, too
+	MaxTokensPerBatch: func(cfg moduletools.ClassConfig) int { return 300000 },
+	HasTokenLimit:     true,
+	ReturnsRateLimit:  true,
 }
 
 func New() *OpenAIModule {


### PR DESCRIPTION
### What's being changed:

error from openai: Requested 313102 tokens, max 300000 tokens per request

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
