### PR TITLE
Read fully loaded segments always from memory

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -108,8 +108,8 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context) error {
 			return err
 		}
 
-		meteredReader := diskio.NewMeteredReader(bufio.NewReaderSize(cl.file, 32*1024), b.metrics.TrackStartupReadWALDiskIO)
-
+		meteredReader := diskio.NewMeteredReader(cl.file, b.metrics.TrackStartupReadWALDiskIO)
+		bufio.NewReaderSize(meteredReader, 32*1024)
 		err = newCommitLoggerParser(b.strategy, meteredReader, mt).Do()
 		if err != nil {
 			b.logger.WithField("action", "lsm_recover_from_active_wal_corruption").

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -258,7 +258,7 @@ func (s *segmentCursorReplace) parseReplaceNode(offset nodeOffset) (segmentRepla
 }
 
 func (s *segmentCursorReplace) parseReplaceNodeInto(offset nodeOffset, buf []byte) error {
-	if s.segment.mmapContents {
+	if s.segment.readFromMemory {
 		return s.parse(buf)
 	}
 

--- a/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
@@ -31,7 +31,7 @@ func (sg *SegmentGroup) newRoaringSetRangeReaders() ([]roaringsetrange.InnerRead
 
 func (s *segment) newRoaringSetRangeReader() *roaringsetrange.SegmentReader {
 	var segmentCursor roaringsetrange.SegmentCursor
-	if s.mmapContents {
+	if s.readFromMemory {
 		segmentCursor = roaringsetrange.NewSegmentCursorMmap(s.contents[s.dataStartPos:s.dataEndPos])
 	} else {
 		sectionReader := io.NewSectionReader(s.contentFile, int64(s.dataStartPos), int64(s.dataEndPos))
@@ -46,7 +46,7 @@ func (s *segment) newRoaringSetRangeReader() *roaringsetrange.SegmentReader {
 }
 
 func (s *segment) newRoaringSetRangeCursor() roaringsetrange.SegmentCursor {
-	if s.mmapContents {
+	if s.readFromMemory {
 		return roaringsetrange.NewSegmentCursorMmap(s.contents[s.dataStartPos:s.dataEndPos])
 	}
 

--- a/adapters/repos/db/lsmkv/memtable_metrics.go
+++ b/adapters/repos/db/lsmkv/memtable_metrics.go
@@ -21,7 +21,7 @@ type memtableMetrics struct {
 	getMap          NsObserver
 	getCollection   NsObserver
 	size            Setter
-	writeMemtable   BytesObserver
+	writeMemtable   BytesWriteObserver
 }
 
 // newMemtableMetrics curries the prometheus-functions just once to make sure

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -28,7 +28,7 @@ var blockMaxBufferSize = 4096
 
 func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
 	var buf []byte
-	if s.mmapContents {
+	if s.readFromMemory {
 		buf = s.contents[node.Start : node.Start+uint64(8+12*terms.ENCODE_AS_FULL_BYTES)]
 	} else {
 		// read first 8 bytes to get
@@ -64,7 +64,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 	blockCount := (docCount + uint64(terms.BLOCK_SIZE-1)) / uint64(terms.BLOCK_SIZE)
 
 	entries := make([]*terms.BlockEntry, blockCount)
-	if s.mmapContents {
+	if s.readFromMemory {
 		buf = s.contents[node.Start+16 : node.Start+16+uint64(blockCount*20)]
 	} else {
 		r, err := s.newNodeReader(nodeOffset{node.Start + 16, node.Start + 16 + uint64(blockCount*20)})
@@ -88,7 +88,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 
 // todo: check if there is a performance impact of starting to sectionReader at offset and not have to pass offset here
 func (s *segment) loadBlockDataReusable(sectionReader *io.SectionReader, blockDataBufferOffset, offset, offsetStart, offsetEnd uint64, buf []byte, encoded *terms.BlockData) (uint64, error) {
-	if s.mmapContents {
+	if s.readFromMemory {
 		terms.DecodeBlockDataReusable(s.contents[offsetStart:offsetEnd], encoded)
 		return offsetStart, nil
 	} else {
@@ -208,7 +208,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 
 	var sectionReader *io.SectionReader
 
-	if !s.mmapContents {
+	if !s.readFromMemory {
 		sectionReader = io.NewSectionReader(s.contentFile, int64(node.Start), int64(node.End))
 	}
 

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -61,7 +61,7 @@ func (s *segment) segmentNodeFromBuffer(offset nodeOffset) (*roaringset.SegmentN
 		contents = s.contents[offset.start:offset.end]
 	} else {
 		contents = make([]byte, offset.end-offset.start)
-		r, err := s.bufferedReaderAt(offset.start)
+		r, err := s.bufferedReaderAt(offset.start, "roaringSetRead")
 		if err != nil {
 			return nil, false, err
 		}

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -57,7 +57,7 @@ func (s *segment) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
 func (s *segment) segmentNodeFromBuffer(offset nodeOffset) (*roaringset.SegmentNode, bool, error) {
 	var contents []byte
 	copied := false
-	if s.mmapContents {
+	if s.readFromMemory {
 		contents = s.contents[offset.start:offset.end]
 	} else {
 		contents = make([]byte, offset.end-offset.start)

--- a/entities/diskio/metered_reader.go
+++ b/entities/diskio/metered_reader.go
@@ -12,15 +12,19 @@
 package diskio
 
 import (
-	"io"
 	"time"
 )
+
+type Reader interface {
+	Read(p []byte) (n int, err error)
+	ReadAt(p []byte, off int64) (n int, err error)
+}
 
 type MeteredReaderCallback func(read int64, nanoseconds int64)
 
 type MeteredReader struct {
-	r  io.Reader
-	cb MeteredReaderCallback
+	file Reader
+	cb   MeteredReaderCallback
 }
 
 // Read passes the read through to the underlying reader. On a successful read,
@@ -28,7 +32,7 @@ type MeteredReader struct {
 // callback is set, it will ignore it.
 func (m *MeteredReader) Read(p []byte) (n int, err error) {
 	start := time.Now()
-	n, err = m.r.Read(p)
+	n, err = m.file.Read(p)
 	took := time.Since(start).Nanoseconds()
 	if err != nil {
 		return
@@ -41,6 +45,24 @@ func (m *MeteredReader) Read(p []byte) (n int, err error) {
 	return
 }
 
-func NewMeteredReader(r io.Reader, cb MeteredReaderCallback) *MeteredReader {
-	return &MeteredReader{r: r, cb: cb}
+// ReadAt passes the read through to the underlying reader. On a successful read,
+// it will trigger the attached callback and provide it with metrics. If no
+// callback is set, it will ignore it.
+func (m *MeteredReader) ReadAt(p []byte, off int64) (n int, err error) {
+	start := time.Now()
+	n, err = m.file.ReadAt(p, off)
+	took := time.Since(start).Nanoseconds()
+	if err != nil {
+		return
+	}
+
+	if m.cb != nil {
+		m.cb(int64(n), took)
+	}
+
+	return
+}
+
+func NewMeteredReader(file Reader, cb MeteredReaderCallback) *MeteredReader {
+	return &MeteredReader{file: file, cb: cb}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -73,6 +73,7 @@ type PrometheusMetrics struct {
 	BackupRestoreDataTransferred        *prometheus.CounterVec
 	BackupStoreDataTransferred          *prometheus.CounterVec
 	FileIOWrites                        *prometheus.SummaryVec
+	FileIOReads                         *prometheus.SummaryVec
 	MmapOperations                      *prometheus.CounterVec
 	MmapProcMaps                        prometheus.Gauge
 
@@ -494,6 +495,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "file_io_writes_total_bytes",
 			Help: "Total number of bytes written to disk",
 		}, []string{"operation", "strategy"}),
+		FileIOReads: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "file_io_reads_total_bytes",
+			Help: "Total number of bytes read from disk",
+		}, []string{"operation"}),
 		MmapOperations: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "mmap_operations_total",
 			Help: "Total number of mmap operations",


### PR DESCRIPTION
### What's being changed:

We fully load small segments into memory. However, with pread as MMAP access strategy we would still read from the file.

- First two commits add some metrics for read IOPS
- Third commit adds that data is always read from memory if we loaded the file

```
- Before: file_io_reads_total_bytes_count{operation="ReadFromSegment"} 549207
- After: file_io_reads_total_bytes_count{operation="ReadFromSegment"} 165153
```


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
