### PR TITLE
fix replication to forbid multiple move op on the same source

### DIFF
--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -60,6 +60,7 @@ func (m *Manager) Replicate(logId uint64, c *cmd.ApplyRequest) error {
 	if err := ValidateReplicationReplicateShard(m.schemaReader, req); err != nil {
 		return err
 	}
+
 	// Store the shard replication op in the FSM
 	return m.replicationFSM.Replicate(logId, req)
 }

--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -21,7 +21,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/replication/types"
 )
 
-var ErrShardAlreadyReplicating = errors.New("target shard is already being replicated")
+var ErrShardAlreadyReplicating = errors.New("replica is already being replicated")
 
 func (s *ShardReplicationFSM) Replicate(id uint64, c *api.ReplicationReplicateShardRequest) error {
 	s.opsLock.Lock()
@@ -64,6 +64,34 @@ func (s *ShardReplicationFSM) writeOpIntoFSM(op ShardReplicationOp, status Shard
 		return ErrShardAlreadyReplicating
 	}
 
+	if existingOps, ok := s.opsBySourceFQDN[op.SourceShard]; ok {
+		for _, existingOp := range existingOps {
+			// First check the status of the existing op. If it's READY or CANCELLED we can accept a new op
+			// If it's ongoing we need to check if it's a move, in which case we can't accept any new op
+			// Otherwise we can accept a copy if the existing op is also a copy
+			if existingOpStatus, ok := s.statusById[existingOp.ID]; !ok {
+				// This should never happen
+				return fmt.Errorf("could not find op status for op %d", existingOp.ID)
+			} else if existingOpStatus.GetCurrentState() == api.CANCELLED {
+				continue
+			} else if existingOpStatus.GetCurrentState() == api.READY && existingOp.TransferType == api.COPY {
+				continue
+			}
+
+			// If any of the ops we're handling is a move we can't accept any new op
+			if existingOp.TransferType == api.MOVE {
+				return ErrShardAlreadyReplicating
+			}
+
+			// At this point we know the existing op is a copy, if our new op is a move we can't accept it
+			if op.TransferType == api.MOVE {
+				return ErrShardAlreadyReplicating
+			}
+
+			// Existing op is an ongoing copy, our new op is also a copy, we can accept it
+		}
+	}
+
 	s.idsByUuid[op.UUID] = op.ID
 	s.opsBySource[op.SourceShard.NodeId] = append(s.opsBySource[op.SourceShard.NodeId], op)
 	s.opsByTarget[op.TargetShard.NodeId] = append(s.opsByTarget[op.TargetShard.NodeId], op)
@@ -74,7 +102,7 @@ func (s *ShardReplicationFSM) writeOpIntoFSM(op ShardReplicationOp, status Shard
 	s.opsByCollectionAndShard[op.SourceShard.CollectionId][op.SourceShard.ShardId] = append(s.opsByCollectionAndShard[op.SourceShard.CollectionId][op.SourceShard.ShardId], op)
 	s.opsByCollection[op.SourceShard.CollectionId] = append(s.opsByCollection[op.SourceShard.CollectionId], op)
 	s.opsByTargetFQDN[op.TargetShard] = op
-	s.opsBySourceFQDN[op.SourceShard] = op
+	s.opsBySourceFQDN[op.SourceShard] = append(s.opsBySourceFQDN[op.SourceShard], op)
 	s.opsById[op.ID] = op
 	s.statusById[op.ID] = status
 
@@ -270,6 +298,15 @@ func (s *ShardReplicationFSM) removeReplicationOp(id uint64) error {
 	opsReplace, ok = findAndDeleteOp(op.ID, ops)
 	if ok {
 		s.opsByCollection[op.SourceShard.CollectionId] = opsReplace
+	}
+
+	ops, ok = s.opsBySourceFQDN[op.SourceShard]
+	if !ok {
+		err = multierror.Append(err, fmt.Errorf("could not find op in ops by source fqdn, this should not happen"))
+	}
+	opsReplace, ok = findAndDeleteOp(op.ID, ops)
+	if ok {
+		s.opsBySourceFQDN[op.SourceShard] = opsReplace
 	}
 
 	shardOps, ok := s.opsByCollectionAndShard[op.SourceShard.CollectionId]

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -73,7 +73,7 @@ type ShardReplicationFSM struct {
 	// opsByTargetFQDN stores the registered ShardReplicationOp (if any) for each destination replica
 	opsByTargetFQDN map[shardFQDN]ShardReplicationOp
 	// opsBySourceFQDN stores the registered ShardReplicationOp (if any) for each source replica
-	opsBySourceFQDN map[shardFQDN]ShardReplicationOp
+	opsBySourceFQDN map[shardFQDN][]ShardReplicationOp
 	// opsById stores opId -> replicationOp
 	opsById map[uint64]ShardReplicationOp
 	// opsStatus stores op -> opStatus
@@ -90,7 +90,7 @@ func newShardReplicationFSM(reg prometheus.Registerer) *ShardReplicationFSM {
 		opsByCollection:         make(map[string][]ShardReplicationOp),
 		opsByCollectionAndShard: make(map[string]map[string][]ShardReplicationOp),
 		opsByTargetFQDN:         make(map[shardFQDN]ShardReplicationOp),
-		opsBySourceFQDN:         make(map[shardFQDN]ShardReplicationOp),
+		opsBySourceFQDN:         make(map[shardFQDN][]ShardReplicationOp),
 		opsById:                 make(map[uint64]ShardReplicationOp),
 		statusById:              make(map[uint64]ShardReplicationOpStatus),
 	}
@@ -293,26 +293,26 @@ func (s *ShardReplicationFSM) filterOneReplicaReadWrite(node string, collection 
 // if found is true it means there's a source replication op for that replica and readOk and writeOk should be considered
 func (s *ShardReplicationFSM) filterOneReplicaAsSourceReadWrite(node string, collection string, shard string) (bool, bool) {
 	replicaFQDN := newShardFQDN(node, collection, shard)
-	op, ok := s.opsBySourceFQDN[replicaFQDN]
+	ops, ok := s.opsBySourceFQDN[replicaFQDN]
 	// No source replication ops for that replica it can be used for both read and writes
 	if !ok {
 		return true, true
 	}
 
-	opState, ok := s.statusById[op.ID]
-	if !ok {
-		// TODO: This should never happens
-		return true, true
-	}
-
-	// Filter read/write based on the state of the replica op
 	readOk := true
 	writeOk := true
-	switch opState.GetCurrentState() {
-	case api.DEHYDRATING:
-		readOk = false
-		writeOk = false
-	default:
+	for _, op := range ops {
+		opState, ok := s.statusById[op.ID]
+		if !ok {
+			// This should never happen
+			continue
+		}
+		switch opState.GetCurrentState() {
+		case api.DEHYDRATING:
+			readOk = false
+			writeOk = false
+		default:
+		}
 	}
 	return readOk, writeOk
 }


### PR DESCRIPTION
### What's being changed:

Change write op into FSM to allow the following
1. Multiple COPY in parallel for the same source replica
2. Only one MOVE for a source replica

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
