### PR TITLE
DO NOT MERGE Add a shardName filter to get node status to avoid iterating all shards

### DIFF
--- a/adapters/clients/cluster_node.go
+++ b/adapters/clients/cluster_node.go
@@ -31,13 +31,16 @@ func NewRemoteNode(httpClient *http.Client) *RemoteNode {
 	return &RemoteNode{client: httpClient}
 }
 
-func (c *RemoteNode) GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error) {
+func (c *RemoteNode) GetNodeStatus(ctx context.Context, hostName, className, shardName, output string) (*models.NodeStatus, error) {
 	p := "/nodes/status"
 	if className != "" {
 		p = path.Join(p, className)
 	}
 	method := http.MethodGet
 	params := url.Values{"output": []string{output}}
+	if shardName != "" {
+		params.Add("shard", shardName)
+	}
 	url := url.URL{Scheme: "http", Host: hostName, Path: p, RawQuery: params.Encode()}
 
 	req, err := http.NewRequestWithContext(ctx, method, url.String(), nil)

--- a/adapters/handlers/rest/clusterapi/nodes.go
+++ b/adapters/handlers/rest/clusterapi/nodes.go
@@ -25,7 +25,7 @@ import (
 )
 
 type nodesManager interface {
-	GetNodeStatus(ctx context.Context, className, output string) (*models.NodeStatus, error)
+	GetNodeStatus(ctx context.Context, className, shardName, output string) (*models.NodeStatus, error)
 	GetStatistics(ctx context.Context) (*models.Statistics, error)
 }
 
@@ -89,12 +89,15 @@ func (s *nodes) incomingNodeStatus() http.Handler {
 			className = args[3]
 		}
 
+		// shard is an optional query parameter
+		shardName := r.URL.Query().Get("shard")
+
 		output := verbosity.OutputMinimal
 		out, found := r.URL.Query()["output"]
 		if found && len(out) > 0 {
 			output = out[0]
 		}
-		nodeStatus, err := s.nodesManager.GetNodeStatus(r.Context(), className, output)
+		nodeStatus, err := s.nodesManager.GetNodeStatus(r.Context(), className, shardName, output)
 		if err != nil {
 			http.Error(w, "/nodes fulfill request: "+err.Error(),
 				http.StatusBadRequest)

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2087,6 +2087,11 @@ func init() {
             "required": true
           },
           {
+            "type": "string",
+            "name": "shardName",
+            "in": "query"
+          },
+          {
             "$ref": "#/parameters/CommonOutputVerbosityParameterQuery"
           }
         ],
@@ -10140,6 +10145,11 @@ func init() {
             "name": "className",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "shardName",
+            "in": "query"
           },
           {
             "type": "string",

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -42,7 +42,7 @@ func (n *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *m
 		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
 	}
 
-	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, "", output)
+	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, "", "", output)
 	if err != nil {
 		return n.handleGetNodesError(err)
 	}
@@ -61,7 +61,12 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
 	}
 
-	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, params.ClassName, output)
+	shardName := ""
+	if params.ShardName != nil {
+		shardName = *params.ShardName
+	}
+
+	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, params.ClassName, shardName, output)
 	if err != nil {
 		return n.handleGetNodesError(err)
 	}

