### PR TITLE
Check h.nodes length during tombstone cleanup

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -845,7 +845,9 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 
 		h.resetLock.Lock()
 		h.shardedNodeLocks.Lock(id)
-		h.nodes[id] = nil
+		if uint64(len(h.nodes)) > id {
+			h.nodes[id] = nil
+		}
 		h.shardedNodeLocks.Unlock(id)
 		if h.compressed.Load() {
 			h.compressor.Delete(context.TODO(), id)


### PR DESCRIPTION
### What's being changed:
- This is mainly to fix the flaky test `Test_ResetNodesDuringTombstoneCleanup` as in normal operations `h.nodes` is not expected to be truncated while a tombstone cleanup is running.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
