### PR TITLE
refact(raft-config): introduce raft timeouts multipler and adjust Query() and Apply() retries 

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -490,6 +490,8 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		BootstrapExpect:        appState.ServerConfig.Config.Raft.BootstrapExpect,
 		HeartbeatTimeout:       appState.ServerConfig.Config.Raft.HeartbeatTimeout,
 		ElectionTimeout:        appState.ServerConfig.Config.Raft.ElectionTimeout,
+		LeaderLeaseTimeout:     appState.ServerConfig.Config.Raft.LeaderLeaseTimeout,
+		TimeoutsMultiplier:     appState.ServerConfig.Config.Raft.TimeoutsMultiplier,
 		SnapshotInterval:       appState.ServerConfig.Config.Raft.SnapshotInterval,
 		SnapshotThreshold:      appState.ServerConfig.Config.Raft.SnapshotThreshold,
 		TrailingLogs:           appState.ServerConfig.Config.Raft.TrailingLogs,

--- a/cluster/backoff.go
+++ b/cluster/backoff.go
@@ -1,0 +1,45 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+// backoffConfig creates a backoff configuration based on the election timeout.
+// The initial interval is set to 1/20th of the election timeout, and the max interval
+// is set to the election timeout itself. This ensures that retries are aggressive
+// enough to detect leader changes quickly while not overwhelming the system.
+// With exponential backoff, each retry doubles the previous interval, but is capped at the max interval.
+// For example, with a 1s election timeout:
+// - Initial interval: 50ms (1/20th of election timeout)
+// - Max interval: 1s (election timeout)
+// - Max retries: 10
+// If electionTimeout = 1s → max time ≈ 5.55s (raft default)
+// If electionTimeout = 2s → max time ≈ 11.1s
+// If electionTimeout = 5s → max time ≈ 27.75s
+func backoffConfig(ctx context.Context, electionTimeout time.Duration) backoff.BackOffContext {
+	initialInterval := electionTimeout / 20
+	return backoff.WithContext(
+		backoff.WithMaxRetries(
+			backoff.NewExponentialBackOff(
+				backoff.WithInitialInterval(initialInterval),
+				backoff.WithMaxInterval(electionTimeout),
+			),
+			10,
+		),
+		ctx,
+	)
+}

