### PR TITLE
Turn wal recovery log msg to debug

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -148,7 +148,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 
 		b.logger.WithField("action", "lsm_recover_from_active_wal_success").
 			WithField("path", filepath.Join(b.dir, fname)).
-			Info("successfully recovered from write-ahead-log")
+			Debug("successfully recovered from write-ahead-log")
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:

This is a follow-up to #8214, which already changed one of the wal-recovery logs _before_ recovery to debug. However, one was still left that logged a successful recovery at the `info` level. With the changes introduced in #8116, a WAL recovery is a normal event, so there is no need to log it every time.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
