### PR TITLE
chore: Add INFO logs for every change in runtime overrides config.

### DIFF
--- a/tools/dev/config.runtime-overrides.yaml
+++ b/tools/dev/config.runtime-overrides.yaml
@@ -3,4 +3,3 @@ autoschema_enabled: true
 async_replication_disabled: false
 tenant_activity_read_log_level: info
 tenant_activity_write_log_level: info
-

--- a/usecases/config/runtime/manager.go
+++ b/usecases/config/runtime/manager.go
@@ -41,7 +41,7 @@ var (
 type Parser[T any] func([]byte) (*T, error)
 
 // Updater try to update `source` config with newly `parsed` config.
-type Updater[T any] func(source, parsed *T) error
+type Updater[T any] func(log logrus.FieldLogger, source, parsed *T) error
 
 // ConfigManager takes care of periodically loading the config from
 // given filepath for every interval period.
@@ -138,7 +138,7 @@ func (cm *ConfigManager[T]) loadConfig() error {
 		return errors.Join(ErrFailedToParseConfig, err)
 	}
 
-	if err := cm.update(cm.currentConfig, cfg); err != nil {
+	if err := cm.update(cm.log, cm.currentConfig, cfg); err != nil {
 		return err
 	}
 

--- a/usecases/config/runtime/manager_test.go
+++ b/usecases/config/runtime/manager_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,7 @@ func parseYaml(buf []byte) (*testConfig, error) {
 	return &c, nil
 }
 
-func updater(source, parsed *testConfig) error {
+func updater(_ logrus.FieldLogger, source, parsed *testConfig) error {
 	source.BackupInterval.SetValue(parsed.BackupInterval.Get())
 	return nil
 }

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
 	"gopkg.in/yaml.v3"
 )
@@ -53,12 +54,12 @@ func ParseRuntimeConfig(buf []byte) (*WeaviateRuntimeConfig, error) {
 
 // UpdateConfig does in-place update of `source` config based on values available in
 // `parsed` config.
-func UpdateRuntimeConfig(source, parsed *WeaviateRuntimeConfig) error {
+func UpdateRuntimeConfig(log logrus.FieldLogger, source, parsed *WeaviateRuntimeConfig) error {
 	if source == nil || parsed == nil {
 		return fmt.Errorf("source and parsed cannot be nil")
 	}
 
-	updateRuntimeConfig(reflect.ValueOf(*source), reflect.ValueOf(*parsed))
+	updateRuntimeConfig(log, reflect.ValueOf(*source), reflect.ValueOf(*parsed))
 	return nil
 }
 
@@ -97,7 +98,7 @@ But this approach has two serious drawbacks
 With this reflection method, we avoided that extra step from the consumer. This reflection approach is "logically" same as above implementation.
 See "runtimeconfig_test.go" for more examples.
 */
-func updateRuntimeConfig(source, parsed reflect.Value) {
+func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value) {
 	// Basically we do following
 	//
 	// 1. Loop through all the `source` fields
@@ -106,43 +107,97 @@ func updateRuntimeConfig(source, parsed reflect.Value) {
 	//    so that it's default value takes preference.
 	// 4. If parsed config does contain the field from `source`, We update the value via `SetValue`.
 
+	logRecords := make([]updateLogRecord, 0)
+
 	for i := range source.NumField() {
 		sf := source.Field(i)
 		pf := parsed.Field(i)
 
-		if pf.IsNil() {
-			si := sf.Interface()
-			src, ok := si.(interface{ Reset() })
-			if !ok {
-				panic(fmt.Sprintf("type doesn't have Reset() method: %#v", si))
-			}
-			src.Reset()
-			continue
+		r := updateLogRecord{
+			field: source.Type().Field(i).Name,
 		}
 
 		si := sf.Interface()
-		pi := pf.Interface()
+		var pi any
+		if !pf.IsNil() {
+			pi = pf.Interface()
+		}
 
 		switch sv := si.(type) {
 		case *runtime.DynamicValue[int]:
-			// this casting is fine, because both `parsed` and `source` are same struct.
-			p := pi.(*runtime.DynamicValue[int])
-			sv.SetValue(p.Get())
+			r.oldV = sv.Get()
+			if pf.IsNil() {
+				// Means the config is removed
+				sv.Reset()
+			} else {
+				p := pi.(*runtime.DynamicValue[int])
+				sv.SetValue(p.Get())
+			}
+			r.newV = sv.Get()
 		case *runtime.DynamicValue[float64]:
-			p := pi.(*runtime.DynamicValue[float64])
-			sv.SetValue(p.Get())
+			r.oldV = sv.Get()
+			if pf.IsNil() {
+				// Means the config is removed
+				sv.Reset()
+			} else {
+				p := pi.(*runtime.DynamicValue[float64])
+				sv.SetValue(p.Get())
+			}
+			r.newV = sv.Get()
 		case *runtime.DynamicValue[bool]:
-			p := pi.(*runtime.DynamicValue[bool])
-			sv.SetValue(p.Get())
+			r.oldV = sv.Get()
+			if pf.IsNil() {
+				// Means the config is removed
+				sv.Reset()
+			} else {
+				p := pi.(*runtime.DynamicValue[bool])
+				sv.SetValue(p.Get())
+			}
+			r.newV = sv.Get()
 		case *runtime.DynamicValue[time.Duration]:
-			p := pi.(*runtime.DynamicValue[time.Duration])
-			sv.SetValue(p.Get())
+			r.oldV = sv.Get()
+			if pf.IsNil() {
+				// Means the config is removed
+				sv.Reset()
+			} else {
+				p := pi.(*runtime.DynamicValue[time.Duration])
+				sv.SetValue(p.Get())
+			}
+			r.newV = sv.Get()
 		case *runtime.DynamicValue[string]:
-			p := pi.(*runtime.DynamicValue[string])
-			sv.SetValue(p.Get())
+			r.oldV = sv.Get()
+			if pf.IsNil() {
+				// Means the config is removed
+				sv.Reset()
+			} else {
+				p := pi.(*runtime.DynamicValue[string])
+				sv.SetValue(p.Get())
+			}
+			r.newV = sv.Get()
 		default:
 			panic(fmt.Sprintf("not recognized type: %#v, %#v", pi, si))
 		}
 
+		if r.newV != r.oldV {
+			logRecords = append(logRecords, r)
+
+		}
+
 	}
+
+	// log the changes made as INFO for auditing.
+	for _, v := range logRecords {
+		log.WithFields(logrus.Fields{
+			"action":    "runtime_overrides_changed",
+			"field":     v.field,
+			"old_value": v.oldV,
+			"new_value": v.newV,
+		}).Infof("runtime overrides: config '%v' changed from '%v' to '%v'", v.field, v.oldV, v.newV)
+	}
+}
+
+// updateLogRecord is used to record changes during updating runtime config.
+type updateLogRecord struct {
+	field      string
+	oldV, newV any
 }

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -12,10 +12,13 @@
 package config
 
 import (
+	"bytes"
+	"io"
 	"regexp"
 	"testing"
 
 	"github.com/go-jose/go-jose/v4/json"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
@@ -80,6 +83,9 @@ func assertConfigKey(t *testing.T, key string) {
 }
 
 func TestUpdateRuntimeConfig(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
 	t.Run("updating should reflect changes in registered configs", func(t *testing.T) {
 		var (
 			colCount                 runtime.DynamicValue[int]
@@ -109,7 +115,7 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, false, autoSchema.Get())
 		assert.Equal(t, 0, colCount.Get())
 
-		require.NoError(t, UpdateRuntimeConfig(reg, parsed))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed))
 
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
@@ -139,11 +145,62 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, false, autoSchema.Get())
 		assert.Equal(t, 0, colCount.Get())
 
-		require.NotPanics(t, func() { UpdateRuntimeConfig(reg, parsed) })
+		require.NotPanics(t, func() { UpdateRuntimeConfig(log, reg, parsed) })
 
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
 		assert.Equal(t, 13, colCount.Get())
+	})
+
+	t.Run("updating config should split out corresponding log lines", func(t *testing.T) {
+		log := logrus.New()
+		logs := bytes.Buffer{}
+		log.SetOutput(&logs)
+
+		var (
+			colCount   = runtime.NewDynamicValue(7)
+			autoSchema runtime.DynamicValue[bool]
+		)
+
+		reg := &WeaviateRuntimeConfig{
+			MaximumAllowedCollectionsCount: colCount,
+			AutoschemaEnabled:              &autoSchema,
+		}
+
+		// parsed from yaml configs for example
+		buf := []byte(`autoschema_enabled: true
+maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
+		parsed, err := ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+
+		// before update (zero values)
+		assert.Equal(t, false, autoSchema.Get())
+		assert.Equal(t, 7, colCount.Get())
+
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed))
+		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '7' to '13'" action=runtime_overrides_changed field=MaximumAllowedCollectionsCount new_value=13 old_value=7`)
+		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'AutoschemaEnabled' changed from 'false' to 'true'" action=runtime_overrides_changed field=AutoschemaEnabled new_value=true old_value=false`)
+		logs.Reset()
+
+		// change configs
+		buf = []byte(`autoschema_enabled: false
+maximum_allowed_collections_count: 10`)
+		parsed, err = ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed))
+		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '13' to '10'" action=runtime_overrides_changed field=MaximumAllowedCollectionsCount new_value=10 old_value=13`)
+		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'AutoschemaEnabled' changed from 'true' to 'false'" action=runtime_overrides_changed field=AutoschemaEnabled new_value=false old_value=true`)
+		logs.Reset()
+
+		// remove configs (`maximum_allowed_collections_count`)
+		buf = []byte(`autoschema_enabled: false`)
+		parsed, err = ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed))
+		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '10' to '7'" action=runtime_overrides_changed field=MaximumAllowedCollectionsCount new_value=7 old_value=10`)
+
 	})
 
 	t.Run("updating priorities", func(t *testing.T) {
@@ -180,7 +237,7 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, 0, colCount.Get())
 		assert.Equal(t, false, asyncRep.Get()) // this field doesn't exist in original config file.
 
-		require.NoError(t, UpdateRuntimeConfig(reg, parsed))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed))
 
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
@@ -197,7 +254,7 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, 13, colCount.Get())
 		assert.Equal(t, false, asyncRep.Get()) // this field doesn't exist in original config file, should return default value.
 
