### PR TITLE
fix: replace unsupported gemini-1.0-pro-vision model with gemini-2.0-flash-001 in Google e2e tests

### DIFF
--- a/test/modules/generative-google/generative_google_test.go
+++ b/test/modules/generative-google/generative_google_test.go
@@ -73,8 +73,8 @@ func testGenerativeGoogle(rest, grpc, gcpProject, generativeGoogle string) func(
 				absentModuleConfig: true,
 			},
 			{
-				name:            "gemini-1.0-pro-vision",
-				generativeModel: "gemini-1.0-pro-vision",
+				name:            "gemini-2.0-flash-001",
+				generativeModel: "gemini-2.0-flash-001",
 				withImages:      true,
 			},
 		}


### PR DESCRIPTION
### What's being changed:

Remove unsupported `gemini-1.0-pro-vision` model from generative Google e2e tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
