### PR TITLE
chore(runtime): Improve log message and fix flaky test

### DIFF
--- a/usecases/config/runtime/manager.go
+++ b/usecases/config/runtime/manager.go
@@ -164,11 +164,11 @@ func (cm *ConfigManager[T]) loop(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			if err := cm.loadConfig(); err != nil {
-				cm.log.Errorf("loading runtime config every %s failed, using old config: %w", cm.interval, err)
+				cm.log.Errorf("loading runtime config every %s failed, using old config: %v", cm.interval, err)
 			}
 		case <-sighup:
 			if err := cm.loadConfig(); err != nil {
-				cm.log.Error("loading runtime config through SIGHUP failed, using old config: %w", err)
+				cm.log.Error("loading runtime config through SIGHUP failed, using old config: %v", err)
 			}
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
### What's being changed:
This fixes two problems:
1. replace `%w` -> `%v` for better printing of errors.
2. Fix flaky tests with config reload.

(2) was tricky to find. Turns out the problem is with filesystem cache. The race between file writer and config manager (reader). Somtimes the reader reads the file as empty due to this race. I verified this with printing the hash changes. The fix is to use `tmpfile + rename()` to do it atomically at filesystem level.

Thanks Etienne for pointing it out.

Fixing flaky tests (without this patch following run should fail)
```
go test -count 100 -failfast ./usecases/config/runtime/...
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
