### PR TITLE
Move unlocked FSM map reads in replication manager into locked methods in FSM manager

### DIFF
--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -1135,6 +1135,8 @@ func TestConsumerOpDuplication(t *testing.T) {
 				if time.Since(start) > 20*time.Second {
 					break
 				}
+				time.Sleep(1 * time.Second)
+				// Simulate a long-running operation
 			}
 			return nil
 		}).Times(1)

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -1132,7 +1132,7 @@ func TestConsumerOpDuplication(t *testing.T) {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				if time.Since(start) > 10*time.Second {
+				if time.Since(start) > 20*time.Second {
 					break
 				}
 			}
@@ -1178,7 +1178,7 @@ func TestConsumerOpDuplication(t *testing.T) {
 	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "test-shard", api.COPY)
 	status := replication.NewShardReplicationStatus(api.HYDRATING)
 
-	// Simulate the copying step that will loop for 10s before exiting
+	// Simulate the copying step that will loop for 20s before exiting
 	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	completionWg.Add(1)
 	// Send the same operation again to make sure it isn't reprocessed

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -117,19 +117,15 @@ func (m *Manager) GetReplicationDetailsByReplicationId(c *cmd.QueryRequest) ([]b
 		return nil, fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	id, ok := m.replicationFSM.idsByUuid[subCommand.Uuid]
+	op, ok := m.replicationFSM.GetOpByUuid(subCommand.Uuid)
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", types.ErrReplicationOperationNotFound, subCommand.Uuid)
 	}
 
-	response, err := m.getReplicationDetailsResponse(id)
-	if err != nil {
-		return nil, fmt.Errorf("could not get replication operation details: %w", err)
-	}
-
+	response := makeReplicationDetailsResponse(&op.Op, &op.Status)
 	payload, err := json.Marshal(response)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal query response for replication operation '%d': %w", id, err)
+		return nil, fmt.Errorf("could not marshal query response for replication operation '%s': %w", op.Op.UUID, err)
 	}
 
 	return payload, nil
