### PR TITLE
chore: Fix panic in test when introducing new runtime config 

### DIFF
--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -65,6 +65,10 @@ func (dv *DynamicValue[T]) Get() T {
 
 // Reset removes the old dynamic value.
 func (dv *DynamicValue[T]) Reset() {
+	if dv == nil {
+		return
+	}
+
 	dv.mu.Lock()
 	defer dv.mu.Unlock()
 


### PR DESCRIPTION
### What's being changed:
1. Fix panic in test when introducing new runtime config 
2. add test to lock the panic behavior of Reset() in runtime configmanager

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
