### PR TITLE
feat: :sparkles: skip hashbeat if maintenance mode is enabled

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -409,13 +409,13 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			MinimumFactor:            1,
 			AsyncReplicationDisabled: appState.ServerConfig.Config.Replication.AsyncReplicationDisabled,
 		},
-		MaximumConcurrentShardLoads:        appState.ServerConfig.Config.MaximumConcurrentShardLoads,
-		TenantActivityReadLogLevel:         appState.ServerConfig.Config.TenantActivityReadLogLevel,
-		TenantActivityWriteLogLevel:        appState.ServerConfig.Config.TenantActivityWriteLogLevel,
-		QuerySlowLogEnabled:                appState.ServerConfig.Config.QuerySlowLogEnabled,
-		QuerySlowLogThreshold:              appState.ServerConfig.Config.QuerySlowLogThreshold,
-		InvertedSorterDisabled:             appState.ServerConfig.Config.InvertedSorterDisabled,
-		MaintenanceModeEnabledForLocalhost: appState.Cluster.MaintenanceModeEnabledForLocalhost,
+		MaximumConcurrentShardLoads: appState.ServerConfig.Config.MaximumConcurrentShardLoads,
+		TenantActivityReadLogLevel:  appState.ServerConfig.Config.TenantActivityReadLogLevel,
+		TenantActivityWriteLogLevel: appState.ServerConfig.Config.TenantActivityWriteLogLevel,
+		QuerySlowLogEnabled:         appState.ServerConfig.Config.QuerySlowLogEnabled,
+		QuerySlowLogThreshold:       appState.ServerConfig.Config.QuerySlowLogThreshold,
+		InvertedSorterDisabled:      appState.ServerConfig.Config.InvertedSorterDisabled,
+		MaintenanceModeEnabled:      appState.Cluster.MaintenanceModeEnabledForLocalhost,
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics, appState.MemWatch) // TODO client
 	if err != nil {
 		appState.Logger.

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -409,12 +409,13 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			MinimumFactor:            1,
 			AsyncReplicationDisabled: appState.ServerConfig.Config.Replication.AsyncReplicationDisabled,
 		},
