### PR TITLE
bug(raft-snapshot): fix downgrade path for new snapshots structure

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -75,6 +75,15 @@ func (s *SchemaManager) SetIndexer(idx Indexer) {
 	s.schema.shardReader = idx
 }
 
+func (s *SchemaManager) MetaClasses() map[string]any {
+	classes := s.schema.MetaClasses()
+	classesMap := make(map[string]any)
+	for k, v := range classes {
+		classesMap[k] = v
+	}
+	return classesMap
+}
+
 func (s *SchemaManager) Snapshot() ([]byte, error) {
 	var buf bytes.Buffer
 

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -38,10 +38,11 @@ func (s *Store) Persist(sink raft.SnapshotSink) (err error) {
 		return fmt.Errorf("rbac snapshot: %w", err)
 	}
 	snap := fsm.Snapshot{
-		NodeID:     s.cfg.NodeID,
-		SnapshotID: sink.ID(),
-		Schema:     schemaSnapshot,
-		RBAC:       rbacSnapshot,
+		NodeID:       s.cfg.NodeID,
+		SnapshotID:   sink.ID(),
+		LegacySchema: s.schemaManager.MetaClasses(),
+		Schema:       schemaSnapshot,
+		RBAC:         rbacSnapshot,
 	}
 	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
 		return fmt.Errorf("encode: %w", err)


### PR DESCRIPTION
### What's being changed:
in order to support downgrade path in case of snapshot was created with newer version this makes sure that we produce snapshot readable for legacy 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
