### PR TITLE
feat: :sparkles: overriding migration vars with endpoint call

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
+	"slices"
 	"strings"
 	"time"
 
@@ -71,22 +71,45 @@ func setupDebugHandlers(appState *state.State) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
-	http.HandleFunc("/debug/index/rebuild/inverted/abort", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		appState.ReindexCtxCancel(fmt.Errorf("abort endpoint"))
+	http.HandleFunc("/debug/index/rebuild/inverted/cancelReindexContext", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appState.ReindexCtxCancel(fmt.Errorf("cancelReindexContext endpoint"))
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
+	http.HandleFunc("/debug/index/rebuild/inverted/suspend", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("paused.mig", false, logger, appState, r, w)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/resume", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("paused.mig", true, logger, appState, r, w)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/rollback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("rollback.mig", false, logger, appState, r, w)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/unrollback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("rollback.mig", true, logger, appState, r, w)
+	}))
+
 	http.HandleFunc("/debug/index/rebuild/inverted/start", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("start.mig", false, logger, appState, r, w)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/unstart", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("start.mig", true, logger, appState, r, w)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/reload", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		colName := r.URL.Query().Get("collection")
-		forceRestartString := r.URL.Query().Get("force")
-		rootPath := appState.DB.GetConfig().RootPath
+		shardsToMigrateString := r.URL.Query().Get("shards")
 
 		if colName == "" {
-			http.Error(w, "collection and shard are required", http.StatusBadRequest)
+			http.Error(w, "collection name is required", http.StatusBadRequest)
 			return
 		}
 
-		forceRestart := config.Enabled(forceRestartString)
+		shardsToMigrate := strings.Split(shardsToMigrateString, ",")[1:]
 
 		className := schema.ClassName(colName)
 		classNameString := strings.ToLower(className.String())
@@ -101,100 +124,51 @@ func setupDebugHandlers(appState *state.State) {
 		paths := make(map[string]string)
 		shards := make(map[string]db.ShardLike)
 
+		output := make(map[string]map[string]string, len(paths))
 		// shards will not be force loaded, as we are only getting the name
+		rootPath := appState.DB.GetConfig().RootPath
 		err := idx.ForEachShard(
 			func(shardName string, shard db.ShardLike) error {
-				shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
-				paths[shardName] = shardPath
-				shards[shardName] = shard
+				if len(shardsToMigrate) == 0 || slices.Contains(shardsToMigrate, shardName) {
+					err := idx.IncomingReinitShard(
+						context.Background(),
+						shardName,
+					)
+					if err != nil {
+						logger.WithField("shard", shardName).Error("failed to reinit shard " + err.Error())
+						output[shardName] = map[string]string{
+							"shard":       shardName,
+							"shardStatus": shard.GetStatusNoLoad().String(),
+							"status":      "error",
+							"message":     "failed to reinit shard",
+							"error":       err.Error(),
+						}
+						return nil
+					}
+					shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
+					paths[shardName] = shardPath
+					shards[shardName] = shard
+					output[shardName] = map[string]string{
+						"shard":       shardName,
+						"shardStatus": shard.GetStatusNoLoad().String(),
+						"status":      "reinit",
+						"message":     "reinit shard started",
+					}
+				}
 				return nil
 			},
 		)
-		if err != nil {
-			logger.WithField("collection", colName).Error("failed to get shard names")
-			http.Error(w, "failed to get shard names", http.StatusInternalServerError)
-			return
-		}
-
-		migratingShards := make([]string, 0, len(paths))
-
-		output := make(map[string]map[string]string, len(paths))
-		for i, path := range paths {
-			output[i] = map[string]string{
-				"shard":  i,
-				"status": "unknown",
-			}
-			if path == "" {
-				output[i]["status"] = "shard_not_loaded"
-				output[i]["message"] = "shard not loaded"
-				continue
-			}
-
-			// check if the shard directory exists
-			_, err := os.Stat(path)
-			if err != nil {
-				output[i]["status"] = "shard_not_loaded"
-				output[i]["message"] = "shard directory does not exist"
-				continue
-			}
-
-			// check if a .migrations/searchable_map_to_blockmax exists
-			_, err = os.Stat(path + ".migrations/searchable_map_to_blockmax")
-			if err != nil {
-				output[i]["status"] = "not_started"
-				output[i]["message"] = "no searchable_map_to_blockmax folder found"
-				continue
-			}
-
-			path += ".migrations/searchable_map_to_blockmax/"
-			// check if started.mig exists
-			_, err = os.Stat(path + "started.mig")
-			if err == nil && !forceRestart {
-				output[i]["status"] = "started"
-				output[i]["message"] = "reindexing started"
-				continue
-			}
-
-			// migration is not started yet, create start file as start.mig
-			// check if start.mig exists
-			_, err = os.Stat(path + "start.mig")
-			if err == nil && !forceRestart {
-				output[i]["status"] = "started"
-				output[i]["message"] = "reindexing started"
-				continue
-			}
-			// create start.mig file
-			startedFile, err := os.Create(path + "start.mig")
-			if err != nil && !forceRestart {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to create start.mig"
-				continue
-			}
-			startedFile.Close()
-
-			shard := shards[i]
-
-			migratingShards = append(migratingShards, shard.Name())
-
-		}
-		for _, shard := range migratingShards {
-			err := idx.IncomingReinitShard(
-				context.Background(),
-				shard,
-			)
-			if err != nil {
-				logger.WithField("shard", shard).Error("failed to reinit shard")
-				http.Error(w, "failed to reinit shard", http.StatusInternalServerError)
-				return
-			}
-			logger.WithField("shard", shard).Info("reinit shard started")
-			output[shard]["status"] = "reinit"
-			output[shard]["message"] = "reinit shard started"
-		}
 
 		response := map[string]interface{}{
 			"shards": output,
 		}
+
+		if err != nil {
+			logger.WithField("collection", colName).Error("failed to get shard names")
+			http.Error(w, "failed to get shard names", http.StatusInternalServerError)
+			response["error"] = "failed to get shard names: " + err.Error()
+		}
+
 		jsonBytes, err := json.Marshal(response)
 		if err != nil {
 			logger.WithError(err).Error("marshal failed on stats")
@@ -206,288 +180,296 @@ func setupDebugHandlers(appState *state.State) {
 	}))
 
 	http.HandleFunc("/debug/index/rebuild/inverted/status", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		colName := r.URL.Query().Get("collection")
-		rootPath := appState.DB.GetConfig().RootPath
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		if colName == "" {
-			http.Error(w, "collection and shard are required", http.StatusBadRequest)
-			return
+		response := map[string]interface{}{
+			"BlockMax WAND": "unknown",
+			"status":        "unknown",
 		}
-		className := schema.ClassName(colName)
-		info := appState.SchemaManager.SchemaReader.ClassInfo(className.String())
-
-		classNameString := strings.ToLower(className.String())
-		idx := appState.DB.GetIndex(className)
-
-		if idx == nil {
-			logger.WithField("collection", colName).Error("collection not found or not ready")
-			http.Error(w, "collection not found or not ready", http.StatusNotFound)
-			return
-		}
-
-		blockMaxStatus := "not_ready"
-		blockMaxEnabled := idx.GetInvertedIndexConfig().UsingBlockMaxWAND
-		if blockMaxEnabled {
-			blockMaxStatus = "enabled"
-		}
-		// shard map: shardName -> shardPath
-		paths := make(map[string]string)
-
-		// shards will not be force loaded, as we are only getting the name
-		err := idx.ForEachShard(
-			func(shardName string, shard db.ShardLike) error {
-				shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
-				paths[shardName] = shardPath
-				return nil
-			},
-		)
-		if err != nil {
-			logger.WithField("collection", colName).Error("failed to get shard names")
-			http.Error(w, "failed to get shard names", http.StatusInternalServerError)
-			return
-		}
-
-		// tenant map: tenantName -> *models.TenantResponse
-		tenantMap := make(map[string]*models.Tenant)
-
-		if info.MultiTenancy.Enabled {
-
-			tenantResponses, err := appState.SchemaManager.GetConsistentTenants(ctx, nil, colName, true, []string{})
+		output := make(map[string]map[string]interface{})
+		func() {
+			rootPath := appState.DB.GetConfig().RootPath
+			colName := r.URL.Query().Get("collection")
+			className := schema.ClassName(colName)
+			classNameString, _, idx, err := parseIndexAndShards(appState, r)
 			if err != nil {
-				logger.WithField("collection", colName).Error("failed to get tenant responses")
-				http.Error(w, "failed to get tenant responses", http.StatusInternalServerError)
+				logger.WithError(err).Error("failed to parse index and shards")
+				response["status"] = "error"
+				response["error"] = err.Error()
 				return
 			}
 
-			for _, tenant := range tenantResponses {
-				tenantMap[tenant.Name] = tenant
+			response["BlockMax WAND"] = "not_ready"
+			blockMaxEnabled := idx.GetInvertedIndexConfig().UsingBlockMaxWAND
+			if blockMaxEnabled {
+				response["BlockMax WAND"] = "enabled"
 			}
-		} else {
-			for name := range paths {
-				tenantMap[name] = &models.Tenant{
-					Name: name,
+			// shard map: shardName -> shardPath
+			paths := make(map[string]string)
+
+			// shards will not be force loaded, as we are only getting the name
+			err = idx.ForEachShard(
+				func(shardName string, shard db.ShardLike) error {
+					shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
+					paths[shardName] = shardPath
+					output[shardName] = map[string]interface{}{
+						"shardStatus": shard.GetStatusNoLoad().String(),
+						"status":      "unknown",
+					}
+					return nil
+				},
+			)
+			if err != nil {
+				logger.WithField("collection", colName).Error("failed to get shard names")
+				response["status"] = "error"
+				response["error"] = err.Error()
+				return
+			}
+
+			// tenant map: tenantName -> *models.TenantResponse
+			tenantMap := make(map[string]*models.Tenant)
+
+			info := appState.SchemaManager.SchemaReader.ClassInfo(className.String())
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if info.MultiTenancy.Enabled {
+
+				tenantResponses, err := appState.SchemaManager.GetConsistentTenants(ctx, nil, colName, true, []string{})
+				if err != nil {
+					logger.WithField("collection", colName).Error("failed to get tenant responses")
+					response["status"] = "error"
+					response["error"] = err.Error()
+					return
+				}
+
+				for _, tenant := range tenantResponses {
+					tenantMap[tenant.Name] = tenant
+				}
+			} else {
+				for name := range paths {
+					tenantMap[name] = &models.Tenant{
+						Name: name,
+					}
 				}
 			}
-		}
 
-		if len(tenantMap) == 0 {
-			http.Error(w, "no shards or tenants found", http.StatusNotFound)
+			if len(tenantMap) == 0 {
+				logger.WithField("collection", colName).Error("no tenants found")
+				response["status"] = "error"
+				response["error"] = "no tenants found"
+				return
+			}
+
+			for i, tenant := range tenantMap {
+				path := paths[tenant.Name]
+
+				if path == "" {
+					output[i]["status"] = "shard_not_loaded"
+					output[i]["message"] = "shard not loaded"
+					output[i]["action"] = "load shard or activate tenant"
+					continue
+				}
+				// check if the shard directory exists
+				_, err := os.Stat(path)
+				if err != nil {
+					output[i]["status"] = "shard_not_loaded"
+					output[i]["message"] = "shard directory does not exist"
+					output[i]["action"] = "load shard or activate tenant"
+					continue
+				}
+
+				// check if a .migrations/searchable_map_to_blockmax exists
+				_, err = os.Stat(path + ".migrations/searchable_map_to_blockmax")
+				if err != nil {
+					output[i]["status"] = "not_started"
+					output[i]["message"] = "no searchable_map_to_blockmax folder found"
+					output[i]["action"] = "enable relevant REINDEX_MAP_TO_BLOCKMAX_* env vars"
+					continue
+				}
+
+				keyParser := &db.UuidKeyParser{}
+				rt := db.NewFileMapToBlockmaxReindexTracker(path, keyParser)
+
+				status, message, action := rt.GetStatusStrings()
+
+				if appState.ServerConfig.Config.ReindexMapToBlockmaxConfig.ConditionalStart && !rt.HasStartCondition() {
+					message = "reindexing not started, no start condition file found"
+					status = "not_started"
+					action = "call /start?collection=<> endpoint to start reindexing"
+				}
+
+				output[i]["status"] = status
+				output[i]["message"] = message
+				output[i]["action"] = action
+
+				properties, _ := rt.GetProps()
+				if properties != nil {
+					output[i]["properties"] = properties
+				}
+				output[i]["times"] = rt.GetTimes()
+
+				migratedCount, snapshots, _ := rt.GetMigratedCount()
+
+				output[i]["migratedCount"] = fmt.Sprintf("%d", migratedCount)
+				output[i]["snapshotCount"] = fmt.Sprintf("%d", len(snapshots))
+				output[i]["snapshots"] = snapshots
+
+			}
+			response["status"] = "success"
+		}()
+
+		response["shards"] = output
+		jsonBytes, err := json.Marshal(response)
+		if err != nil {
+			logger.WithError(err).Error("marshal failed on stats")
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		output := make(map[string]map[string]string, len(paths))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonBytes)
+	}))
 
-		for i, tenant := range tenantMap {
-			output[i] = map[string]string{
-				"shard":  i,
-				"status": "unknown",
-			}
-			path := paths[tenant.Name]
-			if path == "" {
-				output[i]["status"] = "shard_not_loaded"
-				output[i]["message"] = "shard not loaded"
-				continue
-			}
+	http.HandleFunc("/debug/index/rebuild/inverted/overrides", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{}
 
-			// check if the shard directory exists
-			_, err := os.Stat(path)
+		func() {
+			classNameString, shardsToMigrate, idx, err := parseIndexAndShards(appState, r)
 			if err != nil {
-				output[i]["status"] = "shard_not_loaded"
-				output[i]["message"] = "shard directory does not exist"
-				continue
+				logger.WithError(err).Error("failed to parse index and shards")
+				response["error"] = err.Error()
+				return
 			}
 
-			// check if a .migrations/searchable_map_to_blockmax exists
-			_, err = os.Stat(path + ".migrations/searchable_map_to_blockmax")
-			if err != nil {
-				output[i]["status"] = "not_started"
-				output[i]["message"] = "no searchable_map_to_blockmax folder found"
-				continue
-			}
+			rootPath := appState.DB.GetConfig().RootPath
+			err = idx.ForEachShard(
+				func(shardName string, shard db.ShardLike) error {
+					if len(shardsToMigrate) == 0 || slices.Contains(shardsToMigrate, shardName) {
+						shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
+						_, err := os.Stat(shardPath + ".migrations/searchable_map_to_blockmax")
+						if err != nil {
+							return fmt.Errorf("shard not found or not ready")
+						}
+						filename := "overrides.mig"
+						_, err = os.Stat(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+						if err != nil {
+							response[shardName] = map[string]string{
+								"status":    "not found",
+								"overrides": "no overrides.mig file found",
+							}
+							return nil
+						}
+						// read the overrides.mig file
+						file, err := os.ReadFile(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+						if err != nil {
+							return fmt.Errorf("failed to read %s in shard %s: %w", filename, shardName, err)
+						}
+						// parse the file content
+						lines := strings.Split(string(file), "\n")
+						overrides := make(map[string]string)
+						for _, line := range lines {
+							line = strings.TrimSpace(line)
+							if line == "" || strings.HasPrefix(line, "#") {
+								continue // skip empty lines and comments
+							}
+							parts := strings.SplitN(line, "=", 2)
+							if len(parts) != 2 {
+								return fmt.Errorf("invalid override format in %s: %s", filename, line)
+							}
+							key := strings.TrimSpace(parts[0])
+							value := strings.TrimSpace(parts[1])
+							overrides[key] = value
+						}
 
-			path += ".migrations/searchable_map_to_blockmax/"
-			// check if started.mig exists
-			_, err = os.Stat(path + "started.mig")
-			if err != nil {
-				output[i]["status"] = "not_started"
-				output[i]["message"] = "no started.mig found"
-				continue
-			}
-			// load the started.mig file and add it's value to the output
-			startedFile, err := os.ReadFile(path + "started.mig")
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read started.mig"
-				continue
-			}
-			output[i]["status"] = "started"
-			output[i]["start_time"] = string(startedFile)
-
-			// check if the properties.mig file exists
-			_, err = os.Stat(path + "properties.mig")
-			if err != nil {
-				output[i]["message"] = "computing properties to reindex"
-				continue
-			}
-
-			// load the properties.mig file and add it's value to the output
-			propertiesFile, err := os.ReadFile(path + "properties.mig")
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read properties.mig"
-				continue
-			}
-
-			output[i]["properties"] = string(propertiesFile)
-			output[i]["message"] = "re-indexing started"
-
-			// count the progress.mig.* files in the shard directory
-			files, err := os.ReadDir(path)
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read shard directory"
-				continue
-			}
-			progressCount := 0
-			objectsMigratedCountTotal := 0
-
-			// files sorted by filename
-
-			for _, file := range files {
-				if strings.HasPrefix(file.Name(), "progress.mig.") {
-					progressCount++
-					// open progress file
-
-					progressFilePath := path + file.Name()
-					progressFile, err := os.ReadFile(progressFilePath)
-					if err != nil {
-						output[i]["status"] = "error"
-						output[i]["message"] = fmt.Sprintf("failed to read %s", progressFilePath)
-						continue
+						response[shardName] = map[string]interface{}{
+							"status":    "success",
+							"overrides": overrides,
+						}
 					}
-
-					// parse progress file
-					progressFileFields := strings.Split(string(progressFile), "\n")
-					if len(progressFileFields) != 4 {
-						output[i]["status"] = "error"
-						output[i]["message"] = fmt.Sprintf("invalid progress file %s", progressFilePath)
-						continue
-					}
-					// parse objects migrated count
-					objectsMigratedCount, err := strconv.Atoi(strings.Split(progressFileFields[3], " ")[1])
-					if err != nil {
-						output[i]["status"] = "error"
-						output[i]["message"] = fmt.Sprintf("failed to parse objects migrated count %s", progressFilePath)
-						continue
-					}
-					objectsMigratedCountTotal += objectsMigratedCount
-					output[i]["objects_migrated"] = fmt.Sprintf("%d", objectsMigratedCountTotal)
-				}
-			}
-			if progressCount == 0 {
-				output[i]["message"] = "migration started recently, no snapshots yet"
-				continue
-			}
-
-			// load latest progress.mig.* file and add it's value to the output
-			progressFile, err := os.ReadFile(path + fmt.Sprintf("progress.mig.%09d", progressCount))
+					return nil
+				},
+			)
 			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = fmt.Sprintf("failed to read progress.mig.%09d", progressCount)
-				continue
+				logger.WithField("collection", classNameString).WithField("shards", shardsToMigrate).WithError(err).Error("failed to iterate over shards")
+				response["error"] = err.Error()
+				return
 			}
+		}()
 
-			output[i]["latest_snapshot"] = strings.Join(strings.Split(string(progressFile), "\n"), ", ")
-
-			output[i]["status"] = "in progress"
-			output[i]["snapshot_count"] = fmt.Sprintf("%d", progressCount)
-
-			// check if reindexed.mig exists
-			_, err = os.Stat(path + "reindexed.mig")
-			if err == nil {
-				output[i]["status"] = "reindexed"
-				output[i]["message"] = "reindexing done"
-			} else {
-				continue
-			}
-
-			// load the reindexed.mig file and add it's value to the output
-			reindexedFile, err := os.ReadFile(path + "reindexed.mig")
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read reindexed.mig"
-				continue
-			}
-			output[i]["reindexed"] = strings.Join(strings.Split(string(reindexedFile), "\n"), ", ")
-
-			// check if merged.mig exists
-			_, err = os.Stat(path + "merged.mig")
-			if err != nil {
-				output[i]["message"] = "reindexing done, merging buckets"
-				continue
-			}
-
-			output[i]["status"] = "merged"
-			output[i]["message"] = "merged reindex and ingest buckets"
-
-			// load the merged.mig file and add it's value to the output
-			mergedFile, err := os.ReadFile(path + "merged.mig")
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read merged.mig"
-				continue
-			}
-			output[i]["merged"] = string(mergedFile)
-
-			// check if swapped.mig.* exists
-			swappedFiles, err := os.ReadDir(path)
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read shard directory"
-				continue
-			}
-			swappedCount := 0
-			for _, file := range swappedFiles {
-				if strings.HasPrefix(file.Name(), "swapped.mig.") {
-					swappedCount++
-				}
-			}
-
-			if swappedCount > 0 {
-				output[i]["status"] = "swapped"
-				output[i]["message"] = fmt.Sprintf("swapped %d files", swappedCount)
-			}
-
-			// check if swapped.mig exists
-			_, err = os.Stat(path + "swapped.mig")
-			if err != nil {
-				output[i]["message"] = "reindexing done, buckets not swapped yet"
-				continue
-			}
-
-			output[i]["status"] = "swapped"
-			output[i]["message"] = "swapped buckets"
-
-			// load the swapped.mig file and add it's value to the output
-			swappedFile, err := os.ReadFile(path + "swapped.mig")
-			if err != nil {
-				output[i]["status"] = "error"
-				output[i]["message"] = "failed to read swapped.mig"
-				continue
-			}
-			output[i]["swapped"] = string(swappedFile)
-			output[i]["message"] = "reindexing done"
-			output[i]["status"] = "done"
-
+		jsonBytes, err := json.Marshal(response)
+		if err != nil {
+			logger.WithError(err).Error("marshal failed on stats")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 
-		response := map[string]interface{}{
-			"shards":        output,
-			"BlockMax WAND": blockMaxStatus,
-		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonBytes)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/set_overrides", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{}
+
+		clear := config.Enabled(r.URL.Query().Get("clear"))
+		func() {
+			classNameString, shardsToMigrate, idx, err := parseIndexAndShards(appState, r)
+			if err != nil {
+				logger.WithError(err).Error("failed to parse index and shards")
+				response["error"] = err.Error()
+				return
+			}
+
+			rootPath := appState.DB.GetConfig().RootPath
+			err = idx.ForEachShard(
+				func(shardName string, shard db.ShardLike) error {
+					if len(shardsToMigrate) == 0 || slices.Contains(shardsToMigrate, shardName) {
+						shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
+						_, err := os.Stat(shardPath + ".migrations/searchable_map_to_blockmax")
+						if err != nil {
+							return fmt.Errorf("shard not found or not ready")
+						}
+						filename := "overrides.mig"
+						// open file for writing
+						filePath := shardPath + ".migrations/searchable_map_to_blockmax/" + filename
+						if clear {
+							err := os.Remove(filePath)
+							if err != nil && !os.IsNotExist(err) {
+								return fmt.Errorf("failed to clear %s in shard %s: %w", filename, shardName, err)
+							}
+						}
+						file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+						if err != nil {
+							return fmt.Errorf("failed to open %s in shard %s: %w", filename, shardName, err)
+						}
+						defer file.Close()
+						// get overrides from query params
+						overridesURL := r.URL.Query()
+						overrides := make(map[string][]string)
+						for key, values := range overridesURL {
+							if key == "clear" || key == "collection" || key == "shards" {
+								continue
+							}
+							for _, value := range values {
+								overrides[key] = append(overrides[key], value)
+								_, err := file.WriteString(fmt.Sprintf("%s=%s\n", key, value))
+								if err != nil {
+									return fmt.Errorf("failed to write to %s in shard %s: %w", filename, shardName, err)
+								}
+							}
+						}
+
+						response[shardName] = map[string]interface{}{
+							"status": "success",
+							"wrote":  overrides,
+						}
+					}
+					return nil
+				},
+			)
+			if err != nil {
+				logger.WithField("collection", classNameString).WithField("shards", shardsToMigrate).WithError(err).Error("failed to iterate over shards")
+				response["error"] = err.Error()
+				return
+			}
+		}()
 
 		jsonBytes, err := json.Marshal(response)
 		if err != nil {

--- a/adapters/handlers/rest/handlers_debug_bmw_aux.go
+++ b/adapters/handlers/rest/handlers_debug_bmw_aux.go
@@ -1,0 +1,129 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func parseIndexAndShards(appState *state.State, r *http.Request) (string, []string, *db.Index, error) {
+	colName := r.URL.Query().Get("collection")
+	if colName == "" {
+		return "", nil, nil, fmt.Errorf("collection is required")
+	}
+
+	shardsToMigrateString := r.URL.Query().Get("shards")
+	shardsToMigrate := strings.Split(shardsToMigrateString, ",")[1:]
+
+	className := schema.ClassName(colName)
+	classNameString := strings.ToLower(className.String())
+	idx := appState.DB.GetIndex(className)
+
+	if idx == nil {
+		return "", nil, nil, fmt.Errorf("collection not found or not ready")
+	}
+
+	return classNameString, shardsToMigrate, idx, nil
+}
+
+func changeFile(filename string, delete bool, logger *logrus.Entry, appState *state.State, r *http.Request, w http.ResponseWriter) {
+	response := map[string]interface{}{}
+
+	func() {
+		classNameString, shardsToMigrate, idx, err := parseIndexAndShards(appState, r)
+		if err != nil {
+			logger.WithError(err).Error("failed to parse index and shards")
+			response["error"] = err.Error()
+			return
+		}
+
+		rootPath := appState.DB.GetConfig().RootPath
+		err = idx.ForEachShard(
+			func(shardName string, shard db.ShardLike) error {
+				alreadyDid := false
+				if len(shardsToMigrate) == 0 || slices.Contains(shardsToMigrate, shardName) {
+					shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
+					_, err := os.Stat(shardPath + ".migrations/searchable_map_to_blockmax")
+					if err != nil {
+						return fmt.Errorf("shard not found or not ready")
+					}
+					if delete {
+						err = os.Remove(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+						if os.IsNotExist(err) {
+							alreadyDid = true
+						} else if err != nil {
+							return fmt.Errorf("failed to delete %s: %w", filename, err)
+						}
+					} else {
+						// check if the file already exists
+						_, err = os.Stat(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+						if err == nil {
+							alreadyDid = true
+						} else {
+							file, err := os.Create(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+							if os.IsExist(err) {
+								alreadyDid = true
+							} else if err != nil {
+								return fmt.Errorf("failed to create %s: %w", filename, err)
+							}
+							defer file.Close()
+						}
+					}
+
+				}
+				response[shardName] = map[string]string{
+					"status": "success",
+					"message": fmt.Sprintf("file %s %s in shard %s", filename,
+						func() string {
+							if delete {
+								if alreadyDid {
+									return "already deleted"
+								}
+								return "deleted"
+							} else {
+								if alreadyDid {
+									return "already created"
+								}
+							}
+							return "created"
+						}(), shardName),
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			logger.WithField("collection", classNameString).WithField("shards", shardsToMigrate).WithError(err).Error("failed to iterate over shards")
+			response["error"] = err.Error()
+			return
+		}
+	}()
+
+	jsonBytes, err := json.Marshal(response)
+	if err != nil {
+		logger.WithError(err).Error("marshal failed on stats")
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonBytes)
+}

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/additional"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -41,12 +42,12 @@ func NewShardInvertedReindexTaskMapToBlockmax(logger logrus.FieldLogger,
 	cptSelected []config.CollectionPropsTenants, schemaManager *schema.Manager,
 ) *ShardReindexTask_MapToBlockmax {
 	name := "MapToBlockmax"
-	keyParser := &uuidKeyParser{}
+	keyParser := &UuidKeyParser{}
 	objectsIteratorAsync := uuidObjectsIteratorAsync
 
 	logger = logger.WithField("task", name)
 	newReindexTracker := func(lsmPath string) (mapToBlockmaxReindexTracker, error) {
-		rt := newFileMapToBlockmaxReindexTracker(lsmPath, keyParser)
+		rt := NewFileMapToBlockmaxReindexTracker(lsmPath, keyParser)
 		if err := rt.init(); err != nil {
 			return nil, err
 		}
@@ -94,6 +95,7 @@ func NewShardInvertedReindexTaskMapToBlockmax(logger logrus.FieldLogger,
 		selectionEnabled:              selectionEnabled,
 		selectedPropsByCollection:     selectedPropsByCollection,
 		selectedShardsByCollection:    selectedShardsByCollection,
+		perObjectDelay:                0 * time.Millisecond,
 	}
 
 	logger.WithField("config", fmt.Sprintf("%+v", config)).Debug("task created")
@@ -130,6 +132,7 @@ type mapToBlockmaxConfig struct {
 	memtableOptBlockmaxFactor     int
 	processingDuration            time.Duration
 	pauseDuration                 time.Duration
+	perObjectDelay                time.Duration
 	checkProcessingEveryNoObjects int
 	selectionEnabled              bool
 	selectedPropsByCollection     map[string]map[string]struct{}
@@ -169,7 +172,14 @@ func (t *ShardReindexTask_MapToBlockmax) OnBeforeLsmInit(ctx context.Context, sh
 		return
 	}
 
-	if t.config.conditionalStart && !rt.hasStartCondition() {
+	rt.checkOverrides(logger, &t.config)
+
+	if rt.IsRollback() {
+		// make it so it "survives" the rt.reset()
+		t.config.rollback = true
+	}
+
+	if t.config.conditionalStart && !rt.HasStartCondition() {
 		err = fmt.Errorf("conditional start is set, but file trigger is not found")
 		return
 	}
@@ -181,13 +191,13 @@ func (t *ShardReindexTask_MapToBlockmax) OnBeforeLsmInit(ctx context.Context, sh
 	}
 
 	if t.config.rollback {
-		logger.Debug("rollback started")
+		logger.Debugf("rollback started: config=%v, runtime=%v", t.config.rollback, rt.IsRollback())
 
-		if rt.isTidied() {
+		if rt.IsTidied() {
 			err = fmt.Errorf("rollback: searchable map buckets are deleted, can not restore")
 			return
 		}
-		if rt.isSwapped() {
+		if rt.IsSwapped() {
 			if err = t.unswapIngestAndMapBuckets(ctx, logger, shard, rt, props); err != nil {
 				err = fmt.Errorf("rollback: unswapping buckets: %w", err)
 				return
@@ -220,8 +230,8 @@ func (t *ShardReindexTask_MapToBlockmax) OnBeforeLsmInit(ctx context.Context, sh
 		return
 	}
 
-	isMerged := rt.isMerged()
-	if !isMerged && rt.isReindexed() {
+	isMerged := rt.IsMerged()
+	if !isMerged && rt.IsReindexed() {
 		logger.Debug("reindexed, not merged. merging buckets")
 
 		if err = t.mergeReindexAndIngestBuckets(ctx, logger, shard, rt, props); err != nil {
@@ -236,8 +246,8 @@ func (t *ShardReindexTask_MapToBlockmax) OnBeforeLsmInit(ctx context.Context, sh
 		return
 	}
 
-	isSwapped := rt.isSwapped()
-	isTidied := rt.isTidied()
+	isSwapped := rt.IsSwapped()
+	isTidied := rt.IsTidied()
 	if isMerged {
 		if isSwapped {
 			if t.config.unswapBuckets {
@@ -323,12 +333,19 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInit(ctx context.Context, sha
 		return
 	}
 
-	if t.config.conditionalStart && !rt.hasStartCondition() {
+	rt.checkOverrides(logger, &t.config)
+
+	if rt.IsRollback() {
+		logger.Debug("rollback. nothing to do")
+		return
+	}
+
+	if t.config.conditionalStart && !rt.HasStartCondition() {
 		err = fmt.Errorf("conditional start is set, but file trigger is not found")
 		return
 	}
 
-	isStarted := rt.isStarted()
+	isStarted := rt.IsStarted()
 	if !isStarted && !isShardSelected {
 		logger.Debug("different collection/shard selected. nothing to do")
 		return nil
@@ -352,8 +369,8 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInit(ctx context.Context, sha
 		}
 	}
 
-	if rt.isSwapped() {
-		if !rt.isTidied() {
+	if rt.IsSwapped() {
+		if !rt.IsTidied() {
 			logger.Debug("swapped, not tidied. starting map buckets")
 
 			if err = t.loadMapSearchBuckets(ctx, logger, shard, props); err != nil {
@@ -366,11 +383,11 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInit(ctx context.Context, sha
 			}
 		}
 	} else {
-		isMerged := rt.isMerged()
+		isMerged := rt.IsMerged()
 		if isMerged {
 			logger.Debug("merged, not swapped. starting ingest buckets")
 		} else {
-			if !rt.isReindexed() {
+			if !rt.IsReindexed() {
 				logger.Debug("not reindexed. starting reindex buckets")
 
 				if err = t.loadReindexSearchBuckets(ctx, logger, shard, props); err != nil {
@@ -425,18 +442,50 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 		return zerotime, false, nil
 	}
 
-	if t.config.rollback {
-		logger.Debug("rollback. nothing to do")
-		return zerotime, false, nil
-	}
-
 	rt, err := t.newReindexTracker(shard.pathLSM())
 	if err != nil {
 		err = fmt.Errorf("creating reindex tracker: %w", err)
 		return zerotime, false, err
 	}
 
-	if t.config.conditionalStart && !rt.hasStartCondition() {
+	rt.checkOverrides(logger, &t.config)
+
+	// rollback initiated by the user after restart, stop double writes
+	if rt.IsRollback() {
+		logger.Debug("rollback started")
+		props, err2 := t.readPropsToReindex(rt)
+		if err2 != nil {
+			err = fmt.Errorf("reading reindexable props for rollback: %w", err2)
+			return zerotime, false, err
+		}
+		err = nil
+
+		if !rt.IsSwapped() {
+			err = t.unloadReindexBuckets(ctx, logger, shard, props)
+			if err != nil {
+				err = fmt.Errorf("unloading reindex buckets: %w", err)
+				return zerotime, false, err
+			}
+			logger.Info("reindex buckets unloaded")
+			err = t.unloadIngestBuckets(ctx, logger, shard, props)
+			if err != nil {
+				err = fmt.Errorf("unloading ingest buckets: %w", err)
+				return zerotime, false, err
+			}
+			logger.Info("ingest buckets unloaded")
+		} else {
+			logger.Warnf("inverted bucket is being used for search, will not be unloaded: %s. Rollback will proceed on restart", shard.Name())
+		}
+		// return early to stop ingestion
+		return zerotime, false, nil
+	}
+
+	if t.config.rollback {
+		logger.Debug("rollback. nothing to do")
+		return zerotime, false, nil
+	}
+
+	if t.config.conditionalStart && !rt.HasStartCondition() {
 		err = fmt.Errorf("conditional start is set, but file trigger is not found")
 		return zerotime, false, err
 	}
@@ -447,7 +496,12 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 		return zerotime, false, err
 	}
 
-	if rt.isTidied() {
+	if rt.IsPaused() {
+		logger.Debug("paused. waiting for resuming")
+		return time.Now().Add(t.config.pauseDuration), false, nil
+	}
+
+	if rt.IsTidied() {
 		err = updateToBlockMaxInvertedIndexConfig(ctx, t.schemaManager, shard.Index().Config.ClassName.String())
 		if err != nil {
 			err = fmt.Errorf("updating inverted index config: %w", err)
@@ -460,13 +514,13 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 		return zerotime, false, nil
 	}
 
-	if rt.isReindexed() {
+	if rt.IsReindexed() {
 		logger.Debug("reindexed. nothing to do")
 		return zerotime, false, nil
 	}
 
 	var reindexStarted time.Time
-	if !rt.isStarted() {
+	if !rt.IsStarted() {
 		err = fmt.Errorf("missing reindex started")
 		return zerotime, false, err
 	} else if reindexStarted, err = rt.getStarted(); err != nil {
@@ -475,7 +529,7 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 	}
 
 	var lastStoredKey indexKey
-	if lastStoredKey, err = rt.getProgress(); err != nil {
+	if lastStoredKey, _, err = rt.GetProgress(); err != nil {
 		err = fmt.Errorf("getting reindex progress: %w", err)
 		return zerotime, false, err
 	}
@@ -547,9 +601,8 @@ func (t *ShardReindexTask_MapToBlockmax) OnAfterLsmInitAsync(ctx context.Context
 			processedCount++
 			lastProcessedKey = md.key
 
-			// check execution time every X objects processed to close the cursor and pause shard's migration
-			breakCh <- processedCount%t.config.checkProcessingEveryNoObjects == 0 &&
-				time.Since(processingStarted) > t.config.processingDuration
+			breakCh <- processedCount%t.config.checkProcessingEveryNoObjects == 0 && (time.Since(processingStarted) > t.config.processingDuration || rt.IsPaused())
+			time.Sleep(t.config.perObjectDelay)
 		}
 	}
 	if !bytes.Equal(lastStoredKey.Bytes(), lastProcessedKey.Bytes()) {
@@ -695,7 +748,7 @@ func (t *ShardReindexTask_MapToBlockmax) swapIngestAndMapBuckets(ctx context.Con
 	for i := range props {
 		propName := props[i]
 
-		if !rt.isSwappedProp(props[i]) {
+		if !rt.IsSwappedProp(props[i]) {
 			eg.Go(func() error {
 				bucketName := helpers.BucketSearchableFromPropNameLSM(propName)
 				bucketPath := filepath.Join(lsmPath, bucketName)
@@ -745,7 +798,7 @@ func (t *ShardReindexTask_MapToBlockmax) unswapIngestAndMapBuckets(ctx context.C
 	for i := range props {
 		propName := props[i]
 
-		if rt.isSwappedProp(props[i]) {
+		if rt.IsSwappedProp(props[i]) {
 			eg.Go(func() error {
 				bucketName := helpers.BucketSearchableFromPropNameLSM(propName)
 				bucketPath := filepath.Join(lsmPath, bucketName)
@@ -851,6 +904,45 @@ func (t *ShardReindexTask_MapToBlockmax) loadBuckets(ctx context.Context,
 			bucketName := bucketNamer(propName)
 			logger.WithField("bucket", bucketName).Debug("loading bucket")
 			if err := store.CreateOrLoadBucket(gctx, bucketName, bucketOpts...); err != nil {
+				return err
+			}
+			logger.WithField("bucket", bucketName).Debug("bucket loaded")
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ShardReindexTask_MapToBlockmax) unloadIngestBuckets(ctx context.Context,
+	logger logrus.FieldLogger, shard ShardLike, props []string,
+) error {
+	return t.unloadBuckets(ctx, logger, shard, props, t.ingestBucketName)
+}
+
+func (t *ShardReindexTask_MapToBlockmax) unloadReindexBuckets(ctx context.Context,
+	logger logrus.FieldLogger, shard ShardLike, props []string,
+) error {
+	return t.unloadBuckets(ctx, logger, shard, props, t.reindexBucketName)
+}
+
+func (t *ShardReindexTask_MapToBlockmax) unloadBuckets(ctx context.Context,
+	logger logrus.FieldLogger, shard ShardLike, props []string, bucketNamer func(string) string,
+) error {
+	store := shard.Store()
+
+	eg, gctx := enterrors.NewErrorGroupWithContextWrapper(logger, ctx)
+	eg.SetLimit(t.config.concurrency)
+	for i := range props {
+		propName := props[i]
+
+		eg.Go(func() error {
+			bucketName := bucketNamer(propName)
+			logger.WithField("bucket", bucketName).Debug("loading bucket")
+			if err := store.ShutdownBucket(gctx, bucketName); err != nil {
 				return err
 			}
 			logger.WithField("bucket", bucketName).Debug("bucket loaded")
@@ -1071,8 +1163,8 @@ func (t *ShardReindexTask_MapToBlockmax) findPropsToReindex(shard ShardLike) (pr
 }
 
 func (t *ShardReindexTask_MapToBlockmax) getPropsToReindex(shard ShardLike, rt mapToBlockmaxReindexTracker) ([]string, error) {
-	if rt.hasProps() {
-		props, err := rt.getProps()
+	if rt.HasProps() {
+		props, err := rt.GetProps()
 		if err != nil {
 			return nil, err
 		}
@@ -1088,8 +1180,8 @@ func (t *ShardReindexTask_MapToBlockmax) getPropsToReindex(shard ShardLike, rt m
 }
 
 func (t *ShardReindexTask_MapToBlockmax) readPropsToReindex(rt mapToBlockmaxReindexTracker) ([]string, error) {
-	if rt.hasProps() {
-		props, err := rt.getProps()
+	if rt.HasProps() {
+		props, err := rt.GetProps()
 		if err != nil {
 			return nil, err
 		}
@@ -1189,38 +1281,43 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 // -----------------------------------------------------------------------------
 
 type mapToBlockmaxReindexTracker interface {
-	hasStartCondition() bool
-	isStarted() bool
+	HasStartCondition() bool
+	IsStarted() bool
 	markStarted(time.Time) error
 	getStarted() (time.Time, error)
 
 	markProgress(lastProcessedKey indexKey, processedCount, indexedCount int) error
-	getProgress() (indexKey, error)
+	GetProgress() (indexKey, *time.Time, error)
 
-	isReindexed() bool
+	IsReindexed() bool
 	markReindexed() error
 
-	isMerged() bool
+	IsMerged() bool
 	markMerged() error
 
-	isSwapped() bool
+	IsSwapped() bool
 	markSwapped() error
 	unmarkSwapped() error
-	isSwappedProp(propName string) bool
+	IsSwappedProp(propName string) bool
 	markSwappedProp(propName string) error
 	unmarkSwappedProp(propName string) error
 
-	isTidied() bool
+	IsTidied() bool
 	markTidied() error
 
-	hasProps() bool
-	getProps() ([]string, error)
+	HasProps() bool
+	GetProps() ([]string, error)
 	saveProps([]string) error
 
+	IsPaused() bool
+	IsRollback() bool
+
 	reset() error
+
+	checkOverrides(logger logrus.FieldLogger, config *mapToBlockmaxConfig)
 }
 
-func newFileMapToBlockmaxReindexTracker(lsmPath string, keyParser indexKeyParser) *fileMapToBlockmaxReindexTracker {
+func NewFileMapToBlockmaxReindexTracker(lsmPath string, keyParser indexKeyParser) *fileMapToBlockmaxReindexTracker {
 	return &fileMapToBlockmaxReindexTracker{
 		progressCheckpoint: 1,
 		keyParser:          keyParser,
@@ -1233,6 +1330,9 @@ func newFileMapToBlockmaxReindexTracker(lsmPath string, keyParser indexKeyParser
 			filenameSwapped:    "swapped.mig",
 			filenameTidied:     "tidied.mig",
 			filenameProperties: "properties.mig",
+			filenameRollback:   "rollback.mig",
+			filenamePaused:     "paused.mig",
+			filenameOverrides:  "overrides.mig",
 			migrationPath:      filepath.Join(lsmPath, ".migrations", "searchable_map_to_blockmax"),
 		},
 	}
@@ -1253,6 +1353,9 @@ type fileReindexTrackerConfig struct {
 	filenameSwapped    string
 	filenameTidied     string
 	filenameProperties string
+	filenameRollback   string
+	filenamePaused     string
+	filenameOverrides  string
 	migrationPath      string
 }
 
@@ -1263,11 +1366,11 @@ func (t *fileMapToBlockmaxReindexTracker) init() error {
 	return nil
 }
 
-func (t *fileMapToBlockmaxReindexTracker) hasStartCondition() bool {
+func (t *fileMapToBlockmaxReindexTracker) HasStartCondition() bool {
 	return t.fileExists(t.config.filenameStart)
 }
 
-func (t *fileMapToBlockmaxReindexTracker) isStarted() bool {
+func (t *fileMapToBlockmaxReindexTracker) IsStarted() bool {
 	return t.fileExists(t.config.filenameStarted)
 }
 
@@ -1275,13 +1378,17 @@ func (t *fileMapToBlockmaxReindexTracker) markStarted(started time.Time) error {
 	return t.createFile(t.config.filenameStarted, []byte(t.encodeTime(started)))
 }
 
-func (t *fileMapToBlockmaxReindexTracker) getStarted() (time.Time, error) {
-	path := t.filepath(t.config.filenameStarted)
+func (t *fileMapToBlockmaxReindexTracker) getTime(filePath string) (time.Time, error) {
+	path := t.filepath(filePath)
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return time.Time{}, err
 	}
 	return t.decodeTime(string(content))
+}
+
+func (t *fileMapToBlockmaxReindexTracker) getStarted() (time.Time, error) {
+	return t.getTime(t.config.filenameStarted)
 }
 
 func (t *fileMapToBlockmaxReindexTracker) findLastProgressFile() (string, error) {
@@ -1321,37 +1428,139 @@ func (t *fileMapToBlockmaxReindexTracker) markProgress(lastProcessedKey indexKey
 	return nil
 }
 
-func (t *fileMapToBlockmaxReindexTracker) getProgress() (indexKey, error) {
+func (t *fileMapToBlockmaxReindexTracker) GetProgress() (indexKey, *time.Time, error) {
 	filename, err := t.findLastProgressFile()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if filename == "" {
-		return t.keyParser.FromBytes(nil), nil
+		return t.keyParser.FromBytes(nil), nil, nil
 	}
 
 	checkpoint, err := strconv.Atoi(strings.TrimPrefix(filename, t.config.filenameProgress+"."))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	path := t.filepath(filename)
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	split := strings.Split(string(content), "\n")
 	key, err := t.keyParser.FromString(split[1])
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	timeStr := strings.TrimSpace(split[0])
+	if timeStr == "" {
+		return key, nil, fmt.Errorf("progress file '%s' is empty", filename)
+	}
+
+	tm, err := t.decodeTime(timeStr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decoding time from '%s': %w", timeStr, err)
 	}
 
 	t.progressCheckpoint = checkpoint + 1
-	return key, nil
+	return key, &tm, nil
 }
 
-func (t *fileMapToBlockmaxReindexTracker) isReindexed() bool {
+func (t *fileMapToBlockmaxReindexTracker) parseProgressFile(filename string) (lastProcessedKey indexKey, tm time.Time, allCount int, idxCount int, err error) {
+	// open progress file
+	/*
+		2025-06-26T19:05:12.473157Z
+		57849825-b584-4d8d-8da5-a86be7fd1207
+		all 145
+		idx 145
+	*/
+	progressFilePath := filename
+	progressFile, err := os.ReadFile(progressFilePath)
+	if err != nil {
+		err = fmt.Errorf("failed to read %s: %w", progressFilePath, err)
+		return
+	}
+	// check if the file is empty
+	if len(progressFile) == 0 {
+		err = fmt.Errorf("progress file %s is empty", progressFilePath)
+		return
+	}
+
+	// parse progress file
+	progressFileFields := strings.Split(string(progressFile), "\n")
+	if len(progressFileFields) != 4 {
+		err = fmt.Errorf("progress file %s has unexpected format, expected 4 lines, got %d", progressFilePath, len(progressFileFields))
+		return
+	}
+
+	// timestamp parsing
+	tm, err = t.decodeTime(strings.TrimSpace(progressFileFields[0]))
+	if err != nil {
+		err = fmt.Errorf("failed to parse timestamp from %s: %w", progressFilePath, err)
+		return
+	}
+
+	// parse last processed key
+	lastProcessedKey, err = t.keyParser.FromString(progressFileFields[1])
+	if err != nil {
+		err = fmt.Errorf("failed to parse last processed key from %s: %w", progressFilePath, err)
+		return
+	}
+	// parse objects migrated count
+	allCount, err = strconv.Atoi(strings.Split(progressFileFields[2], " ")[1])
+	if err != nil {
+		err = fmt.Errorf("failed to parse objects migrated count from %s: %w", progressFilePath, err)
+		return
+	}
+	// parse index count
+	idxCount, err = strconv.Atoi(strings.Split(progressFileFields[3], " ")[1])
+	if err != nil {
+		err = fmt.Errorf("failed to parse index count from %s: %w", progressFilePath, err)
+		return
+	}
+
+	return
+}
+
+func (t *fileMapToBlockmaxReindexTracker) GetMigratedCount() (objectsMigratedCountTotal int, snapshots []map[string]string, err error) {
+	// count the progress.mig.* files in the shard directory
+	snapshots = make([]map[string]string, 0)
+	files, err := os.ReadDir(t.config.migrationPath)
+	objectsMigratedCountTotal = 0
+	progressCount := 0
+
+	if err != nil {
+		return
+	}
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "progress.mig.") {
+			snapshot := map[string]string{
+				"checkpoint": strings.TrimPrefix(file.Name(), "progress.mig."),
+			}
+			progressCount++
+			// open progress file
+
+			progressFilePath := t.config.migrationPath + "/" + file.Name()
+			key, tm, allCount, idxCount, err2 := t.parseProgressFile(progressFilePath)
+			if err2 != nil {
+				err = fmt.Errorf("failed to parse progress file %s: %w", progressFilePath, err2)
+				return
+			}
+
+			objectsMigratedCountTotal += allCount
+			snapshot["lastProcessedKey"] = key.String()
+			snapshot["timestamp"] = tm.Format(time.RFC3339)
+			snapshot["allCount"] = fmt.Sprintf("%d", allCount)
+			snapshot["idxCount"] = fmt.Sprintf("%d", idxCount)
+			snapshots = append(snapshots, snapshot)
+		}
+	}
+	return
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsReindexed() bool {
 	return t.fileExists(t.config.filenameReindexed)
 }
 
@@ -1359,7 +1568,11 @@ func (t *fileMapToBlockmaxReindexTracker) markReindexed() error {
 	return t.createFile(t.config.filenameReindexed, []byte(t.encodeTimeNow()))
 }
 
-func (t *fileMapToBlockmaxReindexTracker) isMerged() bool {
+func (t *fileMapToBlockmaxReindexTracker) getReindexed() (time.Time, error) {
+	return t.getTime(t.config.filenameReindexed)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsMerged() bool {
 	return t.fileExists(t.config.filenameMerged)
 }
 
@@ -1367,7 +1580,11 @@ func (t *fileMapToBlockmaxReindexTracker) markMerged() error {
 	return t.createFile(t.config.filenameMerged, []byte(t.encodeTimeNow()))
 }
 
-func (t *fileMapToBlockmaxReindexTracker) isSwappedProp(propName string) bool {
+func (t *fileMapToBlockmaxReindexTracker) getMerged() (time.Time, error) {
+	return t.getTime(t.config.filenameMerged)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsSwappedProp(propName string) bool {
 	return t.fileExists(t.config.filenameSwapped + "." + propName)
 }
 
@@ -1379,7 +1596,7 @@ func (t *fileMapToBlockmaxReindexTracker) unmarkSwappedProp(propName string) err
 	return t.removeFile(t.config.filenameSwapped + "." + propName)
 }
 
-func (t *fileMapToBlockmaxReindexTracker) isSwapped() bool {
+func (t *fileMapToBlockmaxReindexTracker) IsSwapped() bool {
 	return t.fileExists(t.config.filenameSwapped)
 }
 
@@ -1391,8 +1608,16 @@ func (t *fileMapToBlockmaxReindexTracker) unmarkSwapped() error {
 	return t.removeFile(t.config.filenameSwapped)
 }
 
-func (t *fileMapToBlockmaxReindexTracker) isTidied() bool {
+func (t *fileMapToBlockmaxReindexTracker) getSwapped() (time.Time, error) {
+	return t.getTime(t.config.filenameSwapped)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsTidied() bool {
 	return t.fileExists(t.config.filenameTidied)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) getTidied() (time.Time, error) {
+	return t.getTime(t.config.filenameTidied)
 }
 
 func (t *fileMapToBlockmaxReindexTracker) markTidied() error {
@@ -1448,7 +1673,7 @@ func (t *fileMapToBlockmaxReindexTracker) decodeTime(tm string) (time.Time, erro
 	return time.Parse(time.RFC3339Nano, tm)
 }
 
-func (t *fileMapToBlockmaxReindexTracker) hasProps() bool {
+func (t *fileMapToBlockmaxReindexTracker) HasProps() bool {
 	return t.fileExists(t.config.filenameProperties)
 }
 
@@ -1457,7 +1682,7 @@ func (t *fileMapToBlockmaxReindexTracker) saveProps(propNames []string) error {
 	return t.createFile(t.config.filenameProperties, props)
 }
 
-func (t *fileMapToBlockmaxReindexTracker) getProps() ([]string, error) {
+func (t *fileMapToBlockmaxReindexTracker) GetProps() ([]string, error) {
 	content, err := os.ReadFile(t.filepath(t.config.filenameProperties))
 	if err != nil {
 		return nil, err
@@ -1470,6 +1695,249 @@ func (t *fileMapToBlockmaxReindexTracker) getProps() ([]string, error) {
 
 func (t *fileMapToBlockmaxReindexTracker) reset() error {
 	return os.RemoveAll(t.config.migrationPath)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsRollback() bool {
+	return t.fileExists(t.config.filenameRollback)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsPaused() bool {
+	return t.fileExists(t.config.filenamePaused)
+}
+
+func (t *fileMapToBlockmaxReindexTracker) GetStatusStrings() (status string, message string, action string) {
+	if !t.IsStarted() {
+		status = "not started"
+		message = "reindexing not started"
+		action = "enable relevant REINDEX_MAP_TO_BLOCKMAX_* env vars"
+		if t.HasStartCondition() {
+			message = "reindexing will start on next restart"
+			action = "restart"
+		}
+		return
+	}
+	message = "reindexing started"
+	action = "wait"
+
+	if !t.HasProps() {
+		status = "computing properties"
+		message = "computing properties to reindex"
+		return
+	}
+
+	count, _, err := t.GetMigratedCount()
+	if err != nil {
+		status = "error"
+		message = fmt.Sprintf("failed to get migrated count: %v", err)
+		return
+	}
+
+	status = "in progress"
+
+	if count == 0 {
+		message = "reindexing just started, no snapshots yet"
+	}
+
+	if t.IsReindexed() {
+		status = "reindexed"
+		message = "reindexing done, needs restart to merge buckets"
+		action = "restart"
+	}
+
+	if t.IsMerged() {
+		status = "merged"
+		message = "reindexing done, buckets merged"
+		action = "restart"
+	}
+
+	if t.IsSwapped() {
+		status = "swapped"
+		message = "reindexing done, buckets swapped"
+		action = "restart"
+	}
+
+	if t.IsPaused() {
+		status = "paused"
+		message = "reindexing paused, needs resume or rollback"
+		action = "resume or rollback"
+	}
+
+	if t.IsRollback() {
+		status = "rollback"
+		message = "reindexing rollback in progress, will finish on next restart"
+		action = "restart"
+	}
+
+	if t.IsTidied() {
+		status = "tidied"
+		message = "reindexing done, buckets tidied"
+		action = "nothing to do"
+	}
+
+	return
+}
+
+func (t *fileMapToBlockmaxReindexTracker) GetTimes() map[string]string {
+	times := map[string]string{}
+
+	started, err := t.getStarted()
+	if err != nil {
+		times["started"] = ""
+	} else {
+		times["started"] = t.encodeTime(started)
+	}
+	_, tm, _ := t.GetProgress()
+	if tm == nil {
+		times["reindexSnapshot"] = ""
+	} else {
+		times["reindexSnapshot"] = t.encodeTime(*tm)
+	}
+
+	reindexed, err := t.getReindexed()
+	if err != nil {
+		times["reindexFinished"] = ""
+	} else {
+		times["reindexFinished"] = t.encodeTime(reindexed)
+	}
+	merged, err := t.getMerged()
+	if err != nil {
+		times["merged"] = ""
+	} else {
+		times["merged"] = t.encodeTime(merged)
+	}
+
+	swapped, err := t.getSwapped()
+	if err != nil {
+		times["swapped"] = ""
+	} else {
+		times["swapped"] = t.encodeTime(swapped)
+	}
+
+	tidied, err := t.getTidied()
+	if err != nil {
+		times["tidied"] = ""
+	} else {
+		times["tidied"] = t.encodeTime(tidied)
+	}
+
+	return times
+}
+
+func (t *fileMapToBlockmaxReindexTracker) checkOverrides(logger logrus.FieldLogger, config *mapToBlockmaxConfig) {
+	if !t.fileExists(t.config.filenameOverrides) {
+		return
+	}
+	if config == nil {
+		return
+	}
+	content, err := os.ReadFile(t.filepath(t.config.filenameOverrides))
+	if err != nil {
+		return
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) == 0 {
+		return
+	}
+
+	for _, line := range lines {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			logger.WithField("line", line).Warn("invalid override line, expected 'key=value'")
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		logger.WithFields(logrus.Fields{
+			"key":   key,
+			"value": value,
+		}).Info("processing override")
+
+		switch key {
+		case "swapBuckets":
+			config.swapBuckets = entcfg.Enabled(value)
+		case "unswapBuckets":
+			config.unswapBuckets = entcfg.Enabled(value)
+		case "tidyBuckets":
+			config.tidyBuckets = entcfg.Enabled(value)
+		case "reloadShards":
+			config.reloadShards = entcfg.Enabled(value)
+		case "rollback":
+			config.rollback = entcfg.Enabled(value)
+		case "conditionalStart":
+			config.conditionalStart = entcfg.Enabled(value)
+		case "concurrency":
+			concurrency, err := strconv.Atoi(value)
+			if err != nil {
+				logger.WithField("value", value).Warn("invalid concurrency value, must be an integer")
+				continue
+			}
+			if concurrency <= 0 {
+				logger.WithField("value", value).Warn("invalid concurrency value, must be greater than 0")
+				continue
+			}
+			config.concurrency = concurrency
+		case "memtableOptBlockmaxFactor":
+			memtableOptBlockmaxFactor, err := strconv.Atoi(value)
+			if err != nil {
+				logger.WithField("value", value).Warn("invalid memtableOptBlockmaxFactor value, must be an integer")
+				continue
+			}
+			if memtableOptBlockmaxFactor <= 0 {
+				logger.WithField("value", value).Warn("invalid memtableOptBlockmaxFactor value, must be greater than 0")
+				continue
+			}
+			config.memtableOptBlockmaxFactor = memtableOptBlockmaxFactor
+		case "processingDuration":
+			processingDuration, err := time.ParseDuration(value)
+			if err != nil {
+				logger.WithField("value", value).Warnf("invalid processingDuration value: %v", err)
+				continue
+			}
+			if processingDuration <= 0 {
+				logger.WithField("value", value).Warn("invalid processingDuration value, must be greater than 0")
+				continue
+			}
+			config.processingDuration = processingDuration
+		case "pauseDuration":
+			pauseDuration, err := time.ParseDuration(value)
+			if err != nil {
+				logger.WithField("value", value).Warnf("invalid pauseDuration value: %v", err)
+				continue
+			}
+			if pauseDuration <= 0 {
+				logger.WithField("value", value).Warn("invalid pauseDuration value, must be greater than 0")
+				continue
+			}
+			config.pauseDuration = pauseDuration
+		case "perObjectDelay":
+			perObjectDelay, err := time.ParseDuration(value)
+			if err != nil {
+				logger.WithField("value", value).Warnf("invalid perObjectDelay value: %v", err)
+				continue
+			}
+			if perObjectDelay < 0 {
+				logger.WithField("value", value).Warn("invalid perObjectDelay value, must be greater than or equal to 0")
+				continue
+			}
+			config.perObjectDelay = perObjectDelay
+		case "checkProcessingEveryNoObjects":
+			checkProcessingEveryNoObjects, err := strconv.Atoi(value)
+			if err != nil {
+				logger.WithField("value", value).Warnf("invalid checkProcessingEveryNoObjects value: %v", err)
+				continue
+			}
+			if checkProcessingEveryNoObjects <= 0 {
+				logger.WithField("value", value).Warn("invalid checkProcessingEveryNoObjects value, must be greater than 0")
+				continue
+			}
+			config.checkProcessingEveryNoObjects = checkProcessingEveryNoObjects
+		default:
+			logger.WithField("key", key).Warnf("unknown override key, ignoring: %s", key)
+			continue
+		}
+	}
+
+	logger.WithField("config", fmt.Sprintf("%+v", config)).Debug("reindex config overrides applied")
 }
 
 // -----------------------------------------------------------------------------
@@ -1529,9 +1997,9 @@ type indexKeyParser interface {
 	FromBytes(key []byte) indexKey
 }
 
-type uuidKeyParser struct{}
+type UuidKeyParser struct{}
 
-func (p *uuidKeyParser) FromString(key string) (indexKey, error) {
+func (p *UuidKeyParser) FromString(key string) (indexKey, error) {
 	uid, err := uuid.Parse(key)
 	if err != nil {
 		return nil, err
@@ -1543,7 +2011,7 @@ func (p *uuidKeyParser) FromString(key string) (indexKey, error) {
 	return uuidBytes(buf), nil
 }
 
-func (p *uuidKeyParser) FromBytes(key []byte) indexKey {
+func (p *UuidKeyParser) FromBytes(key []byte) indexKey {
 	return uuidBytes(key)
 }
 


### PR DESCRIPTION
### What's being changed:

Enable overriding BMW migration vars with endpoint call.
Better reporting of migration status
Add /pause, /suspend and /rollback endpoints to allow stopping the process early without restart

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
