### PR TITLE
Make adding/removing replica to shards idempotent to not fail on retries

### DIFF
--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -632,12 +632,12 @@ func (c *CopyOpConsumer) processDehydratingOp(ctx context.Context, op ShardRepli
 	logger.Info("processing dehydrating replication operation")
 
 	replicaExists := false
-	nodes, err := c.schemaReader.ShardReplicas(op.Op.TargetShard.CollectionId, op.Op.TargetShard.ShardId)
+	nodes, err := c.schemaReader.ShardReplicas(op.Op.SourceShard.CollectionId, op.Op.SourceShard.ShardId)
 	if err != nil {
 		logger.WithError(err).Error("failure while getting shard replicas")
 		return api.ShardReplicationState(""), err
 	}
-	if slices.Contains(nodes, op.Op.TargetShard.NodeId) {
+	if slices.Contains(nodes, op.Op.SourceShard.NodeId) {
 		replicaExists = true
 	}
 

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -172,10 +172,7 @@ func TestConsumerWithCallbacks(t *testing.T) {
 			doneChan <- consumer.Consume(ctx, opsChan)
 		}()
 
-		opsChan <- replication.NewShardReplicationOpAndStatus(
-			replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "TestCollection", "shard1", api.COPY),
-			replication.NewShardReplicationStatus(api.REGISTERED),
-		)
+		opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		waitChan := make(chan struct{})
 		go func() {
 			completionWg.Wait()
@@ -467,8 +464,8 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		}()
 
 		for i := 0; i < randomNumberOfOps; i++ {
-			shard := fmt.Sprintf("shard-%d", i)
-			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", "node2", "TestCollection", shard, api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+			node := fmt.Sprintf("node-%d", i)
+			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", node, "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		}
 
 		waitChan := make(chan struct{})
@@ -599,8 +596,8 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		require.NoError(t, err, "error while generating random op id start")
 
 		for i := 0; i < totalOps; i++ {
-			shard := fmt.Sprintf("shard-%d", i)
-			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", "node2", "TestCollection", shard, api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+			node := fmt.Sprintf("node-%d", i)
+			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", node, "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		}
 
 		close(opsChan)
@@ -689,10 +686,10 @@ func TestConsumerWithCallbacks(t *testing.T) {
 					CopyReplica(mock.Anything, "node1", "TestCollection", mock.Anything, mock.Anything).
 					Return(nil)
 				mockFSMUpdater.EXPECT().
-					AddReplicaToShard(mock.Anything, "TestCollection", mock.Anything, "node2").
+					AddReplicaToShard(mock.Anything, "TestCollection", mock.Anything, mock.Anything).
 					Return(uint64(i), nil)
 				mockReplicaCopier.EXPECT().
-					AsyncReplicationStatus(mock.Anything, "node1", "node2", "TestCollection", mock.Anything).
+					AsyncReplicationStatus(mock.Anything, "node1", mock.Anything, "TestCollection", mock.Anything).
 					Return(models.AsyncReplicationStatus{
 						ObjectsPropagated:       0,
 						StartDiffTimeUnixMillis: time.Now().Add(200 * time.Second).UnixMilli(),
@@ -775,8 +772,8 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		}()
 
 		for i := 0; i < totalOps; i++ {
-			shard := fmt.Sprintf("shard-%d", i)
-			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", "node2", "TestCollection", shard, api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+			node := fmt.Sprintf("node-%d", i)
+			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", node, "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		}
 
 		waitChan := make(chan struct{})
@@ -1079,6 +1076,13 @@ func TestConsumerOpDuplication(t *testing.T) {
 	parser := fakes.NewMockParser()
 	parser.On("ParseClass", mock.Anything).Return(nil)
 	schemaManager := schema.NewSchemaManager("test-node", nil, parser, prometheus.NewPedanticRegistry(), logrus.New())
+	schemaManager.AddClass(
+		buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
+			Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
+			State: &sharding.State{
+				Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1"}}},
+			},
+		}), "node1", true, false)
 	schemaReader := schemaManager.NewSchemaReader()
 	schemaManager.AddClass(
 		buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -72,14 +72,14 @@ func TestConsumerWithCallbacks(t *testing.T) {
 			ReplicationUpdateReplicaOpStatus(uint64(opId), api.READY).
 			Return(nil)
 		mockFSMUpdater.EXPECT().
-			AddReplicaToShard(mock.Anything, "TestCollection", mock.Anything, "node2").
+			AddReplicaToShard(mock.Anything, "TestCollection", "shard1", "node2").
 			Return(uint64(0), nil)
 		mockFSMUpdater.EXPECT().
-			SyncShard(mock.Anything, "TestCollection", mock.Anything, "node1").
+			SyncShard(mock.Anything, "TestCollection", "shard1", "node1").
 			Return(uint64(0), nil).
 			Times(1)
 		mockFSMUpdater.EXPECT().
-			SyncShard(mock.Anything, "TestCollection", mock.Anything, "node2").
+			SyncShard(mock.Anything, "TestCollection", "shard1", "node2").
 			Return(uint64(0), nil).
 			Times(1)
 		mockReplicaCopier.EXPECT().
@@ -87,16 +87,16 @@ func TestConsumerWithCallbacks(t *testing.T) {
 				mock.Anything,
 				"node1",
 				"TestCollection",
-				mock.Anything,
+				"shard1",
 				mock.Anything,
 			).
 			Once().
 			Return(nil)
 		mockReplicaCopier.EXPECT().
-			InitAsyncReplicationLocally(mock.Anything, "TestCollection", mock.Anything).
+			InitAsyncReplicationLocally(mock.Anything, "TestCollection", "shard1").
 			Return(nil)
 		mockReplicaCopier.EXPECT().
-			AsyncReplicationStatus(mock.Anything, "node1", "node2", "TestCollection", mock.Anything).
+			AsyncReplicationStatus(mock.Anything, "node1", "node2", "TestCollection", "shard1").
 			Return(models.AsyncReplicationStatus{
 				ObjectsPropagated:       0,
 				StartDiffTimeUnixMillis: time.Now().Add(200 * time.Second).UnixMilli(),
@@ -106,7 +106,7 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		mockReplicaCopier.EXPECT().
 			RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).Return(nil)
 		mockReplicaCopier.EXPECT().
-			RevertAsyncReplicationLocally(mock.Anything, "TestCollection", mock.Anything).Return(nil)
+			RevertAsyncReplicationLocally(mock.Anything, "TestCollection", "shard1").Return(nil)
 
 		var (
 			prepareProcessingCallbacksCounter int
@@ -172,7 +172,10 @@ func TestConsumerWithCallbacks(t *testing.T) {
 			doneChan <- consumer.Consume(ctx, opsChan)
 		}()
 
-		opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "TestCollection", "test-shard", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+		opsChan <- replication.NewShardReplicationOpAndStatus(
+			replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "TestCollection", "shard1", api.COPY),
+			replication.NewShardReplicationStatus(api.REGISTERED),
+		)
 		waitChan := make(chan struct{})
 		go func() {
 			completionWg.Wait()
@@ -233,7 +236,7 @@ func TestConsumerWithCallbacks(t *testing.T) {
 				mock.Anything,
 				"node1",
 				"TestCollection",
-				"test-shard",
+				"shard1",
 				mock.Anything,
 			).
 			Once().
@@ -305,7 +308,7 @@ func TestConsumerWithCallbacks(t *testing.T) {
 			doneChan <- consumer.Consume(ctx, opsChan)
 		}()
 
-		opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "TestCollection", "test-shard", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+		opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(opId), "node1", "node2", "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		waitChan := make(chan struct{})
 		go func() {
 			completionWg.Wait()
@@ -343,16 +346,19 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		parser.On("ParseClass", mock.Anything).Return(nil)
 		schemaManager := schema.NewSchemaManager("test-node", nil, parser, prometheus.NewPedanticRegistry(), logrus.New())
 		schemaReader := schemaManager.NewSchemaReader()
-		schemaManager.AddClass(
-			buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
-				Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
-				State: &sharding.State{
-					Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1"}}},
-				},
-			}), "node1", true, false)
 
 		randomNumberOfOps, err := randInt(t, 10, 20)
 		require.NoError(t, err, "error while generating random number of operations")
+
+		physical := make(map[string]sharding.Physical)
+		for i := 0; i < randomNumberOfOps; i++ {
+			physical[fmt.Sprintf("shard-%d", i)] = sharding.Physical{BelongsToNodes: []string{"node1"}}
+		}
+		schemaManager.AddClass(
+			buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
+				Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
+				State: &sharding.State{Physical: physical},
+			}), "node1", true, false)
 
 		randomStartOpId, err := randInt(t, 1000, 2000)
 		require.NoError(t, err, "error while generating random op id start")
@@ -625,16 +631,20 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		parser.On("ParseClass", mock.Anything).Return(nil)
 		schemaManager := schema.NewSchemaManager("test-node", nil, parser, prometheus.NewPedanticRegistry(), logrus.New())
 		schemaReader := schemaManager.NewSchemaReader()
-		schemaManager.AddClass(
-			buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
-				Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
-				State: &sharding.State{
-					Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1"}}},
-				},
-			}), "node1", true, false)
 
 		totalOps, err := randInt(t, 10, 20)
 		require.NoError(t, err, "error while generating random number of operations")
+
+		physical := make(map[string]sharding.Physical)
+		for i := 0; i < totalOps; i++ {
+			physical[fmt.Sprintf("shard-%d", i)] = sharding.Physical{BelongsToNodes: []string{"node1"}}
+		}
+
+		schemaManager.AddClass(
+			buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
+				Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
+				State: &sharding.State{Physical: physical},
+			}), "node1", true, false)
 
 		var (
 			mutex                  sync.Mutex
@@ -894,7 +904,7 @@ func TestConsumerOpCancellation(t *testing.T) {
 			}
 		}).Maybe()
 
