### PR TITLE
optimization: wal reuse upon restart

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -151,7 +151,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 ) (*Bucket, error) {
 	beforeAll := time.Now()
 	defaultMemTableThreshold := uint64(10 * 1024 * 1024)
-	defaultMinWalThreshold := uint64(1024 * 1024)
+	defaultMinWalThreshold := uint64(4096)
 	defaultWalThreshold := uint64(1024 * 1024 * 1024)
 	defaultFlushAfterDirty := FlushAfterDirtyDefault
 	defaultStrategy := StrategyReplace

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -151,7 +151,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 ) (*Bucket, error) {
 	beforeAll := time.Now()
 	defaultMemTableThreshold := uint64(10 * 1024 * 1024)
-	defaultMinWalThreshold := uint64(32 * 1024)
+	defaultMinWalThreshold := uint64(4096)
 	defaultWalThreshold := uint64(1024 * 1024 * 1024)
 	defaultFlushAfterDirty := FlushAfterDirtyDefault
 	defaultStrategy := StrategyReplace

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -151,7 +151,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 ) (*Bucket, error) {
 	beforeAll := time.Now()
 	defaultMemTableThreshold := uint64(10 * 1024 * 1024)
-	defaultMinWalThreshold := uint64(4096)
+	defaultMinWalThreshold := uint64(32 * 1024)
 	defaultWalThreshold := uint64(1024 * 1024 * 1024)
 	defaultFlushAfterDirty := FlushAfterDirtyDefault
 	defaultStrategy := StrategyReplace

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -45,6 +45,13 @@ func WithMinMMapSize(minMMapSize int64) BucketOption {
 	}
 }
 
