### PR TITLE
no need to check until we've reached the time we need

### DIFF
--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -746,24 +746,6 @@ func (c *CopyOpConsumer) waitForAsyncReplication(
 	asyncReplicationUpperTimeBoundUnixMillis int64,
 	logger *logrus.Entry,
 ) error {
-	// Wait until we've passed the upper time bound before starting status checks
-	// to avoid unnecessary status checks before the upper time bound has passed
-	currentTimeMillis := time.Now().UnixMilli()
-	if currentTimeMillis < asyncReplicationUpperTimeBoundUnixMillis {
-		waitDuration := time.Duration(asyncReplicationUpperTimeBoundUnixMillis-currentTimeMillis) * time.Millisecond
-		logger.WithFields(logrus.Fields{
-			"wait_duration_ms": waitDuration.Milliseconds(),
-			"upper_bound_ms":   asyncReplicationUpperTimeBoundUnixMillis,
-		}).Info("waiting to reach upper time bound before starting async replication status checks")
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(waitDuration):
-			// Time has passed, continue below with the status checks
-		}
-	}
-
 	remainingErrorsAllowed := asyncStatusMaxErrors
 	retryNum := -1
 	return backoff.Retry(func() error {
@@ -803,6 +785,24 @@ func (c *CopyOpConsumer) waitForAsyncReplication(
 		}).Info("async replication status")
 		if asyncReplStatus.ObjectsPropagated == 0 && asyncReplIsPastUpperTimeBound {
 			return nil
+		}
+
+		// Wait until we've passed the upper time bound before starting status checks
+		// to avoid unnecessary status checks before the upper time bound has passed
+		currentTimeMillis := time.Now().UnixMilli()
+		if currentTimeMillis < asyncReplicationUpperTimeBoundUnixMillis {
+			waitDuration := time.Duration(asyncReplicationUpperTimeBoundUnixMillis-currentTimeMillis) * time.Millisecond
+			logger.WithFields(logrus.Fields{
+				"wait_duration_ms": waitDuration.Milliseconds(),
+				"upper_bound_ms":   asyncReplicationUpperTimeBoundUnixMillis,
+			}).Info("waiting to reach upper time bound before starting async replication status checks")
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(waitDuration):
+				// Time has passed, continue below with the status checks
+			}
 		}
 
 		return errors.New("async replication not done")


### PR DESCRIPTION
### What's being changed:

There's no need to check the async replication status until we've at least reached the upper time bound, as it can't complete until after that time. To reduce log noise and decrease network traffic, wait until we've reached the upper time bound on the local node. The times will obviously differ between the source/destination nodes, but for this status check that is fine as we're just removing unnecessary status checks which will never return "done".

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
