### PR TITLE
Revert "fix(runtime-config): panic in runtime config setter (#8395)"

### DIFF
--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -77,10 +77,6 @@ func (dv *DynamicValue[T]) Reset() {
 
 // Set is used by the config manager to update the dynamic value.
 func (dv *DynamicValue[T]) SetValue(val T) {
-	if dv == nil {
-		return
-	}
-
 	dv.mu.Lock()
 	defer dv.mu.Unlock()
 

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -22,9 +22,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
-
 	"github.com/weaviate/weaviate/usecases/config/runtime"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseRuntimeConfig(t *testing.T) {
@@ -159,61 +158,6 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, 13, colCount.Get())
 	})
 
-	t.Run("SetValue on nil receiver should not panic", func(t *testing.T) {
-		var (
-			nilInt    *runtime.DynamicValue[int]
-			nilFloat  *runtime.DynamicValue[float64]
-			nilBool   *runtime.DynamicValue[bool]
-			nilDur    *runtime.DynamicValue[time.Duration]
-			nilString *runtime.DynamicValue[string]
-		)
-
-		// These should not panic
-		require.NotPanics(t, func() {
-			nilInt.SetValue(42)
-		})
-		require.NotPanics(t, func() {
-			nilFloat.SetValue(3.14)
-		})
-		require.NotPanics(t, func() {
-			nilBool.SetValue(true)
-		})
-		require.NotPanics(t, func() {
-			nilDur.SetValue(5 * time.Second)
-		})
-		require.NotPanics(t, func() {
-			nilString.SetValue("test")
-		})
-
-		// Values should remain unchanged (still return zero values)
-		assert.Equal(t, 0, nilInt.Get())
-		assert.Equal(t, float64(0), nilFloat.Get())
-		assert.Equal(t, false, nilBool.Get())
-		assert.Equal(t, time.Duration(0), nilDur.Get())
-		assert.Equal(t, "", nilString.Get())
-	})
-
-	t.Run("SetValue on initialized receiver should work normally", func(t *testing.T) {
-		dInt := runtime.NewDynamicValue(10)
-		dFloat := runtime.NewDynamicValue(2.5)
-		dBool := runtime.NewDynamicValue(false)
-		dDur := runtime.NewDynamicValue(1 * time.Second)
-		dString := runtime.NewDynamicValue("initial")
-
-		// Set new values
-		dInt.SetValue(20)
-		dFloat.SetValue(3.14)
-		dBool.SetValue(true)
-		dDur.SetValue(2 * time.Second)
-		dString.SetValue("updated")
-
-		// Values should be updated
-		assert.Equal(t, 20, dInt.Get())
-		assert.Equal(t, 3.14, dFloat.Get())
-		assert.Equal(t, true, dBool.Get())
-		assert.Equal(t, 2*time.Second, dDur.Get())
-		assert.Equal(t, "updated", dString.Get())
-	})
 	t.Run("updating config should split out corresponding log lines", func(t *testing.T) {
 		log := logrus.New()
 		logs := bytes.Buffer{}


### PR DESCRIPTION
This reverts commit 7cdae34a40ac04009cbcde797541caedf3287888.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
