### PR TITLE
fix: adjust sleep times in segment group cleanup tests

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_cleanup_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup_test.go
@@ -222,7 +222,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("2nd round, no candiates due to no new segments", func(t *testing.T) {
@@ -302,7 +302,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("new segments created", func(t *testing.T) {
@@ -368,7 +368,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("3rd round, no candidates due to no new segments", func(t *testing.T) {
@@ -452,7 +452,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("new segments created", func(t *testing.T) {
@@ -498,7 +498,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("3rd round, no candidates due to no new segments", func(t *testing.T) {
@@ -525,7 +525,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("4th round, new and old candidates due to sum of new sizes big enough", func(t *testing.T) {
@@ -687,7 +687,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("2nd round, no candidates due to no new segments", func(t *testing.T) {
@@ -709,7 +709,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("3rd round, new segments cleaned and some old ones", func(t *testing.T) {
@@ -781,7 +781,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("4th round, no candidates due to no new segments", func(t *testing.T) {
@@ -802,7 +802,7 @@ func TestSegmentGroup_CleanupCandidates(t *testing.T) {
 		})
 
 		t.Run("wait interval for next round", func(t *testing.T) {
-			time.Sleep(sg.cleanupInterval * 4 / 3)
+			time.Sleep(sg.cleanupInterval * 3 / 2)
 		})
 
 		t.Run("5th round, new segments cleaned and some old ones", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
