### PR TITLE
Optimize binary quantization

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_quantization.go
@@ -27,36 +27,21 @@ func NewBinaryQuantizer(distancer distancer.Provider) BinaryQuantizer {
 
 func (bq BinaryQuantizer) Encode(vec []float32) []uint64 {
 	len := len(vec)
-	total := (len + 63) >> 6
-	fullBlocks := len >> 6
-	code := make([]uint64, total)
+	blocks := (len + 63) >> 6 // ceil(len / 64)
+	code := make([]uint64, blocks)
 	i := 0
-	// Process vec in blocks of 64 elements
-	for block := 0; block < fullBlocks; block++ {
+	for b := range blocks {
 		var bits uint64
-		var bit uint64 = 1
-		for bit != 0 {
+		for bit := uint64(1); bit != 0; bit <<= 1 {
 			if vec[i] < 0 {
 				bits |= bit
 			}
 			i++
-			bit <<= 1
-		}
-		code[block] = bits
-	}
-	// Process the tail block (fewer than 64 elements)
-	if tail := len & 63; tail != 0 {
-		var bits uint64
-		var bit uint64 = 1
-		for tail != 0 {
-			if vec[i] < 0 {
-				bits |= bit
+			if i == len {
+				break
 			}
-			bit <<= 1
-			i++
-			tail--
 		}
-		code[fullBlocks] = bits
+		code[b] = bits
 	}
 	return code
 }


### PR DESCRIPTION
This patch attempts to optimize BinaryQuantizer.Encode by:
- processing the vector in blocks of 64 elements, to reduce the amount of expensive arithmetics and to optimize the memory access pattern for the result array
- replacing expensive integer arithmetics (/, %) by bit operations where possible

The results of BenchmarkBinaryQuantization indicate up to 30-50% performance improvement (the improvement becomes more significant with larger vectors).

The output from benchstat for BenchmarkBinaryQuantization comparing the previous version (old.txt) vs the new one (new.txt):
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
                                                  │   old.txt    │               new.txt               │
                                                  │    sec/op    │   sec/op     vs base                │
BinaryQuantization/BinaryQuantization-dim-32-16      50.65n ± 4%   44.09n ± 5%  -12.96% (p=0.000 n=10)
BinaryQuantization/BinaryQuantization-dim-64-16      90.01n ± 3%   61.37n ± 4%  -31.82% (p=0.000 n=10)
BinaryQuantization/BinaryQuantization-dim-100-16     135.4n ± 2%   101.1n ± 5%  -25.33% (p=0.000 n=10)
BinaryQuantization/BinaryQuantization-dim-256-16     337.9n ± 4%   216.4n ± 4%  -35.96% (p=0.000 n=10)
BinaryQuantization/BinaryQuantization-dim-500-16     665.7n ± 3%   414.9n ± 5%  -37.67% (p=0.000 n=10)
BinaryQuantization/BinaryQuantization-dim-1024-16   1407.5n ± 3%   789.9n ± 3%  -43.88% (p=0.000 n=10)
BinaryQuantization/BinaryQuantization-dim-4096-16    6.043µ ± 3%   3.135µ ± 5%  -48.13% (p=0.000 n=10)
geomean                                              381.7n        249.9n       -34.54%
```

### Review checklist

- [x] Documentation has been updated, if necessary. _Not necessary, pure (minor) performance enhancement._
- [x] Chaos pipeline run or not necessary. _Not necessary, the change is covered by unit tests._
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. _The specific change has been benchmarked._