### PR TITLE
feat(runtime): Support `String()` method for dynamic values

### DIFF
--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -12,6 +12,7 @@
 package runtime
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -97,4 +98,14 @@ func (dv *DynamicValue[T]) UnmarshalYAML(node *yaml.Node) error {
 
 	dv.val = &val
 	return nil
+}
+
+// String implements Stringer interface for `%v` formatting
+// for any dynamic value types.
+func (dv *DynamicValue[T]) String() string {
+	res := dv.val
+	if res == nil {
+		res = &dv.def
+	}
+	return fmt.Sprintf("%v", *res)
 }

--- a/usecases/config/runtime/values_test.go
+++ b/usecases/config/runtime/values_test.go
@@ -12,6 +12,7 @@
 package runtime
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -141,4 +142,20 @@ func TestDynamicValue(t *testing.T) {
 	assert.Equal(t, false, zeroBool.Get())
 	assert.Equal(t, time.Duration(0), zeroDur.Get())
 	assert.Equal(t, "", zeroString.Get())
+}
+
+func Test_String(t *testing.T) {
+	s := time.Second * 2
+
+	zeroInt := NewDynamicValue(89)
+	zeroFloat := NewDynamicValue(7.8)
+	zeroBool := NewDynamicValue(true)
+	zeroDur := NewDynamicValue(s)
+	zeroString := NewDynamicValue("weaviate")
+
+	assert.Equal(t, "89", fmt.Sprintf("%v", zeroInt))
+	assert.Equal(t, "7.8", fmt.Sprintf("%v", zeroFloat))
+	assert.Equal(t, "true", fmt.Sprintf("%v", zeroBool))
+	assert.Equal(t, s.String(), fmt.Sprintf("%v", zeroDur))
+	assert.Equal(t, "weaviate", fmt.Sprintf("%v", zeroString))
 }


### PR DESCRIPTION
Some old log lines using %v formatting on dynamic values where printing not nicely.

Before: `auto schema enabled setting is set to "&{<nil> {{{} {0 0}} 0 0 {{} 0} {{} 0}} true}"`
After: `auto schema enabled setting is set to "true"`

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
