### PR TITLE
chore(runtimeconfig): Add test to lock lower_snake_case in config

### DIFF
--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -12,11 +12,14 @@
 package config
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/go-jose/go-jose/v4/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseRuntimeConfig(t *testing.T) {
@@ -34,6 +37,46 @@ func TestParseRuntimeConfig(t *testing.T) {
 		require.ErrorContains(t, err, "autoschema_enbaled") // should contain misspelled field
 		assert.Nil(t, cfg)
 	})
+
+	t.Run("YAML tag should be lower_snake_case", func(t *testing.T) {
+		var r WeaviateRuntimeConfig
+
+		jd, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		var vv map[string]any
+		require.NoError(t, json.Unmarshal(jd, &vv))
+
+		for k, _ := range vv {
+			// check if all the keys lower_snake_case.
+			assertConfigKey(t, k)
+		}
+	})
+
+	t.Run("JSON tag should be lower_snake_case in the runtime config", func(t *testing.T) {
+		var r WeaviateRuntimeConfig
+
+		yd, err := yaml.Marshal(r)
+		require.NoError(t, err)
+
+		var vv map[string]any
+		require.NoError(t, yaml.Unmarshal(yd, &vv))
+
+		for k, _ := range vv {
+			// check if all the keys lower_snake_case.
+			assertConfigKey(t, k)
+		}
+	})
+}
+
+// assertConfigKey asserts if the `yaml` key is standard `lower_snake_case` (e.g: not `UPPER_CASE`)
+func assertConfigKey(t *testing.T, key string) {
+	t.Helper()
+
+	re := regexp.MustCompile(`^[a-z]+(_[a-z]+)*$`)
+	if !re.MatchString(key) {
+		t.Fatalf("given key %v is not lower snake case. The json/yaml tag for runtime config should be all lower snake case (e.g my_key, not MY_KEY)", key)
+	}
 }
 
 func TestUpdateRuntimeConfig(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -47,7 +47,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 		var vv map[string]any
 		require.NoError(t, json.Unmarshal(jd, &vv))
 
-		for k, _ := range vv {
+		for k := range vv {
 			// check if all the keys lower_snake_case.
 			assertConfigKey(t, k)
 		}
@@ -62,7 +62,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 		var vv map[string]any
 		require.NoError(t, yaml.Unmarshal(yd, &vv))
 
-		for k, _ := range vv {
+		for k := range vv {
 			// check if all the keys lower_snake_case.
 			assertConfigKey(t, k)
 		}


### PR DESCRIPTION
### What's being changed:
Lock the behavior of allowing only `lower_snake_case` JSON and YAML tags in Weaviate runtime config files via tests.

This is to avoid having situation like mixing [cases like this](https://github.com/weaviate/weaviate/blob/7b077624d0bfc3733f5af32f354a460402899da1/usecases/config/runtimeconfig.go#L32)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