--- a/adapters/handlers/rest/operations/nodes/nodes_get_class_parameters.go
+++ b/adapters/handlers/rest/operations/nodes/nodes_get_class_parameters.go
@@ -59,6 +59,10 @@ type NodesGetClassParams struct {
 	  Default: "minimal"
 	*/
 	Output *string
+	/*
+	  In: query
+	*/
+	ShardName *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -79,6 +83,11 @@ func (o *NodesGetClassParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	qOutput, qhkOutput, _ := qs.GetOK("output")
 	if err := o.bindOutput(qOutput, qhkOutput, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qShardName, qhkShardName, _ := qs.GetOK("shardName")
+	if err := o.bindShardName(qShardName, qhkShardName, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -116,6 +125,24 @@ func (o *NodesGetClassParams) bindOutput(rawData []string, hasKey bool, formats 
 		return nil
 	}
 	o.Output = &raw
+
+	return nil
+}
+
+// bindShardName binds and validates parameter ShardName from query.
+func (o *NodesGetClassParams) bindShardName(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.ShardName = &raw
 
 	return nil
 }

--- a/adapters/handlers/rest/operations/nodes/nodes_get_class_urlbuilder.go
+++ b/adapters/handlers/rest/operations/nodes/nodes_get_class_urlbuilder.go
@@ -27,7 +27,8 @@ import (
 type NodesGetClassURL struct {
 	ClassName string
 
-	Output *string
+	Output    *string
+	ShardName *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -76,6 +77,14 @@ func (o *NodesGetClassURL) Build() (*url.URL, error) {
 	}
 	if outputQ != "" {
 		qs.Set("output", outputQ)
+	}
+
+	var shardNameQ string
+	if o.ShardName != nil {
+		shardNameQ = *o.ShardName
+	}
+	if shardNameQ != "" {
+		qs.Set("shardName", shardNameQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -308,7 +308,7 @@ func (f *fakeNodeResolver) NodeHostname(string) (string, bool) {
 
 type fakeRemoteNodeClient struct{}
 
-func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error) {
+func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName, className, shardName, output string) (*models.NodeStatus, error) {
 	return &models.NodeStatus{}, nil
 }
 

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -647,7 +647,7 @@ func makeTestSortingClass(repo *DB) func(t *testing.T) {
 
 func testNodesAPI(repo *DB) func(t *testing.T) {
 	return func(t *testing.T) {
-		nodeStatues, err := repo.GetNodeStatus(context.Background(), "", verbosity.OutputVerbose)
+		nodeStatues, err := repo.GetNodeStatus(context.Background(), "", "", verbosity.OutputVerbose)
 		require.Nil(t, err)
 		require.NotNil(t, nodeStatues)
 

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -25,14 +25,14 @@ import (
 )
 
 // GetNodeStatus returns the status of all Weaviate nodes.
-func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity string) ([]*models.NodeStatus, error) {
+func (db *DB) GetNodeStatus(ctx context.Context, className, shardName string, verbosity string) ([]*models.NodeStatus, error) {
 	nodeStatuses := make([]*models.NodeStatus, len(db.schemaGetter.Nodes()))
 	eg := enterrors.NewErrorGroupWrapper(db.logger)
 	eg.SetLimit(_NUMCPU)
 	for i, nodeName := range db.schemaGetter.Nodes() {
 		i, nodeName := i, nodeName
 		eg.Go(func() error {
-			status, err := db.GetOneNodeStatus(ctx, nodeName, className, verbosity)
+			status, err := db.GetOneNodeStatus(ctx, nodeName, className, shardName, verbosity)
 			if err != nil {
 				return fmt.Errorf("node: %v: %w", nodeName, err)
 			}
@@ -56,11 +56,11 @@ func (db *DB) GetNodeStatus(ctx context.Context, className string, verbosity str
 	return nodeStatuses, nil
 }
 
-func (db *DB) GetOneNodeStatus(ctx context.Context, nodeName string, className, output string) (*models.NodeStatus, error) {
+func (db *DB) GetOneNodeStatus(ctx context.Context, nodeName string, className, shardName, output string) (*models.NodeStatus, error) {
 	if db.schemaGetter.NodeName() == nodeName {
-		return db.LocalNodeStatus(ctx, className, output), nil
+		return db.LocalNodeStatus(ctx, className, shardName, output), nil
 	}
-	status, err := db.remoteNode.GetNodeStatus(ctx, nodeName, className, output)
+	status, err := db.remoteNode.GetNodeStatus(ctx, nodeName, className, shardName, output)
 	if err != nil {
 		var errSendHttpRequest *enterrors.ErrSendHttpRequest
 		switch {
@@ -83,11 +83,11 @@ func (db *DB) GetOneNodeStatus(ctx context.Context, nodeName string, className, 
 }
 
 // IncomingGetNodeStatus returns the index if it exists or nil if it doesn't
-func (db *DB) IncomingGetNodeStatus(ctx context.Context, className, verbosity string) (*models.NodeStatus, error) {
-	return db.LocalNodeStatus(ctx, className, verbosity), nil
+func (db *DB) IncomingGetNodeStatus(ctx context.Context, className, shardName, verbosity string) (*models.NodeStatus, error) {
+	return db.LocalNodeStatus(ctx, className, shardName, verbosity), nil
 }
 
-func (db *DB) LocalNodeStatus(ctx context.Context, className, output string) *models.NodeStatus {
+func (db *DB) LocalNodeStatus(ctx context.Context, className, shardName, output string) *models.NodeStatus {
 	if className != "" && db.GetIndex(schema.ClassName(className)) == nil {
 		// class not found
 		return &models.NodeStatus{}
@@ -98,7 +98,7 @@ func (db *DB) LocalNodeStatus(ctx context.Context, className, output string) *mo
 		nodeStats *models.NodeStats
 	)
 	if output == verbosity.OutputVerbose {
-		nodeStats = db.localNodeShardStats(ctx, &shards, className)
+		nodeStats = db.localNodeShardStats(ctx, &shards, className, shardName)
 	}
 
 	clusterHealthStatus := models.NodeStatusStatusHEALTHY
@@ -120,7 +120,7 @@ func (db *DB) LocalNodeStatus(ctx context.Context, className, output string) *mo
 }
 
 func (db *DB) localNodeShardStats(ctx context.Context,
-	status *[]*models.NodeShardStatus, className string,
+	status *[]*models.NodeShardStatus, className, shardName string,
 ) *models.NodeStats {
 	var objectCount, shardCount int64
 	if className == "" {
@@ -132,7 +132,7 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 					Warningf("no resource found for index %q", name)
 				continue
 			}
-			objects, shards := idx.getShardsNodeStatus(ctx, status)
+			objects, shards := idx.getShardsNodeStatus(ctx, status, shardName)
 			objectCount, shardCount = objectCount+objects, shardCount+shards
 		}
 		return &models.NodeStats{
@@ -146,7 +146,7 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 			Warningf("no index found for class %q", className)
 		return nil
 	}
-	objectCount, shardCount = idx.getShardsNodeStatus(ctx, status)
+	objectCount, shardCount = idx.getShardsNodeStatus(ctx, status, shardName)
 	return &models.NodeStats{
 		ObjectCount: objectCount,
 		ShardCount:  shardCount,
@@ -164,8 +164,80 @@ func (db *DB) localNodeBatchStats() *models.BatchStats {
 }
 
 func (i *Index) getShardsNodeStatus(ctx context.Context,
-	status *[]*models.NodeShardStatus,
+	status *[]*models.NodeShardStatus, shardName string,
 ) (totalCount, shardCount int64) {
+	// TODO just adding this to use for debugging
+	if shardName != "" {
+		shard, release, err := i.GetShard(ctx, shardName)
+		if err != nil {
+			i.logger.Errorf("error while getting shard %s: %w", shardName, err)
+			return 0, 0
+		}
+		defer release()
+
+		// Don't force load a lazy shard to get nodes status
+		if lazy, ok := shard.(*LazyLoadShard); ok {
+			if !lazy.isLoaded() {
+				class := shard.Index().Config.ClassName.String()
+				shardingState := shard.Index().getSchema.CopyShardingState(class)
+				numberOfReplicas, err := shardingState.NumberOfReplicas(shard.Name())
+				if err != nil {
+					i.logger.Errorf("error while getting number of replicas for shard %s: %w", shard.Name(), err)
+				}
+				shardStatus := &models.NodeShardStatus{
+					Name:                   shardName,
+					Class:                  class,
+					VectorIndexingStatus:   shard.GetStatus().String(),
+					Loaded:                 false,
+					ReplicationFactor:      shardingState.ReplicationFactor,
+					NumberOfReplicas:       numberOfReplicas,
+					AsyncReplicationStatus: shard.getAsyncReplicationStats(ctx),
+				}
+				*status = append(*status, shardStatus)
+				shardCount++
+				return
+			}
+		}
+
+		objectCount := int64(shard.ObjectCountAsync())
+		totalCount += objectCount
+
+		// FIXME stats of target vectors
+		var queueLen int64
+		_ = shard.ForEachVectorQueue(func(_ string, queue *VectorIndexQueue) error {
+			queueLen += queue.Size()
+			return nil
+		})
+
+		var compressed bool
+		_ = shard.ForEachVectorIndex(func(_ string, index VectorIndex) error {
+			compressed = compressed || index.Compressed()
+			return nil
+		})
+
+		class := shard.Index().Config.ClassName.String()
+		shardingState := shard.Index().getSchema.CopyShardingState(class)
+		numberOfReplicas, err := shardingState.NumberOfReplicas(shard.Name())
+		if err != nil {
+			i.logger.Errorf("error while getting number of replicas for shard %s: %w", shard.Name(), err)
+		}
+
+		shardStatus := &models.NodeShardStatus{
+			Name:                   shardName,
+			Class:                  class,
+			ObjectCount:            objectCount,
+			VectorIndexingStatus:   shard.GetStatus().String(),
+			VectorQueueLength:      queueLen,
+			Compressed:             compressed,
+			Loaded:                 true,
+			AsyncReplicationStatus: shard.getAsyncReplicationStats(ctx),
+			ReplicationFactor:      shardingState.ReplicationFactor,
+			NumberOfReplicas:       numberOfReplicas,
+		}
+		*status = append(*status, shardStatus)
+		shardCount++
+		return
+	}
 	i.ForEachShard(func(name string, shard ShardLike) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -181,12 +253,13 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 					i.logger.Errorf("error while getting number of replicas for shard %s: %w", shard.Name(), err)
 				}
 				shardStatus := &models.NodeShardStatus{
-					Name:                 name,
-					Class:                class,
-					VectorIndexingStatus: shard.GetStatus().String(),
-					Loaded:               false,
-					ReplicationFactor:    shardingState.ReplicationFactor,
-					NumberOfReplicas:     numberOfReplicas,
+					Name:                   name,
+					Class:                  class,
+					VectorIndexingStatus:   shard.GetStatus().String(),
+					Loaded:                 false,
+					ReplicationFactor:      shardingState.ReplicationFactor,
+					NumberOfReplicas:       numberOfReplicas,
+					AsyncReplicationStatus: shard.getAsyncReplicationStats(ctx),
 				}
 				*status = append(*status, shardStatus)
 				shardCount++

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -53,7 +53,7 @@ func TestNodesAPI_Journey(t *testing.T) {
 	migrator := NewMigrator(repo, logger)
 
 	// check nodes api response on empty DB
-	nodeStatues, err := repo.GetNodeStatus(context.Background(), "", verbosity.OutputVerbose)
+	nodeStatues, err := repo.GetNodeStatus(context.Background(), "", "", verbosity.OutputVerbose)
 	require.Nil(t, err)
 	require.NotNil(t, nodeStatues)
 
@@ -121,7 +121,7 @@ func TestNodesAPI_Journey(t *testing.T) {
 	assert.Nil(t, batchRes[1].Err)
 
 	// check nodes api after importing 2 objects to DB
-	nodeStatues, err = repo.GetNodeStatus(context.Background(), "", verbosity.OutputVerbose)
+	nodeStatues, err = repo.GetNodeStatus(context.Background(), "", "", verbosity.OutputVerbose)
 	require.Nil(t, err)
 	require.NotNil(t, nodeStatues)
 

--- a/client/nodes/nodes_get_class_parameters.go
+++ b/client/nodes/nodes_get_class_parameters.go
@@ -83,6 +83,9 @@ type NodesGetClassParams struct {
 	*/
 	Output *string
 
+	// ShardName.
+	ShardName *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -169,6 +172,17 @@ func (o *NodesGetClassParams) SetOutput(output *string) {
 	o.Output = output
 }
 
+// WithShardName adds the shardName to the nodes get class params
+func (o *NodesGetClassParams) WithShardName(shardName *string) *NodesGetClassParams {
+	o.SetShardName(shardName)
+	return o
+}
+
+// SetShardName adds the shardName to the nodes get class params
+func (o *NodesGetClassParams) SetShardName(shardName *string) {
+	o.ShardName = shardName
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *NodesGetClassParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -194,6 +208,23 @@ func (o *NodesGetClassParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		if qOutput != "" {
 
 			if err := r.SetQueryParam("output", qOutput); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.ShardName != nil {
+
+		// query param shardName
+		var qrShardName string
+
+		if o.ShardName != nil {
+			qrShardName = *o.ShardName
+		}
+		qShardName := qrShardName
+		if qShardName != "" {
+
+			if err := r.SetQueryParam("shardName", qShardName); err != nil {
 				return err
 			}
 		}

--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -312,7 +312,7 @@ func (c *Copier) RevertAsyncReplicationLocally(ctx context.Context, collectionNa
 // The first two return values are the number of objects propagated and the start diff time in unix milliseconds.
 func (c *Copier) AsyncReplicationStatus(ctx context.Context, srcNodeId, targetNodeId, collectionName, shardName string) (models.AsyncReplicationStatus, error) {
 	// TODO can using verbose here blow up if the node has many shards/tenants? i could add a new method to get only one shard?
-	status, err := c.dbWrapper.GetOneNodeStatus(ctx, srcNodeId, collectionName, "verbose")
+	status, err := c.dbWrapper.GetOneNodeStatus(ctx, srcNodeId, collectionName, shardName, "verbose")
 	if err != nil {
 		return models.AsyncReplicationStatus{}, err
 	}

--- a/cluster/replication/copier/types/types.go
+++ b/cluster/replication/copier/types/types.go
@@ -29,7 +29,7 @@ type DbWrapper interface {
 	GetIndex(name schema.ClassName) *db.Index
 
 	// GetOneNodeStatus See adapters/repos/db.DB.GetOneNodeStatus
-	GetOneNodeStatus(ctx context.Context, nodeName string, className, output string) (*models.NodeStatus, error)
+	GetOneNodeStatus(ctx context.Context, nodeName string, className, shardName, output string) (*models.NodeStatus, error)
 }
 
 // ShardLoader is a type that can load a shard from disk files, this is used to avoid a circular

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -7841,6 +7841,12 @@
             "type": "string"
           },
           {
+            "name": "shardName",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
             "$ref": "#/parameters/CommonOutputVerbosityParameterQuery"
           }
         ],

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -541,7 +541,7 @@ func (f *fakeNodeResolver) NodeHostname(string) (string, bool) {
 
 type fakeRemoteNodeClient struct{}
 
-func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error) {
+func (f *fakeRemoteNodeClient) GetNodeStatus(ctx context.Context, hostName, className, shardName, output string) (*models.NodeStatus, error) {
 	return &models.NodeStatus{}, nil
 }
 

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -29,7 +29,7 @@ import (
 const GetNodeStatusTimeout = 30 * time.Second
 
 type db interface {
-	GetNodeStatus(ctx context.Context, className, verbosity string) ([]*models.NodeStatus, error)
+	GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error)
 	GetNodeStatistics(ctx context.Context) ([]*models.Statistics, error)
 }
 
@@ -50,7 +50,7 @@ func NewManager(logger logrus.FieldLogger, authorizer authorization.Authorizer,
 // GetNodeStatus aggregates the status across all nodes. It will try for a
 // maximum of the configured timeout, then mark nodes as timed out.
 func (m *Manager) GetNodeStatus(ctx context.Context,
-	principal *models.Principal, className string, verbosityString string,
+	principal *models.Principal, className, shardName, verbosityString string,
 ) ([]*models.NodeStatus, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
 	defer cancel()
@@ -64,7 +64,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 		}
 	}
 
-	status, err := m.db.GetNodeStatus(ctxWithTimeout, className, verbosityString)
+	status, err := m.db.GetNodeStatus(ctxWithTimeout, className, shardName, verbosityString)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/sharding/remote_node.go
+++ b/usecases/sharding/remote_node.go
@@ -19,7 +19,7 @@ import (
 )
 
 type RemoteNodeClient interface {
-	GetNodeStatus(ctx context.Context, hostName, className, output string) (*models.NodeStatus, error)
+	GetNodeStatus(ctx context.Context, hostName, className, shardName, output string) (*models.NodeStatus, error)
 	GetStatistics(ctx context.Context, hostName string) (*models.Statistics, error)
 }
 
@@ -35,12 +35,12 @@ func NewRemoteNode(nodeResolver nodeResolver, client RemoteNodeClient) *RemoteNo
 	}
 }
 
-func (rn *RemoteNode) GetNodeStatus(ctx context.Context, nodeName, className, output string) (*models.NodeStatus, error) {
+func (rn *RemoteNode) GetNodeStatus(ctx context.Context, nodeName, className, shardName, output string) (*models.NodeStatus, error) {
 	host, ok := rn.nodeResolver.NodeHostname(nodeName)
 	if !ok {
 		return nil, fmt.Errorf("resolve node name %q to host", nodeName)
 	}
-	return rn.client.GetNodeStatus(ctx, host, className, output)
+	return rn.client.GetNodeStatus(ctx, host, className, shardName, output)
 }
 
 func (rn *RemoteNode) GetStatistics(ctx context.Context, nodeName string) (*models.Statistics, error) {

--- a/usecases/sharding/remote_node_incoming.go
+++ b/usecases/sharding/remote_node_incoming.go
@@ -18,7 +18,7 @@ import (
 )
 
 type RemoteNodeIncomingRepo interface {
-	IncomingGetNodeStatus(ctx context.Context, className, output string) (*models.NodeStatus, error)
+	IncomingGetNodeStatus(ctx context.Context, className, shardName, output string) (*models.NodeStatus, error)
 	IncomingGetNodeStatistics() (*models.Statistics, error)
 }
 
@@ -32,8 +32,8 @@ func NewRemoteNodeIncoming(repo RemoteNodeIncomingRepo) *RemoteNodeIncoming {
 	}
 }
 
-func (rni *RemoteNodeIncoming) GetNodeStatus(ctx context.Context, className, output string) (*models.NodeStatus, error) {
-	return rni.repo.IncomingGetNodeStatus(ctx, className, output)
+func (rni *RemoteNodeIncoming) GetNodeStatus(ctx context.Context, className, shardName, output string) (*models.NodeStatus, error) {
+	return rni.repo.IncomingGetNodeStatus(ctx, className, shardName, output)
 }
 
 func (rni *RemoteNodeIncoming) GetStatistics(ctx context.Context) (*models.Statistics, error) {

--- a/usecases/telemetry/fakes_for_test.go
+++ b/usecases/telemetry/fakes_for_test.go
@@ -24,7 +24,7 @@ type fakeNodesStatusGetter struct {
 }
 
 func (n *fakeNodesStatusGetter) LocalNodeStatus(ctx context.Context,
-	className, verbosity string,
+	className, shardName, verbosity string,
 ) *models.NodeStatus {
 	args := n.Called(ctx, className, verbosity)
 	if args.Get(0) != nil {

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -41,7 +41,7 @@ const (
 )
 
 type nodesStatusGetter interface {
-	LocalNodeStatus(ctx context.Context, className, output string) *models.NodeStatus
+	LocalNodeStatus(ctx context.Context, className, shardName, output string) *models.NodeStatus
 }
 
 type schemaManager interface {
@@ -249,7 +249,7 @@ func (tel *Telemeter) determineModule(name string, cfg interface{}) string {
 }
 
 func (tel *Telemeter) getObjectCount(ctx context.Context) (int64, error) {
-	status := tel.nodesStatusGetter.LocalNodeStatus(ctx, "", verbosity.OutputVerbose)
+	status := tel.nodesStatusGetter.LocalNodeStatus(ctx, "", "", verbosity.OutputVerbose)
 	if status == nil || status.Stats == nil {
 		return 0, fmt.Errorf("received nil node stats")
 	}

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -36,7 +36,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Run("on init", func(t *testing.T) {
 			tel, sg, sm := newTestTelemeter()
-			sg.On("LocalNodeStatus", context.Background(), "", verbosity.OutputVerbose).Return(
+			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
 						ObjectCount: 100,
@@ -141,7 +141,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 
 		t.Run("on update", func(t *testing.T) {
 			tel, sg, sm := newTestTelemeter()
-			sg.On("LocalNodeStatus", context.Background(), "", verbosity.OutputVerbose).Return(
+			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
 						ObjectCount: 1000,
@@ -195,7 +195,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 
 		t.Run("on terminate", func(t *testing.T) {
 			tel, sg, _ := newTestTelemeter()
-			sg.On("LocalNodeStatus", context.Background(), "", verbosity.OutputVerbose).Return(
+			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
 						ObjectCount: 300_000_000_000,
@@ -216,7 +216,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 	t.Run("failure path", func(t *testing.T) {
 		t.Run("fail to get node status", func(t *testing.T) {
 			tel, sg, _ := newTestTelemeter()
-			sg.On("LocalNodeStatus", context.Background(), "", verbosity.OutputVerbose).Return(nil)
+			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(nil)
 			payload, err := tel.buildPayload(context.Background(), PayloadType.Terminate)
 			assert.Nil(t, payload)
 			assert.NotNil(t, err)
@@ -225,7 +225,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 
 		t.Run("fail to get node status stats", func(t *testing.T) {
 			tel, sg, _ := newTestTelemeter()
-			sg.On("LocalNodeStatus", context.Background(), "", verbosity.OutputVerbose).Return(&models.NodeStatus{})
+			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(&models.NodeStatus{})
 			payload, err := tel.buildPayload(context.Background(), PayloadType.Terminate)
 			assert.Nil(t, payload)
 			assert.NotNil(t, err)
@@ -246,7 +246,7 @@ func TestTelemetry_WithConsumer(t *testing.T) {
 	}
 	tel, sg, sm := newTestTelemeter(opts...)
 
-	sg.On("LocalNodeStatus", context.Background(), "", verbosity.OutputVerbose).Return(
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 		&models.NodeStatus{
 			Stats: &models.NodeStats{
 				ObjectCount: 100,


### PR DESCRIPTION
### What's being changed:

Debugging if the get node status call is slow because of iterating all shards

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
