### PR TITLE
Capped HNSW level generation

### DIFF
--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -128,7 +128,7 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 		if maxId < id {
 			maxId = id
 		}
-		levels[i] = int(math.Floor(-math.Log(h.randFunc()) * h.levelNormalizer))
+		levels[i] = int(h.generateLevel()) // TODO: represent level as uint8
 	}
 	h.RLock()
 	if maxId >= uint64(len(h.nodes)) {
@@ -270,7 +270,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 		numVectors := len(vectors[i])
 		levels := make([]int, numVectors)
 		for j := range numVectors {
-			levels[j] = int(math.Floor(-math.Log(h.randFunc()) * h.levelNormalizer))
+			levels[j] = int(h.generateLevel()) // TODO: represent level as uint8
 		}
 
 		h.Lock()
@@ -522,4 +522,8 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 
 	// go h.insertHook(node.id, 0, node.connections)
 	return nil
+}
+
+func (h *hnsw) generateLevel() uint8 {
+	return uint8(math.Floor(-math.Log(max(h.randFunc(), 1e-19)) * h.levelNormalizer))
 }

--- a/adapters/repos/db/vector/hnsw/insert_test.go
+++ b/adapters/repos/db/vector/hnsw/insert_test.go
@@ -1,0 +1,148 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHnswCappedLevel(t *testing.T) {
+	type testCase struct {
+		name           string
+		maxConnections int
+		randomValue    float64
+		expectedLevel  uint8
+	}
+
+	testCases := []testCase{
+		{
+			name:           "test max function with normal value",
+			maxConnections: 64,
+			randomValue:    0.3,
+			expectedLevel:  0,
+		},
+		{
+			name:           "randFunc returning 1-eps (very close to 1)",
+			maxConnections: 16,
+			randomValue:    1.0 - 1e-15,
+			expectedLevel:  0,
+		},
+		{
+			name:           "randFunc returning 1",
+			maxConnections: 16,
+			randomValue:    1.0,
+			expectedLevel:  0,
+		},
+		{
+			name:           "randFunc returning 0.5",
+			maxConnections: 32,
+			randomValue:    0.5,
+			expectedLevel:  0,
+		},
+		{
+			name:           "randFunc returning 0.1",
+			maxConnections: 16,
+			randomValue:    0.1,
+			expectedLevel:  0,
+		},
+		{
+			name:           "randFunc returning 0.01",
+			maxConnections: 16,
+			randomValue:    0.01,
+			expectedLevel:  1,
+		},
+		{
+			name:           "randFunc returning 1e-10",
+			maxConnections: 16,
+			randomValue:    1e-10,
+			expectedLevel:  8,
+		},
+		{
+			name:           "randFunc returning exactly 1e-20",
+			maxConnections: 16,
+			randomValue:    1e-20,
+			expectedLevel:  15,
+		},
+		{
+			name:           "randFunc returning value less than 1e-20",
+			maxConnections: 16,
+			randomValue:    1e-25,
+			expectedLevel:  15,
+		},
+		{
+			name:           "different maxConnections: 8 with 0.1",
+			maxConnections: 8,
+			randomValue:    0.1,
+			expectedLevel:  1,
+		},
+		{
+			name:           "different maxConnections: 32 with 0.1",
+			maxConnections: 32,
+			randomValue:    0.1,
+			expectedLevel:  0,
+		},
+		{
+			name:           "different maxConnections: 8 with 0.01",
+			maxConnections: 8,
+			randomValue:    0.01,
+			expectedLevel:  2,
+		},
+		{
+			name:           "different maxConnections: 32 with 0.01",
+			maxConnections: 32,
+			randomValue:    0.01,
+			expectedLevel:  1,
+		},
+		{
+			name:           "test max function with very small value",
+			maxConnections: 2,
+			randomValue:    1e-50,
+			expectedLevel:  63, // Should use 1e-20 due to max function, same as 1e-20 case
+		},
+		{
+			name:           "test max function with very small value",
+			maxConnections: 2,
+			randomValue:    1e-100,
+			expectedLevel:  63, // Should use 1e-20 due to max function, same as 1e-20 case
+		},
+		{
+			name:           "test max function with zero small value",
+			maxConnections: 2,
+			randomValue:    0.0,
+			expectedLevel:  63,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create minimal HNSW struct with only the fields needed for level() function
+			h := &hnsw{
+				randFunc:        func() float64 { return tc.randomValue },
+				levelNormalizer: 1.0 / math.Log(float64(tc.maxConnections)),
+			}
+
+			level := h.generateLevel()
+
+			oldLevel := 0
+			if tc.randomValue != 0 {
+				oldLevel = int(math.Floor(-math.Log(tc.randomValue) * h.levelNormalizer))
+			}
+
+			assert.Equal(t, tc.expectedLevel, level,
+				"Test case: %s\nRandom value: %f\nMaxConnections: %d\nLevelNormalizer: %f\nExpected: %d, Got: %d, OldLevel: %d",
+				tc.name, tc.randomValue, tc.maxConnections, h.levelNormalizer, tc.expectedLevel, level, oldLevel)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

The current HNSW level generation for Weaviate closely matches the original implementation:
```math
\begin{align}
\text{levelNormalizer} &= \frac{1}{\ln(\text{maxConnections})} \\
\text{level} &= \lfloor -\ln(\text{uniform}[0,1)) \times \text{levelNormalizer} \rfloor
\end{align}
```

This PR caps the random value to be in range $$[10^{-19},1)$$ which means even with 2 maxConnections, the largest number of levels for a graph is 63. The reason for this change is we can now represent level as a `uint8` internally and save on storage and memory costs. There will be a followup PR to change how `level` is used internally to `uint8`.

```math
\begin{align}
\text{level} &= \lfloor -\ln(\max(\text{uniform}[0,1), 10^{-19})) \times \text{levelNormalizer} \rfloor
\end{align}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
