### PR TITLE
Make `READY` state mock idempotent to avoid flaky test

### DIFF
--- a/cluster/replication/producer_consumer_test.go
+++ b/cluster/replication/producer_consumer_test.go
@@ -52,6 +52,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 			name:         "All operations are processed in order in copy mode",
 			transferType: api.COPY,
 			setupMocksFunc: func(wg *sync.WaitGroup, mockFSMUpdater *types.MockFSMUpdater, mockReplicaCopier *types.MockReplicaCopier) {
+				var once sync.Once
 				wg.Add(1)
 				mockFSMUpdater.EXPECT().
 					WaitForUpdate(mock.Anything, mock.Anything).
@@ -97,15 +98,15 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.READY).
 					Run(func(ctx context.Context, opId uint64, state api.ShardReplicationState) {
-						wg.Done()
-					}).
-					Return(nil)
+						once.Do(wg.Done)
+					}).Return(nil).Maybe()
 			},
 		},
 		{
 			name:         "consumer resumes on state change failure",
 			transferType: api.COPY,
 			setupMocksFunc: func(wg *sync.WaitGroup, mockFSMUpdater *types.MockFSMUpdater, mockReplicaCopier *types.MockReplicaCopier) {
+				var once sync.Once
 				wg.Add(1)
 				mockFSMUpdater.EXPECT().
 					WaitForUpdate(mock.Anything, mock.Anything).
@@ -154,16 +155,16 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					Return(uint64(0), nil)
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.READY).
-					Run(func(ctx context.Context, opId uint64, state api.ShardReplicationState) {
-						wg.Done()
-					}).
-					Return(nil)
+					Run(func(ctx context.Context, id uint64, state api.ShardReplicationState) {
+						once.Do(wg.Done)
+					}).Return(nil).Maybe()
 			},
 		},
 		{
 			name:         "consumer resumes on replica copier failures",
 			transferType: api.COPY,
 			setupMocksFunc: func(wg *sync.WaitGroup, mockFSMUpdater *types.MockFSMUpdater, mockReplicaCopier *types.MockReplicaCopier) {
+				var once sync.Once
 				wg.Add(1)
 				mockFSMUpdater.EXPECT().
 					WaitForUpdate(mock.Anything, mock.Anything).
@@ -216,15 +217,15 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.READY).
 					Run(func(ctx context.Context, opId uint64, state api.ShardReplicationState) {
-						wg.Done()
-					}).
-					Return(nil)
+						once.Do(wg.Done)
+					}).Return(nil).Maybe()
 			},
 		},
 		{
 			name:         "consumer resumes on async replication failures",
 			transferType: api.COPY,
 			setupMocksFunc: func(wg *sync.WaitGroup, mockFSMUpdater *types.MockFSMUpdater, mockReplicaCopier *types.MockReplicaCopier) {
+				var once sync.Once
 				wg.Add(1)
 				mockFSMUpdater.EXPECT().
 					WaitForUpdate(mock.Anything, mock.Anything).
@@ -288,15 +289,15 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.READY).
 					Run(func(ctx context.Context, opId uint64, state api.ShardReplicationState) {
-						wg.Done()
-					}).
-					Return(nil)
+						once.Do(wg.Done)
+					}).Return(nil).Maybe()
 			},
 		},
 		{
 			name:         "All operations are processed in order in move mode",
 			transferType: api.MOVE,
 			setupMocksFunc: func(wg *sync.WaitGroup, mockFSMUpdater *types.MockFSMUpdater, mockReplicaCopier *types.MockReplicaCopier) {
+				var once sync.Once
 				wg.Add(1)
 				mockFSMUpdater.EXPECT().
 					WaitForUpdate(mock.Anything, mock.Anything).
@@ -348,9 +349,8 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.READY).
 					Run(func(ctx context.Context, opId uint64, state api.ShardReplicationState) {
-						wg.Done()
-					}).
-					Return(nil)
+						once.Do(wg.Done)
+					}).Return(nil).Maybe()
 			},
 		},
 	}

--- a/cluster/replication/producer_consumer_test.go
+++ b/cluster/replication/producer_consumer_test.go
@@ -450,6 +450,7 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 			// Assert that the mock expectations were met
 			mockFSMUpdater.AssertExpectations(t)
 			mockReplicaCopier.AssertExpectations(t)
+			require.True(t, mockFSMUpdater.AssertCalled(t, "ReplicationUpdateReplicaOpStatus", mock.Anything, uint64(opId), api.READY), "READY should be called at least once")
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:

#### 🔴 Problem
The test `TestConsumerStateChangeOrder` was flaky due to a `sync.WaitGroup` panic when the mocked call

```go
ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.READY)
```

was invoked multiple times, triggering several `wg.Done()` calls after a single `wg.Add(1)` (Done/Add mismatch).

This happens when the same op is re-queued by the producer and processed again by the consumer before the first run of the op finishes. Under load or in longer runs, `ReplicationUpdateReplicaOpStatus` can therefore be called more than once (twice or even more) with the same `opId`/`state` combination (e.g. `opId=123`, `state=api.READY`) just because the same replication operation appears more than once on the channel between the producer and the consumer.

#### ✅ Solution
* Wrap `wg.Done()` in a `sync.Once` so it fires at most once.  
* Add `.Maybe()` to the `READY` mock expectation to allow multiple invocations without failing the test.

Together, these changes “deduplicate” the mock calls and prevent extra `wg.Done()` executions.

**Note:** we deliberately assert **at-least-once** rather than **exactly-once** semantics.
The producer polls every second and may re-queue an op while the first run is still in flight, so the consumer can emit two (or more) identical `READY` updates. Treating duplicates as a failure would make the test timing-dependent and flaky,
even though those duplicates are perfectly valid and idempotent in production. Also, we still verify the call to `ReplicationUpdateReplicaOpStatus` happened by adding a specific assertion.

#### 🛡️ Not a production issue
In production, repeated updates to the same state are idempotent and safe. The consumer can legitimately re-process the same op, and multiple `READY` updates are handled correctly. The panic was purely a test-setup issue.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
