### PR TITLE
test: use require.EventuallyWithT to ensure all nodes are healthy

### DIFF
--- a/test/acceptance/replication/async_replication/async_repair_insertions_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_insertions_test.go
@@ -84,7 +84,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			verbose := verbosity.OutputVerbose
 			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
 			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
@@ -95,15 +95,15 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 			require.Len(ct, resp.Nodes, clusterSize)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
-				assert.Equal(ct, "HEALTHY", *n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
 			}
 		}, 15*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run(fmt.Sprintf("assert node %d has all the objects", node), func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			resp := common.GQLGet(t, compose.ContainerURI(node), "Paragraph", types.ConsistencyLevelOne)
-			assert.Len(ct, resp, len(paragraphIDs))
+			require.Len(ct, resp, len(paragraphIDs))
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})
 }

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -116,7 +116,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			verbose := verbosity.OutputVerbose
 			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
 			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
@@ -127,15 +127,15 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 			require.Len(ct, resp.Nodes, clusterSize)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
-				assert.Equal(ct, "HEALTHY", *n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
 			}
 		}, 15*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("validate async object propagation", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
-			assert.Len(ct, resp, objectCount)
+			require.Len(ct, resp, objectCount)
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})
 }

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -200,7 +200,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			verbose := verbosity.OutputVerbose
 			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
 			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
@@ -211,31 +211,31 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 			require.Len(ct, resp.Nodes, 3)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
-				assert.Equal(ct, "HEALTHY", *n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
 			}
 		}, 15*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("assert updated object read repair was made", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode(2).URI(),
 				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-			assert.Nil(ct, err)
-			assert.True(ct, exists)
+			require.Nil(ct, err)
+			require.True(ct, exists)
 
 			resp, err := common.GetObjectCL(t, compose.GetWeaviate().URI(),
 				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
-			assert.Nil(ct, err)
-			assert.NotNil(ct, resp)
+			require.Nil(ct, err)
+			require.NotNil(ct, resp)
 
 			if resp == nil {
 				return
 			}
 
-			assert.Equal(ct, replaceObj.ID, resp.ID)
-			assert.Equal(ct, replaceObj.Class, resp.Class)
-			assert.EqualValues(ct, replaceObj.Properties, resp.Properties)
-			assert.EqualValues(ct, replaceObj.Vector, resp.Vector)
+			require.Equal(ct, replaceObj.ID, resp.ID)
+			require.Equal(ct, replaceObj.Class, resp.Class)
+			require.EqualValues(ct, replaceObj.Properties, resp.Properties)
+			require.EqualValues(ct, replaceObj.Vector, resp.Vector)
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})
 }

--- a/test/acceptance/replication/async_replication/async_repair_updates_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_updates_test.go
@@ -96,7 +96,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			verbose := verbosity.OutputVerbose
 			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
 			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
@@ -107,26 +107,21 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 			require.Len(ct, resp.Nodes, clusterSize)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
-				assert.Equal(ct, "HEALTHY", *n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
 			}
 		}, 15*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run(fmt.Sprintf("assert node %d has all the objects at its latest version", node), func(t *testing.T) {
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			count := common.CountObjects(t, compose.GetWeaviateNode(node).URI(), paragraphClass.Class)
-			assert.EqualValues(ct, len(paragraphIDs), count)
+			require.EqualValues(ct, len(paragraphIDs), count)
 
 			for i, id := range paragraphIDs {
 				resp, err := common.GetObjectCL(t, compose.GetWeaviateNode(node).URI(), paragraphClass.Class, id, types.ConsistencyLevelOne)
-				assert.NoError(ct, err)
-				assert.NotNil(ct, resp)
-
-				if resp == nil {
-					continue
-				}
-
-				assert.Equal(ct, id, resp.ID)
+				require.NoError(ct, err)
+				require.NotNil(ct, resp)
+				require.Equal(ct, id, resp.ID)
 
 				props := resp.Properties.(map[string]interface{})
 				props["contents"] = fmt.Sprintf("paragraph#%d", i)


### PR DESCRIPTION
### What's being changed:

This pull request refactors test cases in the `AsyncReplicationTestSuite` to improve consistency and reliability by replacing `assert` statements with `require` statements. This ensures that tests fail immediately when conditions are not met, avoiding potential cascading errors. Additionally, redundant object retrieval before deletion has been removed in one test case to streamline the logic.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