-	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "test-shard", api.COPY)
+	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 
 	status := replication.NewShardReplicationStatus(api.HYDRATING)
 	mockFSMUpdater.EXPECT().
@@ -1024,7 +1034,7 @@ func TestConsumerOpDeletion(t *testing.T) {
 			}
 		}).Maybe()
 
-	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "test-shard", api.COPY)
+	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 
 	status := replication.NewShardReplicationStatus(api.HYDRATING)
 	mockFSMUpdater.EXPECT().
@@ -1177,7 +1187,7 @@ func TestConsumerOpDuplication(t *testing.T) {
 	mockFSMUpdater.EXPECT().
 		SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(1), nil)
 
-	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "test-shard", api.COPY)
+	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 	status := replication.NewShardReplicationStatus(api.HYDRATING)
 
 	// Simulate the copying step that will loop for 20s before exiting

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -464,8 +464,8 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		}()
 
 		for i := 0; i < randomNumberOfOps; i++ {
-			node := fmt.Sprintf("node-%d", i)
-			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", node, "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+			shard := fmt.Sprintf("shard-%d", i)
+			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", "node2", "TestCollection", shard, api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		}
 
 		waitChan := make(chan struct{})
@@ -772,8 +772,8 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		}()
 
 		for i := 0; i < totalOps; i++ {
-			node := fmt.Sprintf("node-%d", i)
-			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", node, "TestCollection", "shard1", api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
+			shard := fmt.Sprintf("shard-%d", i)
+			opsChan <- replication.NewShardReplicationOpAndStatus(replication.NewShardReplicationOp(uint64(randomStartOpId+i), "node1", "node2", "TestCollection", shard, api.COPY), replication.NewShardReplicationStatus(api.REGISTERED))
 		}
 
 		waitChan := make(chan struct{})

