### PR TITLE
fix(yaml): upgrade to yaml.v3 for startup config unmarshaling

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/weaviate/weaviate/deprecations"
 	entcfg "github.com/weaviate/weaviate/entities/config"

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -119,6 +119,86 @@ func TestConfigModules(t *testing.T) {
 }
 
 func TestConfigParsing(t *testing.T) {
+	t.Run("parse config.yaml with oidc config - yaml", func(t *testing.T) {
+		configFileName := "config.yaml"
+		configYaml := `authentication:
+  oidc:
+    enabled: true
+    issuer: http://localhost:9090/auth/realms/weaviate
+    username_claim: preferred_username
+    groups_claim: groups
+    client_id: demo
+    skip_client_id_check: false
+    scopes: ['email', 'openid']
+    certificate: "valid-certificate"
+`
+
+		filepath := fmt.Sprintf("%s/%s", t.TempDir(), configFileName)
+		f, err := os.Create(filepath)
+		require.Nil(t, err)
+		defer f.Close()
+		_, err2 := f.WriteString(configYaml)
+		require.Nil(t, err2)
+
+		file, err := os.ReadFile(filepath)
+		require.Nil(t, err)
+		weaviateConfig := &WeaviateConfig{}
+		config, err := weaviateConfig.parseConfigFile(file, configFileName)
+		require.Nil(t, err)
+
+		assert.True(t, config.Authentication.OIDC.Enabled)
+		assert.Equal(t, "http://localhost:9090/auth/realms/weaviate", config.Authentication.OIDC.Issuer.Get())
+		assert.Equal(t, "preferred_username", config.Authentication.OIDC.UsernameClaim.Get())
+		assert.Equal(t, "groups", config.Authentication.OIDC.GroupsClaim.Get())
+		assert.Equal(t, "demo", config.Authentication.OIDC.ClientID.Get())
+		assert.False(t, config.Authentication.OIDC.SkipClientIDCheck.Get())
+		assert.ElementsMatch(t, []string{"email", "openid"}, config.Authentication.OIDC.Scopes.Get())
+		assert.Equal(t, "valid-certificate", config.Authentication.OIDC.Certificate.Get())
+
+	})
+
+	t.Run("parse config.yaml with oidc config - json", func(t *testing.T) {
+		configFileName := "config.json"
+		configYaml := `{
+  "authentication": {
+    "oidc": {
+      "enabled": true,
+      "issuer": "http://localhost:9090/auth/realms/weaviate",
+      "username_claim": "preferred_username",
+      "groups_claim": "groups",
+      "client_id": "demo",
+      "skip_client_id_check": false,
+      "scopes": ["email", "openid"],
+      "certificate": "valid-certificate"
+    }
+  }
+}
+`
+
+		filepath := fmt.Sprintf("%s/%s", t.TempDir(), configFileName)
+		f, err := os.Create(filepath)
+		require.Nil(t, err)
+		defer f.Close()
+		_, err2 := f.WriteString(configYaml)
+		require.Nil(t, err2)
+
+		file, err := os.ReadFile(filepath)
+		require.Nil(t, err)
+		weaviateConfig := &WeaviateConfig{}
+		config, err := weaviateConfig.parseConfigFile(file, configFileName)
+		require.Nil(t, err)
+
+		assert.True(t, config.Authentication.OIDC.Enabled)
+		assert.Equal(t, "http://localhost:9090/auth/realms/weaviate", config.Authentication.OIDC.Issuer.Get())
+		assert.Equal(t, "preferred_username", config.Authentication.OIDC.UsernameClaim.Get())
+		assert.Equal(t, "groups", config.Authentication.OIDC.GroupsClaim.Get())
+		assert.Equal(t, "demo", config.Authentication.OIDC.ClientID.Get())
+		assert.False(t, config.Authentication.OIDC.SkipClientIDCheck.Get())
+		assert.ElementsMatch(t, []string{"email", "openid"}, config.Authentication.OIDC.Scopes.Get())
+		assert.Equal(t, "valid-certificate", config.Authentication.OIDC.Certificate.Get())
+
+	})
+
 	t.Run("parse config.yaml file with admin_list and read_only_users", func(t *testing.T) {
 		configFileName := "config.yaml"
 		configYaml := `authorization:


### PR DESCRIPTION
### What's being changed:
Also implement unmarshaling JSON for the dynamic types to be future proof. 

Startup yaml config was using yaml.v2 to parse the config file, but DyamicValue types uses yaml.v3. this PR upgrades to yaml.v3 everywhere

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
