### PR TITLE
Limit maximum HNSW connections

### DIFF
--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -38,8 +38,9 @@ const (
 	DefaultFilterStrategy = FilterStrategySweeping
 
 	// Fail validation if those criteria are not met
-	MinmumMaxConnections = 4
-	MinmumEFConstruction = 4
+	MinmumMaxConnections  = 4
+	MaximumMaxConnections = 2047
+	MinmumEFConstruction  = 4
 )
 
 // UserConfig bundles all values settable by a user in the per-class settings
@@ -247,6 +248,13 @@ func (u *UserConfig) validate() error {
 		errMsgs = append(errMsgs, fmt.Sprintf(
 			"maxConnections must be a positive integer with a minimum of %d",
 			MinmumMaxConnections,
+		))
+	}
+
+	if u.MaxConnections > MaximumMaxConnections {
+		errMsgs = append(errMsgs, fmt.Sprintf(
+			"maxConnections must be less than %d",
+			MaximumMaxConnections+1,
 		))
 	}
 

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -838,6 +838,65 @@ func Test_UserConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "max connections at maximum allowed value (2047)",
+			input: map[string]interface{}{
+				"maxConnections": json.Number("2047"),
+			},
+			expected: UserConfig{
+				CleanupIntervalSeconds: DefaultCleanupIntervalSeconds,
+				MaxConnections:         2047,
+				EFConstruction:         DefaultEFConstruction,
+				VectorCacheMaxObjects:  common.DefaultVectorCacheMaxObjects,
+				EF:                     DefaultEF,
+				Skip:                   DefaultSkip,
+				FlatSearchCutoff:       DefaultFlatSearchCutoff,
+				DynamicEFMin:           DefaultDynamicEFMin,
+				DynamicEFMax:           DefaultDynamicEFMax,
+				DynamicEFFactor:        DefaultDynamicEFFactor,
+				Distance:               common.DefaultDistanceMetric,
+				PQ: PQConfig{
+					Enabled:        DefaultPQEnabled,
+					BitCompression: DefaultPQBitCompression,
+					Segments:       DefaultPQSegments,
+					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
+					Encoder: PQEncoder{
+						Type:         DefaultPQEncoderType,
+						Distribution: DefaultPQEncoderDistribution,
+					},
+				},
+				SQ: SQConfig{
+					Enabled:       DefaultSQEnabled,
+					TrainingLimit: DefaultSQTrainingLimit,
+					RescoreLimit:  DefaultSQRescoreLimit,
+				},
+				RQ: RQConfig{
+					Enabled:      DefaultRQEnabled,
+					Bits:         DefaultRQBits,
+					RescoreLimit: DefaultRQRescoreLimit,
+				},
+				FilterStrategy: DefaultFilterStrategy,
+				Multivector: MultivectorConfig{
+					Enabled:     DefaultMultivectorEnabled,
+					Aggregation: DefaultMultivectorAggregation,
+					MuveraConfig: MuveraConfig{
+						Enabled:      DefaultMultivectorMuveraEnabled,
+						KSim:         DefaultMultivectorKSim,
+						DProjections: DefaultMultivectorDProjections,
+						Repetitions:  DefaultMultivectorRepetitions,
+					},
+				},
+			},
+		},
+		{
+			name: "max connections exceeds maximum allowed value (2048)",
+			input: map[string]interface{}{
+				"maxConnections": json.Number("2048"),
+			},
+			expectErr:    true,
+			expectErrMsg: "maxConnections must be less than 2048",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What's being changed:

- Currently we have a default max connections of 32, and originally had a limit of 64.
- For most users the defaults are on the conservative side and best performance to recall ratio is with max connections in range 16 - 28. Realistically having max connections > 1000 would destroy performance and is not recommended.
- With the new compressed connections https://github.com/weaviate/weaviate/pull/8391 feature we are trying to minimize connection related sizes.  As part of this we have a byte encoding scheme that packs the scheme (2,3,4,5,8 bytes) with the length in a header where we are using 4 bits for the scheme and 12 bits for the count.
- This means we need to enforce a limit < 4096. As max connections on layer 0 is 2 times the normal layers this means we need to enforce limit < 2048.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
