### PR TITLE
Add debug handler to remove async replication target overrides

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -496,6 +496,20 @@ func (i *Index) IncomingRemoveAsyncReplicationTargetNode(ctx context.Context,
 	return shard.removeTargetNodeOverride(ctx, targetNodeOverride)
 }
 
+// IncomingAllRemoveAsyncReplicationTargetNodes removes all target node overrides for async
+// replication. Async replication will be reset to it's default configuration.
+func (i *Index) IncomingRemoveAllAsyncReplicationTargetNodes(ctx context.Context,
+	shardName string,
+) error {
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil || shard == nil {
+		return fmt.Errorf("incoming remove all async replication target nodes get shard %s: %w", shardName, err)
+	}
+	defer release()
+
+	return shard.removeAllTargetNodeOverrides(ctx)
+}
+
 func (s *Shard) filePutter(ctx context.Context,
 	filePath string,
 ) (io.WriteCloser, error) {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -168,6 +168,9 @@ type ShardLike interface {
 	addTargetNodeOverride(ctx context.Context, targetNodeOverride additional.AsyncReplicationTargetNodeOverride) error
 	// removeTargetNodeOverride removes a target node override from the shard.
 	removeTargetNodeOverride(ctx context.Context, targetNodeOverride additional.AsyncReplicationTargetNodeOverride) error
+	// removeAllTargetNodeOverrides removes all target node overrides from the shard
+	// and resets the async replication config.
+	removeAllTargetNodeOverrides(ctx context.Context) error
 
 	// getAsyncReplicationStats returns all current sync replication stats for this node/shard
 	getAsyncReplicationStats(ctx context.Context) []*models.AsyncReplicationStatus

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -296,6 +296,13 @@ func (l *LazyLoadShard) removeTargetNodeOverride(ctx context.Context, targetNode
 	return nil
 }
 
+func (l *LazyLoadShard) removeAllTargetNodeOverrides(ctx context.Context) error {
+	if err := l.Load(ctx); err != nil {
+		return err
+	}
+	return l.shard.removeAllTargetNodeOverrides(ctx)
+}
+
 func (l *LazyLoadShard) getAsyncReplicationStats(ctx context.Context) []*models.AsyncReplicationStatus {
 	if err := l.Load(ctx); err != nil {
 		return nil


### PR DESCRIPTION
### What's being changed:

Adds a debug handler to remove async replication target overrides, this is a just a "backup" in case we init the async replication hashtree due to replica movement but do to an unexpected error, they get "orphaned". Currently, this approach requires that you specific the shards/tenants, if needed in the future we can add a "for all shards/tenants" endpoint.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
