### PR TITLE
make sure we delete from onFlight only if we acquired it in that worker to avoid side effect

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -470,8 +470,11 @@ func (i *Index) IncomingAddAsyncReplicationTargetNode(
 	targetNodeOverride additional.AsyncReplicationTargetNodeOverride,
 ) error {
 	shard, release, err := i.GetShard(ctx, shardName)
-	if err != nil || shard == nil {
-		return fmt.Errorf("incoming add async replication target node get shard %s: %w", shardName, err)
+	if err != nil {
+		return fmt.Errorf("incoming add async replication get shard %s err: %w", shardName, err)
+	}
+	if shard == nil {
+		return fmt.Errorf("incoming add async replication get shard %s: shard not found", shardName)
 	}
 	defer release()
 

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -207,13 +207,13 @@ func (c *CopyOpConsumer) Consume(workerCtx context.Context, in <-chan ShardRepli
 			// allowing another worker to proceed. This ensures only a limited number of workers is concurrently
 			// running replication operations and avoids overloading the system.
 			case c.tokens <- struct{}{}:
-
 				// Here we capture the op argument used by the func below as the enterrors.GoWrapper requires calling
 				// a function without arguments.
 				operation := op
 				opLogger := getLoggerForOpAndStatus(c.logger.Logger, operation.Op, op.Status)
 				shouldSkip := false
-				if c.ongoingOps.LoadOrStore(op.Op.ID) {
+				opAlreadyInFlight := c.ongoingOps.LoadOrStore(op.Op.ID)
+				if opAlreadyInFlight {
 					// Check if the operation is already in progress
 					// Avoid scheduling unnecessary work or incorrectly counting metrics
 					// for operations that are already in progress or completed.
@@ -225,11 +225,13 @@ func (c *CopyOpConsumer) Consume(workerCtx context.Context, in <-chan ShardRepli
 					// For now, we need it to ensure eventual consistency between the FSM and the consumer
 					state, err := c.leaderClient.ReplicationGetReplicaOpStatus(workerCtx, op.Op.ID)
 					if err != nil {
-						c.logger.WithFields(logrus.Fields{"op": op}).Error("error while checking status of replication op")
+						c.logger.Error("error while checking status of replication op")
 						shouldSkip = true
+						c.ongoingOps.DeleteInFlight(op.Op.ID)
 					} else if state.String() != op.Status.GetCurrent().State.String() {
-						c.logger.WithFields(logrus.Fields{"op": op}).Debug("replication op skipped as state has changed")
+						c.logger.Debug("replication op skipped as state has changed")
 						shouldSkip = true
+						c.ongoingOps.DeleteInFlight(op.Op.ID)
 					}
 				}
 
@@ -247,8 +249,10 @@ func (c *CopyOpConsumer) Consume(workerCtx context.Context, in <-chan ShardRepli
 					opLogger.Debug("replication op skipped as already running")
 					// Need to release the token to let other consumers process queued replication operations.
 					<-c.tokens
-					c.ongoingOps.DeleteInFlight(op.Op.ID)
 					c.engineOpCallbacks.OnOpSkipped(c.nodeId)
+					if !opAlreadyInFlight {
+						c.ongoingOps.DeleteInFlight(op.Op.ID)
+					}
 					continue
 				}
 
@@ -268,25 +272,24 @@ func (c *CopyOpConsumer) Consume(workerCtx context.Context, in <-chan ShardRepli
 						opCancel()
 					}()
 
-					opLogger.Debug("worker processing replication operation")
-
 					// If the operation has been cancelled in the time between it being added to the channel and
 					// being processed, we need to cancel it in the FSM and return
 					if c.ongoingOps.HasBeenCancelled(op.Op.ID) {
-						c.logger.WithFields(logrus.Fields{"op": operation}).Debug("replication op cancelled, stopping replication operation")
+						c.logger.Info("replication op cancelled, stopping replication operation")
 						c.cancelOp(operation, opLogger)
 						return
 					}
 
+					opLogger.Debug("worker processing replication operation")
 					err := c.dispatchReplicationOp(opCtx, operation)
 					if err == nil {
+						opLogger.Debug("worker completed replication operation")
 						c.opsGateway.RegisterFinished(op.Op.ID)
 						c.engineOpCallbacks.OnOpComplete(c.nodeId)
 						return
-					} else {
-						c.opsGateway.RegisterFailure(op.Op.ID)
 					}
 
+					c.opsGateway.RegisterFailure(op.Op.ID)
 					if errors.Is(err, context.DeadlineExceeded) {
 						c.engineOpCallbacks.OnOpFailed(c.nodeId)
 						opLogger.WithError(err).Error("replication operation timed out")
@@ -294,12 +297,12 @@ func (c *CopyOpConsumer) Consume(workerCtx context.Context, in <-chan ShardRepli
 					}
 					// TODO: Refactor this error handling
 					if errors.Is(err, context.Canceled) && c.ongoingOps.HasBeenCancelled(op.Op.ID) {
-						opLogger.WithError(err).Debug("replication operation cancelled")
+						opLogger.WithError(err).Info("replication operation cancelled")
 						c.cancelOp(operation, opLogger)
 						return
 					}
 					if errors.Is(err, errOpCancelled) {
-						opLogger.WithError(err).Debug("replication operation cancelled")
+						opLogger.WithError(err).Info("replication operation cancelled")
 						c.cancelOp(operation, opLogger)
 						return
 					}

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -227,11 +227,9 @@ func (c *CopyOpConsumer) Consume(workerCtx context.Context, in <-chan ShardRepli
 					if err != nil {
 						c.logger.Error("error while checking status of replication op")
 						shouldSkip = true
-						c.ongoingOps.DeleteInFlight(op.Op.ID)
 					} else if state.String() != op.Status.GetCurrent().State.String() {
 						c.logger.Debug("replication op skipped as state has changed")
 						shouldSkip = true
-						c.ongoingOps.DeleteInFlight(op.Op.ID)
 					}
 				}
 

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -1147,16 +1147,13 @@ func TestConsumerOpDuplication(t *testing.T) {
 
 	mockFSMUpdater.EXPECT().
 		ReplicationGetReplicaOpStatus(mock.Anything, uint64(1)).
-		Return(api.FINALIZING, nil).
-		Times(1)
+		Return(api.FINALIZING, nil)
 	mockFSMUpdater.EXPECT().
 		ReplicationGetReplicaOpStatus(mock.Anything, uint64(1)).
-		Return(api.READY, nil).
-		Times(1)
+		Return(api.READY, nil)
 	mockFSMUpdater.EXPECT().
 		ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(1), api.READY).
-		Return(nil).
-		Times(1)
+		Return(nil)
 	mockFSMUpdater.EXPECT().
 		AddReplicaToShard(mock.Anything, "TestCollection", "shard1", "node2").
 		Return(uint64(1), nil)
@@ -1189,6 +1186,148 @@ func TestConsumerOpDuplication(t *testing.T) {
 
 	// Send the same operation again to make sure it isn't reprocessed after a state change
 	// as mocked in the above expectations
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
+	completionWg.Add(1)
+
+	waitChan := make(chan struct{})
+	go func() {
+		completionWg.Wait()
+		waitChan <- struct{}{}
+	}()
+
+	select {
+	case <-waitChan:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("Test timed out waiting for operation completion")
+	}
+
+	close(opsChan)
+	err := <-doneChan
+
+	// THEN
+	require.NoError(t, err, "expected consumer to stop without error")
+
+	mockFSMUpdater.AssertExpectations(t)
+	mockReplicaCopier.AssertExpectations(t)
+}
+
+func TestConsumerOpSkip(t *testing.T) {
+	// GIVEN
+	logger, _ := logrustest.NewNullLogger()
+	mockFSMUpdater := types.NewMockFSMUpdater(t)
+	mockReplicaCopier := types.NewMockReplicaCopier(t)
+	parser := fakes.NewMockParser()
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	schemaManager := schema.NewSchemaManager("test-node", nil, parser, prometheus.NewPedanticRegistry(), logrus.New())
+	schemaManager.AddClass(
+		buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
+			Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
+			State: &sharding.State{
+				Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1"}}},
+			},
+		}), "node1", true, false)
+	schemaReader := schemaManager.NewSchemaReader()
+	schemaManager.AddClass(
+		buildApplyRequest("TestCollection", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{
+			Class: &models.Class{Class: "TestCollection", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false}},
+			State: &sharding.State{
+				Physical: map[string]sharding.Physical{"shard1": {BelongsToNodes: []string{"node1"}}},
+			},
+		}), "node1", true, false)
+
+	var completionWg sync.WaitGroup
+
+	metricsCallbacks := metrics.NewReplicationEngineOpsCallbacksBuilder().
+		WithPrepareProcessing(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in prepare processing callback")
+		}).
+		WithOpPendingCallback(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in pending op callback")
+		}).
+		WithOpSkippedCallback(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in skipped op callback")
+			completionWg.Done()
+		}).
+		WithOpStartCallback(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in start op callback")
+		}).
+		WithOpCompleteCallback(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in complete op callback")
+			completionWg.Done()
+		}).
+		WithOpFailedCallback(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in failed op callback")
+		}).
+		WithOpCancelledCallback(func(node string) {
+			require.Equal(t, "node2", node, "invalid node in cancelled op callback")
+		}).
+		Build()
+
+	consumer := replication.NewCopyOpConsumer(
+		logger,
+		mockFSMUpdater,
+		mockReplicaCopier,
+		"node2",
+		&backoff.StopBackOff{},
+		replication.NewOpsCache(),
+		time.Second*10,
+		3,
+		runtime.NewDynamicValue(time.Second*100),
+		metricsCallbacks,
+		schemaReader,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opsChan := make(chan replication.ShardReplicationOpAndStatus, 4)
+	doneChan := make(chan error, 1)
+
+	// WHEN
+	go func() {
+		doneChan <- consumer.Consume(ctx, opsChan)
+	}()
+
+	mockFSMUpdater.EXPECT().
+		ReplicationGetReplicaOpStatus(mock.Anything, uint64(1)).
+		Return(api.FINALIZING, nil)
+	mockFSMUpdater.EXPECT().
+		ReplicationGetReplicaOpStatus(mock.Anything, uint64(1)).
+		Return(api.READY, nil)
+	mockFSMUpdater.EXPECT().
+		ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(1), api.READY).
+		Return(nil)
+	mockFSMUpdater.EXPECT().
+		AddReplicaToShard(mock.Anything, "TestCollection", "shard1", "node2").
+		Return(uint64(1), nil)
+	mockReplicaCopier.EXPECT().
+		AsyncReplicationStatus(mock.Anything, "node1", "node2", "TestCollection", "shard1").
+		RunAndReturn(func(context.Context, string, string, string, string) (models.AsyncReplicationStatus, error) {
+			time.Sleep(5 * time.Second)
+			return models.AsyncReplicationStatus{
+				ObjectsPropagated:       0,
+				StartDiffTimeUnixMillis: time.Now().Add(200 * time.Second).UnixMilli(),
+			}, nil
+		})
+	mockReplicaCopier.EXPECT().
+		AddAsyncReplicationTargetNode(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockReplicaCopier.EXPECT().
+		RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).Return(nil)
+	mockReplicaCopier.EXPECT().
+		InitAsyncReplicationLocally(mock.Anything, "TestCollection", "shard1").
+		Return(nil)
+	mockReplicaCopier.EXPECT().
+		RevertAsyncReplicationLocally(mock.Anything, "TestCollection", "shard1").Return(nil)
+	mockFSMUpdater.EXPECT().
+		SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(1), nil)
+
+	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
+	status := replication.NewShardReplicationStatus(api.FINALIZING)
+
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
+	completionWg.Add(1)
+
+	// Send the same operation again twice to make sure it is skipped
 	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	completionWg.Add(1)
 

--- a/cluster/replication/producer_consumer_test.go
+++ b/cluster/replication/producer_consumer_test.go
@@ -210,8 +210,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				wg.Add(1)
 				mockFSMUpdater.EXPECT().
 					ReplicationGetReplicaOpStatus(mock.Anything, uint64(opId)).
-					Return(api.REGISTERED, nil).
-					Times(4) // equal to the op plus number of times the op failed
+					Return(api.REGISTERED, nil)
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.HYDRATING).
 					Return(nil)


### PR DESCRIPTION
### What's being changed:
Ensure that we're not deleting from the onFlight map if we're skipping the op and we didn't acquire it


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
