### PR TITLE
Reduce reads for segmentCursorCollectionReusable

### DIFF
--- a/adapters/handlers/rest/authz/mock_controller_and_get_users.go
+++ b/adapters/handlers/rest/authz/mock_controller_and_get_users.go
@@ -663,8 +663,7 @@ func (_c *MockControllerAndGetUsers_UpdateRolesPermissions_Call) RunAndReturn(ru
 func NewMockControllerAndGetUsers(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockControllerAndGetUsers {
+}) *MockControllerAndGetUsers {
 	mock := &MockControllerAndGetUsers{}
 	mock.Mock.Test(t)
 

--- a/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
+++ b/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
@@ -528,8 +528,7 @@ func (_c *MockDbUserAndRolesGetter_RotateKey_Call) RunAndReturn(run func(string,
 func NewMockDbUserAndRolesGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockDbUserAndRolesGetter {
+}) *MockDbUserAndRolesGetter {
 	mock := &MockDbUserAndRolesGetter{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/lsmkv/compaction_bench_test.go
+++ b/adapters/repos/db/lsmkv/compaction_bench_test.go
@@ -27,56 +27,73 @@ func BenchmarkCompaction(b *testing.B) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
-	opts := []BucketOption{
-		WithStrategy(StrategyMapCollection),
-		WithKeepTombstones(true),
-		WithPread(true),
-	}
-
 	valuesPerSegment := 10000
 
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		// avoid page cache by having a unique dir per run and have the content of the segments unique
-		b.StopTimer()
-		tmpDir := b.TempDir()
-
-		bu, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
-		require.NoError(b, err)
-
-		for j := 0; j < valuesPerSegment; j++ {
-			require.NoError(b, bu.MapSet(
-				[]byte(fmt.Sprintf("key%d_%d", j, i)), MapPair{Key: []byte(fmt.Sprintf("keyMP%d_%d", j, i)), Value: []byte(fmt.Sprintf("value_%d_%d", j, i))}))
-			if j%10 == 0 {
-				require.NoError(b, bu.MapDeleteKey([]byte(fmt.Sprintf("key2_%d_%d", j, i)), []byte(fmt.Sprintf("keyMP2_%d_%d", j, i))))
+	for _, strategy := range []string{StrategyMapCollection, StrategyReplace} {
+		for _, pread := range []bool{true, false} {
+			opts := []BucketOption{
+				WithStrategy(strategy),
+				WithKeepTombstones(true),
+				WithPread(pread),
 			}
+
+			b.Run(fmt.Sprintf("strategy %s with pread: %t", strategy, pread), func(b *testing.B) {
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					// avoid page cache by having a unique dir per run and have the content of the segments unique
+					b.StopTimer()
+					tmpDir := b.TempDir()
+
+					bu, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+						cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					require.NoError(b, err)
+
+					for j := 0; j < valuesPerSegment; j++ {
+						addData(b, bu, i, j, "key", "key2", strategy)
+					}
+					require.NoError(b, bu.FlushMemtable())
+
+					fileTypes := getFiles(b, tmpDir)
+					require.Equal(b, 1, fileTypes[".db"])
+
+					for j := 0; j < valuesPerSegment; j++ {
+						addData(b, bu, i, j, "key2", "key", strategy)
+					}
+					require.NoError(b, bu.FlushMemtable())
+
+					fileTypes = getFiles(b, tmpDir)
+					require.Equal(b, 2, fileTypes[".db"])
+					b.StartTimer()
+
+					once, err := bu.disk.compactOnce()
+					require.NoError(b, err)
+					require.True(b, once)
+
+					require.NoError(b, bu.Shutdown(ctx))
+				}
+			})
 		}
-		require.NoError(b, bu.FlushMemtable())
+	}
+}
 
-		fileTypes := getFiles(b, tmpDir)
-		require.Equal(b, 1, fileTypes[".db"])
-
-		for j := 0; j < valuesPerSegment; j++ {
-			require.NoError(b, bu.MapSet(
-				[]byte(fmt.Sprintf("key2%d_%d", j, i)), MapPair{Key: []byte(fmt.Sprintf("keyMP2%d_%d", j, i)), Value: []byte(fmt.Sprintf("value%d_%d", j, i))}))
-			if j%10 == 0 {
-				require.NoError(b, bu.MapDeleteKey([]byte(fmt.Sprintf("key%d_%d", j, i)), []byte(fmt.Sprintf("keyMP%d_%d", j, i))))
-			}
+func addData(b testing.TB, bu *Bucket, i, j int, prefixInsert, prefixDelete, strategy string) {
+	if strategy == StrategyReplace {
+		require.NoError(b, bu.Put([]byte(fmt.Sprintf("%s%d_%d", prefixInsert, j, i)), []byte(fmt.Sprintf("value%d_%d", j, i))))
+	} else if strategy == StrategySetCollection {
+		require.NoError(b, bu.SetAdd([]byte(fmt.Sprintf("%s%d_%d", prefixInsert, j, i)), [][]byte{[]byte(fmt.Sprintf("value%d_%d", j, i))}))
+	} else if strategy == StrategyRoaringSet {
+		require.NoError(b, bu.RoaringSetAddOne([]byte(fmt.Sprintf("%s%d_%d", prefixInsert, j, i)), uint64(i+j)))
+	} else if strategy == StrategyMapCollection {
+		require.NoError(b, bu.MapSet(
+			[]byte(fmt.Sprintf("%s%d_%d", prefixInsert, j, i)), MapPair{Key: []byte(fmt.Sprintf("%sMP%d_%d", prefixInsert, j, i)), Value: []byte(fmt.Sprintf("value%d_%d", j, i))}))
+		if j%10 == 0 {
+			require.NoError(b, bu.MapDeleteKey([]byte(fmt.Sprintf("%s%d_%d", prefixDelete, j, i)), []byte(fmt.Sprintf("%sMP%d_%d", prefixDelete, j, i))))
 		}
-		require.NoError(b, bu.FlushMemtable())
-
-		fileTypes = getFiles(b, tmpDir)
-		require.Equal(b, 2, fileTypes[".db"])
-		b.StartTimer()
-
-		once, err := bu.disk.compactOnce()
-		require.NoError(b, err)
-		require.True(b, once)
-
-		require.NoError(b, bu.Shutdown(ctx))
+	} else if strategy == StrategyRoaringSetRange {
+		require.NoError(b, bu.RoaringSetRangeAdd(uint64(i+j), uint64(i+j)))
+	} else {
+		require.Fail(b, "unknown strategy %s", strategy)
 	}
 }
 

--- a/adapters/repos/db/lsmkv/compaction_bench_test.go
+++ b/adapters/repos/db/lsmkv/compaction_bench_test.go
@@ -1,0 +1,91 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func BenchmarkCompaction(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	opts := []BucketOption{
+		WithStrategy(StrategyMapCollection),
+		WithKeepTombstones(true),
+		WithPread(true),
+	}
+
+	valuesPerSegment := 10000
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		// avoid page cache by having a unique dir per run and have the content of the segments unique
+		b.StopTimer()
+		tmpDir := b.TempDir()
+
+		bu, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		require.NoError(b, err)
+
+		for j := 0; j < valuesPerSegment; j++ {
+			require.NoError(b, bu.MapSet(
+				[]byte(fmt.Sprintf("key%d_%d", j, i)), MapPair{Key: []byte(fmt.Sprintf("keyMP%d_%d", j, i)), Value: []byte(fmt.Sprintf("value_%d_%d", j, i))}))
+			if j%10 == 0 {
+				require.NoError(b, bu.MapDeleteKey([]byte(fmt.Sprintf("key2_%d_%d", j, i)), []byte(fmt.Sprintf("keyMP2_%d_%d", j, i))))
+			}
+		}
+		require.NoError(b, bu.FlushMemtable())
+
+		fileTypes := getFiles(b, tmpDir)
+		require.Equal(b, 1, fileTypes[".db"])
+
+		for j := 0; j < valuesPerSegment; j++ {
+			require.NoError(b, bu.MapSet(
+				[]byte(fmt.Sprintf("key2%d_%d", j, i)), MapPair{Key: []byte(fmt.Sprintf("keyMP2%d_%d", j, i)), Value: []byte(fmt.Sprintf("value%d_%d", j, i))}))
+			if j%10 == 0 {
+				require.NoError(b, bu.MapDeleteKey([]byte(fmt.Sprintf("key%d_%d", j, i)), []byte(fmt.Sprintf("keyMP%d_%d", j, i))))
+			}
+		}
+		require.NoError(b, bu.FlushMemtable())
+
+		fileTypes = getFiles(b, tmpDir)
+		require.Equal(b, 2, fileTypes[".db"])
+		b.StartTimer()
+
+		once, err := bu.disk.compactOnce()
+		require.NoError(b, err)
+		require.True(b, once)
+
+		require.NoError(b, bu.Shutdown(ctx))
+	}
+}
+
+func getFiles(t testing.TB, dirName string) map[string]int {
+	entries, err := os.ReadDir(dirName)
+	require.NoError(t, err)
+	fileTypes := map[string]int{}
+	for _, entry := range entries {
+		fileTypes[filepath.Ext(entry.Name())] += 1
+	}
+	return fileTypes
+}

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -232,6 +232,13 @@ func TestCompaction(t *testing.T) {
 			},
 		},
 		{
+			name: "compactionMapStrategy_HugeEntries",
+			f:    compactionMapStrategy_HugeEntries,
+			opts: []BucketOption{
+				WithStrategy(StrategyMapCollection),
+			},
+		},
+		{
 			name: "compactionMapStrategy_RemoveUnnecessary_KeepTombstones",
 			f:    compactionMapStrategy_RemoveUnnecessary,
 			opts: []BucketOption{

--- a/adapters/repos/db/lsmkv/compaction_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_map_integration_test.go
@@ -426,6 +426,46 @@ func compactionMapStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 		})
 }
 
+func compactionMapStrategy_HugeEntries(ctx context.Context, t *testing.T, opts []BucketOption) {
+	dirName := t.TempDir()
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+	require.Nil(t, err)
+
+	// so big it effectively never triggers as part of this test
+	b.SetMemtableThreshold(1e9)
+	key := []byte("my-key")
+
+	// test with very big values to make sure that the read cache can handle it
+	byteKey := make([]byte, 10000)
+	byteVal := make([]byte, 10000)
+
+	for i := 0; i < len(byteKey); i++ {
+		byteKey[i] = byteKey[i] + 1
+		byteVal[i] = byteVal[i] + 1
+	}
+
+	// first segment
+	require.NoError(t, b.MapSet(key, MapPair{Key: byteKey, Value: byteVal}))
+	require.NoError(t, b.FlushMemtable())
+
+	// second segment
+	require.NoError(t, b.MapSet(key, MapPair{Key: byteKey, Value: byteVal}))
+	require.NoError(t, b.FlushMemtable())
+
+	// compact and check that value is the same
+	once, err := b.disk.compactOnce()
+	require.NoError(t, err)
+	require.True(t, once)
+
+	list, err := b.MapList(ctx, key)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+
+	require.Equal(t, byteKey, list[0].Key)
+	require.Equal(t, byteVal, list[0].Value)
+}
+
 func compactionMapStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, opts []BucketOption) {
 	// in this test each segment reverses the action of the previous segment so
 	// that in the end a lot of information is present in the individual segments

--- a/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
@@ -105,7 +105,7 @@ func (c *cacheReader) Read(p []byte) (n int, err error) {
 }
 
 func (c *cacheReader) loadDataIntoCache(readLength int) error {
-	at, err := c.segment.newNodeReader(nodeOffset{start: c.positionInSegment}, "ReadFromSegmentInvertedReusableWithCache")
+	at, err := c.segment.newNodeReader(nodeOffset{start: c.positionInSegment}, "CursorCollectionReusable")
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
@@ -113,6 +113,10 @@ func (c *cacheReader) loadDataIntoCache(readLength int) error {
 	// Restore the original buffer capacity before reading
 	c.readCache = c.readCache[:cap(c.readCache)]
 
+	if readLength > len(c.readCache) {
+		c.readCache = make([]byte, readLength)
+	}
+
 	read, err := at.Read(c.readCache)
 	if err != nil && (!errors.Is(err, io.EOF) || read == 0) {
 		return err

--- a/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
@@ -16,72 +16,102 @@ import (
 )
 
 type segmentCursorCollectionReusable struct {
-	segment    *segment
-	nextOffset uint64
-	nodeBuf    segmentCollectionNode
+	cache   *cacheReader
+	nodeBuf segmentCollectionNode
 }
 
 func (s *segment) newCollectionCursorReusable() *segmentCursorCollectionReusable {
 	return &segmentCursorCollectionReusable{
-		segment: s,
+		cache: newCacheReader(s),
 	}
-}
-
-func (s *segmentCursorCollectionReusable) seek(key []byte) ([]byte, []value, error) {
-	node, err := s.segment.index.Seek(key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	err = s.parseCollectionNodeInto(nodeOffset{node.Start, node.End})
-	if err != nil {
-		return s.nodeBuf.primaryKey, nil, err
-	}
-
-	s.nextOffset = node.End
-
-	return s.nodeBuf.primaryKey, s.nodeBuf.values, nil
 }
 
 func (s *segmentCursorCollectionReusable) next() ([]byte, []value, error) {
-	if s.nextOffset >= s.segment.dataEndPos {
-		return nil, nil, lsmkv.NotFound
+	if err := s.cache.CheckPosition(); err != nil {
+		return nil, nil, err
 	}
-
-	err := s.parseCollectionNodeInto(nodeOffset{start: s.nextOffset})
-	// make sure to set the next offset before checking the error. The error
-	// could be 'entities.Deleted' which would require that the offset is still advanced
-	// for the next cycle
-	s.nextOffset = s.nextOffset + uint64(s.nodeBuf.offset)
-	if err != nil {
-		return s.nodeBuf.primaryKey, nil, err
-	}
-
-	return s.nodeBuf.primaryKey, s.nodeBuf.values, nil
+	return s.parseCollectionNodeInto()
 }
 
 func (s *segmentCursorCollectionReusable) first() ([]byte, []value, error) {
-	if s.segment.dataStartPos == s.segment.dataEndPos {
-		return nil, nil, lsmkv.NotFound
+	s.cache.Reset()
+	if err := s.cache.CheckPosition(); err != nil {
+		return nil, nil, err
 	}
+	return s.parseCollectionNodeInto()
+}
 
-	s.nextOffset = s.segment.dataStartPos
-
-	err := s.parseCollectionNodeInto(nodeOffset{start: s.nextOffset})
+func (s *segmentCursorCollectionReusable) parseCollectionNodeInto() ([]byte, []value, error) {
+	err := ParseCollectionNodeInto(s.cache, &s.nodeBuf)
 	if err != nil {
 		return s.nodeBuf.primaryKey, nil, err
 	}
 
-	s.nextOffset = s.nextOffset + uint64(s.nodeBuf.offset)
-
 	return s.nodeBuf.primaryKey, s.nodeBuf.values, nil
 }
 
-func (s *segmentCursorCollectionReusable) parseCollectionNodeInto(offset nodeOffset) error {
-	r, err := s.segment.newNodeReader(offset, "segmentCursorCollectionReusable")
+type cacheReader struct {
+	readCache         []byte
+	positionInCache   uint64
+	segment           *segment
+	positionInSegment uint64
+}
+
+func newCacheReader(s *segment) *cacheReader {
+	cacheSize := uint64(4096)
+	if s.dataEndPos-s.dataStartPos < cacheSize {
+		cacheSize = s.dataEndPos - s.dataStartPos
+	}
+
+	return &cacheReader{
+		readCache:         make([]byte, 0, cacheSize),
+		segment:           s,
+		positionInSegment: s.dataStartPos,
+	}
+}
+
+func (c *cacheReader) CheckPosition() error {
+	if c.positionInSegment >= c.segment.dataEndPos {
+		return lsmkv.NotFound
+	}
+	return nil
+}
+
+func (c *cacheReader) Reset() {
+	c.positionInCache = 0
+	c.positionInSegment = c.segment.dataStartPos
+	c.readCache = c.readCache[:0] // forces a new read
+}
+
+func (c *cacheReader) Read(p []byte) (n int, err error) {
+	length := uint64(len(p))
+	if c.positionInCache+length > uint64(len(c.readCache)) {
+		if err := c.loadDataIntoCache(); err != nil {
+			return 0, err
+		}
+	}
+	copy(p, c.readCache[c.positionInCache:c.positionInCache+length])
+
+	c.positionInSegment += length
+	c.positionInCache += length
+
+	return len(p), nil
+}
+
+func (c *cacheReader) loadDataIntoCache() error {
+	at, err := c.segment.newNodeReader(nodeOffset{start: c.positionInSegment}, "ReadFromSegmentInvertedReusableWithCache")
 	if err != nil {
 		return err
 	}
 
-	return ParseCollectionNodeInto(r, &s.nodeBuf)
+	// Restore the original buffer capacity before reading
+	c.readCache = c.readCache[:cap(c.readCache)]
+
+	read, err := at.Read(c.readCache)
+	if err != nil {
+		return err
+	}
+	c.readCache = c.readCache[:read]
+	c.positionInCache = 0
+	return nil
 }

--- a/adapters/repos/db/lsmkv/mock_bucket_creator.go
+++ b/adapters/repos/db/lsmkv/mock_bucket_creator.go
@@ -119,8 +119,7 @@ func (_c *MockBucketCreator_NewBucket_Call) RunAndReturn(run func(context.Contex
 func NewMockBucketCreator(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockBucketCreator {
+}) *MockBucketCreator {
 	mock := &MockBucketCreator{}
 	mock.Mock.Test(t)
 

--- a/entities/modulecapabilities/mock_backup_backend.go
+++ b/entities/modulecapabilities/mock_backup_backend.go
@@ -617,8 +617,7 @@ func (_c *MockBackupBackend_WriteToFile_Call) RunAndReturn(run func(context.Cont
 func NewMockBackupBackend(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockBackupBackend {
+}) *MockBackupBackend {
 	mock := &MockBackupBackend{}
 	mock.Mock.Test(t)
 

--- a/usecases/auth/authorization/mock_authorizer.go
+++ b/usecases/auth/authorization/mock_authorizer.go
@@ -234,8 +234,7 @@ func (_c *MockAuthorizer_FilterAuthorizedResources_Call) RunAndReturn(run func(*
 func NewMockAuthorizer(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockAuthorizer {
+}) *MockAuthorizer {
 	mock := &MockAuthorizer{}
 	mock.Mock.Test(t)
 

--- a/usecases/auth/authorization/mock_controller.go
+++ b/usecases/auth/authorization/mock_controller.go
@@ -588,8 +588,7 @@ func (_c *MockController_UpdateRolesPermissions_Call) RunAndReturn(run func(map[
 func NewMockController(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockController {
+}) *MockController {
 	mock := &MockController{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mock_backup_backend_provider.go
+++ b/usecases/backup/mock_backup_backend_provider.go
@@ -141,8 +141,7 @@ func (_c *MockBackupBackendProvider_EnabledBackupBackends_Call) RunAndReturn(run
 func NewMockBackupBackendProvider(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockBackupBackendProvider {
+}) *MockBackupBackendProvider {
 	mock := &MockBackupBackendProvider{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mock_node_resolver.go
+++ b/usecases/backup/mock_node_resolver.go
@@ -226,8 +226,7 @@ func (_c *MockNodeResolver_NodeHostname_Call) RunAndReturn(run func(string) (str
 func NewMockNodeResolver(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockNodeResolver {
+}) *MockNodeResolver {
 	mock := &MockNodeResolver{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mock_selector.go
+++ b/usecases/backup/mock_selector.go
@@ -191,8 +191,7 @@ func (_c *MockSelector_Shards_Call) RunAndReturn(run func(context.Context, strin
 func NewMockSelector(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockSelector {
+}) *MockSelector {
 	mock := &MockSelector{}
 	mock.Mock.Test(t)
 

--- a/usecases/schema/mock_schema_getter.go
+++ b/usecases/schema/mock_schema_getter.go
@@ -723,8 +723,7 @@ func (_c *MockSchemaGetter_TenantsShards_Call) RunAndReturn(run func(context.Con
 func NewMockSchemaGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockSchemaGetter {
+}) *MockSchemaGetter {
 	mock := &MockSchemaGetter{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
### What's being changed:

- chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/15628748927
- e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/15628747891

benchmark old vs new:
```
BenchmarkCompaction-10    	      24	  46605940 ns/op	107999189 B/op	  215516 allocs/op
BenchmarkCompaction-10    	      62	  16851106 ns/op	14595423 B/op	   86000 allocs/op
```

Note that with mmap there was also a small speedup (<5%)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
