### PR TITLE
Add ability to parse s3:// links containing custom certificate

### DIFF
--- a/test/docker/minio.go
+++ b/test/docker/minio.go
@@ -62,10 +62,6 @@ func startMinIO(ctx context.Context, networkName string, buckets map[string]stri
 			if err != nil {
 				return nil, fmt.Errorf("failed to create bucket %s: %s", bName, err.Error())
 			}
-			_, _, err = container.Exec(ctx, []string{"mc", "mb", "--region", region, fmt.Sprintf("data/%s", bName)})
-			if err != nil {
-				return nil, fmt.Errorf("failed to create bucket %s: %s", bName, err.Error())
-			}
 		}
 	}
 	uri, err := container.PortEndpoint(ctx, port, "")

--- a/usecases/auth/authentication/oidc/middleware_test.go
+++ b/usecases/auth/authentication/oidc/middleware_test.go
@@ -211,7 +211,7 @@ func Test_Middleware_CertificateDownload(t *testing.T) {
 	})
 
 	t.Run("unparseable string", func(t *testing.T) {
-		client := newClientWithCertificate("s3://")
+		client := newClientWithCertificate("unparseable")
 		clientWithCertificate, err := client.useCertificate()
 		require.Nil(t, clientWithCertificate)
 		require.Error(t, err)


### PR DESCRIPTION
### What's being changed:

Add ability to parse s3:// links containing custom certificate

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
