### PR TITLE
chore: update licence script to dynamically detect year

### DIFF
--- a/tools/license_headers/main.go
+++ b/tools/license_headers/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar"
 )
@@ -26,14 +27,20 @@ var (
 	headerSectionRe *regexp.Regexp
 	buildTagRe      *regexp.Regexp
 	targetHeader    []byte
+	yearRe          *regexp.Regexp
 )
 
 func init() {
 	headerSectionRe = regexp.MustCompile(`^(//.*\n)*\n`)
 	buildTagRe = regexp.MustCompile(`^//go:build`)
+	yearRe = regexp.MustCompile(`2016 - \d{4}`)
 	h, err := os.ReadFile("tools/license_headers/header.txt")
 	fatal(err)
-	targetHeader = bytes.TrimSpace(h)
+
+	// Replace the year with current year
+	currentYear := time.Now().Year()
+	targetHeader = yearRe.ReplaceAll(h, []byte(fmt.Sprintf("2016 - %d", currentYear)))
+	targetHeader = bytes.TrimSpace(targetHeader)
 }
 
 func main() {


### PR DESCRIPTION
### What's being changed:
this change makes sure any time there is generation the header consider the current year dynamically 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
