### PR TITLE
feat: :sparkles: support to compacting without lvl increase

### DIFF
--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -823,9 +823,9 @@ func (t *ShardReindexTask_MapToBlockmax) loadReindexSearchBuckets(ctx context.Co
 
 func (t *ShardReindexTask_MapToBlockmax) loadIngestSearchBuckets(ctx context.Context,
 	logger logrus.FieldLogger, shard ShardLike, props []string,
-	disableCompaction, keepTombstones bool,
+	keepLevelCompaction, keepTombstones bool,
 ) error {
-	bucketOpts := t.bucketOptions(shard, lsmkv.StrategyInverted, disableCompaction, keepTombstones, t.config.memtableOptBlockmaxFactor)
+	bucketOpts := t.bucketOptions(shard, lsmkv.StrategyInverted, keepLevelCompaction, keepTombstones, t.config.memtableOptBlockmaxFactor)
 	return t.loadBuckets(ctx, logger, shard, props, t.ingestBucketName, bucketOpts)
 }
 
@@ -999,7 +999,7 @@ func (t *ShardReindexTask_MapToBlockmax) calcPropLenInverted(items []inverted.Co
 }
 
 func (t *ShardReindexTask_MapToBlockmax) bucketOptions(shard ShardLike, strategy string,
-	disableCompaction, keepTombstones bool, memtableOptFactor int,
+	keepLevelCompaction, keepTombstones bool, memtableOptFactor int,
 ) []lsmkv.BucketOption {
 	index := shard.Index()
 
@@ -1016,7 +1016,7 @@ func (t *ShardReindexTask_MapToBlockmax) bucketOptions(shard ShardLike, strategy
 		lsmkv.WithMaxSegmentSize(index.Config.MaxSegmentSize),
 		lsmkv.WithSegmentsChecksumValidationEnabled(index.Config.LSMEnableSegmentsChecksumValidation),
 		lsmkv.WithStrategy(strategy),
-		lsmkv.WithDisableCompaction(disableCompaction),
+		lsmkv.WithKeepLevelCompaction(keepLevelCompaction),
 		lsmkv.WithKeepTombstones(keepTombstones),
 	}
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -130,6 +130,11 @@ type Bucket struct {
 	forceCompaction   bool
 	disableCompaction bool
 
+	// if true, don't increase the segment level during compaction.
+	// useful for migrations, as it allows to merge reindex and ingest buckets
+	// without discontinuities in segment levels.
+	keepLevelCompaction bool
+
 	// optionally supplied to prevent starting memory-intensive
 	// processes when memory pressure is high
 	allocChecker memwatch.AllocChecker
@@ -227,6 +232,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 			keepSegmentsInMemory:     b.keepSegmentsInMemory,
 			MinMMapSize:              b.minMMapSize,
 			bm25config:               b.bm25Config,
+			keepLevelCompaction:      b.keepLevelCompaction,
 		}, b.allocChecker)
 	if err != nil {
 		return nil, fmt.Errorf("init disk segments: %w", err)

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -209,6 +209,13 @@ func WithDisableCompaction(disable bool) BucketOption {
 	}
 }
 
+func WithKeepLevelCompaction(keepLevelCompaction bool) BucketOption {
+	return func(b *Bucket) error {
+		b.keepLevelCompaction = keepLevelCompaction
+		return nil
+	}
+}
+
 func WithKeepSegmentsInMemory(keep bool) BucketOption {
 	return func(b *Bucket) error {
 		b.keepSegmentsInMemory = keep

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -79,6 +79,7 @@ type SegmentGroup struct {
 	compactLeftOverSegments  bool // see bucket for more details
 	enableChecksumValidation bool
 	MinMMapSize              int64
+	keepLevelCompaction      bool // see bucket for more details
 
 	allocChecker   memwatch.AllocChecker
 	maxSegmentSize int64
@@ -102,6 +103,7 @@ type sgConfig struct {
 	useBloomFilter           bool
 	calcCountNetAdditions    bool
 	forceCompaction          bool
+	keepLevelCompaction      bool
 	maxSegmentSize           int64
 	cleanupInterval          time.Duration
 	enableChecksumValidation bool


### PR DESCRIPTION
### What's being changed:

Compact two segments and keep the level.
This enables doing a migration with ingest and reindex buckets and merging them without breaking segment levels.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
