### PR TITLE
trim load shard end of hydrating

### DIFF
--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -516,11 +516,6 @@ func (c *CopyOpConsumer) processHydratingOp(ctx context.Context, op ShardReplica
 		return api.ShardReplicationState(""), ctx.Err()
 	}
 
-	if err := c.replicaCopier.LoadLocalShard(ctx, op.Op.SourceShard.CollectionId, op.Op.SourceShard.ShardId); err != nil {
-		logger.WithError(err).Error("failure while loading shard")
-		return api.ShardReplicationState(""), err
-	}
-
 	return api.FINALIZING, nil
 }
 

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -1306,6 +1306,9 @@ func TestConsumerOpSkip(t *testing.T) {
 	mockFSMUpdater.EXPECT().
 		ReplicationGetReplicaOpStatus(mock.Anything, uint64(1)).
 		Return(api.READY, nil)
+	mockReplicaCopier.EXPECT().
+		LoadLocalShard(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
 	mockFSMUpdater.EXPECT().
 		ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(1), api.READY).
 		Return(nil)


### PR DESCRIPTION
### What's being changed:

No need to call shard load twice


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
