### PR TITLE
Fix filtered search with multivec

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -215,6 +215,7 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 	h.insertViableEntrypointsAsCandidatesAndResults(entrypoints, candidates,
 		results, level, visited, allowList)
 
+	isMultivec := h.multivector.Load()
 	var worstResultDistance float32
 	var err error
 	if h.compressed.Load() {
@@ -325,11 +326,21 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 						continue
 					}
 					if !visitedExp.Visited(nodeId) {
-						if allowList.Contains(nodeId) {
-							connectionsReusable[realLen] = nodeId
-							realLen++
-							visitedExp.Visit(nodeId)
-							continue
+						if !isMultivec {
+							if allowList.Contains(nodeId) {
+								connectionsReusable[realLen] = nodeId
+								realLen++
+								visitedExp.Visit(nodeId)
+								continue
+							}
+						} else {
+							docID, _ := h.cache.GetKeys(nodeId)
+							if allowList.Contains(docID) {
+								connectionsReusable[realLen] = nodeId
+								realLen++
+								visitedExp.Visit(nodeId)
+								continue
+							}
 						}
 					} else {
 						continue
@@ -356,13 +367,25 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 							break
 						}
 
-						if allowList.Contains(expId) {
-							visitedExp.Visit(expId)
-							connectionsReusable[realLen] = expId
-							realLen++
-						} else if hop < maxHops {
-							visitedExp.Visit(expId)
-							pendingNextRound = append(pendingNextRound, expId)
+						if !isMultivec {
+							if allowList.Contains(expId) {
+								visitedExp.Visit(expId)
+								connectionsReusable[realLen] = expId
+								realLen++
+							} else if hop < maxHops {
+								visitedExp.Visit(expId)
+								pendingNextRound = append(pendingNextRound, expId)
+							}
+						} else {
+							docID, _ := h.cache.GetKeys(expId)
+							if allowList.Contains(docID) {
+								visitedExp.Visit(expId)
+								connectionsReusable[realLen] = expId
+								realLen++
+							} else if hop < maxHops {
+								visitedExp.Visit(expId)
+								pendingNextRound = append(pendingNextRound, expId)
+							}
 						}
 					}
 				}
@@ -383,7 +406,12 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 			visited.Visit(neighborID)
 
 			if strategy == RRE && level == 0 {
-				if !allowList.Contains(neighborID) {
+				if isMultivec {
+					docID, _ := h.cache.GetKeys(neighborID)
+					if !allowList.Contains(docID) {
+						continue
+					}
+				} else if !allowList.Contains(neighborID) {
 					continue
 				}
 			}
@@ -415,7 +443,12 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 					// have an allow list (i.e. the user has probably set some sort of a
 					// filter restricting this search further. As a result we have to
 					// ignore items not on the list
-					if !allowList.Contains(neighborID) {
+					if isMultivec {
+						docID, _ := h.cache.GetKeys(neighborID)
+						if !allowList.Contains(docID) {
+							continue
+						}
+					} else if !allowList.Contains(neighborID) {
 						continue
 					}
 				}
@@ -464,6 +497,7 @@ func (h *hnsw) insertViableEntrypointsAsCandidatesAndResults(
 	entrypoints, candidates, results *priorityqueue.Queue[any], level int,
 	visitedList visited.ListSet, allowList helpers.AllowList,
 ) {
+	isMultivec := h.multivector.Load()
 	for entrypoints.Len() > 0 {
 		ep := entrypoints.Pop()
 		visitedList.Visit(ep.ID)
@@ -473,7 +507,12 @@ func (h *hnsw) insertViableEntrypointsAsCandidatesAndResults(
 			// have an allow list (i.e. the user has probably set some sort of a
 			// filter restricting this search further. As a result we have to
 			// ignore items not on the list
-			if !allowList.Contains(ep.ID) {
+			if isMultivec {
+				docID, _ := h.cache.GetKeys(ep.ID)
+				if !allowList.Contains(docID) {
+					continue
+				}
+			} else if !allowList.Contains(ep.ID) {
 				continue
 			}
 		}
@@ -690,6 +729,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 	entryPointNode := h.nodes[entryPointID]
 	h.shardedNodeLocks.RUnlock(entryPointID)
 	useAcorn := h.acornEnabled(allowList)
+	isMultivec := h.multivector.Load()
 	if useAcorn {
 		if entryPointNode == nil {
 			strategy = RRE
@@ -700,6 +740,9 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 				strategy = ACORN
 			} else {
 				for _, id := range entryPointNode.connections[0] {
+					if isMultivec {
+						id, _ = h.cache.GetKeys(id)
+					}
 					if allowList.Contains(id) {
 						counter++
 					}
@@ -720,8 +763,16 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		it := allowList.Iterator()
 		idx, ok := it.Next()
 		h.shardedNodeLocks.RLockAll()
-		for ok && h.nodes[idx] == nil && h.hasTombstone(idx) {
-			idx, ok = it.Next()
+		if !isMultivec {
+			for ok && h.nodes[idx] == nil && h.hasTombstone(idx) {
+				idx, ok = it.Next()
+			}
+		} else {
+			_, exists := h.docIDVectors[idx]
+			for ok && !exists {
+				idx, ok = it.Next()
+				_, exists = h.docIDVectors[idx]
+			}
 		}
 		h.shardedNodeLocks.RUnlockAll()
 


### PR DESCRIPTION
### What's being changed:
- Filtered search was not correctly working when multivec was enabled. This fix handles the docID-nodeID mapping when multivec is enabled
- After this PR is merged then the fix will be propagated to newer releases. Version 1.30 may require a fix to handle the multivec + quantization case

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