+func WithMinWalThreshold(threshold uint64) BucketOption {
+	return func(b *Bucket) error {
+		b.minWalThreshold = threshold
+		return nil
+	}
+}
+
 func WithWalThreshold(threshold uint64) BucketOption {
 	return func(b *Bucket) error {
 		b.walThreshold = threshold

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -108,7 +108,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 			return err
 		}
 
-		meteredReader := diskio.NewMeteredReader(bufio.NewReader(cl.file), b.metrics.TrackStartupReadWALDiskIO)
+		meteredReader := diskio.NewMeteredReader(bufio.NewReaderSize(cl.file, 32*1024), b.metrics.TrackStartupReadWALDiskIO)
 
 		err = newCommitLoggerParser(b.strategy, meteredReader, mt).Do()
 		if err != nil {

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"bufio"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,25 +76,34 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 		logOnceWhenRecoveringFromWAL.Do(func() {
 			b.logger.WithField("action", "lsm_recover_from_active_wal").
 				WithField("path", b.dir).
-				Warning("active write-ahead-log found. Did weaviate crash prior to this?")
+				Warning("active write-ahead-log found")
 		})
 	}
 
 	// recover from each log
-	for _, fname := range walFileNames {
+	for i, fname := range walFileNames {
+		walForActiveMemtable := i == len(walFileNames)-1
+
 		path := filepath.Join(b.dir, strings.TrimSuffix(fname, ".wal"))
 
 		cl, err := newCommitLogger(path, b.strategy)
 		if err != nil {
 			return errors.Wrap(err, "init commit logger")
 		}
-		defer cl.close()
+		if !walForActiveMemtable {
+			defer cl.close()
+		}
 
 		cl.pause()
 		defer cl.unpause()
 
 		mt, err := newMemtable(path, b.strategy, b.secondaryIndices,
 			cl, b.metrics, b.logger, b.enableChecksumValidation)
+		if err != nil {
+			return err
+		}
+
+		_, err = cl.file.Seek(0, io.SeekStart)
 		if err != nil {
 			return err
 		}
@@ -107,16 +117,25 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 				Error(errors.Wrap(err, "write-ahead-log ended abruptly, some elements may not have been recovered"))
 		}
 
-		if err := mt.flush(); err != nil {
-			return errors.Wrap(err, "flush memtable after WAL recovery")
-		}
+		if walForActiveMemtable {
+			_, err = cl.file.Seek(0, io.SeekEnd)
+			if err != nil {
+				return err
+			}
 
-		if mt.Size() == 0 {
-			continue
-		}
+			b.active = mt
+		} else {
+			if err := mt.flush(); err != nil {
+				return errors.Wrap(err, "flush memtable after WAL recovery")
+			}
 
-		if err := b.disk.add(path + ".db"); err != nil {
-			return err
+			if mt.Size() == 0 {
+				continue
+			}
+
+			if err := b.disk.add(path + ".db"); err != nil {
+				return err
+			}
 		}
 
 		if b.strategy == StrategyReplace && b.monitorCount {

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -13,7 +13,9 @@ package lsmkv
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -305,4 +307,108 @@ func TestBucketGetBySecondary(t *testing.T) {
 
 	_, err = b.GetBySecondary(1, []byte("bonjour"))
 	require.Error(t, err)
+}
+
+func TestBucketWalReload(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	// initial bucket, always create segment, even if it is just a single entry
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello"), []byte("world"), WithSecondaryKey(0, []byte("bonjour"))))
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err := os.ReadDir(dirName)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "single wal file should be created")
+
+	// start fresh with a new memtable, new entries will stay in way until size is reached
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err = os.ReadDir(dirName)
+	require.NoError(t, err)
+	fileTypes := map[string]int{}
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	require.Equal(t, 0, fileTypes[".db"], "no segment file")
+	require.Equal(t, 1, fileTypes[".wal"], "single wal file")
+
+	// will load wal and reuse memtable
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello3"), []byte("world3"), WithSecondaryKey(0, []byte("bonjour3"))))
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err = os.ReadDir(dirName)
+	require.NoError(t, err)
+	clear(fileTypes)
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	require.Equal(t, 0, fileTypes[".db"], "no segment file")
+	require.Equal(t, 1, fileTypes[".wal"], "single wal file")
+
+	// now add a lot of entries to hit .wal file limit
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	for i := 4; i < 120; i++ { // larger than pagesize
+		require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i)), WithSecondaryKey(0, []byte(fmt.Sprintf("bonjour%d", i)))))
+	}
+	require.NoError(t, b.Shutdown(ctx))
+
+	entries, err = os.ReadDir(dirName)
+	require.NoError(t, err)
+	clear(fileTypes)
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	require.Equal(t, 0, fileTypes[".db"], "no segment file")
+	require.Equal(t, 1, fileTypes[".wal"], "single wal file")
+
+	// recover from memtable and check that files are there
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	get, err := b.Get([]byte("hello3"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("world3"), get)
+
+	get, err = b.Get([]byte("hello4"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("world4"), get)
+	require.NoError(t, b.Shutdown(ctx))
+
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
+	require.NoError(t, err)
+
+	get, err = b.Get([]byte("hello4"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("world4"), get)
+
+	get, err = b.Get([]byte("hello3"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("world3"), get)
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -310,105 +310,175 @@ func TestBucketGetBySecondary(t *testing.T) {
 }
 
 func TestBucketWalReload(t *testing.T) {
+	for _, strategy := range []string{StrategyReplace, StrategySetCollection, StrategyMapCollection, StrategyRoaringSet, StrategyRoaringSetRange} {
+		t.Run(strategy, func(t *testing.T) {
+			ctx := context.Background()
+			dirName := t.TempDir()
+
+			logger, _ := test.NewNullLogger()
+
+			secondaryIndicesCount := uint16(0)
+			if strategy == StrategyReplace {
+				secondaryIndicesCount = 1
+			}
+
+			// initial bucket, always create segment, even if it is just a single entry
+			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount))
+			require.NoError(t, err)
+
+			if strategy == StrategyReplace {
+				require.NoError(t, b.Put([]byte("hello1"), []byte("world1"), WithSecondaryKey(0, []byte("bonjour1"))))
+			} else if strategy == StrategySetCollection {
+				require.NoError(t, b.SetAdd([]byte("hello1"), [][]byte{[]byte("world1")}))
+			} else if strategy == StrategyRoaringSet {
+				require.NoError(t, b.RoaringSetAddOne([]byte("hello1"), uint64(1)))
+			} else if strategy == StrategyMapCollection {
+				require.NoError(t, b.MapSet([]byte("hello1"), MapPair{Key: []byte("hello1"), Value: []byte("world1")}))
+			} else if strategy == StrategyRoaringSetRange {
+				require.NoError(t, b.RoaringSetRangeAdd(uint64(1), uint64(1)))
+			} else {
+				require.Fail(t, "unknown strategy %s", strategy)
+			}
+			testContent(t, strategy, b, 2)
+
+			require.NoError(t, b.Shutdown(ctx))
+
+			entries, err := os.ReadDir(dirName)
+			require.NoError(t, err)
+			require.Len(t, entries, 1, "single wal file should be created")
+
+			testContent(t, strategy, b, 2)
+
+			// start fresh with a new memtable, new entries will stay in way until size is reached
+			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount))
+			require.NoError(t, err)
+
+			if strategy == StrategyReplace {
+				require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
+			} else if strategy == StrategySetCollection {
+				require.NoError(t, b.SetAdd([]byte("hello2"), [][]byte{[]byte("world2")}))
+			} else if strategy == StrategyRoaringSet {
+				require.NoError(t, b.RoaringSetAddOne([]byte("hello2"), uint64(2)))
+			} else if strategy == StrategyMapCollection {
+				require.NoError(t, b.MapSet([]byte("hello2"), MapPair{Key: []byte("hello2"), Value: []byte("world2")}))
+			} else if strategy == StrategyRoaringSetRange {
+				require.NoError(t, b.RoaringSetRangeAdd(uint64(2), uint64(2)))
+			}
+			require.NoError(t, b.Shutdown(ctx))
+
+			entries, err = os.ReadDir(dirName)
+			require.NoError(t, err)
+			fileTypes := map[string]int{}
+			for _, entry := range entries {
+				fileTypes[filepath.Ext(entry.Name())] += 1
+			}
+			require.Equal(t, 0, fileTypes[".db"], "no segment file")
+			require.Equal(t, 1, fileTypes[".wal"], "single wal file")
+
+			// will load wal and reuse memtable
+			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(strategy), WithSecondaryIndices(1))
+			require.NoError(t, err)
+
+			testContent(t, strategy, b, 3)
+
+			if strategy == StrategyReplace {
+				require.NoError(t, b.Put([]byte("hello3"), []byte("world3"), WithSecondaryKey(0, []byte("bonjour3"))))
+			} else if strategy == StrategySetCollection {
+				require.NoError(t, b.SetAdd([]byte("hello3"), [][]byte{[]byte("world3")}))
+			} else if strategy == StrategyRoaringSet {
+				require.NoError(t, b.RoaringSetAddOne([]byte("hello3"), uint64(3)))
+			} else if strategy == StrategyMapCollection {
+				require.NoError(t, b.MapSet([]byte("hello3"), MapPair{Key: []byte("hello3"), Value: []byte("world3")}))
+			} else if strategy == StrategyRoaringSetRange {
+				require.NoError(t, b.RoaringSetRangeAdd(uint64(3), uint64(3)))
+				require.NoError(t, err)
+			}
+			require.NoError(t, b.Shutdown(ctx))
+
+			entries, err = os.ReadDir(dirName)
+			require.NoError(t, err)
+			clear(fileTypes)
+			for _, entry := range entries {
+				fileTypes[filepath.Ext(entry.Name())] += 1
+			}
+			require.Equal(t, 0, fileTypes[".db"], "no segment file")
+			require.Equal(t, 1, fileTypes[".wal"], "single wal file")
+
+			// now add a lot of entries to hit .wal file limit
+			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount), WithMinWalThreshold(4096))
+			require.NoError(t, err)
+
+			testContent(t, strategy, b, 4)
+
+			for i := 4; i < 120; i++ { // larger than min .wal threshold
+				if strategy == StrategyReplace {
+					require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i)), WithSecondaryKey(0, []byte(fmt.Sprintf("bonjour%d", i)))))
+				} else if strategy == StrategySetCollection {
+					require.NoError(t, b.SetAdd([]byte(fmt.Sprintf("hello%d", i)), [][]byte{[]byte(fmt.Sprintf("world%d", i))}))
+				} else if strategy == StrategyRoaringSet {
+					require.NoError(t, b.RoaringSetAddOne([]byte(fmt.Sprintf("hello%d", i)), uint64(i)))
+				} else if strategy == StrategyMapCollection {
+					require.NoError(t, b.MapSet([]byte(fmt.Sprintf("hello%d", i)), MapPair{Key: []byte(fmt.Sprintf("hello%d", i)), Value: []byte(fmt.Sprintf("world%d", i))}))
+				} else if strategy == StrategyRoaringSetRange {
+					require.NoError(t, b.RoaringSetRangeAdd(uint64(4), uint64(4)))
+				}
+			}
+			testContent(t, strategy, b, 120)
+
+			require.NoError(t, b.Shutdown(ctx))
+
+			entries, err = os.ReadDir(dirName)
+			require.NoError(t, err)
+			clear(fileTypes)
+			for _, entry := range entries {
+				fileTypes[filepath.Ext(entry.Name())] += 1
+			}
+			require.Equal(t, 1, fileTypes[".db"], "no segment file")
+			require.Equal(t, 0, fileTypes[".wal"], "single wal file")
+
+			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount))
+			require.NoError(t, err)
+
+			testContent(t, strategy, b, 120)
+		})
+	}
+}
+
+func testContent(t *testing.T, strategy string, b *Bucket, maxObject int) {
+	t.Helper()
 	ctx := context.Background()
-	dirName := t.TempDir()
-
-	logger, _ := test.NewNullLogger()
-
-	// initial bucket, always create segment, even if it is just a single entry
-	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
-	require.NoError(t, err)
-
-	require.NoError(t, b.Put([]byte("hello"), []byte("world"), WithSecondaryKey(0, []byte("bonjour"))))
-	require.NoError(t, b.Shutdown(ctx))
-
-	entries, err := os.ReadDir(dirName)
-	require.NoError(t, err)
-	require.Len(t, entries, 1, "single wal file should be created")
-
-	// start fresh with a new memtable, new entries will stay in way until size is reached
-	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
-	require.NoError(t, err)
-
-	require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
-	require.NoError(t, b.Shutdown(ctx))
-
-	entries, err = os.ReadDir(dirName)
-	require.NoError(t, err)
-	fileTypes := map[string]int{}
-	for _, entry := range entries {
-		fileTypes[filepath.Ext(entry.Name())] += 1
+	for i := 1; i < maxObject; i++ {
+		key := []byte(fmt.Sprintf("hello%d", i))
+		val := []byte(fmt.Sprintf("world%d", i))
+		if strategy == StrategyReplace {
+			get, err := b.Get(key)
+			require.NoError(t, err)
+			require.Equal(t, val, get)
+		} else if strategy == StrategySetCollection {
+			get, err := b.SetList(key)
+			require.NoError(t, err)
+			require.Equal(t, val, get[0])
+		} else if strategy == StrategyRoaringSet {
+			get, err := b.RoaringSetGet(key)
+			require.NoError(t, err)
+			require.True(t, get.Contains(uint64(i)))
+		} else if strategy == StrategyRoaringSetRange {
+			//_, err :=  b.Rang
+			//require.NoError(t,err)
+		} else if strategy == StrategyMapCollection {
+			get, err := b.MapList(ctx, key)
+			require.NoError(t, err)
+			require.Equal(t, val, get[0].Value)
+		}
 	}
-	require.Equal(t, 0, fileTypes[".db"], "no segment file")
-	require.Equal(t, 1, fileTypes[".wal"], "single wal file")
-
-	// will load wal and reuse memtable
-	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
-	require.NoError(t, err)
-
-	require.NoError(t, b.Put([]byte("hello3"), []byte("world3"), WithSecondaryKey(0, []byte("bonjour3"))))
-	require.NoError(t, b.Shutdown(ctx))
-
-	entries, err = os.ReadDir(dirName)
-	require.NoError(t, err)
-	clear(fileTypes)
-	for _, entry := range entries {
-		fileTypes[filepath.Ext(entry.Name())] += 1
-	}
-	require.Equal(t, 0, fileTypes[".db"], "no segment file")
-	require.Equal(t, 1, fileTypes[".wal"], "single wal file")
-
-	// now add a lot of entries to hit .wal file limit
-	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
-	require.NoError(t, err)
-
-	for i := 4; i < 120; i++ { // larger than pagesize
-		require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i)), WithSecondaryKey(0, []byte(fmt.Sprintf("bonjour%d", i)))))
-	}
-	require.NoError(t, b.Shutdown(ctx))
-
-	entries, err = os.ReadDir(dirName)
-	require.NoError(t, err)
-	clear(fileTypes)
-	for _, entry := range entries {
-		fileTypes[filepath.Ext(entry.Name())] += 1
-	}
-	require.Equal(t, 0, fileTypes[".db"], "no segment file")
-	require.Equal(t, 1, fileTypes[".wal"], "single wal file")
-
-	// recover from memtable and check that files are there
-	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
-	require.NoError(t, err)
-
-	get, err := b.Get([]byte("hello3"))
-	require.NoError(t, err)
-	require.Equal(t, []byte("world3"), get)
-
-	get, err = b.Get([]byte("hello4"))
-	require.NoError(t, err)
-	require.Equal(t, []byte("world4"), get)
-	require.NoError(t, b.Shutdown(ctx))
-
-	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
-	require.NoError(t, err)
-
-	get, err = b.Get([]byte("hello4"))
-	require.NoError(t, err)
-	require.Equal(t, []byte("world4"), get)
-
-	get, err = b.Get([]byte("hello3"))
-	require.NoError(t, err)
-	require.Equal(t, []byte("world3"), get)
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -464,6 +464,10 @@ func testContent(t *testing.T, strategy string, b *Bucket, maxObject int) {
 			get, err := b.Get(key)
 			require.NoError(t, err)
 			require.Equal(t, val, get)
+
+			secondary, err := b.GetBySecondary(0, []byte(fmt.Sprintf("bonjour%d", i)))
+			require.NoError(t, err)
+			require.Equal(t, val, secondary)
 		} else if strategy == StrategySetCollection {
 			get, err := b.SetList(key)
 			require.NoError(t, err)

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -51,7 +51,9 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 		cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(1024*1024*1024),
-		WithWalThreshold(walThreshold))
+		WithWalThreshold(walThreshold),
+		WithMinWalThreshold(0), // small enough to not affect this test
+	)
 	require.Nil(t, err)
 
 	// generate only a small amount of sequential values. this allows