--- a/cluster/backoff_test.go
+++ b/cluster/backoff_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package cluster
 
 import (

--- a/cluster/backoff_test.go
+++ b/cluster/backoff_test.go
@@ -1,0 +1,159 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		electionTimeout time.Duration
+		wantInitial     time.Duration
+		wantMax         time.Duration
+	}{
+		{
+			name:            "1 second election timeout",
+			electionTimeout: time.Second,
+			wantInitial:     time.Millisecond * 50, // 1/20th of 1s
+			wantMax:         time.Second,           // same as election timeout
+		},
+		{
+			name:            "2 second election timeout",
+			electionTimeout: time.Second * 2,
+			wantInitial:     time.Millisecond * 100, // 1/20th of 2s
+			wantMax:         time.Second * 2,        // same as election timeout
+		},
+		{
+			name:            "500ms election timeout",
+			electionTimeout: time.Millisecond * 500,
+			wantInitial:     time.Millisecond * 25,  // 1/20th of 500ms
+			wantMax:         time.Millisecond * 500, // same as election timeout
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			bo := backoffConfig(ctx, tt.electionTimeout)
+
+			// Test initial interval with larger delta to account for randomization
+			firstInterval := bo.NextBackOff()
+			// Allow up to 50% variation for initial interval
+			assert.InDelta(t, float64(tt.wantInitial), float64(firstInterval), float64(tt.wantInitial)*0.5)
+
+			// Collect all intervals
+			var intervals []time.Duration
+			for i := 0; i < 15; i++ { // Try more than max retries to ensure we get all intervals
+				next := bo.NextBackOff()
+				if next == backoff.Stop {
+					break
+				}
+				intervals = append(intervals, next)
+			}
+
+			// Verify we got at least 9 intervals (the backoff library might stop at 9)
+			assert.GreaterOrEqual(t, len(intervals), 9)
+			assert.LessOrEqual(t, len(intervals), 10)
+
+			// Verify max interval is within 50% of expected
+			maxInterval := intervals[len(intervals)-1]
+			assert.InDelta(t, float64(tt.wantMax), float64(maxInterval), float64(tt.wantMax)*0.5)
+
+			// Verify overall pattern:
+			// 1. All intervals should be between initial and max
+			// 2. Later intervals should generally be larger than earlier ones
+			minAllowed := float64(tt.wantInitial) * 0.5      // Allow 50% below initial
+			maxAllowed := float64(tt.wantMax) * float64(1.5) // Allow 50% above max
+
+			// Track the running average to detect general increase
+			var sum float64
+			var count int
+
+			for i, interval := range intervals {
+				duration := float64(interval)
+
+				// Check bounds
+				assert.GreaterOrEqual(t, duration, minAllowed, "interval %d too small", i)
+				assert.LessOrEqual(t, duration, maxAllowed, "interval %d too large", i)
+
+				// Update running average
+				sum += duration
+				count++
+				avg := sum / float64(count)
+
+				// After first few intervals, check that we're generally increasing
+				if i > 2 {
+					// Current interval should be at least 80% of the average so far
+					// This allows for some variation while ensuring general increase
+					assert.GreaterOrEqual(t, duration, avg*0.8,
+						"interval %d (%v) too small compared to average so far (%v)",
+						i, interval, time.Duration(avg))
+				}
+			}
+
+			// Verify context is properly set
+			assert.Equal(t, ctx, bo.Context())
+		})
+	}
+}
+
+func TestBackoffBehavior(t *testing.T) {
+	ctx := context.Background()
+	electionTimeout := time.Second
+	bo := backoffConfig(ctx, electionTimeout)
+
+	// Test that intervals increase exponentially but are capped at max interval
+	intervals := make([]time.Duration, 0)
+	for i := 0; i < 15; i++ { // Try more than max retries to verify capping
+		next := bo.NextBackOff()
+		if next == backoff.Stop {
+			break
+		}
+		intervals = append(intervals, next)
+	}
+
+	// Should have between 9 and 10 retries
+	assert.GreaterOrEqual(t, len(intervals), 9)
+	assert.LessOrEqual(t, len(intervals), 10)
+
+	// Verify overall pattern using the same approach as TestBackoffConfig
+	minAllowed := float64(time.Millisecond * 25)      // 50% of initial (50ms)
+	maxAllowed := float64(time.Second) * float64(1.5) // 50% above max (1s)
+
+	var sum float64
+	var count int
+
+	for i, interval := range intervals {
+		duration := float64(interval)
+
+		// Check bounds
+		assert.GreaterOrEqual(t, duration, minAllowed, "interval %d too small", i)
+		assert.LessOrEqual(t, duration, maxAllowed, "interval %d too large", i)
+
+		// Update running average
+		sum += duration
+		count++
+		avg := sum / float64(count)
+
+		// After first few intervals, check that we're generally increasing
+		if i > 2 {
+			assert.GreaterOrEqual(t, duration, avg*0.8,
+				"interval %d (%v) too small compared to average so far (%v)",
+				i, interval, time.Duration(avg))
+		}
+	}
+
+	// Verify total time is within reasonable bounds
+	totalTime := time.Duration(0)
+	for _, interval := range intervals {
+		totalTime += interval
+	}
+	expectedTotal := time.Millisecond * 5550 // 50 + 100 + 200 + 400 + 800 + 1000*5
+	// Allow 40% variation for total time due to randomization
+	assert.InDelta(t, float64(expectedTotal), float64(totalTime), float64(expectedTotal)*0.4)
+}

--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/raft"
@@ -242,8 +241,7 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		}
 		schemaVersion = resp.Version
 		return nil
