### PR TITLE
chore: remove model name validation in text2vec-voyageai module

### DIFF
--- a/modules/text2vec-voyageai/ent/class_settings.go
+++ b/modules/text2vec-voyageai/ent/class_settings.go
@@ -12,7 +12,6 @@
 package ent
 
 import (
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
@@ -28,21 +27,6 @@ const (
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	LowerCaseInput               = false
-)
-
-var (
-	availableVoyageAIModels = []string{
-		"voyage-3",
-		"voyage-3-lite",
-		"voyage-large-2",
-		"voyage-code-2",
-		"voyage-2",
-		"voyage-law-2",
-		"voyage-large-2-instruct",
-		"voyage-finance-2",
-		"voyage-multilingual-2",
-	}
-	experimetnalVoyageAIModels = []string{}
 )
 
 type classSettings struct {
@@ -70,11 +54,5 @@ func (cs classSettings) Validate(class *models.Class) error {
 	if err := cs.BaseClassSettings.Validate(class); err != nil {
 		return err
 	}
-
-	model := cs.Model()
-	if !basesettings.ValidateSetting[string](model, append(availableVoyageAIModels, experimetnalVoyageAIModels...)) {
-		return errors.Errorf("wrong VoyageAI model name, available model names are: %v", availableVoyageAIModels)
-	}
-
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

This PR removes model name validation from `text2vec-voyageai` module so that it would be possible to pass any model name.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