@@ -141,13 +137,13 @@ func (m *Manager) GetReplicationOperationState(c *cmd.QueryRequest) ([]byte, err
 		return nil, fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	status, ok := m.replicationFSM.statusById[subCommand.Id]
+	op, ok := m.replicationFSM.GetOpById(subCommand.Id)
 	if !ok {
 		return nil, fmt.Errorf("unable to retrieve replication operation '%d' status", subCommand.Id)
 	}
 
 	response := cmd.ReplicationOperationStateResponse{
-		State: status.GetCurrent().State,
+		State: op.Status.GetCurrent().State,
 	}
 	payload, err := json.Marshal(response)
 	if err != nil {
@@ -170,11 +166,7 @@ func (m *Manager) GetReplicationDetailsByCollection(c *cmd.QueryRequest) ([]byte
 	}
 
 	for _, op := range ops {
-		response, err := m.getReplicationDetailsResponse(op.ID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get replication operation details: %w", err)
-		}
-		responses = append(responses, response)
+		responses = append(responses, makeReplicationDetailsResponse(&op.Op, &op.Status))
 	}
 
 	payload, err := json.Marshal(responses)
@@ -197,11 +189,7 @@ func (m *Manager) GetReplicationDetailsByCollectionAndShard(c *cmd.QueryRequest)
 	}
 
 	for _, op := range ops {
-		response, err := m.getReplicationDetailsResponse(op.ID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get replication operation details: %w", err)
-		}
-		responses = append(responses, response)
+		responses = append(responses, makeReplicationDetailsResponse(&op.Op, &op.Status))
 	}
 
 	payload, err := json.Marshal(responses)
@@ -224,11 +212,7 @@ func (m *Manager) GetReplicationDetailsByTargetNode(c *cmd.QueryRequest) ([]byte
 	}
 
 	for _, op := range ops {
-		response, err := m.getReplicationDetailsResponse(op.ID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get replication operation details: %w", err)
-		}
-		responses = append(responses, response)
+		responses = append(responses, makeReplicationDetailsResponse(&op.Op, &op.Status))
 	}
 
 	payload, err := json.Marshal(responses)
@@ -326,20 +310,6 @@ func makeReplicationDetailsResponse(op *ShardReplicationOp, status *ShardReplica
 		Status:        status.GetCurrent().ToAPIFormat(),
 		StatusHistory: status.GetHistory().ToAPIFormat(),
 	}
-}
-
-func (m *Manager) getReplicationDetailsResponse(id uint64) (cmd.ReplicationDetailsResponse, error) {
-	op, ok := m.replicationFSM.opsById[id]
-	if !ok {
-		return cmd.ReplicationDetailsResponse{}, fmt.Errorf("%w: %d", types.ErrReplicationOperationNotFound, id)
-	}
-
-	status, ok := m.replicationFSM.statusById[op.ID]
-	if !ok {
-		return cmd.ReplicationDetailsResponse{}, fmt.Errorf("unable to retrieve replication operation '%d' status", op.ID)
-	}
-
-	return makeReplicationDetailsResponse(&op, &status), nil
 }
 
 func (m *Manager) CancelReplication(c *cmd.ApplyRequest) error {

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -162,38 +162,85 @@ func (s *ShardReplicationFSM) resetState() {
 	s.opsByStateGauge.Reset()
 }
 
+func (s *ShardReplicationFSM) GetOpByUuid(uuid strfmt.UUID) (ShardReplicationOpAndStatus, bool) {
+	s.opsLock.RLock()
+	defer s.opsLock.RUnlock()
+	id, ok := s.idsByUuid[uuid]
+	if !ok {
+		return ShardReplicationOpAndStatus{}, false
+	}
+	op, ok := s.opsById[id]
+	if !ok {
+		return ShardReplicationOpAndStatus{}, false
+	}
+	status, ok := s.statusById[id]
+	if !ok {
+		return ShardReplicationOpAndStatus{}, false
+	}
+	return NewShardReplicationOpAndStatus(op, status), true
+}
+
+func (s *ShardReplicationFSM) GetOpById(id uint64) (ShardReplicationOpAndStatus, bool) {
+	s.opsLock.RLock()
+	defer s.opsLock.RUnlock()
+	op, ok := s.opsById[id]
+	if !ok {
+		return ShardReplicationOpAndStatus{}, false
+	}
+	status, ok := s.statusById[id]
+	if !ok {
+		return ShardReplicationOpAndStatus{}, false
+	}
+	return NewShardReplicationOpAndStatus(op, status), true
+}
+
 func (s *ShardReplicationFSM) GetOpsForTarget(node string) []ShardReplicationOp {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
 	return s.opsByTarget[node]
 }
 
-func (s *ShardReplicationFSM) GetOpsForCollection(collection string) ([]ShardReplicationOp, bool) {
+func (s *ShardReplicationFSM) GetOpsForCollection(collection string) ([]ShardReplicationOpAndStatus, bool) {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
-	val, ok := s.opsByCollection[collection]
-	return val, ok
+	ops, ok := s.opsByCollection[collection]
+	if !ok {
+		return nil, false
+	}
+	return s.getOpsWithStatus(ops), true
 }
 
-func (s *ShardReplicationFSM) GetOpsForCollectionAndShard(collection string, shard string) ([]ShardReplicationOp, bool) {
+func (s *ShardReplicationFSM) GetOpsForCollectionAndShard(collection string, shard string) ([]ShardReplicationOpAndStatus, bool) {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
 	shardOps, ok := s.opsByCollectionAndShard[collection]
 	if !ok {
 		return nil, false
 	}
-	val, ok := shardOps[shard]
+	ops, ok := shardOps[shard]
 	if !ok {
 		return nil, false
 	}
-	return val, true
+	return s.getOpsWithStatus(ops), true
 }
 
-func (s *ShardReplicationFSM) GetOpsForTargetNode(node string) ([]ShardReplicationOp, bool) {
+func (s *ShardReplicationFSM) getOpsWithStatus(ops []ShardReplicationOp) []ShardReplicationOpAndStatus {
+	opsWithStatus := make([]ShardReplicationOpAndStatus, 0, len(ops))
+	for _, op := range ops {
+		status, ok := s.statusById[op.ID]
+		if !ok {
+			continue
+		}
+		opsWithStatus = append(opsWithStatus, NewShardReplicationOpAndStatus(op, status))
+	}
+	return opsWithStatus
+}
+
+func (s *ShardReplicationFSM) GetOpsForTargetNode(node string) ([]ShardReplicationOpAndStatus, bool) {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
-	val, ok := s.opsByTarget[node]
-	return val, ok
+	ops, ok := s.opsByTarget[node]
+	return s.getOpsWithStatus(ops), ok
 }
 
 func (s *ShardReplicationFSM) GetStatusByOps() map[ShardReplicationOp]ShardReplicationOpStatus {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
