### PR TITLE
fix: simplify and unify object deletion logic

### DIFF
--- a/adapters/repos/db/shard_replication.go
+++ b/adapters/repos/db/shard_replication.go
@@ -122,17 +122,9 @@ func (s *Shard) prepareMergeObject(ctx context.Context, requestID string, doc *o
 }
 
 func (s *Shard) prepareDeleteObject(ctx context.Context, requestID string, uuid strfmt.UUID, deletionTime time.Time) replica.SimpleResponse {
-	bucket, obj, idBytes, docID, updateTime, err := s.canDeleteOne(ctx, uuid)
-	if err != nil {
-		return replica.SimpleResponse{
-			Errors: []replica.Error{
-				{Code: replica.StatusPreconditionFailed, Msg: err.Error()},
-			},
-		}
-	}
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
-		if err := s.deleteOne(ctx, bucket, obj, idBytes, docID, updateTime, deletionTime); err != nil {
+		if err := s.DeleteObject(ctx, uuid, deletionTime); err != nil {
 			resp.Errors = []replica.Error{
 				{Code: replica.StatusConflict, Msg: err.Error()},
 			}


### PR DESCRIPTION
### What's being changed:

This pull request simplifies the `Shard` deletion logic in the database layer by removing redundant methods and delegating the deletion process to the existing `DeleteObject` method. 

### Simplification of deletion logic:

* Removed the `canDeleteOne` and `deleteOne` methods from `adapters/repos/db/shard_write_delete.go`, consolidating their functionality into the existing `DeleteObject` method. This reduces code duplication and simplifies the deletion process.
* Updated the `prepareDeleteObject` function in `adapters/repos/db/shard_replication.go` to directly call `DeleteObject`, streamlining the deletion workflow.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