--- a/cluster/replication/manager_test.go
+++ b/cluster/replication/manager_test.go
@@ -127,6 +127,27 @@ func TestManager_Replicate(t *testing.T) {
 					buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
 						Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
 						State: &sharding.State{
+							Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1", "node2"}}},
+						},
+					}), "node1", true, false)
+			},
+			request: &api.ReplicationReplicateShardRequest{
+				Uuid:             uuid4(),
+				SourceCollection: "TestCollection",
+				SourceShard:      "shard1",
+				SourceNode:       "node1",
+				TargetNode:       "node2",
+				TransferType:     api.COPY.String(),
+			},
+			expectedError: replication.ErrAlreadyExists,
+		},
+		{
+			name: "source and target are identicals",
+			schemaSetup: func(t *testing.T, s *schema.SchemaManager) error {
+				return s.AddClass(
+					buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
+						Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
+						State: &sharding.State{
 							Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1"}}},
 						},
 					}), "node1", true, false)
@@ -139,7 +160,7 @@ func TestManager_Replicate(t *testing.T) {
 				TargetNode:       "node1",
 				TransferType:     api.COPY.String(),
 			},
-			expectedError: replication.ErrAlreadyExists,
+			expectedError: replication.ErrBadRequest,
 		},
 	}
 

--- a/cluster/replication/validate.go
+++ b/cluster/replication/validate.go
@@ -31,6 +31,9 @@ func ValidateReplicationReplicateShard(schemaReader schema.SchemaReader, c *api.
 	if c.Uuid == "" {
 		return fmt.Errorf("uuid is required: %w", ErrBadRequest)
 	}
+	if c.SourceNode == c.TargetNode {
+		return fmt.Errorf("source and target node are the same: %w", ErrBadRequest)
+	}
 
 	classInfo := schemaReader.ClassInfo(c.SourceCollection)
 	// ClassInfo doesn't return an error, so the only way to know if the class exist is to check if the Exists

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -29,9 +29,7 @@ import (
 
 const shardNameLength = 12
 
-var (
-	ErrReplicaAlreadyExists = errors.New("replica already exists")
-)
+var ErrReplicaAlreadyExists = errors.New("replica already exists")
 
 type State struct {
 	IndexID             string              `json:"indexID"` // for monitoring, reporting purposes. Does not influence the shard-calculations

--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -12,6 +12,7 @@
 package sharding
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -27,6 +28,10 @@ import (
 )
 
 const shardNameLength = 12
+
+var (
+	ErrReplicaAlreadyExists = errors.New("replica already exists")
+)
 
 type State struct {
 	IndexID             string              `json:"indexID"` // for monitoring, reporting purposes. Does not influence the shard-calculations
@@ -104,7 +109,7 @@ func (s *State) DeleteReplicaFromShard(shard string, replica string) error {
 
 func (p *Physical) AddReplica(replica string) error {
 	if slices.Contains(p.BelongsToNodes, replica) {
-		return fmt.Errorf("replica %s already exists", replica)
+		return fmt.Errorf("%w: %s", ErrReplicaAlreadyExists, replica)
 	}
 	p.BelongsToNodes = append(p.BelongsToNodes, replica)
 	return nil


### PR DESCRIPTION
### What's being changed:

Make operations adding/removing replicas to the sharding state idempotent and handle the replica already existing/being deleted.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
