### PR TITLE
Improve logs for async replication during replica move ops

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -644,6 +645,17 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 					if (err == nil || errors.Is(err, replica.ErrNoDiffFound)) && stats != nil {
 						for _, stat := range stats {
 							if stat != nil {
+								s.index.logger.WithFields(logrus.Fields{
+									"source_shard":                s.name,
+									"target_shard":                s.name,
+									"target_node":                 stat.targetNodeName,
+									"objects_propagated":          stat.objectsPropagated,
+									"start_diff_time_unix_millis": stat.diffStartTime.UnixMilli(),
+									"diff_calculation_took":       stat.diffCalculationTook.String(),
+									"local_objects":               stat.localObjects,
+									"remote_objects":              stat.remoteObjects,
+									"object_progation_took":       stat.objectProgationTook.String(),
+								}).Info("updating async replication stats")
 								s.asyncReplicationStatsByTargetNode[stat.targetNodeName] = stat
 							}
 						}


### PR DESCRIPTION
### What's being changed:

Improve logs during replica move ops for async replication so you can easily find the tenant/shard/op on the source/target node and see if things are making progress or not.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
