### PR TITLE
refact(cluster server): gracefully shutdown internal REST server

### DIFF
--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -12,16 +12,29 @@
 package clusterapi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 
 	sentryhttp "github.com/getsentry/sentry-go/http"
+
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/types"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-func Serve(appState *state.State) {
+// Server represents the cluster API server
+type Server struct {
+	server   *http.Server
+	appState *state.State
+}
+
+// Ensure Server implements interfaces.ClusterServer
+var _ types.ClusterServer = (*Server)(nil)
+
+// NewServer creates a new cluster API server instance
+func NewServer(appState *state.State) *Server {
 	port := appState.ServerConfig.Config.Cluster.DataBindPort
 	auth := NewBasicAuthHandler(appState.ServerConfig.Config.Cluster.AuthConfig)
 
@@ -75,7 +88,45 @@ func Serve(appState *state.State) {
 		)
 	}
 
-	http.ListenAndServe(fmt.Sprintf(":%d", port), handler)
+	return &Server{
+		server: &http.Server{
+			Addr:    fmt.Sprintf(":%d", port),
+			Handler: handler,
+		},
+		appState: appState,
+	}
+}
+
+// Serve starts the server and blocks until an error occurs
+func (s *Server) Serve() error {
+	s.appState.Logger.WithField("action", "cluster_api_startup").
+		Infof("cluster api server is ready to handle requests on %s", s.server.Addr)
+	return s.server.ListenAndServe()
+}
+
+// Close gracefully shuts down the server
+func (s *Server) Close(ctx context.Context) error {
+	s.appState.Logger.WithField("action", "cluster_api_shutdown").
+		Info("server is shutting down")
+
+	if err := s.server.Shutdown(ctx); err != nil {
+		s.appState.Logger.WithField("action", "cluster_api_shutdown").
+			WithError(err).
+			Error("could not stop server gracefully")
+		return s.server.Close()
+	}
+	return nil
+}
+
+// Serve is kept for backward compatibility
+func Serve(appState *state.State) (*Server, error) {
+	server := NewServer(appState)
+	if err := server.Serve(); err != nil && err != http.ErrServerClosed {
+		appState.Logger.WithField("action", "cluster_api_shutdown").
+			WithError(err).
+			Error("server error")
+	}
+	return server, nil
 }
 
 func index() http.Handler {

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -14,6 +14,7 @@ package clusterapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -121,7 +122,7 @@ func (s *Server) Close(ctx context.Context) error {
 // Serve is kept for backward compatibility
 func Serve(appState *state.State) (*Server, error) {
 	server := NewServer(appState)
-	if err := server.Serve(); err != nil && err != http.ErrServerClosed {
+	if err := server.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		appState.Logger.WithField("action", "cluster_api_shutdown").
 			WithError(err).
 			Error("server error")

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1581,18 +1581,14 @@ func reasonableHttpClient(authConfig cluster.AuthConfig) *http.Client {
 	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			// TCP timeouts are often around 3 minutes timeout to handle longer pod startup times during rollouts
-			Timeout: 180 * time.Second, //
-			// More frequent keepalive to detect pod terminations faster
-			KeepAlive: 15 * time.Second,
+			Timeout:   30 * time.Second,
+			KeepAlive: 120 * time.Second,
 		}).DialContext,
-		// TODO: MaxIdleConns* shall be configurable and relate to the number of nodes in the cluster
-		MaxIdleConnsPerHost:   20, // formula MaxIdleConns / (number_of_nodes * 2)
+		MaxIdleConnsPerHost:   100,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		ForceAttemptHTTP2:     true,
 	}
 
 	if authConfig.BasicAuth.Enabled() {

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1581,10 +1581,13 @@ func reasonableHttpClient(authConfig cluster.AuthConfig) *http.Client {
 	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   120 * time.Second,
+			// TCP timeouts are often around 3 minutes timeout to handle longer pod startup times during rollouts
+			Timeout: 180 * time.Second, //
+			// More frequent keepalive to detect pod terminations faster
 			KeepAlive: 15 * time.Second,
 		}).DialContext,
-		MaxIdleConnsPerHost:   100,
+		// TODO: MaxIdleConns* shall be configurable and relate to the number of nodes in the cluster
+		MaxIdleConnsPerHost:   20, // formula MaxIdleConns / (number_of_nodes * 2)
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1581,14 +1581,15 @@ func reasonableHttpClient(authConfig cluster.AuthConfig) *http.Client {
 	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 120 * time.Second,
+			Timeout:   120 * time.Second,
+			KeepAlive: 15 * time.Second,
 		}).DialContext,
 		MaxIdleConnsPerHost:   100,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
 	}
 
 	if authConfig.BasicAuth.Enabled() {

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/handlers/graphql"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/tenantactivity"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/types"
 	"github.com/weaviate/weaviate/adapters/repos/classifications"
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	rCluster "github.com/weaviate/weaviate/cluster"
@@ -83,6 +84,7 @@ type State struct {
 
 	ClusterService *rCluster.Service
 	TenantActivity *tenantactivity.Handler
+	InternalServer types.ClusterServer
 
 	Migrator *db.Migrator
 }

--- a/adapters/handlers/rest/types/cluster.go
+++ b/adapters/handlers/rest/types/cluster.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package types
 
 import "context"

--- a/adapters/handlers/rest/types/cluster.go
+++ b/adapters/handlers/rest/types/cluster.go
@@ -1,0 +1,9 @@
+package types
+
+import "context"
+
+// ClusterServer defines the interface for cluster API server operations
+type ClusterServer interface {
+	Serve() error
+	Close(ctx context.Context) error
+}


### PR DESCRIPTION
### What's being changed:
we don't gracefully shutdown internal server which serves `replication`, `backup` and many more internal handlers which leads to many context.Cancelled, context.DeadlineExceeded ,  and/or unnecessary retries. 

This PR makes sure we gracefully shutdown the internal server to avoid and context errors or unnecessary retries and   connected to [PR](https://github.com/weaviate/weaviate/pull/8270)
 where we handle the client side
 
 
this PR will need a followup to mitigate the amount of errors under heavy load 

 Before
![Screenshot 2025-05-27 at 10 50 12](https://github.com/user-attachments/assets/23f4e388-7cd5-49a4-951d-f0ad14addbe9)

After 
![Screenshot 2025-05-27 at 10 50 39](https://github.com/user-attachments/assets/7141634a-815e-4e27-8b07-40252a4e089f)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15271531971
 run 2 after rebase  :https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15304438580
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
