### PR TITLE
fix(memberlist): rejoin list on single node split brain

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -965,6 +965,16 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 		logger.Exit(1)
 	}
 
+	// In a multi-node cluster, periodically check for split-brain
+	if appState.ServerConfig.Config.Raft.BootstrapExpect > 1 {
+		go func() {
+			for {
+				time.Sleep(time.Minute)
+				clusterState.MaybeRejoinMemberlistCluster(logger)
+			}
+		}()
+	}
+
 	appState.Cluster = clusterState
 	appState.Logger.
 		WithField("action", "startup").

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -71,7 +71,8 @@ type Config struct {
 	// bool because it allows us to set the same config/env vars on all nodes to put a subset of
 	// them in maintenance mode. In addition, we may want to have the cluster nodes not in
 	// maintenance mode be aware of which nodes are in maintenance mode in the future.
-	MaintenanceNodes []string `json:"maintenanceNodes" yaml:"maintenanceNodes"`
+	MaintenanceNodes    []string `json:"maintenanceNodes" yaml:"maintenanceNodes"`
+	RaftBootstrapExpect int
 }
 
 type AuthConfig struct {
@@ -87,7 +88,8 @@ func (ba BasicAuth) Enabled() bool {
 	return ba.Username != "" || ba.Password != ""
 }
 
-func Init(userConfig Config, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {
+func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {
+	userConfig.RaftBootstrapExpect = raftBootstrapExpect
 	cfg := memberlist.DefaultLANConfig()
 	cfg.LogOutput = newLogParser(logger)
 	cfg.Name = userConfig.Hostname
@@ -157,33 +159,6 @@ func Init(userConfig Config, dataPath string, nonStorageNodes map[string]struct{
 	}
 
 	return &state, nil
-}
-
-func (state *State) MaybeRejoinMemberlistCluster(logger logrus.FieldLogger) {
-	nodeCount := state.NodeCount()
-	if nodeCount <= 1 {
-		logger.Warn("Detected single node split-brain, attempting to rejoin memberlist cluster")
-
-		var joinAddr []string
-		if state.config.Join != "" {
-			joinAddr = strings.Split(state.config.Join, ",")
-		}
-
-		if len(joinAddr) > 0 {
-			_, err := state.list.Join(joinAddr)
-			if err != nil {
-				logger.WithFields(logrus.Fields{
-					"action":          "memberlist_rejoin",
-					"remote_hostname": joinAddr,
-				}).WithError(err).Error("memberlist rejoin not successful")
-			} else {
-				logger.WithFields(logrus.Fields{
-					"action":     "memberlist_rejoin_successful",
-					"node_count": state.NodeCount(),
-				}).Info("Successfully rejoined the memberlist cluster")
-			}
-		}
-	}
 }
 
 // Hostnames for all live members, except self. Use AllHostnames to include
@@ -333,6 +308,34 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 func (s *State) NodeAddress(id string) string {
 	s.listLock.RLock()
 	defer s.listLock.RUnlock()
+
+	// network interruption detection which can cause a single node to be isolated from the cluster (split brain)
+	nodeCount := s.list.NumMembers()
+	var joinAddr []string
+	if s.config.Join != "" {
+		joinAddr = strings.Split(s.config.Join, ",")
+	}
+	logger := s.delegate.log
+	if nodeCount == 1 && len(joinAddr) > 0 && s.config.RaftBootstrapExpect > 1 {
+		logger.WithFields(logrus.Fields{
+			"action":     "memberlist_rejoin",
+			"node_count": nodeCount,
+		}).Warn("detected single node split-brain, attempting to rejoin memberlist cluster")
+		// Only attempt rejoin if we're supposed to be part of a larger cluster
+		_, err := s.list.Join(joinAddr)
+		if err != nil {
+			logger.WithFields(logrus.Fields{
+				"action":          "memberlist_rejoin",
+				"remote_hostname": joinAddr,
+			}).WithError(err).Error("memberlist rejoin not successful")
+		} else {
+			logger.WithFields(logrus.Fields{
+				"action":     "memberlist_rejoin",
+				"node_count": nodeCount,
+			}).Info("Successfully rejoined the memberlist cluster")
+		}
+	}
+
 	for _, mem := range s.list.Members() {
 		if mem.Name == id {
 			return mem.Addr.String()

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -160,8 +160,12 @@ func Init(userConfig Config, dataPath string, nonStorageNodes map[string]struct{
 }
 
 func (state *State) MaybeRejoinMemberlistCluster(logger logrus.FieldLogger) {
-	logger.Debug("Checking for single node split-brain")
-	if state.NodeCount() <= 1 {
+	nodeCount := state.NodeCount()
+	logger.WithFields(logrus.Fields{
+		"action":     "memberlist_rejoin",
+		"node_count": nodeCount,
+	}).Debug("Checking for single node split-brain")
+	if nodeCount <= 1 {
 		logger.Warn("Detected single node split-brain, attempting to rejoin memberlist cluster")
 
 		var joinAddr []string

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -164,6 +164,7 @@ func (state *State) MaybeRejoinMemberlistCluster(logger logrus.FieldLogger) {
 	logger.WithFields(logrus.Fields{
 		"action":     "memberlist_rejoin",
 		"node_count": nodeCount,
+		"join":       state.config.Join,
 	}).Debug("Checking for single node split-brain")
 	if nodeCount <= 1 {
 		logger.Warn("Detected single node split-brain, attempting to rejoin memberlist cluster")
@@ -174,7 +175,9 @@ func (state *State) MaybeRejoinMemberlistCluster(logger logrus.FieldLogger) {
 		}
 
 		if len(joinAddr) > 0 {
+			logger.Debug("Before rejoin")
 			_, err := state.list.Join(joinAddr)
+			logger.Debug("After rejoin")
 			if err != nil {
 				logger.WithFields(logrus.Fields{
 					"action":          "memberlist_rejoin",

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -161,11 +161,6 @@ func Init(userConfig Config, dataPath string, nonStorageNodes map[string]struct{
 
 func (state *State) MaybeRejoinMemberlistCluster(logger logrus.FieldLogger) {
 	nodeCount := state.NodeCount()
-	logger.WithFields(logrus.Fields{
-		"action":     "memberlist_rejoin",
-		"node_count": nodeCount,
-		"join":       state.config.Join,
-	}).Debug("Checking for single node split-brain")
 	if nodeCount <= 1 {
 		logger.Warn("Detected single node split-brain, attempting to rejoin memberlist cluster")
 
@@ -175,9 +170,7 @@ func (state *State) MaybeRejoinMemberlistCluster(logger logrus.FieldLogger) {
 		}
 
 		if len(joinAddr) > 0 {
-			logger.Debug("Before rejoin")
 			_, err := state.list.Join(joinAddr)
-			logger.Debug("After rejoin")
 			if err != nil {
 				logger.WithFields(logrus.Fields{
 					"action":          "memberlist_rejoin",

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -315,21 +315,20 @@ func (s *State) NodeAddress(id string) string {
 	if s.config.Join != "" {
 		joinAddr = strings.Split(s.config.Join, ",")
 	}
-	logger := s.delegate.log
 	if nodeCount == 1 && len(joinAddr) > 0 && s.config.RaftBootstrapExpect > 1 {
-		logger.WithFields(logrus.Fields{
+		s.delegate.log.WithFields(logrus.Fields{
 			"action":     "memberlist_rejoin",
 			"node_count": nodeCount,
 		}).Warn("detected single node split-brain, attempting to rejoin memberlist cluster")
 		// Only attempt rejoin if we're supposed to be part of a larger cluster
 		_, err := s.list.Join(joinAddr)
 		if err != nil {
-			logger.WithFields(logrus.Fields{
+			s.delegate.log.WithFields(logrus.Fields{
 				"action":          "memberlist_rejoin",
 				"remote_hostname": joinAddr,
 			}).WithError(err).Error("memberlist rejoin not successful")
 		} else {
-			logger.WithFields(logrus.Fields{
+			s.delegate.log.WithFields(logrus.Fields{
 				"action":     "memberlist_rejoin",
 				"node_count": nodeCount,
 			}).Info("Successfully rejoined the memberlist cluster")


### PR DESCRIPTION
### What's being changed:
This is a solution for the probably most common reason for https://github.com/weaviate/weaviate/issues/6555. If a node has temporary network issues, it removes all other nodes from its memberlist, leaving it alone behind (split brain situation), also after the network is back. For details about this issue with memberlist see the following issue, especially comment https://github.com/hashicorp/memberlist/issues/222#issuecomment-1836636639.

This implementation follows the same idea: regularly check if we are supposed to have more than one node, but actually have only one node in our memberlist and if that is the case, try to rejoin the memberlist cluster. Note that this will only be possible if `CLUSTER_JOIN` is set to a non-empty value (so not on the founding node of a docker based setup).

## Reproduce issue & test fix
To reproduce the issue / test if the proposed fix solves the problem, perform the following steps:

Start a three-node docker based Weaviate cluster:
```
docker compose -f docker-compose-three-nodes.yml up
```
```
# docker-compose-three-nodes.yml
services:
  weaviate-0:
    image: cr.weaviate.io/semitechnologies/weaviate:1.30.4
    container_name: weaviate-0
    restart: on-failure:0
    ports:
      - "8080:8080"
      - "7100:7100"
      - "7101:7101"
      - "50051:50051"
    environment:
      GRPC_PORT: 50051
      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: true
      PERSISTENCE_DATA_PATH: "${PERSISTENCE_DATA_PATH}-weaviate-0"
      CLUSTER_HOSTNAME: "weaviate-0"
      CLUSTER_GOSSIP_BIND_PORT: "7100"
      CLUSTER_DATA_BIND_PORT: "7101"
      RAFT_JOIN: "weaviate-0,weaviate-1,weaviate-2"
      RAFT_BOOTSTRAP_EXPECT: 3
      LOG_LEVEL: "debug"

  weaviate-1:
    image: cr.weaviate.io/semitechnologies/weaviate:1.30.4
    container_name: weaviate-1
    restart: on-failure:0
    ports:
      - "8081:8080"
      - "7102:7102"
      - "7103:7103"
      - "50052:50052"
    environment:
      GRPC_PORT: 50052
      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: true
      PERSISTENCE_DATA_PATH: "${PERSISTENCE_DATA_PATH}-weaviate-1"
      CLUSTER_HOSTNAME: "weaviate-1"
      CLUSTER_GOSSIP_BIND_PORT: "7102"
      CLUSTER_DATA_BIND_PORT: "7103"
      CLUSTER_JOIN: weaviate-0:7100
      RAFT_JOIN: "weaviate-0,weaviate-1,weaviate-2"
      RAFT_BOOTSTRAP_EXPECT: 3
      LOG_LEVEL: "debug"

  weaviate-2:
    image: cr.weaviate.io/semitechnologies/weaviate:1.30.4
    container_name: weaviate-2
    restart: on-failure:0
    ports:
      - "8082:8080"
      - "7104:7104"
      - "7105:7105"
      - "50053:50053"
    environment:
      GRPC_PORT: 50053
      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: true
      PERSISTENCE_DATA_PATH: "${PERSISTENCE_DATA_PATH}-weaviate-2"
      CLUSTER_HOSTNAME: "weaviate-2"
      CLUSTER_GOSSIP_BIND_PORT: "7104"
      CLUSTER_DATA_BIND_PORT: "7105"
      CLUSTER_JOIN: weaviate-0:7100
      RAFT_JOIN: "weaviate-0,weaviate-1,weaviate-2"
      RAFT_BOOTSTRAP_EXPECT: 3
      LOG_LEVEL: "debug"
```

After the cluster came up successfully, run `docker network disconnect weaviate_default weaviate-2` to simulate a network outage of node 2. After the node has reached permanent error state, which you can see from it repeatedly outputting "dial tcp: address 99999999: invalid port", run `docker network connect weaviate_default weaviate-2` to reconnect the node to the network.

Behaviour after the node has its network back is different depending on if the code change proposed in this Pull Request is active: Without this code, the node will continue to output "dial tcp: address 99999999: invalid port" (remain in its split-brain situation). If you have this code included, within one minute, the node will rejoin the memberlist and will therefore be functional again.