### PR TITLE
chore(gcs-test): use STORAGE_EMULATOR_HOST for gcs backup test clients

### DIFF
--- a/test/helper/modules/modules_helper.go
+++ b/test/helper/modules/modules_helper.go
@@ -106,7 +106,11 @@ func CreateTestFiles(t *testing.T, dirPath string) []string {
 
 func CreateGCSBucket(ctx context.Context, t *testing.T, projectID, bucketName string) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+		opts := []option.ClientOption{option.WithoutAuthentication()}
+		if emulatorHost := os.Getenv("STORAGE_EMULATOR_HOST"); emulatorHost != "" {
+			opts = append(opts, option.WithEndpoint(emulatorHost))
+		}
+		client, err := storage.NewClient(ctx, opts...)
 		assert.Nil(t, err)
 		defer client.Close()
 
@@ -116,7 +120,11 @@ func CreateGCSBucket(ctx context.Context, t *testing.T, projectID, bucketName st
 
 func DeleteGCSBucket(ctx context.Context, t *testing.T, bucketName string) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+		opts := []option.ClientOption{option.WithoutAuthentication()}
+		if emulatorHost := os.Getenv("STORAGE_EMULATOR_HOST"); emulatorHost != "" {
+			opts = append(opts, option.WithEndpoint(emulatorHost))
+		}
+		client, err := storage.NewClient(ctx, opts...)
 		assert.Nil(t, err)
 		defer client.Close()
 


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
