### PR TITLE
feat(backups-listing): expose list backups endpoint and fix gcs list all backup 

### DIFF
--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/entities/backup"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
@@ -139,21 +140,23 @@ func (a *azureClient) AllBackups(ctx context.Context) ([]*backup.DistributedBack
 		if err != nil {
 			return nil, fmt.Errorf("get next blob: %w", err)
 		}
+
 		if blob.ListBlobsFlatSegmentResponse.Segment != nil {
 			for _, item := range blob.ListBlobsFlatSegmentResponse.Segment.BlobItems {
-				if item.Name != nil {
-					if strings.Contains(*item.Name, ubak.GlobalBackupFile) {
-						contents, err := a.getObject(ctx, a.config.Container, *item.Name)
-						if err != nil {
-							return nil, fmt.Errorf("get blob item %q: %w", *item.Name, err)
-						}
-						var desc backup.DistributedBackupDescriptor
-						if err := json.Unmarshal(contents, &desc); err != nil {
-							return nil, fmt.Errorf("unmarshal blob item %q: %w", *item.Name, err)
-						}
-						meta = append(meta, &desc)
-					}
+				if item.Name == nil || !strings.Contains(*item.Name, ubak.GlobalBackupFile) {
+					continue
 				}
+
+				// now we have ubak.GlobalBackupFile
+				contents, err := a.getObject(ctx, a.config.Container, *item.Name)
+				if err != nil {
+					return nil, fmt.Errorf("get blob item %q: %w", *item.Name, err)
+				}
+				var desc backup.DistributedBackupDescriptor
+				if err := json.Unmarshal(contents, &desc); err != nil {
+					return nil, fmt.Errorf("unmarshal blob item %q: %w", *item.Name, err)
+				}
+				meta = append(meta, &desc)
 			}
 		}
 	}

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -130,6 +130,11 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 			return nil, fmt.Errorf("get next object: %w", err)
 		}
 
