### PR TITLE
Rplc mvmnt/fix sync shard belongs to nodes

### DIFF
--- a/test/acceptance/replication/replica_replication/move_test.go
+++ b/test/acceptance/replication/replica_replication/move_test.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica_replication
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/replication"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+func (suite *ReplicationTestSuiteEndpoints) TestReplicationReplicateMOVEDeletesSourceReplica() {
+	t := suite.T()
+	mainCtx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		Start(mainCtx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(mainCtx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	paragraphClass := articles.ParagraphsClass()
+	helper.DeleteClass(t, paragraphClass.Class)
+	helper.CreateClass(t, paragraphClass)
+
+	req := getRequest(t, paragraphClass.Class)
+
+	move := "MOVE"
+	req.TransferType = &move
+	// Create MOVE replication operation and wait until the shard is in the sharding state (meaning it is uncancellable)
+	created, err := helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(req), nil)
+	require.Nil(t, err)
+	id := *created.Payload.ID
+
+	// Wait until the replication operation is READY
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		status, err := helper.Client(t).Replication.ReplicationDetails(replication.NewReplicationDetailsParams().WithID(id), nil)
+		require.Nil(t, err)
+		require.Equal(ct, "READY", status.Payload.Status.State)
+	}, 60*time.Second, 100*time.Millisecond, "Replication operation should be in READY state")
+
+	t.Run("ensure target and source replicas are there/gone respectively", func(t *testing.T) {
+		verbose := verbosity.OutputVerbose
+		nodes, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+		require.Nil(t, err)
+		foundSrc := false
+		foundDst := false
+		for _, node := range nodes.Payload.Nodes {
+			if *req.SourceNodeName == node.Name {
+				for _, shard := range node.Shards {
+					if shard.Name == *req.ShardID {
+						foundSrc = true
+					}
+				}
+			}
+			if *req.DestinationNodeName == node.Name {
+				for _, shard := range node.Shards {
+					if shard.Name == *req.ShardID {
+						foundDst = true
+					}
+				}
+			}
+		}
+		require.False(t, foundSrc, "source replica should not be there")
+		require.True(t, foundDst, "destination replica should be there")
+	})
+}


### PR DESCRIPTION
### What's being changed:

- Fixes bug associated with `MOVE` operations whereby the source shard was not removed from the DB appropriately by the action of `SyncShard`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
