### PR TITLE
refact: split modules interface w/o http handler

### DIFF
--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/handlers/rest/raft"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/swagger_middleware"
@@ -88,7 +89,7 @@ func makeAddModuleHandlers(modules *modules.Provider) func(http.Handler) http.Ha
 	return func(next http.Handler) http.Handler {
 		mux := http.NewServeMux()
 
-		for _, mod := range modules.GetAll() {
+		for _, mod := range modules.GetAllWithHTTPHandlers() {
 			prefix := fmt.Sprintf("/v1/modules/%s", mod.Name())
 			mux.Handle(fmt.Sprintf("%s/", prefix),
 				http.StripPrefix(prefix, mod.RootHandler()))

--- a/adapters/repos/db/hybrid_search_test.go
+++ b/adapters/repos/db/hybrid_search_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"testing"
 
@@ -1063,11 +1062,6 @@ func (m *TesterModule) Init(ctx context.Context,
 }
 
 func (m *TesterModule) InitExtension(modules []modulecapabilities.Module) error {
-	return nil
-}
-
-func (m *TesterModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/entities/modulecapabilities/module.go
+++ b/entities/modulecapabilities/module.go
@@ -41,8 +41,13 @@ const (
 type Module interface {
 	Name() string
 	Init(ctx context.Context, params moduletools.ModuleInitParams) error
-	RootHandler() http.Handler // TODO: remove from overall module, this is a capability
 	Type() ModuleType
+}
+
+// ModuleWithHTTPHandlers is an optional capability interface for modules that provide HTTP endpoints
+type ModuleWithHTTPHandlers interface {
+	Module
+	RootHandler() http.Handler
 }
 
 type ModuleExtension interface {

--- a/modules/backup-azure/module.go
+++ b/modules/backup-azure/module.go
@@ -13,7 +13,6 @@ package modstgazure
 
 import (
 	"context"
-	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
@@ -91,11 +90,6 @@ func (m *Module) Init(ctx context.Context,
 		return errors.Wrap(err, "init Azure client")
 	}
 	m.azureClient = client
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/backup-filesystem/module.go
+++ b/modules/backup-filesystem/module.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -114,11 +113,6 @@ func (m *Module) AllBackups(context.Context) ([]*backup.DistributedBackupDescrip
 		}
 	}
 	return meta, nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *Module) MetaInfo() (map[string]interface{}, error) {

--- a/modules/backup-gcs/module.go
+++ b/modules/backup-gcs/module.go
@@ -13,7 +13,6 @@ package modstggcs
 
 import (
 	"context"
-	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
@@ -91,11 +90,6 @@ func (m *Module) Init(ctx context.Context,
 		return errors.Wrap(err, "init gcs client")
 	}
 	m.gcsClient = client
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/backup-s3/module.go
+++ b/modules/backup-s3/module.go
@@ -13,7 +13,6 @@ package modstgs3
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"strings"
 
@@ -86,11 +85,6 @@ func (m *Module) Init(ctx context.Context,
 		return errors.Wrap(err, "initialize S3 backup module")
 	}
 	m.s3Client = client
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-anthropic/module.go
+++ b/modules/generative-anthropic/module.go
@@ -13,7 +13,6 @@ package modgenerativeanthropic
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -78,11 +77,6 @@ func (m *GenerativeAnthropicModule) MetaInfo() (map[string]interface{}, error) {
 
 func (m *GenerativeAnthropicModule) AdditionalGenerativeProperties() map[string]modulecapabilities.GenerativeProperty {
 	return m.additionalPropertiesProvider
-}
-
-func (m *GenerativeAnthropicModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 // verify we implement the modules.Module interface

--- a/modules/generative-anyscale/module.go
+++ b/modules/generative-anyscale/module.go
@@ -13,7 +13,6 @@ package modgenerativeanyscale
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeAnyscaleModule) initAdditional(ctx context.Context, timeout t
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(client)
 
-	return nil
-}
-
-func (m *GenerativeAnyscaleModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-aws/module.go
+++ b/modules/generative-aws/module.go
@@ -13,7 +13,6 @@ package modgenerativeaws
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -85,11 +84,6 @@ func (m *GenerativeAWSModule) getAWSSecretAccessKey() string {
 		return os.Getenv("AWS_SECRET_ACCESS_KEY")
 	}
 	return os.Getenv("AWS_SECRET_KEY")
-}
-
-func (m *GenerativeAWSModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *GenerativeAWSModule) MetaInfo() (map[string]interface{}, error) {

--- a/modules/generative-cohere/module.go
+++ b/modules/generative-cohere/module.go
@@ -13,7 +13,6 @@ package modgenerativecohere
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeCohereModule) initAdditional(ctx context.Context, timeout tim
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeCohereModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-databricks/module.go
+++ b/modules/generative-databricks/module.go
@@ -13,7 +13,6 @@ package modgenerativedatabricks
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -67,11 +66,6 @@ func (m *GenerativeDatabricksModule) initAdditional(ctx context.Context, timeout
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeDatabricksModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-dummy/module.go
+++ b/modules/generative-dummy/module.go
@@ -13,7 +13,6 @@ package modgenerativedummy
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -59,11 +58,6 @@ func (m *GenerativeDummyModule) initAdditional(ctx context.Context, timeout time
 	logger logrus.FieldLogger,
 ) error {
 	m.generative = clients.New(logger)
-	return nil
-}
-
-func (m *GenerativeDummyModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-friendliai/module.go
+++ b/modules/generative-friendliai/module.go
@@ -13,7 +13,6 @@ package modgenerativefriendliai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeFriendliAIModule) initAdditional(ctx context.Context, timeout
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeFriendliAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-google/module.go
+++ b/modules/generative-google/module.go
@@ -13,7 +13,6 @@ package modgenerativegoogle
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -77,11 +76,6 @@ func (m *GenerativeGoogleModule) initAdditional(ctx context.Context, timeout tim
 	client := clients.New(apiKey, useGoogleAuth, timeout, logger)
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
-	return nil
-}
-
-func (m *GenerativeGoogleModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-mistral/module.go
+++ b/modules/generative-mistral/module.go
@@ -13,7 +13,6 @@ package modgenerativemistral
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeMistralModule) initAdditional(ctx context.Context, timeout ti
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeMistralModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-nvidia/module.go
+++ b/modules/generative-nvidia/module.go
@@ -13,7 +13,6 @@ package modgenerativenvidia
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeNvidiaModule) initAdditional(ctx context.Context, timeout tim
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeNvidiaModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-octoai/module.go
+++ b/modules/generative-octoai/module.go
@@ -13,7 +13,6 @@ package modgenerativeoctoai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeOctoAIModule) initAdditional(ctx context.Context, timeout tim
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeOctoAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-ollama/module.go
+++ b/modules/generative-ollama/module.go
@@ -13,7 +13,6 @@ package modgenerativeollama
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -64,11 +63,6 @@ func (m *GenerativeOllamaModule) initAdditional(ctx context.Context, timeout tim
 	client := ollama.New(timeout, logger)
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
-	return nil
-}
-
-func (m *GenerativeOllamaModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-openai/module.go
+++ b/modules/generative-openai/module.go
@@ -13,7 +13,6 @@ package modgenerativeopenai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -69,11 +68,6 @@ func (m *GenerativeOpenAIModule) initAdditional(ctx context.Context, timeout tim
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeOpenAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/generative-xai/module.go
+++ b/modules/generative-xai/module.go
@@ -13,7 +13,6 @@ package modgenerativexai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,11 +67,6 @@ func (m *GenerativeXaiModule) initAdditional(ctx context.Context, timeout time.D
 	m.generative = client
 	m.additionalPropertiesProvider = parameters.AdditionalGenerativeParameters(m.generative)
 
-	return nil
-}
-
-func (m *GenerativeXaiModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/img2vec-neural/module.go
+++ b/modules/img2vec-neural/module.go
@@ -13,7 +13,6 @@ package modimage
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -86,11 +85,6 @@ func (m *ImageModule) initVectorizer(ctx context.Context, timeout time.Duration,
 
 	m.vectorizer = vectorizer.New(client)
 
-	return nil
-}
-
-func (m *ImageModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-bind/module.go
+++ b/modules/multi2vec-bind/module.go
@@ -13,7 +13,6 @@ package modbind
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -155,11 +154,6 @@ func (m *BindModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.textVectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *BindModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-clip/module.go
+++ b/modules/multi2vec-clip/module.go
@@ -13,7 +13,6 @@ package modclip
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -127,11 +126,6 @@ func (m *ClipModule) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.textVectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *ClipModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-cohere/module.go
+++ b/modules/multi2vec-cohere/module.go
@@ -13,7 +13,6 @@ package modclip
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -101,11 +100,6 @@ func (m *Module) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.vectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-google/module.go
+++ b/modules/multi2vec-google/module.go
@@ -13,7 +13,6 @@ package modclip
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -138,11 +137,6 @@ func (m *Module) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.videoVectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-jinaai/module.go
+++ b/modules/multi2vec-jinaai/module.go
@@ -13,7 +13,6 @@ package modclip
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -101,11 +100,6 @@ func (m *Module) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.vectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-nvidia/module.go
+++ b/modules/multi2vec-nvidia/module.go
@@ -13,7 +13,6 @@ package modclip
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -101,11 +100,6 @@ func (m *Module) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.vectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/multi2vec-voyageai/module.go
+++ b/modules/multi2vec-voyageai/module.go
@@ -13,7 +13,6 @@ package modclip
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -101,11 +100,6 @@ func (m *Module) initVectorizer(ctx context.Context, timeout time.Duration,
 	m.vectorizer = vectorizer.New(client)
 	m.metaClient = client
 
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/ner-transformers/module.go
+++ b/modules/ner-transformers/module.go
@@ -13,7 +13,6 @@ package modner
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -86,11 +85,6 @@ func (m *NERModule) initAdditional(ctx context.Context, timeout time.Duration,
 	tokenProvider := neradditionaltoken.New(m.ner)
 	m.additionalPropertiesProvider = neradditional.New(tokenProvider)
 
-	return nil
-}
-
-func (m *NERModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -14,7 +14,6 @@ package modsloads3
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -213,10 +212,6 @@ func (m *Module) Init(ctx context.Context,
 		s3Bucket:                m.Bucket,
 		"PERSISTENCE_DATA_PATH": m.DataPath,
 	}).Info("offload module loaded")
-	return nil
-}
-
-func (m *Module) RootHandler() http.Handler {
 	return nil
 }
 

--- a/modules/qna-openai/module.go
+++ b/modules/qna-openai/module.go
@@ -13,7 +13,6 @@ package modqnaopenai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -144,11 +143,6 @@ func (m *QnAModule) initAdditional(ctx context.Context, timeout time.Duration,
 	answerProvider := qnaadditionalanswer.New(m.qna, qnaask.NewParamsHelper())
 	m.additionalPropertiesProvider = qnaadditional.New(answerProvider)
 
-	return nil
-}
-
-func (m *QnAModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/qna-transformers/module.go
+++ b/modules/qna-transformers/module.go
@@ -13,7 +13,6 @@ package modqna
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -158,11 +157,6 @@ func (m *QnAModule) initAdditional(ctx context.Context, timeout time.Duration,
 	answerProvider := qnaadditionalanswer.New(m.qna, qnaask.NewParamsHelper())
 	m.additionalPropertiesProvider = qnaadditional.New(answerProvider)
 
-	return nil
-}
-
-func (m *QnAModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/ref2vec-centroid/module.go
+++ b/modules/ref2vec-centroid/module.go
@@ -13,9 +13,9 @@ package modcentroid
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
@@ -40,11 +40,6 @@ func (m *CentroidModule) Name() string {
 
 func (m *CentroidModule) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
 	m.logger = params.GetLogger()
-	return nil
-}
-
-func (m *CentroidModule) RootHandler() http.Handler {
-	// TODO: remove from overall module, this is a capability
 	return nil
 }
 

--- a/modules/ref2vec-centroid/module_test.go
+++ b/modules/ref2vec-centroid/module_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
@@ -47,11 +48,6 @@ func TestRef2VecCentroid(t *testing.T) {
 	t.Run("Init", func(t *testing.T) {
 		err := mod.Init(ctx, params)
 		assert.Nil(t, err)
-	})
-
-	t.Run("RootHandler", func(t *testing.T) {
-		h := mod.RootHandler()
-		assert.Nil(t, h)
 	})
 
 	t.Run("Type", func(t *testing.T) {

--- a/modules/reranker-cohere/module.go
+++ b/modules/reranker-cohere/module.go
@@ -13,12 +13,12 @@ package modrerankercohere
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/reranker-cohere/clients"
@@ -72,11 +72,6 @@ func (m *ReRankerCohereModule) initAdditional(ctx context.Context, timeout time.
 
 func (m *ReRankerCohereModule) MetaInfo() (map[string]interface{}, error) {
 	return m.reranker.MetaInfo()
-}
-
-func (m *ReRankerCohereModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *ReRankerCohereModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {

--- a/modules/reranker-dummy/module.go
+++ b/modules/reranker-dummy/module.go
@@ -13,11 +13,11 @@ package modrerankerdummy
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/reranker-dummy/clients"
@@ -70,11 +70,6 @@ func (m *ReRankerDummyModule) initAdditional(ctx context.Context, timeout time.D
 
 func (m *ReRankerDummyModule) MetaInfo() (map[string]interface{}, error) {
 	return m.reranker.MetaInfo()
-}
-
-func (m *ReRankerDummyModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *ReRankerDummyModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {

--- a/modules/reranker-jinaai/module.go
+++ b/modules/reranker-jinaai/module.go
@@ -13,12 +13,12 @@ package modrerankerjinaai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/reranker-jinaai/clients"
@@ -72,11 +72,6 @@ func (m *ReRankerJinaaiModule) initAdditional(_ context.Context, timeout time.Du
 
 func (m *ReRankerJinaaiModule) MetaInfo() (map[string]interface{}, error) {
 	return m.reranker.MetaInfo()
-}
-
-func (m *ReRankerJinaaiModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *ReRankerJinaaiModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {

--- a/modules/reranker-nvidia/module.go
+++ b/modules/reranker-nvidia/module.go
@@ -13,12 +13,12 @@ package modrerankernvidia
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	client "github.com/weaviate/weaviate/modules/reranker-nvidia/clients"
@@ -72,11 +72,6 @@ func (m *RerankerModule) initAdditional(ctx context.Context, timeout time.Durati
 
 func (m *RerankerModule) MetaInfo() (map[string]interface{}, error) {
 	return m.reranker.MetaInfo()
-}
-
-func (m *RerankerModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *RerankerModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {

--- a/modules/reranker-transformers/module.go
+++ b/modules/reranker-transformers/module.go
@@ -13,7 +13,6 @@ package modrerankertransformers
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -89,11 +88,6 @@ func (m *ReRankerModule) initAdditional(ctx context.Context, timeout time.Durati
 
 func (m *ReRankerModule) MetaInfo() (map[string]interface{}, error) {
 	return m.reranker.MetaInfo()
-}
-
-func (m *ReRankerModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *ReRankerModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {

--- a/modules/reranker-voyageai/module.go
+++ b/modules/reranker-voyageai/module.go
@@ -13,12 +13,12 @@ package modrerankervoyageai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/reranker-voyageai/clients"
@@ -72,11 +72,6 @@ func (m *ReRankerVoyageAIModule) initAdditional(ctx context.Context, timeout tim
 
 func (m *ReRankerVoyageAIModule) MetaInfo() (map[string]interface{}, error) {
 	return m.reranker.MetaInfo()
-}
-
-func (m *ReRankerVoyageAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *ReRankerVoyageAIModule) AdditionalProperties() map[string]modulecapabilities.AdditionalProperty {

--- a/modules/sum-transformers/module.go
+++ b/modules/sum-transformers/module.go
@@ -13,7 +13,6 @@ package modsum
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -86,11 +85,6 @@ func (m *SUMModule) initAdditional(ctx context.Context, timeout time.Duration,
 	tokenProvider := sumadditionalsummary.New(m.sum)
 	m.additionalPropertiesProvider = sumadditional.New(tokenProvider)
 
-	return nil
-}
-
-func (m *SUMModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text-spellcheck/module.go
+++ b/modules/text-spellcheck/module.go
@@ -13,7 +13,6 @@ package modspellcheck
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -83,11 +82,6 @@ func (m *SpellCheckModule) initTextTransformers() {
 func (m *SpellCheckModule) initAdditional() {
 	spellCheckProvider := spellcheckadditionalspellcheck.New(m.spellCheck)
 	m.additionalPropertiesProvider = spellcheckadditional.New(spellCheckProvider)
-}
-
-func (m *SpellCheckModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
-	return nil
 }
 
 func (m *SpellCheckModule) MetaInfo() (map[string]interface{}, error) {

--- a/modules/text2colbert-jinaai/module.go
+++ b/modules/text2colbert-jinaai/module.go
@@ -13,23 +13,20 @@ package modjinaai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2colbert-jinaai/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2colbert-jinaai/clients"
+	"github.com/weaviate/weaviate/modules/text2colbert-jinaai/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2colbert-jinaai"
@@ -122,11 +119,6 @@ func (m *JinaAIModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *JinaAIModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *JinaAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-aws/module.go
+++ b/modules/text2vec-aws/module.go
@@ -13,22 +13,20 @@ package modaws
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-aws/clients"
 	"github.com/weaviate/weaviate/modules/text2vec-aws/vectorizer"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-aws"
@@ -119,11 +117,6 @@ func (m *AwsModule) getAWSSecretAccessKey() string {
 
 func (m *AwsModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *AwsModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-bigram/bigram.go
+++ b/modules/text2vec-bigram/bigram.go
@@ -14,7 +14,6 @@ package t2vbigram
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -87,10 +86,6 @@ func (m *BigramModule) VectorizableProperties(cfg moduletools.ClassConfig) (bool
 }
 
 func (m *BigramModule) InitAdditionalPropertiesProvider() error {
-	return nil
-}
-
-func (m *BigramModule) RootHandler() http.Handler {
 	return nil
 }
 

--- a/modules/text2vec-cohere/module.go
+++ b/modules/text2vec-cohere/module.go
@@ -13,23 +13,20 @@ package modcohere
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-cohere/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-cohere/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-cohere/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-cohere"
@@ -116,11 +113,6 @@ func (m *CohereModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *CohereModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *CohereModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-contextionary/helpers_test.go
+++ b/modules/text2vec-contextionary/helpers_test.go
@@ -14,7 +14,6 @@ package modcontextionary
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/tailor-inc/graphql"
@@ -135,10 +134,6 @@ func (m *mockText2vecContextionaryModule) Name() string {
 }
 
 func (m *mockText2vecContextionaryModule) Init(params moduletools.ModuleInitParams) error {
-	return nil
-}
-
-func (m *mockText2vecContextionaryModule) RootHandler() http.Handler {
 	return nil
 }
 

--- a/modules/text2vec-contextionary/module.go
+++ b/modules/text2vec-contextionary/module.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"

--- a/modules/text2vec-databricks/module.go
+++ b/modules/text2vec-databricks/module.go
@@ -13,23 +13,20 @@ package moddatabricks
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-databricks/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-databricks/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-databricks/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const (
@@ -120,11 +117,6 @@ func (m *DatabricksModule) initVectorizer(ctx context.Context, timeout time.Dura
 
 func (m *DatabricksModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *DatabricksModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-google/module.go
+++ b/modules/text2vec-google/module.go
@@ -13,16 +13,12 @@ package modgoogle
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
@@ -30,6 +26,8 @@ import (
 	"github.com/weaviate/weaviate/modules/text2vec-google/clients"
 	"github.com/weaviate/weaviate/modules/text2vec-google/vectorizer"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const (
@@ -116,11 +114,6 @@ func (m *GoogleModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *GoogleModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *GoogleModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-gpt4all/module.go
+++ b/modules/text2vec-gpt4all/module.go
@@ -13,16 +13,12 @@ package modtransformers
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
@@ -30,6 +26,8 @@ import (
 	"github.com/weaviate/weaviate/modules/text2vec-gpt4all/clients"
 	"github.com/weaviate/weaviate/modules/text2vec-gpt4all/vectorizer"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-gpt4all"
@@ -118,11 +116,6 @@ func (m *GPT4AllModule) initVectorizer(ctx context.Context, timeout time.Duratio
 
 func (m *GPT4AllModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *GPT4AllModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-huggingface/module.go
+++ b/modules/text2vec-huggingface/module.go
@@ -13,23 +13,20 @@ package modhuggingface
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-huggingface/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-huggingface/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-huggingface/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-huggingface"
@@ -116,11 +113,6 @@ func (m *HuggingFaceModule) initVectorizer(ctx context.Context, timeout time.Dur
 
 func (m *HuggingFaceModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *HuggingFaceModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-jinaai/module.go
+++ b/modules/text2vec-jinaai/module.go
@@ -13,23 +13,20 @@ package modjinaai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-jinaai/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-jinaai/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-jinaai/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-jinaai"
@@ -120,11 +117,6 @@ func (m *JinaAIModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *JinaAIModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *JinaAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-mistral/module.go
+++ b/modules/text2vec-mistral/module.go
@@ -13,23 +13,20 @@ package modmistral
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-mistral/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-mistral/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-mistral/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-mistral"
@@ -118,11 +115,6 @@ func (m *MistralModule) initVectorizer(ctx context.Context, timeout time.Duratio
 
 func (m *MistralModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *MistralModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-model2vec/module.go
+++ b/modules/text2vec-model2vec/module.go
@@ -13,7 +13,6 @@ package modtransformers
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -113,11 +112,6 @@ func (m *Model2VecModule) initVectorizer(ctx context.Context, timeout time.Durat
 
 func (m *Model2VecModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *Model2VecModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-nvidia/module.go
+++ b/modules/text2vec-nvidia/module.go
@@ -13,7 +13,6 @@ package modnvidia
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -116,11 +115,6 @@ func (m *NvidiaModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *NvidiaModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *NvidiaModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-octoai/module.go
+++ b/modules/text2vec-octoai/module.go
@@ -13,22 +13,19 @@ package modoctoai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-octoai/clients"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/text2vec-octoai/clients"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-octoai"
@@ -107,11 +104,6 @@ func (m *OctoAIModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *OctoAIModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *OctoAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-ollama/module.go
+++ b/modules/text2vec-ollama/module.go
@@ -13,21 +13,19 @@ package modollama
 
 import (
 	"context"
-	"net/http"
 	"time"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-ollama/clients"
 	"github.com/weaviate/weaviate/modules/text2vec-ollama/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-ollama"
@@ -113,11 +111,6 @@ func (m *OllamaModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *OllamaModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *OllamaModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-openai/module.go
+++ b/modules/text2vec-openai/module.go
@@ -13,24 +13,21 @@ package modopenai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-	"github.com/weaviate/weaviate/usecases/monitoring"
-
-	"github.com/weaviate/weaviate/modules/text2vec-openai/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-openai/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-openai/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 const (
@@ -125,11 +122,6 @@ func (m *OpenAIModule) initVectorizer(ctx context.Context, timeout time.Duration
 
 func (m *OpenAIModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *OpenAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-transformers/module.go
+++ b/modules/text2vec-transformers/module.go
@@ -13,14 +13,12 @@ package modtransformers
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
@@ -28,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/modules/text2vec-transformers/clients"
 	"github.com/weaviate/weaviate/modules/text2vec-transformers/vectorizer"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-transformers"
@@ -134,11 +133,6 @@ func (m *TransformersModule) initVectorizer(ctx context.Context, timeout time.Du
 
 func (m *TransformersModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *TransformersModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-voyageai/module.go
+++ b/modules/text2vec-voyageai/module.go
@@ -13,7 +13,6 @@ package modvoyageai
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
@@ -127,11 +126,6 @@ func (m *VoyageAIModule) initVectorizer(ctx context.Context, timeout time.Durati
 
 func (m *VoyageAIModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *VoyageAIModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/modules/text2vec-weaviate/module.go
+++ b/modules/text2vec-weaviate/module.go
@@ -13,23 +13,20 @@ package modweaviateembed
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
-
-	"github.com/weaviate/weaviate/modules/text2vec-weaviate/ent"
-
-	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/modules/text2vec-weaviate/clients"
+	"github.com/weaviate/weaviate/modules/text2vec-weaviate/ent"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
 )
 
 const Name = "text2vec-weaviate"
@@ -116,11 +113,6 @@ func (m *WeaviateEmbedModule) initVectorizer(ctx context.Context, timeout time.D
 
 func (m *WeaviateEmbedModule) initAdditionalPropertiesProvider() error {
 	m.additionalPropertiesProvider = additional.NewText2VecProvider()
-	return nil
-}
-
-func (m *WeaviateEmbedModule) RootHandler() http.Handler {
-	// TODO: remove once this is a capability interface
 	return nil
 }
 

--- a/usecases/modules/fakes_for_test.go
+++ b/usecases/modules/fakes_for_test.go
@@ -13,10 +13,10 @@ package modules
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/mock"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
@@ -54,11 +54,6 @@ func (m dummyText2VecModuleNoCapabilities) Name() string {
 func (m dummyText2VecModuleNoCapabilities) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	return nil
-}
-
-// TODO remove as this is a capability
-func (m dummyText2VecModuleNoCapabilities) RootHandler() http.Handler {
 	return nil
 }
 
@@ -104,11 +99,6 @@ func (m dummyText2ColBERTModuleNoCapabilities) Init(ctx context.Context,
 	return nil
 }
 
-// TODO remove as this is a capability
-func (m dummyText2ColBERTModuleNoCapabilities) RootHandler() http.Handler {
-	return nil
-}
-
 func (m dummyText2ColBERTModuleNoCapabilities) Type() modulecapabilities.ModuleType {
 	return modulecapabilities.Text2ColBERT
 }
@@ -150,11 +140,6 @@ func (m dummyRef2VecModuleNoCapabilities) Init(ctx context.Context,
 	return nil
 }
 
-// TODO remove as this is a capability
-func (m dummyRef2VecModuleNoCapabilities) RootHandler() http.Handler {
-	return nil
-}
-
 func (m dummyRef2VecModuleNoCapabilities) Type() modulecapabilities.ModuleType {
 	return modulecapabilities.Ref2Vec
 }
@@ -181,11 +166,6 @@ func (m dummyNonVectorizerModule) Name() string {
 func (m dummyNonVectorizerModule) Init(ctx context.Context,
 	params moduletools.ModuleInitParams,
 ) error {
-	return nil
-}
-
-// TODO remove as this is a capability
-func (m dummyNonVectorizerModule) RootHandler() http.Handler {
 	return nil
 }
 

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tailor-inc/graphql"
 	"github.com/tailor-inc/graphql/language/ast"
+
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
@@ -91,6 +92,17 @@ func (p *Provider) GetAll() []modulecapabilities.Module {
 	for _, mod := range p.registered {
 		out[i] = mod
 		i++
+	}
+
+	return out
+}
+
+func (p *Provider) GetAllWithHTTPHandlers() []modulecapabilities.ModuleWithHTTPHandlers {
+	out := make([]modulecapabilities.ModuleWithHTTPHandlers, 0)
+	for _, mod := range p.registered {
+		if modWithHTTPHandlers, ok := mod.(modulecapabilities.ModuleWithHTTPHandlers); ok {
+			out = append(out, modWithHTTPHandlers)
+		}
 	}
 
 	return out

--- a/usecases/modules/modules_test.go
+++ b/usecases/modules/modules_test.go
@@ -15,12 +15,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/tailor-inc/graphql"
+
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
@@ -498,10 +498,6 @@ func (m *dummyBackupModuleWithAltNames) AltNames() []string {
 }
 
 func (m *dummyBackupModuleWithAltNames) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
-	return nil
-}
-
-func (m *dummyBackupModuleWithAltNames) RootHandler() http.Handler {
 	return nil
 }
 

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -14,7 +14,6 @@ package objects
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -521,10 +520,6 @@ func (m *nearCustomTextModule) Name() string {
 }
 
 func (m *nearCustomTextModule) Init(params moduletools.ModuleInitParams) error {
-	return nil
-}
-
-func (m *nearCustomTextModule) RootHandler() http.Handler {
 	return nil
 }
 

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -14,13 +14,13 @@ package traverser
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/tailor-inc/graphql"
 	"github.com/tailor-inc/graphql/language/ast"
+
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/descriptions"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -369,10 +369,6 @@ func (m *fakeText2vecContextionaryModule) Init(params moduletools.ModuleInitPara
 	return nil
 }
 
-func (m *fakeText2vecContextionaryModule) RootHandler() http.Handler {
-	return nil
-}
-
 func (m *fakeText2vecContextionaryModule) Arguments() map[string]modulecapabilities.GraphQLArgument {
 	return newNearCustomTextModule(m.getExtender(), m.getProjector(), m.getPathBuilder(), m.getInterpretation()).Arguments()
 }
@@ -480,10 +476,6 @@ func (m *nearCustomTextModule) Name() string {
 }
 
 func (m *nearCustomTextModule) Init(params moduletools.ModuleInitParams) error {
-	return nil
-}
-
-func (m *nearCustomTextModule) RootHandler() http.Handler {
 	return nil
 }
 


### PR DESCRIPTION
### What's being changed:
we have 1 module rn serve http handler this PR split the module interface to separate modules for seperation of concern and to avoid boiler plate code and removes a lot of TODOs 

```
type ModuleWithHTTPHandlers interface {
	Module
	RootHandler() http.Handler
}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
