### PR TITLE
Rename `REPLICA_MOVEMENT_ENABLED` to `REPLICA_MOVEMENT_DISABLED`

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -546,7 +546,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		AuthNConfig:                     appState.ServerConfig.Config.Authentication,
 		ReplicationEngineMaxWorkers:     appState.ServerConfig.Config.ReplicationEngineMaxWorkers,
 		DistributedTasks:                appState.ServerConfig.Config.DistributedTasks,
-		ReplicaMovementEnabled:          appState.ServerConfig.Config.ReplicaMovementEnabled,
+		ReplicaMovementDisabled:         appState.ServerConfig.Config.ReplicaMovementDisabled,
 		ReplicaMovementMinimumAsyncWait: appState.ServerConfig.Config.ReplicaMovementMinimumAsyncWait,
 	}
 	for _, name := range appState.ServerConfig.Config.Raft.Join[:rConfig.BootstrapExpect] {
@@ -841,7 +841,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.Authorizer,
 		appState.Logger)
 
-	replicationHandlers.SetupHandlers(appState.ServerConfig.Config.ReplicaMovementEnabled, api, appState.ClusterService.Raft, appState.Metrics, appState.Authorizer, appState.Logger)
+	replicationHandlers.SetupHandlers(!appState.ServerConfig.Config.ReplicaMovementDisabled, api, appState.ClusterService.Raft, appState.Metrics, appState.Authorizer, appState.Logger)
 
 	remoteDbUsers := clients.NewRemoteUser(appState.ClusterHttpClient, appState.Cluster)
 	db_users.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication, appState.ServerConfig.Config.Authorization, remoteDbUsers, appState.SchemaManager, appState.Logger)

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -119,7 +119,7 @@ func New(cfg Config, authZController authorization.Controller, snapshotter fsm.S
 }
 
 func (c *Service) onFSMCaughtUp(ctx context.Context) {
-	if !c.config.ReplicaMovementEnabled {
+	if c.config.ReplicaMovementDisabled {
 		return
 	}
 
@@ -217,7 +217,7 @@ func (c *Service) Close(ctx context.Context) error {
 		c.closeOnFSMCaughtUp <- struct{}{}
 	}, c.logger)
 
-	if c.config.ReplicaMovementEnabled {
+	if !c.config.ReplicaMovementDisabled {
 		c.logger.Info("closing replication engine ...")
 		if c.cancelReplicationEngine != nil {
 			c.cancelReplicationEngine()

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -177,7 +177,7 @@ type Config struct {
 	// DistributedTasks is the configuration for the distributed task manager.
 	DistributedTasks config.DistributedTasksConfig
 
-	ReplicaMovementEnabled bool
+	ReplicaMovementDisabled bool
 
 	// ReplicaMovementMinimumAsyncWait is the minimum time bound that replica movement operations will wait before
 	// async replication can complete.

--- a/test/acceptance/authz/replication_replicate_test.go
+++ b/test/acceptance/authz/replication_replicate_test.go
@@ -42,7 +42,6 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 
 	compose, err := docker.New().
 		WithWeaviateEnv("AUTOSCHEMA_ENABLED", "false").
-		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		With3NodeCluster().
 		WithRBAC().
 		WithApiKey().

--- a/test/acceptance/authz/setup.go
+++ b/test/acceptance/authz/setup.go
@@ -24,7 +24,7 @@ import (
 func composeUp(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string) (*docker.DockerCompose, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 
-	builder := docker.New().WithWeaviateEnv("AUTOSCHEMA_ENABLED", "false").WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").WithWeaviateWithGRPC().WithRBAC().WithApiKey()
+	builder := docker.New().WithWeaviateEnv("AUTOSCHEMA_ENABLED", "false").WithWeaviateWithGRPC().WithRBAC().WithApiKey()
 	adminUserNames := make([]string, 0, len(admins))
 	viewerUserNames := make([]string, 0, len(viewers))
 	for userName, key := range admins {

--- a/test/acceptance/replication/replica_replication/fast/endpoints_test.go
+++ b/test/acceptance/replication/replica_replication/fast/endpoints_test.go
@@ -46,7 +46,6 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
-		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		Start(mainCtx)
 	require.Nil(t, err)
 	suite.compose = compose

--- a/test/acceptance/replication/replica_replication/fast/not_implemented_test.go
+++ b/test/acceptance/replication/replica_replication/fast/not_implemented_test.go
@@ -42,7 +42,7 @@ func (suite *ReplicationNotImplementedTestSuite) SetupSuite() {
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
-		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "false").
+		WithWeaviateEnv("REPLICA_MOVEMENT_DISABLED", "true").
 		Start(mainCtx)
 	require.Nil(t, err)
 	suite.compose = compose

--- a/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
+++ b/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
@@ -69,7 +69,6 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 		WithWeaviateCluster(3).
 		WithText2VecContextionary().
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
-		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {
@@ -255,7 +254,6 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 		WithWeaviateCluster(3).
 		WithText2VecContextionary().
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
-		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/replication/replica_replication/slow_file_copy/slow_file_copy_test.go
+++ b/test/acceptance/replication/replica_replication/slow_file_copy/slow_file_copy_test.go
@@ -59,7 +59,6 @@ func (suite *ReplicationTestSuite) TestReplicaMovementOneWriteExtraSlowFileCopy(
 		WithWeaviateCluster(3).
 		WithText2VecContextionary().
 		WithWeaviateEnv("WEAVIATE_TEST_COPY_REPLICA_SLEEP", "20s").
-		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -172,7 +172,7 @@ type Config struct {
 
 	RuntimeOverrides RuntimeOverrides `json:"runtime_overrides" yaml:"runtime_overrides"`
 
-	ReplicaMovementEnabled          bool                                 `json:"replica_movement_enabled" yaml:"replica_movement_enabled"`
+	ReplicaMovementDisabled         bool                                 `json:"replica_movement_disabled" yaml:"replica_movement_disabled"`
 	ReplicaMovementMinimumAsyncWait *runtime.DynamicValue[time.Duration] `json:"REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT" yaml:"REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT"`
 
 	// TenantActivityReadLogLevel is 'debug' by default as every single READ

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -795,8 +795,8 @@ func FromEnv(config *Config) error {
 		config.DistributedTasks.Enabled = entcfg.Enabled(v)
 	}
 
-	if v := os.Getenv("REPLICA_MOVEMENT_ENABLED"); v != "" {
-		config.ReplicaMovementEnabled = entcfg.Enabled(v)
+	if v := os.Getenv("REPLICA_MOVEMENT_DISABLED"); v != "" {
+		config.ReplicaMovementDisabled = entcfg.Enabled(v)
 	}
 
 	if v := os.Getenv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT"); v != "" {


### PR DESCRIPTION
### What's being changed:

This PR enables replica movement by default but allows for disabling it still using the env var `REPLICA_MOVEMENT_DISABLED`, which defaults to `false`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
