### PR TITLE
fix: :bug: pause objects bucket compaction during BMW migration

### DIFF
--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -514,6 +514,12 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 	breakCh <- false
 	finished := false
 
+	err = store.PauseObjectBucketCompaction(ctx)
+	if err != nil {
+		return zerotime, false, err
+	}
+	defer store.ResumeObjectBucketCompaction(ctx)
+
 	processingStarted, mdCh := t.objectsIteratorAsync(logger, shard, lastStoredKey, t.keyParser.FromBytes,
 		propExtraction, reindexStarted, breakCh)
 

--- a/adapters/repos/db/lsmkv/bucket_pauses.go
+++ b/adapters/repos/db/lsmkv/bucket_pauses.go
@@ -1,0 +1,33 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+func (b *Bucket) doStartPauseTimer() {
+	label := b.GetDir()
+	if monitoring.GetMetrics().Group {
+		label = "n/a"
+	}
+	if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label); err == nil {
+		b.pauseTimer = prometheus.NewTimer(metric)
+	}
+}
+
+func (b *Bucket) doStopPauseTimer() {
+	if b.pauseTimer != nil {
+		b.pauseTimer.ObserveDuration()
+	}
+}

--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -15,8 +15,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // PauseCompaction waits for all ongoing compactions to finish,
@@ -41,13 +39,7 @@ func (s *Store) PauseCompaction(ctx context.Context) error {
 
 	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
 	for _, b := range s.bucketsByName {
-		label := b.GetDir()
-		if monitoring.GetMetrics().Group {
-			label = "n/a"
-		}
-		if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label); err == nil {
-			b.pauseTimer = prometheus.NewTimer(metric)
-		}
+		b.doStartPauseTimer()
 	}
 
 	return nil
@@ -64,9 +56,7 @@ func (s *Store) ResumeCompaction(ctx context.Context) error {
 
 	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
 	for _, b := range s.bucketsByName {
-		if b.pauseTimer != nil {
-			b.pauseTimer.ObserveDuration()
-		}
+		b.doStopPauseTimer()
 	}
 
 	return nil

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -15,8 +15,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 )
 
 // PauseObjectBucketCompaction pauses the compaction cycle for the objects bucket.
@@ -26,16 +25,10 @@ func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	b := s.bucketsByName["objects"]
+	b := s.Bucket(helpers.ObjectsBucketLSM)
 
 	b.disk.compactionCallbackCtrl.Deactivate(ctx)
-	label := b.GetDir()
-	if monitoring.GetMetrics().Group {
-		label = "n/a"
-	}
-	if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label); err == nil {
-		b.pauseTimer = prometheus.NewTimer(metric)
-	}
+	b.doStartPauseTimer()
 	return nil
 }
 
@@ -44,7 +37,7 @@ func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	b := s.bucketsByName["objects"]
+	b := s.Bucket(helpers.ObjectsBucketLSM)
 	if b == nil {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
 	}
@@ -52,12 +45,8 @@ func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
 	if err := b.disk.compactionCallbackCtrl.Activate(); err != nil {
 		return err
 	}
-	s.bucketAccessLock.RLock()
-	defer s.bucketAccessLock.RUnlock()
 
-	if b.pauseTimer != nil {
-		b.pauseTimer.ObserveDuration()
-	}
+	b.doStopPauseTimer()
 
 	return nil
 }

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -1,0 +1,63 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// PauseObjectBucketCompaction pauses the compaction cycle for the objects bucket.
+// This is so that the BMW migration can run without interference from the
+// compaction process, as they both use the same locks.
+func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
+	s.bucketAccessLock.RLock()
+	defer s.bucketAccessLock.RUnlock()
+
+	b := s.bucketsByName["objects"]
+
+	b.disk.compactionCallbackCtrl.Deactivate(ctx)
+	label := b.GetDir()
+	if monitoring.GetMetrics().Group {
+		label = "n/a"
+	}
+	if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label); err == nil {
+		b.pauseTimer = prometheus.NewTimer(metric)
+	}
+	return nil
+}
+
+// ResumeObjectBucketCompaction resumes the compaction cycle for the objects bucket.
+func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
+	s.bucketAccessLock.RLock()
+	defer s.bucketAccessLock.RUnlock()
+
+	b := s.bucketsByName["objects"]
+	if b == nil {
+		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
+	}
+
+	if err := b.disk.compactionCallbackCtrl.Activate(); err != nil {
+		return err
+	}
+	s.bucketAccessLock.RLock()
+	defer s.bucketAccessLock.RUnlock()
+
+	if b.pauseTimer != nil {
+		b.pauseTimer.ObserveDuration()
+	}
+
+	return nil
+}


### PR DESCRIPTION
### What's being changed:

Pause objects bucket compaction during BMW migration, so that we don't have lock contention on the objects segments

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
