### PR TITLE
refact(usage-module): runtime config initiation

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -217,6 +217,8 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 	appState := startupRoutine(ctx, options)
 
+	// this is before initRuntimeOverrides to be able to init module configs
+	// as runtime overrides are applied after initModules
 	if err := registerModules(appState); err != nil {
 		appState.Logger.
 			WithField("action", "startup").WithError(err).

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -217,6 +217,31 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 	appState := startupRoutine(ctx, options)
 
+	if err := registerModules(appState); err != nil {
+		appState.Logger.
+			WithField("action", "startup").WithError(err).
+			Fatal("modules didn't load")
+	}
+
+	// while we accept an overall longer startup, e.g. due to a recovery, we
+	// still want to limit the module startup context, as that's mostly service
+	// discovery / dependency checking
+	moduleCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
+	if err := initModules(moduleCtx, appState); err != nil {
+		appState.Logger.
+			WithField("action", "startup").WithError(err).
+			Fatal("modules didn't initialize")
+	}
+	// now that modules are loaded we can run the remaining config validation
+	// which is module dependent
+	if err := appState.ServerConfig.Config.ValidateModules(appState.Modules); err != nil {
+		appState.Logger.
+			WithField("action", "startup").WithError(err).
+			Fatal("invalid config")
+	}
+
 	// initializing at the top to reflect the config changes before we pass on to different components.
 	initRuntimeOverrides(appState)
 
@@ -342,21 +367,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	}
 
 	limitResources(appState)
-
-	err := registerModules(appState)
-	if err != nil {
-		appState.Logger.
-			WithField("action", "startup").WithError(err).
-			Fatal("modules didn't load")
-	}
-
-	// now that modules are loaded we can run the remaining config validation
-	// which is module dependent
-	if err := appState.ServerConfig.Config.ValidateModules(appState.Modules); err != nil {
-		appState.Logger.
-			WithField("action", "startup").WithError(err).
-			Fatal("invalid config")
-	}
 
 	appState.ClusterHttpClient = reasonableHttpClient(appState.ServerConfig.Config.Cluster.AuthConfig)
 	appState.MemWatch = memwatch.NewMonitor(memwatch.LiveHeapReader, debug.SetMemoryLimit, 0.97)
@@ -602,19 +612,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 	updateSchemaCallback := makeUpdateSchemaCall(appState)
 	executor.RegisterSchemaUpdateCallback(updateSchemaCallback)
-
-	// while we accept an overall longer startup, e.g. due to a recovery, we
-	// still want to limit the module startup context, as that's mostly service
-	// discovery / dependency checking
-	moduleCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
-	defer cancel()
-
-	err = initModules(moduleCtx, appState)
-	if err != nil {
-		appState.Logger.
-			WithField("action", "startup").WithError(err).
-			Fatal("modules didn't initialize")
-	}
 
 	var reindexCtx context.Context
 	reindexCtx, appState.ReindexCtxCancel = context.WithCancelCause(context.Background())
@@ -1631,7 +1628,7 @@ func initModules(ctx context.Context, appState *state.State) error {
 	// TODO: gh-1481 don't pass entire appState in, but only what's needed. Probably only
 	// config?
 	moduleParams := moduletools.NewInitParams(storageProvider, appState,
-		appState.ServerConfig.Config, appState.Logger, prometheus.DefaultRegisterer)
+		&appState.ServerConfig.Config, appState.Logger, prometheus.DefaultRegisterer)
 
 	appState.Logger.
 		WithField("action", "startup").
