### PR TITLE
fix: asyncreplication using halt for transfer instead of pause compaction

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_backup.go
+++ b/adapters/repos/db/lsmkv/bucket_backup.go
@@ -55,8 +55,12 @@ func (b *Bucket) ListFiles(ctx context.Context, basePath string) ([]string, erro
 			continue
 		}
 
-		// ignore .wal files because they are not immutable
-		if filepath.Ext(entry.Name()) == ".wal" {
+		ext := filepath.Ext(entry.Name())
+
+		// ignore .wal files because they are not immutable,
+		// ignore .tmp files because they are temporary files created during compaction or flushing
+		// and are not part of the stable state of the bucket
+		if ext == ".wal" || ext == ".tmp" {
 			continue
 		}
 

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -324,7 +324,7 @@ func (s *Shard) initAsyncReplication() error {
 	// sync hashtree with current object states
 
 	enterrors.GoWrapper(func() {
-		err := s.store.PauseCompaction(ctx)
+		err := s.HaltForTransfer(ctx, false, 0)
 		if err != nil {
 			s.index.logger.
 				WithField("action", "async_replication").
@@ -333,7 +333,7 @@ func (s *Shard) initAsyncReplication() error {
 				Errorf("pausing compaction during hashtree initialization: %v", err)
 			return
 		}
-		defer s.store.ResumeCompaction(ctx)
+		defer s.resumeMaintenanceCycles(ctx)
 
 		objCount := 0
 		prevProgressLogging := time.Now()


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