@@ -152,7 +154,9 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 		cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
 		WithStrategy(StrategyReplace),
-		WithMemtableThreshold(memtableThreshold))
+		WithMemtableThreshold(memtableThreshold),
+		WithMinWalThreshold(0),
+	)
 	require.Nil(t, err)
 
 	t.Run("generate random data", func(t *testing.T) {
@@ -247,6 +251,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
+			WithMinWalThreshold(0),      // small enough to not affect this test
 			WithDirtyThreshold(10*time.Millisecond),
 		)
 		require.Nil(t, err)
@@ -291,6 +296,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
+			WithMinWalThreshold(0),      // small enough to not affect this test
 			WithDirtyThreshold(50*time.Millisecond),
 		)
 		require.Nil(t, err)
@@ -339,6 +345,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
+			WithMinWalThreshold(0),      // small enough to not affect this test
 			WithDirtyThreshold(50*time.Millisecond),
 		)
 		require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -37,7 +37,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
 			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-			WithStrategy(StrategyReplace))
+			WithStrategy(StrategyReplace), WithMinWalThreshold(0))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -72,7 +72,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 			var err error
 			b, err = NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(StrategyReplace))
+				WithStrategy(StrategyReplace), WithMinWalThreshold(0))
 			require.Nil(t, err)
 		})
 
