### PR TITLE
Repl-mvmt/debug-no-copy-cna-files

### DIFF
--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -105,6 +105,10 @@ func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName
 	eg.SetLimit(concurrency)
 	for _, relativeFilePath := range relativeFilePaths {
 		relativeFilePath := relativeFilePath
+		// skip cna files, as they will be regenerated on the target node
+		if strings.HasSuffix(relativeFilePath, ".cna") {
+			continue
+		}
 		eg.Go(func() error {
 			return c.syncFile(gctx, sourceNodeHostname, collectionName, shardName, relativeFilePath)
 		})


### PR DESCRIPTION
### What's being changed:

Try not copying *.cna files during replica movement to test effect

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
