### PR TITLE
fix(raft): make sure store is open no matter the error status on catchup

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -185,7 +185,7 @@ type Store struct {
 	schemaManager *schema.SchemaManager
 	// lastAppliedIndexToDB represents the index of the last applied command when the store is opened.
 	lastAppliedIndexToDB atomic.Uint64
-	// / lastAppliedIndex index of latest update to the store
+	// lastAppliedIndex index of latest update to the store
 	lastAppliedIndex atomic.Uint64
 
 	metrics *storeMetrics

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -105,7 +105,6 @@ func (st *Store) Apply(l *raft.Log) any {
 	catchingUp := l.Index != 0 && l.Index <= st.lastAppliedIndexToDB.Load()
 	schemaOnly := catchingUp || st.cfg.MetadataOnlyVoters
 	defer func() {
-
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.
 		// we do this at the beginning to handle situation were schema was catching up

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -105,6 +105,21 @@ func (st *Store) Apply(l *raft.Log) any {
 	catchingUp := l.Index != 0 && l.Index <= st.lastAppliedIndexToDB.Load()
 	schemaOnly := catchingUp || st.cfg.MetadataOnlyVoters
 	defer func() {
+
+		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
+		// that means we're done doing schema only.
+		// we do this at the beginning to handle situation were schema was catching up
+		// and to make sure no matter is the error status we are going to open the db on startup
+		if l.Index != 0 && l.Index == st.lastAppliedIndexToDB.Load() {
+			st.log.WithFields(logrus.Fields{
+				"log_type":                     l.Type,
+				"log_name":                     l.Type.String(),
+				"log_index":                    l.Index,
+				"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
+			}).Info("reloading local DB as RAFT and local DB are now caught up")
+			st.reloadDBFromSchema()
+		}
+
 		if ret.Error != nil {
 			st.metrics.applyFailures.Inc()
 			st.log.WithFields(logrus.Fields{
@@ -116,18 +131,6 @@ func (st *Store) Apply(l *raft.Log) any {
 				"cmd_class":     cmd.Class,
 			}).WithError(ret.Error).Error("apply command")
 			return
-		}
-
-		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
-		// that means we're done doing schema only.
-		if l.Index != 0 && l.Index == st.lastAppliedIndexToDB.Load() {
-			st.log.WithFields(logrus.Fields{
-				"log_type":                     l.Type,
-				"log_name":                     l.Type.String(),
-				"log_index":                    l.Index,
-				"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
-			}).Info("reloading local DB as RAFT and local DB are now caught up")
-			st.reloadDBFromSchema()
 		}
 
 		st.lastAppliedIndex.Store(l.Index)

--- a/cluster/store_apply_index_test.go
+++ b/cluster/store_apply_index_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -28,6 +30,8 @@ import (
 func setupTestData(t *testing.T, initialIndex uint64) (MockStore, *raft.Log) {
 	mockStore := NewMockStore(t, "Node-1", 0)
 	mockStore.store.lastAppliedIndex.Store(initialIndex)
+	mockStore.store.metrics = newStoreMetrics("Node-1", prometheus.NewPedanticRegistry())
+	mockStore.store.metrics.fsmLastAppliedIndex.Set(float64(initialIndex))
 
 	cls := &models.Class{
 		Class: "TestClass",
@@ -80,7 +84,6 @@ func TestStore_ApplyIndex(t *testing.T) {
 	t.Run("Apply index fails due to parse error", func(t *testing.T) {
 		mockStore, log := setupTestData(t, 100)
 		mockStore.parser.On("ParseClass", mock.Anything).Return(errors.New("parse error"))
-
 		result := mockStore.store.Apply(log)
 
 		// Verify that the result contains an error
@@ -89,8 +92,10 @@ func TestStore_ApplyIndex(t *testing.T) {
 		assert.Error(t, resp.Error)
 
 		// Verify that lastAppliedIndex was not updated
-		currentIndex := mockStore.store.lastAppliedIndex.Load()
 		assert.Equal(t, uint64(101), log.Index)
-		assert.Equal(t, uint64(100), currentIndex, "lastAppliedIndex should not be updated when there's an error")
+		// we depend on metrics to check if the index was updated
+		// as we allow lastAppliedIndex to be updated even when there's an error
+		// to handle edge cases in the DB layer for already released versions
+		assert.Equal(t, float64(100), testutil.ToFloat64(mockStore.store.metrics.fsmLastAppliedIndex), "lastAppliedIndex should not be updated when there's an error")
 	})
 }

--- a/test/acceptance/recovery/restart_after_faulty_update_test.go
+++ b/test/acceptance/recovery/restart_after_faulty_update_test.go
@@ -1,0 +1,114 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package recovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/schema"
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func TestUpdatePropertyFieldFailureWithRestart(t *testing.T) {
+	className := "C2"
+	propName := "p1"
+	nestedPropName := "np1"
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		With1NodeCluster().
+		Start(ctx)
+	require.Nil(t, err)
+
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	delete := func() {
+		params := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		_, err := helper.Client(t).Schema.SchemaObjectsDelete(params, nil)
+		assert.Nil(t, err)
+	}
+	defer delete()
+
+	params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     propName,
+				DataType: []string{"object"},
+				NestedProperties: []*models.NestedProperty{{
+					Name:     nestedPropName,
+					DataType: []string{"text"},
+				}},
+			},
+		},
+	})
+
+	_, err = helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+	assert.Nil(t, err)
+
+	newDescription := "its updated description"
+
+	t.Run("update property and nested property data type and shall fail", func(t *testing.T) {
+		params := clschema.NewSchemaObjectsGetParams().
+			WithClassName(className)
+
+		res, err := helper.Client(t).Schema.SchemaObjectsGet(params, nil)
+		require.Nil(t, err)
+		assert.Equal(t, "", res.Payload.Properties[0].Description)
+
+		prop := res.Payload.Properties[0]
+		prop.Description = newDescription
+		prop.NestedProperties[0].Description = newDescription
+		prop.NestedProperties[0].Name = "faulty-np2"
+		prop.NestedProperties[0].DataType = []string{"boolean"}
+		updateParams := clschema.NewSchemaObjectsUpdateParams().
+			WithClassName(className).
+			WithObjectClass(&models.Class{
+				Class:      className,
+				Properties: []*models.Property{prop},
+			})
+		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
+		require.Error(t, err)
+
+		helper.AssertRequestFail(t, nil, err, func() {
+			errResponse, ok := err.(*schema.SchemaObjectsUpdateUnprocessableEntity)
+			require.True(t, ok)
+			require.Contains(t, errResponse.Payload.Error[0].Message, "property fields other than description cannot be updated through updating the class")
+		})
+	})
+
+	t.Run("restart node", func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, 0)
+		common.StartNodeAt(ctx, t, compose, 0)
+	})
+
+	t.Run("verify node is running after faulty schema update", func(t *testing.T) {
+		helper.SetupClient(compose.GetWeaviate().URI())
+		require.NotNil(t, helper.GetClass(t, className))
+	})
+}


### PR DESCRIPTION
### What's being changed:
in case of `Apply()` we were retuning in case of error early. this would have blocked marking the db open in case of schema is catching up. 

this PR shall fix this [test case ](https://github.com/weaviate/weaviate/pull/8167)
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15067419552
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
