### PR TITLE
Remove introduction of `getNoInitLocalShard`

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2049,31 +2049,6 @@ func (i *Index) getOrInitShard(ctx context.Context, shardName string) (
 	return i.getOptInitLocalShard(ctx, shardName, true)
 }
 
-// getNoInitLocalShard returns the local shard with the given name.
-// This method returns the shard if it is in memory.
-// If, for whatever reason, it is not in memory (e.g. on disk, deleted, lazy loading), then
-// shard not found error is returned
-func (i *Index) getNoInitLocalShard(shardName string) (ShardLike, func(), error) {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
-		return nil, func() {}, errAlreadyShutdown
-	}
-
-	shard := i.shards.Load(shardName)
-	if shard == nil {
-		return nil, func() {}, fmt.Errorf("get local shard %q, not found", shardName)
-	}
-
-	release, err := shard.preventShutdown()
-	if err != nil {
-		return nil, func() {}, fmt.Errorf("get local shard %q, no shutdown: %w", shardName, err)
-	}
-
-	return shard, release, nil
-}
-
 // getOptInitLocalShard returns the local shard with the given name.
 // It is ensured that the returned instance is a fully loaded shard if ensureInit is set to true.
 // The returned shard may be a lazy shard instance or nil if the shard hasn't yet been initialized.

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -434,7 +434,7 @@ func (i *Index) IncomingAddAsyncReplicationTargetNode(
 	targetNodeOverride additional.AsyncReplicationTargetNodeOverride,
 ) error {
 	// TODO do we want to init the shard if it's deactivated (eg on disk) or has been deleted in the meantime?
-	localShard, release, err := i.getNoInitLocalShard(shardName)
+	localShard, release, err := i.getOrInitShard(ctx, shardName)
 	if err != nil {
 		return err
 	}

--- a/test/run.sh
+++ b/test/run.sh
@@ -375,7 +375,7 @@ function run_acceptance_only_authz() {
 
 function run_acceptance_replica_replication_tests() {
   for pkg in $(go list ./.../ | grep 'test/acceptance/replication/replica_replication'); do
-    if ! go test -v -timeout=20m -count 1 -race "$pkg"; then
+    if ! go test -timeout=30m -count 1 -race "$pkg"; then
       echo "Test for $pkg failed" >&2
       return 1
     fi


### PR DESCRIPTION
### What's being changed:

- shard should always be optionally created even if it was deleted in the meantime
- will be cleaned up anyway eventually by `cancelOp`
- this way, it may just live longer but doesn't collide with tenant activation

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
