### PR TITLE
Repl-mvmt/preserve-files-and-no-copy-cna-flags

### DIFF
--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -106,7 +106,12 @@ func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName
 	for _, relativeFilePath := range relativeFilePaths {
 		relativeFilePath := relativeFilePath
 		// skip cna files, as they will be regenerated on the target node
-		if strings.HasSuffix(relativeFilePath, ".cna") {
+		if os.Getenv("WEAVIATE_DEBUG_SKIP_CNA_FILES") == "true" && strings.HasSuffix(relativeFilePath, ".cna") {
+			c.logger.WithFields(logrus.Fields{
+				"collectionName":   collectionName,
+				"shardName":        shardName,
+				"relativeFilePath": relativeFilePath,
+			}).Info("skipping cna file in debug mode")
 			continue
 		}
 		eg.Go(func() error {

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -365,6 +366,14 @@ func (s *SchemaManager) DeleteReplicaFromShard(cmd *command.ApplyRequest, schema
 			},
 			updateStore: func() error {
 				if req.TargetNode == s.schema.nodeID {
+					if os.Getenv("WEAVIATE_DEBUG_PRESERVE_SHARD_DIR") == "true" {
+						s.log.WithFields(logrus.Fields{
+							"class":      cmd.Class,
+							"shard":      req.Shard,
+							"targetNode": req.TargetNode,
+						}).Info("skipping shard deletion in debug mode")
+						return nil
+					}
 					return s.db.DeleteReplicaFromShard(req.Class, req.Shard, req.TargetNode)
 				}
 				return nil


### PR DESCRIPTION
### What's being changed:

Debug build to test adding flags to preserve the source node's shard files after a replica move and a flag to skip copying .cna files:

Set `WEAVIATE_DEBUG_PRESERVE_SHARD_DIR=true` and `WEAVIATE_DEBUG_SKIP_CNA_FILES=true`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
