### PR TITLE
feat: wrap DistributedTasks under enabled flag to be opt-in feature

### DIFF
--- a/test/acceptance/authz/rbac_auto_no_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_no_permissions_test.go
@@ -74,6 +74,7 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		"/replication/replicate/{id}", // for the same reason as backups above
 		"/replication/replicate/{id}/cancel",
 		"/replication/sharding-state",
+		"/tasks",                // tasks is internal endpoint
 		"/classifications/{id}", // requires to get classification by id first before checking of authz permissions
 	}
 

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -349,6 +349,7 @@ type Profiling struct {
 }
 
 type DistributedTasksConfig struct {
+	Enabled               bool          `json:"enabled" yaml:"enabled"`
 	CompletedTaskTTL      time.Duration `json:"completedTaskTTL" yaml:"completedTaskTTL"`
 	SchedulerTickInterval time.Duration `json:"schedulerTickInterval" yaml:"schedulerTickInterval"`
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -750,6 +750,10 @@ func FromEnv(config *Config) error {
 		return err
 	}
 
+	if v := os.Getenv("DISTRIBUTED_TASKS_ENABLED"); v != "" {
+		config.DistributedTasks.Enabled = entcfg.Enabled(v)
+	}
+
 	if v := os.Getenv("REPLICA_MOVEMENT_ENABLED"); v != "" {
 		config.ReplicaMovementEnabled = entcfg.Enabled(v)
 	}


### PR DESCRIPTION
### What's being changed:
 task management feature was a ground work for revectorization task, since we didn't pursue further with it, we have left this feature essentially now unmaintained and half way done. 
 
at the moment on startup it has an error
```
{"action":"startup", "build_git_commit":"097711a", "build_go_version":"go1.24.4", "build_image_tag":"v1.31.1", "build_wv_version":"1.31.1", "error":"list distributed tasks: list distributed tasks: failed to execute query: rpc error: code = Canceled desc = context canceled", "level":"error", "msg":"failed to start distributed task scheduler"}
```
 this PR wrap the feature under a flag to make sure it doesn't confuse anyone until further investigation 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
