### PR TITLE
Fix/2588 error code consistency

### DIFF
--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -20,5 +20,13 @@ import (
 func ErrPayloadFromSingleErr(err error) *models.ErrorResponse {
 	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
 		Message: fmt.Sprintf("%s", err),
+		Code:    500,
+	}}}
+}
+
+func ErrPayloadFromSingleErrWithCode(err error, code int64) *models.ErrorResponse {
+	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
+		Message: fmt.Sprintf("%s", err),
+		Code:    code,
 	}}}
 }

--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -94,6 +94,7 @@ func setupGraphQLHandlers(
 			errorResponse.Error = []*models.ErrorResponseErrorItems0{
 				{
 					Message: "query cannot be empty",
+					Code:    422,
 				},
 			}
 			return graphql.NewGraphqlPostUnprocessableEntity().WithPayload(errorResponse)
@@ -111,6 +112,7 @@ func setupGraphQLHandlers(
 			errorResponse.Error = []*models.ErrorResponseErrorItems0{
 				{
 					Message: "no graphql provider present, this is most likely because no schema is present. Import a schema first!",
+					Code:    422,
 				},
 			}
 			return graphql.NewGraphqlPostUnprocessableEntity().WithPayload(errorResponse)
@@ -128,6 +130,7 @@ func setupGraphQLHandlers(
 			errorResponse.Error = []*models.ErrorResponseErrorItems0{
 				{
 					Message: fmt.Sprintf("couldn't marshal json: %s", jsonErr),
+					Code:    500,
 				},
 			}
 			return graphql.NewGraphqlPostUnprocessableEntity().WithPayload(errorResponse)
@@ -143,6 +146,7 @@ func setupGraphQLHandlers(
 			errorResponse.Error = []*models.ErrorResponseErrorItems0{
 				{
 					Message: fmt.Sprintf("couldn't unmarshal json: %s\noriginal result was %#v", marshallErr, result),
+					Code:    500,
 				},
 			}
 			return graphql.NewGraphqlPostUnprocessableEntity().WithPayload(errorResponse)

--- a/adapters/handlers/rest/helpers.go
+++ b/adapters/handlers/rest/helpers.go
@@ -26,6 +26,7 @@ func createErrorResponseObject(messages ...string) *models.ErrorResponse {
 	for _, message := range messages {
 		er.Error = append(er.Error, &models.ErrorResponseErrorItems0{
 			Message: message,
+			Code:    500,
 		})
 	}
 
@@ -35,5 +36,13 @@ func createErrorResponseObject(messages ...string) *models.ErrorResponse {
 func errPayloadFromSingleErr(err error) *models.ErrorResponse {
 	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
 		Message: fmt.Sprintf("%s", err),
+		Code:    500,
+	}}}
+}
+
+func errPayloadFromSingleErrWithCode(err error, code int64) *models.ErrorResponse {
+	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
+		Message: fmt.Sprintf("%s", err),
+		Code:    code,
 	}}}
 }

--- a/adapters/handlers/rest/helpers.go
+++ b/adapters/handlers/rest/helpers.go
@@ -39,10 +39,3 @@ func errPayloadFromSingleErr(err error) *models.ErrorResponse {
 		Code:    500,
 	}}}
 }
-
-func errPayloadFromSingleErrWithCode(err error, code int64) *models.ErrorResponse {
-	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
-		Message: fmt.Sprintf("%s", err),
-		Code:    code,
-	}}}
-}

--- a/entities/errors/errors_graphql.go
+++ b/entities/errors/errors_graphql.go
@@ -42,15 +42,23 @@ func NewErrGraphQLUser(err error, operation, className string) ErrGraphQLUser {
 }
 
 type ErrRateLimit struct {
-	err error
+	err  error
+	code int
 }
 
 func (e ErrRateLimit) Error() string {
 	return e.err.Error()
 }
 
+func (e ErrRateLimit) Code() int {
+	return e.code
+}
+
 func NewErrRateLimit() ErrRateLimit {
-	return ErrRateLimit{errors.New("429 Too many requests")}
+	return ErrRateLimit{
+		err:  errors.New("Too many requests"),
+		code: 429,
+	}
 }
 
 type ErrLockConnector struct {

--- a/entities/models/error_response.go
+++ b/entities/models/error_response.go
@@ -133,6 +133,7 @@ type ErrorResponseErrorItems0 struct {
 
 	// message
 	Message string `json:"message,omitempty"`
+	Code    int64  `json:"code,omitempty"`
 }
 
 // Validate validates this error response error items0


### PR DESCRIPTION
## Add error_code to error objects for consistent API responses

  **Fixes #2588**

  ### What's being changed:

 This PR addresses the inconsistency in error response formats across Weaviate's REST and GraphQL APIs by adding proper HTTP status codes to all error objects. Previously, error responses contained only message fields, making it difficult for clients to programmatically handle different error types.

  #### Key Changes:
  - **Error Response Models**: Added `Code` field to error response structures
  - **REST API Errors**: All REST errors now include both `message` and `code` fields
  - **GraphQL API Errors**: Enhanced GraphQL error handling to include status codes
  - **Error Creation Functions**: Updated error helpers to propagate HTTP status codes