### PR TITLE
fix(shard shutdown): make sure shard is shut down when it's marked for shutdown 

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -533,6 +533,7 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 				defer idx.closeLock.RUnlock()
 
 				if idx.closed {
+					m.logger.WithField("index", idx.ID()).Debug("index is already shut down or dropped")
 					ec.Add(errAlreadyShutdown)
 					return nil
 				}
@@ -542,19 +543,21 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 
 				shard, ok := idx.shards.LoadAndDelete(name)
 				if !ok {
+					m.logger.WithField("shard", name).Debug("already shut down or dropped")
 					return nil // shard already does not exist or inactive
 				}
+
+				m.logger.WithField("shard", name).Debug("starting shutdown")
 
 				if err := shard.Shutdown(ctx); err != nil {
 					if errors.Is(err, errAlreadyShutdown) {
 						m.logger.WithField("shard", shard.Name()).Debug("already shut down or dropped")
 					} else {
-						ec.Add(err)
-
 						idx.logger.
 							WithField("action", "shutdown_shard").
 							WithField("shard", shard.ID()).
 							Error(err)
+						ec.Add(err)
 					}
 				}
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -55,6 +55,7 @@ import (
 const IdLockPoolSize = 128
 
 var errAlreadyShutdown = errors.New("already shut or dropped")
+var errShutdownInProgress = errors.New("shard shutdown in progress")
 
 type ShardLike interface {
 	Index() *Index                  // Get the parent index

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -239,7 +239,8 @@ type Shard struct {
 	// indicates whether shard in being used at the moment (e.g. write request)
 	inUseCounter atomic.Int64
 	// allows concurrent shut read/write
-	shutdownLock      *sync.RWMutex
+	shutdownLock *sync.RWMutex
+	// shutdownRequested marks shard as requested for shutdown
 	shutdownRequested atomic.Bool
 }
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -239,8 +239,8 @@ type Shard struct {
 	// indicates whether shard in being used at the moment (e.g. write request)
 	inUseCounter atomic.Int64
 	// allows concurrent shut read/write
-	shutdownLock *sync.RWMutex
-	WantShutdown atomic.Bool
+	shutdownLock      *sync.RWMutex
+	shutdownRequested atomic.Bool
 }
 
 func (s *Shard) ID() string {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -232,11 +232,12 @@ type Shard struct {
 	activityTracker atomic.Int32
 
 	// indicates whether shard is shut down or dropped (or ongoing)
-	shut bool
+	shut atomic.Bool
 	// indicates whether shard in being used at the moment (e.g. write request)
 	inUseCounter atomic.Int64
 	// allows concurrent shut read/write
 	shutdownLock *sync.RWMutex
+	WantShutdown atomic.Bool
 }
 
 func (s *Shard) ID() string {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -54,8 +54,10 @@ import (
 
 const IdLockPoolSize = 128
 
-var errAlreadyShutdown = errors.New("already shut or dropped")
-var errShutdownInProgress = errors.New("shard shutdown in progress")
+var (
+	errAlreadyShutdown    = errors.New("already shut or dropped")
+	errShutdownInProgress = errors.New("shard shutdown in progress")
+)
 
 type ShardLike interface {
 	Index() *Index                  // Get the parent index

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -59,7 +59,6 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		scheduler:             scheduler,
 		indexCheckpoints:      indexCheckpoints,
 
-		shut:         false,
 		shutdownLock: new(sync.RWMutex),
 
 		status: ShardStatus{Status: storagestate.StatusLoading},

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -183,7 +183,7 @@ func (s *Shard) RefCountSub() {
 	// if the counter is 0, we can shutdown
 	if s.inUseCounter.Load() == 0 {
 		if s.WantShutdown.Load() {
-			s.Shutdown(context.TODO())
+			s.ActuallyShutdown(context.TODO())
 		}
 	}
 }

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
-
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.WantShutdown.Store(true)
 	s.ActuallyShutdown(ctx)
@@ -55,7 +54,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 func (s *Shard) ActuallyShutdown(ctx context.Context) (err error) {
 	s.shutdownLock.Lock()
 	defer s.shutdownLock.Unlock()
-	if ! s.WantShutdown.Load() {
+	if !s.WantShutdown.Load() {
 		return fmt.Errorf("shard %q is not marked for shutdown", s.name)
 	}
 	if s.shut.Load() {
@@ -188,7 +187,6 @@ func (s *Shard) RefCountSub() {
 		}
 	}
 }
-
 
 // // cleanupPartialInit is called when the shard was only partially initialized.
 // // Internally it just uses [Shutdown], but also adds some logging.

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -156,8 +156,19 @@ func (s *Shard) preventShutdown() (release func(), err error) {
 		return func() {}, errAlreadyShutdown
 	}
 
+	s.RefCountAdd()
+	return func() { s.RefCountSub()}, nil
+}
+
+func (s *Shard) RefCountAdd() {
 	s.inUseCounter.Add(1)
-	return func() { s.inUseCounter.Add(-1) }, nil
+}
+func (s *Shard) RefCountSub() {
+	s.inUseCounter.Add(-1)
+	// if the counter is 0, we can shutdown
+	if s.inUseCounter.Load() == 0 {
+		//s.Shutdown(context.TODO())
+	}
 }
 
 func (s *Shard) waitForShutdown(ctx context.Context) error {

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -176,7 +176,7 @@ func (s *Shard) waitForShutdown(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("Shard::proceedWithShutdown: %w", ctx.Err())
+				return nil
 			case <-ticker.C:
 				if eligible, err := s.checkEligibleForShutdown(); err != nil {
 					return err

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -63,6 +63,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	defer s.shutdownLock.Unlock()
 
 	if s.shut.Load() {
+		s.shutdownRequested.Store(false)
 		s.index.logger.
 			WithField("action", "shutdown").
 			Debugf("shard %q is already shut down", s.name)
@@ -76,6 +77,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 		return fmt.Errorf("shard %q is still in use", s.name)
 	}
 	s.shut.Store(true)
+	s.shutdownRequested.Store(false)
 	start := time.Now()
 	defer func() {
 		s.index.metrics.ObserveUpdateShardStatus(storagestate.StatusShutdown.String(), time.Since(start))

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -55,12 +55,21 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.shutdownLock.Lock()
 	defer s.shutdownLock.Unlock()
 	if !s.WantShutdown.Load() {
+		s.index.logger.
+			WithField("action", "shutdown").
+			Debugf("shard %q is not marked for shutdown", s.name)
 		return fmt.Errorf("shard %q is not marked for shutdown", s.name)
 	}
 	if s.shut.Load() {
+		s.index.logger.
+			WithField("action", "shutdown").
+			Debugf("shard %q is already shut down", s.name)
 		return fmt.Errorf("shard %q is already shut down", s.name)
 	}
 	if s.inUseCounter.Load() > 0 {
+		s.index.logger.
+			WithField("action", "shutdown").
+			Debugf("shard %q is still in use", s.name)
 		return fmt.Errorf("shard %q is still in use", s.name)
 	}
 	s.shut.Store(true)

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -30,7 +30,6 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		// this retry to make sure it's retried in case
 		// the performShutdown() returned shard still in use
 		return s.performShutdown(ctx)
-
 	}, backoff.WithContext(backoff.WithMaxRetries(
 		// this will try with max 2 seconds could be configurable later on
 		backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx))

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -37,7 +37,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 		s.index.logger.
 			WithField("action", "shutdown").
 			Debugf("shard %q did not shutdown", s.name)
-			return err
+		return err
 	}
 
 	return nil

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -157,17 +157,18 @@ func (s *Shard) preventShutdown() (release func(), err error) {
 	}
 
 	s.RefCountAdd()
-	return func() { s.RefCountSub()}, nil
+	return func() { s.RefCountSub() }, nil
 }
 
 func (s *Shard) RefCountAdd() {
 	s.inUseCounter.Add(1)
 }
+
 func (s *Shard) RefCountSub() {
 	s.inUseCounter.Add(-1)
 	// if the counter is 0, we can shutdown
 	if s.inUseCounter.Load() == 0 {
-		//s.Shutdown(context.TODO())
+		// s.Shutdown(context.TODO())
 	}
 }
 

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -90,7 +90,6 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 		return fmt.Errorf("shard %q is still in use", s.name)
 	}
 	s.shut.Store(true)
-	s.WantShutdown.Store(false)
 	start := time.Now()
 	defer func() {
 		s.index.metrics.ObserveUpdateShardStatus(storagestate.StatusShutdown.String(), time.Since(start))

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -187,6 +187,7 @@ func (s *Shard) waitForShutdown(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
+				s.shut = true
 				return nil
 			case <-ticker.C:
 				if eligible, err := s.checkEligibleForShutdown(); err != nil {

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -172,6 +172,9 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 }
 
 func (s *Shard) preventShutdown() (release func(), err error) {
+	if s.WantShutdown.Load() {
+		return func() {}, errShutdownInProgress
+	}
 	s.shutdownLock.RLock()
 	defer s.shutdownLock.RUnlock()
 

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -24,7 +24,7 @@ import (
 
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.WantShutdown.Store(true)
-	s.PerformShutdown(ctx)
+	s.performShutdown(ctx)
 	return nil
 }
 
@@ -51,7 +51,7 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 // idempotent Shutdown methods. In other parts, it explicitly checks if a
 // component was initialized. If not, it turns it into a noop to prevent
 // blocking.
-func (s *Shard) PerformShutdown(ctx context.Context) (err error) {
+func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.shutdownLock.Lock()
 	defer s.shutdownLock.Unlock()
 	if !s.WantShutdown.Load() {
@@ -183,7 +183,7 @@ func (s *Shard) refCountSub() {
 	// if the counter is 0, we can shutdown
 	if s.inUseCounter.Load() == 0 {
 		if s.WantShutdown.Load() {
-			s.PerformShutdown(context.TODO())
+			s.performShutdown(context.TODO())
 		}
 	}
 }

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -24,7 +24,7 @@ import (
 
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.WantShutdown.Store(true)
-	for i := 0; i < 30; i++ {
+	for i := 0; (i < 30) && !s.shut.Load(); i++ {
 		s.performShutdown(ctx)
 		time.Sleep(1 * time.Second)
 	}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -25,11 +25,10 @@ import (
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.WantShutdown.Store(true)
 	for i := 0; (i < 30) && !s.shut.Load(); i++ {
-		s.performShutdown(ctx)
+		err = s.performShutdown(ctx)
 		time.Sleep(1 * time.Second)
 	}
 
-	err = s.performShutdown(ctx)
 	s.shutdownLock.Lock()
 	defer s.shutdownLock.Unlock()
 	if !s.shut.Load() {

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -1,0 +1,121 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
+
+	r := getRandomSeed()
+	dirName := t.TempDir()
+
+	shardState := singleShardState()
+	logger := logrus.New()
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: shardState,
+	}
+	repo, err := New(logger, Config{
+		RootPath:                  dirName,
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		TrackVectorDimensions:     true,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil, memwatch.NewDummyMonitor())
+	require.Nil(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.Nil(t, repo.WaitForStartup(testCtx()))
+	defer repo.Shutdown(context.Background())
+
+	migrator := NewMigrator(repo, logger)
+
+	t.Run("set schema", func(t *testing.T) {
+		class := &models.Class{
+			Class:               "Test",
+			VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+			InvertedIndexConfig: invertedConfig(),
+		}
+		schema := schema.Schema{
+			Objects: &models.Schema{
+				Classes: []*models.Class{class},
+			},
+		}
+
+		require.Nil(t,
+			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+
+		schemaGetter.schema = schema
+	})
+
+	t.Run("import objects with d=128", func(t *testing.T) {
+		dim := 128
+		for i := 0; i < 100; i++ {
+			vec := make([]float32, dim)
+			for j := range vec {
+				vec[j] = r.Float32()
+			}
+
+			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
+			obj := &models.Object{Class: "Test", ID: id}
+			err := repo.PutObject(context.Background(), obj, vec, nil, nil, 0)
+			require.Nil(t, err)
+		}
+		dimAfter := GetDimensionsFromRepo(context.Background(), repo, "Test")
+		require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(context.Background(), repo, "Test", 64)
+		require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
+	})
+
+	require.Nil(t, err)
+	index := repo.GetIndex(schema.ClassName("Test"))
+	var testShard string
+	index.shards.Range(func(name string, shard ShardLike) error {
+		testShard = name
+		return nil
+	})
+	t.Logf("testShard: %s", testShard)
+	shard, release, err := index.GetShard(context.TODO(), testShard)
+	require.Nil(t, err)
+	defer release()
+	require.NotNil(t, shard)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+	defer cancel()
+
+	shutdownErrCh := make(chan error)
+	go func() {
+		err := shard.Shutdown(ctx)
+		shutdownErrCh <- err
+	}()
+
+	fmt.Printf("Waiting for shutdown to complete at %v\n", time.Now())
+	// Wait for 33s which should be long enough for the shutdown timeout (30s)
+	time.Sleep(33 * time.Second)
+	fmt.Printf("Shutdown timeout reached, waiting for shutdown to complete...\n")
+
+	select {
+	case err := <-shutdownErrCh:
+		fmt.Printf("Shutdown completed at %v\n", time.Now())
+		fmt.Printf("Shutdown error: %v\n", err)
+		fmt.Printf("Shard state: %v\n", shard.(*LazyLoadShard).shard.shut)
+		require.NoError(t, err)
+		require.True(t, shard.(*LazyLoadShard).shard.shut, "shard should be marked as shut down due to timeout")
+	case <-time.After(5 * time.Second):
+		fmt.Printf("Shutdown did not complete in time after timeout\n")
+		// This is a failure case, we expect the shutdown to complete
+		t.Fatal("shutdown did not complete in time after timeout")
+	}
+	fmt.Println("Shutdown test completed successfully")
+}

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -9,6 +9,8 @@
 //  CONTACT: hello@weaviate.io
 //
 
+//go:build integrationTest
+
 package db
 
 import (

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -107,6 +107,7 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 		release()
 	}()
 	shard.Shutdown(context.Background())
+	t.Logf("Shard %+v\n", shard)
 	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
 	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -30,7 +30,94 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
+func TestShardShutdownWithInactivity(t *testing.T) {
+	r := getRandomSeed()
+	dirName := t.TempDir()
+
+	shardState := singleShardState()
+	logger := logrus.New()
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: shardState,
+	}
+	repo, err := New(logger, Config{
+		RootPath:                  dirName,
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		TrackVectorDimensions:     true,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil, memwatch.NewDummyMonitor())
+	require.Nil(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.Nil(t, repo.WaitForStartup(testCtx()))
+	defer repo.Shutdown(context.Background())
+
+	migrator := NewMigrator(repo, logger)
+
+	t.Run("set schema", func(t *testing.T) {
+		class := &models.Class{
+			Class:               "Test",
+			VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+			InvertedIndexConfig: invertedConfig(),
+		}
+		schema := schema.Schema{
+			Objects: &models.Schema{
+				Classes: []*models.Class{class},
+			},
+		}
+
+		require.Nil(t,
+			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+
+		schemaGetter.schema = schema
+	})
+
+	t.Run("import objects with d=128", func(t *testing.T) {
+		dim := 128
+		for i := 0; i < 100; i++ {
+			vec := make([]float32, dim)
+			for j := range vec {
+				vec[j] = r.Float32()
+			}
+
+			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
+			obj := &models.Object{Class: "Test", ID: id}
+			err := repo.PutObject(context.Background(), obj, vec, nil, nil, 0)
+			require.Nil(t, err)
+		}
+		dimAfter := GetDimensionsFromRepo(context.Background(), repo, "Test")
+		require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(context.Background(), repo, "Test", 64)
+		require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
+	})
+
+	require.Nil(t, err)
+	index := repo.GetIndex(schema.ClassName("Test"))
+	var testShard string
+	index.shards.Range(func(name string, shard ShardLike) error {
+		testShard = name
+		return nil
+	})
+	t.Logf("testShard: %s", testShard)
+	shard, release, err := index.GetShard(context.TODO(), testShard)
+	require.Nil(t, err)
+	require.NotNil(t, shard)
+
+
+
+	shard.Shutdown(context.Background())
+	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
+	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down yet")
+	release()
+	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")
+	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
+}
+
+
+
+// This tests the old behaviour - shutdown should be forced after 30s
+
 func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
+	if false {
 	r := getRandomSeed()
 	dirName := t.TempDir()
 
@@ -118,9 +205,11 @@ func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
 	select {
 	case err := <-shutdownErrCh:
 		require.NoError(t, err)
-		require.True(t, shard.(*LazyLoadShard).shard.shut, "shard should be marked as shut down due to timeout")
+		require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should be marked as shut down due to timeout")
 	case <-time.After(5 * time.Second):
 		// This is a failure case, we expect the shutdown to complete
 		t.Fatal("shutdown did not complete in time after timeout")
 	}
+}
+
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -109,8 +109,8 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 	shard.Shutdown(context.Background())
 	s := shard.(*LazyLoadShard).shard
 	t.Logf("Shard %+v\n", s)
-	t.Logf("Shard shut: %v, wantshut: %v, loaded: %v\n", s.shut.Load(), s.WantShutdown.Load(), shard.(*LazyLoadShard).loaded)
-	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
+	t.Logf("Shard shut: %v, wantshut: %v, loaded: %v\n", s.shut.Load(), s.shutdownRequested.Load(), shard.(*LazyLoadShard).loaded)
+	require.True(t, shard.(*LazyLoadShard).shard.shutdownRequested.Load(), "shard should be marked for shut down")
 	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
 }
 
@@ -188,6 +188,6 @@ func TestShardShutdownFailure(t *testing.T) {
 
 	t.Logf("Shard: %+v\n", shard)
 	shard.Shutdown(context.Background())
-	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")
+	require.False(t, shard.(*LazyLoadShard).shard.shutdownRequested.Load(), "shard should not be marked for shut down")
 	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down ")
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -107,7 +107,9 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 		release()
 	}()
 	shard.Shutdown(context.Background())
-	t.Logf("Shard %+v\n", shard)
+	s := shard.(*LazyLoadShard).shard
+	t.Logf("Shard %+v\n", s)
+	t.Logf("Shard shut: %v, wantshut: %v, loaded: %v\n", s.shut.Load(), s.WantShutdown.Load(), shard.(*LazyLoadShard).loaded)
 	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
 	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (
@@ -18,7 +29,6 @@ import (
 )
 
 func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
-
 	r := getRandomSeed()
 	dirName := t.TempDir()
 
@@ -100,10 +110,8 @@ func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
 		shutdownErrCh <- err
 	}()
 
-
 	// Wait for 33s which should be long enough for the shutdown timeout (30s)
 	time.Sleep(33 * time.Second)
-
 
 	select {
 	case err := <-shutdownErrCh:

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -102,8 +102,6 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, shard)
 
-
-
 	shard.Shutdown(context.Background())
 	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
 	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down yet")
@@ -112,104 +110,101 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
 }
 
-
-
 // This tests the old behaviour - shutdown should be forced after 30s
 
 func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
 	if false {
-	r := getRandomSeed()
-	dirName := t.TempDir()
+		r := getRandomSeed()
+		dirName := t.TempDir()
 
-	shardState := singleShardState()
-	logger := logrus.New()
-	schemaGetter := &fakeSchemaGetter{
-		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
-		shardState: shardState,
-	}
-	repo, err := New(logger, Config{
-		RootPath:                  dirName,
-		QueryMaximumResults:       10000,
-		MaxImportGoroutinesFactor: 1,
-		TrackVectorDimensions:     true,
-	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil, memwatch.NewDummyMonitor())
-	require.Nil(t, err)
-	repo.SetSchemaGetter(schemaGetter)
-	require.Nil(t, repo.WaitForStartup(testCtx()))
-	defer repo.Shutdown(context.Background())
-
-	migrator := NewMigrator(repo, logger)
-
-	t.Run("set schema", func(t *testing.T) {
-		class := &models.Class{
-			Class:               "Test",
-			VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
-			InvertedIndexConfig: invertedConfig(),
+		shardState := singleShardState()
+		logger := logrus.New()
+		schemaGetter := &fakeSchemaGetter{
+			schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+			shardState: shardState,
 		}
-		schema := schema.Schema{
-			Objects: &models.Schema{
-				Classes: []*models.Class{class},
-			},
-		}
+		repo, err := New(logger, Config{
+			RootPath:                  dirName,
+			QueryMaximumResults:       10000,
+			MaxImportGoroutinesFactor: 1,
+			TrackVectorDimensions:     true,
+		}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil, memwatch.NewDummyMonitor())
+		require.Nil(t, err)
+		repo.SetSchemaGetter(schemaGetter)
+		require.Nil(t, repo.WaitForStartup(testCtx()))
+		defer repo.Shutdown(context.Background())
 
-		require.Nil(t,
-			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+		migrator := NewMigrator(repo, logger)
 
-		schemaGetter.schema = schema
-	})
-
-	t.Run("import objects with d=128", func(t *testing.T) {
-		dim := 128
-		for i := 0; i < 100; i++ {
-			vec := make([]float32, dim)
-			for j := range vec {
-				vec[j] = r.Float32()
+		t.Run("set schema", func(t *testing.T) {
+			class := &models.Class{
+				Class:               "Test",
+				VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+				InvertedIndexConfig: invertedConfig(),
+			}
+			schema := schema.Schema{
+				Objects: &models.Schema{
+					Classes: []*models.Class{class},
+				},
 			}
 
-			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
-			obj := &models.Object{Class: "Test", ID: id}
-			err := repo.PutObject(context.Background(), obj, vec, nil, nil, 0)
-			require.Nil(t, err)
+			require.Nil(t,
+				migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+
+			schemaGetter.schema = schema
+		})
+
+		t.Run("import objects with d=128", func(t *testing.T) {
+			dim := 128
+			for i := 0; i < 100; i++ {
+				vec := make([]float32, dim)
+				for j := range vec {
+					vec[j] = r.Float32()
+				}
+
+				id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
+				obj := &models.Object{Class: "Test", ID: id}
+				err := repo.PutObject(context.Background(), obj, vec, nil, nil, 0)
+				require.Nil(t, err)
+			}
+			dimAfter := GetDimensionsFromRepo(context.Background(), repo, "Test")
+			require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
+			quantDimAfter := GetQuantizedDimensionsFromRepo(context.Background(), repo, "Test", 64)
+			require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
+		})
+
+		require.Nil(t, err)
+		index := repo.GetIndex(schema.ClassName("Test"))
+		var testShard string
+		index.shards.Range(func(name string, shard ShardLike) error {
+			testShard = name
+			return nil
+		})
+		t.Logf("testShard: %s", testShard)
+		shard, release, err := index.GetShard(context.TODO(), testShard)
+		require.Nil(t, err)
+		defer release()
+		require.NotNil(t, shard)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+		defer cancel()
+
+		shutdownErrCh := make(chan error)
+		go func() {
+			err := shard.Shutdown(ctx)
+			shutdownErrCh <- err
+		}()
+
+		// Wait for 33s which should be long enough for the shutdown timeout (30s)
+		time.Sleep(33 * time.Second)
+
+		select {
+		case err := <-shutdownErrCh:
+			require.NoError(t, err)
+			require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should be marked as shut down due to timeout")
+		case <-time.After(5 * time.Second):
+			// This is a failure case, we expect the shutdown to complete
+			t.Fatal("shutdown did not complete in time after timeout")
 		}
-		dimAfter := GetDimensionsFromRepo(context.Background(), repo, "Test")
-		require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
-		quantDimAfter := GetQuantizedDimensionsFromRepo(context.Background(), repo, "Test", 64)
-		require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
-	})
-
-	require.Nil(t, err)
-	index := repo.GetIndex(schema.ClassName("Test"))
-	var testShard string
-	index.shards.Range(func(name string, shard ShardLike) error {
-		testShard = name
-		return nil
-	})
-	t.Logf("testShard: %s", testShard)
-	shard, release, err := index.GetShard(context.TODO(), testShard)
-	require.Nil(t, err)
-	defer release()
-	require.NotNil(t, shard)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
-	defer cancel()
-
-	shutdownErrCh := make(chan error)
-	go func() {
-		err := shard.Shutdown(ctx)
-		shutdownErrCh <- err
-	}()
-
-	// Wait for 33s which should be long enough for the shutdown timeout (30s)
-	time.Sleep(33 * time.Second)
-
-	select {
-	case err := <-shutdownErrCh:
-		require.NoError(t, err)
-		require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should be marked as shut down due to timeout")
-	case <-time.After(5 * time.Second):
-		// This is a failure case, we expect the shutdown to complete
-		t.Fatal("shutdown did not complete in time after timeout")
 	}
-}
-
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -103,15 +103,13 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 	require.NotNil(t, shard)
 
 	go func() {
-		time.Sleep(5*time.Second)
+		time.Sleep(5 * time.Second)
 		release()
 	}()
 	shard.Shutdown(context.Background())
 	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
 	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
 }
-
-
 
 func TestShardShutdownFailure(t *testing.T) {
 	r := getRandomSeed()
@@ -181,11 +179,10 @@ func TestShardShutdownFailure(t *testing.T) {
 		return nil
 	})
 	t.Logf("testShard: %s", testShard)
-	shard, release, err := index.GetShard(context.TODO(), testShard)
+	shard, _, err := index.GetShard(context.TODO(), testShard)
 	require.Nil(t, err)
 	require.NotNil(t, shard)
 
-	release()
 	t.Logf("Shard: %+v\n", shard)
 	shard.Shutdown(context.Background())
 	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -181,12 +181,12 @@ func TestShardShutdownFailure(t *testing.T) {
 		return nil
 	})
 	t.Logf("testShard: %s", testShard)
-	shard, _, err := index.GetShard(context.TODO(), testShard)
+	shard, release, err := index.GetShard(context.TODO(), testShard)
 	require.Nil(t, err)
 	require.NotNil(t, shard)
 
+	release()
 	shard.Shutdown(context.Background())
-
 	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")
-	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  not be marked as shut down ")
+	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down ")
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -186,6 +186,7 @@ func TestShardShutdownFailure(t *testing.T) {
 	require.NotNil(t, shard)
 
 	release()
+	t.Logf("Shard: %+v\n", shard)
 	shard.Shutdown(context.Background())
 	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")
 	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down ")

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -102,109 +102,91 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, shard)
 
+	go func() {
+		time.Sleep(5*time.Second)
+		release()
+	}()
 	shard.Shutdown(context.Background())
 	require.True(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should be marked for shut down")
-	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down yet")
-	release()
-	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")
 	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
 }
 
-// This tests the old behaviour - shutdown should be forced after 30s
 
-func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
-	if false {
-		r := getRandomSeed()
-		dirName := t.TempDir()
 
-		shardState := singleShardState()
-		logger := logrus.New()
-		schemaGetter := &fakeSchemaGetter{
-			schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
-			shardState: shardState,
-		}
-		repo, err := New(logger, Config{
-			RootPath:                  dirName,
-			QueryMaximumResults:       10000,
-			MaxImportGoroutinesFactor: 1,
-			TrackVectorDimensions:     true,
-		}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil, memwatch.NewDummyMonitor())
-		require.Nil(t, err)
-		repo.SetSchemaGetter(schemaGetter)
-		require.Nil(t, repo.WaitForStartup(testCtx()))
-		defer repo.Shutdown(context.Background())
+func TestShardShutdownFailure(t *testing.T) {
+	r := getRandomSeed()
+	dirName := t.TempDir()
 
-		migrator := NewMigrator(repo, logger)
-
-		t.Run("set schema", func(t *testing.T) {
-			class := &models.Class{
-				Class:               "Test",
-				VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
-				InvertedIndexConfig: invertedConfig(),
-			}
-			schema := schema.Schema{
-				Objects: &models.Schema{
-					Classes: []*models.Class{class},
-				},
-			}
-
-			require.Nil(t,
-				migrator.AddClass(context.Background(), class, schemaGetter.shardState))
-
-			schemaGetter.schema = schema
-		})
-
-		t.Run("import objects with d=128", func(t *testing.T) {
-			dim := 128
-			for i := 0; i < 100; i++ {
-				vec := make([]float32, dim)
-				for j := range vec {
-					vec[j] = r.Float32()
-				}
-
-				id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
-				obj := &models.Object{Class: "Test", ID: id}
-				err := repo.PutObject(context.Background(), obj, vec, nil, nil, 0)
-				require.Nil(t, err)
-			}
-			dimAfter := GetDimensionsFromRepo(context.Background(), repo, "Test")
-			require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
-			quantDimAfter := GetQuantizedDimensionsFromRepo(context.Background(), repo, "Test", 64)
-			require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
-		})
-
-		require.Nil(t, err)
-		index := repo.GetIndex(schema.ClassName("Test"))
-		var testShard string
-		index.shards.Range(func(name string, shard ShardLike) error {
-			testShard = name
-			return nil
-		})
-		t.Logf("testShard: %s", testShard)
-		shard, release, err := index.GetShard(context.TODO(), testShard)
-		require.Nil(t, err)
-		defer release()
-		require.NotNil(t, shard)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
-		defer cancel()
-
-		shutdownErrCh := make(chan error)
-		go func() {
-			err := shard.Shutdown(ctx)
-			shutdownErrCh <- err
-		}()
-
-		// Wait for 33s which should be long enough for the shutdown timeout (30s)
-		time.Sleep(33 * time.Second)
-
-		select {
-		case err := <-shutdownErrCh:
-			require.NoError(t, err)
-			require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should be marked as shut down due to timeout")
-		case <-time.After(5 * time.Second):
-			// This is a failure case, we expect the shutdown to complete
-			t.Fatal("shutdown did not complete in time after timeout")
-		}
+	shardState := singleShardState()
+	logger := logrus.New()
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: shardState,
 	}
+	repo, err := New(logger, Config{
+		RootPath:                  dirName,
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		TrackVectorDimensions:     true,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, &fakeRemoteNodeClient{}, &fakeReplicationClient{}, nil, memwatch.NewDummyMonitor())
+	require.Nil(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.Nil(t, repo.WaitForStartup(testCtx()))
+	defer repo.Shutdown(context.Background())
+
+	migrator := NewMigrator(repo, logger)
+
+	t.Run("set schema", func(t *testing.T) {
+		class := &models.Class{
+			Class:               "Test",
+			VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+			InvertedIndexConfig: invertedConfig(),
+		}
+		schema := schema.Schema{
+			Objects: &models.Schema{
+				Classes: []*models.Class{class},
+			},
+		}
+
+		require.Nil(t,
+			migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+
+		schemaGetter.schema = schema
+	})
+
+	t.Run("import objects with d=128", func(t *testing.T) {
+		dim := 128
+		for i := 0; i < 100; i++ {
+			vec := make([]float32, dim)
+			for j := range vec {
+				vec[j] = r.Float32()
+			}
+
+			id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
+			obj := &models.Object{Class: "Test", ID: id}
+			err := repo.PutObject(context.Background(), obj, vec, nil, nil, 0)
+			require.Nil(t, err)
+		}
+		dimAfter := GetDimensionsFromRepo(context.Background(), repo, "Test")
+		require.Equal(t, 12800, dimAfter, "dimensions should not have changed")
+		quantDimAfter := GetQuantizedDimensionsFromRepo(context.Background(), repo, "Test", 64)
+		require.Equal(t, 6400, quantDimAfter, "quantized dimensions should not have changed")
+	})
+
+	require.Nil(t, err)
+	index := repo.GetIndex(schema.ClassName("Test"))
+	var testShard string
+	index.shards.Range(func(name string, shard ShardLike) error {
+		testShard = name
+		return nil
+	})
+	t.Logf("testShard: %s", testShard)
+	shard, _, err := index.GetShard(context.TODO(), testShard)
+	require.Nil(t, err)
+	require.NotNil(t, shard)
+
+	shard.Shutdown(context.Background())
+
+	require.False(t, shard.(*LazyLoadShard).shard.WantShutdown.Load(), "shard should not be marked for shut down")
+	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  not be marked as shut down ")
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -111,7 +111,12 @@ func TestShardShutdownWithInactivity(t *testing.T) {
 	t.Logf("Shard %+v\n", s)
 	t.Logf("Shard shut: %v, wantshut: %v, loaded: %v\n", s.shut.Load(), s.shutdownRequested.Load(), shard.(*LazyLoadShard).loaded)
 	require.True(t, shard.(*LazyLoadShard).shard.shutdownRequested.Load(), "shard should be marked for shut down")
-	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should  be marked as shut down ")
+	require.False(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should not be marked as shut down while still in use")
+
+	// Wait for release to happen
+	time.Sleep(6 * time.Second)
+	require.True(t, shard.(*LazyLoadShard).shard.shutdownRequested.Load(), "shard should still be marked for shut down")
+	require.True(t, shard.(*LazyLoadShard).shard.shut.Load(), "shard should be marked as shut down after release")
 }
 
 func TestShardShutdownFailure(t *testing.T) {

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -100,20 +100,16 @@ func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
 		shutdownErrCh <- err
 	}()
 
-	fmt.Printf("Waiting for shutdown to complete at %v\n", time.Now())
+
 	// Wait for 33s which should be long enough for the shutdown timeout (30s)
 	time.Sleep(33 * time.Second)
-	fmt.Printf("Shutdown timeout reached, waiting for shutdown to complete...\n")
+
 
 	select {
 	case err := <-shutdownErrCh:
-		fmt.Printf("Shutdown completed at %v\n", time.Now())
-		fmt.Printf("Shutdown error: %v\n", err)
-		fmt.Printf("Shard state: %v\n", shard.(*LazyLoadShard).shard.shut)
 		require.NoError(t, err)
 		require.True(t, shard.(*LazyLoadShard).shard.shut, "shard should be marked as shut down due to timeout")
 	case <-time.After(5 * time.Second):
-		fmt.Printf("Shutdown did not complete in time after timeout\n")
 		// This is a failure case, we expect the shutdown to complete
 		t.Fatal("shutdown did not complete in time after timeout")
 	}

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -121,5 +121,4 @@ func TestShardShutdownWithInUseRefTimeout(t *testing.T) {
 		// This is a failure case, we expect the shutdown to complete
 		t.Fatal("shutdown did not complete in time after timeout")
 	}
-	fmt.Println("Shutdown test completed successfully")
 }

--- a/usecases/auth/authorization/docs/generator.go
+++ b/usecases/auth/authorization/docs/generator.go
@@ -139,7 +139,6 @@ func main() {
 		})
 		return nil
 	})
-
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error walking directory: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
### What's being changed:

Redo shutdown for shards.  Now, Shutdown() sets a flag on the shard indicating it should shutdown.  Then, the next time the shard becomes idle, it will shutdown.  If the shard already was idle, it shuts down immediately.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
  - 1st run without retry : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15040289712 
  - 2nd run with retry and report errors from performShutdown() : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15042447270



latest runs 
- chaos : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15064157138/job/42351780272
- e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/15064454070/job/42346239266
- e2e 2nd run https://github.com/weaviate/weaviate-e2e-tests/actions/runs/15064454070
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
