### PR TITLE
Fix unit tests

### DIFF
--- a/cluster/replication/producer_consumer_test.go
+++ b/cluster/replication/producer_consumer_test.go
@@ -77,7 +77,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					Return(nil)
 				mockReplicaCopier.EXPECT().
 					RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).
-					Return(nil)
+					Return(nil).Maybe()
 				mockReplicaCopier.EXPECT().
 					RevertAsyncReplicationLocally(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -132,7 +132,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					Return(nil)
 				mockReplicaCopier.EXPECT().
 					RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).
-					Return(nil)
+					Return(nil).Maybe()
 				mockReplicaCopier.EXPECT().
 					RevertAsyncReplicationLocally(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -190,7 +190,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					Return(nil)
 				mockReplicaCopier.EXPECT().
 					RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).
-					Return(nil)
+					Return(nil).Maybe()
 				mockReplicaCopier.EXPECT().
 					RevertAsyncReplicationLocally(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -248,7 +248,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					Times(1)
 				mockReplicaCopier.EXPECT().
 					RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).
-					Return(nil)
+					Return(nil).Maybe()
 				mockReplicaCopier.EXPECT().
 					RevertAsyncReplicationLocally(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -310,7 +310,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					Return(nil)
 				mockReplicaCopier.EXPECT().
 					RemoveAsyncReplicationTargetNode(mock.Anything, mock.Anything).
-					Return(nil)
+					Return(nil).Maybe()
 				mockReplicaCopier.EXPECT().
 					RevertAsyncReplicationLocally(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)


### PR DESCRIPTION
### What's being changed:

`RemoveAsyncReplicationTargetNode` will not be called during dehydrating now because we remove the source node shard first

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
