### PR TITLE
fix(raft-snapshot): backward compatibility downgrade path for new snapshots structure

### DIFF
--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -542,7 +542,7 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 		if err := json.Unmarshal(snap.Schema, &classes); err != nil {
 			return fmt.Errorf("restore snapshot: decode json: %w", err)
 		}
-		s.classes = classes
+		snap.classes = classes
 	}
 
 	for _, cls := range snap.Classes {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -537,19 +537,12 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 	}
 
 	if len(snap.Schema) > 0 {
-		if len(s.classes) == 0 {
-			s.classes = make(map[string]*metaClass, len(snap.Schema))
+		// handle new version of schema
+		var classes map[string]*metaClass
+		if err := json.Unmarshal(snap.Schema, &classes); err != nil {
+			return fmt.Errorf("restore snapshot: decode json: %w", err)
 		}
-
-		for _, cls := range snap.Schema {
-			mClass := cls.(*metaClass)
-			snap.Classes[mClass.Class.Class] = &metaClass{
-				Class:        mClass.Class,
-				ClassVersion: mClass.ClassVersion,
-				Sharding:     mClass.Sharding.DeepCopy(),
-				ShardVersion: mClass.ShardVersion,
-			}
-		}
+		s.classes = classes
 	}
 
 	for _, cls := range snap.Classes {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -537,7 +537,7 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 	}
 
 	if len(snap.Schema) > 0 {
-		// handle new version of schema
+		// handle new version of schema snapshot
 		var classes map[string]*metaClass
 		if err := json.Unmarshal(snap.Schema, &classes); err != nil {
 			return fmt.Errorf("restore snapshot: decode json: %w", err)

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -542,7 +542,7 @@ func (s *schema) Restore(r io.Reader, parser Parser) error {
 		if err := json.Unmarshal(snap.Schema, &classes); err != nil {
 			return fmt.Errorf("restore snapshot: decode json: %w", err)
 		}
-		snap.classes = classes
+		snap.Classes = classes
 	}
 
 	for _, cls := range snap.Classes {

--- a/cluster/schema/snapshot.go
+++ b/cluster/schema/snapshot.go
@@ -25,7 +25,7 @@ type snapshot struct {
 	NodeID     string                `json:"node_id"`
 	SnapshotID string                `json:"snapshot_id"`
 	Classes    map[string]*metaClass `json:"classes,omitempty"`
-	Schema     map[string]any        `json:"schema,omitempty"`
+	Schema     []byte                `json:"schema,omitempty"`
 }
 
 // LegacySnapshot returns a ready-to-use in-memory Raft snapshot based on the provided legacy schema

--- a/cluster/schema/snapshot.go
+++ b/cluster/schema/snapshot.go
@@ -25,7 +25,10 @@ type snapshot struct {
 	NodeID     string                `json:"node_id"`
 	SnapshotID string                `json:"snapshot_id"`
 	Classes    map[string]*metaClass `json:"classes,omitempty"`
-	Schema     []byte                `json:"schema,omitempty"`
+	// Schema is added for backward compatibility, we have changed the schema snapshot
+	// format in 1.28.13 and this field is added to be able to read schema snapshot
+	// created in newer versions.
+	Schema []byte `json:"schema,omitempty"`
 }
 
 // LegacySnapshot returns a ready-to-use in-memory Raft snapshot based on the provided legacy schema

--- a/cluster/schema/snapshot.go
+++ b/cluster/schema/snapshot.go
@@ -17,6 +17,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/raft"
+
 	"github.com/weaviate/weaviate/cluster/types"
 )
 
@@ -24,6 +25,7 @@ type snapshot struct {
 	NodeID     string                `json:"node_id"`
 	SnapshotID string                `json:"snapshot_id"`
 	Classes    map[string]*metaClass `json:"classes"`
+	Schema     map[string]any        `json:"schema,omitempty"`
 }
 
 // LegacySnapshot returns a ready-to-use in-memory Raft snapshot based on the provided legacy schema

--- a/cluster/schema/snapshot.go
+++ b/cluster/schema/snapshot.go
@@ -24,7 +24,7 @@ import (
 type snapshot struct {
 	NodeID     string                `json:"node_id"`
 	SnapshotID string                `json:"snapshot_id"`
-	Classes    map[string]*metaClass `json:"classes"`
+	Classes    map[string]*metaClass `json:"classes,omitempty"`
 	Schema     map[string]any        `json:"schema,omitempty"`
 }
 


### PR DESCRIPTION
### What's being changed:
in order to support downgrade path in case of snapshot was created with newer version this makes sure that we produce snapshot readable for legacy

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
