### PR TITLE
chore: add node metadata management for cluster nodes

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1044,7 +1044,10 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 	if cfg := serverConfig.Config.Raft; cfg.MetadataOnlyVoters {
 		nonStorageNodes = parseVotersNames(cfg)
 	}
-	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Raft.BootstrapExpect, dataPath, nonStorageNodes, logger)
+
+	grpcPort := serverConfig.Config.GRPC.Port
+
+	clusterState, err := cluster.Init(serverConfig.Config.Cluster, grpcPort, serverConfig.Config.Raft.BootstrapExpect, dataPath, nonStorageNodes, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).
 			Error("could not init cluster state")

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1045,9 +1045,7 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 		nonStorageNodes = parseVotersNames(cfg)
 	}
 
-	grpcPort := serverConfig.Config.GRPC.Port
-
-	clusterState, err := cluster.Init(serverConfig.Config.Cluster, grpcPort, serverConfig.Config.Raft.BootstrapExpect, dataPath, nonStorageNodes, logger)
+	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.GRPC.Port, serverConfig.Config.Raft.BootstrapExpect, dataPath, nonStorageNodes, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).
 			Error("could not init cluster state")

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -14,6 +14,7 @@ package cluster
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -119,6 +120,13 @@ type delegate struct {
 
 	mutex    sync.Mutex
 	hostInfo NodeInfo
+
+	metadata NodeMetadata
+}
+
+type NodeMetadata struct {
+	RestPort int `json:"rest_port"`
+	GrpcPort int `json:"grpc_port"`
 }
 
 func (d *delegate) setOwnSpace(x DiskUsage) {
@@ -159,7 +167,14 @@ func (d *delegate) init(diskSpace func(path string) (DiskUsage, error)) error {
 // when broadcasting an alive message. It's length is limited to
 // the given byte size. This metadata is available in the Node structure.
 func (d *delegate) NodeMeta(limit int) (meta []byte) {
-	return nil
+	data, err := json.Marshal(d.metadata)
+	if err != nil {
+		return nil
+	}
+	if len(data) > limit {
+		return nil
+	}
+	return data
 }
 
 // LocalState is used for a TCP Push/Pull. This is sent to

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -12,6 +12,7 @@
 package cluster
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"slices"
@@ -44,7 +45,9 @@ type NodeSelector interface {
 }
 
 type State struct {
-	config Config
+	config        Config
+	localGrpcPort int
+
 	// that lock to serialize access to memberlist
 	listLock             sync.RWMutex
 	list                 *memberlist.Memberlist
@@ -93,18 +96,23 @@ func (ba BasicAuth) Enabled() bool {
 	return ba.Username != "" || ba.Password != ""
 }
 
-func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {
+func Init(userConfig Config, grpcPort, raftBootstrapExpect int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {
 	userConfig.RaftBootstrapExpect = raftBootstrapExpect
 	cfg := memberlist.DefaultLANConfig()
 	cfg.LogOutput = newLogParser(logger)
 	cfg.Name = userConfig.Hostname
 	state := State{
 		config:          userConfig,
+		localGrpcPort:   grpcPort,
 		nonStorageNodes: nonStorageNodes,
 		delegate: delegate{
 			Name:     cfg.Name,
 			dataPath: dataPath,
 			log:      logger,
+			metadata: NodeMetadata{
+				RestPort: userConfig.DataBindPort,
+				GrpcPort: grpcPort,
+			},
 		},
 	}
 	if err := state.delegate.init(diskSpace); err != nil {
@@ -180,13 +188,53 @@ func (s *State) Hostnames() []string {
 		if m.Name == s.list.LocalNode().Name {
 			continue
 		}
-		// TODO: how can we find out the actual data port as opposed to relying on
-		// the convention that it's 1 higher than the gossip port
-		out[i] = fmt.Sprintf("%s:%d", m.Addr.String(), m.Port+1)
+
+		out[i] = fmt.Sprintf("%s:%d", m.Addr.String(), s.dataPort(m))
 		i++
 	}
 
 	return out[:i]
+}
+
+func nodeMetadata(m *memberlist.Node) (NodeMetadata, error) {
+	if len(m.Meta) == 0 {
+		return NodeMetadata{}, errors.New("no metadata available")
+	}
+
+	var meta NodeMetadata
+	if err := json.Unmarshal(m.Meta, &meta); err != nil {
+		return NodeMetadata{}, errors.Wrap(err, "unmarshal node metadata")
+	}
+
+	return meta, nil
+}
+
+func (s *State) dataPort(m *memberlist.Node) int {
+	meta, err := nodeMetadata(m)
+	if err != nil {
+		s.delegate.log.WithFields(logrus.Fields{
+			"action": "data_port_fallback",
+			"node":   m.Name,
+		}).WithError(err).Debug("unable to get node metadata, falling back to default data port")
+
+		return s.config.DataBindPort // fallback to default
+	}
+
+	return meta.RestPort
+}
+
+func (s *State) grpcPort(m *memberlist.Node) int {
+	meta, err := nodeMetadata(m)
+	if err != nil {
+		s.delegate.log.WithFields(logrus.Fields{
+			"action": "grpc_port_fallback",
+			"node":   m.Name,
+		}).WithError(err).Debug("unable to get node metadata, falling back to default gRPC port")
+
+		return s.localGrpcPort // fallback to default gRPC port
+	}
+
+	return meta.GrpcPort
 }
 
 // AllHostnames for live members, including self.
@@ -202,9 +250,7 @@ func (s *State) AllHostnames() []string {
 	out := make([]string, len(mem))
 
 	for i, m := range mem {
-		// TODO: how can we find out the actual data port as opposed to relying on
-		// the convention that it's 1 higher than the gossip port
-		out[i] = fmt.Sprintf("%s:%d", m.Addr.String(), m.Port+1)
+		out[i] = fmt.Sprintf("%s:%d", m.Addr.String(), s.dataPort(m))
 	}
 
 	return out
@@ -300,9 +346,7 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 
 	for _, mem := range s.list.Members() {
 		if mem.Name == nodeName {
-			// TODO: how can we find out the actual data port as opposed to relying on
-			// the convention that it's 1 higher than the gossip port
-			return fmt.Sprintf("%s:%d", mem.Addr.String(), mem.Port+1), true
+			return fmt.Sprintf("%s:%d", mem.Addr.String(), s.dataPort(mem)), true
 		}
 	}
 
@@ -347,6 +391,15 @@ func (s *State) NodeAddress(id string) string {
 		}
 	}
 	return ""
+}
+
+func (s *State) NodeGRPCPort(nodeID string) (int, error) {
+	for _, mem := range s.list.Members() {
+		if mem.Name == nodeID {
+			return s.grpcPort(mem), nil
+		}
+	}
+	return 0, fmt.Errorf("node not found: %s", nodeID)
 }
 
 func (s *State) SchemaSyncIgnored() bool {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -217,7 +217,7 @@ func (s *State) dataPort(m *memberlist.Node) int {
 			"node":   m.Name,
 		}).WithError(err).Debug("unable to get node metadata, falling back to default data port")
 
-		return s.config.DataBindPort // fallback to default
+		return int(m.Port) + 1 // the convention that it's 1 higher than the gossip port
 	}
 
 	return meta.RestPort

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1273,11 +1273,6 @@ func parseClusterConfig() (cluster.Config, error) {
 		cfg.DataBindPort = cfg.GossipBindPort + 1
 	}
 
-	if cfg.DataBindPort != cfg.GossipBindPort+1 {
-		return cfg, fmt.Errorf("CLUSTER_DATA_BIND_PORT must be one port " +
-			"number greater than CLUSTER_GOSSIP_BIND_PORT")
-	}
-
 	cfg.IgnoreStartupSchemaSync = entcfg.Enabled(
 		os.Getenv("CLUSTER_IGNORE_SCHEMA_SYNC"))
 	cfg.SkipSchemaSyncRepair = entcfg.Enabled(

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -12,7 +12,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -304,21 +303,17 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid cluster config - both ports provided",
+			name: "valid cluster config - both ports provided",
 			envVars: map[string]string{
 				"CLUSTER_GOSSIP_BIND_PORT": "7100",
 				"CLUSTER_DATA_BIND_PORT":   "7111",
 			},
-			expectedErr: errors.New("CLUSTER_DATA_BIND_PORT must be one port " +
-				"number greater than CLUSTER_GOSSIP_BIND_PORT"),
-		},
-		{
-			name: "invalid config - only data bind port provided",
-			envVars: map[string]string{
-				"CLUSTER_DATA_BIND_PORT": "7101",
+			expectedResult: cluster.Config{
+				Hostname:         hostname,
+				GossipBindPort:   7100,
+				DataBindPort:     7111,
+				MaintenanceNodes: make([]string, 0),
 			},
-			expectedErr: errors.New("CLUSTER_DATA_BIND_PORT must be one port " +
-				"number greater than CLUSTER_GOSSIP_BIND_PORT"),
 		},
 		{
 			name: "schema sync disabled",


### PR DESCRIPTION
### What's being changed:

Introduced a new `NodeMetadata` struct to encapsulate node-specific metadata, including `rest_port`, and `grpc_port`. This metadata is now serialized and broadcasted as part of the `NodeMeta` method in the cluster's delegate. (`usecases/cluster/delegate.go`). Replacing the previous convention of assuming the data port is one higher than the gossip port with metadata-based resolution for both REST and gRPC ports.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
