### PR TITLE
Better metrics for Mmap usage

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -187,6 +187,14 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		"operation": "segmentMetadata",
 	})
 
+	if unMapContents {
+		// a map was created, track it
+		monitoring.GetMetrics().MmapOperations.With(prometheus.Labels{
+			"operation": "mmap",
+			"strategy":  stratLabel,
+		}).Inc()
+	}
+
 	seg := &segment{
 		level:                 header.Level,
 		path:                  path,
@@ -246,6 +254,11 @@ func (s *segment) close() error {
 	if s.unMapContents {
 		m := mmap.MMap(s.contents)
 		munmapErr = m.Unmap()
+		stratLabel := s.strategy.String()
+		monitoring.GetMetrics().MmapOperations.With(prometheus.Labels{
+			"operation": "munmap",
+			"strategy":  stratLabel,
+		}).Inc()
 	}
 	if s.contentFile != nil {
 		fileCloseErr = s.contentFile.Close()

--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 const (
@@ -178,6 +179,7 @@ func (m *Monitor) obtainCurrentUsage() {
 
 func (m *Monitor) obtainCurrentMappings() {
 	used := getCurrentMappings()
+	monitoring.GetMetrics().MmapProcMaps.Set(float64(used))
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.usedMappings = used

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -73,6 +73,8 @@ type PrometheusMetrics struct {
 	BackupRestoreDataTransferred        *prometheus.CounterVec
 	BackupStoreDataTransferred          *prometheus.CounterVec
 	FileIOWrites                        *prometheus.SummaryVec
+	MmapOperations                      *prometheus.CounterVec
+	MmapProcMaps                        prometheus.Gauge
 
 	// offload metric
 	TenantCloudOffloadDurations       *prometheus.SummaryVec
@@ -483,6 +485,14 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "file_io_writes_total_bytes",
 			Help: "Total number of bytes written to disk",
 		}, []string{"operation", "strategy"}),
+		MmapOperations: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "mmap_operations_total",
+			Help: "Total number of mmap operations",
+		}, []string{"operation", "strategy"}),
+		MmapProcMaps: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "mmap_proc_maps",
+			Help: "Number of entries in /proc/self/maps",
+		}),
 
 		// Async indexing metrics
 		IndexQueuePushDuration: promauto.NewSummaryVec(prometheus.SummaryOpts{


### PR DESCRIPTION
### What's being changed:
- A gauge for `/proc/self/maps`: `mmap_proc_maps`
- A counter for mmap and munmap by bucket type: `mmap_operations_total`


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
