### PR TITLE
fix: panic when trying to parse unparseable custom certificate string

### DIFF
--- a/usecases/auth/authentication/oidc/middleware.go
+++ b/usecases/auth/authentication/oidc/middleware.go
@@ -210,9 +210,12 @@ func (c *Client) useCertificate() (*http.Client, error) {
 	}
 
 	certBlock, _ := pem.Decode([]byte(certificate))
+	if certBlock == nil || len(certBlock.Bytes) == 0 {
+		return nil, fmt.Errorf("failed to decode certificate")
+	}
 	cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode certificate: %w", err)
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
 	certPool := x509.NewCertPool()

--- a/usecases/auth/authentication/oidc/middleware_test.go
+++ b/usecases/auth/authentication/oidc/middleware_test.go
@@ -208,4 +208,12 @@ func Test_Middleware_CertificateDownload(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, clientWithCertificate)
 	})
+
+	t.Run("unparseable string", func(t *testing.T) {
+		client := newClientWithCertificate("s3://")
+		clientWithCertificate, err := client.useCertificate()
+		require.Nil(t, clientWithCertificate)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to decode certificate")
+	})
 }


### PR DESCRIPTION
### What's being changed:

Fixes panic:
```
{"action":"startup","build_git_commit":"ee623d1","build_go_version":"go1.24.4","build_image_tag":"audit_log_domain","build_wv_version":"1.30.9","default_vectorizer_module":"none","level":"info","msg":"the default vectorizer modules is set to \"none\", as a result all new schema classes without an explicit vectorizer setting, will use this vectorizer","time":"2025-06-26T04:25:24Z"}
weaviate {"action":"startup","auto_schema_enabled":{},"build_git_commit":"ee623d1","build_go_version":"go1.24.4","build_image_tag":"audit_log_domain","build_wv_version":"1.30.9","level":"info","msg":"auto schema enabled setting is set to \"\u0026{\u003cnil\u003e {{{} {0 0}} 0 0 {{} 0} {{} 0}} true}\"","time":"2025-06-26T04:25:24Z"}
weaviate panic: runtime error: invalid memory address or nil pointer dereference
weaviate [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x17bc36a]
weaviate 
weaviate goroutine 1 [running]:
weaviate github.com/weaviate/weaviate/usecases/auth/authentication/oidc.(*Client).useCertificate(0xc003f2c990?)
weaviate     /go/src/github.com/weaviate/weaviate/usecases/auth/authentication/oidc/middleware.go:213 +0x3ea
weaviate github.com/weaviate/weaviate/usecases/auth/authentication/oidc.(*Client).init(0xc003f2c990)
weaviate     /go/src/github.com/weaviate/weaviate/usecases/auth/authentication/oidc/middleware.go:67 +0x85
weaviate github.com/weaviate/weaviate/usecases/auth/authentication/oidc.New({{0x0, 0x0}, 0x0, {0x64}, 0x186a0, 0x186a0, 0x5, {{0x0, 0x0}}, {{0x1, ...}, ...}, ...})
weaviate     /go/src/github.com/weaviate/weaviate/usecases/auth/authentication/oidc/middleware.go:53 +0x7e
weaviate github.com/weaviate/weaviate/adapters/handlers/rest.configureOIDC(0xc00401a000)
weaviate     /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_server.go:90 +0x70
weaviate github.com/weaviate/weaviate/adapters/handlers/rest.startupRoutine({0x3f6b8c0, 0xc0040169a0}, 0xc00400e840)
weaviate     /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:954 +0xd25
weaviate github.com/weaviate/weaviate/adapters/handlers/rest.MakeAppState({0x3f6b8c0, 0xc0040169a0}, 0xc00400e840)
weaviate     /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:212 +0xc5
weaviate github.com/weaviate/weaviate/adapters/handlers/rest.configureAPI(0xc0001d3808)
weaviate     /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/configure_api.go:750 +0x85
weaviate github.com/weaviate/weaviate/adapters/handlers/rest.(*Server).ConfigureAPI(...)
weaviate     /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/server.go:68
weaviate main.main()
weaviate     /go/src/github.com/weaviate/weaviate/cmd/weaviate-server/main.go:62 +0x4ff
Stream closed EOF for weaviate/weaviate-2 (weaviate)
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
