### PR TITLE
fix: filter out nil values in generative query

### DIFF
--- a/usecases/modulecomponents/additional/generate/generate_result.go
+++ b/usecases/modulecomponents/additional/generate/generate_result.go
@@ -145,6 +145,12 @@ func (p *GenerateProvider) getProperties(result search.Result,
 		if len(properties) > 0 && !p.containsProperty(property, properties) {
 			continue
 		}
+
+		// Nil property is not useful as an input to a generative model.
+		if value == nil {
+			continue
+		}
+
 		if dt, ok := propertyDataTypes[property]; ok {
 			switch dt {
 			// todo: add rest of types

--- a/usecases/modulecomponents/additional/generate/generate_test.go
+++ b/usecases/modulecomponents/additional/generate/generate_test.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 )
 
@@ -87,4 +89,18 @@ func (c *fakeClient) getResult(task string) *modulecapabilities.GenerateResponse
 	return &modulecapabilities.GenerateResponse{
 		Result: &task,
 	}
+}
+
+func Test_getProperties(t *testing.T) {
+	var provider GenerateProvider
+	result := search.Result{
+		Schema: models.PropertySchema(map[string]interface{}{
+			"missing": nil,
+		}),
+	}
+
+	// Get provider to iterate over a result object with a nil property.
+	require.NotPanics(t, func() {
+		provider.getProperties(result, []string{"missing"}, map[string]schema.DataType{"missing": schema.DataTypeBlob})
+	})
 }


### PR DESCRIPTION
### What's being changed:

GenerativeProvider skips nil-properties of the result object to prevent a panic.
See Details for stack trace.

<details>

```sh
weaviate-1  | goroutine 1741351 [running]:
weaviate-1  | runtime/debug.Stack()
weaviate-1  | 	/usr/local/go/src/runtime/debug/stack.go:26 +0x64
weaviate-1  | runtime/debug.PrintStack()
weaviate-1  | 	/usr/local/go/src/runtime/debug/stack.go:18 +0x1c
weaviate-1  | github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).setDeferFunc.func1({0x4003f453a0, 0x1, 0x1})
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:76 +0x138
weaviate-1  | panic({0x2119a60?, 0x40032eae10?})
weaviate-1  | 	/usr/local/go/src/runtime/panic.go:792 +0x124
weaviate-1  | github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate.(*GenerateProvider).getProperties(0x40032ea810?, {{0x400338dda0, 0x24}, 0x40022262b8, {0x4003a8e3a8, 0x4}, 0x0, 0x0, {0x0, 0x0}, ...}, ...)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate/generate_result.go:154 +0x448
weaviate-1  | github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate.(*GenerateProvider).generateForAllSearchResults(0x40032ea810, {0x38e7ff8, 0x40068ff8c0}, {0x4003857408, 0x3, 0x3}, {0x400414c020, 0x1b}, {0x40068ff830, 0x3, ...}, ...)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate/generate_result.go:130 +0x418
weaviate-1  | github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate.(*GenerateProvider).generateResult(0x40032ea810, {0x38e7ff8, 0x40068ff8c0}, {0x4003857408, 0x3, 0x3}, 0x4002f1eac8?, 0x1030528?, 0xb79bf87554248bb6?, {0x38f1ba8, ...})
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate/generate_result.go:54 +0x1ac
weaviate-1  | github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate.(*GenerateProvider).AdditionalPropertyFn(0x267fd87?, {0x38e7ff8?, 0x40068ff8c0?}, {0x4003857408?, 0x4002f1eac8?, 0x1030b0c?}, {0x20ad000?, 0x400260d900?}, 0x4002f1f501?, 0x23ee580?, ...)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/modulecomponents/additional/generate/generate.go:76 +0xbc
weaviate-1  | github.com/weaviate/weaviate/usecases/modules.(*Provider).additionalExtend(0x4002a6fc08, {0x38e7ff8, 0x40068ff8c0}, {0x4003857408, 0x3, 0x3}, 0x40068ff800, {0x1f320c0, 0x4003416e10}, {0x268518a, ...}, ...)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/modules/modules.go:739 +0xa8c
weaviate-1  | github.com/weaviate/weaviate/usecases/modules.(*Provider).GetExploreAdditionalExtend(0x0?, {0x38e7ff8?, 0x40068ff8c0?}, {0x4003857408?, 0x0?, 0x0?}, 0x0?, {0x1f320c0?, 0x4003416e10?}, 0x3?)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/modules/modules.go:670 +0x40
weaviate-1  | github.com/weaviate/weaviate/usecases/traverser.(*Explorer).searchForTargets(_, {_, _}, {0x0, {0x40030ac674, 0x4}, 0x4003176c48, 0x0, {0x0, 0x0, ...}, ...}, ...)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/traverser/explorer.go:299 +0x438
weaviate-1  | github.com/weaviate/weaviate/usecases/traverser.denseSearch({_, _}, _, {0x0, {0x40030ac674, 0x4}, 0x4003176c48, 0x0, {0x0, 0x0, ...}, ...}, ...)
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/traverser/explorer_hybrid.go:91 +0xac
weaviate-1  | github.com/weaviate/weaviate/usecases/traverser.(*Explorer).Hybrid.func1()
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/usecases/traverser/explorer_hybrid.go:312 +0x7ec
weaviate-1  | github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).Go.func1()
weaviate-1  | 	/go/src/github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:90 +0x88
weaviate-1  | golang.org/x/sync/errgroup.(*Group).add.func1()
weaviate-1  | 	/go/pkg/mod/golang.org/x/sync@v0.14.0/errgroup/errgroup.go:130 +0x88
weaviate-1  | created by golang.org/x/sync/errgroup.(*Group).add in goroutine 1741350
weaviate-1  | 	/go/pkg/mod/golang.org/x/sync@v0.14.0/errgroup/errgroup.go:98 +0x80
```

</details>

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
