### PR TITLE
fix(raft): reloadDB with 1st apply encounter where index is greater than or eq

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -776,8 +776,12 @@ type Response struct {
 
 var _ raft.FSM = &Store{}
 
-func lastSnapshotIndex(ss *raft.FileSnapshotStore) uint64 {
-	ls, err := ss.List()
+func lastSnapshotIndex(snapshotStore *raft.FileSnapshotStore) uint64 {
+	if snapshotStore == nil {
+		return 0
+	}
+
+	ls, err := snapshotStore.List()
 	if err != nil || len(ls) == 0 {
 		return 0
 	}

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -110,8 +110,8 @@ func (st *Store) Apply(l *raft.Log) any {
 		// we do this at the beginning to handle situation were schema was catching up
 		// and to make sure no matter is the error status we are going to open the db on startup
 		// we reload the db only if we have a previous state and the db is not loaded
-		shouldReloadDB := st.lastAppliedIndexToDB.Load() != 0 && !st.dbLoaded.Load()
-		if shouldReloadDB && l.Index != 0 && l.Index >= st.lastAppliedIndexToDB.Load() {
+		dbReloadRequired := st.lastAppliedIndexToDB.Load() != 0 && !st.dbLoaded.Load()
+		if dbReloadRequired && l.Index != 0 && l.Index >= st.lastAppliedIndexToDB.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,
 				"log_name":                     l.Type.String(),

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -109,7 +109,8 @@ func (st *Store) Apply(l *raft.Log) any {
 		// that means we're done doing schema only.
 		// we do this at the beginning to handle situation were schema was catching up
 		// and to make sure no matter is the error status we are going to open the db on startup
-		if l.Index != 0 && l.Index == st.lastAppliedIndexToDB.Load() {
+		appliedToDb := st.lastAppliedIndexToDB.Load()
+		if l.Index != 0 && appliedToDb > 0 && l.Index >= appliedToDb {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,
 				"log_name":                     l.Type.String(),
@@ -117,6 +118,8 @@ func (st *Store) Apply(l *raft.Log) any {
 				"last_store_log_applied_index": st.lastAppliedIndexToDB.Load(),
 			}).Info("reloading local DB as RAFT and local DB are now caught up")
 			st.reloadDBFromSchema()
+			// reset the last applied index to 0 to avoid reloading the DB multiple times
+			st.lastAppliedIndexToDB.Store(0)
 		}
 
 		// we update no mater the error status to avoid any edge cases in the DB layer for already released versions,

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -110,7 +110,7 @@ func (st *Store) Apply(l *raft.Log) any {
 		// we do this at the beginning to handle situation were schema was catching up
 		// and to make sure no matter is the error status we are going to open the db on startup
 		// we reload the db only if we have a previous state and the db is not loaded
-		shouldReloadDB := st.lastAppliedIndexToDB.Load() > 0 && !st.dbLoaded.Load()
+		shouldReloadDB := st.lastAppliedIndexToDB.Load() != 0 && !st.dbLoaded.Load()
 		if shouldReloadDB && l.Index != 0 && l.Index >= st.lastAppliedIndexToDB.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,

--- a/cluster/store_apply_test.go
+++ b/cluster/store_apply_test.go
@@ -1,0 +1,406 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	clusterschema "github.com/weaviate/weaviate/cluster/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestStore_Apply_LogTypes(t *testing.T) {
+	ms, _ := setupApplyTest(t)
+
+	tests := []struct {
+		name     string
+		logType  raft.LogType
+		expected bool
+	}{
+		{
+			name:     "Valid LogCommand type",
+			logType:  raft.LogCommand,
+			expected: true,
+		},
+		{
+			name:     "LogNoop type",
+			logType:  raft.LogNoop,
+			expected: true, // Noop logs are valid but don't do anything
+		},
+		{
+			name:     "LogBarrier type",
+			logType:  raft.LogBarrier,
+			expected: true, // Barrier logs are valid but don't do anything
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &raft.Log{
+				Index: 1,
+				Type:  tt.logType,
+				Data:  []byte{},
+			}
+
+			result := ms.store.Apply(log)
+			resp, ok := result.(Response)
+			assert.True(t, ok)
+			assert.NoError(t, resp.Error) // All log types return no error, but LogCommand is the only one that processes data
+
+			// Verify all mock expectations
+			ms.parser.AssertExpectations(t)
+			ms.indexer.AssertExpectations(t)
+		})
+	}
+}
+
+func TestStore_Apply_CommandTypes(t *testing.T) {
+	// Create test data that will be reused
+	cls := &models.Class{
+		Class: "TestClass",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	ss := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"T1": {
+				Name:           "T1",
+				BelongsToNodes: []string{"Node-1"},
+				Status:         "HOT",
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		cmdType     api.ApplyRequest_Type
+		setupMocks  func(MockStore)
+		expectError bool
+		cmdData     interface{}
+		preApply    func(MockStore) // Function to run before applying the command
+	}{
+		{
+			name:    "AddClass command",
+			cmdType: api.ApplyRequest_TYPE_ADD_CLASS,
+			setupMocks: func(ms MockStore) {
+				ms.parser.On("ParseClass", mock.Anything).Return(nil)
+				ms.indexer.On("AddClass", mock.Anything).Return(nil)
+				ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+			},
+			expectError: false,
+			cmdData:     api.AddClassRequest{Class: cls, State: ss},
+		},
+		{
+			name:    "UpdateClass command",
+			cmdType: api.ApplyRequest_TYPE_UPDATE_CLASS,
+			setupMocks: func(ms MockStore) {
+				// For UpdateClass, we need to set up ParseClassUpdate
+				// Note: ParseClass is called by the schema manager during update
+				ms.parser.On("ParseClass", mock.Anything).Return(nil)
+				ms.parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(cls, nil)
+				ms.indexer.On("UpdateClass", mock.Anything).Return(nil)
+				ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+			},
+			expectError: false,
+			cmdData:     api.UpdateClassRequest{Class: cls, State: ss},
+			preApply: func(ms MockStore) {
+				// First add the class so it exists for update
+				addLog := &raft.Log{
+					Index: 1,
+					Type:  raft.LogCommand,
+					Data:  cmdAsBytes("TestClass", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{Class: cls, State: ss}, nil),
+				}
+				// Set up separate mock expectations for the add operation
+				ms.parser.On("ParseClass", mock.Anything).Return(nil)
+				ms.indexer.On("AddClass", mock.Anything).Return(nil)
+				ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+				ms.store.Apply(addLog)
+				// Reset mock expectations after add operation
+				ms.parser.ExpectedCalls = nil
+				ms.indexer.ExpectedCalls = nil
+			},
+		},
+		{
+			name:    "DeleteClass command",
+			cmdType: api.ApplyRequest_TYPE_DELETE_CLASS,
+			setupMocks: func(ms MockStore) {
+				ms.indexer.On("DeleteClass", mock.Anything).Return(nil)
+				ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+			},
+			expectError: false,
+			cmdData:     nil,
+		},
+		{
+			name:    "Unknown command type",
+			cmdType: api.ApplyRequest_Type(999), // Non-existent type
+			setupMocks: func(ms MockStore) {
+				// No mocks needed for unknown type
+			},
+			expectError: false, // Unknown commands don't return errors, they just log
+			cmdData:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms, log := setupApplyTest(t)
+
+			// Run pre-apply setup if needed
+			if tt.preApply != nil {
+				tt.preApply(ms)
+			}
+
+			// Set up mocks after pre-apply to ensure they're not affected by pre-apply operations
+			tt.setupMocks(ms)
+
+			// Update log with test command type and data
+			log.Data = cmdAsBytes("TestClass", tt.cmdType, tt.cmdData, nil)
+
+			result := ms.store.Apply(log)
+			resp, ok := result.(Response)
+			assert.True(t, ok)
+
+			if tt.expectError {
+				assert.Error(t, resp.Error)
+			} else {
+				assert.NoError(t, resp.Error)
+			}
+
+			// Verify all mock expectations
+			ms.parser.AssertExpectations(t)
+			ms.indexer.AssertExpectations(t)
+		})
+	}
+}
+
+func TestStore_Apply_CatchingUp(t *testing.T) {
+	tests := []struct {
+		name       string
+		logIndex   uint64
+		schemaOnly bool
+	}{
+		{
+			name:       "Catching up (index <= lastAppliedIndexToDB)",
+			logIndex:   50,
+			schemaOnly: true,
+		},
+		{
+			name:       "Caught up (index > lastAppliedIndexToDB)",
+			logIndex:   150,
+			schemaOnly: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms, log := setupApplyTest(t)
+			// Set lastAppliedIndexToDB to simulate catching up scenario
+			ms.store.lastAppliedIndexToDB.Store(uint64(100))
+			log.Index = tt.logIndex
+
+			// Setup mock to verify schemaOnly parameter
+			ms.parser.On("ParseClass", mock.Anything).Return(nil)
+			if !tt.schemaOnly {
+				ms.indexer.On("AddClass", mock.Anything).Return(nil)
+				ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+			}
+
+			// The snapshot store is now properly initialized in setupApplyTest
+			result := ms.store.Apply(log)
+			resp, ok := result.(Response)
+			assert.True(t, ok)
+			assert.NoError(t, resp.Error)
+
+			// Verify schemaOnly was set correctly by checking if the class was added
+			class := ms.store.SchemaReader().ReadOnlyClass("TestClass")
+			if tt.schemaOnly {
+				assert.NotNil(t, class, "Class should be added in schema-only mode")
+			} else {
+				assert.NotNil(t, class, "Class should be added in full mode")
+			}
+
+			// Verify all mock expectations
+			ms.parser.AssertExpectations(t)
+			ms.indexer.AssertExpectations(t)
+		})
+	}
+}
+
+func TestStore_Apply_ReloadDB(t *testing.T) {
+	t.Run("Reload DB when caught up", func(t *testing.T) {
+		ms, log := setupApplyTest(t)
+		// Set lastAppliedIndexToDB to trigger DB reload
+		ms.store.lastAppliedIndexToDB.Store(uint64(100))
+		log.Index = 150 // Greater than lastAppliedIndexToDB
+
+		// Setup mocks
+		ms.parser.On("ParseClass", mock.Anything).Return(nil)
+		ms.indexer.On("AddClass", mock.Anything).Return(nil)
+		ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+		result := ms.store.Apply(log)
+		resp, ok := result.(Response)
+		assert.True(t, ok)
+		assert.NoError(t, resp.Error)
+
+		// Verify lastAppliedIndexToDB was reset
+		assert.Equal(t, uint64(0), ms.store.lastAppliedIndexToDB.Load())
+
+		// Verify all mock expectations
+		ms.parser.AssertExpectations(t)
+		ms.indexer.AssertExpectations(t)
+	})
+}
+
+func TestStore_Apply_Metrics(t *testing.T) {
+	t.Run("Metrics are updated correctly", func(t *testing.T) {
+		ms, log := setupApplyTest(t)
+
+		// Setup mocks
+		ms.parser.On("ParseClass", mock.Anything).Return(nil)
+		ms.indexer.On("AddClass", mock.Anything).Return(nil)
+		ms.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+		// Apply the log
+		result := ms.store.Apply(log)
+		resp, ok := result.(Response)
+		assert.True(t, ok)
+		assert.NoError(t, resp.Error)
+
+		// Verify metrics were updated
+		assert.Equal(t, float64(1), testutil.ToFloat64(ms.store.metrics.fsmLastAppliedIndex))
+		assert.Equal(t, float64(1), testutil.ToFloat64(ms.store.metrics.raftLastAppliedIndex))
+		assert.Equal(t, float64(0), testutil.ToFloat64(ms.store.metrics.applyFailures))
+
+		// Verify all mock expectations
+		ms.parser.AssertExpectations(t)
+		ms.indexer.AssertExpectations(t)
+	})
+}
+
+func TestStore_Apply_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupMocks  func(MockStore)
+		expectError bool
+		expectPanic bool
+	}{
+		{
+			name: "Schema manager error",
+			setupMocks: func(ms MockStore) {
+				ms.parser.On("ParseClass", mock.Anything).Return(errors.New("schema error"))
+			},
+			expectError: true,
+			expectPanic: false,
+		},
+		{
+			name: "Invalid proto data",
+			setupMocks: func(ms MockStore) {
+				// No mocks needed, we'll modify the log data directly
+			},
+			expectError: true,
+			expectPanic: true, // The Apply function panics on invalid proto data
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms, log := setupApplyTest(t)
+			tt.setupMocks(ms)
+
+			if tt.name == "Invalid proto data" {
+				log.Data = []byte("invalid proto data")
+			}
+
+			if tt.expectPanic {
+				// Use assert.Panics to verify that the function panics as expected
+				assert.PanicsWithValue(t, "error proto un-marshalling log data", func() {
+					ms.store.Apply(log)
+				})
+				// For panic cases, we still want to verify mock expectations
+				ms.parser.AssertExpectations(t)
+				ms.indexer.AssertExpectations(t)
+				return
+			}
+
+			result := ms.store.Apply(log)
+			resp, ok := result.(Response)
+			assert.True(t, ok)
+
+			if tt.expectError {
+				assert.Error(t, resp.Error)
+				assert.Equal(t, float64(1), testutil.ToFloat64(ms.store.metrics.applyFailures))
+			} else {
+				assert.NoError(t, resp.Error)
+				assert.Equal(t, float64(0), testutil.ToFloat64(ms.store.metrics.applyFailures))
+			}
+
+			// Verify all mock expectations
+			ms.parser.AssertExpectations(t)
+			ms.indexer.AssertExpectations(t)
+		})
+	}
+}
+
+func setupApplyTest(t *testing.T) (MockStore, *raft.Log) {
+	mockStore := NewMockStore(t, "Node-1", 0)
+	mockStore.store.metrics = newStoreMetrics("Node-1", prometheus.NewPedanticRegistry())
+
+	// Create a temporary directory for the snapshot store
+	tmpDir := t.TempDir()
+	snapshotStore, err := raft.NewFileSnapshotStore(tmpDir, 3, nil)
+	if err != nil {
+		t.Fatalf("failed to create snapshot store: %v", err)
+	}
+	mockStore.store.snapshotStore = snapshotStore
+
+	// Create a basic class for testing
+	cls := &models.Class{
+		Class: "TestClass",
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+	}
+
+	ss := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"T1": {
+				Name:           "T1",
+				BelongsToNodes: []string{"Node-1"},
+				Status:         "HOT",
+			},
+		},
+	}
+
+	// Create a basic log entry
+	log := &raft.Log{
+		Index: 1,
+		Type:  raft.LogCommand,
+		Data:  cmdAsBytes("TestClass", api.ApplyRequest_TYPE_ADD_CLASS, api.AddClassRequest{Class: cls, State: ss}, nil),
+	}
+
+	// Initialize the schema manager to avoid nil pointer dereference
+	mockStore.store.schemaManager = clusterschema.NewSchemaManager("Node-1", mockStore.indexer, mockStore.parser, prometheus.NewPedanticRegistry(), mockStore.logger)
+
+	return mockStore, log
+}


### PR DESCRIPTION
### What's being changed:
there is some situations we have discovered were we don't open the db if the lastAppliedIndex were greater than the raft restore applied index
e. g. 
```
{"build_git_commit":"ca35d6b","build_go_version":"go1.24.3","build_image_tag":"v1.30.3","build_wv_version":"1.30.3","last_applied_index":10526,"last_snapshot_index":8194,"last_store_log_applied_index":10526,"level":"info","msg":"successfully reloaded indexes from snapshot","n":2,"time":"2025-05-20T14:53:57Z"} 
```
this PR makes sure in case of applying and the index is greater than or equal what was applied to reload the database and open it with 1st encounter 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15398027481
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
