### PR TITLE
Use SetShard for incoming replica ops to avoid recreating a shard that has been deleted on the source node

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -275,14 +275,13 @@ func (i *Index) AbortReplication(shard, requestID string) interface{} {
 func (i *Index) IncomingFilePutter(ctx context.Context, shardName,
 	filePath string,
 ) (io.WriteCloser, error) {
-	localShard, release, err := i.getOrInitShard(context.Background(), shardName)
-	if err != nil {
-		return nil, fmt.Errorf("shard %q does not exist locally", shardName)
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return nil, fmt.Errorf("incoming file putter get shard %s: %w", shardName, err)
 	}
-
 	defer release()
 
-	return localShard.filePutter(ctx, filePath)
+	return shard.filePutter(ctx, filePath)
 }
 
 func (i *Index) IncomingCreateShard(ctx context.Context, className string, shardName string) error {
@@ -328,13 +327,13 @@ func (i *Index) IncomingReinitShard(ctx context.Context, shardName string) error
 func (i *Index) IncomingPauseFileActivity(ctx context.Context,
 	shardName string,
 ) error {
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return fmt.Errorf("shard %q could not be found locally", shardName)
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return fmt.Errorf("incoming pause file activity get shard %s: %w", shardName, err)
 	}
 	defer release()
 
-	err = localShard.HaltForTransfer(ctx, false, i.Config.TransferInactivityTimeout)
+	err = shard.HaltForTransfer(ctx, false, i.Config.TransferInactivityTimeout)
 	if err != nil {
 		return fmt.Errorf("shard %q could not be halted for transfer: %w", shardName, err)
 	}
@@ -346,13 +345,13 @@ func (i *Index) IncomingPauseFileActivity(ctx context.Context,
 func (i *Index) IncomingResumeFileActivity(ctx context.Context,
 	shardName string,
 ) error {
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return fmt.Errorf("shard %q could not be found locally", shardName)
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return fmt.Errorf("incoming resume file activity get shard %s: %w", shardName, err)
 	}
 	defer release()
 
-	err = localShard.resumeMaintenanceCycles(ctx)
+	err = shard.resumeMaintenanceCycles(ctx)
 	if err != nil {
 		return fmt.Errorf("shard %q could not be resumed after transfer: %w", shardName, err)
 	}
@@ -367,9 +366,9 @@ func (i *Index) IncomingResumeFileActivity(ctx context.Context,
 func (i *Index) IncomingListFiles(ctx context.Context,
 	shardName string,
 ) ([]string, error) {
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return nil, fmt.Errorf("shard %q could not be found locally", shardName)
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return nil, fmt.Errorf("incoming list files get shard %s: %w", shardName, err)
 	}
 	defer release()
 
@@ -380,11 +379,11 @@ func (i *Index) IncomingListFiles(ctx context.Context,
 	defer i.shardTransferMutex.Unlock()
 
 	// flushing memtable before gathering the files to prevent the inclusion of a partially written file
-	if err = localShard.Store().FlushMemtables(ctx); err != nil {
+	if err = shard.Store().FlushMemtables(ctx); err != nil {
 		return nil, fmt.Errorf("flush memtables: %w", err)
 	}
 
-	if err := localShard.ListBackupFiles(ctx, &sd); err != nil {
+	if err := shard.ListBackupFiles(ctx, &sd); err != nil {
 		return nil, fmt.Errorf("shard %q could not list backup files: %w", shardName, err)
 	}
 
@@ -401,13 +400,13 @@ func (i *Index) IncomingListFiles(ctx context.Context,
 // IncomingGetFileMetadata returns file metadata at the given path in the specified shards's root
 // directory.
 func (i *Index) IncomingGetFileMetadata(ctx context.Context, shardName, relativeFilePath string) (file.FileMetadata, error) {
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return file.FileMetadata{}, fmt.Errorf("shard %q does not exist locally", shardName)
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return file.FileMetadata{}, fmt.Errorf("incoming get file metadata get shard %s: %w", shardName, err)
 	}
 	defer release()
 
-	return localShard.GetFileMetadata(ctx, relativeFilePath)
+	return shard.GetFileMetadata(ctx, relativeFilePath)
 }
 
 // IncomingGetFile returns a reader for the file at the given path in the specified shard's root
@@ -415,13 +414,13 @@ func (i *Index) IncomingGetFileMetadata(ctx context.Context, shardName, relative
 func (i *Index) IncomingGetFile(ctx context.Context, shardName,
 	relativeFilePath string,
 ) (io.ReadCloser, error) {
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return nil, fmt.Errorf("shard %q does not exist locally", shardName)
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return nil, fmt.Errorf("incoming get file metadata get shard %s: %w", shardName, err)
 	}
 	defer release()
 
-	return localShard.GetFile(ctx, relativeFilePath)
+	return shard.GetFile(ctx, relativeFilePath)
 }
 
 // IncomingAddAsyncReplicationTargetNode adds the given target node override for async replication.
@@ -433,14 +432,13 @@ func (i *Index) IncomingAddAsyncReplicationTargetNode(
 	shardName string,
 	targetNodeOverride additional.AsyncReplicationTargetNodeOverride,
 ) error {
-	// TODO do we want to init the shard if it's deactivated (eg on disk) or has been deleted in the meantime?
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return err
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return fmt.Errorf("incoming add async replication target node get shard %s: %w", shardName, err)
 	}
 	defer release()
 
-	return localShard.addTargetNodeOverride(ctx, targetNodeOverride)
+	return shard.addTargetNodeOverride(ctx, targetNodeOverride)
 }
 
 // IncomingRemoveAsyncReplicationTargetNode removes the given target node override for async
@@ -452,13 +450,13 @@ func (i *Index) IncomingRemoveAsyncReplicationTargetNode(ctx context.Context,
 	shardName string,
 	targetNodeOverride additional.AsyncReplicationTargetNodeOverride,
 ) error {
-	localShard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return err
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return fmt.Errorf("incoming remove async replication target node get shard %s: %w", shardName, err)
 	}
 	defer release()
 
-	return localShard.removeTargetNodeOverride(ctx, targetNodeOverride)
+	return shard.removeTargetNodeOverride(ctx, targetNodeOverride)
 }
 
 func (s *Shard) filePutter(ctx context.Context,


### PR DESCRIPTION
### What's being changed:

I've found that there are cases where these "incoming" methods on the Index get called after a replica move op has completed, haven't found the root cause of that yet. However because these methods were using `getOrInitShard` instead of `GetShard`, they would recreate the shard replica on the source node after it had been removed/deleted. This would then break the e2e replica movement multitenant test because the reads in that test sent to the source node after the shard was recreated would return 0 objects (those reads check if the shard is nil directly, they don't use the router). This fix uses `GetShard` to avoid creating the shard if it doesn't already exist.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