-		require.NoError(t, UpdateRuntimeConfig(reg, parsed))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed))
 
 		// after update.
 		assert.Equal(t, false, autoSchema.Get())


### PR DESCRIPTION

### What's being changed:

This is emitted only if fields are actually changed. If no change between relods, no logs are printed. This also includes if any configs were removed from the file. In that case it prints the default value as new value.

Example logs
```
INFO[0030] runtime overrides: config 'AsyncReplicationDisabled' changed from 'true' to 'false'  action=runtime_overrides_changed build_git_commit=3a61f76ae8 build_go_version=go1.24.3 build_image_tag=kavirajk/handle-test-panic build_wv_version=1.30.6 field=AsyncReplicationDisabled new_value=false old_value=true

INFO[0150] runtime overrides: config 'AsyncReplicationDisabled' changed from 'false' to 'true'  action=runtime_overrides_changed build_git_commit=3a61f76ae8 build_go_version=go1.24.3 build_image_tag=kavirajk/handle-test-panic build_wv_version=1.30.6 field=AsyncReplicationDisabled new_value=true old_value=false

INFO[0180] runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '7' to '-1'  action=runtime_overrides_changed build_git_commit=3a61f76ae8 build_go_version=go1.24.3 build_image_tag=kavirajk/handle-test-panic build_wv_version=1.30.6 field=MaximumAllowedCollectionsCount new_value=-1 old_value=7

INFO[0180] runtime overrides: config 'AsyncReplicationDisabled' changed from 'true' to 'false'  action=runtime_overrides_changed build_git_commit=3a61f76ae8 build_go_version=go1.24.3 build_image_tag=kavirajk/handle-test-panic build_wv_version=1.30.6 field=AsyncReplicationDisabled new_value=false old_value=true

INFO[0360] runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '-1' to '7'  action=runtime_overrides_changed build_git_commit=3a61f76ae8 build_go_version=go1.24.3 build_image_tag=kavirajk/handle-test-panic build_wv_version=1.30.6 field=MaximumAllowedCollectionsCount new_value=7 old_value=-1
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