@@ -1801,11 +1798,14 @@ func initRuntimeOverrides(appState *state.State) {
 		registered.QuerySlowLogEnabled = appState.ServerConfig.Config.QuerySlowLogEnabled
 		registered.QuerySlowLogThreshold = appState.ServerConfig.Config.QuerySlowLogThreshold
 		registered.InvertedSorterDisabled = appState.ServerConfig.Config.InvertedSorterDisabled
-		registered.UsageGCSBucket = appState.ServerConfig.Config.Usage.GCSBucket
-		registered.UsageGCSPrefix = appState.ServerConfig.Config.Usage.GCSPrefix
-		registered.UsageGCSAuth = appState.ServerConfig.Config.Usage.GCSAuth
-		registered.UsageScrapeInterval = appState.ServerConfig.Config.Usage.ScrapeInterval
-		registered.UsagePolicyVersion = appState.ServerConfig.Config.Usage.PolicyVersion
+
+		if appState.Modules.UsageEnabled() {
+			registered.UsageGCSBucket = appState.ServerConfig.Config.Usage.GCSBucket
+			registered.UsageGCSPrefix = appState.ServerConfig.Config.Usage.GCSPrefix
+			registered.UsageGCSAuth = appState.ServerConfig.Config.Usage.GCSAuth
+			registered.UsageScrapeInterval = appState.ServerConfig.Config.Usage.ScrapeInterval
+			registered.UsagePolicyVersion = appState.ServerConfig.Config.Usage.PolicyVersion
+		}
 
 		cm, err := configRuntime.NewConfigManager(
 			appState.ServerConfig.Config.RuntimeOverrides.Path,

--- a/entities/moduletools/init_params.go
+++ b/entities/moduletools/init_params.go
@@ -24,18 +24,21 @@ type ModuleInitParams interface {
 	GetLogger() logrus.FieldLogger
 	GetConfig() config.Config
 	GetMetricsRegisterer() prometheus.Registerer
+	// GetConfigPointer() used to be a pointer to a config.Config, to be used for
+	// runtime overrides.
+	GetConfigPointer() *config.Config
 }
 
 type InitParams struct {
 	storageProvider StorageProvider
 	appState        interface{}
-	config          config.Config
+	config          *config.Config
 	logger          logrus.FieldLogger
 	registerer      prometheus.Registerer
 }
 
 func NewInitParams(storageProvider StorageProvider, appState interface{},
-	config config.Config, logger logrus.FieldLogger, registerer prometheus.Registerer,
+	config *config.Config, logger logrus.FieldLogger, registerer prometheus.Registerer,
 ) ModuleInitParams {
 	return &InitParams{storageProvider, appState, config, logger, registerer}
 }
@@ -53,6 +56,10 @@ func (p *InitParams) GetLogger() logrus.FieldLogger {
 }
 
 func (p *InitParams) GetConfig() config.Config {
+	return *p.config
+}
+
+func (p *InitParams) GetConfigPointer() *config.Config {
 	return p.config
 }
 

--- a/entities/moduletools/init_params.go
+++ b/entities/moduletools/init_params.go
@@ -24,9 +24,9 @@ type ModuleInitParams interface {
 	GetLogger() logrus.FieldLogger
 	GetConfig() config.Config
 	GetMetricsRegisterer() prometheus.Registerer
-	// GetConfigPointer() used to be a pointer to a config.Config, to be used for
+	// GetConfigPtr() used to be a pointer to a config.Config, to be used for
 	// runtime overrides.
-	GetConfigPointer() *config.Config
+	GetConfigPtr() *config.Config
 }
 
 type InitParams struct {
@@ -59,7 +59,7 @@ func (p *InitParams) GetConfig() config.Config {
 	return *p.config
 }
 
-func (p *InitParams) GetConfigPointer() *config.Config {
+func (p *InitParams) GetConfigPtr() *config.Config {
 	return p.config
 }
 

--- a/entities/moduletools/init_params.go
+++ b/entities/moduletools/init_params.go
@@ -23,10 +23,10 @@ type ModuleInitParams interface {
 	GetAppState() interface{}
 	GetLogger() logrus.FieldLogger
 	GetConfig() config.Config
-	GetMetricsRegisterer() prometheus.Registerer
-	// GetConfigPtr() used to be a pointer to a config.Config, to be used for
-	// runtime overrides.
+	// GetConfigPtr() used to be a pointer to a config.Config to be used for
+	// runtime overrides initialization.
 	GetConfigPtr() *config.Config
+	GetMetricsRegisterer() prometheus.Registerer
 }
 
 type InitParams struct {

--- a/entities/moduletools/init_params.go
+++ b/entities/moduletools/init_params.go
@@ -22,10 +22,7 @@ type ModuleInitParams interface {
 	GetStorageProvider() StorageProvider
 	GetAppState() interface{}
 	GetLogger() logrus.FieldLogger
-	GetConfig() config.Config
-	// GetConfigPtr() used to be a pointer to a config.Config to be used for
-	// runtime overrides initialization.
-	GetConfigPtr() *config.Config
+	GetConfig() *config.Config
 	GetMetricsRegisterer() prometheus.Registerer
 }
 
@@ -55,11 +52,7 @@ func (p *InitParams) GetLogger() logrus.FieldLogger {
 	return p.logger
 }
 
-func (p *InitParams) GetConfig() config.Config {
-	return *p.config
-}
-
-func (p *InitParams) GetConfigPtr() *config.Config {
+func (p *InitParams) GetConfig() *config.Config {
 	return p.config
 }
 

--- a/entities/moduletools/mock_module_init_params.go
+++ b/entities/moduletools/mock_module_init_params.go
@@ -83,18 +83,20 @@ func (_c *MockModuleInitParams_GetAppState_Call) RunAndReturn(run func() interfa
 }
 
 // GetConfig provides a mock function with no fields
-func (_m *MockModuleInitParams) GetConfig() config.Config {
+func (_m *MockModuleInitParams) GetConfig() *config.Config {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConfig")
 	}
 
-	var r0 config.Config
-	if rf, ok := ret.Get(0).(func() config.Config); ok {
+	var r0 *config.Config
+	if rf, ok := ret.Get(0).(func() *config.Config); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(config.Config)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*config.Config)
+		}
 	}
 
 	return r0
@@ -117,59 +119,12 @@ func (_c *MockModuleInitParams_GetConfig_Call) Run(run func()) *MockModuleInitPa
 	return _c
 }
 
-func (_c *MockModuleInitParams_GetConfig_Call) Return(_a0 config.Config) *MockModuleInitParams_GetConfig_Call {
+func (_c *MockModuleInitParams_GetConfig_Call) Return(_a0 *config.Config) *MockModuleInitParams_GetConfig_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockModuleInitParams_GetConfig_Call) RunAndReturn(run func() config.Config) *MockModuleInitParams_GetConfig_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetConfigPtr provides a mock function with no fields
-func (_m *MockModuleInitParams) GetConfigPtr() *config.Config {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetConfigPtr")
-	}
-
-	var r0 *config.Config
-	if rf, ok := ret.Get(0).(func() *config.Config); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*config.Config)
-		}
-	}
-
-	return r0
-}
-
-// MockModuleInitParams_GetConfigPtr_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfigPtr'
-type MockModuleInitParams_GetConfigPtr_Call struct {
-	*mock.Call
-}
-
-// GetConfigPtr is a helper method to define mock.On call
-func (_e *MockModuleInitParams_Expecter) GetConfigPtr() *MockModuleInitParams_GetConfigPtr_Call {
-	return &MockModuleInitParams_GetConfigPtr_Call{Call: _e.mock.On("GetConfigPtr")}
-}
-
-func (_c *MockModuleInitParams_GetConfigPtr_Call) Run(run func()) *MockModuleInitParams_GetConfigPtr_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockModuleInitParams_GetConfigPtr_Call) Return(_a0 *config.Config) *MockModuleInitParams_GetConfigPtr_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockModuleInitParams_GetConfigPtr_Call) RunAndReturn(run func() *config.Config) *MockModuleInitParams_GetConfigPtr_Call {
+func (_c *MockModuleInitParams_GetConfig_Call) RunAndReturn(run func() *config.Config) *MockModuleInitParams_GetConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/entities/moduletools/mock_module_init_params.go
+++ b/entities/moduletools/mock_module_init_params.go
@@ -127,6 +127,53 @@ func (_c *MockModuleInitParams_GetConfig_Call) RunAndReturn(run func() config.Co
 	return _c
 }
 
+// GetConfigPtr provides a mock function with no fields
+func (_m *MockModuleInitParams) GetConfigPtr() *config.Config {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConfigPtr")
+	}
+
+	var r0 *config.Config
+	if rf, ok := ret.Get(0).(func() *config.Config); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*config.Config)
+		}
+	}
+
+	return r0
+}
+
+// MockModuleInitParams_GetConfigPtr_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfigPtr'
+type MockModuleInitParams_GetConfigPtr_Call struct {
+	*mock.Call
+}
+
+// GetConfigPtr is a helper method to define mock.On call
+func (_e *MockModuleInitParams_Expecter) GetConfigPtr() *MockModuleInitParams_GetConfigPtr_Call {
+	return &MockModuleInitParams_GetConfigPtr_Call{Call: _e.mock.On("GetConfigPtr")}
+}
+
+func (_c *MockModuleInitParams_GetConfigPtr_Call) Run(run func()) *MockModuleInitParams_GetConfigPtr_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockModuleInitParams_GetConfigPtr_Call) Return(_a0 *config.Config) *MockModuleInitParams_GetConfigPtr_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockModuleInitParams_GetConfigPtr_Call) RunAndReturn(run func() *config.Config) *MockModuleInitParams_GetConfigPtr_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLogger provides a mock function with no fields
 func (_m *MockModuleInitParams) GetLogger() logrus.FieldLogger {
 	ret := _m.Called()

--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -173,6 +173,10 @@ func (f *fakeModuleParams) GetConfig() config.Config {
 	return f.config
 }
 
+func (f *fakeModuleParams) GetConfigPtr() *config.Config {
+	return &f.config
+}
+
 func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
 	return prometheus.NewPedanticRegistry()
 }