-		// Retry at most for 2 seconds, it shouldn't take longer for an election to take place
-	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx))
+	}, backoffConfig(ctx, s.store.cfg.ElectionTimeout))
 
 	return schemaVersion, err
 }

--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -241,7 +241,8 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		}
 		schemaVersion = resp.Version
 		return nil
-	}, backoffConfig(ctx, s.store.cfg.ElectionTimeout))
+		// pass in the election timeout after applying multiplier
+	}, backoffConfig(ctx, s.store.raftConfig().ElectionTimeout))
 
 	return schemaVersion, err
 }

--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -383,7 +383,8 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 		}
 
 		return nil
-	}, backoffConfig(ctx, s.store.cfg.ElectionTimeout)); err != nil {
+		// pass in the election timeout after applying multiplier
+	}, backoffConfig(ctx, s.store.raftConfig().ElectionTimeout)); err != nil {
 		s.log.Warnf("query: failed to find leader after retries: %s", err)
 		return &cmd.QueryResponse{}, err
 	}

--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/getsentry/sentry-go"
@@ -380,15 +379,12 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 	var leader string
 	if err := backoff.Retry(func() error {
 		if leader = s.store.Leader(); leader == "" {
-			err := s.leaderErr()
-			s.log.Warnf("query: could not find leader: %s", err)
-			return err
+			return s.leaderErr()
 		}
 
 		return nil
-	}, backoff.WithContext(backoff.WithMaxRetries(
-		backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx)); err != nil {
-		s.log.Errorf("query: failed to find leader after retries: %s", err)
+	}, backoffConfig(ctx, s.store.cfg.ElectionTimeout)); err != nil {
+		s.log.Warnf("query: failed to find leader after retries: %s", err)
 		return &cmd.QueryResponse{}, err
 	}
 

