### PR TITLE
fix: :bug: retry migration later if index == nil

### DIFF
--- a/adapters/repos/db/inverted_reindexer_v3.go
+++ b/adapters/repos/db/inverted_reindexer_v3.go
@@ -312,6 +312,13 @@ func (r *shardReindexerV3) runScheduledTask(ctx context.Context, key string, tas
 
 	index := r.getIndex(schema.ClassName(collectionName))
 	if index == nil {
+		// try again later, as we have observed that index can be nil
+		// for a short period of time after shard is created, but before it is loaded
+		r.locked(func() {
+			if ctx.Err() == nil {
+				r.queue.insert(key, tasks, time.Now().Add(1*time.Minute))
+			}
+		})
 		err = fmt.Errorf("index for shard '%s' of collection '%s' not found", shardName, collectionName)
 		return
 	}


### PR DESCRIPTION
### What's being changed:

Retry migration later if index == nil, as we observed it happening during testing.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
