### PR TITLE
chore: use inmem and ondisk cursors to list object digests

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -139,31 +139,67 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	cursor := bucket.Cursor()
+	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
+	cursor := bucket.CursorOnDisk()
 	defer cursor.Close()
 
 	n := 0
 
+	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
+	err = func() error {
+		inMemCursor := bucket.CursorInMem()
+		defer inMemCursor.Close()
+
+		for k, v := inMemCursor.Seek(initialUUIDBytes); n < limit && k != nil && bytes.Compare(k, finalUUIDBytes) < 1; k, v = inMemCursor.Next() {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				obj, err := storobj.FromBinaryUUIDOnly(v)
+				if err != nil {
+					return fmt.Errorf("cannot unmarshal object: %w", err)
+				}
+
+				replicaObj := replica.RepairResponse{
+					ID:         obj.ID().String(),
+					UpdateTime: obj.LastUpdateTimeUnix(),
+					// TODO: use version when supported
+					Version: 0,
+				}
+
+				objs = append(objs, replicaObj)
+
+				n++
+			}
+		}
+
+		return nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
 	for k, v := cursor.Seek(initialUUIDBytes); n < limit && k != nil && bytes.Compare(k, finalUUIDBytes) < 1; k, v = cursor.Next() {
-		if ctx.Err() != nil {
+		select {
+		case <-ctx.Done():
 			return objs, ctx.Err()
+		default:
+			obj, err := storobj.FromBinaryUUIDOnly(v)
+			if err != nil {
+				return objs, fmt.Errorf("cannot unmarshal object: %w", err)
+			}
+
+			replicaObj := replica.RepairResponse{
+				ID:         obj.ID().String(),
+				UpdateTime: obj.LastUpdateTimeUnix(),
+				// TODO: use version when supported
+				Version: 0,
+			}
+
+			objs = append(objs, replicaObj)
+
+			n++
 		}
-
-		obj, err := storobj.FromBinaryUUIDOnly(v)
-		if err != nil {
-			return objs, fmt.Errorf("cannot unmarshal object: %w", err)
-		}
-
-		replicaObj := replica.RepairResponse{
-			ID:         obj.ID().String(),
-			UpdateTime: obj.LastUpdateTimeUnix(),
-			// TODO: use version when supported
-			Version: 0,
-		}
-
-		objs = append(objs, replicaObj)
-
-		n++
 	}
 
 	return objs, nil


### PR DESCRIPTION
### What's being changed:

This pull request refactors the `ObjectDigestsInRange` method in `shard_read.go` to improve performance and ensure proper handling of in-memory and on-disk cursors. The changes primarily focus on separating the processing of in-memory and on-disk data to avoid double scanning and potential concurrency issues.

### Improvements to cursor handling and performance:

* Replaced `bucket.Cursor()` with `bucket.CursorOnDisk()` to explicitly create an on-disk cursor, preventing potential double scanning over the flushing memtable.
* Introduced a new inner function to handle in-memory cursor operations (`bucket.CursorInMem`). This ensures that read-write access to active and flushing memtables is blocked only during the scope of this function, reducing contention.
* Added logic to process objects from the in-memory cursor first, followed by the on-disk cursor, ensuring a clear separation of responsibilities and improving efficiency. [[1]](diffhunk://#diff-d08244a2bbe99960c516af6a929befc67a879b42950ca0dadbcde372fb7c8cfaL142-R186) [[2]](diffhunk://#diff-d08244a2bbe99960c516af6a929befc67a879b42950ca0dadbcde372fb7c8cfaR203)

These changes enhance the method's performance and reliability, especially in scenarios involving concurrent access to in-memory and on-disk data.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