-		MaximumConcurrentShardLoads: appState.ServerConfig.Config.MaximumConcurrentShardLoads,
-		TenantActivityReadLogLevel:  appState.ServerConfig.Config.TenantActivityReadLogLevel,
-		TenantActivityWriteLogLevel: appState.ServerConfig.Config.TenantActivityWriteLogLevel,
-		QuerySlowLogEnabled:         appState.ServerConfig.Config.QuerySlowLogEnabled,
-		QuerySlowLogThreshold:       appState.ServerConfig.Config.QuerySlowLogThreshold,
-		InvertedSorterDisabled:      appState.ServerConfig.Config.InvertedSorterDisabled,
+		MaximumConcurrentShardLoads:        appState.ServerConfig.Config.MaximumConcurrentShardLoads,
+		TenantActivityReadLogLevel:         appState.ServerConfig.Config.TenantActivityReadLogLevel,
+		TenantActivityWriteLogLevel:        appState.ServerConfig.Config.TenantActivityWriteLogLevel,
+		QuerySlowLogEnabled:                appState.ServerConfig.Config.QuerySlowLogEnabled,
+		QuerySlowLogThreshold:              appState.ServerConfig.Config.QuerySlowLogThreshold,
+		InvertedSorterDisabled:             appState.ServerConfig.Config.InvertedSorterDisabled,
+		MaintenanceModeEnabledForLocalhost: appState.Cluster.MaintenanceModeEnabledForLocalhost,
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics, appState.MemWatch) // TODO client
 	if err != nil {
 		appState.Logger.

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -676,6 +676,8 @@ type IndexConfig struct {
 	QuerySlowLogEnabled                 *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold               *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled              *configRuntime.DynamicValue[bool]
+
+	MaintenanceModeEnabledForLocalhost func() bool
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -676,8 +676,7 @@ type IndexConfig struct {
 	QuerySlowLogEnabled                 *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold               *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled              *configRuntime.DynamicValue[bool]
-
-	MaintenanceModeEnabledForLocalhost func() bool
+	MaintenanceModeEnabled              func() bool
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -114,6 +114,7 @@ func (db *DB) init(ctx context.Context) error {
 				QuerySlowLogEnabled:                 db.config.QuerySlowLogEnabled,
 				QuerySlowLogThreshold:               db.config.QuerySlowLogThreshold,
 				InvertedSorterDisabled:              db.config.InvertedSorterDisabled,
+				MaintenanceModeEnabledForLocalhost:  db.config.MaintenanceModeEnabledForLocalhost,
 			}, db.schemaGetter.CopyShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -114,7 +114,7 @@ func (db *DB) init(ctx context.Context) error {
 				QuerySlowLogEnabled:                 db.config.QuerySlowLogEnabled,
 				QuerySlowLogThreshold:               db.config.QuerySlowLogThreshold,
 				InvertedSorterDisabled:              db.config.InvertedSorterDisabled,
-				MaintenanceModeEnabledForLocalhost:  db.config.MaintenanceModeEnabledForLocalhost,
+				MaintenanceModeEnabled:              db.config.MaintenanceModeEnabled,
 			}, db.schemaGetter.CopyShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -231,6 +231,7 @@ type Config struct {
 	QuerySlowLogEnabled                 *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold               *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled              *configRuntime.DynamicValue[bool]
+	MaintenanceModeEnabledForLocalhost  func() bool
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -231,7 +231,7 @@ type Config struct {
 	QuerySlowLogEnabled                 *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold               *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled              *configRuntime.DynamicValue[bool]
-	MaintenanceModeEnabledForLocalhost  func() bool
+	MaintenanceModeEnabled              func() bool
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -78,20 +78,21 @@ const (
 )
 
 type asyncReplicationConfig struct {
-	hashtreeHeight              int
-	frequency                   time.Duration
-	frequencyWhilePropagating   time.Duration
-	aliveNodesCheckingFrequency time.Duration
-	loggingFrequency            time.Duration
-	initShieldCPUEveryN         int
-	diffBatchSize               int
-	diffPerNodeTimeout          time.Duration
-	prePropagationTimeout       time.Duration
-	propagationTimeout          time.Duration
-	propagationLimit            int
-	propagationDelay            time.Duration
-	propagationConcurrency      int
-	propagationBatchSize        int
+	hashtreeHeight                     int
+	frequency                          time.Duration
+	frequencyWhilePropagating          time.Duration
+	aliveNodesCheckingFrequency        time.Duration
+	loggingFrequency                   time.Duration
+	initShieldCPUEveryN                int
+	diffBatchSize                      int
+	diffPerNodeTimeout                 time.Duration
+	prePropagationTimeout              time.Duration
+	propagationTimeout                 time.Duration
+	propagationLimit                   int
+	propagationDelay                   time.Duration
+	propagationConcurrency             int
+	propagationBatchSize               int
+	maintenanceModeEnabledForLocalhost func() bool
 }
 
 func (s *Shard) getAsyncReplicationConfig() (config asyncReplicationConfig, err error) {
@@ -175,6 +176,11 @@ func (s *Shard) getAsyncReplicationConfig() (config asyncReplicationConfig, err 
 		os.Getenv("ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE"), defaultPropagationBatchSize, minPropagationBatchSize, maxPropagationBatchSize)
 	if err != nil {
 		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE", err)
+	}
+
+	config.maintenanceModeEnabledForLocalhost = s.index.Config.MaintenanceModeEnabledForLocalhost
+	if config.maintenanceModeEnabledForLocalhost == nil {
+		return asyncReplicationConfig{}, fmt.Errorf("maintenance mode enabled function is not set")
 	}
 
 	return
@@ -554,6 +560,23 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 			case <-ctx.Done():
 				return
 			case <-propagationRequired:
+
+				if config.maintenanceModeEnabledForLocalhost != nil &&
+					config.maintenanceModeEnabledForLocalhost() {
+					// if maintenance mode is enabled for localhost, skip async replication
+					s.index.logger.
+						WithField("action", "async_replication").
+						WithField("class_name", s.class.Class).
+						WithField("shard_name", s.name).
+						Info("skipping async replication in maintenance mode")
+					backoffTimer.Reset()
+					lastHashbeatMux.Lock()
+					lastHashbeat = time.Now()
+					lastHashbeatPropagatedObjects = false
+					lastHashbeatMux.Unlock()
+					continue
+				}
+
 				stats, err := s.hashBeat(ctx, config)
 				if err != nil {
 					if ctx.Err() != nil {

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -78,21 +78,21 @@ const (
 )
 
 type asyncReplicationConfig struct {
-	hashtreeHeight                     int
-	frequency                          time.Duration
-	frequencyWhilePropagating          time.Duration
-	aliveNodesCheckingFrequency        time.Duration
-	loggingFrequency                   time.Duration
-	initShieldCPUEveryN                int
-	diffBatchSize                      int
-	diffPerNodeTimeout                 time.Duration
-	prePropagationTimeout              time.Duration
-	propagationTimeout                 time.Duration
-	propagationLimit                   int
-	propagationDelay                   time.Duration
-	propagationConcurrency             int
-	propagationBatchSize               int
-	maintenanceModeEnabledForLocalhost func() bool
+	hashtreeHeight              int
+	frequency                   time.Duration
+	frequencyWhilePropagating   time.Duration
+	aliveNodesCheckingFrequency time.Duration
+	loggingFrequency            time.Duration
+	initShieldCPUEveryN         int
+	diffBatchSize               int
+	diffPerNodeTimeout          time.Duration
+	prePropagationTimeout       time.Duration
+	propagationTimeout          time.Duration
+	propagationLimit            int
+	propagationDelay            time.Duration
+	propagationConcurrency      int
+	propagationBatchSize        int
+	maintenanceModeEnabled      func() bool
 }
 
 func (s *Shard) getAsyncReplicationConfig() (config asyncReplicationConfig, err error) {
@@ -178,8 +178,8 @@ func (s *Shard) getAsyncReplicationConfig() (config asyncReplicationConfig, err 
 		return asyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE", err)
 	}
 
-	config.maintenanceModeEnabledForLocalhost = s.index.Config.MaintenanceModeEnabledForLocalhost
-	if config.maintenanceModeEnabledForLocalhost == nil {
+	config.maintenanceModeEnabled = s.index.Config.MaintenanceModeEnabled
+	if config.maintenanceModeEnabled == nil {
 		return asyncReplicationConfig{}, fmt.Errorf("maintenance mode enabled function is not set")
 	}
 
@@ -561,8 +561,8 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 				return
 			case <-propagationRequired:
 
-				if config.maintenanceModeEnabledForLocalhost != nil &&
-					config.maintenanceModeEnabledForLocalhost() {
+				if config.maintenanceModeEnabled != nil &&
+					config.maintenanceModeEnabled() {
 					// if maintenance mode is enabled for localhost, skip async replication
 					s.index.logger.
 						WithField("action", "async_replication").


### PR DESCRIPTION
### What's being changed:

Skip async replication hashbeats if maintenance mode is enabled, to avoid adding new data to node.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