+		// mostly needed for testing on the emulator
+		if !strings.HasSuffix(next.Name, ubak.GlobalBackupFile) {
+			continue
+		}
+
 		contents, err := g.getObject(ctx, bucket, next.Name)
 		if err != nil {
 			return nil, fmt.Errorf("read object %q: %w", next.Name, err)

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -119,11 +119,8 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 	if err != nil {
 		return nil, fmt.Errorf("find bucket: %w", err)
 	}
-	if bucket == nil {
-		return nil, nil
-	}
 
-	iter := bucket.Objects(ctx, &storage.Query{Prefix: g.config.BackupPath, MatchGlob: "*json"})
+	iter := bucket.Objects(ctx, &storage.Query{Prefix: g.config.BackupPath, MatchGlob: "**/" + ubak.GlobalBackupFile})
 	for {
 		next, err := iter.Next()
 		if errors.Is(err, iterator.Done) {
@@ -132,17 +129,17 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 		if err != nil {
 			return nil, fmt.Errorf("get next object: %w", err)
 		}
-		if strings.Contains(next.Name, ubak.GlobalBackupFile) {
-			contents, err := g.getObject(ctx, bucket, next.Name)
-			if err != nil {
-				return nil, fmt.Errorf("read object %q: %w", next.Name, err)
-			}
-			var desc backup.DistributedBackupDescriptor
-			if err := json.Unmarshal(contents, &desc); err != nil {
-				return nil, fmt.Errorf("unmarshal object %q: %w", next.Name, err)
-			}
-			meta = append(meta, &desc)
+
+		contents, err := g.getObject(ctx, bucket, next.Name)
+		if err != nil {
+			return nil, fmt.Errorf("read object %q: %w", next.Name, err)
 		}
+		var desc backup.DistributedBackupDescriptor
+		if err := json.Unmarshal(contents, &desc); err != nil {
+			return nil, fmt.Errorf("unmarshal object %q: %w", next.Name, err)
+		}
+		meta = append(meta, &desc)
+
 	}
 
 	return meta, nil

--- a/test/helper/journey/backup_journey.go
+++ b/test/helper/journey/backup_journey.go
@@ -301,7 +301,7 @@ func backupJourneyWithCancellation(t *testing.T, className, backend, basebackupI
 }
 
 func backupJourneyWithListing(t *testing.T, journeyType journeyType, className, backend, backupID string, overrideBucket, overridePath string) {
-	if journeyType == clusterJourney && backend == "filesystem" {
+	if journeyType == clusterJourney && backend == "filesystem" || overrideBucket != "" {
 		return
 	}
 	if overridePath != "" {

--- a/test/helper/journey/cluster_backup_journey.go
+++ b/test/helper/journey/cluster_backup_journey.go
@@ -69,6 +69,10 @@ func clusterBackupJourneyTest(t *testing.T, backend, className,
 		backupJourneyWithCancellation(t, className, backend, fmt.Sprintf("%s_with_cancellation", backupID), clusterJourney, overrideBucket, overrideLocation)
 	})
 
+	t.Run(fmt.Sprintf("listing backups with coordinator endpoint: %s", coordinatorEndpoint), func(t *testing.T) {
+		backupJourneyWithListing(t, clusterJourney, className, backend, backupID, overrideBucket, overrideLocation)
+	})
+
 	t.Run("cleanup", func(t *testing.T) {
 		helper.DeleteClass(t, className)
 	})

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/entities/modulecapabilities"
 
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
@@ -147,6 +147,11 @@ func Test_Authorization(t *testing.T) {
 				modcapabilities.On("PutObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 				modcapabilities.On("Initialize", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+				// AllBackups mock expectation for List method
+				if test.methodName == "List" {
+					modcapabilities.On("AllBackups", mock.Anything).Return([]*backup.DistributedBackupDescriptor{&dd}, nil)
+				}
 
 				nodeResolver.On("NodeCount").Return(1).Maybe()
 				nodeResolver.On("LeaderID").Return("node-0").Maybe()

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -15,12 +15,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"sync"
 
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 )
@@ -107,8 +107,14 @@ func (fb *fakeBackend) HomeDir(backupID, overrideBucket, overridePath string) st
 	return args.String(0)
 }
 
-func (fb *fakeBackend) AllBackups(context.Context) ([]*backup.DistributedBackupDescriptor, error) {
-	return nil, fmt.Errorf("not implemented")
+func (fb *fakeBackend) AllBackups(ctx context.Context) ([]*backup.DistributedBackupDescriptor, error) {
+	fb.RLock()
+	defer fb.RUnlock()
+	args := fb.Called(ctx)
+	if args.Get(0) != nil {
+		return args.Get(0).([]*backup.DistributedBackupDescriptor), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (fb *fakeBackend) PutFile(ctx context.Context, backupID, key, srcPath, overrideBucket, overridePath string) error {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -315,8 +315,27 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 		logOperation(s.logger, "list_backup", "", backend, time.Now(), err)
 	}(time.Now())
 
-	// TODO : wire it with newly implemented list backups
-	return nil, fmt.Errorf("not implemented")
+	backupBackend, err := s.backends.BackupBackend(backend)
+	if err != nil {
+		return nil, err
+	}
+
+	backups, err := backupBackend.AllBackups(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	response := make(models.BackupListResponse, len(backups))
+	for i, b := range backups {
+		status := string(b.Status)
+		response[i] = &models.BackupListResponseItems0{
+			ID:      b.ID,
+			Status:  status,
+			Classes: b.Classes(),
+		}
+	}
+
+	return &response, nil
 }
 
 func coordBackend(provider BackupBackendProvider, backend, id, overrideBucket, overridePath string) (coordStore, error) {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -327,10 +327,9 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 
 	response := make(models.BackupListResponse, len(backups))
 	for i, b := range backups {
-		status := string(b.Status)
 		response[i] = &models.BackupListResponseItems0{
 			ID:      b.ID,
-			Status:  status,
+			Status:  string(b.Status),
 			Classes: b.Classes(),
 		}
 	}


### PR DESCRIPTION
### What's being changed:
we had the implementation previously but we never integrated the internal implementation with the endpoint. this PR wires the endpoint to the internal implementation 

this PR : 
- link the list backup implementation with the exposed endpoint 
- fix discovered bugs in list AllBackups in gcs where we were using MatchGlobal: `*.json` and this didn't lookup the file in multiple level paths 
- simplify the implementation 
- add acceptance tests for list backups endpoints 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
