### PR TITLE
ensure that batch autotenant waits for version once tenants have been created to avoid EC issues

### DIFF
--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -593,8 +593,15 @@ func (m *AutoSchemaManager) addTenants(ctx context.Context, principal *models.Pr
 		return fmt.Errorf(
 			"tenants must be included for multitenant-enabled class %q", class)
 	}
-	if _, err := m.schemaManager.AddTenants(ctx, principal, class, tenants); err != nil {
+	version, err := m.schemaManager.AddTenants(ctx, principal, class, tenants)
+	if err != nil {
 		return err
 	}
+
+	err = m.schemaManager.WaitForUpdate(ctx, version)
+	if err != nil {
+		return fmt.Errorf("could not wait for update: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
### What's being changed:
When we receive a batch and we have auto tenants configured we will create the tenants and immediately start the batch. This can lead to EC issues if the node is slightly out of data compared to the leader and the subsequent writes will fail.

This change ensure that we wait for raft update to propagate to that node before proceeding.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
