### PR TITLE
chore: fix backup tests pass the correct response

### DIFF
--- a/test/helper/journey/backup_journey.go
+++ b/test/helper/journey/backup_journey.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -276,13 +277,13 @@ func backupJourneyWithCancellation(t *testing.T, className, backend, basebackupI
 				break wait
 			default:
 				statusResp, err := helper.CreateBackupStatus(t, backend, backupID, overrideBucket, overridePath)
-				helper.AssertRequestOk(t, resp, err, func() {
+				helper.AssertRequestOk(t, statusResp, err, func() {
 					require.NotNil(t, statusResp)
 					require.NotNil(t, statusResp.Payload)
 					require.NotNil(t, statusResp.Payload.Status)
 				})
 
-				if *resp.Payload.Status == string(backup.Cancelled) {
+				if *statusResp.Payload.Status == string(backup.Cancelled) {
 					break wait
 				}
 				time.Sleep(500 * time.Millisecond)
@@ -290,7 +291,7 @@ func backupJourneyWithCancellation(t *testing.T, className, backend, basebackupI
 		}
 
 		statusResp, err := helper.CreateBackupStatus(t, backend, backupID, overrideBucket, overridePath)
-		helper.AssertRequestOk(t, resp, err, func() {
+		helper.AssertRequestOk(t, statusResp, err, func() {
 			require.NotNil(t, statusResp)
 			require.NotNil(t, statusResp.Payload)
 			require.NotNil(t, statusResp.Payload.Status)


### PR DESCRIPTION
### What's being changed:
there was a typo in the test which lead to be flakey because was passing previous request response 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
