### PR TITLE
Rename `transferType` to `type` in `schema.json` file

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -7403,7 +7403,7 @@ func init() {
         "targetNodeId",
         "collection",
         "status",
-        "transferType"
+        "type"
       ],
       "properties": {
         "collection": {
@@ -7447,7 +7447,7 @@ func init() {
           "description": "The identifier of the node to which the replica is being moved or copied (the destination node).",
           "type": "string"
         },
-        "transferType": {
+        "type": {
           "description": "Indicates whether the operation is a 'COPY' (source replica remains) or a 'MOVE' (source replica is removed after successful transfer).",
           "type": "string",
           "enum": [
@@ -7558,7 +7558,7 @@ func init() {
           "description": "The name of the Weaviate node currently hosting the shard replica that needs to be moved or copied.",
           "type": "string"
         },
-        "transferType": {
+        "type": {
           "description": "Specifies the type of replication operation to perform. 'COPY' creates a new replica on the destination node while keeping the source replica. 'MOVE' creates a new replica on the destination node and then removes the source replica upon successful completion. Defaults to 'COPY' if omitted.",
           "type": "string",
           "default": "COPY",
@@ -16112,7 +16112,7 @@ func init() {
         "targetNodeId",
         "collection",
         "status",
-        "transferType"
+        "type"
       ],
       "properties": {
         "collection": {
@@ -16156,7 +16156,7 @@ func init() {
           "description": "The identifier of the node to which the replica is being moved or copied (the destination node).",
           "type": "string"
         },
-        "transferType": {
+        "type": {
           "description": "Indicates whether the operation is a 'COPY' (source replica remains) or a 'MOVE' (source replica is removed after successful transfer).",
           "type": "string",
           "enum": [
@@ -16267,7 +16267,7 @@ func init() {
           "description": "The name of the Weaviate node currently hosting the shard replica that needs to be moved or copied.",
           "type": "string"
         },
-        "transferType": {
+        "type": {
           "description": "Specifies the type of replication operation to perform. 'COPY' creates a new replica on the destination node while keeping the source replica. 'MOVE' creates a new replica on the destination node and then removes the source replica upon successful completion. Defaults to 'COPY' if omitted.",
           "type": "string",
           "default": "COPY",

--- a/adapters/handlers/rest/replication/handlers_replicate.go
+++ b/adapters/handlers/rest/replication/handlers_replicate.go
@@ -46,11 +46,11 @@ func (h *replicationHandler) replicate(params replication.ReplicateParams, princ
 	}
 	uuid := strfmt.UUID(id.String())
 
-	transferType := models.ReplicationReplicateReplicaRequestTransferTypeCOPY
-	if params.Body.TransferType != nil {
-		transferType = *params.Body.TransferType
+	replicationType := models.ReplicationReplicateReplicaRequestTypeCOPY
+	if params.Body.Type != nil {
+		replicationType = *params.Body.Type
 	}
-	if err := h.replicationManager.ReplicationReplicateReplica(params.HTTPRequest.Context(), uuid, *params.Body.SourceNodeName, collection, *params.Body.ShardID, *params.Body.DestinationNodeName, transferType); err != nil {
+	if err := h.replicationManager.ReplicationReplicateReplica(params.HTTPRequest.Context(), uuid, *params.Body.SourceNodeName, collection, *params.Body.ShardID, *params.Body.DestinationNodeName, replicationType); err != nil {
 		if errors.Is(err, replicationTypes.ErrInvalidRequest) {
 			return replication.NewReplicateUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 		}
@@ -65,7 +65,7 @@ func (h *replicationHandler) replicate(params replication.ReplicateParams, princ
 		"shardId":      *params.Body.ShardID,
 		"sourceNodeId": *params.Body.SourceNodeName,
 		"destNodeId":   *params.Body.DestinationNodeName,
-		"transferType": params.Body.TransferType,
+		"type":         params.Body.Type,
 	}).Info("replicate operation registered")
 
 	return h.handleReplicationReplicateResponse(uuid)
@@ -126,7 +126,7 @@ func (h *replicationHandler) generateReplicationDetailsResponse(withHistory bool
 			Errors: response.Status.Errors,
 		},
 		StatusHistory: history,
-		TransferType:  &response.TransferType,
+		Type:          &response.TransferType,
 	}
 }
 

--- a/adapters/handlers/rest/replication/handlers_replicate_test.go
+++ b/adapters/handlers/rest/replication/handlers_replicate_test.go
@@ -55,7 +55,7 @@ func TestReplicationReplicate(t *testing.T) {
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
@@ -63,12 +63,12 @@ func TestReplicationReplicate(t *testing.T) {
 				DestinationNodeName: &targetNodeId,
 				ShardID:             &shardId,
 				SourceNodeName:      &sourceNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
 		mockAuthorizer.EXPECT().Authorize(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockReplicationManager.EXPECT().ReplicationReplicateReplica(mock.Anything, mock.AnythingOfType("strfmt.UUID"), sourceNodeId, collection, shardId, targetNodeId, transferType).Return(nil)
+		mockReplicationManager.EXPECT().ReplicationReplicateReplica(mock.Anything, mock.AnythingOfType("strfmt.UUID"), sourceNodeId, collection, shardId, targetNodeId, replicationType).Return(nil)
 
 		// WHEN
 		response := handler.replicate(params, &models.Principal{})
@@ -87,14 +87,14 @@ func TestReplicationReplicate(t *testing.T) {
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
 				DestinationNodeName: &targetNodeId,
 				ShardID:             &shardId,
 				SourceNodeName:      &sourceNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
@@ -112,14 +112,14 @@ func TestReplicationReplicate(t *testing.T) {
 		collection := fmt.Sprintf("Collection%d", randomInt(10))
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
 				CollectionID:   &collection,
 				ShardID:        &shardId,
 				SourceNodeName: &sourceNodeId,
-				TransferType:   &transferType,
+				Type:           &replicationType,
 			},
 		}
 
@@ -137,14 +137,14 @@ func TestReplicationReplicate(t *testing.T) {
 		collection := fmt.Sprintf("Collection%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
 				CollectionID:        &collection,
 				DestinationNodeName: &targetNodeId,
 				SourceNodeName:      &sourceNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
@@ -162,14 +162,14 @@ func TestReplicationReplicate(t *testing.T) {
 		collection := fmt.Sprintf("Collection%d", randomInt(10))
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
 				CollectionID:        &collection,
 				ShardID:             &shardId,
 				DestinationNodeName: &targetNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
@@ -188,7 +188,7 @@ func TestReplicationReplicate(t *testing.T) {
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
@@ -196,12 +196,12 @@ func TestReplicationReplicate(t *testing.T) {
 				DestinationNodeName: &targetNodeId,
 				ShardID:             &shardId,
 				SourceNodeName:      &sourceNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
 		mockAuthorizer.EXPECT().Authorize(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockReplicationManager.EXPECT().ReplicationReplicateReplica(mock.Anything, mock.AnythingOfType("strfmt.UUID"), sourceNodeId, collection, shardId, targetNodeId, transferType).Return(types.ErrInvalidRequest)
+		mockReplicationManager.EXPECT().ReplicationReplicateReplica(mock.Anything, mock.AnythingOfType("strfmt.UUID"), sourceNodeId, collection, shardId, targetNodeId, replicationType).Return(types.ErrInvalidRequest)
 
 		// WHEN
 		response := handler.replicate(params, &models.Principal{})
@@ -220,7 +220,7 @@ func TestReplicationReplicate(t *testing.T) {
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
@@ -228,12 +228,12 @@ func TestReplicationReplicate(t *testing.T) {
 				DestinationNodeName: &targetNodeId,
 				ShardID:             &shardId,
 				SourceNodeName:      &sourceNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
 		mockAuthorizer.EXPECT().Authorize(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockReplicationManager.EXPECT().ReplicationReplicateReplica(mock.Anything, mock.AnythingOfType("strfmt.UUID"), sourceNodeId, collection, shardId, targetNodeId, transferType).Return(errors.New("target node does not exist"))
+		mockReplicationManager.EXPECT().ReplicationReplicateReplica(mock.Anything, mock.AnythingOfType("strfmt.UUID"), sourceNodeId, collection, shardId, targetNodeId, replicationType).Return(errors.New("target node does not exist"))
 
 		// WHEN
 		response := handler.replicate(params, &models.Principal{})
@@ -252,7 +252,7 @@ func TestReplicationReplicate(t *testing.T) {
 		shardId := fmt.Sprintf("shard-%d", randomInt(10))
 		sourceNodeId := fmt.Sprintf("node-%d", randomInt(5)*2)
 		targetNodeId := fmt.Sprintf("node-%d", randomInt(5)*2+1)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 		params := replication.ReplicateParams{
 			HTTPRequest: &http.Request{},
 			Body: &models.ReplicationReplicateReplicaRequest{
@@ -260,7 +260,7 @@ func TestReplicationReplicate(t *testing.T) {
 				DestinationNodeName: &targetNodeId,
 				ShardID:             &shardId,
 				SourceNodeName:      &sourceNodeId,
-				TransferType:        &transferType,
+				Type:                &replicationType,
 			},
 		}
 
@@ -298,7 +298,7 @@ func TestGetReplicationDetailsByReplicationId(t *testing.T) {
 			models.ReplicationReplicateDetailsReplicaStatusStateCANCELLED,
 		}
 		status := randomString(statusOptions)
-		transferType := randomTransferType()
+		replicationType := randomReplicationType()
 
 		expectedResponse := api.ReplicationDetailsResponse{
 			Uuid:         id,
@@ -311,7 +311,7 @@ func TestGetReplicationDetailsByReplicationId(t *testing.T) {
 				Errors: []string{},
 			},
 			StatusHistory: []api.ReplicationDetailsState{},
-			TransferType:  transferType,
+			TransferType:  replicationType,
 		}
 
 		mockAuthorizer.EXPECT().Authorize(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -513,7 +513,7 @@ func randomString(candidates []string) string {
 	return candidates[randomInt(int64(len(candidates)))]
 }
 
-func randomTransferType() string {
+func randomReplicationType() string {
 	if rand.Uint64()%2 == 0 {
 		return api.COPY.String()
 	}

--- a/entities/models/replication_replicate_details_replica_response.go
+++ b/entities/models/replication_replicate_details_replica_response.go
@@ -69,7 +69,7 @@ type ReplicationReplicateDetailsReplicaResponse struct {
 	// Indicates whether the operation is a 'COPY' (source replica remains) or a 'MOVE' (source replica is removed after successful transfer).
 	// Required: true
 	// Enum: [COPY MOVE]
-	TransferType *string `json:"transferType"`
+	Type *string `json:"type"`
 
 	// Whether the replica operation is uncancelable.
 	Uncancelable bool `json:"uncancelable,omitempty"`
@@ -107,7 +107,7 @@ func (m *ReplicationReplicateDetailsReplicaResponse) Validate(formats strfmt.Reg
 		res = append(res, err)
 	}
 
-	if err := m.validateTransferType(formats); err != nil {
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -212,7 +212,7 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateTargetNodeID(format
 	return nil
 }
 
-var replicationReplicateDetailsReplicaResponseTypeTransferTypePropEnum []interface{}
+var replicationReplicateDetailsReplicaResponseTypeTypePropEnum []interface{}
 
 func init() {
 	var res []string
@@ -220,35 +220,35 @@ func init() {
 		panic(err)
 	}
 	for _, v := range res {
-		replicationReplicateDetailsReplicaResponseTypeTransferTypePropEnum = append(replicationReplicateDetailsReplicaResponseTypeTransferTypePropEnum, v)
+		replicationReplicateDetailsReplicaResponseTypeTypePropEnum = append(replicationReplicateDetailsReplicaResponseTypeTypePropEnum, v)
 	}
 }
 
 const (
 
-	// ReplicationReplicateDetailsReplicaResponseTransferTypeCOPY captures enum value "COPY"
-	ReplicationReplicateDetailsReplicaResponseTransferTypeCOPY string = "COPY"
+	// ReplicationReplicateDetailsReplicaResponseTypeCOPY captures enum value "COPY"
+	ReplicationReplicateDetailsReplicaResponseTypeCOPY string = "COPY"
 
-	// ReplicationReplicateDetailsReplicaResponseTransferTypeMOVE captures enum value "MOVE"
-	ReplicationReplicateDetailsReplicaResponseTransferTypeMOVE string = "MOVE"
+	// ReplicationReplicateDetailsReplicaResponseTypeMOVE captures enum value "MOVE"
+	ReplicationReplicateDetailsReplicaResponseTypeMOVE string = "MOVE"
 )
 
 // prop value enum
-func (m *ReplicationReplicateDetailsReplicaResponse) validateTransferTypeEnum(path, location string, value string) error {
-	if err := validate.EnumCase(path, location, value, replicationReplicateDetailsReplicaResponseTypeTransferTypePropEnum, true); err != nil {
+func (m *ReplicationReplicateDetailsReplicaResponse) validateTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, replicationReplicateDetailsReplicaResponseTypeTypePropEnum, true); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *ReplicationReplicateDetailsReplicaResponse) validateTransferType(formats strfmt.Registry) error {
+func (m *ReplicationReplicateDetailsReplicaResponse) validateType(formats strfmt.Registry) error {
 
-	if err := validate.Required("transferType", "body", m.TransferType); err != nil {
+	if err := validate.Required("type", "body", m.Type); err != nil {
 		return err
 	}
 
 	// value enum
-	if err := m.validateTransferTypeEnum("transferType", "body", *m.TransferType); err != nil {
+	if err := m.validateTypeEnum("type", "body", *m.Type); err != nil {
 		return err
 	}
 

--- a/entities/models/replication_replicate_replica_request.go
+++ b/entities/models/replication_replicate_replica_request.go
@@ -49,7 +49,7 @@ type ReplicationReplicateReplicaRequest struct {
 
 	// Specifies the type of replication operation to perform. 'COPY' creates a new replica on the destination node while keeping the source replica. 'MOVE' creates a new replica on the destination node and then removes the source replica upon successful completion. Defaults to 'COPY' if omitted.
 	// Enum: [COPY MOVE]
-	TransferType *string `json:"transferType,omitempty"`
+	Type *string `json:"type,omitempty"`
 }
 
 // Validate validates this replication replicate replica request
@@ -72,7 +72,7 @@ func (m *ReplicationReplicateReplicaRequest) Validate(formats strfmt.Registry) e
 		res = append(res, err)
 	}
 
-	if err := m.validateTransferType(formats); err != nil {
+	if err := m.validateType(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -118,7 +118,7 @@ func (m *ReplicationReplicateReplicaRequest) validateSourceNodeName(formats strf
 	return nil
 }
 
-var replicationReplicateReplicaRequestTypeTransferTypePropEnum []interface{}
+var replicationReplicateReplicaRequestTypeTypePropEnum []interface{}
 
 func init() {
 	var res []string
@@ -126,34 +126,34 @@ func init() {
 		panic(err)
 	}
 	for _, v := range res {
-		replicationReplicateReplicaRequestTypeTransferTypePropEnum = append(replicationReplicateReplicaRequestTypeTransferTypePropEnum, v)
+		replicationReplicateReplicaRequestTypeTypePropEnum = append(replicationReplicateReplicaRequestTypeTypePropEnum, v)
 	}
 }
 
 const (
 
-	// ReplicationReplicateReplicaRequestTransferTypeCOPY captures enum value "COPY"
-	ReplicationReplicateReplicaRequestTransferTypeCOPY string = "COPY"
+	// ReplicationReplicateReplicaRequestTypeCOPY captures enum value "COPY"
+	ReplicationReplicateReplicaRequestTypeCOPY string = "COPY"
 
-	// ReplicationReplicateReplicaRequestTransferTypeMOVE captures enum value "MOVE"
-	ReplicationReplicateReplicaRequestTransferTypeMOVE string = "MOVE"
+	// ReplicationReplicateReplicaRequestTypeMOVE captures enum value "MOVE"
+	ReplicationReplicateReplicaRequestTypeMOVE string = "MOVE"
 )
 
 // prop value enum
-func (m *ReplicationReplicateReplicaRequest) validateTransferTypeEnum(path, location string, value string) error {
-	if err := validate.EnumCase(path, location, value, replicationReplicateReplicaRequestTypeTransferTypePropEnum, true); err != nil {
+func (m *ReplicationReplicateReplicaRequest) validateTypeEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, replicationReplicateReplicaRequestTypeTypePropEnum, true); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *ReplicationReplicateReplicaRequest) validateTransferType(formats strfmt.Registry) error {
-	if swag.IsZero(m.TransferType) { // not required
+func (m *ReplicationReplicateReplicaRequest) validateType(formats strfmt.Registry) error {
+	if swag.IsZero(m.Type) { // not required
 		return nil
 	}
 
 	// value enum
-	if err := m.validateTransferTypeEnum("transferType", "body", *m.TransferType); err != nil {
+	if err := m.validateTypeEnum("type", "body", *m.Type); err != nil {
 		return err
 	}
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -900,7 +900,7 @@
           "description": "The ID of the shard whose replica is to be moved or copied.",
           "type": "string"
         },
-        "transferType": {
+        "type": {
           "description": "Specifies the type of replication operation to perform. 'COPY' creates a new replica on the destination node while keeping the source replica. 'MOVE' creates a new replica on the destination node and then removes the source replica upon successful completion. Defaults to 'COPY' if omitted.",
           "type": "string",
           "enum": ["COPY", "MOVE"],
@@ -1065,7 +1065,7 @@
           "description": "The identifier of the node to which the replica is being moved or copied (the destination node).",
           "type": "string"
         },
-        "transferType": {
+        "type": {
           "description": "Indicates whether the operation is a 'COPY' (source replica remains) or a 'MOVE' (source replica is removed after successful transfer).",
           "type": "string",
           "enum": [
@@ -1098,7 +1098,7 @@
           }
         }
       },
-      "required": ["id", "shardId", "sourceNodeId", "targetNodeId", "collection", "status", "transferType"]
+      "required": ["id", "shardId", "sourceNodeId", "targetNodeId", "collection", "status", "type"]
     },
     "ReplicationReplicateForceDeleteRequest": {
       "description": "Specifies the parameters available when force deleting replication operations.",

--- a/test/acceptance/replication/replica_replication/fast/conflicts_test.go
+++ b/test/acceptance/replication/replica_replication/fast/conflicts_test.go
@@ -134,7 +134,7 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateConflictsMOVE() {
 	req := getRequest(t, paragraphClass.Class)
 
 	move := "MOVE"
-	req.TransferType = &move
+	req.Type = &move
 	// Create MOVE replication operation and wait until the shard is in the sharding state (meaning it is uncancellable)
 	created, err := helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(req), nil)
 	require.Nil(t, err)

--- a/test/acceptance/replication/replica_replication/fast/move_test.go
+++ b/test/acceptance/replication/replica_replication/fast/move_test.go
@@ -46,7 +46,7 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateMOVEDeletesSourceRepl
 	req := getRequest(t, paragraphClass.Class)
 
 	move := "MOVE"
-	req.TransferType = &move
+	req.Type = &move
 	// Create MOVE replication operation and wait until the shard is in the sharding state (meaning it is uncancellable)
 	created, err := helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(req), nil)
 	require.Nil(t, err)

--- a/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
+++ b/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
@@ -163,7 +163,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 				continue
 			}
 
-			transferType := api.COPY.String()
+			replicationType := api.COPY.String()
 			for _, shard := range node.Shards {
 				if shard.Class != paragraphClass.Class {
 					continue
@@ -180,7 +180,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 							SourceNodeName:      &node.Name,
 							DestinationNodeName: &targetNode,
 							ShardID:             &shard.Name,
-							TransferType:        &transferType,
+							Type:                &replicationType,
 						},
 					),
 					nil,


### PR DESCRIPTION
### What's being changed:

- Change `transferType` to `type` when calling `POST /replication/replicate` and `GET /replicate/replicate/{id}`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
