### PR TITLE
refact(backup-size) calculate shard concurrently and remove not needed data for calculation 

### DIFF
--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -479,23 +479,9 @@ func (u *uploader) calculateShardPreCompressionSize(shard *backup.ShardDescripto
 		}
 	}
 
-	// Add size of metadata files that are read from disk
-	metadataSize := int64(0)
-	if len(shard.DocIDCounter) > 0 {
-		metadataSize += int64(len(shard.DocIDCounter))
-	}
-	if len(shard.PropLengthTracker) > 0 {
-		metadataSize += int64(len(shard.PropLengthTracker))
-	}
-	if len(shard.Version) > 0 {
-		metadataSize += int64(len(shard.Version))
-	}
-	totalSize += metadataSize
-
 	u.log.WithFields(logrus.Fields{
 		"shard":          shard.Name,
 		"filesCount":     len(shard.Files),
-		"metadataSize":   metadataSize,
 		"totalSize":      totalSize,
 		"sourceDataPath": sourceDataPath,
 	}).Debug("calculated pre-compression size for shard")

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -47,12 +47,9 @@ func TestCalculateShardPreCompressionSize(t *testing.T) {
 
 	// Create a test shard descriptor
 	shard := &backup.ShardDescriptor{
-		Name:              "test-shard",
-		Node:              "test-node",
-		Files:             testFiles,
-		DocIDCounter:      []byte("docid-data"),
-		PropLengthTracker: []byte("prop-data"),
-		Version:           []byte("version-data"),
+		Name:  "test-shard",
+		Node:  "test-node",
+		Files: testFiles,
 	}
 
 	// Create a mock backend with expectations
@@ -72,14 +69,5 @@ func TestCalculateShardPreCompressionSize(t *testing.T) {
 	// Calculate pre-compression size
 	preCompressionSize := uploader.calculateShardPreCompressionSize(shard)
 
-	// Expected size: sum of file sizes + metadata sizes
-	expectedSize := int64(0)
-	for _, size := range fileSizes {
-		expectedSize += size
-	}
-	expectedSize += int64(len(shard.DocIDCounter))
-	expectedSize += int64(len(shard.PropLengthTracker))
-	expectedSize += int64(len(shard.Version))
-
-	assert.Equal(t, expectedSize, preCompressionSize)
+	assert.Equal(t, int64(100+200+300), preCompressionSize)
 }


### PR DESCRIPTION
### What's being changed:
follow up for https://github.com/weaviate/weaviate/pull/8382
doing it sequentially affects the backup time
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
