### PR TITLE
Fix flaky test due to un-normalized vectors

### DIFF
--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -37,21 +37,21 @@ func TestHnswIndex(t *testing.T) {
 
 	t.Run("searching within cluster 1", func(t *testing.T) {
 		position := 0
-		res, _, err := index.knnSearchByVector(ctx, testVectors[position], 3, 36, nil)
+		res, _, err := index.SearchByVector(ctx, testVectors[position], 3, nil)
 		require.Nil(t, err)
 		assert.ElementsMatch(t, []uint64{0, 1, 2}, res)
 	})
 
 	t.Run("searching within cluster 2", func(t *testing.T) {
 		position := 3
-		res, _, err := index.knnSearchByVector(ctx, testVectors[position], 3, 36, nil)
+		res, _, err := index.SearchByVector(ctx, testVectors[position], 3, nil)
 		require.Nil(t, err)
 		assert.ElementsMatch(t, []uint64{3, 4, 5}, res)
 	})
 
 	t.Run("searching within cluster 3", func(t *testing.T) {
 		position := 6
-		res, _, err := index.knnSearchByVector(ctx, testVectors[position], 3, 36, nil)
+		res, _, err := index.SearchByVector(ctx, testVectors[position], 3, nil)
 		require.Nil(t, err)
 		assert.ElementsMatch(t, []uint64{6, 7, 8}, res)
 	})


### PR DESCRIPTION
### What's being changed:
- Some tests incorrectly used un-normalized vectors with cosine distance and used `knnSearchByVector` which skips query vector normalization (instead of `SearchByVector` the public method which does normalization). With the https://github.com/weaviate/weaviate/pull/8133 change this results in flaky tests due to zero distances.
- We may need to also need to audit other uses of `knnSearchByVector` in tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
