### PR TITLE
Disable bloom filters if segment is loaded into memory

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -149,6 +149,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		}
 	}
 
+	useBloomFilter := cfg.useBloomFilter
 	readFromMemory := cfg.mmapContents
 	if size > cfg.MinMMapSize || allocCheckerErr != nil { // mmap the file if it's too large or if we have memory pressure
 		contents2, err := mmap.MapRegion(file, int(fileInfo.Size()), mmap.RDONLY, 0, 0)
@@ -166,6 +167,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		}
 		unMapContents = false
 		readFromMemory = true
+		useBloomFilter = false
 	}
 	header, err := segmentindex.ParseHeader(contents[:segmentindex.HeaderSize])
 	if err != nil {
@@ -234,7 +236,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		metrics:               metrics,
 		size:                  size,
 		readFromMemory:        readFromMemory,
-		useBloomFilter:        cfg.useBloomFilter,
+		useBloomFilter:        useBloomFilter,
 		calcCountNetAdditions: cfg.calcCountNetAdditions,
 		invertedHeader:        invertedHeader,
 		invertedData: &segmentInvertedData{


### PR DESCRIPTION
### What's being changed:

If the segment is already in memory bloom filters bring no speedup

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