--- a/cluster/store_raft_config_test.go
+++ b/cluster/store_raft_config_test.go
@@ -1,0 +1,166 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaftConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		expectedConfig func(*raft.Config)
+	}{
+		{
+			name: "default configuration",
+			config: Config{
+				NodeID:          "node1",
+				Logger:          logrus.New(),
+				Voter:           true,
+				WorkDir:         t.TempDir(),
+				Host:            "localhost",
+				RaftPort:        9090,
+				RPCPort:         9091,
+				BootstrapExpect: 1,
+			},
+			expectedConfig: func(cfg *raft.Config) {
+				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
+				assert.Equal(t, "info", cfg.LogLevel)
+				assert.True(t, cfg.NoLegacyTelemetry)
+				assert.NotNil(t, cfg.Logger)
+				// Default timeouts should be used since none were specified
+				assert.Equal(t, raft.DefaultConfig().HeartbeatTimeout, cfg.HeartbeatTimeout)
+				assert.Equal(t, raft.DefaultConfig().ElectionTimeout, cfg.ElectionTimeout)
+				assert.Equal(t, raft.DefaultConfig().LeaderLeaseTimeout, cfg.LeaderLeaseTimeout)
+				assert.Equal(t, raft.DefaultConfig().SnapshotInterval, cfg.SnapshotInterval)
+				assert.Equal(t, raft.DefaultConfig().SnapshotThreshold, cfg.SnapshotThreshold)
+				assert.Equal(t, raft.DefaultConfig().TrailingLogs, cfg.TrailingLogs)
+			},
+		},
+		{
+			name: "custom timeouts with multiplier",
+			config: Config{
+				NodeID:             "node1",
+				Logger:             logrus.New(),
+				Voter:              true,
+				WorkDir:            t.TempDir(),
+				Host:               "localhost",
+				RaftPort:           9090,
+				RPCPort:            9091,
+				BootstrapExpect:    1,
+				HeartbeatTimeout:   2 * time.Second,
+				ElectionTimeout:    3 * time.Second,
+				LeaderLeaseTimeout: 4 * time.Second,
+				TimeoutsMultiplier: 2,
+			},
+			expectedConfig: func(cfg *raft.Config) {
+				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
+				assert.Equal(t, "info", cfg.LogLevel)
+				assert.True(t, cfg.NoLegacyTelemetry)
+				assert.NotNil(t, cfg.Logger)
+				// Timeouts should be multiplied by 2
+				assert.Equal(t, 4*time.Second, cfg.HeartbeatTimeout)
+				assert.Equal(t, 6*time.Second, cfg.ElectionTimeout)
+				assert.Equal(t, 8*time.Second, cfg.LeaderLeaseTimeout)
+			},
+		},
+		{
+			name: "custom timeouts without multiplier",
+			config: Config{
+				NodeID:             "node1",
+				Logger:             logrus.New(),
+				Voter:              true,
+				WorkDir:            t.TempDir(),
+				Host:               "localhost",
+				RaftPort:           9090,
+				RPCPort:            9091,
+				BootstrapExpect:    1,
+				HeartbeatTimeout:   2 * time.Second,
+				ElectionTimeout:    3 * time.Second,
+				LeaderLeaseTimeout: 4 * time.Second,
+				// TimeoutsMultiplier not set, should default to 1
+			},
+			expectedConfig: func(cfg *raft.Config) {
+				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
+				assert.Equal(t, "info", cfg.LogLevel)
+				assert.True(t, cfg.NoLegacyTelemetry)
+				assert.NotNil(t, cfg.Logger)
+				// Timeouts should remain unchanged since multiplier is not set
+				assert.Equal(t, 2*time.Second, cfg.HeartbeatTimeout)
+				assert.Equal(t, 3*time.Second, cfg.ElectionTimeout)
+				assert.Equal(t, 4*time.Second, cfg.LeaderLeaseTimeout)
+			},
+		},
+		{
+			name: "custom snapshot settings",
+			config: Config{
+				NodeID:            "node1",
+				Logger:            logrus.New(),
+				Voter:             true,
+				WorkDir:           t.TempDir(),
+				Host:              "localhost",
+				RaftPort:          9090,
+				RPCPort:           9091,
+				BootstrapExpect:   1,
+				SnapshotInterval:  5 * time.Second,
+				SnapshotThreshold: 100,
+				TrailingLogs:      200,
+			},
+			expectedConfig: func(cfg *raft.Config) {
+				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
+				assert.Equal(t, "info", cfg.LogLevel)
+				assert.True(t, cfg.NoLegacyTelemetry)
+				assert.NotNil(t, cfg.Logger)
+				// Snapshot settings should be set to custom values
+				assert.Equal(t, 5*time.Second, cfg.SnapshotInterval)
+				assert.Equal(t, uint64(100), cfg.SnapshotThreshold)
+				assert.Equal(t, uint64(200), cfg.TrailingLogs)
+			},
+		},
+		{
+			name: "debug log level",
+			config: Config{
+				NodeID:          "node1",
+				Logger:          func() *logrus.Logger { l := logrus.New(); l.SetLevel(logrus.DebugLevel); return l }(),
+				Voter:           true,
+				WorkDir:         t.TempDir(),
+				Host:            "localhost",
+				RaftPort:        9090,
+				RPCPort:         9091,
+				BootstrapExpect: 1,
+			},
+			expectedConfig: func(cfg *raft.Config) {
+				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
+				assert.Equal(t, "debug", cfg.LogLevel)
+				assert.True(t, cfg.NoLegacyTelemetry)
+				assert.NotNil(t, cfg.Logger)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewFSM(tt.config, nil, nil, prometheus.NewPedanticRegistry())
+			cfg := store.raftConfig()
+			require.NotNil(t, cfg)
+			tt.expectedConfig(cfg)
+		})
+	}
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -447,6 +447,8 @@ type Raft struct {
 
 	HeartbeatTimeout       time.Duration
 	ElectionTimeout        time.Duration
+	LeaderLeaseTimeout     time.Duration
+	TimeoutsMultiplier     int
 	ConsistencyWaitTimeout time.Duration
 
 	BootstrapTimeout   time.Duration

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -904,22 +904,6 @@ func parsePositiveInt(envName string, cb func(val int), defaultValue int) error 
 	})
 }
 
