### PR TITLE
chore: remove model name validation in text2vec-cohere module

### DIFF
--- a/modules/text2vec-cohere/ent/class_settings.go
+++ b/modules/text2vec-cohere/ent/class_settings.go
@@ -30,16 +30,7 @@ const (
 	LowerCaseInput               = false
 )
 
-var (
-	availableCohereModels = []string{
-		"medium",
-		"large", "small", "multilingual-22-12",
-		"embed-english-v2.0", "embed-english-light-v2.0", "embed-multilingual-v2.0",
-		"embed-english-v3.0", "embed-english-light-v3.0", "embed-multilingual-v3.0", "embed-multilingual-light-v3.0",
-	}
-	experimetnalCohereModels = []string{"multilingual-2210-alpha"}
-	availableTruncates       = []string{"NONE", "START", "END", "LEFT", "RIGHT"}
-)
+var availableTruncates = []string{"NONE", "START", "END", "LEFT", "RIGHT"}
 
 type classSettings struct {
 	basesettings.BaseClassSettings
@@ -67,12 +58,8 @@ func (cs *classSettings) Validate(class *models.Class) error {
 		return err
 	}
 
-	model := cs.Model()
-	if !basesettings.ValidateSetting[string](model, append(availableCohereModels, experimetnalCohereModels...)) {
-		return errors.Errorf("wrong Cohere model name, available model names are: %v", availableCohereModels)
-	}
 	truncate := cs.Truncate()
-	if !basesettings.ValidateSetting[string](truncate, availableTruncates) {
+	if !basesettings.ValidateSetting(truncate, availableTruncates) {
 		return errors.Errorf("wrong truncate type, available types are: %v", availableTruncates)
 	}
 


### PR DESCRIPTION
### What's being changed:

This PR removes model name validation in `text2vec-cohere` module.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