@@ -158,7 +158,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(StrategyReplace))
+				WithStrategy(StrategyReplace), WithMinWalThreshold(0))
 			require.Nil(t, err)
 
 			// so big it effectively never triggers as part of this test

--- a/test/acceptance_lsmkv/data_integrity_test.go
+++ b/test/acceptance_lsmkv/data_integrity_test.go
@@ -71,13 +71,14 @@ func TestLSMKV_ChecksumsCatchCorruptedFiles(t *testing.T) {
 	bucket, err := newTestBucket(dataDir, true)
 	require.NoError(t, err)
 	require.NoError(t, bucket.Put(key, val))
+	require.NoError(t, bucket.FlushAndSwitch())
 	require.NoError(t, bucket.Shutdown(context.Background()))
 
 	entries, err := os.ReadDir(dataDir)
 	require.NoError(t, err)
-	require.Len(t, entries, 1, "single segment file should be created")
+	require.Len(t, entries, 3, "segment files should be created")
 
-	segmentPath := path.Join(dataDir, entries[0].Name())
+	segmentPath := path.Join(dataDir, entries[2].Name())
 	fileContent, err := os.ReadFile(segmentPath)
 	require.NoError(t, err)
 

--- a/usecases/integrity/checksum_writer.go
+++ b/usecases/integrity/checksum_writer.go
@@ -40,6 +40,13 @@ func NewCRC32Writer(w io.Writer) *CRC32Writer {
 	}
 }
 