-func parsePositiveFloat(envName string, cb func(val float64), defaultValue float64) error {
-	if v := os.Getenv(envName); v != "" {
-		asFloat, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return fmt.Errorf("parse %s as float: %w", envName, err)
-		}
-		if asFloat <= 0 {
-			return fmt.Errorf("%s must be a positive value larger than 0. Got: %v", envName, asFloat)
-		}
-		cb(asFloat)
-	} else {
-		cb(defaultValue)
-	}
-	return nil
-}
-
 func parseNonNegativeInt(envName string, cb func(val int), defaultValue int) error {
 	return parseIntVerify(envName, defaultValue, cb, func(val int) error {
 		if val < 0 {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/usecases/cluster"
 )
 
@@ -1176,6 +1177,112 @@ func TestEnvironmentPersistenceMaxReuseWalSize(t *testing.T) {
 				require.NotNil(t, err)
 			} else {
 				require.Equal(t, tt.expected, conf.Persistence.MaxReuseWalSize)
+			}
+		})
+	}
+}
+
+func TestParsePositiveFloat(t *testing.T) {
+	tests := []struct {
+		name         string
+		envName      string
+		envValue     string
+		defaultValue float64
+		expected     float64
+		expectError  bool
+	}{
+		{
+			name:         "valid positive float",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "1.5",
+			defaultValue: 2.0,
+			expected:     1.5,
+			expectError:  false,
+		},
+		{
+			name:         "valid integer as float",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "2",
+			defaultValue: 1.0,
+			expected:     2.0,
+			expectError:  false,
+		},
+		{
+			name:         "use default when env not set",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "",
+			defaultValue: 3.0,
+			expected:     3.0,
+			expectError:  false,
+		},
+		{
+			name:         "zero value should error",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "0",
+			defaultValue: 1.0,
+			expected:     0,
+			expectError:  true,
+		},
+		{
+			name:         "negative value should error",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "-1.5",
+			defaultValue: 1.0,
+			expected:     0,
+			expectError:  true,
+		},
+		{
+			name:         "invalid float should error",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "not-a-float",
+			defaultValue: 1.0,
+			expected:     0,
+			expectError:  true,
+		},
+		{
+			name:         "very small positive float",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "0.0000001",
+			defaultValue: 1.0,
+			expected:     0.0000001,
+			expectError:  false,
+		},
+		{
+			name:         "very large positive float",
+			envName:      "TEST_POSITIVE_FLOAT",
+			envValue:     "999999.999999",
+			defaultValue: 1.0,
+			expected:     999999.999999,
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment
+			if tt.envValue != "" {
+				t.Setenv(tt.envName, tt.envValue)
+			} else {
+				os.Unsetenv(tt.envName)
+			}
+
+			// Create a variable to store the result
+			var result float64
+
+			// Call the function
+			err := parsePositiveFloat(tt.envName, func(val float64) {
+				result = val
+			}, tt.defaultValue)
+
+			// Check error
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.envValue != "" {
+					assert.Contains(t, err.Error(), tt.envName)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:
This PR introduces several improvements to the Raft consensus configuration system, including a new timeouts multiplier feature and backoff mechanism for better cluster stability and performance.

Key factor is improves the cluster's ability to handle network latency and provide more flexible configuration options for different deployment scenarios. The timeouts multiplier feature allows operators to easily adjust cluster timing parameters based on their specific network conditions.

- exposes new raft config `LeaderLeaseTimeout`
- adjust the backoff of retrying in `leader not found` 
- introduce raft `RAFT_TIMEOUTS_MULTIPLIER` which  
  - Allows scaling of all Raft timeouts (heartbeat, election, leader lease) by a single multiplier
  - Defaults to 1 when not specified
  - Helps in tuning cluster behavior for different network conditions

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15114388432
- [x] E2E pipeline : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/15114391986
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