--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -17,14 +17,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/moduletools"
-	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // Test user overrides
@@ -34,12 +31,15 @@ func TestUploadParams(t *testing.T) {
 	defaultHeaderValue := int64(13)
 	testCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	dataDir := t.TempDir()
 
 	azure := New()
 	os.Setenv("BACKUP_AZURE_CONTAINER", "test")
 	os.Setenv("AZURE_STORAGE_ACCOUNT", "test")
-	err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetLogger().Return(logrus.New())
+	params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+	err := azure.Init(testCtx, params)
 	require.Nil(t, err)
 
 	t.Run("getBlockSize with no inputs", func(t *testing.T) {
@@ -50,7 +50,10 @@ func TestUploadParams(t *testing.T) {
 	t.Run("getBlockSize with environment variable", func(t *testing.T) {
 		t.Setenv("AZURE_BLOCK_SIZE", "11")
 		azure := New()
-		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
 		blockSize := azure.getBlockSize(testCtx)
@@ -60,7 +63,10 @@ func TestUploadParams(t *testing.T) {
 	t.Run("getBlockSize with invalid environment variable", func(t *testing.T) {
 		t.Setenv("AZURE_BLOCK_SIZE", "invalid")
 		azure := New()
-		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
 		blockSize := azure.getBlockSize(testCtx)
@@ -100,7 +106,10 @@ func TestUploadParams(t *testing.T) {
 	t.Run("getConcurrency with environment variable", func(t *testing.T) {
 		t.Setenv("AZURE_CONCURRENCY", "11")
 		azure := New()
-		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
 		concurrency := azure.getConcurrency(testCtx)
@@ -110,7 +119,10 @@ func TestUploadParams(t *testing.T) {
 	t.Run("getConcurrency with invalid environment variable", func(t *testing.T) {
 		t.Setenv("AZURE_CONCURRENCY", "invalid")
 		azure := New()
-		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
 		concurrency := azure.getConcurrency(testCtx)
@@ -141,44 +153,6 @@ func TestUploadParams(t *testing.T) {
 		concurrency := azure.getConcurrency(ctxWithValue)
 		assert.Equal(t, defaultHeaderValue, int64(concurrency))
 	})
-}
-
-type fakeModuleParams struct {
-	logger   logrus.FieldLogger
-	provider fakeStorageProvider
-	config   config.Config
-}
-
-func newFakeModuleParams(dataPath string) *fakeModuleParams {
-	logger, _ := logrustest.NewNullLogger()
-	return &fakeModuleParams{
-		logger:   logger,
-		provider: fakeStorageProvider{dataPath: dataPath},
-	}
-}
-
-func (f *fakeModuleParams) GetStorageProvider() moduletools.StorageProvider {
-	return &f.provider
-}
-
-func (f *fakeModuleParams) GetAppState() interface{} {
-	return nil
-}
-
-func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
-	return f.logger
-}
-
-func (f *fakeModuleParams) GetConfig() config.Config {
-	return f.config
-}
-
-func (f *fakeModuleParams) GetConfigPtr() *config.Config {
-	return &f.config
-}
-
-func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
-	return prometheus.NewPedanticRegistry()
 }
 
 type fakeStorageProvider struct {

--- a/modules/ref2vec-centroid/module_test.go
+++ b/modules/ref2vec-centroid/module_test.go
@@ -39,7 +39,7 @@ func TestRef2VecCentroid(t *testing.T) {
 	defer cancel()
 	sp := newFakeStorageProvider(t)
 	logger, _ := test.NewNullLogger()
-	params := moduletools.NewInitParams(sp, nil, config.Config{}, logger, prometheus.NewPedanticRegistry())
+	params := moduletools.NewInitParams(sp, nil, &config.Config{}, logger, prometheus.NewPedanticRegistry())
 
 	mod := New()
 	classConfig := fakeClassConfig(mod.ClassConfigDefaults())

--- a/modules/text2vec-bigram/bigram_test.go
+++ b/modules/text2vec-bigram/bigram_test.go
@@ -79,6 +79,10 @@ func (f *fakeModuleParams) GetConfig() config.Config {
 	return f.config
 }
 
+func (f *fakeModuleParams) GetConfigPtr() *config.Config {
+	return &f.config
+}
+
 func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
 	return prometheus.NewPedanticRegistry()
 }

--- a/modules/text2vec-bigram/bigram_test.go
+++ b/modules/text2vec-bigram/bigram_test.go
@@ -15,17 +15,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
-	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/modules"
 )
 
@@ -42,49 +38,12 @@ func TestBigramModule_Type(t *testing.T) {
 func TestBigramModule_Init(t *testing.T) {
 	t.Setenv("BIGRAM", "alphabet")
 	mod := New()
-	params := newFakeModuleParams("data")
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetLogger().Return(logrus.New())
+	params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
 	err := mod.Init(context.Background(), params)
 	assert.NoError(t, err)
 	assert.Equal(t, "alphabet", mod.activeVectoriser)
-}
-
-type fakeModuleParams struct {
-	logger   logrus.FieldLogger
-	provider fakeStorageProvider
-	config   config.Config
-	appState *state.State
-}
-
-func newFakeModuleParams(dataPath string) *fakeModuleParams {
-	logger, _ := logrustest.NewNullLogger()
-	return &fakeModuleParams{
-		logger:   logger,
-		provider: fakeStorageProvider{dataPath: dataPath},
-	}
-}
-
-func (f *fakeModuleParams) GetStorageProvider() moduletools.StorageProvider {
-	return &f.provider
-}
-
-func (f *fakeModuleParams) GetAppState() interface{} {
-	return f.appState
-}
-
-func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
-	return f.logger
-}
-
-func (f *fakeModuleParams) GetConfig() config.Config {
-	return f.config
-}
-
-func (f *fakeModuleParams) GetConfigPtr() *config.Config {
-	return &f.config
-}
-
-func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
-	return prometheus.NewPedanticRegistry()
 }
 
 type fakeStorageProvider struct {

--- a/modules/usage-gcs/module.go
+++ b/modules/usage-gcs/module.go
@@ -73,7 +73,7 @@ func (m *module) Type() modulecapabilities.ModuleType {
 
 func (m *module) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
 	// Usage module configuration
-	m.config = params.GetConfigPtr()
+	m.config = params.GetConfig()
 	if err := parseUsageConfig(m.config); err != nil {
 		return err
 	}

--- a/modules/usage-gcs/module.go
+++ b/modules/usage-gcs/module.go
@@ -44,7 +44,7 @@ const (
 
 // module handles collecting and uploading usage metrics
 type module struct {
-	config        config.Config
+	config        *config.Config
 	logger        logrus.FieldLogger
 	storageClient *storage.Client
 	bucketName    string
@@ -73,8 +73,8 @@ func (m *module) Type() modulecapabilities.ModuleType {
 
 func (m *module) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
 	// Usage module configuration
-	m.config = params.GetConfig()
-	if err := parseUsageConfig(&m.config); err != nil {
+	m.config = params.GetConfigPointer()
+	if err := parseUsageConfig(m.config); err != nil {
 		return err
 	}
 

--- a/modules/usage-gcs/module.go
+++ b/modules/usage-gcs/module.go
@@ -73,7 +73,7 @@ func (m *module) Type() modulecapabilities.ModuleType {
 
 func (m *module) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
 	// Usage module configuration
-	m.config = params.GetConfigPointer()
+	m.config = params.GetConfigPtr()
 	if err := parseUsageConfig(m.config); err != nil {
 		return err
 	}

--- a/modules/usage-gcs/module.go
+++ b/modules/usage-gcs/module.go
@@ -26,10 +26,12 @@ import (
 	"google.golang.org/api/option"
 	storageapi "google.golang.org/api/storage/v1"
 
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 const (
@@ -70,7 +72,12 @@ func (m *module) Type() modulecapabilities.ModuleType {
 }
 
 func (m *module) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
+	// Usage module configuration
 	m.config = params.GetConfig()
+	if err := parseUsageConfig(&m.config); err != nil {
+		return err
+	}
+
 	if m.config.Cluster.Hostname == "" {
 		return fmt.Errorf("cluster hostname is not set")
 	}
@@ -391,6 +398,29 @@ func (m *module) usage(ctx context.Context) (*UsageResponse, error) {
 			},
 		},
 	}, nil
+}
+
+func parseUsageConfig(config *config.Config) error {
+	if v := os.Getenv("USAGE_GCS_USE_AUTH"); v != "" {
+		config.Usage.GCSAuth = runtime.NewDynamicValue(entcfg.Enabled(v))
+	}
+	if v := os.Getenv("USAGE_GCS_BUCKET"); v != "" {
+		config.Usage.GCSBucket = runtime.NewDynamicValue(v)
+	}
+	if v := os.Getenv("USAGE_GCS_PREFIX"); v != "" {
+		config.Usage.GCSPrefix = runtime.NewDynamicValue(v)
+	}
+	if v := os.Getenv("USAGE_SCRAPE_INTERVAL"); v != "" {
+		duration, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", "USAGE_SCRAPE_INTERVAL", err)
+		}
+		config.Usage.ScrapeInterval = runtime.NewDynamicValue(duration)
+	}
+	if v := os.Getenv("USAGE_POLICY_VERSION"); v != "" {
+		config.Usage.PolicyVersion = runtime.NewDynamicValue(v)
+	}
+	return nil
 }
 
 // verify we implement the modules.ModuleWithClose interface

--- a/modules/usage-gcs/module_test.go
+++ b/modules/usage-gcs/module_test.go
@@ -148,7 +148,7 @@ func TestModule_ConfigBasedIntervalUpdate(t *testing.T) {
 			ScrapeInterval: runtime.NewDynamicValue(2 * time.Hour),
 		},
 	}
-	mod.config = testConfig
+	mod.config = &testConfig
 
 	// Test that interval gets updated from config
 	oldInterval := mod.interval
@@ -168,7 +168,7 @@ func TestModule_CollectAndUploadPeriodically_ContextCancellation(t *testing.T) {
 	mod.interval = 100 * time.Millisecond // Short interval for testing
 
 	// Set up config with proper RuntimeOverrides to prevent panic
-	mod.config = config.Config{
+	mod.config = &config.Config{
 		RuntimeOverrides: config.RuntimeOverrides{
 			LoadInterval: 2 * time.Minute, // Use default value
 		},
@@ -205,7 +205,7 @@ func TestModule_CollectAndUploadPeriodically_StopSignal(t *testing.T) {
 	mod.interval = 100 * time.Millisecond // Short interval for testing
 
 	// Set up config with proper RuntimeOverrides to prevent panic
-	mod.config = config.Config{
+	mod.config = &config.Config{
 		RuntimeOverrides: config.RuntimeOverrides{
 			LoadInterval: 2 * time.Minute, // Use default value
 		},
@@ -403,7 +403,7 @@ func TestModule_ConfigurationChanges(t *testing.T) {
 			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
 		},
 	}
-	mod.config = testConfig
+	mod.config = &testConfig
 
 	// Test interval update
 	if interval := mod.config.Usage.ScrapeInterval.Get(); interval > 0 && mod.interval != interval {
@@ -533,7 +533,7 @@ func TestCollectAndUploadPeriodically_ConfigChangesAndStop(t *testing.T) {
 			LoadInterval: 2 * time.Minute, // Use default value
 		},
 	}
-	mod.config = testConfig
+	mod.config = &testConfig
 	mod.bucketName = "bucket1"
 	mod.prefix = "prefix1"
 
@@ -583,7 +583,7 @@ func TestModule_ZeroIntervalProtection(t *testing.T) {
 	mod.interval = 0 // Set invalid interval
 
 	// Set up config with zero runtime overrides interval
-	mod.config = config.Config{
+	mod.config = &config.Config{
 		RuntimeOverrides: config.RuntimeOverrides{
 			LoadInterval: 0, // Invalid interval
 		},

--- a/modules/usage-gcs/module_test.go
+++ b/modules/usage-gcs/module_test.go
@@ -78,7 +78,7 @@ func TestModule_Init_Success(t *testing.T) {
 	}
 
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfig().Return(testConfig)
+	params.EXPECT().GetConfigPtr().Return(&testConfig)
 	params.EXPECT().GetLogger().Return(logger)
 	params.EXPECT().GetMetricsRegisterer().Return(prometheus.NewPedanticRegistry())
 
@@ -96,7 +96,7 @@ func TestModule_Init_MissingHostname(t *testing.T) {
 	logger.SetOutput(os.Stdout)
 
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfig().Return(config.Config{
+	params.EXPECT().GetConfigPtr().Return(&config.Config{
 		Cluster: cluster.Config{
 			Hostname: "",
 		},
@@ -122,7 +122,7 @@ func TestModule_Init_MissingBucket(t *testing.T) {
 	}
 
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfig().Return(testConfig)
+	params.EXPECT().GetConfigPtr().Return(&testConfig)
 
 	err := mod.Init(context.Background(), params)
 	assert.Error(t, err)
@@ -453,7 +453,7 @@ func TestModule_Init_MissingConfig(t *testing.T) {
 
 	// Test with missing hostname
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfig().Return(config.Config{
+	params.EXPECT().GetConfigPtr().Return(&config.Config{
 		Cluster: cluster.Config{
 			Hostname: "",
 		},

--- a/modules/usage-gcs/module_test.go
+++ b/modules/usage-gcs/module_test.go
@@ -78,7 +78,7 @@ func TestModule_Init_Success(t *testing.T) {
 	}
 
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfigPtr().Return(&testConfig)
+	params.EXPECT().GetConfig().Return(&testConfig)
 	params.EXPECT().GetLogger().Return(logger)
 	params.EXPECT().GetMetricsRegisterer().Return(prometheus.NewPedanticRegistry())
 
@@ -96,7 +96,7 @@ func TestModule_Init_MissingHostname(t *testing.T) {
 	logger.SetOutput(os.Stdout)
 
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfigPtr().Return(&config.Config{
+	params.EXPECT().GetConfig().Return(&config.Config{
 		Cluster: cluster.Config{
 			Hostname: "",
 		},
@@ -122,7 +122,7 @@ func TestModule_Init_MissingBucket(t *testing.T) {
 	}
 
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfigPtr().Return(&testConfig)
+	params.EXPECT().GetConfig().Return(&testConfig)
 
 	err := mod.Init(context.Background(), params)
 	assert.Error(t, err)
@@ -453,7 +453,7 @@ func TestModule_Init_MissingConfig(t *testing.T) {
 
 	// Test with missing hostname
 	params := moduletools.NewMockModuleInitParams(t)
-	params.EXPECT().GetConfigPtr().Return(&config.Config{
+	params.EXPECT().GetConfig().Return(&config.Config{
 		Cluster: cluster.Config{
 			Hostname: "",
 		},

--- a/test/modules/backup-azure/backup_backend_test.go
+++ b/test/modules/backup-azure/backup_backend_test.go
@@ -19,9 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,7 +29,6 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
-	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_AzureBackend_Start(t *testing.T) {
@@ -107,7 +104,6 @@ func testAzureBackendBackup(overrideBucket, overridePath string) func(t *testing
 func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath string) {
 	testCtx := context.Background()
 
-	dataDir := t.TempDir()
 	className := "BackupClass"
 	backupID := "backup_id"
 	containerName := "container-level-store-backup-meta"
@@ -127,7 +123,10 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 	t.Run("store backup meta in Azure", func(t *testing.T) {
 		t.Setenv(envAzureContainer, containerName)
 		azure := mod.New()
-		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := azure.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("access permissions", func(t *testing.T) {
@@ -194,7 +193,6 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 	testCtx := context.Background()
 
-	dataDir := t.TempDir()
 	key := "moduleLevelCopyObjects"
 	backupID := "backup_id"
 	containerName := "container-level-copy-objects"
@@ -213,7 +211,10 @@ func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 	t.Run("copy objects", func(t *testing.T) {
 		t.Setenv(envAzureContainer, containerName)
 		azure := mod.New()
-		err := azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := azure.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("put object to bucket", func(t *testing.T) {
@@ -261,7 +262,10 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 
 		t.Setenv(envAzureContainer, containerName)
 		azure := mod.New()
-		err = azure.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
+		err = azure.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("verify source data path", func(t *testing.T) {
@@ -288,44 +292,6 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 			assert.Equal(t, expectedContents, contents)
 		})
 	})
-}
-
-type fakeModuleParams struct {
-	logger   logrus.FieldLogger
-	provider fakeStorageProvider
-	config   config.Config
-}
-
-func newFakeModuleParams(dataPath string) *fakeModuleParams {
-	logger, _ := logrustest.NewNullLogger()
-	return &fakeModuleParams{
-		logger:   logger,
-		provider: fakeStorageProvider{dataPath: dataPath},
-	}
-}
-
-func (f *fakeModuleParams) GetStorageProvider() moduletools.StorageProvider {
-	return &f.provider
-}
-
-func (f *fakeModuleParams) GetAppState() interface{} {
-	return nil
-}
-
-func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
-	return f.logger
-}
-
-func (f *fakeModuleParams) GetConfig() config.Config {
-	return f.config
-}
-
-func (f *fakeModuleParams) GetConfigPtr() *config.Config {
-	return &f.config
-}
-
-func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
-	return prometheus.NewPedanticRegistry()
 }
 
 type fakeStorageProvider struct {

--- a/test/modules/backup-azure/backup_backend_test.go
+++ b/test/modules/backup-azure/backup_backend_test.go
@@ -320,6 +320,10 @@ func (f *fakeModuleParams) GetConfig() config.Config {
 	return f.config
 }
 
+func (f *fakeModuleParams) GetConfigPtr() *config.Config {
+	return &f.config
+}
+
 func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
 	return prometheus.NewPedanticRegistry()
 }

--- a/test/modules/backup-filesystem/backup_backend_test.go
+++ b/test/modules/backup-filesystem/backup_backend_test.go
@@ -62,7 +62,7 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath, over
 	t.Run("store backup meta in fs"+overrideDescription, func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		sp := fakeStorageProvider{dataDir}
-		params := moduletools.NewInitParams(sp, nil, config.Config{}, logger, prometheus.NewPedanticRegistry())
+		params := moduletools.NewInitParams(sp, nil, &config.Config{}, logger, prometheus.NewPedanticRegistry())
 
 		fs := modstgfs.New()
 		err := fs.Init(testCtx, params)
@@ -126,7 +126,7 @@ func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath, override
 	t.Run("copy objects"+overrideDescription, func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		sp := fakeStorageProvider{dataDir}
-		params := moduletools.NewInitParams(sp, nil, config.Config{}, logger, prometheus.NewPedanticRegistry())
+		params := moduletools.NewInitParams(sp, nil, &config.Config{}, logger, prometheus.NewPedanticRegistry())
 
 		fs := modstgfs.New()
 		err := fs.Init(testCtx, params)
@@ -165,7 +165,7 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath, overrideDe
 
 		logger, _ := test.NewNullLogger()
 		sp := fakeStorageProvider{dataDir}
-		params := moduletools.NewInitParams(sp, nil, config.Config{}, logger, prometheus.NewPedanticRegistry())
+		params := moduletools.NewInitParams(sp, nil, &config.Config{}, logger, prometheus.NewPedanticRegistry())
 
 		fs := modstgfs.New()
 		err = fs.Init(testCtx, params)

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -286,6 +286,10 @@ func (f *fakeModuleParams) GetConfig() config.Config {
 	return f.config
 }
 
+func (f *fakeModuleParams) GetConfigPtr() *config.Config {
+	return &f.config
+}
+
 func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
 	return prometheus.NewPedanticRegistry()
 }

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -20,9 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,7 +30,6 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
-	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_GcsBackend_Start(t *testing.T) {
@@ -62,7 +59,6 @@ func gCSBackend_Backup(t *testing.T, overrideBucket, overridePath string) {
 func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath string) {
 	testCtx := context.Background()
 
-	dataDir := t.TempDir()
 	className := "BackupClass"
 	backupID := "backup_id"
 	bucketName := "bucket-level-store-backup-meta"
@@ -87,7 +83,10 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 	t.Run("store backup meta in gcs", func(t *testing.T) {
 		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
 		gcs := mod.New()
-		err := gcs.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("access permissions", func(t *testing.T) {
@@ -154,7 +153,6 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 	testCtx := context.Background()
 
-	dataDir := t.TempDir()
 	key := "moduleLevelCopyObjects"
 	backupID := "backup_id"
 	bucketName := "bucket-level-copy-objects"
@@ -178,7 +176,10 @@ func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 	t.Run("copy objects", func(t *testing.T) {
 		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
 		gcs := mod.New()
-		err := gcs.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("put object to bucket", func(t *testing.T) {
@@ -227,7 +228,10 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 
 		t.Setenv("BACKUP_GCS_BUCKET", bucketName)
 		gcs := mod.New()
-		err = gcs.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
+		err = gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("verify source data path", func(t *testing.T) {
@@ -254,44 +258,6 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 			assert.Equal(t, expectedContents, contents)
 		})
 	})
-}
-
-type fakeModuleParams struct {
-	logger   logrus.FieldLogger
-	provider fakeStorageProvider
-	config   config.Config
-}
-
-func newFakeModuleParams(dataPath string) *fakeModuleParams {
-	logger, _ := logrustest.NewNullLogger()
-	return &fakeModuleParams{
-		logger:   logger,
-		provider: fakeStorageProvider{dataPath: dataPath},
-	}
-}
-
-func (f *fakeModuleParams) GetStorageProvider() moduletools.StorageProvider {
-	return &f.provider
-}
-
-func (f *fakeModuleParams) GetAppState() interface{} {
-	return nil
-}
-
-func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
-	return f.logger
-}
-
-func (f *fakeModuleParams) GetConfig() config.Config {
-	return f.config
-}
-
-func (f *fakeModuleParams) GetConfigPtr() *config.Config {
-	return &f.config
-}
-
-func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
-	return prometheus.NewPedanticRegistry()
 }
 
 type fakeStorageProvider struct {

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -20,9 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,7 +30,6 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
-	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func Test_S3Backend_Start(t *testing.T) {
@@ -83,7 +80,6 @@ func moduleLevelStoreBackupMeta(t *testing.T, override bool, containerName, over
 
 	bucketName := containerName
 
-	dataDir := t.TempDir()
 	className := "BackupClass"
 	backupID := "backup_id"
 	endpoint := os.Getenv(envMinioEndpoint)
@@ -95,7 +91,10 @@ func moduleLevelStoreBackupMeta(t *testing.T, override bool, containerName, over
 		t.Setenv(envS3UseSSL, "false")
 		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
-		err := s3.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := s3.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("access permissions", func(t *testing.T) {
@@ -164,7 +163,6 @@ func moduleLevelCopyObjects(t *testing.T, override bool, containerName, override
 	testCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	dataDir := t.TempDir()
 	key := "moduleLevelCopyObjects"
 	backupID := "backup_id"
 	endpoint := os.Getenv(envMinioEndpoint)
@@ -177,7 +175,10 @@ func moduleLevelCopyObjects(t *testing.T, override bool, containerName, override
 		t.Setenv(envS3UseSSL, "false")
 		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
-		err := s3.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		err := s3.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("put object to bucket", func(t *testing.T) {
@@ -214,7 +215,10 @@ func moduleLevelCopyFiles(t *testing.T, override bool, containerName, overrideBu
 		t.Setenv(envS3UseSSL, "false")
 		t.Setenv(envS3Endpoint, endpoint)
 		s3 := mod.New()
-		err = s3.Init(testCtx, newFakeModuleParams(dataDir))
+		params := moduletools.NewMockModuleInitParams(t)
+		params.EXPECT().GetLogger().Return(logrus.New())
+		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
+		err = s3.Init(testCtx, params)
 		require.Nil(t, err)
 
 		t.Run("verify source data path", func(t *testing.T) {
@@ -243,44 +247,6 @@ func moduleLevelCopyFiles(t *testing.T, override bool, containerName, overrideBu
 			assert.Equal(t, expectedContents, contents)
 		})
 	})
-}
-
-type fakeModuleParams struct {
-	logger   logrus.FieldLogger
-	provider fakeStorageProvider
-	config   config.Config
-}
-
-func newFakeModuleParams(dataPath string) *fakeModuleParams {
-	logger, _ := logrustest.NewNullLogger()
-	return &fakeModuleParams{
-		logger:   logger,
-		provider: fakeStorageProvider{dataPath: dataPath},
-	}
-}
-
-func (f *fakeModuleParams) GetStorageProvider() moduletools.StorageProvider {
-	return &f.provider
-}
-
-func (f *fakeModuleParams) GetAppState() interface{} {
-	return nil
-}
-
-func (f *fakeModuleParams) GetLogger() logrus.FieldLogger {
-	return f.logger
-}
-
-func (f *fakeModuleParams) GetConfig() config.Config {
-	return f.config
-}
-
-func (f *fakeModuleParams) GetConfigPtr() *config.Config {
-	return &f.config
-}
-
-func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
-	return prometheus.NewPedanticRegistry()
 }
 
 type fakeStorageProvider struct {

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -275,6 +275,10 @@ func (f *fakeModuleParams) GetConfig() config.Config {
 	return f.config
 }
 
+func (f *fakeModuleParams) GetConfigPtr() *config.Config {
+	return &f.config
+}
+
 func (f *fakeModuleParams) GetMetricsRegisterer() prometheus.Registerer {
 	return prometheus.NewPedanticRegistry()
 }

--- a/tools/dev/config.runtime-overrides.yaml
+++ b/tools/dev/config.runtime-overrides.yaml
@@ -6,6 +6,7 @@ tenant_activity_write_log_level: info
 query_slow_log_enabled: true
 query_slow_log_threshold: 100ms
 inverted_sorter_disabled: false
-usage_scrape_interval: 60m
-usage_gcs_bucket: weaviate-usage
-usage_gcs_prefix: billing
+# for usage module if enabled make sure that usage-gcs module is enabled
+# usage_scrape_interval: 1s
+# usage_gcs_bucket: weaviate-usage
+# usage_gcs_prefix: billing

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -103,11 +103,11 @@ type RuntimeOverrides struct {
 
 // UsageConfig holds configuration for usage data collection and upload
 type UsageConfig struct {
-	GCSAuth        *runtime.DynamicValue[bool]          `json:"gcs_use_auth" yaml:"gcs_use_auth"`
-	GCSBucket      *runtime.DynamicValue[string]        `json:"gcs_bucket" yaml:"gcs_bucket"`
-	GCSPrefix      *runtime.DynamicValue[string]        `json:"gcs_prefix" yaml:"gcs_prefix"`
-	ScrapeInterval *runtime.DynamicValue[time.Duration] `json:"scrape_interval" yaml:"scrape_interval"`
-	PolicyVersion  *runtime.DynamicValue[string]        `json:"policy_version" yaml:"policy_version"`
+	GCSAuth        *runtime.DynamicValue[bool]          `json:"usage_gcs_auth" yaml:"usage_gcs_auth"`
+	GCSBucket      *runtime.DynamicValue[string]        `json:"usage_gcs_bucket" yaml:"usage_gcs_bucket"`
+	GCSPrefix      *runtime.DynamicValue[string]        `json:"usage_gcs_prefix" yaml:"usage_gcs_prefix"`
+	ScrapeInterval *runtime.DynamicValue[time.Duration] `json:"usage_scrape_interval" yaml:"usage_scrape_interval"`
+	PolicyVersion  *runtime.DynamicValue[string]        `json:"usage_policy_version" yaml:"usage_policy_version"`
 }
 
 // Config outline of the config file
@@ -220,13 +220,6 @@ type Config struct {
 	InvertedSorterDisabled *runtime.DynamicValue[bool] `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
 
 	// Usage configuration for the usage module
-	// example:
-	// usage:
-	//   gcp_use_auth: true
-	//   gcp_bucket: "my-bucket"
-	//   gcs_prefix: "my-prefix"
-	//   scrape_interval: 1m
-	//   policy_version: "2025-06-01"
 	Usage UsageConfig `json:"usage" yaml:"usage"`
 }
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -787,34 +787,6 @@ func FromEnv(config *Config) error {
 	}
 	config.InvertedSorterDisabled = runtime.NewDynamicValue(invertedSorterDisabled)
 
-	// Usage module configuration
-	if err := parseUsageConfig(config); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func parseUsageConfig(config *Config) error {
-	if v := os.Getenv("USAGE_GCS_USE_AUTH"); v != "" {
-		config.Usage.GCSAuth = runtime.NewDynamicValue(entcfg.Enabled(v))
-	}
-	if v := os.Getenv("USAGE_GCS_BUCKET"); v != "" {
-		config.Usage.GCSBucket = runtime.NewDynamicValue(v)
-	}
-	if v := os.Getenv("USAGE_GCS_PREFIX"); v != "" {
-		config.Usage.GCSPrefix = runtime.NewDynamicValue(v)
-	}
-	if v := os.Getenv("USAGE_SCRAPE_INTERVAL"); v != "" {
-		duration, err := time.ParseDuration(v)
-		if err != nil {
-			return fmt.Errorf("invalid %s: %w", "USAGE_SCRAPE_INTERVAL", err)
-		}
-		config.Usage.ScrapeInterval = runtime.NewDynamicValue(duration)
-	}
-	if v := os.Getenv("USAGE_POLICY_VERSION"); v != "" {
-		config.Usage.PolicyVersion = runtime.NewDynamicValue(v)
-	}
 	return nil
 }
 

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
+	modusagegcs "github.com/weaviate/weaviate/modules/usage-gcs"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 )
@@ -1138,4 +1139,13 @@ func (p *Provider) EnabledBackupBackends() []modulecapabilities.BackupBackend {
 		}
 	}
 	return backends
+}
+
+func (p *Provider) UsageEnabled() bool {
+	if module := p.GetByName(modusagegcs.Name); module != nil {
+		if module.Type() == modulecapabilities.Usage {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### What's being changed:
- move module configs under module `Init()`
- register and init modules before runtime config to be able to use it 
- introduce `GetConfigPtr()` to be able to assign runtime config from modules 
- register usage module to runtime config only if is enabled 
- remove `fakeModuleParams` and use mocks instead for testing

**future approach** would be having a specific name space for module in the runtime config and add the ability for runtime config to handle nested structs


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