+func NewCRC32WriterWithSeed(w io.Writer, seed uint32) *CRC32Writer {
+	return &CRC32Writer{
+		w:    w,
+		hash: NewCRC32Resumable(seed),
+	}
+}
+
 func (wc *CRC32Writer) Write(p []byte) (n int, err error) {
 	n, err = wc.w.Write(p)
 	wc.n += n

--- a/usecases/integrity/resumable_crc32.go
+++ b/usecases/integrity/resumable_crc32.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package integrity
+
+import (
+	"hash/crc32"
+)
+
+// Fixed table for crc32.IEEE
+var ieeeTable = crc32.MakeTable(crc32.IEEE)
+
+// CRC32Resumable implements hash.Hash32 and supports reseeding.
+// Always uses crc32.IEEE polynomial.
+type CRC32Resumable struct {
+	crc uint32
+}
+
+// NewCRC32Resumable creates a new CRC32Resumable starting at a given CRC seed.
+func NewCRC32Resumable(seed uint32) *CRC32Resumable {
+	return &CRC32Resumable{crc: seed}
+}
+
+// Write updates the CRC with data.
+func (c *CRC32Resumable) Write(p []byte) (n int, err error) {
+	c.crc = crc32.Update(c.crc, ieeeTable, p)
+	return len(p), nil
+}
+
+// Sum returns the checksum appended to b in big-endian order.
+func (c *CRC32Resumable) Sum(b []byte) []byte {
+	s := c.Sum32()
+	return append(b,
+		byte(s>>24),
+		byte(s>>16),
+		byte(s>>8),
+		byte(s),
+	)
+}
+
+// Reset resets the CRC to zero.
+func (c *CRC32Resumable) Reset() {
+	c.crc = 0
+}
+
+// Size returns the number of bytes Sum will return (4).
+func (c *CRC32Resumable) Size() int { return 4 }
+
+// BlockSize returns the block size of the hash (1).
+func (c *CRC32Resumable) BlockSize() int { return 1 }
+
+// Sum32 returns the current CRC value.
+func (c *CRC32Resumable) Sum32() uint32 { return c.crc }
+
+// Reseed manually sets a new CRC seed value.
+func (c *CRC32Resumable) Reseed(seed uint32) {
+	c.crc = seed
+}


### PR DESCRIPTION
### What's being changed:

prevent memtable flushing towards wal reuse if WalThreshold is not met

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
