### PR TITLE
Add missing `cancel()` call in timeout case

### DIFF
--- a/cluster/replication/producer_consumer_test.go
+++ b/cluster/replication/producer_consumer_test.go
@@ -435,6 +435,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 			}()
 			select {
 			case <-time.After(30 * time.Second):
+				cancel()
 				t.Fatal("Test timed out waiting for operation completion")
 			case <-waitChan:
 				cancel()


### PR DESCRIPTION
### What's being changed:

The `golangci-lint` was failing with a `lostcancel` error in `TestConsumerStateChangeOrder`. The `cancel()` function wasn't being called on all code paths. To be more precise a call to `cancel()` is missing in the timeout case, leading to potential goroutine leaks

Added `cancel()` call before `t.Fatal()` in the timeout case to ensure proper context cancellation on all paths.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.